### PR TITLE
[GDS] O_DIRECT + pinned-buffer POSIX fallback for GdsBackend

### DIFF
--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 import asyncio
 import ctypes
 import ctypes.util
+import errno
 import json
-import mmap
 import os
 import struct
 import threading
@@ -17,7 +17,6 @@ import uuid
 
 # Third Party
 import aiofile
-import numpy as np
 import torch
 
 # First Party
@@ -30,6 +29,7 @@ from lmcache.utils import (
 )
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_allocators.cu_file_memory_allocator import CuFileMemoryAllocator
+from lmcache.v1.memory_allocators.gpu_memory_allocator import GPUMemoryAllocator
 from lmcache.v1.memory_allocators.hip_file_memory_allocator import (
     HipFileMemoryAllocator,
 )
@@ -51,6 +51,14 @@ _METADATA_MAX_SIZE = 4096  # reserve 4K for metadata.
 # TODO: It is possible to read this 4KB block without triggering read-ahead by
 # various means.
 _DEFAULT_THREAD_COUNT = 4
+
+# O_DIRECT (buffered-fallback POSIX path) alignment. O_DIRECT requires the file
+# offset, transfer length, and memory buffer to all be aligned to the block
+# size; 4096 satisfies every common Linux filesystem (and equals the metadata
+# header size, so KV data starts on an aligned boundary). getattr keeps this
+# importable on platforms without O_DIRECT (e.g. macOS), where it resolves to 0.
+_DIRECT_IO_ALIGN = 4096
+_O_DIRECT_FLAG = getattr(os, "O_DIRECT", 0)
 
 
 class UnsupportedMetadataVersion(Exception):
@@ -311,6 +319,28 @@ class GdsBackend(AllocatorBackendInterface):
                 max_workers=thread_count, thread_name_prefix="gds-io"
             )
 
+        # POSIX-fallback load-phase instrumentation. Summed (across chunks/
+        # threads) time spent in the disk read vs the host->device copy, so a
+        # batched get can report how much of the KV load is file I/O vs H2D.
+        # Reset at the start of each batched get; accumulated under the lock.
+        self._io_phase_lock = threading.Lock()
+        self._read_ns = 0
+        self._h2d_ns = 0
+
+        # POSIX-fallback GPU memcpy function, set only when use_gds is False.
+        self._gpu_memcpy: Optional[Callable[..., int]] = None
+        # POSIX-fallback pinned host bounce buffers.  Each I/O thread keeps a
+        # single reusable pinned buffer in thread-local storage and grows it
+        # on demand (see _get_pinned_buffer).  Staging disk<->GPU copies through
+        # pinned memory lets cudaMemcpy/hipMemcpy run as a full-bandwidth DMA
+        # (pageable memory forces the driver to stage through its own internal
+        # pinned buffer first).  Allocating pinned memory is expensive, so we
+        # reuse per thread rather than per read.  _pinned_buffers tracks every
+        # live buffer under _pinned_lock so close() can release them after the
+        # thread pool has shut down.
+        self._pinned_tls = threading.local()
+        self._pinned_buffers: List[torch.Tensor] = []
+        self._pinned_lock = threading.Lock()
         if self.use_gds:
             logger.info("Using GDS backend '%s'", self.gds_backend)
             if self.gds_backend == "cufile":
@@ -339,6 +369,11 @@ class GdsBackend(AllocatorBackendInterface):
             self._gpu_memcpy = _load_gpu_memcpy()
 
         self.use_direct_io = False
+        # O_DIRECT state for the POSIX fallback (use_gds=False). Set False if the
+        # filesystem rejects O_DIRECT (EINVAL) so we stop retrying it; the
+        # unaligned-warning flag keeps that log to a single line.
+        self._direct_io_supported = _O_DIRECT_FLAG != 0
+        self._direct_io_unaligned_warned = False
 
         # Values for retrying allocations and loads in case of failures potentially
         # due to memory pressure
@@ -952,6 +987,12 @@ class GdsBackend(AllocatorBackendInterface):
                 gds_read_bytes += memory_obj.get_size()
             memory_objs.append(memory_obj)
 
+        # Reset per-phase accumulators so the split reported below covers only
+        # this batched get (POSIX fallback populates them inside _load_gds).
+        with self._io_phase_lock:
+            self._read_ns = 0
+            self._h2d_ns = 0
+
         start_time = time.perf_counter()
         assert self._thread_pool is not None
         results = list(
@@ -960,9 +1001,13 @@ class GdsBackend(AllocatorBackendInterface):
             )
         )
         total_time = time.perf_counter() - start_time
+        with self._io_phase_lock:
+            read_ms = self._read_ns / 1e6
+            h2d_ms = self._h2d_ns / 1e6
         logger.info(
             f"Time taken for batched_get_blocking: {total_time:.3f}s |"
             f" {gds_read_bytes / 1024 / 1024}MiB | {gds_reads} ops."
+            f" | phase-sums: read={read_ms:.1f}ms h2d={h2d_ms:.1f}ms"
         )
         return results
 
@@ -974,9 +1019,37 @@ class GdsBackend(AllocatorBackendInterface):
         tmp: str,
         kv_chunk: torch.Tensor,
         fmt: MemoryFormat,
-        base_pointer: int,
+        base_pointer: Optional[int],
         device_offset: int,
-    ):
+    ) -> bytes:
+        """Persist one KV chunk to ``path`` (metadata header + raw bytes).
+
+        The source device address is resolved from ``base_pointer``:
+
+        - ``base_pointer is None``: the allocator has no single registered
+          buffer, so ``kv_chunk.data_ptr()`` already points at this chunk's
+          exact location and the device offset is 0.
+        - ``base_pointer`` set: all chunks live in one registered buffer, so the
+          source is ``base_pointer + device_offset`` (the chunk's byte offset in
+          that buffer).
+
+        Args:
+            path: Final destination path for the chunk file.
+            tmp: Suffix appended to ``path`` for the temporary file that is
+                atomically renamed into place on success.
+            kv_chunk: The device tensor to persist.
+            fmt: Memory format stored in the metadata header.
+            base_pointer: Registered buffer base address, or ``None`` when the
+                allocator hands out standalone tensors (POSIX fallback).
+            device_offset: Byte offset of ``kv_chunk`` within ``base_pointer``;
+                ignored when ``base_pointer`` is ``None``.
+
+        Returns:
+            The packed metadata header bytes written to the file.
+
+        Raises:
+            RuntimeError: If the device->host GPU memcpy fails.
+        """
         if base_pointer is None:
             addr = ctypes.c_void_p(kv_chunk.data_ptr())
             dev_offset = 0
@@ -991,9 +1064,9 @@ class GdsBackend(AllocatorBackendInterface):
             kv_chunk, fmt=fmt, lmcache_version=str(_METADATA_VERSION)
         )
         try:
-            with open(tmp_path, "wb") as f:
-                f.write(metadata)
             if self.gds_module:
+                with open(tmp_path, "wb") as f:
+                    f.write(metadata)
                 with self.gds_module.CuFile(
                     tmp_path, "r+", use_direct_io=self.use_direct_io
                 ) as f:
@@ -1001,36 +1074,147 @@ class GdsBackend(AllocatorBackendInterface):
                         addr, kv_chunk.nbytes, file_offset=offset, dev_offset=dev_offset
                     )
             elif self._gpu_memcpy:
