### PR TITLE
[Fix][CI] Fix two 2026-07-30 dependency breakages in vLLM CI installs

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -112,10 +112,22 @@ if [[ -n "${PINNED_VLLM_VERSION:-}" ]]; then
         PINNED_VLLM_INDEX_ARGS+=(--extra-index-url "${archive_url}")
     fi
 else
-    VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]"
+    # ">=0.0.0.dev0" is an explicit pre-release specifier: under uv's
+    # default if-necessary-or-explicit strategy it opts vllm (and only
+    # vllm) into pre-releases, which is required to pick up nightly dev
+    # wheels. The pinned branch above needs nothing extra -- an exact ==
+    # pin to a dev/rc version is itself an explicit pre-release specifier.
+    #
+    # Do NOT add a global --pre to the install below: it drags every
+    # transitive dep onto pre-releases too. NVIDIA placeholder packages
+    # (e.g. cuda-tile, via vllm -> flashinfer-python) publish their PyPI
+    # stub sdist before the real wheels finish uploading to
+    # pypi.nvidia.com, and any install during that window dies with
+    # "Didn't find wheel for cuda-tile X.Y.ZrcN" (build #3805).
+    VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0"
     echo "Installing latest vLLM nightly (no pin)"
 fi
-uv pip install -U "${VLLM_INSTALL_SPEC}" --pre \
+uv pip install -U "${VLLM_INSTALL_SPEC}" \
     --reinstall-package transformers \
     --reinstall-package tokenizers \
     --reinstall-package huggingface-hub \

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -112,18 +112,8 @@ if [[ -n "${PINNED_VLLM_VERSION:-}" ]]; then
         PINNED_VLLM_INDEX_ARGS+=(--extra-index-url "${archive_url}")
     fi
 else
-    # ">=0.0.0.dev0" is an explicit pre-release specifier: under uv's
-    # default if-necessary-or-explicit strategy it opts vllm (and only
-    # vllm) into pre-releases, which is required to pick up nightly dev
-    # wheels. The pinned branch above needs nothing extra -- an exact ==
-    # pin to a dev/rc version is itself an explicit pre-release specifier.
-    #
-    # Do NOT add a global --pre to the install below: it drags every
-    # transitive dep onto pre-releases too. NVIDIA placeholder packages
-    # (e.g. cuda-tile, via vllm -> flashinfer-python) publish their PyPI
-    # stub sdist before the real wheels finish uploading to
-    # pypi.nvidia.com, and any install during that window dies with
-    # "Didn't find wheel for cuda-tile X.Y.ZrcN" (build #3805).
+    # ">=0.0.0.dev0" explicitly limits vLLM to be the only pre-release
+    # package.
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0"
     echo "Installing latest vLLM nightly (no pin)"
 fi

--- a/.buildkite/pipelines/end-to-end-tests.yml
+++ b/.buildkite/pipelines/end-to-end-tests.yml
@@ -13,7 +13,11 @@ steps:
       uv pip install -e . --no-build-isolation
       uv pip install matplotlib
       uv pip install pandas
-      uv pip install -U vllm --pre --extra-index-url https://wheels.vllm.ai/nightly
+      # ">=0.0.0.dev0" opts vllm (and only vllm) into pre-releases so the
+      # nightly dev wheel resolves. A global --pre would also pull NVIDIA
+      # placeholder packages (cuda-tile etc.) onto brand-new rc versions
+      # whose real wheels may not be on pypi.nvidia.com yet.
+      uv pip install -U "vllm>=0.0.0.dev0" --extra-index-url https://wheels.vllm.ai/nightly
       uv pip freeze
 
 

--- a/.buildkite/pipelines/end-to-end-tests.yml
+++ b/.buildkite/pipelines/end-to-end-tests.yml
@@ -13,10 +13,7 @@ steps:
       uv pip install -e . --no-build-isolation
       uv pip install matplotlib
       uv pip install pandas
-      # ">=0.0.0.dev0" opts vllm (and only vllm) into pre-releases so the
-      # nightly dev wheel resolves. A global --pre would also pull NVIDIA
-      # placeholder packages (cuda-tile etc.) onto brand-new rc versions
-      # whose real wheels may not be on pypi.nvidia.com yet.
+      # ">=0.0.0.dev0" explicitly limits vLLM to be the only pre-release package.
       uv pip install -U "vllm>=0.0.0.dev0" --extra-index-url https://wheels.vllm.ai/nightly
       uv pip freeze
 

--- a/.github/scripts/install_vllm_cpu.sh
+++ b/.github/scripts/install_vllm_cpu.sh
@@ -35,8 +35,15 @@ VLLM_CPU_NIGHTLY_SPEC="${VLLM_CPU_NIGHTLY_SPEC:-vllm-cpu-nightly}"
 # `--extra-index-url` is required because the wheel pins torch==2.11.0
 # which only lives on the pytorch CPU index. Harmless on macOS.
 ${PIP_BIN} install "numpy<2"
