### PR TITLE
fix: honour num_external_tokens in MP connector's update_state_after_alloc

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -864,8 +864,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if any(new_block_ids):
             tracker.append_block_ids(tuple(new_block_ids))
 
-        # Update the state of the tracker
-        condition = tracker.needs_retrieve()
+        # Update the state of the tracker.
+        #
+        # num_external_tokens == 0 means MultiConnector picked a different
+        # sub-connector as the winner for this request. Retrieving anyway
+        # double-reports it through get_finished and crashes EngineCore (see
+        # tests/v1/test_mp_connector_multi_connector_selection.py).
+        condition = tracker.needs_retrieve() and num_external_tokens > 0
         if tracker.state == LMCacheMPRequestState.PREFETCHING:
             # If need to retrieve, change to WAITING_FOR_LOAD
             # Otherwise, change to READY

--- a/tests/v1/test_mp_connector_multi_connector_selection.py
+++ b/tests/v1/test_mp_connector_multi_connector_selection.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests that the MP connector honours vLLM's ``num_external_tokens``.
+
+See the comment on ``update_state_after_alloc`` in ``lmcache_mp_connector.py``
+for why a losing ``MultiConnector`` sub-connector must not retrieve. These
+tests drive that method directly with the scheduler adapter stubbed out.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
+
+# Third Party
+from vllm.v1.utils import ConstantList  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+    LMCacheMPRequestState,
+    LMCacheMPRequestTracker,
+)
+
+TOKENS_PER_CHUNK = 256
+
+
+class _FakeRequest:
+    """Duck-typed vLLM Request carrying only what the tracker reads."""
+
+    def __init__(self, request_id: str, num_tokens: int):
+        self.request_id = request_id
+        self.cache_salt = ""
+        self.prompt_token_ids = list(range(num_tokens))
+        self._live_token_ids = list(self.prompt_token_ids)
+        self.all_token_ids = ConstantList(self._live_token_ids)
+        self.mm_features: list[object] = []
+
+
+class _FakeBlocks:
+    """Duck-typed ``KVCacheBlocks`` exposing only ``get_block_ids``."""
+
+    def __init__(self, block_ids: tuple[list[int], ...]):
+        self._block_ids = block_ids
+
+    def get_block_ids(self) -> tuple[list[int], ...]:
+        return self._block_ids
+
+
+def _make_connector_and_tracker(
+    *,
+    num_vllm_hit_tokens: int,
+    num_lmcache_hit_tokens: int,
+) -> tuple[LMCacheMPConnector, LMCacheMPRequestTracker, _FakeRequest]:
+    """Connector/tracker pair in the post-lookup PREFETCHING state, with
+    ``__init__`` bypassed since it would otherwise talk to a cache server."""
+    request = _FakeRequest("req-0", num_lmcache_hit_tokens)
+    tracker = LMCacheMPRequestTracker(request)
+    tracker.num_vllm_hit_tokens = num_vllm_hit_tokens
+    tracker.num_lmcache_hit_tokens = num_lmcache_hit_tokens
+    tracker.state = LMCacheMPRequestState.PREFETCHING
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector.request_trackers = {request.request_id: tracker}
+    connector.scheduler_adapter = MagicMock(name="scheduler_adapter")
+    connector.scheduler_adapter.lmcache_tokens_per_chunk = TOKENS_PER_CHUNK
+    return connector, tracker, request
+
+
+def test_losing_connector_emits_no_retrieve():
+    """``num_external_tokens == 0`` with a hit means another connector won."""
+    connector, tracker, request = _make_connector_and_tracker(
+        num_vllm_hit_tokens=TOKENS_PER_CHUNK,
+        num_lmcache_hit_tokens=TOKENS_PER_CHUNK * 3,
+    )
+
+    connector.update_state_after_alloc(request, _FakeBlocks(([0, 1, 2],)), 0)
+
+    assert tracker.state is LMCacheMPRequestState.READY
+
+
+def test_losing_connector_releases_every_lookup_lock():
+    """The cancelled retrieve would have released the tail locks; do it here."""
+    connector, tracker, request = _make_connector_and_tracker(
+        num_vllm_hit_tokens=TOKENS_PER_CHUNK,
+        num_lmcache_hit_tokens=TOKENS_PER_CHUNK * 3,
+    )
+
+    connector.update_state_after_alloc(request, _FakeBlocks(([0, 1, 2],)), 0)
+
+    kwargs = connector.scheduler_adapter.free_lookup_locks.call_args.kwargs
+    assert kwargs["start"] == 0
+    assert kwargs["end"] == TOKENS_PER_CHUNK * 3
+
+
+def test_winning_connector_still_retrieves():
+    """A non-zero count means this connector was selected."""
+    connector, tracker, request = _make_connector_and_tracker(
+        num_vllm_hit_tokens=TOKENS_PER_CHUNK,
+        num_lmcache_hit_tokens=TOKENS_PER_CHUNK * 3,
+    )
+
+    connector.update_state_after_alloc(
+        request, _FakeBlocks(([0, 1, 2],)), TOKENS_PER_CHUNK * 2
+    )
+
+    assert tracker.state is LMCacheMPRequestState.WAITING_FOR_LOAD
+    kwargs = connector.scheduler_adapter.free_lookup_locks.call_args.kwargs
+    assert kwargs["end"] == TOKENS_PER_CHUNK
+
+
+def test_zero_tokens_without_a_hit_is_unchanged():
+    """Single-connector deployments pass 0 whenever the lookup missed."""
+    connector, tracker, request = _make_connector_and_tracker(
+        num_vllm_hit_tokens=0,
+        num_lmcache_hit_tokens=0,
+    )
+
+    connector.update_state_after_alloc(request, _FakeBlocks(([0],)), 0)
+
+    assert tracker.state is LMCacheMPRequestState.READY
+    connector.scheduler_adapter.free_lookup_locks.assert_not_called()


