### PR TITLE
[MP][DAX] Add experimental coordinator-owned shared Device-DAX L1

### DIFF
--- a/docs/design/v1/distributed/shared_l1/shared_devdax_l1.md
+++ b/docs/design/v1/distributed/shared_l1/shared_devdax_l1.md
@@ -1,0 +1,203 @@
+# Shared Device-DAX L1 M0
+
+Status: experimental, non-reclaiming functional addon
+
+This implementation proves that SGLang and vLLM MP servers can use one physical
+Device-DAX/CXL KV pool without running independent allocators over the same
+bytes. It is the monotonic M0 described by
+[issue #4307](https://github.com/LMCache/LMCache/issues/4307), not the complete
+production design.
+
+## Scope
+
+The supported profile is intentionally fixed:
+
+- one existing MP coordinator with one metadata child process;
+- one shared region and layout ID;
+- two or more MP servers with host-local mappings of the same physical bytes;
+- TP=1 and LMCache-driven transfers;
+- immutable KV objects and monotonic allocation;
+- CUDA registration and a platform-qualified visibility operation.
+
+P2P, L2, GDS, hybrid DRAM/DAX, eviction, reuse, hotplug, coordinator HA, and
+automatic crash recovery are rejected or deferred. The manager transport uses
+authenticated Python `BaseManager` RPC and assumes a trusted test cluster.
+
+## Ownership and data path
+
+Two Device-DAX paths may expose the same CXL bytes while using different path
+names and virtual addresses. Only the coordinator child allocates offsets:
+
+```text
+MP coordinator pod
+  FastAPI parent
+    `-- starts/stops one metadata child
+          `-- allocation cursor, key state, reservations
+                       ^
+                       | authenticated metadata-only RPC
+             +---------+---------+
+             |                   |
+        MP server A         MP server B
+        local DAX mmap      local DAX mmap
+        GPU D2H/H2D         GPU D2H/H2D
+             \                   /
+              +-- same CXL bytes +
+```
+
+Serving-engine pods do not map Device-DAX. Payload bytes, virtual addresses,
+CUDA pointers, and GPU descriptors never pass through the coordinator.
+
+## Region and object contracts
+
+Every MP server validates this immutable startup contract:
+
+```text
+SharedRegionContract {
+    region_id, capacity, alignment, layout_id, generation_epoch
+}
+```
+
+`region_id` is operator-provisioned; LMCache cannot infer physical identity
+from a device path. `generation_epoch` changes with each metadata child and
+fences a coordinated reset.
+
+Each object has an address-independent handle:
+
+```text
+SharedObjectHandle {
+    region_id, offset, length, generation
+}
+```
+
+The coordinator also retains the existing `MemoryLayoutDesc` written with the
+object. A remote reader receives that layout with its reservation, so the
+public list-oriented `L1Manager.reserve_read(keys, extra_count)` API is
+unchanged.
+
+## M0 state and batching
+
+M0 implements:
+
+```text
+absent -> WRITING -> VALID
+             |
+             +-> aborted metadata; extent remains consumed
+```
+
+- one writer wins a duplicate-key race;
+- only its opaque token can finish or abort the write;
+- readers see only `VALID` objects;
+- read tokens remain active until H2D completion or cancellation;
+- committed objects are immutable;
+- abort never rewinds the allocation cursor;
+- allocation, reserve, finish, and release are serialized by the child.
+
+Each existing `L1Manager` key list produces one coordinator operation:
+
+```text
+reserve_writes(keys)
+finish_writes(reservations)
+abort_writes(reservations)
+reserve_reads(keys)
+finish_reads(reservations)
+abort_reads(reservations)
+```
+
+Write reservation and commit validate the whole batch before changing state.
+Read reservation is partial: hits receive tokens while misses return `None`.
+Internal per-layer DMA work does not create more metadata calls.
+
+## Transfer ordering
+
+Write publication is:
+
+```text
+reserve_writes
+  -> enqueue all D2H copies into mapped tensors
+  -> synchronize the transfer event
+  -> publish every exact DAX range
+  -> atomically finish_writes
+  -> report STORE success
+```
+
+Any transfer, synchronization, visibility, or commit failure aborts remaining
+`WRITING` reservations. The normal private L1 path retains its asynchronous
+host callback.
+
+Read consumption is:
+
+```text
+reserve_reads
+  -> validate contract, bounds, generation, and stored layout
+  -> acquire each exact DAX range
+  -> expose TensorMemoryObj views
+  -> enqueue H2D
+  -> finish_reads after H2D completion
+```
+
+Shared reads reject `extra_count > 0`. Shutdown drains every registered GPU
+transfer stream before releasing tokens, unregistering, and unmapping.
+
+## Visibility and CUDA registration
+
+The operator supplies an absolute library path exporting:
+
+```c
+int lmcache_shared_l1_visibility_v1(
+    const char *mode,
+    uint32_t operation,
+    int device_fd,
+    void *mapped_address,
+    uint64_t device_offset,
+    size_t length,
+    uint64_t generation);
+```
+
+Mode is `software_fenced`; operation 1 publishes and operation 2 acquires.
+Return zero on success or a negative errno. `MAP_SHARED`, `msync`, or equal
+physical media alone are not accepted as cross-host visibility proof.
+
+The entire mapping is registered with CUDA at startup. Registration failure is
+fatal; M0 has no pageable-staging fallback. A successful path is
+`direct-pinned`, but DAX-to-GPU consumption still performs H2D DMA.
+
+## Configuration
+
+The coordinator uses:
+
+```text
+LMCACHE_MP_COORDINATOR_SHARED_L1_{HOST,PORT,AUTHKEY_FILE,REGION_ID,
+                                  CAPACITY_BYTES,ALIGNMENT_BYTES,LAYOUT_ID}
+```
+
+Each MP server supplies:
+
+```text
+--l1-devdax-path PATH
+--l1-size-gb SIZE --no-l1-use-lazy --shm-name ""
+--shared-l1-coordinator HOST:PORT
+--shared-l1-authkey-file ABSOLUTE_PATH
+--shared-l1-region-id ID --shared-l1-layout-id ID
+--shared-l1-mapping-offset BYTES
+--shared-l1-visibility-library-path ABSOLUTE_PATH
+--supported-transfer-mode lmcache_driven
+--eviction-policy noop
+```
+
+Authentication key bytes are read from mounted files, not serialized config.
+
+## Verification and deferred work
+
+Tests cover batched state transitions, duplicate writers, non-overlapping
+concurrent allocation, stale tokens/handles, exact visibility ranges, CUDA
+registration failure, coordinator authentication/lifecycle, `L1Manager`
+integration, and STORE failure cleanup. The two-host Kubernetes qualification
+additionally proves an SGLang-produced object can be loaded by vLLM through the
+same physical region.
+
+Free-list reuse and `EVICTING`, TTL renewal, client incarnation/idempotency,
+restart fencing, metrics, production transport, and HA remain follow-ups.
+Restart requires quiescing all MP servers, resetting the pool, and validating
+the new epoch. The eventual fleet directory in
+[issue #4226](https://github.com/LMCache/LMCache/issues/4226) cannot authorize
+shared reads or reconstruct allocator state.

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -159,6 +159,40 @@ class L1MemoryManagerConfig:
             self.use_lazy = False
 
 
+@dataclass(frozen=True)
+class SharedL1Config:
+    """Connection and host-local mapping settings for shared Device-DAX L1.
+
+    The coordinator owns object metadata and offsets. Each MP server supplies
+    only the path and mapping offset for its local view of the same physical
+    region; virtual addresses are intentionally not part of this contract.
+    """
+
+    coordinator_host: str
+    coordinator_port: int
+    authkey_file: str
+    region_id: str
+    layout_id: str
+    mapping_offset: int
+    visibility_library_path: str
+
+    def __post_init__(self) -> None:
+        if not self.coordinator_host:
+            raise ValueError("shared-L1 coordinator host must not be empty")
+        if not 1 <= self.coordinator_port <= 65535:
+            raise ValueError("shared-L1 coordinator port must be between 1 and 65535")
+        if not os.path.isabs(self.authkey_file):
+            raise ValueError("shared-L1 authkey file path must be absolute")
+        if not self.region_id:
+            raise ValueError("shared-L1 region id must not be empty")
+        if not self.layout_id:
+            raise ValueError("shared-L1 layout id must not be empty")
+        if self.mapping_offset < 0:
+            raise ValueError("shared-L1 mapping offset must be non-negative")
+        if not os.path.isabs(self.visibility_library_path):
+            raise ValueError("shared-L1 visibility library path must be absolute")
+
+
 @dataclass
 class GdsL1Config:
     """Configuration for the GDS slab-file L1 tier.
@@ -203,6 +237,9 @@ class L1ManagerConfig:
 
     read_ttl_seconds: int = field(default=300)
     """ Time to live for each object's read lock. Default is 300s (5 minutes). """
+
+    shared_l1_config: "SharedL1Config | None" = None
+    """Optional coordinator-owned shared Device-DAX functional path."""
 
 
 @dataclass
@@ -276,6 +313,11 @@ def normalize_storage_manager_config(config: StorageManagerConfig) -> None:
     Raises:
         ValueError: If more than one DAX device matches ``l1-devdax-path``.
     """
+    if config.l1_manager_config.shared_l1_config is not None:
+        # Shared L1 owns the complete Device-DAX region. Do not consume a
+        # matching DAX L2 adapter as private-L1 overflow before validation can
+        # reject the unsupported L2 combination.
+        return
     memory_config = config.l1_manager_config.memory_config
     _infer_l1_devdax_overflow_from_dax_adapter(memory_config, config.l2_adapter_config)
 
@@ -303,6 +345,22 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
         raise ValueError("gds-l1-path cannot be used with l1-devdax-path")
 
     memory_config = config.l1_manager_config.memory_config
+    shared_config = config.l1_manager_config.shared_l1_config
+    if shared_config is not None:
+        if not memory_config.devdax_path:
+            raise ValueError("shared L1 requires l1-devdax-path")
+        if config.l1_manager_config.gds_l1_config is not None:
+            raise ValueError("shared L1 cannot be used with GDS L1")
+        if config.l2_adapter_config.adapters:
+            raise ValueError(
+                "the minimal shared-L1 functional path cannot be combined "
+                "with L2 adapters"
+            )
+        if config.eviction_config.eviction_policy != "noop":
+            raise ValueError(
+                "the minimal shared-L1 functional path requires eviction_policy='noop'"
+            )
+
     if not (memory_config.devdax_path and memory_config.devdax_size_in_bytes):
         return
 
@@ -403,6 +461,47 @@ def add_storage_manager_args(
             "If a DAX L2 adapter with the same device_path is registered, "
             "that adapter's max_dax_size_gb is used as L1 overflow size."
         ),
+    )
+    shared_group = parser.add_argument_group(
+        "Shared Device-DAX L1",
+        "Minimal coordinator-owned shared Device-DAX functional path.",
+    )
+    shared_group.add_argument(
+        "--shared-l1-coordinator",
+        type=str,
+        default=None,
+        metavar="HOST:PORT",
+        help="Coordinator child-process address. Unset disables shared L1.",
+    )
+    shared_group.add_argument(
+        "--shared-l1-authkey-file",
+        type=str,
+        default=None,
+        help="Absolute path to the BaseManager authentication key file.",
+    )
+    shared_group.add_argument(
+        "--shared-l1-region-id",
+        type=str,
+        default=None,
+        help="Expected stable identity of the shared physical region.",
+    )
+    shared_group.add_argument(
+        "--shared-l1-layout-id",
+        type=str,
+        default=None,
+        help="Expected operator-supplied physical layout fingerprint.",
+    )
+    shared_group.add_argument(
+        "--shared-l1-mapping-offset",
+        type=int,
+        default=0,
+        help="Host-local byte offset at which the logical shared pool starts.",
+    )
+    shared_group.add_argument(
+        "--shared-l1-visibility-library-path",
+        type=str,
+        default=None,
+        help="Absolute path to a platform-qualified visibility ABI library.",
     )
 
     # GDS L1 tier (optional, opt-in via --gds-l1-path)
@@ -583,11 +682,45 @@ def parse_args_to_config(
             use_direct_io=args.gds_l1_use_direct_io,
         )
 
+    shared_l1_config: SharedL1Config | None = None
+    shared_l1_coordinator = getattr(args, "shared_l1_coordinator", None)
+    if shared_l1_coordinator is not None:
+        try:
+            coordinator_host, coordinator_port_raw = shared_l1_coordinator.rsplit(
+                ":", maxsplit=1
+            )
+            coordinator_port = int(coordinator_port_raw)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ValueError("shared-l1-coordinator must use HOST:PORT") from exc
+        required_values = {
+            "shared-l1-authkey-file": args.shared_l1_authkey_file,
+            "shared-l1-region-id": args.shared_l1_region_id,
+            "shared-l1-layout-id": args.shared_l1_layout_id,
+            "shared-l1-visibility-library-path": (
+                args.shared_l1_visibility_library_path
+            ),
+        }
+        missing = [name for name, value in required_values.items() if not value]
+        if missing:
+            raise ValueError(
+                "shared L1 requires " + ", ".join(f"--{name}" for name in missing)
+            )
+        shared_l1_config = SharedL1Config(
+            coordinator_host=coordinator_host,
+            coordinator_port=coordinator_port,
+            authkey_file=args.shared_l1_authkey_file,
+            region_id=args.shared_l1_region_id,
+            layout_id=args.shared_l1_layout_id,
+            mapping_offset=args.shared_l1_mapping_offset,
+            visibility_library_path=args.shared_l1_visibility_library_path,
+        )
+
     l1_manager_config = L1ManagerConfig(
         memory_config=memory_config,
         gds_l1_config=gds_l1_config,
         write_ttl_seconds=args.l1_write_ttl_seconds,
         read_ttl_seconds=args.l1_read_ttl_seconds,
+        shared_l1_config=shared_l1_config,
     )
 
     eviction_config = EvictionConfig(

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -23,6 +23,8 @@ from lmcache.v1.distributed.memory_manager import (
 from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
     DevDaxL1MemoryManager,
 )
+from lmcache.v1.distributed.shared_l1.client import SharedL1Client
+from lmcache.v1.distributed.shared_l1.pool import OutOfSpaceError
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
@@ -193,8 +195,16 @@ class L1Manager:
 
         # GDS, Device-DAX, and CPU L1 are mutually exclusive tiers. Each tier
         # owns its backing allocator instead of branching inside the CPU path.
-        self._memory_manager: L1ManagerProtocol
-        if config.gds_l1_config is not None:
+        self._memory_manager: L1ManagerProtocol | None
+        self._shared_client: SharedL1Client | None = None
+        if config.shared_l1_config is not None:
+            self._memory_manager = None
+            self._shared_client = SharedL1Client(
+                config.shared_l1_config,
+                config.memory_config,
+            )
+            logger.info("L1Manager: coordinator-owned shared Device-DAX L1 enabled")
+        elif config.gds_l1_config is not None:
             self._memory_manager = GDSL1MemoryManager(config.gds_l1_config)
             logger.info("L1Manager: GDS L1 tier enabled; CPU pinned-DRAM L1 disabled")
         elif config.memory_config.devdax_path:
@@ -239,6 +249,11 @@ class L1Manager:
         with self._lock:
             self._registered_listeners.append(listener)
 
+    @property
+    def uses_shared_l1(self) -> bool:
+        """Return whether this manager uses coordinator-owned shared L1."""
+        return self._shared_client is not None
+
     @l1_mgr_synchronized
     def reserve_read(
         self,
@@ -255,7 +270,6 @@ class L1Manager:
                 key = 1 + extra_count.  Useful when multiple
                 workers each consume one read lock for the
                 same key (e.g. MLA models with TP > 1).
-
         Returns:
             A dictionary mapping each object key to a tuple
             of (L1Error, Optional[MemoryObj]).
@@ -265,6 +279,9 @@ class L1Manager:
             KEY_NOT_READABLE: The key exists but is not
                 readable.
         """
+        if self._shared_client is not None:
+            return self._shared_reserve_read(keys, extra_count)
+
         extra_count = _validate_extra_count(extra_count)
         total = 1 + extra_count
         ret: dict[ObjectKey, L1OperationResult] = {}
@@ -295,6 +312,72 @@ class L1Manager:
                 metadata={"keys": successful_keys},
             )
         )
+        return ret
+
+    def _shared_reserve_read(
+        self,
+        keys: list[ObjectKey],
+        extra_count: int,
+    ) -> dict[ObjectKey, L1OperationResult]:
+        """Acquire a whole key list and attach remote tensor views."""
+        client = self._shared_client
+        assert client is not None
+        extra_count = _validate_extra_count(extra_count)
+        if extra_count:
+            raise ValueError("shared L1 currently supports TP=1 reads only")
+        ret: dict[ObjectKey, L1OperationResult] = {}
+        reserved_keys: list[ObjectKey] = []
+        released_keys: set[ObjectKey] = set()
+        successful_keys: list[ObjectKey] = []
+
+        try:
+            memory_objects = client.reserve_reads(keys)
+            reserved_keys = [
+                key
+                for key, memory_obj in zip(keys, memory_objects, strict=True)
+                if memory_obj is not None
+            ]
+            for key, memory_obj in zip(keys, memory_objects, strict=True):
+                if memory_obj is None:
+                    ret[key] = (L1Error.KEY_NOT_EXIST, None)
+                    continue
+                entry = self._objects.get(key)
+                if entry is not None and not entry.available_for_read():
+                    client.abort_reads([key])
+                    released_keys.add(key)
+                    ret[key] = (L1Error.KEY_NOT_READABLE, None)
+                    continue
+                if entry is None:
+                    entry = L1ObjectState(
+                        memory_obj=memory_obj,
+                        write_lock=TTLLock(self._write_ttl_seconds),
+                        read_lock=TTLLock(self._read_ttl_seconds),
+                        is_temporary=False,
+                    )
+                    self._objects[key] = entry
+                else:
+                    entry.memory_obj = memory_obj
+                entry.read_lock.lock()
+                successful_keys.append(key)
+                ret[key] = (L1Error.SUCCESS, entry.memory_obj)
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_reserved_read(successful_keys)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_READ_RESERVED,
+                    metadata={"keys": successful_keys},
+                )
+            )
+        except BaseException:
+            try:
+                client.abort_reads(
+                    [key for key in reserved_keys if key not in released_keys]
+                )
+            finally:
+                for key in successful_keys:
+                    self._objects[key].read_lock.unlock()
+            raise
+
         return ret
 
     @l1_mgr_synchronized
@@ -364,6 +447,9 @@ class L1Manager:
                 non-read-locked, which means the reader may
                 read inconsistent data.
         """
+        if self._shared_client is not None:
+            return self._shared_finish_read(keys, extra_count)
+
         extra_count = _validate_extra_count(extra_count)
         total = 1 + extra_count
         need_to_free: list[MemoryObj] = []
@@ -414,6 +500,7 @@ class L1Manager:
             ret[key] = L1Error.SUCCESS
             successful_keys.append(key)
 
+        assert self._memory_manager is not None
         self._memory_manager.free(need_to_free)
 
         for listener in self._registered_listeners:
@@ -432,6 +519,48 @@ class L1Manager:
             )
         )
 
+        return ret
+
+    def _shared_finish_read(
+        self,
+        keys: list[ObjectKey],
+        extra_count: int,
+    ) -> dict[ObjectKey, L1Error]:
+        """Release one coordinator batch before dropping local read locks."""
+        client = self._shared_client
+        assert client is not None
+        extra_count = _validate_extra_count(extra_count)
+        if extra_count:
+            raise ValueError("shared L1 currently supports TP=1 reads only")
+        ret: dict[ObjectKey, L1Error] = {}
+        successful_keys: list[ObjectKey] = []
+        for key in keys:
+            entry = self._objects.get(key)
+            if (
+                entry is None
+                or entry.write_lock.is_locked()
+                or not entry.read_lock.is_locked()
+            ):
+                ret[key] = (
+                    L1Error.KEY_NOT_EXIST
+                    if entry is None
+                    else L1Error.KEY_IN_WRONG_STATE
+                )
+                continue
+            ret[key] = L1Error.SUCCESS
+            successful_keys.append(key)
+
+        client.finish_reads(successful_keys)
+        for key in successful_keys:
+            self._objects[key].read_lock.unlock()
+        for listener in self._registered_listeners:
+            listener.on_l1_keys_read_finished(successful_keys)
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_READ_FINISHED,
+                metadata={"keys": successful_keys},
+            )
+        )
         return ret
 
     @l1_mgr_synchronized
@@ -463,6 +592,14 @@ class L1Manager:
             KEY_NOT_WRITABLE: The key exists but is not writable.
             OUT_OF_MEMORY: Not enough memory to allocate for the object.
         """
+        if self._shared_client is not None:
+            return self._shared_reserve_write(
+                keys,
+                is_temporary,
+                layout_desc,
+                mode,
+            )
+
         need_to_allocate: list[tuple[ObjectKey, bool]] = []
         ret: dict[ObjectKey, L1OperationResult] = {}
         successful_keys: list[ObjectKey] = []
@@ -495,6 +632,7 @@ class L1Manager:
                 ret[key] = (L1Error.KEY_NOT_WRITABLE, None)
             return ret
 
+        assert self._memory_manager is not None
         err, allocated_objs = self._memory_manager.allocate(
             layout_desc, len(need_to_allocate)
         )
@@ -531,6 +669,76 @@ class L1Manager:
         )
         return ret
 