+# Cap apache-tvm-ffi below 0.1.13 (published 2026-07-30): xgrammar's
+# macOS arm64 wheels were built against the 0.1.12 ABI and segfault at
+# import (xgrammar::__TVMFFIStaticInitFunc0) when the 0.1.13 dylib is
+# loaded, which kills `vllm serve` before it can bind its port. Linux
+# happens to load 0.1.13 fine, but both legs get the cap so the whole
+# matrix runs the validated version. Lift the cap once xgrammar ships
+# wheels built against apache-tvm-ffi>=0.1.13.
 # shellcheck disable=SC2086
-${PIP_BIN} install "${VLLM_CPU_NIGHTLY_SPEC}" \
+${PIP_BIN} install "${VLLM_CPU_NIGHTLY_SPEC}" "apache-tvm-ffi<0.1.13" \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   ${PIP_INSTALL_EXTRA_ARGS}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two independent CI outages, both caused by upstream packages published on 2026-07-30. Neither is related to any code in this repo — every PR branch is hitting them.

### 1. Buildkite k3 pipelines: global `--pre` chases NVIDIA rc placeholders

All k3 jobs died in `setup-env.sh` ([build #3805](https://buildkite.com/lmcache/k3-multiprocess-test/builds/3805)) with:

```
Failed to build `cuda-tile==1.6.0rc3`
RuntimeError: Didn't find wheel for cuda-tile 1.6.0rc3
```

Root cause: the vLLM install uses a **global `--pre`** flag, so every transitive dependency may resolve to pre-releases — not just vLLM. When NVIDIA published `cuda-tile 1.6.0rc1`/`1.6.0rc3` to PyPI (pulled in via `vllm → flashinfer-python → cuda-tile>=1.4.0`), uv picked the rc over stable 1.5.0. `cuda-tile` on PyPI is a placeholder sdist that downloads the real wheel from pypi.nvidia.com at install time, and NVIDIA had only uploaded the cp310 wheel for rc3 at that point — CI runs Python 3.12, so the install failed. Build #3803 a few hours earlier passed on `1.6.0rc1` only because that rc's cp312 wheel had already landed; #3805 lost the upload race on rc3. This recurs on every new NVIDIA rc unless the resolver stops chasing them.

Fix: drop `--pre` and opt only vllm into pre-releases:

- **Pinned path** (`vllm==<version>`): needs nothing extra — an exact `==` pin to a dev/rc version is already an explicit pre-release specifier under uv's default `if-necessary-or-explicit` strategy.
- **Unpinned nightly path**: use `vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0` as the explicit per-package opt-in.

Same fix applied to the analogous install in `.buildkite/pipelines/end-to-end-tests.yml`.

Validated all three install paths with `uv pip compile` (py3.12, `x86_64-manylinux_2_28`, same index args as CI):

| Scenario | vllm resolves to | cuda-tile resolves to |
|---|---|---|
| Current (`--pre`, pin 0.26.0) | 0.26.0 | 1.6.0rc3 (reproduces #3805) |
| Fixed, pin 0.26.0 | 0.26.0 | 1.5.0 |
| Fixed, unpinned nightly | 0.26.1rc1.dev158+g… | 1.5.0 |
| Fixed, pin to dev version | 0.26.1rc1.dev158+g… | 1.5.0 |

Also checked that vLLM 0.26.0's 97 declared dependencies contain no pre-release specifiers, so nothing else in the closure relied on the global `--pre`.

### 2. CPU Device Tests (GitHub Actions): apache-tvm-ffi 0.1.13 segfaults xgrammar on macOS

Both macOS legs fail with `vLLM server did not become ready within 300s`; the vLLM log shows a startup segfault:

```
Segmentation fault: 11
  File "<unknown>", line 0, in TVMFFIEnvRegisterCAPI
  File "<unknown>", line 0, in tvm::ffi::reflection::Metadata::ToJSON(...)
  File "<unknown>", line 0, in xgrammar::__TVMFFIStaticInitFunc0()
```

`apache-tvm-ffi 0.1.13` was published 2026-07-30 15:47 UTC — squarely between the last green run (14:44 UTC) and the first red run (16:57 UTC); every run since fails, across all branches. The last passing macOS run differs from the failing ones **only** in `apache-tvm-ffi 0.1.12 → 0.1.13` (same `xgrammar 0.2.3`, same pinned `vllm-cpu-nightly`). xgrammar's macOS arm64 wheel was built against the 0.1.12 ABI and crashes in TVM-FFI static registration when the 0.1.13 dylib is loaded. Linux happens to load 0.1.13 fine (today's ubuntu legs passed with it).

Fix: cap `apache-tvm-ffi<0.1.13` in `install_vllm_cpu.sh` (both OS legs, so the whole matrix runs the validated version). Lift the cap once xgrammar ships wheels built against >=0.1.13.

**Special notes for your reviewers**:

- A plain retry of Buildkite #3805 would pass today (NVIDIA has since uploaded the cp312 rc3 wheels), but without fix 1 the k3 pipelines keep racing NVIDIA's wheel uploads on every new rc.
- The green signal to check on this PR's k3 run is that setup installs `cuda-tile==1.5.0` (not an rc); for the CPU workflow, that the macOS legs pass with `apache-tvm-ffi 0.1.12`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)