### PR DESCRIPTION
**What this PR does / why we need it**:

`LMCacheMPConnector.update_state_after_alloc` never reads its `num_external_tokens` argument — it decides whether to retrieve purely from its own lookup result. That breaks vLLM's `MultiConnector`, which is winner-takes-all: the first sub-connector whose `get_num_new_matched_tokens` returns a non-zero count is assigned the request, and every other sub-connector is called with `(empty_blocks, 0)` to say it contributes nothing.

A losing LMCache connector therefore still enters `WAITING_FOR_LOAD`, has `build_connector_meta` emit retrieve metadata, performs the load, and reports the request through `get_finished`. The winner reports the same request id, and `MultiConnector.get_finished` de-duplicates only `finished_sending`, never `finished_recving`. The scheduler then sees the request twice:

1. first report — status is `WAITING_FOR_REMOTE_KVS`, so the request is promoted and rescheduled;
2. second report — status is now `RUNNING`, which trips

```
File "vllm/v1/core/sched/scheduler.py", in _update_from_kv_xfer_finished
    assert RequestStatus.is_finished(req.status)
AssertionError
```

killing EngineCore. The API server then returns `500 EngineDeadError` for every subsequent request.

This PR gates `condition` on `num_external_tokens > 0` so a losing connector falls through to the existing "no retrieve needed" branch. That branch also releases **every** lock the lookup took (`free_end = tracker.num_lmcache_hit_tokens`), which is exactly what we want once the retrieve that would have released the tail is cancelled — otherwise the server holds those chunk read locks until TTL expiry and cannot evict them.

**Special notes for your reviewers**:

*How it was found.* Reproduced deterministically on a prefill/decode disaggregated deployment with `MultiConnector` wrapping `[NixlConnector, LMCacheMPConnector]` (nixl first). Every request that both connectors matched killed the decode EngineCore. Wrapping each sub-connector's `get_finished` showed both reporting the same request id in consecutive scheduler steps:

```
[1] LMCacheMPConnector.get_finished -> recving=['cmpl-...-0-9d1eed60']
    scheduler: recving=[...] status={'cmpl-...': 'WAITING_FOR_REMOTE_KVS'}   <- ok
[0] NixlConnector.get_finished     -> recving=['cmpl-...-0-9d1eed60']
    scheduler: recving=[...] status={'cmpl-...': 'RUNNING'}                  <- AssertionError
```

Note the ordering: LMCache reported first even though it is the *second* connector, because its shared-memory load completes faster than the RDMA transfer. So this is a race between the two loads, not an ordering artifact — reversing the connector list does not avoid it.

*Why the guard is safe for single-connector deployments.* There, `num_external_tokens` is the value we ourselves returned from `get_num_new_matched_tokens`, so it is zero only when the lookup found nothing — and `needs_retrieve()` is already `False` in that case, making the added term a no-op. The second `update_state_after_alloc` call that the docstring describes (after an async load completes) also passes `0`, but by then the tracker is no longer `PREFETCHING`, so the whole block is skipped regardless.

*Effect once fixed.* On the deployment above, with a 2560-token prompt whose first 2048 tokens were in LMCache:

| | before (crash) | after |
|---|---|---|
| prefill computed tokens | — | 512 (2048 from LMCache) |
| decode computed tokens | — | 0 (2560 via nixl) |
| total | — | **512** |

Generated output was verified token-identical to a reference instance running with no KV connector at all (`temperature=0`, deterministic prompt, 3/3 repeats).

*There is a second, independent gap.* `MultiConnector.get_finished` de-duplicating `finished_sending` but not `finished_recving` is a vLLM-side issue; any two async-loading connectors that match the same request can still collide there. That needs a separate fix in vllm-project/vllm — this PR only stops LMCache from being one of the two reporters.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

`tests/v1/test_mp_connector_multi_connector_selection.py` — 4 tests covering: losing connector emits no retrieve; losing connector releases every lookup lock; winning connector still retrieves and only releases the vLLM-computed span; zero-tokens-without-a-hit is unchanged. Verified that the first two fail without the one-line change and pass with it.