+    def _shared_reserve_write(
+        self,
+        keys: list[ObjectKey],
+        is_temporary: list[bool],
+        layout_desc: MemoryLayoutDesc,
+        mode: Literal["new", "update", "all"],
+    ) -> dict[ObjectKey, L1OperationResult]:
+        """Reserve immutable placements with one coordinator batch."""
+        client = self._shared_client
+        assert client is not None
+        ret: dict[ObjectKey, L1OperationResult] = {}
+        successful_keys: list[ObjectKey] = []
+        pending: list[tuple[ObjectKey, bool]] = []
+        for key, is_temp in zip(keys, is_temporary, strict=False):
+            if mode == "update" or key in self._objects:
+                ret[key] = (L1Error.KEY_NOT_WRITABLE, None)
+                continue
+            pending.append((key, is_temp))
+
+        try:
+            memory_objects = client.reserve_writes(
+                [key for key, _ in pending],
+                layout_desc,
+            )
+        except OutOfSpaceError:
+            for key, _ in pending:
+                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+            return ret
+
+        granted_keys = [
+            key
+            for (key, _), memory_obj in zip(pending, memory_objects, strict=True)
+            if memory_obj is not None
+        ]
+        try:
+            for (key, is_temp), memory_obj in zip(
+                pending,
+                memory_objects,
+                strict=True,
+            ):
+                if memory_obj is None:
+                    ret[key] = (L1Error.KEY_NOT_WRITABLE, None)
+                    continue
+                entry = L1ObjectState(
+                    memory_obj=memory_obj,
+                    write_lock=TTLLock(self._write_ttl_seconds),
+                    read_lock=TTLLock(self._read_ttl_seconds),
+                    is_temporary=is_temp,
+                )
+                entry.write_lock.lock()
+                self._objects[key] = entry
+                successful_keys.append(key)
+                ret[key] = (L1Error.SUCCESS, memory_obj)
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_reserved_write(successful_keys)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_WRITE_RESERVED,
+                    metadata={"keys": successful_keys},
+                )
+            )
+        except BaseException:
+            try:
+                client.abort_writes(granted_keys)
+            finally:
+                for key in successful_keys:
+                    del self._objects[key]
+            raise
+        return ret
+
     @l1_mgr_synchronized
     def finish_write(
         self,
@@ -549,6 +757,9 @@ class L1Manager:
             KEY_IN_WRONG_STATE: The key is not write-locked, or it's read-locked,
                 which means the writer may have caused inconsistent data.
         """
+        if self._shared_client is not None:
+            return self._shared_finish_write(keys)
+
         ret: dict[ObjectKey, L1Error] = {}
         successful_keys: list[ObjectKey] = []
 
@@ -590,6 +801,97 @@ class L1Manager:
         )
         return ret
 
+    def _shared_finish_write(
+        self,
+        keys: list[ObjectKey],
+    ) -> dict[ObjectKey, L1Error]:
+        """Publish the complete payload batch before one metadata commit."""
+        client = self._shared_client
+        assert client is not None
+        ret: dict[ObjectKey, L1Error] = {}
+        if len(keys) != len(set(keys)):
+            raise ValueError("shared-L1 finish_write keys must be unique")
+
+        failed = False
+        for key in keys:
+            entry = self._objects.get(key)
+            if entry is None:
+                ret[key] = L1Error.KEY_NOT_EXIST
+                failed = True
+                continue
+            if not entry.write_lock.is_locked() or entry.read_lock.is_locked():
+                ret[key] = L1Error.KEY_IN_WRONG_STATE
+                failed = True
+                continue
+            ret[key] = L1Error.SUCCESS
+
+        if failed:
+            # No object in a request batch may become globally readable unless
+            # every local reservation is ready to commit.
+            for key, result in list(ret.items()):
+                if result == L1Error.SUCCESS:
+                    ret[key] = L1Error.KEY_IN_WRONG_STATE
+            return ret
+
+        client.finish_writes(keys)
+        for key in keys:
+            entry = self._objects[key]
+            entry.write_lock.unlock()
+
+        for listener in self._registered_listeners:
+            listener.on_l1_keys_write_finished(keys)
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_WRITE_FINISHED,
+                metadata={"keys": keys},
+            )
+        )
+        return ret
+
+    @l1_mgr_synchronized
+    def abort_write(
+        self,
+        keys: list[ObjectKey],
+    ) -> dict[ObjectKey, L1Error]:
+        """Abort coordinator-owned writes that never became readable.
+
+        The existing local allocators do not expose an abort operation. This
+        method is therefore intentionally limited to the shared-L1 path, where
+        leaving a failed transfer in ``WRITING`` would block that object key for
+        every MP server connected to the coordinator.
+        """
+        client = self._shared_client
+        if client is None:
+            raise RuntimeError("abort_write is only supported by shared L1")
+
+        ret: dict[ObjectKey, L1Error] = {}
+        aborted_keys: list[ObjectKey] = []
+        for key in keys:
+            entry = self._objects.get(key)
+            if entry is None:
+                ret[key] = L1Error.KEY_NOT_EXIST
+                continue
+            if not entry.write_lock.is_locked() or entry.read_lock.is_locked():
+                ret[key] = L1Error.KEY_IN_WRONG_STATE
+                continue
+            ret[key] = L1Error.SUCCESS
+            aborted_keys.append(key)
+
+        client.abort_writes(aborted_keys)
+        for key in aborted_keys:
+            self._objects[key].memory_obj.invalidate()
+            del self._objects[key]
+        if aborted_keys:
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_deleted_by_manager(aborted_keys)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_KEYS_EVICTED,
+                    metadata={"keys": aborted_keys},
+                )
+            )
+        return ret
+
     @l1_mgr_synchronized
     def finish_write_and_reserve_read(
         self,
@@ -619,6 +921,9 @@ class L1Manager:
             KEY_IN_WRONG_STATE: The key is not write-locked, or it already
                 has read locks.
         """
+        if self._shared_client is not None:
+            raise RuntimeError("shared L1 does not support the L2 prefetch transition")
+
         extra_count = _validate_extra_count(extra_count)
         total = 1 + extra_count
         ret: dict[ObjectKey, L1OperationResult] = {}
@@ -683,6 +988,18 @@ class L1Manager:
             KEY_IS_LOCKED: The key is write-locked or read-locked and cannot be
                 deleted. Never returned when ``force`` is True.
         """
+        if self._shared_client is not None:
+            # M0 never reuses extents, so a local MP must not pretend that
+            # deleting its view reclaimed the global object.
+            return {
+                key: (
+                    L1Error.KEY_IS_LOCKED
+                    if key in self._objects
+                    else L1Error.KEY_NOT_EXIST
+                )
+                for key in keys
+            }
+
         need_to_free: list[MemoryObj] = []
         ret: dict[ObjectKey, L1Error] = {}
         successful_keys: list[ObjectKey] = []
@@ -705,6 +1022,7 @@ class L1Manager:
             ret[key] = L1Error.SUCCESS
             successful_keys.append(key)
 
+        assert self._memory_manager is not None
         self._memory_manager.free(need_to_free)
 
         for listener in self._registered_listeners:
@@ -736,6 +1054,10 @@ class L1Manager:
                 If False (default), only clear unlocked objects, keeping
                 write-locked and read-locked objects intact.
         """
+        if self._shared_client is not None:
+            logger.info("L1Manager: shared-L1 M0 does not reclaim objects")
+            return
+
         if force:
             logger.warning(
                 "L1Manager: force-clearing all %d objects "
@@ -745,6 +1067,7 @@ class L1Manager:
             )
             all_keys = list(self._objects.keys())
             all_memory_objs = [entry.memory_obj for entry in self._objects.values()]
+            assert self._memory_manager is not None
             self._memory_manager.free(all_memory_objs)
             self._objects.clear()
             for listener in self._registered_listeners:
@@ -775,6 +1098,7 @@ class L1Manager:
         for key in keys_to_clear:
             del self._objects[key]
 
+        assert self._memory_manager is not None
         self._memory_manager.free(objs_to_free)
 
         if keys_to_clear:
@@ -822,19 +1146,32 @@ class L1Manager:
             In the future, we many want to make a "callback" based mechanism
             via "L1ManagerListener" to notify the memory usage changes.
         """
+        if self._shared_client is not None:
+            return self._shared_client.get_memory_usage()
+        assert self._memory_manager is not None
         return self._memory_manager.get_memory_usage()
 
     def get_l1_memory_desc(self):
         """Return an L1MemoryDesc describing the underlying L1 memory buffer."""
+        if self._shared_client is not None:
+            return self._shared_client.get_l1_memory_desc()
+        assert self._memory_manager is not None
         return self._memory_manager.get_l1_memory_desc()
 
     def close(self) -> None:
         """Close the L1Manager and free all resources."""
+        if self._shared_client is not None:
+            with self._lock:
+                self._objects.clear()
+            self._shared_client.close()
+            return
         with self._lock:
             all_memory_objs = [entry.memory_obj for entry in self._objects.values()]
+            assert self._memory_manager is not None
             self._memory_manager.free(all_memory_objs)
             self._objects.clear()
 
+        assert self._memory_manager is not None
         self._memory_manager.close()
 
     # Status reporting
@@ -851,9 +1188,16 @@ class L1Manager:
                 read_locked += 1
             if entry.is_temporary:
                 temporary += 1
-        used, total = self._memory_manager.get_memory_usage()
+        if self._shared_client is not None:
+            used, total = self._shared_client.get_memory_usage()
+            healthy = self._shared_client.memcheck()
+        else:
+            assert self._memory_manager is not None
+            used, total = self._memory_manager.get_memory_usage()
+            healthy = self._memory_manager.memcheck()
         return {
-            "is_healthy": self._memory_manager.memcheck(),
+            "is_healthy": healthy,
+            "shared_l1": self._shared_client is not None,
             "total_object_count": len(self._objects),
             "write_locked_count": write_locked,
             "read_locked_count": read_locked,
@@ -881,7 +1225,11 @@ class L1Manager:
     @l1_mgr_synchronized
     def memcheck(self) -> bool:
         """Perform memory check for L1 cache."""
-        mem_check_result = self._memory_manager.memcheck()
+        if self._shared_client is not None:
+            mem_check_result = self._shared_client.memcheck()
+        else:
+            assert self._memory_manager is not None
+            mem_check_result = self._memory_manager.memcheck()
 
         # Log the locked objects for debugging
         num_write_locked = 0

--- a/lmcache/v1/distributed/shared_l1/__init__.py
+++ b/lmcache/v1/distributed/shared_l1/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator-owned shared Device-DAX L1 support."""

--- a/lmcache/v1/distributed/shared_l1/client.py
+++ b/lmcache/v1/distributed/shared_l1/client.py
@@ -1,0 +1,492 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MP-side Device-DAX mapping for coordinator-owned shared objects."""
+
+# Standard
+from collections import defaultdict, deque
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Protocol
+import ctypes
+import json
+import mmap
+import os
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.integration.vllm.utils import get_size_bytes
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import L1MemoryManagerConfig, SharedL1Config
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.shared_l1.pool import (
+    ReadReservation,
+    SharedObjectHandle,
+    SharedRegionContract,
+    WriteReservation,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import current_device_spec
+
+logger = init_logger(__name__)
+
+_PUBLISH = 1
+_ACQUIRE = 2
+_VISIBILITY_SYMBOL = "lmcache_shared_l1_visibility_v1"
+
+
+class _Visibility(Protocol):
+    """Platform operation that publishes or acquires one exact DAX range."""
+
+    @property
+    def granularity(self) -> int: ...
+
+    def apply(
+        self,
+        operation: int,
+        device_fd: int,
+        mapped_address: int,
+        device_offset: int,
+        length: int,
+        generation: int,
+    ) -> None: ...
+
+
+class NativeDeviceDaxVisibility:
+    """Call a platform-qualified visibility implementation supplied by the operator."""
+
+    def __init__(self, library_path: str) -> None:
+        path = Path(library_path)
+        if not path.is_absolute() or not path.is_file():
+            raise ValueError(
+                "shared-L1 visibility library must be an absolute regular file"
+            )
+        try:
+            library = ctypes.CDLL(str(path), use_errno=True)
+            function = getattr(library, _VISIBILITY_SYMBOL)
+        except (OSError, AttributeError) as exc:
+            raise RuntimeError(f"{path} does not provide {_VISIBILITY_SYMBOL}") from exc
+        function.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_uint64,
+            ctypes.c_size_t,
+            ctypes.c_uint64,
+        ]
+        function.restype = ctypes.c_int
+        self._library = library
+        self._function = function
+
+    @property
+    def granularity(self) -> int:
+        """The current ABI isolates x86 cache-line-sized ranges."""
+        return 64
+
+    def apply(
+        self,
+        operation: int,
+        device_fd: int,
+        mapped_address: int,
+        device_offset: int,
+        length: int,
+        generation: int,
+    ) -> None:
+        """Apply publish/acquire without embedding host-specific code in LMCache."""
+        result = self._function(
+            b"software_fenced",
+            operation,
+            device_fd,
+            ctypes.c_void_p(mapped_address),
+            device_offset,
+            length,
+            generation,
+        )
+        if result:
+            error_number = -int(result)
+            detail = (
+                os.strerror(error_number)
+                if 0 < error_number < 4096
+                else f"native status {result}"
+            )
+            raise RuntimeError(
+                f"shared-L1 visibility operation {operation} failed: {detail}"
+            )
+
+
+def _stable_object_key(key: ObjectKey) -> str:
+    """Return the same metadata key in every MP process."""
+    return json.dumps(
+        asdict(key.to_encoded_object_key()),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+class SharedL1Client:
+    """Map one shared region locally while the coordinator owns its offsets."""
+
+    def __init__(
+        self,
+        config: SharedL1Config,
+        memory_config: L1MemoryManagerConfig,
+        *,
+        pool: Any | None = None,
+        visibility: _Visibility | None = None,
+        register_cuda: bool = True,
+    ) -> None:
+        if not memory_config.devdax_path:
+            raise ValueError("shared L1 requires a Device-DAX path")
+        self._manager: object | None = None
+        if pool is None:
+            # Import lazily because the coordinator imports the pool state.
+            # First Party
+            from lmcache.v1.mp_coordinator.shared_l1_service import (
+                connect_shared_l1_manager,
+                read_shared_l1_authkey,
+            )
+
+            manager = connect_shared_l1_manager(
+                config.coordinator_host,
+                config.coordinator_port,
+                read_shared_l1_authkey(config.authkey_file),
+            )
+            pool = manager.get_pool()
+            self._manager = manager
+        self._pool = pool
+
+        contract = pool.region_contract()
+        expected = (
+            config.region_id,
+            memory_config.size_in_bytes,
+            memory_config.align_bytes,
+            config.layout_id,
+        )
+        actual = (
+            contract.region_id,
+            contract.capacity,
+            contract.alignment,
+            contract.layout_id,
+        )
+        if not isinstance(contract, SharedRegionContract) or actual != expected:
+            raise ValueError(
+                f"shared-L1 coordinator/local contract mismatch: {actual!r} "
+                f"!= {expected!r}"
+            )
+
+        self._visibility = visibility or NativeDeviceDaxVisibility(
+            config.visibility_library_path
+        )
+        granularity = self._visibility.granularity
+        if (
+            granularity <= 0
+            or granularity & (granularity - 1)
+            or contract.alignment % granularity
+            or config.mapping_offset % max(mmap.PAGESIZE, granularity)
+        ):
+            raise ValueError("shared-L1 mapping violates visibility alignment")
+
+        file_descriptor = os.open(memory_config.devdax_path, os.O_RDWR)
+        mapping: mmap.mmap | None = None
+        marker: ctypes.c_ubyte | None = None
+        buffer = torch.empty(0, dtype=torch.uint8)
+        registered_ptr: int | None = None
+        try:
+            mapping = mmap.mmap(
+                file_descriptor,
+                contract.capacity,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+                offset=config.mapping_offset,
+            )
+            marker = ctypes.c_ubyte.from_buffer(mapping)
+            mapped_address = ctypes.addressof(marker)
+            if mapped_address % granularity:
+                raise RuntimeError("shared-L1 mapping base is not visibility-aligned")
+            buffer = torch.frombuffer(mapping, dtype=torch.uint8)
+            if register_cuda:
+                pointer = buffer.data_ptr()
+                if not current_device_spec.pin_memory(
+                    pointer,
+                    contract.capacity,
+                ):
+                    raise RuntimeError(
+                        "CUDA host registration failed for shared Device-DAX; "
+                        "pageable staging is not accepted"
+                    )
+                registered_ptr = pointer
+        except BaseException:
+            if registered_ptr is not None:
+                current_device_spec.unpin_memory(registered_ptr)
+            buffer = torch.empty(0, dtype=torch.uint8)
+            if marker is not None:
+                del marker
+            if mapping is not None:
+                mapping.close()
+            os.close(file_descriptor)
+            raise
+
+        self._contract = contract
+        self._mapping = mapping
+        self._mapping_marker: ctypes.c_ubyte | None = marker
+        self._mapped_address = mapped_address
+        self._file_descriptor = file_descriptor
+        self._buffer = buffer
+        self._registered_ptr = registered_ptr
+        self._mapping_offset = config.mapping_offset
+        self._write_reservations: dict[ObjectKey, WriteReservation] = {}
+        self._read_reservations: dict[ObjectKey, deque[ReadReservation]] = defaultdict(
+            deque
+        )
+        # One immutable physical handle owns one reusable tensor view.
+        self._memory_objects: dict[SharedObjectHandle, TensorMemoryObj] = {}
+        self._lock = threading.RLock()
+        self._closed = False
+
+    def reserve_writes(
+        self,
+        keys: list[ObjectKey],
+        layout: MemoryLayoutDesc,
+    ) -> list[TensorMemoryObj | None]:
+        """Reserve a whole L1Manager key list with one coordinator call."""
+        with self._lock:
+            self._ensure_open()
+            if any(key in self._write_reservations for key in keys):
+                raise RuntimeError("a key already has a local write reservation")
+            reservations = list(
+                self._pool.reserve_writes(
+                    [(_stable_object_key(key), layout) for key in keys]
+                )
+            )
+            granted = [item for item in reservations if item is not None]
+            try:
+                result = [
+                    None
+                    if reservation is None
+                    else self._memory_object(reservation.handle, reservation.layout)
+                    for reservation in reservations
+                ]
+            except BaseException:
+                self._pool.abort_writes(granted)
+                raise
+            for key, reservation in zip(keys, reservations, strict=True):
+                if reservation is not None:
+                    self._write_reservations[key] = reservation
+            return result
+
+    def finish_writes(self, keys: list[ObjectKey]) -> None:
+        """Publish every D2H-complete range, then atomically mark the batch VALID."""
+        with self._lock:
+            reservations = [self._write_reservations[key] for key in keys]
+            try:
+                for reservation in reservations:
+                    self._apply_visibility(_PUBLISH, reservation.handle)
+                self._pool.finish_writes(reservations)
+            except BaseException:
+                try:
+                    self._pool.abort_writes(reservations)
+                except BaseException:
+                    logger.exception("failed to abort shared-L1 write batch")
+                else:
+                    for key, reservation in zip(keys, reservations, strict=True):
+                        del self._write_reservations[key]
+                        self._forget_memory_object(reservation.handle)
+                raise
+            for key in keys:
+                del self._write_reservations[key]
+
+    def abort_writes(self, keys: list[ObjectKey]) -> None:
+        """Abort a failed batch while keeping a failed RPC retryable."""
+        with self._lock:
+            pairs = [
+                (key, self._write_reservations[key])
+                for key in keys
+                if key in self._write_reservations
+            ]
+            if not pairs:
+                return
+            self._pool.abort_writes([reservation for _, reservation in pairs])
+            for key, reservation in pairs:
+                del self._write_reservations[key]
+                self._forget_memory_object(reservation.handle)
+
+    def reserve_reads(self, keys: list[ObjectKey]) -> list[TensorMemoryObj | None]:
+        """Acquire all VALID hits from one coordinator batch."""
+        with self._lock:
+            self._ensure_open()
+            reservations = list(
+                self._pool.reserve_reads([_stable_object_key(key) for key in keys])
+            )
+            granted = [item for item in reservations if item is not None]
+            try:
+                result: list[TensorMemoryObj | None] = []
+                for reservation in reservations:
+                    if reservation is None:
+                        result.append(None)
+                        continue
+                    self._apply_visibility(_ACQUIRE, reservation.handle)
+                    result.append(
+                        self._memory_object(reservation.handle, reservation.layout)
+                    )
+            except BaseException:
+                self._pool.abort_reads(granted)
+                raise
+            for key, reservation in zip(keys, reservations, strict=True):
+                if reservation is not None:
+                    self._read_reservations[key].append(reservation)
+            return result
+
+    def finish_reads(self, keys: list[ObjectKey]) -> None:
+        """Release a read batch after its H2D transfers complete."""
+        with self._lock:
+            reservations = [self._read_reservations[key][0] for key in keys]
+            self._pool.finish_reads(reservations)
+            for key in keys:
+                self._read_reservations[key].popleft()
+                if not self._read_reservations[key]:
+                    del self._read_reservations[key]
+
+    def abort_reads(self, keys: list[ObjectKey]) -> None:
+        """Release the newest reservations for a cancelled batch."""
+        with self._lock:
+            pairs = [
+                (key, self._read_reservations[key][-1])
+                for key in keys
+                if self._read_reservations.get(key)
+            ]
+            if not pairs:
+                return
+            self._pool.abort_reads([reservation for _, reservation in pairs])
+            for key, _ in pairs:
+                self._read_reservations[key].pop()
+                if not self._read_reservations[key]:
+                    del self._read_reservations[key]
+
+    def get_memory_usage(self) -> tuple[int, int]:
+        """Return monotonic allocated bytes and region capacity."""
+        return int(self._pool.snapshot()["next_offset"]), self._contract.capacity
+
+    def get_l1_memory_desc(self) -> L1MemoryDesc:
+        """Describe the CUDA-registered shared mapping."""
+        return L1MemoryDesc(
+            ptr=self._buffer.data_ptr(),
+            size=self._contract.capacity,
+            align_bytes=self._contract.alignment,
+        )
+
+    def memcheck(self) -> bool:
+        """Check the mapping and the coordinator restart epoch."""
+        return (
+            not self._closed
+            and self._buffer.numel() == self._contract.capacity
+            and self._pool.region_contract() == self._contract
+        )
+
+    def close(self) -> None:
+        """Quiesce transfers, release reservations, unpin, and unmap."""
+        with self._lock:
+            if self._closed:
+                return
+            self.abort_writes(list(self._write_reservations))
+            all_reads = [
+                reservation
+                for reservations in self._read_reservations.values()
+                for reservation in reservations
+            ]
+            if all_reads:
+                self._pool.abort_reads(all_reads)
+                self._read_reservations.clear()
+            if self._registered_ptr is not None:
+                if not current_device_spec.unpin_memory(self._registered_ptr):
+                    raise RuntimeError(
+                        "CUDA host unregistration failed for shared Device-DAX"
+                    )
+                self._registered_ptr = None
+            for memory_obj in self._memory_objects.values():
+                memory_obj.invalidate()
+                memory_obj.raw_data = torch.empty(0, dtype=torch.uint8)
+            self._memory_objects.clear()
+            self._buffer = torch.empty(0, dtype=torch.uint8)
+            marker = self._mapping_marker
+            self._mapping_marker = None
+            del marker
+            self._mapping.close()
+            os.close(self._file_descriptor)
+            self._closed = True
+
+    def _apply_visibility(
+        self,
+        operation: int,
+        handle: SharedObjectHandle,
+    ) -> None:
+        if handle.region_id != self._contract.region_id:
+            raise ValueError("shared-L1 handle belongs to another region")
+        end = handle.offset + handle.length
+        if end > self._contract.capacity or handle.offset % self._contract.alignment:
+            raise ValueError("shared-L1 handle lies outside the aligned region")
+        self._visibility.apply(
+            operation,
+            self._file_descriptor,
+            self._mapped_address + handle.offset,
+            self._mapping_offset + handle.offset,
+            handle.length,
+            handle.generation,
+        )
+
+    def _memory_object(
+        self,
+        handle: SharedObjectHandle,
+        layout: MemoryLayoutDesc,
+    ) -> TensorMemoryObj:
+        expected_length = get_size_bytes(layout.shapes, layout.dtypes)
+        if handle.length != expected_length:
+            raise ValueError(
+                "shared-L1 object length does not match its layout: "
+                f"{handle.length} != {expected_length}"
+            )
+        memory_obj = self._memory_objects.get(handle)
+        if memory_obj is not None:
+            if (
+                memory_obj.get_shapes() != layout.shapes
+                or memory_obj.get_dtypes() != layout.dtypes
+            ):
+                raise ValueError("shared-L1 handle has a different layout")
+            return memory_obj
+        end = handle.offset + handle.length
+        memory_obj = TensorMemoryObj(
+            raw_data=self._buffer[handle.offset : end],
+            metadata=MemoryObjMetadata(
+                shape=layout.shapes[0],
+                dtype=layout.dtypes[0],
+                address=handle.offset,
+                phy_size=(
+                    (handle.length + self._contract.alignment - 1)
+                    // self._contract.alignment
+                    * self._contract.alignment
+                ),
+                ref_count=1,
+                fmt=MemoryFormat.KV_2LTD,
+                shapes=layout.shapes,
+                dtypes=layout.dtypes,
+            ),
+            parent_allocator=None,
+        )
+        self._memory_objects[handle] = memory_obj
+        return memory_obj
+
+    def _forget_memory_object(self, handle: SharedObjectHandle) -> None:
+        memory_obj = self._memory_objects.pop(handle, None)
+        if memory_obj is not None:
+            memory_obj.invalidate()
+            memory_obj.raw_data = torch.empty(0, dtype=torch.uint8)
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("shared-L1 client is closed")

--- a/lmcache/v1/distributed/shared_l1/pool.py
+++ b/lmcache/v1/distributed/shared_l1/pool.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator-owned metadata for the non-reclaiming shared-L1 M0."""
+
+# Standard
+from dataclasses import dataclass, field
+import threading
+import uuid
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+
+_MAX_GENERATION = (1 << 64) - 1
+
+
+def _layout_size(layout: MemoryLayoutDesc) -> int:
+    return sum(
+        shape.numel() * dtype.itemsize
+        for shape, dtype in zip(layout.shapes, layout.dtypes, strict=True)
+    )
+
+
+class SharedL1Error(RuntimeError):
+    """Base error for shared-L1 metadata operations."""
+
+
+class OutOfSpaceError(SharedL1Error):
+    """Raised when a complete write batch cannot fit."""
+
+
+class InvalidReservationError(SharedL1Error):
+    """Raised when a reservation does not own an operation."""
+
+
+class StaleHandleError(SharedL1Error):
+    """Raised when a reservation no longer names the current object."""
+
+
+@dataclass(frozen=True)
+class SharedRegionContract:
+    """Immutable identity and geometry shared by every pool mapping."""
+
+    region_id: str
+    capacity: int
+    alignment: int
+    layout_id: str
+    generation_epoch: int
+
+    def __post_init__(self) -> None:
+        if not self.region_id or not self.layout_id:
+            raise ValueError("region_id and layout_id must not be empty")
+        if self.capacity <= 0:
+            raise ValueError("capacity must be positive")
+        if self.alignment <= 0 or self.alignment & (self.alignment - 1):
+            raise ValueError("alignment must be a positive power of two")
+        if self.generation_epoch <= 0:
+            raise ValueError("generation_epoch must be positive")
+
+
+@dataclass(frozen=True)
+class SharedObjectHandle:
+    """Stable location independent of each process's virtual address."""
+
+    region_id: str
+    offset: int
+    length: int
+    generation: int
+
+    def __post_init__(self) -> None:
+        if not self.region_id:
+            raise ValueError("region_id must not be empty")
+        if self.offset < 0 or self.length <= 0:
+            raise ValueError("offset must be non-negative and length positive")
+        if not 0 < self.generation <= _MAX_GENERATION:
+            raise ValueError("generation must fit in an unsigned 64-bit integer")
+
+
+@dataclass(frozen=True)
+class WriteReservation:
+    """Exclusive authority to initialize one shared object."""
+
+    object_key: str
+    handle: SharedObjectHandle
+    token: str
+    layout: MemoryLayoutDesc
+
+
+@dataclass(frozen=True)
+class ReadReservation:
+    """Authority for one active read of a VALID shared object."""
+
+    object_key: str
+    handle: SharedObjectHandle
+    token: str
+    layout: MemoryLayoutDesc
+
+
+@dataclass
+class _ObjectRecord:
+    handle: SharedObjectHandle
+    layout: MemoryLayoutDesc
+    state: str
+    write_token: str | None
+    read_tokens: set[str] = field(default_factory=set)
+
+
+class SharedL1Pool:
+    """The child process's single strong allocation and lifetime index.
+
+    M0 deliberately uses a monotonic allocator: extents are never reclaimed,
+    so aborting a write leaks its bytes until the coordinator is restarted.
+    This is safe for a bounded functional run and avoids pretending that
+    eviction, TTL recovery, or restart fencing are already implemented.
+    """
+
+    def __init__(
+        self,
+        region_id: str,
+        capacity: int,
+        alignment: int,
+        layout_id: str,
+    ) -> None:
+        self._contract = SharedRegionContract(
+            region_id,
+            capacity,
+            alignment,
+            layout_id,
+            uuid.uuid4().int,
+        )
+        self._next_offset = 0
+        self._next_generation = 1
+        self._objects: dict[str, _ObjectRecord] = {}
+        self._lock = threading.RLock()
+
+    def region_contract(self) -> SharedRegionContract:
+        """Return the immutable region identity and restart epoch."""
+        return self._contract
+
+    def reserve_writes(
+        self,
+        requests: list[tuple[str, MemoryLayoutDesc]],
+    ) -> list[WriteReservation | None]:
+        """Reserve absent keys in one atomic coordinator operation.
+
+        ``None`` means that the key is already WRITING or VALID. Capacity and
+        request validation happen before any allocator state changes.
+        """
+        keys = [key for key, _ in requests]
+        if len(keys) != len(set(keys)):
+            raise ValueError("a write batch must not contain duplicate keys")
+        lengths = [_layout_size(layout) for _, layout in requests]
+        if any(not key for key in keys) or any(length <= 0 for length in lengths):
+            raise ValueError("object keys and layouts must not be empty")
+
+        with self._lock:
+            cursor = self._next_offset
+            generation = self._next_generation
+            planned: dict[int, WriteReservation] = {}
+            for index, ((key, layout), length) in enumerate(
+                zip(requests, lengths, strict=True)
+            ):
+                if key in self._objects:
+                    continue
+                if generation > _MAX_GENERATION:
+                    raise OutOfSpaceError("generation space is exhausted")
+                offset = self._align_up(cursor, self._contract.alignment)
+                if length > self._contract.capacity - offset:
+                    raise OutOfSpaceError("write batch does not fit in shared L1")
+                handle = SharedObjectHandle(
+                    self._contract.region_id,
+                    offset,
+                    length,
+                    generation,
+                )
+                planned[index] = WriteReservation(
+                    key,
+                    handle,
+                    uuid.uuid4().hex,
+                    layout,
+                )
+                cursor = offset + length
+                generation += 1
+
+            result: list[WriteReservation | None] = []
+            for index, (key, _) in enumerate(requests):
+                reservation = planned.get(index)
+                result.append(reservation)
+                if reservation is not None:
+                    self._objects[key] = _ObjectRecord(
+                        reservation.handle,
+                        reservation.layout,
+                        "WRITING",
+                        reservation.token,
+                    )
+            self._next_offset = cursor
+            self._next_generation = generation
+            return result
+
+    def finish_writes(
+        self,
+        reservations: list[WriteReservation],
+    ) -> list[SharedObjectHandle]:
+        """Atomically publish a batch after every payload range is visible."""
+        with self._lock:
+            records = self._validate_writes(reservations)
+            for record in records:
+                record.state = "VALID"
+                record.write_token = None
+            return [reservation.handle for reservation in reservations]
+
+    def abort_writes(self, reservations: list[WriteReservation]) -> None:
+        """Drop failed WRITING metadata without reusing its extents."""
+        with self._lock:
+            self._validate_writes(reservations)
+            for reservation in reservations:
+                del self._objects[reservation.object_key]
+
+    def reserve_reads(
+        self,
+        object_keys: list[str],
+    ) -> list[ReadReservation | None]:
+        """Pin every VALID hit in one partial batch operation."""
+        if len(object_keys) != len(set(object_keys)):
+            raise ValueError("a read batch must not contain duplicate keys")
+        with self._lock:
+            result: list[ReadReservation | None] = []
+            for key in object_keys:
+                record = self._objects.get(key)
+                if record is None or record.state != "VALID":
+                    result.append(None)
+                    continue
+                token = uuid.uuid4().hex
+                record.read_tokens.add(token)
+                result.append(ReadReservation(key, record.handle, token, record.layout))
+            return result
+
+    def finish_reads(self, reservations: list[ReadReservation]) -> None:
+        """Release completed reads after their H2D operations finish."""
+        self._release_reads(reservations)
+
+    def abort_reads(self, reservations: list[ReadReservation]) -> None:
+        """Release reads whose local transfer was cancelled."""
+        self._release_reads(reservations)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return token-free metadata for diagnostics and usage reporting."""
+        with self._lock:
+            return {
+                "region_id": self._contract.region_id,
+                "generation_epoch": self._contract.generation_epoch,
+                "capacity": self._contract.capacity,
+                "next_offset": self._next_offset,
+                "objects": {
+                    key: {
+                        "handle": record.handle,
+                        "state": record.state,
+                        "active_readers": len(record.read_tokens),
+                    }
+                    for key, record in self._objects.items()
+                },
+            }
+
+    def _validate_writes(
+        self,
+        reservations: list[WriteReservation],
+    ) -> list[_ObjectRecord]:
+        keys = [reservation.object_key for reservation in reservations]
+        if len(keys) != len(set(keys)):
+            raise InvalidReservationError("duplicate write reservation")
+        records = []
+        for reservation in reservations:
+            record = self._objects.get(reservation.object_key)
+            if (
+                record is None
+                or record.state != "WRITING"
+                or record.write_token != reservation.token
+            ):
+                raise InvalidReservationError("reservation does not own the write")
+            if record.handle != reservation.handle:
+                raise StaleHandleError("write reservation has a stale handle")
+            records.append(record)
+        return records
+
+    def _release_reads(self, reservations: list[ReadReservation]) -> None:
+        tokens = [reservation.token for reservation in reservations]
+        if len(tokens) != len(set(tokens)):
+            raise InvalidReservationError("duplicate read reservation")
+        with self._lock:
+            records = []
+            for reservation in reservations:
+                record = self._objects.get(reservation.object_key)
+                if record is None or reservation.token not in record.read_tokens:
+                    raise InvalidReservationError(
+                        "reservation does not own an active read"
+                    )
+                if record.handle != reservation.handle:
+                    raise StaleHandleError("read reservation has a stale handle")
+                records.append(record)
+            for reservation, record in zip(reservations, records, strict=True):
+                record.read_tokens.remove(reservation.token)
+
+    @staticmethod
+    def _align_up(value: int, alignment: int) -> int:
+        return (value + alignment - 1) // alignment * alignment

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -166,6 +166,11 @@ class StorageManager:
             self.get_l2_usages,
         )
 
+    @property
+    def uses_shared_l1(self) -> bool:
+        """Return whether L1 is the coordinator-owned shared-DAX path."""
+        return self._l1_manager.uses_shared_l1
+
     # External APIs for serving engine integration code to call
     @enable_tracing()
     def reserve_write(
@@ -249,6 +254,27 @@ class StorageManager:
         )
 
         # TODO: global key states update
+        if failed_keys and self.uses_shared_l1:
+            raise RuntimeError(
+                "shared-L1 write batch was not committed: "
+                f"{len(failed_keys)} of {len(keys)} keys failed validation"
+            )
+
+    @enable_tracing()
+    def abort_write(
+        self,
+        keys: list[ObjectKey],
+    ) -> None:
+        """Abort failed writes in the coordinator-owned shared-L1 path."""
+        abort_result = self._l1_manager.abort_write(keys)
+        failed_keys = [
+            key for key, error in abort_result.items() if error != L1Error.SUCCESS
+        ]
+        if failed_keys:
+            raise RuntimeError(
+                "shared-L1 write batch was not fully aborted: "
+                f"{len(failed_keys)} of {len(keys)} keys failed"
+            )
 
     @contextmanager
     def read_prefetched_results(
@@ -440,6 +466,28 @@ class StorageManager:
         l1_read_result = self._l1_manager.reserve_read(
             keys, extra_count=spec.extra_count
         )
+        if self.uses_shared_l1:
+            reserved = [
+                (key, obj)
+                for key, (error, obj) in l1_read_result.items()
+                if error == L1Error.SUCCESS and obj is not None
+            ]
+            mismatched = [
+                key
+                for key, obj in reserved
+                if obj.get_shapes() != spec.layout_desc.shapes
+                or obj.get_dtypes() != spec.layout_desc.dtypes
+            ]
+            if mismatched:
+                # The producer-supplied descriptor locates bytes, but the
+                # consuming engine's registered layout remains authoritative.
+                self._l1_manager.finish_read(
+                    [key for key, _ in reserved],
+                    extra_count=spec.extra_count,
+                )
+                raise RuntimeError(
+                    "shared-L1 object layout does not match the local engine"
+                )
 
         if spec.policy is TrimPolicy.SPARSE:
             # SPARSE: retain a read lock on every L1 hit (not just the leading

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -41,6 +41,10 @@ from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
+from lmcache.v1.mp_coordinator.shared_l1_service import (
+    read_shared_l1_authkey,
+    start_shared_l1_manager,
+)
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.utils.router_discovery import discover_api_routers
 
@@ -164,16 +168,36 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         logger.info(
             "MP coordinator listening on http://%s:%d", config.host, config.port
         )
+        shared_l1_manager = None
         try:
+            if config.shared_l1_port > 0:
+                shared_l1_manager = start_shared_l1_manager(
+                    host=config.shared_l1_host,
+                    port=config.shared_l1_port,
+                    authkey=read_shared_l1_authkey(config.shared_l1_authkey_file),
+                    region_id=config.shared_l1_region_id,
+                    capacity=config.shared_l1_capacity_bytes,
+                    alignment=config.shared_l1_alignment_bytes,
+                    layout_id=config.shared_l1_layout_id,
+                )
+                logger.info(
+                    "Shared-L1 metadata manager listening on %s:%d",
+                    config.shared_l1_host,
+                    config.shared_l1_port,
+                )
             yield
         finally:
-            for task in (health_task, eviction_task, resync_task):
-                if task is not None:
-                    task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await task
-            await eviction_manager.wait_for_in_flight_dispatches()
-            await outbound_client.aclose()
+            try:
+                for task in (health_task, eviction_task, resync_task):
+                    if task is not None:
+                        task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await task
+                await eviction_manager.wait_for_in_flight_dispatches()
+                await outbound_client.aclose()
+            finally:
+                if shared_l1_manager is not None:
+                    shared_l1_manager.shutdown()
 
     app = FastAPI(title="LMCache MP Coordinator", version="1.0.0", lifespan=lifespan)
     # The typed context carries the cache collaborators handlers compose from

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -58,6 +58,13 @@ class MPCoordinatorConfig:
         timeout_keep_alive: Seconds the HTTP server keeps idle connections
             open before closing them. Must be greater than the heartbeat
             interval of MP servers to avoid race-condition disconnects.
+        shared_l1_host: Host the shared-L1 manager binds to.
+        shared_l1_port: Port the shared-L1 manager binds to. ``0`` disables it.
+        shared_l1_authkey_file: Absolute path to the manager authentication key.
+        shared_l1_region_id: Stable identity of the shared payload region.
+        shared_l1_capacity_bytes: Logical shared-region capacity in bytes.
+        shared_l1_alignment_bytes: Allocation alignment in bytes.
+        shared_l1_layout_id: Operator-supplied physical-layout fingerprint.
     """
 
     host: str = "0.0.0.0"
@@ -75,6 +82,13 @@ class MPCoordinatorConfig:
     resync_max_wait: float = 60.0
     resync_page_size: int = 1000
     timeout_keep_alive: int = 10
+    shared_l1_host: str = "127.0.0.1"
+    shared_l1_port: int = 0
+    shared_l1_authkey_file: str = ""
+    shared_l1_region_id: str = ""
+    shared_l1_capacity_bytes: int = 0
+    shared_l1_alignment_bytes: int = 4096
+    shared_l1_layout_id: str = ""
 
     def __post_init__(self) -> None:
         """Validate timing parameters.
@@ -108,6 +122,24 @@ class MPCoordinatorConfig:
             raise ValueError("blend_probe_stride must be positive")
         if self.timeout_keep_alive <= 0:
             raise ValueError("timeout_keep_alive must be positive")
+        if not 0 <= self.shared_l1_port <= 65535:
+            raise ValueError("shared_l1_port must be between 0 and 65535")
+        if self.shared_l1_port > 0:
+            if not self.shared_l1_host.strip():
+                raise ValueError("shared_l1_host must not be empty")
+            if not os.path.isabs(self.shared_l1_authkey_file):
+                raise ValueError("shared_l1_authkey_file must be an absolute path")
+            if not self.shared_l1_region_id.strip():
+                raise ValueError("shared_l1_region_id must not be empty")
+            if self.shared_l1_capacity_bytes <= 0:
+                raise ValueError("shared_l1_capacity_bytes must be positive")
+            alignment = self.shared_l1_alignment_bytes
+            if alignment <= 0 or alignment & (alignment - 1):
+                raise ValueError(
+                    "shared_l1_alignment_bytes must be a positive power of two"
+                )
+            if not self.shared_l1_layout_id.strip():
+                raise ValueError("shared_l1_layout_id must not be empty")
 
     @classmethod
     def from_env(cls) -> "MPCoordinatorConfig":
@@ -168,4 +200,26 @@ class MPCoordinatorConfig:
             timeout_keep_alive=int(
                 _num("TIMEOUT_KEEP_ALIVE", cls.timeout_keep_alive, int)
             ),
+            shared_l1_host=_str("SHARED_L1_HOST", cls.shared_l1_host),
+            shared_l1_port=int(_num("SHARED_L1_PORT", cls.shared_l1_port, int)),
+            shared_l1_authkey_file=_str(
+                "SHARED_L1_AUTHKEY_FILE",
+                cls.shared_l1_authkey_file,
+            ),
+            shared_l1_region_id=_str("SHARED_L1_REGION_ID", cls.shared_l1_region_id),
+            shared_l1_capacity_bytes=int(
+                _num(
+                    "SHARED_L1_CAPACITY_BYTES",
+                    cls.shared_l1_capacity_bytes,
+                    int,
+                )
+            ),
+            shared_l1_alignment_bytes=int(
+                _num(
+                    "SHARED_L1_ALIGNMENT_BYTES",
+                    cls.shared_l1_alignment_bytes,
+                    int,
+                )
+            ),
+            shared_l1_layout_id=_str("SHARED_L1_LAYOUT_ID", cls.shared_l1_layout_id),
         )

--- a/lmcache/v1/mp_coordinator/shared_l1_service.py
+++ b/lmcache/v1/mp_coordinator/shared_l1_service.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Child process that owns shared-L1 allocation metadata, never KV payload."""
+
+# Standard
+from multiprocessing import get_context
+from multiprocessing.managers import BaseManager
+from pathlib import Path
+from typing import Any
+
+# First Party
+from lmcache.v1.distributed.shared_l1.pool import SharedL1Pool
+
+_EXPOSED_METHODS = (
+    "region_contract",
+    "reserve_writes",
+    "finish_writes",
+    "abort_writes",
+    "reserve_reads",
+    "finish_reads",
+    "abort_reads",
+    "snapshot",
+)
+_pool: SharedL1Pool | None = None
+
+
+def read_shared_l1_authkey(authkey_file: str) -> bytes:
+    """Read a nonempty manager key without putting its bytes in configuration."""
+    path = Path(authkey_file)
+    if not path.is_absolute() or not path.is_file():
+        raise ValueError("shared-L1 authkey must be an absolute regular file")
+    authkey = path.read_bytes()
+    if not authkey:
+        raise ValueError("shared-L1 authkey file must not be empty")
+    return authkey
+
+
+def _initialize_pool(
+    region_id: str,
+    capacity: int,
+    alignment: int,
+    layout_id: str,
+) -> None:
+    """Construct the sole allocator inside the child process."""
+    global _pool
+    _pool = SharedL1Pool(region_id, capacity, alignment, layout_id)
+
+
+def _get_pool() -> SharedL1Pool:
+    if _pool is None:
+        raise RuntimeError("shared-L1 pool is not initialized")
+    return _pool
+
+
+class SharedL1Manager(BaseManager):
+    """Manager type shared by the coordinator child and its clients."""
+
+    def get_pool(self) -> Any:
+        """Return the coordinator-owned metadata proxy."""
+        raise NotImplementedError
+
+
+SharedL1Manager.register(
+    "get_pool",
+    callable=_get_pool,
+    exposed=_EXPOSED_METHODS,
+)
+
+
+def connect_shared_l1_manager(
+    host: str,
+    port: int,
+    authkey: bytes,
+) -> SharedL1Manager:
+    """Connect an MP server to the coordinator child."""
+    if not authkey:
+        raise ValueError("shared-L1 authkey must not be empty")
+    manager = SharedL1Manager(address=(host, port), authkey=authkey)
+    manager.connect()
+    return manager
+
+
+def start_shared_l1_manager(
+    *,
+    host: str,
+    port: int,
+    authkey: bytes,
+    region_id: str,
+    capacity: int,
+    alignment: int,
+    layout_id: str,
+) -> SharedL1Manager:
+    """Start the coordinator child and return its lifecycle handle."""
+    manager = SharedL1Manager(
+        address=(host, port),
+        authkey=authkey,
+        ctx=get_context("spawn"),
+    )
+    manager.start(
+        initializer=_initialize_pool,
+        initargs=(region_id, capacity, alignment, layout_id),
+    )
+    return manager

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -755,6 +755,10 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         if not entries:
             return
         for entry in entries:
+            if self._ctx.storage_manager.uses_shared_l1:
+                # Every registered GPU owns a distinct transfer stream. Drain
+                # each one before shared DAX can be unregistered or unmapped.
+                entry.cache_context.stream.synchronize()
             entry.cache_context.close()
             self._ctx.layout_desc_registry.unregister(
                 entry.model_name, entry.world_size
@@ -825,14 +829,14 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
 
     def close(self) -> None:
         """Release GPU resources owned by this module."""
-        # Stop the drain thread before storage_manager.close() so any
-        # in-flight completions reach a live storage manager.
-        self._device_host_func_dispatcher.stop()
-
         with self._lock:
             entries = list(self._cache_contexts.values())
             self._cache_contexts.clear()
+        # Synchronize every shared-DAX transfer stream while the completion
+        # dispatcher is still live, then perform its final drain before
+        # storage_manager.close() can unpin or unmap the region.
         self._release_entries(entries)
+        self._device_host_func_dispatcher.stop()
 
     def register_kv_cache(
         self,
@@ -1103,17 +1107,45 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             except Exception:
                 logger.exception("Cannot store keys due to exception")
             finally:
-                event_backend.record_event(event, cache_context.stream)
                 # Fail closed: commit the reserved objects only when every chunk
                 # copied successfully; otherwise the whole store is skipped.
                 stored_count = len(all_dict) if store_succeeded else 0
-                if stored_count:
+                uses_shared_l1 = self._ctx.storage_manager.uses_shared_l1
+                if stored_count and uses_shared_l1:
+                    # A shared object must not become observable until all D2H
+                    # writes are complete and the exact mapped range has been
+                    # published. The normal host callback is intentionally
+                    # asynchronous to the returned event, so use a synchronous
+                    # completion boundary for this minimal functional path.
+                    try:
+                        event_backend.record_event(event, cache_context.stream)
+                        event_backend.synchronize_event(
+                            event,
+                            cache_context.device,
+                        )
+                        self._ctx.storage_manager.finish_write(list(all_dict.keys()))
+                    except Exception:
+                        logger.exception(
+                            "Cannot publish shared-L1 keys after D2H completion"
+                        )
+                        store_succeeded = False
+                        stored_count = 0
+                else:
+                    event_backend.record_event(event, cache_context.stream)
+                if uses_shared_l1 and not stored_count and all_dict:
+                    try:
+                        self._ctx.storage_manager.abort_write(list(all_dict.keys()))
+                    except Exception:
+                        logger.exception(
+                            "Cannot abort shared-L1 reservations after failed store"
+                        )
+                if stored_count and not uses_shared_l1:
                     submit_callback_to_stream(
                         cache_context.cupy_stream,
                         "finish_write",
                         list(all_dict.keys()),
                     )
-                else:
+                if not stored_count:
                     total_bytes = 0
                 num_tokens = num_chunks * self._ctx.chunk_size if stored_count else 0
                 self._ctx.event_bus.publish_on_stream(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -312,6 +312,20 @@ def _build_modules(
     ]
 
 
+def _validate_shared_l1_runtime_config(
+    mp_config: MPServerConfig,
+    storage_manager_config: StorageManagerConfig,
+) -> None:
+    """Reject transfer paths that the minimal shared-L1 addon does not support."""
+    shared_config = storage_manager_config.l1_manager_config.shared_l1_config
+    if shared_config is None:
+        return
+    if mp_config.supported_transfer_mode != "lmcache_driven":
+        raise ValueError("shared L1 requires supported_transfer_mode='lmcache_driven'")
+    if mp_config.p2p_config.enabled:
+        raise ValueError("shared L1 cannot be combined with P2P")
+
+
 def run_cache_server(
     mp_config: MPServerConfig,
     storage_manager_config: StorageManagerConfig,
@@ -339,6 +353,8 @@ def run_cache_server(
         If return_engine is True: tuple of (MessageQueueServer, MPCacheServer).
         If return_engine is False: None (blocks until interrupted).
     """
+    _validate_shared_l1_runtime_config(mp_config, storage_manager_config)
+
     # mp_config.instance_id is this server's single source of identity (set via
     # --instance-id, else a random UUID v4). Project it onto the OTel
     # service.instance.id unless observability set that attribute explicitly, so

--- a/tests/v1/distributed/shared_l1/test_client.py
+++ b/tests/v1/distributed/shared_l1/test_client.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for mapped Device-DAX views and visibility ordering."""
+
+# Standard
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+import mmap
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import L1MemoryManagerConfig, SharedL1Config
+from lmcache.v1.distributed.shared_l1.client import SharedL1Client
+from lmcache.v1.distributed.shared_l1.pool import SharedL1Pool
+import lmcache.v1.distributed.shared_l1.client as client_module
+
+_CAPACITY = 4096
+_ALIGNMENT = 64
+_MAPPING_OFFSET = mmap.PAGESIZE
+
+
+class _Visibility:
+    def __init__(self, fail_operation: int | None = None) -> None:
+        self.calls: list[tuple[int, int, int, int]] = []
+        self.fail_operation = fail_operation
+
+    @property
+    def granularity(self) -> int:
+        return _ALIGNMENT
+
+    def apply(
+        self,
+        operation: int,
+        _device_fd: int,
+        _mapped_address: int,
+        device_offset: int,
+        length: int,
+        generation: int,
+    ) -> None:
+        self.calls.append((operation, device_offset, length, generation))
+        if operation == self.fail_operation:
+            raise RuntimeError("injected visibility failure")
+
+
+def _key(seed: int = 1) -> ObjectKey:
+    return ObjectKey(seed.to_bytes(4, "big"), "model", 0)
+
+
+def _layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc([torch.Size([4, 4])], [torch.float16])
+
+
+def _configs(path: Path) -> tuple[SharedL1Config, L1MemoryManagerConfig]:
+    return (
+        SharedL1Config(
+            coordinator_host="127.0.0.1",
+            coordinator_port=9301,
+            authkey_file="/unused/authkey",
+            region_id="region",
+            layout_id="layout",
+            mapping_offset=_MAPPING_OFFSET,
+            visibility_library_path="/unused/visibility.so",
+        ),
+        L1MemoryManagerConfig(
+            size_in_bytes=_CAPACITY,
+            use_lazy=False,
+            align_bytes=_ALIGNMENT,
+            shm_name="",
+            devdax_path=str(path),
+        ),
+    )
+
+
+def _region(tmp_path: Path) -> Path:
+    path = tmp_path / "region.bin"
+    with path.open("wb") as region:
+        region.truncate(_MAPPING_OFFSET + _CAPACITY)
+    return path
+
+
+def _client(
+    path: Path,
+    pool: SharedL1Pool,
+    visibility: _Visibility,
+) -> SharedL1Client:
+    shared, memory = _configs(path)
+    return SharedL1Client(
+        shared,
+        memory,
+        pool=pool,
+        visibility=visibility,
+        register_cuda=False,
+    )
+
+
+def test_two_clients_share_one_physical_tensor_with_exact_visibility_range(
+    tmp_path: Path,
+) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    producer_visibility = _Visibility()
+    consumer_visibility = _Visibility()
+    producer = _client(path, pool, producer_visibility)
+    consumer = _client(path, pool, consumer_visibility)
+    try:
+        key = _key()
+        write_obj = producer.reserve_writes([key], _layout())[0]
+        assert write_obj is not None
+        expected = torch.arange(write_obj.get_size(), dtype=torch.uint8)
+        write_obj.raw_data.copy_(expected)
+        producer.finish_writes([key])
+
+        read_obj = consumer.reserve_reads([key])[0]
+        assert read_obj is not None
+        assert torch.equal(read_obj.raw_data, expected)
+        consumer.finish_reads([key])
+        assert consumer.reserve_reads([key])[0] is read_obj
+        consumer.finish_reads([key])
+
+        snapshot = pool.snapshot()
+        objects = cast(dict[str, dict[str, Any]], snapshot["objects"])
+        handle = next(iter(objects.values()))["handle"]
+        expected_call = (
+            _MAPPING_OFFSET + handle.offset,
+            handle.length,
+            handle.generation,
+        )
+        assert producer_visibility.calls == [(1, *expected_call)]
+        assert consumer_visibility.calls == [
+            (2, *expected_call),
+            (2, *expected_call),
+        ]
+        assert objects[next(iter(objects))]["active_readers"] == 0
+    finally:
+        consumer.close()
+        producer.close()
+
+
+def test_contract_mismatch_fails_before_mapping(tmp_path: Path) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    shared, memory = _configs(path)
+    wrong = SharedL1Config(
+        **{
+            **shared.__dict__,
+            "region_id": "wrong-region",
+        }
+    )
+    with pytest.raises(ValueError, match="contract mismatch"):
+        SharedL1Client(
+            wrong,
+            memory,
+            pool=pool,
+            visibility=_Visibility(),
+            register_cuda=False,
+        )
+
+
+@pytest.mark.parametrize("operation", [1, 2])
+def test_visibility_failure_keeps_object_unpublished_or_releases_read(
+    tmp_path: Path,
+    operation: int,
+) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    key = _key()
+    producer = _client(path, pool, _Visibility(fail_operation=operation))
+    try:
+        producer.reserve_writes([key], _layout())
+        if operation == 1:
+            with pytest.raises(RuntimeError, match="visibility failure"):
+                producer.finish_writes([key])
+            assert pool.snapshot()["objects"] == {}
+            return
+        producer.finish_writes([key])
+        with pytest.raises(RuntimeError, match="visibility failure"):
+            producer.reserve_reads([key])
+        objects = cast(dict[str, dict[str, Any]], pool.snapshot()["objects"])
+        assert next(iter(objects.values()))["active_readers"] == 0
+    finally:
+        producer.close()
+
+
+def test_layout_length_mismatch_releases_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    client = _client(path, pool, _Visibility())
+    key = _key()
+    try:
+        client.reserve_writes([key], _layout())
+        client.finish_writes([key])
+        reserve_reads = pool.reserve_reads
+
+        def malformed_reserve(keys: list[str]):
+            reservations = reserve_reads(keys)
+            assert reservations[0] is not None
+            reservations[0] = replace(
+                reservations[0],
+                layout=MemoryLayoutDesc([torch.Size([1])], [torch.float16]),
+            )
+            return reservations
+
+        monkeypatch.setattr(pool, "reserve_reads", malformed_reserve)
+        with pytest.raises(ValueError, match="length does not match"):
+            client.reserve_reads([key])
+        objects = cast(dict[str, dict[str, Any]], pool.snapshot()["objects"])
+        assert next(iter(objects.values()))["active_readers"] == 0
+    finally:
+        client.close()
+
+
+def test_failed_read_release_can_be_retried(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    client = _client(path, pool, _Visibility())
+    try:
+        key = _key()
+        client.reserve_writes([key], _layout())
+        client.finish_writes([key])
+        client.reserve_reads([key])
+        finish_reads = pool.finish_reads
+        monkeypatch.setattr(
+            pool,
+            "finish_reads",
+            lambda _items: (_ for _ in ()).throw(RuntimeError("rpc failed")),
+        )
+        with pytest.raises(RuntimeError, match="rpc failed"):
+            client.finish_reads([key])
+        monkeypatch.setattr(pool, "finish_reads", finish_reads)
+        client.finish_reads([key])
+        objects = cast(dict[str, dict[str, Any]], pool.snapshot()["objects"])
+        assert next(iter(objects.values()))["active_readers"] == 0
+    finally:
+        client.close()
+
+
+def test_cuda_registration_failure_is_not_staged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    shared, memory = _configs(path)
+    unpinned: list[int] = []
+    monkeypatch.setattr(
+        client_module,
+        "current_device_spec",
+        SimpleNamespace(
+            pin_memory=lambda _pointer, _length: False,
+            unpin_memory=lambda pointer: unpinned.append(pointer),
+        ),
+    )
+    with pytest.raises(RuntimeError, match="pageable staging is not accepted"):
+        SharedL1Client(
+            shared,
+            memory,
+            pool=pool,
+            visibility=_Visibility(),
+        )
+    assert unpinned == []
+
+
+def test_cuda_unregistration_failure_keeps_mapping_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _region(tmp_path)
+    pool = SharedL1Pool("region", _CAPACITY, _ALIGNMENT, "layout")
+    shared, memory = _configs(path)
+    unpin_succeeds = False
+    monkeypatch.setattr(
+        client_module,
+        "current_device_spec",
+        SimpleNamespace(
+            pin_memory=lambda _pointer, _length: True,
+            unpin_memory=lambda _pointer: unpin_succeeds,
+        ),
+    )
+    client = SharedL1Client(
+        shared,
+        memory,
+        pool=pool,
+        visibility=_Visibility(),
+    )
+
+    with pytest.raises(RuntimeError, match="host unregistration failed"):
+        client.close()
+    assert client.memcheck()
+
+    unpin_succeeds = True
+    client.close()
+    assert not client.memcheck()

--- a/tests/v1/distributed/shared_l1/test_config.py
+++ b/tests/v1/distributed/shared_l1/test_config.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration tests for the opt-in shared Device-DAX L1 path."""
+
+# Standard
+import argparse
+import json
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.config import (
+    StorageManagerConfig,
+    add_storage_manager_args,
+    parse_args_to_config,
+    validate_storage_manager_config,
+)
+from lmcache.v1.multiprocess.config import MPServerConfig, P2PConfig, add_mp_server_args
+from lmcache.v1.multiprocess.server import _validate_shared_l1_runtime_config
+
+
+def _shared_args() -> list[str]:
+    return [
+        "--l1-size-gb",
+        "2",
+        "--l1-devdax-path",
+        "/dev/dax1.0",
+        "--no-l1-use-lazy",
+        "--shm-name",
+        "",
+        "--l1-align-bytes",
+        "64",
+        "--eviction-policy",
+        "noop",
+        "--shared-l1-coordinator",
+        "coordinator.shared-dax-e2e.svc:9301",
+        "--shared-l1-authkey-file",
+        "/var/run/secrets/lmcache/shared-l1-authkey",
+        "--shared-l1-region-id",
+        "cxl-window-0",
+        "--shared-l1-layout-id",
+        "scratch-v1",
+        "--shared-l1-mapping-offset",
+        "4096",
+        "--shared-l1-visibility-library-path",
+        "/opt/lmcache/lib/liblmcache_shared_l1_visibility.so",
+    ]
+
+
+def _parse_mp_args(args: list[str]) -> StorageManagerConfig:
+    parser = argparse.ArgumentParser()
+    add_mp_server_args(parser)
+    add_storage_manager_args(parser)
+    return parse_args_to_config(parser.parse_args(args))
+
+
+def test_shared_l1_flags_build_expected_config() -> None:
+    config = _parse_mp_args(_shared_args())
+    validate_storage_manager_config(config)
+
+    shared = config.l1_manager_config.shared_l1_config
+    assert shared is not None
+    assert (shared.coordinator_host, shared.coordinator_port) == (
+        "coordinator.shared-dax-e2e.svc",
+        9301,
+    )
+    assert shared.region_id == "cxl-window-0"
+    assert shared.layout_id == "scratch-v1"
+    assert shared.mapping_offset == 4096
+    assert shared.authkey_file == "/var/run/secrets/lmcache/shared-l1-authkey"
+
+
+def test_shared_l1_requires_device_dax() -> None:
+    args = _shared_args()
+    path_index = args.index("--l1-devdax-path")
+    del args[path_index : path_index + 2]
+
+    with pytest.raises(ValueError, match="requires l1-devdax-path"):
+        _parse_mp_args(args)
+
+
+def test_shared_l1_rejects_malformed_coordinator_address() -> None:
+    args = _shared_args()
+    args[args.index("--shared-l1-coordinator") + 1] = "coordinator"
+
+    with pytest.raises(ValueError, match="HOST:PORT"):
+        _parse_mp_args(args)
+
+
+def test_shared_l1_rejects_eviction_and_matching_dax_l2() -> None:
+    eviction_args = _shared_args()
+    eviction_args[eviction_args.index("noop")] = "LRU"
+    with pytest.raises(ValueError, match="eviction_policy='noop'"):
+        _parse_mp_args(eviction_args)
+
+    dax_l2_args = _shared_args() + [
+        "--l2-adapter",
+        json.dumps(
+            {
+                "type": "dax",
+                "slot_bytes": 196608,
+                "device_path": "/dev/dax1.0",
+                "max_dax_size_gb": 2,
+            }
+        ),
+    ]
+    with pytest.raises(ValueError, match="cannot be combined with L2"):
+        _parse_mp_args(dax_l2_args)
+
+
+def test_shared_l1_runtime_requires_lmcache_driven_without_p2p() -> None:
+    storage_config = _parse_mp_args(_shared_args())
+    _validate_shared_l1_runtime_config(
+        MPServerConfig(supported_transfer_mode="lmcache_driven"),
+        storage_config,
+    )
+
+    with pytest.raises(ValueError, match="supported_transfer_mode"):
+        _validate_shared_l1_runtime_config(MPServerConfig(), storage_config)
+    with pytest.raises(ValueError, match="P2P"):
+        _validate_shared_l1_runtime_config(
+            MPServerConfig(
+                supported_transfer_mode="lmcache_driven",
+                p2p_config=P2PConfig(advertise_url="10.0.0.1:9000"),
+            ),
+            storage_config,
+        )

--- a/tests/v1/distributed/shared_l1/test_l1_manager.py
+++ b/tests/v1/distributed/shared_l1/test_l1_manager.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""L1Manager integration for batched coordinator-owned shared L1."""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+    PrefetchRequestSpec,
+)
+from lmcache.v1.distributed.config import (
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    SharedL1Config,
+)
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.storage_manager import StorageManager
+import lmcache.v1.distributed.l1_manager as l1_manager_module
+
+
+def _key(seed: int) -> ObjectKey:
+    return ObjectKey(seed.to_bytes(4, "big"), "model", 0)
+
+
+def _layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc([torch.Size([4, 4])], [torch.float16])
+
+
+def _config() -> L1ManagerConfig:
+    return L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(
+            size_in_bytes=4096,
+            use_lazy=False,
+            align_bytes=64,
+            shm_name="",
+            devdax_path="/dev/dax-test",
+        ),
+        shared_l1_config=SharedL1Config(
+            coordinator_host="127.0.0.1",
+            coordinator_port=9400,
+            authkey_file="/unused/authkey",
+            region_id="region",
+            layout_id="layout",
+            mapping_offset=0,
+            visibility_library_path="/unused/visibility.so",
+        ),
+    )
+
+
+def _manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[L1Manager, MagicMock]:
+    client = MagicMock()
+    monkeypatch.setattr(
+        l1_manager_module,
+        "SharedL1Client",
+        lambda *_args, **_kwargs: client,
+    )
+    return L1Manager(_config()), client
+
+
+def test_shared_manager_write_read_and_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, client = _manager(monkeypatch)
+    layout = _layout()
+    key = _key(1)
+    write_obj = MagicMock()
+    read_obj = MagicMock()
+    client.reserve_writes.return_value = [write_obj]
+    client.reserve_reads.return_value = [read_obj]
+    try:
+        assert manager.reserve_write([key], [False], layout)[key] == (
+            L1Error.SUCCESS,
+            write_obj,
+        )
+        assert manager.finish_write([key])[key] == L1Error.SUCCESS
+        assert manager.reserve_read([key])[key] == (L1Error.SUCCESS, read_obj)
+        assert manager.finish_read([key])[key] == L1Error.SUCCESS
+        client.reserve_writes.assert_called_once_with([key], layout)
+        client.reserve_reads.assert_called_once_with([key])
+        client.finish_writes.assert_called_once_with([key])
+        client.finish_reads.assert_called_once_with([key])
+
+        failed_key = _key(2)
+        failed_obj = MagicMock()
+        client.reserve_writes.return_value = [failed_obj]
+        manager.reserve_write([failed_key], [False], layout)
+        assert manager.abort_write([failed_key])[failed_key] == L1Error.SUCCESS
+        client.abort_writes.assert_called_once_with([failed_key])
+        assert manager.get_object_state(failed_key) is None
+    finally:
+        manager.close()
+
+
+def test_shared_manager_preserves_partial_batch_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, client = _manager(monkeypatch)
+    keys = [_key(1), _key(2)]
+    memory_obj = MagicMock()
+    client.reserve_writes.return_value = [memory_obj, None]
+    try:
+        result = manager.reserve_write(keys, [False, False], _layout())
+        assert result[keys[0]] == (L1Error.SUCCESS, memory_obj)
+        assert result[keys[1]] == (L1Error.KEY_NOT_WRITABLE, None)
+        client.reserve_writes.assert_called_once()
+    finally:
+        manager.close()
+
+
+def test_shared_manager_rejects_multi_reader_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _ = _manager(monkeypatch)
+    try:
+        with pytest.raises(ValueError, match="TP=1"):
+            manager.reserve_read([_key(1)], extra_count=1)
+    finally:
+        manager.close()
+
+
+def test_shared_read_batch_rolls_back_after_local_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, client = _manager(monkeypatch)
+    keys = [_key(1), _key(2)]
+    client.reserve_reads.return_value = [MagicMock(), MagicMock()]
+    broken_entry = MagicMock()
+    broken_entry.available_for_read.side_effect = RuntimeError("injected failure")
+    manager._objects[keys[1]] = broken_entry
+    try:
+        with pytest.raises(RuntimeError, match="injected failure"):
+            manager.reserve_read(keys)
+        client.abort_reads.assert_called_once_with(keys)
+        assert not manager._objects[keys[0]].read_lock.is_locked()
+    finally:
+        manager.close()
+
+
+def test_shared_write_batch_rolls_back_after_local_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, client = _manager(monkeypatch)
+    keys = [_key(1), _key(2)]
+    client.reserve_writes.return_value = [MagicMock(), MagicMock()]
+    l1_object_state = l1_manager_module.L1ObjectState
+    call_count = 0
+
+    def fail_second_state(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise RuntimeError("injected failure")
+        return l1_object_state(*args, **kwargs)
+
+    monkeypatch.setattr(l1_manager_module, "L1ObjectState", fail_second_state)
+    try:
+        with pytest.raises(RuntimeError, match="injected failure"):
+            manager.reserve_write(keys, [False, False], _layout())
+        client.abort_writes.assert_called_once_with(keys)
+        assert not (manager._objects.keys() & keys)
+    finally:
+        manager.close()
+
+
+def test_shared_reader_rejects_producer_layout_mismatch() -> None:
+    manager = StorageManager.__new__(StorageManager)
+    l1_manager = MagicMock(uses_shared_l1=True)
+    manager._l1_manager = l1_manager
+    key = _key(1)
+    memory_obj = MagicMock()
+    memory_obj.get_shapes.return_value = [torch.Size([8, 2])]
+    memory_obj.get_dtypes.return_value = [torch.float16]
+    l1_manager.reserve_read.return_value = {
+        key: (L1Error.SUCCESS, memory_obj),
+    }
+
+    with pytest.raises(RuntimeError, match="layout does not match"):
+        manager.submit_prefetch_task(PrefetchRequestSpec([key], _layout()))
+
+    l1_manager.finish_read.assert_called_once_with([key], extra_count=0)

--- a/tests/v1/distributed/shared_l1/test_pool.py
+++ b/tests/v1/distributed/shared_l1/test_pool.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for the coordinator child's monotonic metadata state."""
+
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from typing import Any, cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.distributed.shared_l1.pool import (
+    InvalidReservationError,
+    OutOfSpaceError,
+    SharedL1Pool,
+    SharedObjectHandle,
+    SharedRegionContract,
+    StaleHandleError,
+)
+
+_REGION = "test-region"
+_LAYOUT = "layout-v1"
+_CAPACITY = 64 * 1024
+_ALIGNMENT = 4096
+
+
+def _layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc([torch.Size([8, 8])], [torch.float16])
+
+
+def _pool(capacity: int = _CAPACITY) -> SharedL1Pool:
+    return SharedL1Pool(_REGION, capacity, _ALIGNMENT, _LAYOUT)
+
+
+def _objects(pool: SharedL1Pool) -> dict[str, dict[str, Any]]:
+    return cast(dict[str, dict[str, Any]], pool.snapshot()["objects"])
+
+
+def test_batched_write_read_state_machine() -> None:
+    pool = _pool()
+    layout = _layout()
+    writes = pool.reserve_writes([("key-a", layout), ("key-b", layout)])
+    assert all(write is not None for write in writes)
+    granted = [write for write in writes if write is not None]
+
+    # Payload bytes may already exist, but WRITING metadata is never readable.
+    assert pool.reserve_reads(["key-a", "missing"]) == [None, None]
+    pool.finish_writes(granted)
+
+    reads = pool.reserve_reads(["key-a", "missing", "key-b"])
+    assert reads[1] is None
+    active = [read for read in reads if read is not None]
+    assert [read.handle for read in active] == [
+        granted[0].handle,
+        granted[1].handle,
+    ]
+    assert all(read.layout == layout for read in active)
+    assert [_objects(pool)[key]["active_readers"] for key in ("key-a", "key-b")] == [
+        1,
+        1,
+    ]
+    pool.finish_reads(active)
+    assert [_objects(pool)[key]["active_readers"] for key in ("key-a", "key-b")] == [
+        0,
+        0,
+    ]
+
+    # Duplicate immutable objects do not allocate a second physical copy.
+    before = pool.snapshot()["next_offset"]
+    assert pool.reserve_writes([("key-a", layout)]) == [None]
+    assert pool.snapshot()["next_offset"] == before
+
+
+def test_batch_validation_and_capacity_fail_without_partial_commit() -> None:
+    pool = _pool(capacity=2 * _ALIGNMENT)
+    layout = _layout()
+    writes = pool.reserve_writes([("key-a", layout), ("key-b", layout)])
+    granted = [write for write in writes if write is not None]
+    stale = replace(
+        granted[1],
+        handle=replace(
+            granted[1].handle,
+            generation=granted[1].handle.generation + 1,
+        ),
+    )
+    with pytest.raises(StaleHandleError):
+        pool.finish_writes([granted[0], stale])
+    assert {item["state"] for item in _objects(pool).values()} == {"WRITING"}
+
+    pool.abort_writes(granted)
+    assert pool.snapshot()["objects"] == {}
+    used_after_abort = pool.snapshot()["next_offset"]
+    with pytest.raises(OutOfSpaceError):
+        pool.reserve_writes([("too-large-a", layout), ("too-large-b", layout)])
+    assert pool.snapshot()["next_offset"] == used_after_abort
+
+
+def test_concurrent_batches_never_overlap_and_same_key_has_one_winner() -> None:
+    pool = _pool(capacity=512 * 1024)
+    layout = _layout()
+
+    def reserve(key: str):
+        return pool.reserve_writes([(key, layout)])[0]
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        distinct = list(executor.map(reserve, [f"key-{index}" for index in range(16)]))
+        duplicates = list(executor.map(reserve, ["same-key"] * 8))
+
+    granted = [write for write in distinct + duplicates if write is not None]
+    assert len(granted) == 17
+    ordered = sorted((write.handle for write in granted), key=lambda item: item.offset)
+    assert all(handle.offset % _ALIGNMENT == 0 for handle in ordered)
+    assert all(
+        left.offset + left.length <= right.offset
+        for left, right in zip(ordered, ordered[1:], strict=False)
+    )
+    assert len({handle.generation for handle in ordered}) == len(ordered)
+    pool.finish_writes(granted)
+    assert _objects(pool)["same-key"]["state"] == "VALID"
+
+
+def test_reservation_tokens_and_restart_epoch_fail_closed() -> None:
+    pool = _pool()
+    layout = _layout()
+    write = pool.reserve_writes([("key", layout)])[0]
+    assert write is not None
+    with pytest.raises(InvalidReservationError):
+        pool.finish_writes([replace(write, token="wrong")])
+    pool.finish_writes([write])
+
+    read = pool.reserve_reads(["key"])[0]
+    assert read is not None
+    with pytest.raises(InvalidReservationError):
+        pool.finish_reads([replace(read, token="wrong")])
+    pool.abort_reads([read])
+
+    replacement = _pool()
+    assert (
+        replacement.region_contract().generation_epoch
+        != pool.region_contract().generation_epoch
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"region_id": ""},
+        {"capacity": 0},
+        {"alignment": 3},
+        {"layout_id": ""},
+        {"generation_epoch": 0},
+    ],
+)
+def test_region_contract_rejects_invalid_geometry(kwargs: dict[str, object]) -> None:
+    values = {
+        "region_id": _REGION,
+        "capacity": _CAPACITY,
+        "alignment": _ALIGNMENT,
+        "layout_id": _LAYOUT,
+        "generation_epoch": 1,
+    }
+    values.update(kwargs)
+    with pytest.raises(ValueError):
+        SharedRegionContract(**values)  # type: ignore[arg-type]
+
+
+def test_handle_is_pool_relative_and_generation_bounded() -> None:
+    handle = SharedObjectHandle(_REGION, 0, 1, 1)
+    assert (handle.region_id, handle.offset, handle.length, handle.generation) == (
+        _REGION,
+        0,
+        1,
+        1,
+    )
+    with pytest.raises(ValueError):
+        SharedObjectHandle(_REGION, 0, 1, 1 << 64)

--- a/tests/v1/mp_coordinator/test_config.py
+++ b/tests/v1/mp_coordinator/test_config.py
@@ -2,6 +2,7 @@
 """Unit tests for MPCoordinatorConfig validation and env loading."""
 
 # Standard
+from typing import Any
 from unittest.mock import patch
 import os
 
@@ -37,3 +38,58 @@ def test_from_env_overrides_and_falls_back():
     assert config.instance_timeout == 42.0
     # Unset variable keeps the default.
     assert config.health_check_interval == MPCoordinatorConfig.health_check_interval
+
+
+def test_shared_l1_from_env() -> None:
+    env = {
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_HOST": "0.0.0.0",
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_PORT": "9400",
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_AUTHKEY_FILE": (
+            "/var/run/secrets/lmcache/shared-l1-authkey"
+        ),
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_REGION_ID": "cxl-region-0",
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_CAPACITY_BYTES": "65536",
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_ALIGNMENT_BYTES": "4096",
+        "LMCACHE_MP_COORDINATOR_SHARED_L1_LAYOUT_ID": "qwen-layout-v1",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        config = MPCoordinatorConfig.from_env()
+
+    assert config.shared_l1_host == "0.0.0.0"
+    assert config.shared_l1_port == 9400
+    assert config.shared_l1_authkey_file == "/var/run/secrets/lmcache/shared-l1-authkey"
+    assert config.shared_l1_region_id == "cxl-region-0"
+    assert config.shared_l1_capacity_bytes == 65536
+    assert config.shared_l1_alignment_bytes == 4096
+    assert config.shared_l1_layout_id == "qwen-layout-v1"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("shared_l1_host", "", "shared_l1_host"),
+        ("shared_l1_authkey_file", "", "shared_l1_authkey_file"),
+        ("shared_l1_region_id", "", "shared_l1_region_id"),
+        ("shared_l1_capacity_bytes", 0, "shared_l1_capacity_bytes"),
+        ("shared_l1_alignment_bytes", 3, "shared_l1_alignment_bytes"),
+        ("shared_l1_layout_id", "", "shared_l1_layout_id"),
+    ],
+)
+def test_enabled_shared_l1_requires_complete_contract(
+    field: str,
+    value: Any,
+    message: str,
+) -> None:
+    values: dict[str, Any] = {
+        "shared_l1_host": "127.0.0.1",
+        "shared_l1_port": 9400,
+        "shared_l1_authkey_file": "/var/run/secrets/lmcache/shared-l1-authkey",
+        "shared_l1_region_id": "region",
+        "shared_l1_capacity_bytes": 65536,
+        "shared_l1_alignment_bytes": 4096,
+        "shared_l1_layout_id": "layout",
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        MPCoordinatorConfig(**values)

--- a/tests/v1/mp_coordinator/test_shared_l1_service.py
+++ b/tests/v1/mp_coordinator/test_shared_l1_service.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator child lifecycle and singleton-pool tests."""
+
+# Standard
+from multiprocessing.context import AuthenticationError
+from pathlib import Path
+import socket
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.shared_l1_service import (
+    connect_shared_l1_manager,
+    read_shared_l1_authkey,
+    start_shared_l1_manager,
+)
+
+_AUTHKEY = b"test-shared-l1-key"
+
+
+def _free_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def _start(port: int):
+    return start_shared_l1_manager(
+        host="127.0.0.1",
+        port=port,
+        authkey=_AUTHKEY,
+        region_id="region",
+        capacity=64 * 1024,
+        alignment=4096,
+        layout_id="layout",
+    )
+
+
+def test_two_clients_share_the_childs_single_pool() -> None:
+    port = _free_port()
+    server = _start(port)
+    try:
+        pool_a = connect_shared_l1_manager("127.0.0.1", port, _AUTHKEY).get_pool()
+        pool_b = connect_shared_l1_manager("127.0.0.1", port, _AUTHKEY).get_pool()
+        layout = MemoryLayoutDesc([torch.Size([4, 4])], [torch.float16])
+        write = pool_a.reserve_writes([("shared-key", layout)])[0]
+        assert write is not None
+        pool_a.finish_writes([write])
+        read = pool_b.reserve_reads(["shared-key"])[0]
+        assert read is not None and read.handle == write.handle
+        pool_b.finish_reads([read])
+        assert pool_a.snapshot()["objects"]["shared-key"] == {
+            "handle": write.handle,
+            "state": "VALID",
+            "active_readers": 0,
+        }
+    finally:
+        server.shutdown()
+
+
+def test_manager_rejects_wrong_authkey() -> None:
+    port = _free_port()
+    server = _start(port)
+    try:
+        with pytest.raises(AuthenticationError):
+            connect_shared_l1_manager("127.0.0.1", port, b"wrong")
+    finally:
+        server.shutdown()
+
+
+def test_app_lifespan_starts_and_stops_child(tmp_path: Path) -> None:
+    port = _free_port()
+    authkey_file = tmp_path / "authkey"
+    authkey_file.write_bytes(_AUTHKEY)
+    app = create_app(
+        MPCoordinatorConfig(
+            health_check_interval=0.0,
+            eviction_check_interval=0.0,
+            enable_startup_resync=False,
+            shared_l1_host="127.0.0.1",
+            shared_l1_port=port,
+            shared_l1_authkey_file=str(authkey_file),
+            shared_l1_region_id="region",
+            shared_l1_capacity_bytes=64 * 1024,
+            shared_l1_alignment_bytes=4096,
+            shared_l1_layout_id="layout",
+        )
+    )
+    with TestClient(app):
+        contract = (
+            connect_shared_l1_manager(
+                "127.0.0.1",
+                port,
+                _AUTHKEY,
+            )
+            .get_pool()
+            .region_contract()
+        )
+        assert contract.region_id == "region"
+
+    with pytest.raises(ConnectionRefusedError):
+        connect_shared_l1_manager("127.0.0.1", port, _AUTHKEY)
+
+
+def test_authkey_file_must_be_nonempty_and_regular(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.write_bytes(b"")
+    with pytest.raises(ValueError, match="empty"):
+        read_shared_l1_authkey(str(empty))
+    with pytest.raises(ValueError, match="regular file"):
+        read_shared_l1_authkey(str(tmp_path))

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -78,8 +78,17 @@ class _NoopDispatcher:
 class _FakeStorageManager:
     """Minimal storage surface used by the server handle-path test."""
 
+    def __init__(self) -> None:
+        self.uses_shared_l1 = False
+        self.reserved: dict[object, object] = {}
+        self.aborted: list[list[object]] = []
+        self.finished: list[list[object]] = []
+
     def finish_write(self, keys: list[object]) -> None:
-        return None
+        self.finished.append(keys)
+
+    def abort_write(self, keys: list[object]) -> None:
+        self.aborted.append(keys)
 
     def finish_read_prefetched(self, keys: list[object]) -> None:
         return None
@@ -90,7 +99,7 @@ class _FakeStorageManager:
         layout: object,
         mode: str,
     ) -> dict[object, object]:
-        return {}
+        return self.reserved
 
     @contextmanager
     def read_prefetched_results(self, keys: list[object]) -> Iterator[list[object]]:
@@ -235,12 +244,13 @@ def test_server_store_and_retrieve_delegate_event_ordering(
     )
 
     storage_manager = _FakeStorageManager()
+    stream_events: list[Any] = []
     server_context = SimpleNamespace(
         chunk_size=1,
         storage_manager=storage_manager,
         event_bus=SimpleNamespace(
             publish=lambda event: None,
-            publish_on_stream=lambda stream, event: None,
+            publish_on_stream=lambda stream, event: stream_events.append(event),
         ),
         resolve_obj_keys=lambda key, group_ids: [[]],
     )
@@ -289,6 +299,95 @@ def test_server_store_and_retrieve_delegate_event_ordering(
     for index, call in enumerate(backend.calls):
         if call[0] == "export":
             assert backend.calls[index - 1][0] == "record"
+
+    shared_key = object()
+    storage_manager.uses_shared_l1 = True
+    storage_manager.reserved = {shared_key: SimpleNamespace(get_size=lambda: 64)}
+    server_context.resolve_obj_keys = lambda key, group_ids: [[shared_key]]
+    assert module.store(key, 1, [[0]], b"shared-store") == (
+        b"completion-handle",
+        True,
+    )
+    assert storage_manager.finished == [[shared_key]]
+    assert [call[0] for call in backend.calls[-5:]] == [
+        "import",
+        "wait",
+        "record",
+        "synchronize",
+        "export",
+    ]
+    assert stream_events[-1].metadata["stored_count"] == 1
+    assert stream_events[-1].metadata["total_bytes"] == 64
+
+    def fail_transfer(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("injected D2H failure")
+
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "transfer_kv_per_object_group",
+        fail_transfer,
+    )
+    assert module.store(key, 1, [[0]], b"failed-store") == (
+        b"completion-handle",
+        False,
+    )
+    assert storage_manager.aborted == [[shared_key]]
+
+    synchronize_key = object()
+    storage_manager.reserved = {synchronize_key: SimpleNamespace(get_size=lambda: 64)}
+    server_context.resolve_obj_keys = lambda key, group_ids: [[synchronize_key]]
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "transfer_kv_per_object_group",
+        lambda *args, **kwargs: None,
+    )
+
+    def fail_synchronize(event: object, device: object) -> None:
+        raise RuntimeError("injected synchronization failure")
+
+    monkeypatch.setattr(backend, "synchronize_event", fail_synchronize)
+    assert module.store(key, 1, [[0]], b"failed-sync") == (
+        b"completion-handle",
+        False,
+    )
+    assert storage_manager.aborted[-1] == [synchronize_key]
+
+
+def test_shared_release_drains_every_transfer_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All GPU transfer streams finish before shared DAX can be unmapped."""
+    # First Party
+    from lmcache.v1.multiprocess.modules import lmcache_driven_transfer
+
+    storage_manager = _FakeStorageManager()
+    storage_manager.uses_shared_l1 = True
+    layout_registry = MagicMock()
+    module = lmcache_driven_transfer.LMCacheDrivenTransferModule.__new__(
+        lmcache_driven_transfer.LMCacheDrivenTransferModule
+    )
+    module._ctx = cast(
+        Any,
+        SimpleNamespace(
+            storage_manager=storage_manager,
+            layout_desc_registry=layout_registry,
+        ),
+    )
+    streams = [MagicMock(), MagicMock()]
+    contexts = [SimpleNamespace(stream=stream, close=MagicMock()) for stream in streams]
+    entries = [
+        lmcache_driven_transfer.ContextEntry(cast(Any, context), "model", 1)
+        for context in contexts
+    ]
+    monkeypatch.setattr(lmcache_driven_transfer.torch_dev, "empty_cache", lambda: None)
+    monkeypatch.setattr(lmcache_driven_transfer.torch_dev, "ipc_collect", lambda: None)
+
+    module._release_entries(entries)
+
+    for stream, context in zip(streams, contexts, strict=True):
+        stream.synchronize.assert_called_once_with()
+        context.close.assert_called_once_with()
+    assert layout_registry.unregister.call_count == 2
 
 
 def test_handle_path_has_no_musa_specific_imports_or_branches() -> None:


### PR DESCRIPTION
### What this PR does / why we need it:

  Process-local Device-DAX allocators are unsafe when multiple MP servers map the same physical CXL region: each server can independently allocate overlapping offsets.

  This PR adds an opt-in, non-reclaiming shared-L1 M0:

  - a coordinator subprocess owns allocation and object metadata for one shared region;
  - MP servers use {region_id, offset, length, generation} handles while maintaining host-local mappings;
  - reserve, finish, and abort operations are batched per L1Manager key list;
  - KV payload remains in Device-DAX and never passes through the coordinator;
  - writes become visible only after D2H completion and publication;
  - reads are released only after acquisition and H2D completion;
  - CUDA registration and platform visibility operations fail closed, with no pageable fallback.

  Refs #4226
  Refs #4307

###  Special notes for your reviewers:

  This is an experimental functional milestone, not the complete #4307 architecture. 
  It currently supports TP=1, one fixed region/layout, immutable objects, monotonic allocation, and noop eviction.

  The current authenticated Python BaseManager connection is a metadata-only shortcut for a trusted qualification cluster. 
  A parent coordinator API with bounded local IPC remains future work.

  The following are out of scope:

  - reclamation, extent reuse, TTL recovery, and coordinator HA;
  - P2P, L2, GDS, and hybrid DRAM/Device-DAX;
  - hotplug, transparent restart, and TP>1;
  - latency, bandwidth, or throughput claims.

  The platform-specific cross-host publish/acquire visibility library is not included. 
MAP_SHARED or msync alone is not considered proof of cross-host visibility.

  ### Two-node Kubernetes E2E

   vLLM, MP-A, coordinator    lmcache-vllm-xxx      RTX PRO 6000 Blackwell 96 GB    /dev/dax1.1
   SGLang, MP-B               lmcache-sglang-xxx    RTX PRO 6000 Blackwell 96 GB    /dev/dax1.0

 This functional test used one GPU per node.

Both DAX paths expose the same 2,196,875,771,904-byte physical region and had permission mode 0666. 
The test reserved
  the final 2 MiB:

  - offset: 0x1ff7fe00000 (2196873674752)
  - length: 0x200000 (2097152)

  Configuration:

  - K3s v1.36.2+k3s1
  - vLLM 0.25.1
  - model Qwen/Qwen2.5-0.5B-Instruct
  - BF16, TP=1, maximum context 512
  - 16-token LMCache chunks and engine blocks/pages
  - engine prefix caching disabled
  - noop MP eviction

  Result:

  - SGLang stored 6 chunks;
  - vLLM on read and loaded all 6 chunks;
  - 96 tokens were attributed to LMCache and 0 to vLLM prefix caching;
  - six VALID objects occupied 1,179,648 unique and physical bytes;
  - duplication factor was 1.0;
  - mandatory CUDA registration passed on both mappings;
  - cold and shared-hit requests had identical prompt-token counts and output;
  - namespace cleanup and byte-for-byte DAX restoration passed.

  This is a one-direction functional sharing proof, not a performance benchmark. 
  The host-specific harness is outside this PR and must be supplied separately, with its machine-specific paths adapted before reproduction.

  If applicable:

  - [x] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests