### PR TITLE
fix(native-connector): complete failed requests after worker death

### DIFF
--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -18,6 +18,7 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace lmcache {
@@ -276,7 +277,8 @@ class ConnectorBase : public IStorageConnector {
       if (!lane_ptr) {
         lane_ptr = std::make_unique<WorkerLane>();
       }
-      start_lane_workers(*lane_ptr, count);
+      lane_ptr->state.live_workers.store(count, std::memory_order_release);
+      start_lane_workers(key, *lane_ptr, count);
     }
 
     // Start shared pool if any lane key in the registry is not configured.
@@ -290,6 +292,8 @@ class ConnectorBase : public IStorageConnector {
     }
 
     if (need_shared) {
+      shared_queue_state_.live_workers.store(num_workers_,
+                                             std::memory_order_release);
       workers_.reserve(static_cast<size_t>(num_workers_));
       for (int i = 0; i < num_workers_; i++) {
         workers_.emplace_back([this]() { this->worker_loop(); });
@@ -365,7 +369,14 @@ class ConnectorBase : public IStorageConnector {
   }
 
  private:
+  struct WorkerQueueState {
+    std::atomic<int> live_workers{0};
+    bool failed = false;
+    std::string fatal_error;
+  };
+
   struct WorkerLane {
+    WorkerQueueState state;
     std::mutex mu;
     std::condition_variable cv;
     std::queue<Request> requests;
@@ -433,19 +444,38 @@ class ConnectorBase : public IStorageConnector {
     const std::string& key = lane_key_for_op(req.op);
     auto it = lanes_.find(key);
     if (it != lanes_.end()) {
-      {
-        std::lock_guard<std::mutex> lk(it->second->mu);
-        it->second->requests.push(std::move(req));
-      }
-      it->second->cv.notify_one();
+      enqueue_request_for_queue(std::move(req), it->second->state,
+                                it->second->mu, it->second->cv,
+                                it->second->requests);
       return;
     }
 
+    enqueue_request_for_queue(std::move(req), shared_queue_state_, req_mu_,
+                              req_cv_, requests_);
+  }
+
+  void enqueue_request_for_queue(Request&& req, WorkerQueueState& state,
+                                 std::mutex& req_mu,
+                                 std::condition_variable& req_cv,
+                                 std::queue<Request>& requests) {
+    bool fail_now = false;
+    std::string error;
     {
-      std::lock_guard<std::mutex> lk(req_mu_);
-      requests_.push(std::move(req));
+      std::lock_guard<std::mutex> lk(req_mu);
+      if (state.failed) {
+        fail_now = true;
+        error = state.fatal_error;
+      } else {
+        requests.push(std::move(req));
+      }
     }
-    req_cv_.notify_one();
+
+    if (fail_now) {
+      fail_request(req, format_queue_unavailable(error));
+      return;
+    }
+
+    req_cv.notify_one();
   }
 
   void push_completion(Completion&& c) {
@@ -493,13 +523,14 @@ class ConnectorBase : public IStorageConnector {
     return it->second;
   }
 
-  void start_lane_workers(WorkerLane& lane, int num_workers) {
+  void start_lane_workers(const std::string& queue_name, WorkerLane& lane,
+                          int num_workers) {
     lane.workers.reserve(static_cast<size_t>(num_workers));
     WorkerLane* lane_ptr = &lane;
     for (int i = 0; i < num_workers; i++) {
-      lane.workers.emplace_back([this, lane_ptr]() {
-        this->worker_loop_for_queue(lane_ptr->mu, lane_ptr->cv,
-                                    lane_ptr->requests);
+      lane.workers.emplace_back([this, lane_ptr, queue_name]() {
+        this->worker_loop_for_queue(queue_name, lane_ptr->state, lane_ptr->mu,
+                                    lane_ptr->cv, lane_ptr->requests);
       });
     }
   }
@@ -519,11 +550,18 @@ class ConnectorBase : public IStorageConnector {
     }
   }
 
-  void worker_loop() { worker_loop_for_queue(req_mu_, req_cv_, requests_); }
+  void worker_loop() {
+    worker_loop_for_queue("shared", shared_queue_state_, req_mu_, req_cv_,
+                          requests_);
+  }
 
-  void worker_loop_for_queue(std::mutex& req_mu,
+  void worker_loop_for_queue(const std::string& queue_name,
+                             WorkerQueueState& queue_state, std::mutex& req_mu,
                              std::condition_variable& req_cv,
                              std::queue<Request>& requests) {
+    bool abnormal_exit = false;
+    std::string fatal_error;
+
     try {
       // create connection (derived class specific)
       ConnectionType conn = create_connection();
@@ -535,9 +573,11 @@ class ConnectorBase : public IStorageConnector {
         {
           std::unique_lock<std::mutex> lk(req_mu);
           req_cv.wait(lk, [&] {
-            return stop_.load(std::memory_order_acquire) || !requests.empty();
+            return stop_.load(std::memory_order_acquire) ||
+                   queue_state.failed || !requests.empty();
           });
-          if (stop_.load(std::memory_order_acquire) && requests.empty()) {
+          if ((stop_.load(std::memory_order_acquire) || queue_state.failed) &&
+              requests.empty()) {
             break;  // exit loop
           }
           req = std::move(requests.front());
@@ -571,21 +611,93 @@ class ConnectorBase : public IStorageConnector {
               break;
           }
         } catch (const std::exception& e) {
-          comp.ok = false;
-          comp.error = e.what();
-          // if shutting down, errors are expected
           if (stop_.load(std::memory_order_acquire)) {
-            break;  // exit without pushing completion
+            break;  // exit without pushing completion during shutdown
           }
+          comp.ok = false;
+          comp.error = format_worker_failure(e.what());
+        } catch (...) {
+          if (stop_.load(std::memory_order_acquire)) {
+            break;  // exit without pushing completion during shutdown
+          }
+          comp.ok = false;
+          comp.error = format_worker_failure("unknown exception");
         }
 
         // 3. update shared batch state and push completion when done
         handle_tile_completion(req, comp);
       }
     } catch (const std::exception& e) {
-      fprintf(stderr, "[LMCache Connector Worker Error] %s\n", e.what());
+      if (!stop_.load(std::memory_order_acquire)) {
+        abnormal_exit = true;
+        fatal_error = format_worker_failure(e.what());
+      }
     } catch (...) {
-      fprintf(stderr, "[LMCache Connector Worker Error] Unknown exception\n");
+      if (!stop_.load(std::memory_order_acquire)) {
+        abnormal_exit = true;
+        fatal_error = format_worker_failure("unknown exception");
+      }
+    }
+
+    handle_worker_exit(queue_name, queue_state, req_mu, req_cv, requests,
+                       abnormal_exit, std::move(fatal_error));
+  }
+
+  static std::string format_worker_failure(const std::string& reason) {
+    return "native connector worker failed: " + reason;
+  }
+
+  static std::string format_queue_unavailable(const std::string& reason) {
+    if (reason.empty()) {
+      return "native connector worker queue unavailable";
+    }
+    return "native connector worker queue unavailable: " + reason;
+  }
+
+  void fail_request(const Request& req, const std::string& error) {
+    Completion comp;
+    comp.future_id = req.future_id;
+    comp.ok = false;
+    comp.error = error;
+    handle_tile_completion(req, comp);
+  }
+
+  void handle_worker_exit(const std::string& queue_name,
+                          WorkerQueueState& queue_state, std::mutex& req_mu,
+                          std::condition_variable& req_cv,
+                          std::queue<Request>& requests, bool abnormal_exit,
+                          std::string fatal_error) {
+    int previous_live =
+        queue_state.live_workers.fetch_sub(1, std::memory_order_acq_rel);
+    int remaining_live = previous_live - 1;
+
+    if (!abnormal_exit || stop_.load(std::memory_order_acquire)) {
+      return;
+    }
+
+    fprintf(stderr, "[LMCache Connector Worker Error] queue=%s %s\n",
+            queue_name.c_str(), fatal_error.c_str());
+
+    if (remaining_live > 0) {
+      return;
+    }
+
+    std::queue<Request> failed_requests;
+    {
+      std::lock_guard<std::mutex> lk(req_mu);
+      if (queue_state.failed) {
+        return;
+      }
+      queue_state.failed = true;
+      queue_state.fatal_error = fatal_error;
+      failed_requests.swap(requests);
+    }
+    req_cv.notify_all();
+
+    std::string error = format_queue_unavailable(fatal_error);
+    while (!failed_requests.empty()) {
+      fail_request(failed_requests.front(), error);
+      failed_requests.pop();
     }
   }
 
@@ -642,6 +754,7 @@ class ConnectorBase : public IStorageConnector {
   std::mutex req_mu_;
   std::condition_variable req_cv_;
   std::queue<Request> requests_;
+  WorkerQueueState shared_queue_state_;
 
   // completion queue (CQ)
   std::mutex comp_mu_;

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -449,6 +449,17 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         lookup_keys,
                     ) = entry
 
+                    if not ok:
+                        logger.warning(
+                            "Native connector task failed: type=%s "
+                            "future_id=%d task_id=%d op=%s error=%s",
+                            self._type_name,
+                            fid,
+                            task_id,
+                            op_type,
+                            error,
+                        )
+
                     if op_type == self._OP_STORE:
                         store_info = self._pending_store_sizes.pop(fid, None)
                         task_bytes = 0

--- a/tests/v1/distributed/test_connector_base_completion_contract.py
+++ b/tests/v1/distributed/test_connector_base_completion_contract.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Completion-contract tests for native connector worker failures."""
+
+# Standard
+from pathlib import Path
+import time
+
+# Third Party
+from torch.utils.cpp_extension import is_ninja_available, load_inline
+import pytest
+
+if not is_ninja_available():
+    pytest.skip(
+        "ninja is required to compile inline C++ connector tests",
+        allow_module_level=True,
+    )
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EXT = None
+
+
+def _extension():
+    global _EXT
+    if _EXT is not None:
+        return _EXT
+
+    source = r"""
+      #include "connector_base.h"
+      #include "connector_pybind_utils.h"
+      #include <atomic>
+      #include <cstring>
+      #include <stdexcept>
+      #include <string>
+      #include <utility>
+
+      namespace py = pybind11;
+      using namespace lmcache::connector;
+
+      struct TestConnection {};
+
+      WorkerPoolConfig make_worker_config(bool dedicated_lookup_lane,
+                                          int num_workers) {
+        WorkerPoolConfig config;
+        if (dedicated_lookup_lane) {
+          config.per_op_workers["lookup"] = num_workers;
+        }
+        return config;
+      }
+
+      class FaultyConnector : public ConnectorBase<TestConnection> {
+       public:
+        FaultyConnector(int num_workers, bool fail_connect,
+                        int unknown_exception_call, std::string std_failure_key,
+                        size_t tiles_override, bool dedicated_lookup_lane)
+            : ConnectorBase<TestConnection>(
+                  num_workers,
+                  make_worker_config(dedicated_lookup_lane, num_workers)),
+              fail_connect_(fail_connect),
+              unknown_exception_call_(unknown_exception_call),
+              std_failure_key_(std::move(std_failure_key)),
+              tiles_override_(tiles_override) {
+          start_workers();
+        }
+
+       protected:
+        TestConnection create_connection() override {
+          if (fail_connect_) {
+            throw std::runtime_error("connect failed");
+          }
+          return {};
+        }
+
+        void do_single_get(TestConnection&, const std::string&, void* buf,
+                           size_t len, size_t) override {
+          std::memset(buf, 1, len);
+        }
+
+        void do_single_set(TestConnection&, const std::string&, const void*,
+                           size_t, size_t) override {}
+
+        bool do_single_exists(TestConnection&, const std::string& key) override {
+          int call = exists_calls_.fetch_add(1, std::memory_order_relaxed) + 1;
+          if (unknown_exception_call_ > 0 && call == unknown_exception_call_) {
+            throw 42;
+          }
+          if (!std_failure_key_.empty() && key == std_failure_key_) {
+            throw std::runtime_error("std failure for " + key);
+          }
+          return true;
+        }
+
+        size_t choose_num_tiles(Op op, size_t num_items) const override {
+          if (tiles_override_ == 0) {
+            return ConnectorBase<TestConnection>::choose_num_tiles(op, num_items);
+          }
+          return std::min<size_t>(tiles_override_, num_items);
+        }
+
+       private:
+        bool fail_connect_;
+        int unknown_exception_call_;
+        std::string std_failure_key_;
+        size_t tiles_override_;
+        std::atomic<int> exists_calls_{0};
+      };
+
+      PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+        py::class_<FaultyConnector>(m, "FaultyConnector")
+            .def(py::init<int, bool, int, std::string, size_t, bool>(),
+                 py::arg("num_workers") = 1, py::arg("fail_connect") = false,
+                 py::arg("unknown_exception_call") = 0,
+                 py::arg("std_failure_key") = "",
+                 py::arg("tiles_override") = 0,
+                 py::arg("dedicated_lookup_lane") = false)
+            LMCACHE_BIND_CONNECTOR_METHODS(FaultyConnector);
+      }
+    """
+
+    _EXT = load_inline(
+        name="lmcache_test_connector_completion_contract",
+        cpp_sources=[source],
+        extra_include_paths=[str(_REPO_ROOT / "csrc" / "storage_backends")],
+        extra_cflags=["-O0", "-std=c++17"],
+        with_cuda=False,
+        verbose=False,
+    )
+    return _EXT
+
+
+def _drain_until(client, expected: int, timeout: float = 5.0):
+    deadline = time.monotonic() + timeout
+    completions = []
+    while time.monotonic() < deadline:
+        completions.extend(client.drain_completions())
+        if len(completions) >= expected:
+            return completions
+        time.sleep(0.01)
+    return completions
+
+
+def test_create_connection_failure_completes_submitted_request():
+    client = _extension().FaultyConnector(fail_connect=True)
+    try:
+        future_id = client.submit_batch_exists(["key-a"])
+
+        completions = _drain_until(client, 1)
+
+        assert len(completions) == 1
+        assert completions[0][0] == future_id
+        assert completions[0][1] is False
+        assert "native connector worker" in completions[0][2]
+    finally:
+        client.close()
+
+
+def test_failed_queue_rejects_later_submissions_with_completion():
+    client = _extension().FaultyConnector(fail_connect=True)
+    try:
+        client.submit_batch_exists(["first"])
+        assert len(_drain_until(client, 1)) == 1
+
+        future_id = client.submit_batch_exists(["second"])
+        completions = _drain_until(client, 1)
+
+        assert len(completions) == 1
+        assert completions[0][0] == future_id
+        assert completions[0][1] is False
+        assert "queue unavailable" in completions[0][2]
+    finally:
+        client.close()
+
+
+def test_per_op_lookup_lane_failure_completes_submitted_request():
+    client = _extension().FaultyConnector(
+        fail_connect=True,
+        dedicated_lookup_lane=True,
+    )
+    try:
+        future_id = client.submit_batch_exists(["key-a"])
+
+        completions = _drain_until(client, 1)
+
+        assert len(completions) == 1
+        assert completions[0][0] == future_id
+        assert completions[0][1] is False
+        assert "native connector worker" in completions[0][2]
+    finally:
+        client.close()
+
+
+def test_unknown_tile_exception_fails_batch_without_killing_worker():
+    client = _extension().FaultyConnector(unknown_exception_call=1)
+    try:
+        failed_future_id = client.submit_batch_exists(["boom"])
+        failed = _drain_until(client, 1)
+
+        assert len(failed) == 1
+        assert failed[0][0] == failed_future_id
+        assert failed[0][1] is False
+        assert "unknown exception" in failed[0][2]
+
+        ok_future_id = client.submit_batch_exists(["ok"])
+        ok = _drain_until(client, 1)
+
+        assert len(ok) == 1
+        assert ok[0][0] == ok_future_id
+        assert ok[0][1] is True
+        assert ok[0][3] == [True]
+    finally:
+        client.close()
+
+
+def test_multi_tile_batch_emits_one_failed_completion():
+    client = _extension().FaultyConnector(
+        num_workers=2,
+        std_failure_key="bad",
+        tiles_override=2,
+    )
+    try:
+        future_id = client.submit_batch_exists(["ok-a", "bad", "ok-b", "ok-c"])
+
+        completions = _drain_until(client, 1)
+        # Give a double-completion bug a small window to show itself.
+        time.sleep(0.05)
+        completions.extend(client.drain_completions())
+
+        assert len(completions) == 1
+        assert completions[0][0] == future_id
+        assert completions[0][1] is False
+        assert "std failure for bad" in completions[0][2]
+    finally:
+        client.close()
+
+
+def test_success_path_still_reports_exists_results():
+    client = _extension().FaultyConnector()
+    try:
+        future_id = client.submit_batch_exists(["key-a", "key-b"])
+
+        completions = _drain_until(client, 1)
+
+        assert len(completions) == 1
+        assert completions[0][0] == future_id
+        assert completions[0][1] is True
+        assert completions[0][3] == [True, True]
+    finally:
+        client.close()
+
+
+def test_close_does_not_synthesize_failure_completion():
+    client = _extension().FaultyConnector()
+
+    client.close()
+
+    assert client.drain_completions() == []

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -155,6 +155,18 @@ class MockNativeConnector:
             pass
 
 
+class FailingStoreCompletionConnector(MockNativeConnector):
+    """Mock connector that accepts stores but completes them as failed."""
+
+    def submit_batch_set(self, keys: list[str], memoryviews: list) -> int:
+        with self._lock:
+            fid = self._next_id
+            self._next_id += 1
+
+        self._push_completion(fid, False, "forced store failure", None)
+        return fid
+
+
 # =============================================================================
 # Test Fixtures
 # =============================================================================
@@ -488,6 +500,28 @@ class TestStoreInterface:
 
         completed = adapter.pop_completed_store_tasks()
         assert completed[task_id].is_successful()
+
+    def test_failed_store_completion_clears_pending_state(self):
+        mock_client = FailingStoreCompletionConnector()
+        adp = NativeConnectorL2Adapter(mock_client)
+        try:
+            key = create_object_key(1)
+            obj = create_memory_obj()
+            store_fd = adp.get_store_event_fd()
+
+            task_id = adp.submit_store_task([key], [obj])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+
+            completed = adp.pop_completed_store_tasks()
+            assert task_id in completed
+            assert not completed[task_id].is_successful()
+            assert completed[task_id].bytes_transferred() == 0
+
+            with adp._lock:
+                assert adp._pending_ops == {}
+                assert adp._pending_store_sizes == {}
+        finally:
+            adp.close()
 
 
 # =============================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4342.

Native connector workers can currently die after Python has already received a `future_id`, without emitting the batch completion that `NativeConnectorL2Adapter` depends on to clear pending state. For store operations, that also leaves the corresponding L1 read locks held until process exit.

This PR tightens the `ConnectorBase` completion contract:

- if native submit successfully returns a `future_id`, the batch eventually receives exactly one completion
- per-request `std::exception` and non-`std::exception` failures become failed batch completions instead of killing the worker
- if all workers for a queue die abnormally, queued requests are drained as failed completions and later submissions fail immediately
- normal `close()` / shutdown behavior is unchanged and does not synthesize failure completions
- Python demux logs failed native completions with connector/task context, while keeping result semantics unchanged

The fix is intentionally scoped to the native connector completion contract. It does not include the store-batch splitting work from #4211.

**Special notes for your reviewers**:

I validated the regression with an A/B run on a remote MI300X/gfx942 ROCm host.

Baseline repro:

- baseline: `origin/dev` at `e38ee4157a11703b07845f45fd98e714b25c13cd`
- test injected from this branch only: `tests/v1/distributed/test_connector_base_completion_contract.py`
- result: `4 failed, 3 passed`
- failures reproduced the stuck-completion behavior: worker stderr reported connection/unknown exceptions, while `drain_completions()` returned zero completions

Fixed branch:

- commit: `ef1e1b619947bd83496b1f2b9849811301cc2e37`
- same regression test with a clean PyTorch extension cache: `7 passed`

Real backend validation:

- Redis: started a real `redis:7-alpine` service and exercised `lmcache.lmcache_redis.LMCacheRedisClient` through `NativeConnectorL2Adapter`; healthy store/lookup/load/delete passed. After killing the Redis container, a new store returned a failed completion, transferred 0 bytes, and cleared pending adapter state. A no-listener Redis port also returned failed completions for the initial connection failure and later queue-fast-fail submission.
- Aerospike: built optional `lmcache.lmcache_aerospike` support, started a real Aerospike CE container, and ran `tests/v1/distributed/test_aerospike_l2_integration.py` (`1 passed`). A separate failure smoke killed the Aerospike container after a healthy native store; the next store returned a failed completion and cleared pending adapter state.
- Mooncake: attempted real native setup with `mooncake-transfer-engine`, but that wheel provides the service binaries without the C++ SDK headers required by LMCache's `lmcache_mooncake` build (`config.h` / `real_client.h` missing), so Mooncake native E2E could not be run in that environment.

Additional validation:

- `python -m pytest -q tests/v1/distributed/test_connector_base_completion_contract.py` -> `7 passed`
- `python -m pytest -q tests/v1/distributed/test_native_connector_l2_adapter.py -k "failure or pending or store"` -> `10 passed, 70 deselected`
- full target files together -> `87 passed`
- related distributed/L2 suite -> `217 passed, 1 skipped`
- `python -m compileall -q lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py tests/v1/distributed/test_connector_base_completion_contract.py tests/v1/distributed/test_native_connector_l2_adapter.py`
- `ruff check lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py tests/v1/distributed/test_connector_base_completion_contract.py tests/v1/distributed/test_native_connector_l2_adapter.py`
- `pre-commit run --files csrc/storage_backends/connector_base.h lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py tests/v1/distributed/test_connector_base_completion_contract.py tests/v1/distributed/test_native_connector_l2_adapter.py`
- `clang-format --dry-run --Werror csrc/storage_backends/connector_base.h`
- `git diff --check`

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