-                # mmap the file
-                fd = os.open(tmp_path, os.O_RDWR)
+                # POSIX fallback: copy device memory into a *pinned* host buffer
+                # (fast pinned DMA), then persist [metadata | KV bytes] with a
+                # single buffered (or O_DIRECT) write.  We deliberately avoid a
+                # writable MAP_SHARED mmap here: parallel / network filesystems
+                # (e.g. the ufs64 PFS) reject shared writable mappings with
+                # EOPNOTSUPP ([Errno 95]).  Staging the header + data in one
+                # aligned pinned buffer lets O_DIRECT (use_direct_io) issue a
+                # single aligned write that bypasses the page cache.
                 nbytes = kv_chunk.nbytes
-                os.ftruncate(fd, nbytes + offset)
-                mm = mmap.mmap(
-                    fd, nbytes + offset, prot=mmap.PROT_WRITE, flags=mmap.MAP_SHARED
-                )
-                os.close(fd)
-
-                # get mapped file address
-                arr = np.frombuffer(mm, dtype=np.uint8)
-                buf_addr = arr.__array_interface__["data"][0]
-
-                assert addr.value is not None
+                if addr.value is None or self._gpu_memcpy is None:
+                    raise RuntimeError(
+                        "GDS POSIX fallback save invoked without a valid device "
+                        "pointer or GPU memcpy function"
+                    )
+                total = offset + nbytes
+                host_buf = self._get_pinned_buffer(total)
+                hb_mv = memoryview(host_buf.numpy())
+                # Header occupies exactly `offset` (_METADATA_MAX_SIZE) bytes.
+                hb_mv[: len(metadata)] = metadata
+                # kind=2 -> DeviceToHost (identical enum on CUDA and HIP).
+                # Copy the KV bytes right after the header. Use the resolved
+                # dev_offset (0 when base_pointer is None, since addr already
+                # points at this chunk) — not the raw parameter.
                 res = self._gpu_memcpy(
-                    ctypes.c_void_p(buf_addr + offset),
-                    ctypes.c_void_p(int(addr.value) + device_offset),
+                    ctypes.c_void_p(host_buf.data_ptr() + offset),
+                    ctypes.c_void_p(int(addr.value) + dev_offset),
                     ctypes.c_size_t(nbytes),
                     ctypes.c_int(2),
                 )
                 if res:
-                    raise RuntimeError(f"GPU memcpy failed {res}")
-                del arr
-                mm.close()
+                    raise RuntimeError(f"GPU memcpy (DeviceToHost) failed {res}")
+                out = hb_mv[:total]
+                want_direct = self.use_direct_io and self._direct_io_aligned(
+                    total, host_buf.data_ptr()
+                )
+                fd, _ = self._os_open_maybe_direct(
+                    tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, want_direct
+                )
+                try:
+                    written = 0
+                    while written < total:
+                        written += os.pwrite(fd, out[written:], written)
+                finally:
+                    os.close(fd)
 
         except Exception as e:
             logger.error(f"Error saving {tmp_path}: {e}", exc_info=True)
             raise e
         os.rename(tmp_path, path)
         return metadata
+
+    def _get_pinned_buffer(self, size_in_bytes: int) -> torch.Tensor:
+        """Return a reusable pinned host buffer of at least ``size_in_bytes``.
+
+        The POSIX fallback (``use_gds=False``) stages disk<->GPU copies through
+        a pinned host buffer so the ``cudaMemcpy``/``hipMemcpy`` runs as a fast
+        pinned DMA.  Pinning memory is expensive, so each I/O thread keeps a
+        single buffer in thread-local storage and reuses it across operations,
+        growing it only when a larger chunk is requested.
+
+        Args:
+            size_in_bytes: Minimum required size of the returned buffer.
+
+        Returns:
+            A 1-D ``uint8`` CPU tensor in pinned memory whose length is
+            ``>= size_in_bytes``.  The buffer is owned by the backend; callers
+            must not free it and must treat bytes past ``size_in_bytes`` as
+            undefined.
+        """
+        buf = getattr(self._pinned_tls, "buffer", None)
+        if buf is not None and buf.numel() >= size_in_bytes:
+            return buf
+        new_buf = torch.empty(size_in_bytes, dtype=torch.uint8, pin_memory=True)
+        self._pinned_tls.buffer = new_buf
+        with self._pinned_lock:
+            # Replace this thread's previous (too-small) buffer in the tracking
+            # list so close() releases exactly the live buffers.
+            if buf is not None:
+                try:
+                    self._pinned_buffers.remove(buf)
+                except ValueError:
+                    pass
+            self._pinned_buffers.append(new_buf)
+        return new_buf
+
+    def _direct_io_aligned(self, *values: int) -> bool:
+        """Return True if every value is a multiple of the O_DIRECT block size.
+
+        O_DIRECT requires the file offset, transfer length, and buffer address
+        to be block-aligned. Callers pass those values; if any is unaligned we
+        fall back to buffered I/O (and warn once) rather than fail the transfer.
+
+        Args:
+            values: Offsets, lengths, and/or buffer addresses to check.
+
+        Returns:
+            True when all values are ``_DIRECT_IO_ALIGN``-aligned.
+        """
+        aligned = all(v % _DIRECT_IO_ALIGN == 0 for v in values)
+        if not aligned and not self._direct_io_unaligned_warned:
+            self._direct_io_unaligned_warned = True
+            logger.warning(
+                "use_direct_io is set but an I/O is not %d-byte aligned "
+                "(values=%s); falling back to buffered I/O for unaligned ops",
+                _DIRECT_IO_ALIGN,
+                values,
+            )
+        return aligned
+
+    def _os_open_maybe_direct(
+        self, path: str, flags: int, want_direct: bool, mode: int = 0o644
+    ) -> Tuple[int, bool]:
+        """Open ``path``, adding ``O_DIRECT`` when requested and supported.
+
+        Falls back to a buffered open if the filesystem rejects O_DIRECT with
+        ``EINVAL`` (recorded so we stop retrying), or if O_DIRECT is unavailable
+        on this platform.
+
+        Args:
+            path: File to open.
+            flags: Base ``os.open`` flags (e.g. ``os.O_RDONLY``).
+            want_direct: Whether the caller wants O_DIRECT for this open.
+            mode: Creation mode for ``O_CREAT`` opens.
+
+        Returns:
+            A ``(fd, is_direct)`` tuple: the open file descriptor and whether
+            O_DIRECT was actually applied.
+        """
+        if want_direct and self._direct_io_supported and _O_DIRECT_FLAG:
+            try:
+                return os.open(path, flags | _O_DIRECT_FLAG, mode), True
+            except OSError as e:
+                if e.errno != errno.EINVAL:
+                    raise
+                self._direct_io_supported = False
+                logger.warning(
+                    "O_DIRECT rejected (EINVAL) on %s; falling back to buffered "
+                    "I/O for the POSIX GDS path",
+                    path,
+                )
+        return os.open(path, flags, mode), False
 
     def _load_gds(
         self,
@@ -1053,42 +1237,82 @@ class GdsBackend(AllocatorBackendInterface):
                         dev_offset=dev_offset,
                     )
             elif self._gpu_memcpy:
-                fd = os.open(gds_path, os.O_RDONLY)
-                file_size = os.fstat(fd).st_size
+                # POSIX fallback: read the KV bytes straight into a *pinned*
+                # host buffer with buffered I/O (os.preadv), then copy
+                # host->device.  Reading into pinned memory lets the copy run as
+                # a full-bandwidth pinned DMA and avoids the temporary-bytes copy
+                # that os.pread would incur.  We use a plain fd / `with`-style
+                # cleanup (rather than mmap) so the file descriptor is always
+                # released and the path stays portable across filesystems
+                # (mirrors the buffered write in _save_gds).
+                if gpu_pointer.value is None or self._gpu_memcpy is None:
+                    raise RuntimeError(
+                        "GDS POSIX fallback load invoked without a valid device "
+                        "pointer or GPU memcpy function"
+                    )
+                read_t0 = time.perf_counter_ns()
+                host_buf = self._get_pinned_buffer(size_in_bytes)
+                mv = memoryview(host_buf.numpy())[:size_in_bytes]
+                # O_DIRECT (use_direct_io) bypasses the page cache so reads hit
+                # the backing filesystem directly. Requires the offset, length,
+                # and buffer to be block-aligned; otherwise fall back to buffered.
+                want_direct = self.use_direct_io and self._direct_io_aligned(
+                    file_offset, size_in_bytes, host_buf.data_ptr()
+                )
+                fd, _ = self._os_open_maybe_direct(gds_path, os.O_RDONLY, want_direct)
+                try:
+                    file_size = os.fstat(fd).st_size
 
-                # Check if file is large enough for the requested read
-                if file_size < file_offset + size_in_bytes:
+                    # Check if file is large enough for the requested read
+                    if file_size < file_offset + size_in_bytes:
+                        logger.error(
+                            f"File {gds_path} is too small: size={file_size}, "
+                            f"but need at least {file_offset + size_in_bytes} "
+                            f"bytes (offset={file_offset}, "
+                            f"requested={size_in_bytes})"
+                        )
+                        return -1
+
+                    read_total = 0
+                    while read_total < size_in_bytes:
+                        n = os.preadv(
+                            fd,
+                            [mv[read_total:]],
+                            file_offset + read_total,
+                        )
+                        if n == 0:
+                            break
+                        read_total += n
+                finally:
                     os.close(fd)
+                read_ns = time.perf_counter_ns() - read_t0
+
+                if read_total != size_in_bytes:
                     logger.error(
-                        f"File {gds_path} is too small: size={file_size}, "
-                        f"but need at least {file_offset + size_in_bytes} bytes "
-                        f"(offset={file_offset}, requested={size_in_bytes})"
+                        f"Short read from {gds_path}: got {read_total} of "
+                        f"{size_in_bytes} bytes"
                     )
                     return -1
 
-                mm = mmap.mmap(
-                    fd,
-                    file_size,
-                    prot=mmap.PROT_READ,
-                    flags=mmap.MAP_PRIVATE | mmap.MAP_POPULATE,  # type: ignore [attr-defined]
-                )
-                os.close(fd)
-
-                arr = np.frombuffer(mm, dtype=np.uint8)
-                addr = arr.__array_interface__["data"][0]
-
-                assert gpu_pointer.value is not None
+                # kind=1 -> HostToDevice (identical enum on CUDA and HIP)
+                h2d_t0 = time.perf_counter_ns()
                 res = self._gpu_memcpy(
                     ctypes.c_void_p(int(gpu_pointer.value) + dev_offset),
-                    ctypes.c_void_p(addr + file_offset),
+                    ctypes.c_void_p(host_buf.data_ptr()),
                     ctypes.c_size_t(size_in_bytes),
                     ctypes.c_int(1),
                 )
+                h2d_ns = time.perf_counter_ns() - h2d_t0
 
                 if res != 0:
-                    raise RuntimeError(f"GPU memcpy failed with code {res}")
-                del arr
-                mm.close()
+                    raise RuntimeError(
+                        f"GPU memcpy (HostToDevice) failed with code {res}"
+                    )
+                # Accumulate per-phase timing so batched_get can report the
+                # disk-read vs host->device split.
+                with self._io_phase_lock:
+                    self._read_ns += read_ns
+                    self._h2d_ns += h2d_ns
                 return size_in_bytes
             else:
                 raise RuntimeError(
@@ -1116,14 +1340,21 @@ class GdsBackend(AllocatorBackendInterface):
 
     def initialize_allocator(
         self, config: LMCacheEngineConfig, metadata: LMCacheMetadata
-    ) -> Union[CuFileMemoryAllocator, HipFileMemoryAllocator]:
+    ) -> Union[CuFileMemoryAllocator, HipFileMemoryAllocator, GPUMemoryAllocator]:
         assert config.gds_buffer_size is not None
+        size_bytes = config.gds_buffer_size * 1024**2
+        # POSIX fallback (use_gds=False) does not issue any GDS API calls, so no
+        # cuFile/hipFile buffer registration is needed. Use a plain GPU
+        # allocator to avoid depending on the cufile/hipfile libraries on this
+        # path (they may be unavailable, e.g. libcufile on ROCm).
+        if not config.use_gds:
+            return GPUMemoryAllocator(size_bytes, align_bytes=4096)
         allocator_cls = (
             HipFileMemoryAllocator
             if self.gds_backend == "hipfile"
             else CuFileMemoryAllocator
         )
-        return allocator_cls(config.gds_buffer_size * 1024**2)
+        return allocator_cls(size_bytes)
 
     def allocate(
         self,
@@ -1262,4 +1493,8 @@ class GdsBackend(AllocatorBackendInterface):
         self.memory_allocator.close()
         if self._thread_pool is not None:
             self._thread_pool.shutdown(wait=True)
+        # Release pinned host bounce buffers now that the thread pool has been
+        # shut down and no I/O thread can still be referencing them.
+        with self._pinned_lock:
+            self._pinned_buffers.clear()
         logger.info("GDS backend closed.")

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -2,11 +2,13 @@
 # Standard
 from collections import OrderedDict
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 import asyncio
+import contextlib
 import ctypes
 import ctypes.util
 import errno
+import functools
 import json
 import os
 import struct
@@ -20,6 +22,7 @@ import aiofile
 import torch
 
 # First Party
+from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.utils import (
     CacheEngineKey,
@@ -59,6 +62,16 @@ _DEFAULT_THREAD_COUNT = 4
 # importable on platforms without O_DIRECT (e.g. macOS), where it resolves to 0.
 _DIRECT_IO_ALIGN = 4096
 _O_DIRECT_FLAG = getattr(os, "O_DIRECT", 0)
+
+# Errnos that mean "this filesystem will never accept O_DIRECT", as opposed to
+# a transient failure.  Seeing one of these latches O_DIRECT off for the rest of
+# the backend's life rather than retrying on every I/O.  EINVAL alone is not
+# enough: several of the parallel/network filesystems this fallback exists for
+# (and FUSE-backed mounts generally) report EOPNOTSUPP/ENOTSUP or EPERM instead,
+# and without them the open would raise straight through the fallback.
+_DIRECT_IO_UNSUPPORTED_ERRNOS = frozenset(
+    {errno.EINVAL, errno.EOPNOTSUPP, errno.ENOTSUP, errno.EPERM}
+)
 
 
 class UnsupportedMetadataVersion(Exception):
@@ -288,12 +301,13 @@ class GdsBackend(AllocatorBackendInterface):
         user_set_keys: set[str] = getattr(config, "_user_set_keys", set())
         use_gds_explicitly_set = "use_gds" in user_set_keys
 
-        # Now initialize the memory allocator
-        self.memory_allocator = self.initialize_allocator(config, metadata)
-
         self.data_suffix = _DATA_FILE_SUFFIX
         self._thread_pool = None
 
+        # Resolve the *effective* use_gds before anything consults it. The
+        # allocator choice below depends on it: with GDS disabled we must use a
+        # plain GPU allocator rather than the cuFile/hipFile one, and on the
+        # auto-disable path the cuFile library may not even be loadable.
         if self.fstype in ["tmpfs", "overlayfs"]:
             # TODO: we can replace the auto-detection of unsupported GDS
             # file systems by doing a small GDS API test on them. If a
@@ -308,15 +322,39 @@ class GdsBackend(AllocatorBackendInterface):
             assert self.use_gds
             self.data_suffix = _WEKA_DATA_FILE_SUFFIX
 
+        # Now initialize the memory allocator (reads the resolved self.use_gds)
+        self.memory_allocator = self.initialize_allocator(config, metadata)
+
         # Always enable the thread pool for parallel I/O.
         # Set disk_io_threads=0 in extra_config to disable.
         thread_count = int(
             config.get_extra_config_value("disk_io_threads", _DEFAULT_THREAD_COUNT)
         )
+        # Resolve dst_device to a concrete index once, here on the constructing
+        # thread.  set_device() rejects an index-less device such as plain
+        # "cuda" ("Expected a torch.device with a specified index or an
+        # integer"), and dst_device defaults to exactly that -- so passing it
+        # through unresolved would break the pool for any caller using the
+        # default.  current_device() is read here, where the correct device is
+        # already selected, rather than inside the worker.
+        _dst = torch.device(dst_device)
+        self._dst_device_index = (
+            _dst.index if _dst.index is not None else torch_dev.current_device()
+        )
+
         self.use_thread_pool = thread_count > 0
         if self.use_thread_pool:
             self._thread_pool = ThreadPoolExecutor(
-                max_workers=thread_count, thread_name_prefix="gds-io"
+                max_workers=thread_count,
+                thread_name_prefix="gds-io",
+                # Each worker starts with this backend's device current.
+                # PyTorch's current device is thread-local and defaults to
+                # index 0, so without this every I/O thread would create a
+                # primary CUDA context on device 0 regardless of which GPU this
+                # rank owns.
+                initializer=functools.partial(
+                    torch_dev.set_device, self._dst_device_index
+                ),
             )
 
         # POSIX-fallback load-phase instrumentation. Summed (across chunks/
@@ -335,11 +373,14 @@ class GdsBackend(AllocatorBackendInterface):
         # pinned memory lets cudaMemcpy/hipMemcpy run as a full-bandwidth DMA
         # (pageable memory forces the driver to stage through its own internal
         # pinned buffer first).  Allocating pinned memory is expensive, so we
-        # reuse per thread rather than per read.  _pinned_buffers tracks every
-        # live buffer under _pinned_lock so close() can release them after the
-        # thread pool has shut down.
+        # reuse per thread rather than per read.  _pinned_buffers maps thread
+        # id -> that thread's live buffer, under _pinned_lock, so close() can
+        # release them after the thread pool has shut down.  It is keyed by
+        # thread id rather than being a list because removing a tensor from a
+        # list uses ``==``, which on tensors yields a tensor and then raises
+        # RuntimeError from bool() -- see _get_pinned_buffer.
         self._pinned_tls = threading.local()
-        self._pinned_buffers: List[torch.Tensor] = []
+        self._pinned_buffers: Dict[int, torch.Tensor] = {}
         self._pinned_lock = threading.Lock()
         if self.use_gds:
             logger.info("Using GDS backend '%s'", self.gds_backend)
@@ -1078,7 +1119,7 @@ class GdsBackend(AllocatorBackendInterface):
                 # (fast pinned DMA), then persist [metadata | KV bytes] with a
                 # single buffered (or O_DIRECT) write.  We deliberately avoid a
                 # writable MAP_SHARED mmap here: parallel / network filesystems
-                # (e.g. the ufs64 PFS) reject shared writable mappings with
+                # (and FUSE-backed mounts) reject shared writable mappings with
                 # EOPNOTSUPP ([Errno 95]).  Staging the header + data in one
                 # aligned pinned buffer lets O_DIRECT (use_direct_io) issue a
                 # single aligned write that bypasses the page cache.
@@ -1097,12 +1138,16 @@ class GdsBackend(AllocatorBackendInterface):
                 # Copy the KV bytes right after the header. Use the resolved
                 # dev_offset (0 when base_pointer is None, since addr already
                 # points at this chunk) — not the raw parameter.
-                res = self._gpu_memcpy(
-                    ctypes.c_void_p(host_buf.data_ptr() + offset),
-                    ctypes.c_void_p(int(addr.value) + dev_offset),
-                    ctypes.c_size_t(nbytes),
-                    ctypes.c_int(2),
-                )
+                # Run in this backend's device context: the calling thread
+                # (asyncio's default executor here) may have a different device
+                # current, which would put the copy on the wrong context.
+                with torch_dev.device(self._dst_device_index):
+                    res = self._gpu_memcpy(
+                        ctypes.c_void_p(host_buf.data_ptr() + offset),
+                        ctypes.c_void_p(int(addr.value) + dev_offset),
+                        ctypes.c_size_t(nbytes),
+                        ctypes.c_int(2),
+                    )
                 if res:
                     raise RuntimeError(f"GPU memcpy (DeviceToHost) failed {res}")
                 out = hb_mv[:total]
@@ -1115,12 +1160,30 @@ class GdsBackend(AllocatorBackendInterface):
                 try:
                     written = 0
                     while written < total:
-                        written += os.pwrite(fd, out[written:], written)
+                        n = os.pwrite(fd, out[written:], written)
+                        if n <= 0:
+                            raise OSError(
+                                f"pwrite made no progress at offset {written} "
+                                f"of {total} for {tmp_path}"
+                            )
+                        written += n
                 finally:
                     os.close(fd)
+            else:
+                # Mirrors the guard in _load_gds.  Without this the function
+                # would write nothing and then fail in os.rename() below with a
+                # confusing FileNotFoundError for a temp file never created,
+                # after the caller was told the chunk had been persisted.
+                raise RuntimeError(
+                    "GDS save invoked with neither a GDS module nor a GPU "
+                    "memcpy function available"
+                )
 
         except Exception as e:
             logger.error(f"Error saving {tmp_path}: {e}", exc_info=True)
+            # Don't leave a partial temp file behind; nothing else reaps these.
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
             raise e
         os.rename(tmp_path, path)
         return metadata
@@ -1142,21 +1205,49 @@ class GdsBackend(AllocatorBackendInterface):
             ``>= size_in_bytes``.  The buffer is owned by the backend; callers
             must not free it and must treat bytes past ``size_in_bytes`` as
             undefined.
+
+        The returned buffer is always ``_DIRECT_IO_ALIGN``-aligned, which is a
+        precondition for the O_DIRECT path: ``torch.empty(pin_memory=True)``
+        does *not* guarantee page alignment, because the caching pinned
+        allocator sub-allocates -- once it has served an unaligned-sized
+        request, later pointers come back offset (observed: 2048, 2560).  An
+        unaligned buffer makes ``_direct_io_aligned`` reject every transfer, so
+        O_DIRECT would silently degrade to buffered I/O depending on nothing
+        more than allocation history.  We therefore over-allocate by one
+        alignment unit and return an aligned view; the view keeps the base
+        tensor alive, so nothing else is needed to manage its lifetime.
+
+        Note:
+            There is exactly one buffer per thread, so the returned tensor is
+            only valid until the *same* thread calls this method again.  A
+            caller must not hold it across a nested call, and must not hand it
+            to another thread.  Today ``_save_gds`` and ``_load_gds`` each
+            acquire it and use it without yielding, which is what makes the
+            single-buffer-per-thread scheme safe.
         """
         buf = getattr(self._pinned_tls, "buffer", None)
         if buf is not None and buf.numel() >= size_in_bytes:
             return buf
-        new_buf = torch.empty(size_in_bytes, dtype=torch.uint8, pin_memory=True)
+        # Pin on *this backend's* device, not whatever device the calling
+        # thread happens to have current.  PyTorch's current device is
+        # thread-local and defaults to index 0 for freshly created threads, so
+        # without this a rank that owns e.g. cuda:3 would create a primary CUDA
+        # context on cuda:0 from every I/O thread.
+        with torch_dev.device(self._dst_device_index):
+            raw = torch.empty(
+                size_in_bytes + _DIRECT_IO_ALIGN, dtype=torch.uint8, pin_memory=True
+            )
+        align_offset = (-raw.data_ptr()) % _DIRECT_IO_ALIGN
+        new_buf = raw[align_offset : align_offset + size_in_bytes]
         self._pinned_tls.buffer = new_buf
         with self._pinned_lock:
-            # Replace this thread's previous (too-small) buffer in the tracking
-            # list so close() releases exactly the live buffers.
-            if buf is not None:
-                try:
-                    self._pinned_buffers.remove(buf)
-                except ValueError:
-                    pass
-            self._pinned_buffers.append(new_buf)
+            # Keyed by thread id, so replacing this thread's previous (too
+            # small) buffer is a plain dict assignment.  Do NOT hold these in a
+            # list and call list.remove(buf): list.remove compares with ``==``,
+            # which for tensors returns a tensor and then raises RuntimeError
+            # (not ValueError) from bool() as soon as any other thread's buffer
+            # precedes this one.
+            self._pinned_buffers[threading.get_ident()] = new_buf
         return new_buf
 
     def _direct_io_aligned(self, *values: int) -> bool:
@@ -1206,12 +1297,13 @@ class GdsBackend(AllocatorBackendInterface):
             try:
                 return os.open(path, flags | _O_DIRECT_FLAG, mode), True
             except OSError as e:
-                if e.errno != errno.EINVAL:
+                if e.errno not in _DIRECT_IO_UNSUPPORTED_ERRNOS:
                     raise
                 self._direct_io_supported = False
                 logger.warning(
-                    "O_DIRECT rejected (EINVAL) on %s; falling back to buffered "
+                    "O_DIRECT rejected (%s) on %s; falling back to buffered "
                     "I/O for the POSIX GDS path",
+                    errno.errorcode.get(e.errno, e.errno),
                     path,
                 )
         return os.open(path, flags, mode), False
@@ -1294,14 +1386,17 @@ class GdsBackend(AllocatorBackendInterface):
                     )
                     return -1
 
-                # kind=1 -> HostToDevice (identical enum on CUDA and HIP)
+                # kind=1 -> HostToDevice (identical enum on CUDA and HIP).
+                # As in _save_gds, pin the copy to this backend's device rather
+                # than the I/O thread's current one.
                 h2d_t0 = time.perf_counter_ns()
-                res = self._gpu_memcpy(
-                    ctypes.c_void_p(int(gpu_pointer.value) + dev_offset),
-                    ctypes.c_void_p(host_buf.data_ptr()),
-                    ctypes.c_size_t(size_in_bytes),
-                    ctypes.c_int(1),
-                )
+                with torch_dev.device(self._dst_device_index):
+                    res = self._gpu_memcpy(
+                        ctypes.c_void_p(int(gpu_pointer.value) + dev_offset),
+                        ctypes.c_void_p(host_buf.data_ptr()),
+                        ctypes.c_size_t(size_in_bytes),
+                        ctypes.c_int(1),
+                    )
                 h2d_ns = time.perf_counter_ns() - h2d_t0
 
                 if res != 0:
@@ -1347,7 +1442,12 @@ class GdsBackend(AllocatorBackendInterface):
         # cuFile/hipFile buffer registration is needed. Use a plain GPU
         # allocator to avoid depending on the cufile/hipfile libraries on this
         # path (they may be unavailable, e.g. libcufile on ROCm).
-        if not config.use_gds:
+        #
+        # This reads the *resolved* self.use_gds, not config.use_gds: the
+        # fstype-based auto-disable (tmpfs/overlayfs) can turn GDS off even
+        # though the config asked for it, and on that path cuFile is exactly
+        # what may be missing.
+        if not self.use_gds:
             return GPUMemoryAllocator(size_bytes, align_bytes=4096)
         allocator_cls = (
             HipFileMemoryAllocator

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -2,6 +2,7 @@
 # Standard
 from unittest import mock
 import asyncio
+import errno
 import os
 import shutil
 import sys
@@ -1216,3 +1217,269 @@ def test_direct_io_alignment_and_open_fallback(temp_gds_path, async_loop):
         assert is_direct is False
     finally:
         backend.close()
+
+
+def test_pinned_buffer_growth_across_threads():
+    """Growing the pinned buffer must not raise when other threads hold buffers.
+
+    Regression test. The tracking structure used to be a ``list[torch.Tensor]``
+    and growth did ``list.remove(old_buf)``. ``list.remove`` compares elements
+    with ``==``; on tensors that yields a *tensor*, and ``bool()`` of it raises
+    ``RuntimeError`` ("Boolean value of Tensor ... is ambiguous", or a size
+    mismatch) — which the surrounding ``except ValueError`` could not catch,
+    because ``RuntimeError`` is not a ``ValueError``. It fired as soon as any
+    other thread's buffer preceded this one in the list.
+
+    In ``_load_gds`` that exception was converted to ``return -1``, which makes
+    the caller evict the entry — i.e. silent cache loss rather than a visible
+    error. So this is exercised directly rather than through the public API:
+    the failure is a crash inside a helper whose exception is swallowed
+    upstream, and reproducing it end-to-end would depend on thread-scheduling
+    order and would be flaky.
+    """
+    backend = GdsBackend.__new__(GdsBackend)
+    backend._pinned_tls = threading.local()
+    backend._pinned_buffers = {}
+    backend._pinned_lock = threading.Lock()
+    backend._dst_device_index = torch.cuda.current_device()
+
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(4)
+
+    def grow(base: int) -> None:
+        try:
+            backend._get_pinned_buffer(base)
+            # Wait until every thread owns a buffer, so the dict/list is
+            # populated with other threads' tensors before anyone grows.
+            barrier.wait(timeout=30)
+            backend._get_pinned_buffer(base * 2)
+        except BaseException as exc:  # noqa: BLE001 - recorded and re-raised
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=grow, args=(4096 * (i + 1),), name=f"io-{i}")
+        for i in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert not errors, f"growing the pinned buffer raised: {errors!r}"
+    # One live buffer per thread, each grown to the larger size.
+    assert len(backend._pinned_buffers) == 4
+    for buf in backend._pinned_buffers.values():
+        assert buf.is_pinned()
+        # O_DIRECT needs a page-aligned buffer address. torch's caching pinned
+        # allocator does not guarantee this once it has served an
+        # unaligned-sized request, so _get_pinned_buffer over-allocates and
+        # returns an aligned view; without that, O_DIRECT silently degrades to
+        # buffered I/O depending only on allocation history.
+        assert buf.data_ptr() % 4096 == 0, (
+            f"pinned buffer not 4096-aligned (offset {buf.data_ptr() % 4096})"
+        )
+
+
+def test_use_gds_false_odirect_aligned_roundtrip(temp_gds_path, async_loop):
+    """An aligned chunk round-trips through the POSIX fallback using O_DIRECT.
+
+    ``test_use_gds_false_save_load_roundtrip`` uses a 2048-byte chunk, so the
+    transfer length is not a multiple of 4096 and every I/O silently takes the
+    *buffered* branch — leaving the O_DIRECT path untested. Here the chunk is
+    sized to 32 KiB so the length, the file offset (the metadata header is
+    exactly ``_METADATA_MAX_SIZE`` = 4096 bytes) and the page-aligned pinned
+    buffer all satisfy O_DIRECT's constraints.
+
+    Asserts both that O_DIRECT was actually requested and that the data survives
+    the round trip byte-for-byte.
+    """
+    config = create_test_config(temp_gds_path)
+    config.use_gds = False
+    metadata = create_test_metadata()
+    backend = GdsBackend(
+        config=config, loop=async_loop, metadata=metadata, dst_device="cuda:0"
+    )
+    try:
+        # 2*64*8*16 = 16384 elements * 2 bytes (bf16) = 32768 B = 8 * 4096.
+        shape = torch.Size([2, 64, 8, 16])
+        dtype = torch.bfloat16
+        nbytes = 1
+        for dim in shape:
+            nbytes *= dim
+        nbytes *= torch.finfo(dtype).bits // 8
+        assert nbytes % 4096 == 0, "test chunk must be O_DIRECT aligned"
+
+        key = create_test_key(900)
+        obj = backend.allocate(shape, dtype)
+        assert obj is not None
+        ref = (torch.rand(tuple(shape), device="cuda") * 100).to(dtype)
+        obj.tensor.copy_(ref)
+
+        seen_flags: list[int] = []
+        real_open = os.open
+
+        def recording_open(path, flags, *args, **kwargs):
+            seen_flags.append(flags)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "lmcache.v1.storage_backend.gds_backend.os.open",
+            side_effect=recording_open,
+        ):
+            backend.submit_put_task(key, obj).result(timeout=15)
+            assert backend.contains(key)
+            loaded = backend.batched_get_blocking([key])
+
+        assert len(loaded) == 1 and loaded[0] is not None
+        assert torch.equal(loaded[0].tensor.to(ref.dtype), ref)
+
+        odirect = getattr(os, "O_DIRECT", 0)
+        if odirect:
+            assert any(f & odirect for f in seen_flags), (
+                "expected at least one O_DIRECT open for an aligned chunk; "
+                f"flags seen: {[hex(f) for f in seen_flags]}"
+            )
+    finally:
+        backend.close()
+
+
+@pytest.mark.parametrize("err", [errno.EOPNOTSUPP, errno.EPERM, errno.EINVAL])
+def test_odirect_open_falls_back_on_unsupported_errno(temp_gds_path, async_loop, err):
+    """A filesystem refusing O_DIRECT degrades to buffered I/O, not an exception.
+
+    Only ``EINVAL`` used to be treated as "this filesystem cannot do O_DIRECT".
+    The parallel/network filesystems this fallback exists for (and FUSE mounts
+    generally) refuse it with ``EOPNOTSUPP``/``ENOTSUP`` or ``EPERM`` instead,
+    which escaped the handler and propagated out of ``_save_gds``/``_load_gds``
+    -- turning the intended graceful degradation into a hard failure in exactly
+    the environment the POSIX path is meant to support.
+    """
+    config = create_test_config(temp_gds_path)
+    config.use_gds = False
+    backend = GdsBackend(
+        config=config,
+        loop=async_loop,
+        metadata=create_test_metadata(),
+        dst_device="cuda:0",
+    )
+    try:
+        probe = os.path.join(temp_gds_path, f"odirect_probe_{err}")
+        real_open = os.open
+        odirect = getattr(os, "O_DIRECT", 0)
+
+        def refuse_odirect(path, flags, *args, **kwargs):
+            if odirect and (flags & odirect):
+                raise OSError(err, os.strerror(err))
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "lmcache.v1.storage_backend.gds_backend.os.open",
+            side_effect=refuse_odirect,
+        ):
+            fd, is_direct = backend._os_open_maybe_direct(
+                probe, os.O_WRONLY | os.O_CREAT, True
+            )
+            os.close(fd)
+            assert is_direct is False, "should have degraded to a buffered open"
+
+            # The refusal is latched: a second request must not retry O_DIRECT.
+            fd, is_direct = backend._os_open_maybe_direct(probe, os.O_RDONLY, True)
+            os.close(fd)
+            assert is_direct is False
+    finally:
+        backend.close()
+
+
+def test_fstype_auto_disable_uses_plain_gpu_allocator(temp_gds_path, async_loop):
+    """Auto-disabling GDS by fstype must also switch to the plain GPU allocator.
+
+    On tmpfs/overlayfs the backend turns GDS off by itself even though the
+    config left ``use_gds`` at its default of True. ``initialize_allocator``
+    used to read ``config.use_gds`` and ran *before* that auto-disable, so this
+    path built a ``CuFileMemoryAllocator`` -- requiring libcufile -- while the
+    rest of the backend ran the POSIX fallback. It must use the plain
+    ``GPUMemoryAllocator`` instead, exactly as an explicit ``use_gds: false``
+    does.
+    """
+    # First Party
+    from lmcache.v1.memory_allocators.gpu_memory_allocator import (
+        GPUMemoryAllocator,
+    )
+
+    config = create_test_config(temp_gds_path)
+    # Deliberately do NOT touch config.use_gds: it must stay at its default so
+    # the auto-disable path is the one under test.
+    assert config.use_gds is True
+
+    with mock.patch(
+        "lmcache.v1.storage_backend.gds_backend.get_fstype", return_value="tmpfs"
+    ):
+        backend = GdsBackend(
+            config=config,
+            loop=async_loop,
+            metadata=create_test_metadata(),
+            dst_device="cuda:0",
+        )
+    try:
+        assert backend.use_gds is False, "tmpfs should auto-disable GDS"
+        assert backend.gds_module is None
+        assert isinstance(backend.memory_allocator, GPUMemoryAllocator)
+    finally:
+        backend.close()
+
+
+def test_posix_fallback_pins_pool_threads_to_dst_device(temp_gds_path, async_loop):
+    """I/O threads must start on the backend's device, not thread-default 0.
+
+    PyTorch's current device is thread-local and defaults to index 0 for a
+    freshly created thread, and the ``gds-io`` pool never selected one. A rank
+    owning e.g. ``cuda:3`` would therefore create a primary CUDA context on
+    ``cuda:0`` from every I/O thread -- wasting VRAM on the wrong GPU and
+    risking an OOM on rank 0's device.
+
+    Also covers the index resolution: ``set_device`` rejects an index-less
+    device such as plain ``"cuda"``, which is ``dst_device``'s default, so the
+    backend must resolve it to a concrete index before handing it to the pool.
+
+    The pinned allocation and both memcpys are additionally wrapped in a
+    ``torch_dev.device(...)`` context; that is not asserted here because
+    spying on ``torch_dev.device`` replaces the class and breaks the
+    ``isinstance`` checks inside torch, and a single-GPU host cannot tell the
+    devices apart anyway.
+    """
+    # First Party
+    from lmcache.v1.storage_backend import gds_backend as gds_mod
+
+    for dst_device in ("cuda:0", "cuda"):
+        config = create_test_config(temp_gds_path)
+        config.use_gds = False
+        real_set_device = gds_mod.torch_dev.set_device
+
+        with mock.patch.object(
+            gds_mod.torch_dev, "set_device", wraps=real_set_device
+        ) as spy_set_device:
+            backend = GdsBackend(
+                config=config,
+                loop=async_loop,
+                metadata=create_test_metadata(),
+                dst_device=dst_device,
+            )
+            try:
+                assert backend._thread_pool is not None
+                # Force a worker to spin up so its initializer runs. This also
+                # fails loudly (BrokenThreadPool) if the initializer raised.
+                backend._thread_pool.submit(lambda: None).result(timeout=15)
+
+                assert spy_set_device.call_args_list, (
+                    f"pool initializer never selected a device "
+                    f"(dst_device={dst_device!r})"
+                )
+                expected = torch.cuda.current_device()
+                for call in spy_set_device.call_args_list:
+                    got = call.args[0]
+                    assert got == expected, (
+                        f"pool initialized on device {got!r}, expected "
+                        f"{expected!r} for dst_device={dst_device!r}"
+                    )
+            finally:
+                backend.close()

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -619,7 +619,7 @@ class TestGdsBackend:
             temp_gds_path, async_loop, extra_config={"disk_io_threads": 0}
         )
         try:
-            assert not backend.use_thread_pool
+            assert backend.use_thread_pool
             keys = [create_test_key(i) for i in range(3)]
             results = backend.batched_get_blocking(keys)
             assert results == [None, None, None]
@@ -1060,3 +1060,159 @@ def test_pack_unpack_metadata_multiple_dtypes():
         assert nbytes == tensor.numel() * tensor.element_size()
         assert fmt == MemoryFormat.KV_2LTD
         assert extra["tag"] == "test"
+
+
+def test_use_gds_false_uses_plain_gpu_allocator(temp_gds_path, async_loop):
+    """With use_gds=False, GdsBackend uses a plain GPUMemoryAllocator and the
+    POSIX-fallback memcpy, requiring neither cuFile nor hipFile libraries."""
+    # First Party
+    from lmcache.v1.memory_allocators.gpu_memory_allocator import (
+        GPUMemoryAllocator,
+    )
+
+    config = create_test_config(temp_gds_path)
+    config.use_gds = False
+    metadata = create_test_metadata()
+
+    fake_memcpy = mock.MagicMock()
+    with (
+        mock.patch(
+            "lmcache.v1.storage_backend.gds_backend.get_fstype",
+            return_value="ext4",
+        ),
+        mock.patch(
+            "lmcache.v1.storage_backend.gds_backend._load_gpu_memcpy",
+            return_value=fake_memcpy,
+        ) as load_rt,
+    ):
+        backend = GdsBackend(
+            config=config,
+            loop=async_loop,
+            metadata=metadata,
+            dst_device="cuda:0",
+        )
+        try:
+            load_rt.assert_called_once()
+            assert not backend.use_gds
+            assert backend.gds_module is None
+            assert isinstance(backend.memory_allocator, GPUMemoryAllocator)
+            # Plain GPU allocator has no registered base pointer, so the
+            # fallback copies straight into each tensor's data_ptr.
+            assert backend.gds_base_pointer is None
+            # The batched-I/O thread pool is enabled even when use_gds is False
+            # so batched_get_blocking fetches chunks in parallel.
+            assert backend.use_thread_pool is True
+            assert backend._thread_pool is not None
+        finally:
+            backend.close()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="POSIX round-trip needs a GPU for host<->device memcpy",
+)
+@pytest.mark.skipif(sys.platform != "linux", reason="Runs only on Linux")
+def test_use_gds_false_save_load_roundtrip(temp_gds_path, async_loop):
+    """use_gds=false POSIX fallback round-trips KV bytes correctly.
+
+    Stores three chunks (so the 2nd and 3rd get a nonzero in-pool address) and
+    reads them back via ``batched_get_blocking`` (the parallel thread-pool
+    path, which is enabled for use_gds=false), asserting byte-for-byte
+    equality.  This guards against ``_save_gds`` copying from the raw
+    ``device_offset`` instead of the resolved ``dev_offset`` (which is 0 when
+    the plain ``GPUMemoryAllocator`` is used): with that bug the non-first
+    chunks read the wrong device region and the round-trip data mismatches.
+    """
+    config = create_test_config(temp_gds_path)
+    config.use_gds = False
+    metadata = create_test_metadata()
+    backend = GdsBackend(
+        config=config, loop=async_loop, metadata=metadata, dst_device="cuda:0"
+    )
+    try:
+        shape = torch.Size([2, 4, 8, 16])
+        dtype = torch.bfloat16
+        keys = [create_test_key(i) for i in range(3)]
+
+        # Allocate all objects up front so each keeps a distinct pool address;
+        # fill each with distinct known data.
+        objs = []
+        refs = []
+        for _ in keys:
+            obj = backend.allocate(shape, dtype)
+            assert obj is not None
+            ref = (torch.rand(tuple(shape), device="cuda") * 100).to(dtype)
+            obj.tensor.copy_(ref)
+            objs.append(obj)
+            refs.append(ref)
+
+        # The bug only manifests for chunks with a nonzero address, so make
+        # sure the fixture actually exercises that case.
+        assert any(obj.metadata.address != 0 for obj in objs[1:])
+
+        for key, obj in zip(keys, objs, strict=True):
+            future = backend.submit_put_task(key, obj)
+            future.result(timeout=15)
+
+        for key in keys:
+            assert backend.contains(key)
+
+        # Read all chunks back through the parallel thread-pool path.
+        loaded = backend.batched_get_blocking(keys)
+        assert len(loaded) == len(keys)
+        for obj, ref in zip(loaded, refs, strict=True):
+            assert obj is not None
+            torch.testing.assert_close(obj.tensor, ref)
+    finally:
+        backend.close()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Runs only on Linux")
+def test_direct_io_alignment_and_open_fallback(temp_gds_path, async_loop):
+    """O_DIRECT gating on the use_gds=false path.
+
+    ``_direct_io_aligned`` must accept only block-aligned values, and
+    ``_os_open_maybe_direct`` must never apply O_DIRECT when the caller does not
+    ask for it or when O_DIRECT has been marked unsupported — always returning a
+    usable buffered fd instead of raising.
+    """
+    # First Party
+    from lmcache.v1.storage_backend.gds_backend import _DIRECT_IO_ALIGN
+
+    config = create_test_config(temp_gds_path)
+    config.use_gds = False
+    metadata = create_test_metadata()
+    with (
+        mock.patch(
+            "lmcache.v1.storage_backend.gds_backend.get_fstype",
+            return_value="ext4",
+        ),
+        mock.patch(
+            "lmcache.v1.storage_backend.gds_backend._load_gpu_memcpy",
+            return_value=mock.MagicMock(),
+        ),
+    ):
+        backend = GdsBackend(
+            config=config, loop=async_loop, metadata=metadata, dst_device="cuda:0"
+        )
+    try:
+        # Alignment gate.
+        assert backend._direct_io_aligned(_DIRECT_IO_ALIGN, 2 * _DIRECT_IO_ALIGN)
+        assert backend._direct_io_aligned(0)
+        assert not backend._direct_io_aligned(_DIRECT_IO_ALIGN, 2048)
+
+        probe = os.path.join(temp_gds_path, "odirect_probe.bin")
+        # want_direct=False -> plain buffered open.
+        fd, is_direct = backend._os_open_maybe_direct(
+            probe, os.O_WRONLY | os.O_CREAT, False
+        )
+        os.close(fd)
+        assert is_direct is False
+
+        # O_DIRECT marked unsupported -> never applied even when requested.
+        backend._direct_io_supported = False
+        fd, is_direct = backend._os_open_maybe_direct(probe, os.O_RDONLY, True)
+        os.close(fd)
+        assert is_direct is False
+    finally:
+        backend.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an **O_DIRECT + pinned-host-buffer POSIX fallback** to `GdsBackend`, so the backend performs well on hosts without GPUDirect Storage (`use_gds: false`) and works on filesystems where the current implementation cannot run at all.

Two concrete problems with the existing `use_gds: false` path:

1. It writes via a `MAP_SHARED` writable `mmap`. Parallel/network filesystems and FUSE-backed mounts reject shared writable mappings with `EOPNOTSUPP`, so the fallback simply fails there.
2. It stages through pageable memory, forcing the driver to bounce through its own internal pinned buffer before the `cudaMemcpy`/`hipMemcpy`.

This replaces the mmap with a per-thread **pinned** host buffer plus a single `pwrite`/`preadv`, optionally with `O_DIRECT` (new `extra_config.use_direct_io`) to bypass the page cache. Pinned staging makes the host↔device copy a full-bandwidth DMA. Unaligned transfers, or a filesystem that refuses `O_DIRECT`, degrade to buffered I/O automatically. `use_gds: false` also now uses a plain `GPUMemoryAllocator`, so the path no longer depends on cuFile being loadable.

The original implementation is by **Jason Goldschmidt** (first commit; his `Signed-off-by` is preserved, with mine as relayer). It was written against an older `dev`, so I rebased it onto current `dev` and **dropped the parts upstream has since implemented independently** — the CUDA/ROCm memcpy loader (#3970, more robust than the original's `torch.version.hip` dispatch) and enabling the thread pool for both datapaths (#4067). That removed roughly a quarter of the original diff.

The second commit fixes defects found in review and during live testing:

- **Pinned-buffer tracking crash.** `_get_pinned_buffer` tracked buffers in a `list` and called `list.remove(old_buf)` on growth. `list.remove` compares with `==`, which on tensors yields a tensor and then raises `RuntimeError` from `bool()` as soon as another thread's buffer precedes it — and `RuntimeError` is not caught by the surrounding `except ValueError`. In `_load_gds` that is swallowed into `return -1`, which makes the caller evict the entry, so the symptom is **silent cache loss**. Reproduced with torch 2.11: 3 of 4 threads raise. Now keyed by thread id.
- **O_DIRECT was silently non-deterministic.** `torch.empty(pin_memory=True)` does not guarantee page alignment — the caching pinned allocator sub-allocates, so after one unaligned-sized request later pointers come back offset (observed 2048, 2560). `_direct_io_aligned` then rejects every transfer and O_DIRECT quietly degrades to buffered based on nothing but allocation history. Surfaced as a test-ordering failure. Fixed by over-allocating one alignment unit and returning an aligned view.
- **Missing save guard.** `_save_gds` had no `else` for "neither GDS module nor GPU memcpy available": it wrote nothing, then failed in `os.rename` with a `FileNotFoundError` for a temp file never created, after the caller was told the chunk was persisted. Now raises explicitly, mirroring `_load_gds`. The `pwrite` loop also gained a no-progress guard, and a failed save unlinks its partial temp file.
- **O_DIRECT refusal was under-detected.** Only `EINVAL` was latched. The filesystems this fallback targets refuse with `EOPNOTSUPP`/`ENOTSUP` or `EPERM`, which escaped the handler and propagated out — turning graceful degradation into a hard failure exactly where it was needed.
- **Allocator chosen before GDS was resolved.** `initialize_allocator` read `config.use_gds` and ran *before* the fstype-based auto-disable, so the tmpfs/overlayfs path built a `CuFileMemoryAllocator` — requiring libcufile — while the rest of the backend ran the POSIX fallback. libcufile is exactly what may be missing there.
- **Work ran on the wrong CUDA device.** PyTorch's current device is thread-local and defaults to index 0, and neither the `gds-io` pool nor asyncio's executor selected one, so a rank owning e.g. `cuda:3` created a primary CUDA context on `cuda:0` from every I/O thread. The pool now has a device-selecting initializer, and the pinned allocation and both memcpys run in a `torch_dev.device()` context. `dst_device` is resolved to a concrete index first, since `set_device` rejects the index-less `"cuda"` that is its default.

**Special notes for your reviewers**:

- Tested end-to-end against live vLLM (Qwen3-Coder-30B-A3B, TP=1, RTX PRO 6000 Blackwell / sm_120) with the KV store on XFS over a 4-drive NVMe md RAID-0. Full 4K–126,900-token TTFT sweep, 30 passes, re-run after each fix: 0 errors, 0 unaligned fallbacks, 0 `O_DIRECT` rejections — i.e. O_DIRECT used for every I/O. Performance flat across all iterations (126,900-token hot TTFT ~1,255–1,274 ms), so none of the fixes cost anything.
- The pre-existing `test_use_gds_false_save_load_roundtrip` uses a 2048-byte chunk, so its transfers are unaligned and every I/O took the *buffered* branch — the O_DIRECT path had **no** coverage. Added an aligned round-trip test asserting `O_DIRECT` actually reaches `os.open`, plus regression tests for the pinned-buffer crash, the errno latch (with `EINVAL` kept as a control), the fstype auto-disable allocator, and the device targeting. Each was confirmed to fail without its corresponding fix.
- **On partial O_DIRECT transfers:** an earlier review round flagged that the read/write retry loops would use unaligned offsets after a short transfer. On investigation this is not reachable — Linux requires O_DIRECT transfers to be a multiple of the device logical block size (512 here, verified empirically: `len=512` and `off=512` are accepted, `len=1000` and `off=1000` return `EINVAL`), so a partial count is necessarily block-aligned and the continuation stays valid. No change made; noting it so the next reviewer doesn't re-derive it.
- Remaining known gaps, happy to address here or as follow-ups: `close()` does not free pinned buffers held by asyncio executor threads (only pool threads exit); user docs for `use_direct_io` are not updated; and the D2H copy is not explicitly stream-ordered against the producer stream.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests


