### PR TITLE
[Perf][MP] Pipeline raw-block restores for SGLang

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -24,6 +24,7 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
     DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_MQ_TIMEOUT,
     HeartbeatThread,
+    get_experimental,
     get_lmcache_chunk_size,
     send_lmcache_request,
 )
@@ -37,6 +38,13 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.protocols.engine import (
+    FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY,
+)
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
 from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
 logger = init_logger(__name__)
@@ -44,6 +52,42 @@ logger = init_logger(__name__)
 # Extra seconds the WAIT_PREFETCH_STATUS response is allowed beyond the daemon's
 # own blocking-wait budget, to cover the request/response round trip.
 _WAIT_LOOKUP_RESPONSE_BUFFER_S = 5.0
+
+
+class CompletionEvent:
+    """Backend-neutral imported event retained by the SGLang connector.
+
+    Args:
+        event_backend: Backend that imported and owns ``event``.
+        event: Backend-native imported event.
+        device: Device that owns the event.
+    """
+
+    def __init__(
+        self,
+        event_backend: EventIPCBackend,
+        event: object,
+        device: object,
+    ) -> None:
+        self._event_backend = event_backend
+        self._event = event
+        self._device = device
+
+    def wait_on_stream(self, stream: object) -> None:
+        """Order ``stream`` after this completion event.
+
+        Args:
+            stream: Backend-native consumer stream.
+        """
+        self._event_backend.wait_event(self._event, stream)
+
+    def synchronize(self) -> None:
+        """Block the host until this completion event finishes."""
+        self._event_backend.synchronize_event(self._event, self._device)
+
+
+class FusedRestoreUndrainedError(RuntimeError):
+    """A fused restore may still be writing its destination KV slots."""
 
 
 def _wrap_sglang_kv_caches(
@@ -124,6 +168,8 @@ class LMCacheMPConnector:
       read-lock reservations.
     """
 
+    undrained_error_type = FusedRestoreUndrainedError
+
     def __init__(
         self,
         sgl_config: ModelConfig,
@@ -153,12 +199,37 @@ class LMCacheMPConnector:
         self._health_event = threading.Event()
         self._health_event.set()
         self._pending_lookups: dict[str, _PendingLookup] = {}
+        self._daemon_session_ids: set[str] = set()
         self._pending_lookups_lock = threading.Lock()
+        self._fused_final_events: dict[str, list[CompletionEvent]] = {}
+        self._undrained_fused_requests: set[str] = set()
 
         self.context = zmq.Context.instance()
         self.mq_client = MessageQueueClient(f"tcp://{host}:{port}", self.context)
 
         self._lmcache_chunk_size = get_lmcache_chunk_size(self.mq_client)
+        self._event_backend = get_event_ipc_backend(self.device)
+        self._event_backend.check_event_support(self.device)
+        try:
+            capabilities = get_experimental(
+                self.mq_client,
+                timeout=self._mq_timeout,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to query LMCache MP capabilities; using generic "
+                "LOOKUP/RETRIEVE",
+                exc_info=True,
+            )
+            capabilities = set()
+        local_supports_fused_raw_block_retrieve = (
+            FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY in capabilities
+        )
+        self._supports_fused_raw_block_retrieve = (
+            self._agree_fused_raw_block_capability(
+                local_supports_fused_raw_block_retrieve
+            )
+        )
         if self._lmcache_chunk_size % self.page_size != 0:
             raise ValueError(
                 "LMCache chunk size must be a multiple of SGLang page size, got "
@@ -209,6 +280,27 @@ class LMCacheMPConnector:
     def chunk_size(self) -> int:
         return self._lmcache_chunk_size
 
+    def supports_fused_raw_block_retrieve(self) -> bool:
+        """Return whether the paired daemon advertised fused raw restore."""
+        return self._supports_fused_raw_block_retrieve
+
+    @torch.no_grad()
+    def _agree_fused_raw_block_capability(self, local_supported: bool) -> bool:
+        """Require every TP rank to select the same fused request sequence."""
+        if self.tp_size == 1:
+            return local_supported
+        supported = torch.tensor(
+            [int(local_supported)],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        dist.all_reduce(
+            supported,
+            op=dist.ReduceOp.MIN,
+            group=self.tp_group,
+        )
+        return bool(supported.item())
+
     @torch.no_grad()
     def _global_min_tokens(self, local_tokens: int) -> int:
         if self.tp_size == 1:
@@ -216,6 +308,25 @@ class LMCacheMPConnector:
         t = torch.tensor([local_tokens], dtype=torch.int32, device=self.device)
         dist.all_reduce(t, op=dist.ReduceOp.MIN, group=self.tp_group)
         return int(t.item())
+
+    @torch.no_grad()
+    def _global_fused_result(
+        self,
+        local_succeeded: bool,
+        local_tokens: int,
+    ) -> tuple[bool, int]:
+        """Agree on success and the exact token count across TP ranks."""
+        if self.tp_size == 1:
+            return local_succeeded, local_tokens
+        result = torch.tensor(
+            [int(local_succeeded), local_tokens, -local_tokens],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        dist.all_reduce(result, op=dist.ReduceOp.MIN, group=self.tp_group)
+        min_tokens = int(result[1].item())
+        max_tokens = -int(result[2].item())
+        return bool(result[0].item()) and min_tokens == max_tokens, min_tokens
 
     def _create_key(
         self,
@@ -388,17 +499,44 @@ class LMCacheMPConnector:
         not bundled into ``store_kv``. Skipped (no wire send) for ids
         we never fired a LOOKUP for, so warmup and short-prompt
         requests don't trigger the daemon's "Session not found,
-        skipping touch" warning. Frees any still-held read locks
-        before sending END_SESSION (covers failure paths where
-        retrieve_kv didn't consume the locks).
+        skipping touch" warning. Fused restores and stores also create daemon
+        hash sessions without pending lookup locks, so their ids are tracked
+        separately. Frees any still-held read locks before sending END_SESSION
+        (covers failure paths where retrieve_kv didn't consume the locks).
         """
+        # Keep every imported final event alive by request id and
+        # host-synchronize it on this cold teardown path before END_SESSION
+        # releases the server-side exporter.
+        with self._pending_lookups_lock:
+            needs_server_drain = request_id in self._undrained_fused_requests
+        if needs_server_drain:
+            try:
+                self._drain_fused_raw_block_retrieve(request_id)
+            except Exception as error:
+                raise FusedRestoreUndrainedError(
+                    "LMCache could not prove fused writes completed before "
+                    f"ending request_id={request_id}"
+                ) from error
+            with self._pending_lookups_lock:
+                self._undrained_fused_requests.discard(request_id)
+
+        with self._pending_lookups_lock:
+            final_events = tuple(self._fused_final_events.get(request_id, ()))
+        for final_event in final_events:
+            final_event.synchronize()
+
         if not self.is_healthy:
+            with self._pending_lookups_lock:
+                self._fused_final_events.pop(request_id, None)
             return
         with self._pending_lookups_lock:
             pending = self._pending_lookups.pop(request_id, None)
-        if pending is None:
+            daemon_session_exists = request_id in self._daemon_session_ids
+            self._daemon_session_ids.discard(request_id)
+            self._fused_final_events.pop(request_id, None)
+        if pending is None and not daemon_session_exists and not final_events:
             return
-        if pending.locks_held and pending.matched_token_num > 0:
+        if pending is not None and pending.locks_held and pending.matched_token_num > 0:
             self._free_lookup_locks(
                 pending.token_ids, 0, pending.matched_token_num, request_id
             )
@@ -411,11 +549,10 @@ class LMCacheMPConnector:
         offset: int,
         matched_end: int,
         block_ids: list[int],
-        skip_prefix_n_blocks: int = 0,
-    ):
-        event = torch_dev.Event(interprocess=True)
-        event.record(torch_dev.current_stream())
-        return send_lmcache_request(
+        skip_first_n_tokens: int = 0,
+    ) -> MessagingFuture[bool]:
+        event, event_handle = self._create_producer_event()
+        future = send_lmcache_request(
             self.mq_client,
             RequestType.RETRIEVE,
             [
@@ -429,35 +566,224 @@ class LMCacheMPConnector:
                 # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
                 # non-hybrid, so wrap the flat list as a single group.
                 [block_ids],
-                event.ipc_handle(),
-                skip_prefix_n_blocks,
+                event_handle,
+                skip_first_n_tokens,
             ],
         ).to_device_future(device=self.device)
+        future._export_event = event  # type: ignore[attr-defined]
+        return future
+
+    def _submit_fused_raw_block_retrieve(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        offset: int,
+        aligned_end: int,
+        block_ids: list[int],
+        prefix_pad: int,
+    ) -> MessagingFuture[tuple[bytes, tuple[int, bool]]]:
+        """Submit fused restore while retaining its producer IPC event."""
+        event, event_handle = self._create_producer_event()
+        with self._pending_lookups_lock:
+            self._daemon_session_ids.add(request_id)
+        future = send_lmcache_request(
+            self.mq_client,
+            RequestType.FUSED_RAW_BLOCK_RETRIEVE,
+            [
+                self._create_key(
+                    token_ids,
+                    start=offset,
+                    end=aligned_end,
+                    request_id=request_id,
+                ),
+                self.instance_id,
+                [block_ids],
+                event_handle,
+                prefix_pad,
+            ],
+        )
+        # The daemon may not have imported the handle when this helper returns.
+        future._export_event = event  # type: ignore[attr-defined]
+        return future
+
+    def _drain_fused_raw_block_retrieve(self, request_id: str) -> None:
+        """Synchronize daemon writes when no final IPC event was importable."""
+        drained = send_lmcache_request(
+            self.mq_client,
+            RequestType.FUSED_RAW_BLOCK_DRAIN,
+            [request_id, self.worker_id],
+        ).result(timeout=self._mq_timeout)
+        if not drained:
+            raise RuntimeError(
+                "LMCache daemon could not find a final event to drain for "
+                f"request_id={request_id}, worker_id={self.worker_id}"
+            )
+
+    def _retrieve_fused_raw_block(self, load_metadata: LoadMetadata) -> int:
+        """Run a fused restore and order the load stream after its final event."""
+        local_succeeded = False
+        local_tokens = 0
+        local_error: Exception | None = None
+        final_event: CompletionEvent | None = None
+        fused_submitted = False
+
+        if not self.is_healthy:
+            local_error = RuntimeError(
+                "LMCache fused raw-block retrieve skipped on an unhealthy "
+                f"rank for request_id={load_metadata.request_id}"
+            )
+        else:
+            try:
+                token_ids = load_metadata.token_ids
+                offset = load_metadata.offset
+                aligned_end = (len(token_ids) // self._lmcache_chunk_size) * (
+                    self._lmcache_chunk_size
+                )
+                if aligned_end <= offset:
+                    local_succeeded = True
+                else:
+                    prefix_pad = load_metadata.prefix_pad
+                    fresh_start = offset + prefix_pad
+                    prefix_pad_pages = prefix_pad // self.page_size
+                    fresh_block_ids = self._slot_mapping_to_block_ids(
+                        load_metadata.slot_mapping[fresh_start:aligned_end]
+                    )
+                    block_ids = [0] * prefix_pad_pages + fresh_block_ids
+
+                    future = self._submit_fused_raw_block_retrieve(
+                        request_id=load_metadata.request_id,
+                        token_ids=token_ids,
+                        offset=offset,
+                        aligned_end=aligned_end,
+                        block_ids=block_ids,
+                        prefix_pad=prefix_pad,
+                    )
+                    fused_submitted = True
+                    response: tuple[bytes, tuple[int, bool]] | None
+                    try:
+                        response = future.result(timeout=self._mq_timeout)
+                    except Exception as error:
+                        local_error = error
+                        # Do not wait forever on the original RPC. A
+                        # rank-specific drain request is queued behind it on
+                        # the same client-identity affinity FIFO.
+                        response = None
+
+                    if response is not None:
+                        final_handle, result = response
+                        final_event = self._import_completion_event(final_handle)
+                        if local_error is None:
+                            local_tokens, local_succeeded = result
+                            max_tokens = aligned_end - offset
+                            if (
+                                local_tokens < 0
+                                or local_tokens > max_tokens
+                                or local_tokens % self._lmcache_chunk_size != 0
+                            ):
+                                local_error = RuntimeError(
+                                    "LMCache fused raw-block retrieve returned "
+                                    f"invalid token count {local_tokens}"
+                                )
+                                local_succeeded = False
+                    if not local_succeeded and local_error is None:
+                        local_error = RuntimeError(
+                            "LMCache fused raw-block retrieve failed for "
+                            f"request_id={load_metadata.request_id}"
+                        )
+            except Exception as error:
+                if local_error is None:
+                    local_error = error
+
+        if fused_submitted and final_event is None:
+            try:
+                self._drain_fused_raw_block_retrieve(load_metadata.request_id)
+                with self._pending_lookups_lock:
+                    self._undrained_fused_requests.discard(load_metadata.request_id)
+            except Exception as drain_error:
+                original_error = local_error
+                local_error = FusedRestoreUndrainedError(
+                    "LMCache fused raw-block retrieve failed before importing "
+                    "its final event, and the server-side drain failed for "
+                    f"request_id={load_metadata.request_id}"
+                )
+                local_error.__cause__ = drain_error
+                if original_error is not None:
+                    local_error.add_note(f"Original fused error: {original_error}")
+                with self._pending_lookups_lock:
+                    self._undrained_fused_requests.add(load_metadata.request_id)
+
+        collective_error: Exception | None = None
+        try:
+            global_succeeded, global_tokens = self._global_fused_result(
+                local_succeeded,
+                local_tokens,
+            )
+        except Exception as error:
+            collective_error = error
+            global_succeeded, global_tokens = False, 0
+
+        if (
+            local_error is not None
+            or collective_error is not None
+            or not global_succeeded
+        ):
+            if final_event is not None:
+                final_event.synchronize()
+        if local_error is not None:
+            raise local_error
+        if collective_error is not None:
+            raise collective_error
+        if not global_succeeded:
+            raise RuntimeError(
+                "LMCache fused raw-block retrieve failed on another TP rank for "
+                f"request_id={load_metadata.request_id}"
+            )
+
+        if final_event is None:
+            # No wire operation is possible only for an empty aligned range.
+            return global_tokens
+        with self._pending_lookups_lock:
+            self._fused_final_events.setdefault(
+                load_metadata.request_id,
+                [],
+            ).append(final_event)
+        final_event.wait_on_stream(torch_dev.current_stream())
+        return global_tokens
+
+    def _create_producer_event(self) -> tuple[object, bytes]:
+        """Record and export an event on the active SGLang stream."""
+        event = self._event_backend.create_event(self.device)
+        self._event_backend.record_event(event, torch_dev.current_stream())
+        return event, self._event_backend.export_event(event, self.device)
+
+    def _import_completion_event(self, handle: bytes) -> CompletionEvent:
+        """Import one daemon event through the selected platform backend."""
+        event = self._event_backend.import_event(handle, self.device)
+        return CompletionEvent(self._event_backend, event, self.device)
 
     def retrieve_kv(self, load_metadata: LoadMetadata) -> int:
-        """Phase 2 of the two-phase load — fires RETRIEVE only.
+        """Restore matched KV into SGLang's allocated accelerator slots.
 
-        Reuses the matched-token count cached by a prior ``lookup_kv``
-        for the same ``request_id`` (no second LOOKUP wire call). The
-        daemon's RETRIEVE handler copies L1 (DRAM) → GPU KV pool slots
-        in a single ``multi_layer_block_kv_transfer`` launch and
-        consumes the held read locks via ``finish_read_prefetched`` —
-        we don't separately free them on the success path.
+        The fused path resolves the actual contiguous raw-block prefix during
+        restore and returns one final completion event. The generic path reuses
+        the matched-token count cached by a prior ``lookup_kv``.
 
         Failure paths free the still-held trailing read locks
         explicitly to avoid leaking them in the daemon.
 
-        Returns ``matched - offset`` (tokens covered by the chunks
-        whose RETRIEVE was issued, equivalent to the legacy
-        ``start_load_kv`` return). Caller subtracts ``prefix_pad`` to
-        compute "newly added to radix".
-        """
-        if not self.is_healthy:
-            return 0
+        Args:
+            load_metadata: Token range, destination slots, and request id.
 
+        Returns:
+            Tokens covered from the chunk-aligned restore offset.
+        """
         request_id = load_metadata.request_id
         with self._pending_lookups_lock:
             pending = self._pending_lookups.get(request_id)
+        if pending is None and self._supports_fused_raw_block_retrieve:
+            return self._retrieve_fused_raw_block(load_metadata)
+        if not self.is_healthy:
+            return 0
         if pending is None or not pending.locks_held:
             raise RuntimeError(
                 f"retrieve_kv called for {request_id} without a pending lookup_kv"
@@ -470,10 +796,10 @@ class LMCacheMPConnector:
         # ``slot_mapping[offset : offset + prefix_pad)`` is sentinel ``-1`` —
         # those tokens already live in the engine's radix tree and must not
         # be overwritten. We still RETRIEVE the full chunk-aligned range
-        # (LMCache stores at chunk granularity), but tell the daemon to skip
-        # the leading ``prefix_pad // page_size`` blocks. Real block_ids are
-        # computed only from the freshly-allocated slot range; the skipped
-        # blocks get harmless placeholder ids the kernel never dereferences.
+        # (LMCache stores at chunk granularity), but pass ``prefix_pad`` in
+        # token units as required by the protocol. Real block_ids are computed
+        # only from the freshly-allocated slot range; skipped pages get
+        # harmless placeholder ids the kernel never dereferences.
         prefix_pad = load_metadata.prefix_pad
         fresh_start = offset + prefix_pad
         prefix_pad_pages = prefix_pad // self.page_size
@@ -497,7 +823,7 @@ class LMCacheMPConnector:
                 offset=offset,
                 matched_end=retrieve_token_num,
                 block_ids=block_ids,
-                skip_prefix_n_blocks=prefix_pad_pages,
+                skip_first_n_tokens=prefix_pad,
             )
             if not future.result(timeout=self._mq_timeout):
                 raise RuntimeError(
@@ -557,8 +883,9 @@ class LMCacheMPConnector:
         block_ids = self._slot_mapping_to_block_ids(
             store_metadata.kv_indices[:aligned_end]
         )
-        event = torch_dev.Event(interprocess=True)
-        event.record(torch_dev.current_stream())
+        event, event_handle = self._create_producer_event()
+        with self._pending_lookups_lock:
+            self._daemon_session_ids.add(request_id)
         future = send_lmcache_request(
             self.mq_client,
             RequestType.STORE,
@@ -573,13 +900,13 @@ class LMCacheMPConnector:
                 # STORE takes per-group block IDs (list[list[int]]); SGLang is
                 # non-hybrid, so wrap the flat list as a single group.
                 [block_ids],
-                event.ipc_handle(),
+                event_handle,
             ],
-        ).to_cuda_future(device=self.device)
-        # Keep the exporting CUDA event alive until the caller releases the
-        # future. Since we return without blocking, the local ``event`` would
+        ).to_device_future(device=self.device)
+        # Keep the exporting device event alive until the caller releases the
+        # future. Since we return without blocking, the local event would
         # otherwise be garbage-collected immediately, destroying the underlying
-        # CUDA event before the daemon imports its IPC handle and waits on it.
+        # event before the daemon imports its IPC handle and waits on it.
         # (Dynamic keepalive attribute; the future type doesn't declare it.)
         future._export_event = event  # type: ignore[attr-defined]
         return future
@@ -598,8 +925,9 @@ class LMCacheMPConnector:
         block_ids = self._slot_mapping_to_block_ids(
             store_metadata.kv_indices[:aligned_end]
         )
-        event = torch_dev.Event(interprocess=True)
-        event.record(torch_dev.current_stream())
+        event, event_handle = self._create_producer_event()
+        with self._pending_lookups_lock:
+            self._daemon_session_ids.add(request_id)
         success = (
             send_lmcache_request(
                 self.mq_client,
@@ -615,7 +943,7 @@ class LMCacheMPConnector:
                     # STORE takes per-group block IDs (list[list[int]]); SGLang is
                     # non-hybrid, so wrap the flat list as a single group.
                     [block_ids],
-                    event.ipc_handle(),
+                    event_handle,
                 ],
             )
             .to_device_future(device=self.device)
@@ -628,7 +956,21 @@ class LMCacheMPConnector:
             raise RuntimeError("LMCache MP store failed")
 
     def reset(self) -> None:
-        pass
+        """Drain and release every request-scoped daemon resource."""
+        with self._pending_lookups_lock:
+            request_ids = sorted(
+                set(self._pending_lookups)
+                | self._daemon_session_ids
+                | set(self._fused_final_events)
+                | self._undrained_fused_requests
+            )
+        for request_id in request_ids:
+            self.end_session(request_id)
+        with self._pending_lookups_lock:
+            self._pending_lookups.clear()
+            self._daemon_session_ids.clear()
+            self._fused_final_events.clear()
+            self._undrained_fused_requests.clear()
 
     def close(self) -> None:
         self.reset()

--- a/lmcache/v1/distributed/internal_api.py
+++ b/lmcache/v1/distributed/internal_api.py
@@ -14,13 +14,21 @@ from lmcache.v1.distributed.api import L1BackendType, ObjectKey
 
 @dataclass(frozen=True)
 class L1MemoryDesc:
-    """
-    Describes the L1 memory buffer registered with an external backend (e.g. Nixl).
+    """Describe the contiguous L1 allocation exposed to external backends.
+
+    Attributes:
+        ptr: Base address of the allocation.
+        size: Total allocation size in bytes.
+        align_bytes: Allocation alignment in bytes.
+        fixed_buffer_registration_size: Stable prefix that a backend may
+            register for the descriptor's full lifetime. Zero disables
+            persistent registration.
     """
 
     ptr: int
     size: int
     align_bytes: int
+    fixed_buffer_registration_size: int = 0
 
 
 @dataclass(frozen=True)

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 # Standard
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 import threading
 
 if TYPE_CHECKING:
@@ -311,8 +311,9 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
         Args:
             config: Validated raw-block adapter configuration.
-            l1_memory_desc: Optional L1 allocation descriptor used to validate
-                O_DIRECT alignment compatibility.
+            l1_memory_desc: Optional L1 allocation descriptor used for
+                O_DIRECT alignment validation and persistent io_uring
+                fixed-buffer registration.
 
         Raises:
             ValueError: If O_DIRECT is enabled and L1 alignment is insufficient.
@@ -345,11 +346,10 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
         try:
             self._core = RawBlockCore(config.to_core_config(), key_namespace="object")
-            if config.io_engine == "io_uring":
-                logger.warning(
-                    "RawBlockL2Adapter: MP raw_block uses io_uring without "
-                    "fixed-buffer registration; zero-copy fixed buffers are "
-                    "disabled unless registered by a future MP allocator path"
+            if l1_memory_desc is not None:
+                self._core.register_l1_fixed_buffers(
+                    l1_memory_desc.ptr,
+                    l1_memory_desc.fixed_buffer_registration_size,
                 )
             self._max_capacity_bytes = int(
                 self._core.report_status().get("usable_capacity_bytes", 0)
@@ -377,6 +377,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
             raise
 
         self._lock = threading.Lock()
+        self._sync_load_cv = threading.Condition(self._lock)
         self._next_task_id: L2TaskId = 0
 
         self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
@@ -386,6 +387,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self._store_inflight_tasks: int = 0
         self._lookup_inflight_tasks: int = 0
         self._load_inflight_tasks: int = 0
+        self._sync_load_inflight: int = 0
 
     def get_store_event_fd(self) -> int:
         """Return the eventfd signaled when store tasks complete."""
@@ -404,6 +406,98 @@ class RawBlockL2Adapter(L2AdapterInterface):
         if self._load_efd is None:
             return -1
         return self._load_efd.fileno()
+
+    def lookup_and_lock_sync(self, keys: list[ObjectKey]) -> list[bool]:
+        """Synchronously look up and lock raw-block objects.
+
+        This MP fast path avoids worker-pool and eventfd round trips when the
+        caller will immediately load the same objects synchronously.
+
+        Args:
+            keys: Object keys to look up and lock.
+
+        Returns:
+            One boolean per key. True means the object exists and remains
+            locked until ``submit_unlock`` is called.
+
+        Raises:
+            RuntimeError: If the adapter is closed.
+        """
+        if not keys:
+            return []
+        specs = [encode_object_key(key) for key in keys]
+        with self._lock:
+            self._raise_if_closed_locked()
+            return self._core.exists_many(
+                [spec.encoded for spec in specs],
+                lock=True,
+            )
+
+    def load_sync(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        *,
+        completion_batch_size: int | None = None,
+        on_batch_loaded: Callable[[int, int], None] | None = None,
+    ) -> list[bool]:
+        """Synchronously batch-load raw-block objects into L1 buffers.
+
+        Args:
+            keys: Object keys to load.
+            objects: Destination memory objects aligned one-to-one with
+                ``keys``.
+            completion_batch_size: Optional logical read completion group size.
+            on_batch_loaded: Optional callback for successfully loaded
+                half-open object ranges.
+
+        Returns:
+            One boolean per key indicating whether its payload was loaded.
+
+        Raises:
+            ValueError: If only one sequence is empty or their lengths differ.
+            RuntimeError: If the adapter is closed.
+        """
+        if not keys and not objects:
+            return []
+        if not keys or not objects:
+            raise ValueError("keys and objects must be non-empty")
+        if len(keys) != len(objects):
+            raise ValueError("keys and objects must have the same length")
+
+        specs = [encode_object_key(key) for key in keys]
+        with self._lock:
+            self._raise_if_closed_locked()
+            self._sync_load_inflight += 1
+        try:
+            load_kwargs: dict[str, Any] = {}
+            if on_batch_loaded is not None:
+                load_kwargs = {
+                    "completion_batch_size": completion_batch_size,
+                    "on_batch_loaded": on_batch_loaded,
+                }
+            results = self._core.load_many_into_batched(
+                [spec.encoded for spec in specs],
+                objects,
+                **load_kwargs,
+            )
+        finally:
+            with self._lock:
+                self._sync_load_inflight -= 1
+                if self._sync_load_inflight == 0:
+                    self._sync_load_cv.notify_all()
+        accessed_keys = [
+            key for key, loaded in zip(keys, results, strict=False) if loaded
+        ]
+        if accessed_keys:
+            try:
+                self._notify_keys_accessed(accessed_keys)
+            except Exception as e:
+                logger.warning(
+                    "RawBlockL2Adapter synchronous access notification failed: %s",
+                    e,
+                )
+        return results
 
     def submit_store_task(
         self,
@@ -487,7 +581,9 @@ class RawBlockL2Adapter(L2AdapterInterface):
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
         """Release L2 locks acquired by lookup-and-lock."""
         encoded_keys = [encode_object_key(key).encoded for key in keys]
-        self._core.unlock_many(encoded_keys)
+        with self._lock:
+            self._raise_if_closed_locked()
+            self._core.unlock_many(encoded_keys)
 
     def submit_load_task(
         self,
@@ -569,6 +665,8 @@ class RawBlockL2Adapter(L2AdapterInterface):
             if self._closed:
                 return
             self._closed = True
+            while self._sync_load_inflight:
+                self._sync_load_cv.wait()
 
         self._store_pool.shutdown(wait=True)
         self._lookup_pool.shutdown(wait=True)
@@ -601,6 +699,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
                 "store_inflight_task_count": self._store_inflight_tasks,
                 "lookup_inflight_task_count": self._lookup_inflight_tasks,
                 "load_inflight_task_count": self._load_inflight_tasks,
+                "sync_load_inflight_count": self._sync_load_inflight,
                 "completed_store_task_count": len(self._completed_store_tasks),
                 "completed_lookup_task_count": len(self._completed_lookup_tasks),
                 "completed_load_task_count": len(self._completed_load_tasks),

--- a/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
@@ -102,6 +102,11 @@ class L1MemoryManager:
         self._allocator = create_memory_allocator(config)
         self._size_in_bytes = config.size_in_bytes
         self._align_bytes = config.align_bytes
+        self._fixed_buffer_registration_size = (
+            config.size_in_bytes
+            if not config.use_lazy or config.init_size_in_bytes >= config.size_in_bytes
+            else 0
+        )
 
     def allocate(
         self, layout_desc: MemoryLayoutDesc, count: int
@@ -214,6 +219,7 @@ class L1MemoryManager:
             ptr=buffer.data_ptr(),
             size=self._size_in_bytes,
             align_bytes=self._align_bytes,
+            fixed_buffer_registration_size=self._fixed_buffer_registration_size,
         )
 
     def close(self) -> None:

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -6,7 +6,7 @@ Distributed multi-tier storage manager for MP mode
 # Standard
 from contextlib import contextmanager
 from dataclasses import replace
-from typing import Iterator, Literal, Optional
+from typing import Callable, Iterator, Literal, Optional
 import threading
 import time
 
@@ -28,6 +28,9 @@ from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
 from lmcache.v1.distributed.l2_adapters.config import L2AdapterConfigBase
+from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
+    RawBlockL2Adapter,
+)
 from lmcache.v1.distributed.l2_adapters.reconfiguration import (
     L2ReconfigurableAdapter,
     L2ReconfigureError,
@@ -68,6 +71,7 @@ class StorageManager:
     def __init__(self, config: StorageManagerConfig):
         self._l1_manager = L1Manager(config.l1_manager_config)
         self._event_bus = get_event_bus()
+        self._store_policy_name = config.store_policy
 
         # L1 eviction controller
         self._eviction_controller = L1EvictionController(
@@ -84,6 +88,13 @@ class StorageManager:
         self._next_adapter_id = 0
         # Serializes add_l2_adapter / delete_l2_adapter against each other.
         self._lifecycle_lock = threading.Lock()
+        # Fused synchronous raw-block operations take a short lease while
+        # holding _lifecycle_lock, then release that global lock for disk I/O.
+        # Adapter deletion/close marks ids draining and waits here until every
+        # lookup-through-unlock lease has finished.
+        self._adapter_lease_condition = threading.Condition()
+        self._adapter_lease_counts: dict[int, int] = {}
+        self._draining_adapter_ids: set[int] = set()
         # Guards the _l2_adapters and _adapter_descriptors dicts.
         self._adapters_lock = threading.Lock()
         self._registered_l2_listeners: list[L2AdapterListener] = []
@@ -249,6 +260,223 @@ class StorageManager:
         )
 
         # TODO: global key states update
+
+    def supports_fused_raw_block_retrieve(self) -> bool:
+        """Return whether synchronous fused raw-block restore is available.
+
+        Returns:
+            ``True`` only for the explicit ``skip_l1`` store policy when the
+            active topology contains exactly one unwrapped raw-block adapter.
+
+        Notes:
+            Adapter lifecycle serialization makes this an instantaneous
+            capability check. The load operation revalidates the topology
+            under the same lock before using the adapter.
+        """
+        with self._lifecycle_lock:
+            entry = self._get_fused_raw_block_adapter()
+            if entry is None:
+                return False
+            adapter_id, _adapter = entry
+            with self._adapter_lease_condition:
+                return adapter_id not in self._draining_adapter_ids
+
+    def load_raw_block_prefix(
+        self,
+        keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
+        *,
+        completion_batch_size: int | None = None,
+        on_batch_loaded: (
+            Callable[
+                [int, int, list[ObjectKey], list[MemoryObj]],
+                None,
+            ]
+            | None
+        ) = None,
+    ) -> tuple[list[ObjectKey], list[MemoryObj]] | None:
+        """Load the longest raw-block prefix into temporary L1 objects.
+
+        The returned objects remain write-locked so an accelerator transfer
+        can read them directly. The caller must invoke
+        :meth:`finish_raw_block_restore` after its final stream operation.
+
+        Args:
+            keys: Ordered object keys whose longest contiguous L2 prefix is
+                requested.
+            layout_desc: Layout used for temporary aligned L1 allocations.
+            completion_batch_size: Optional number of logical objects per
+                completion callback.
+            on_batch_loaded: Optional callback that takes ownership of each
+                successfully loaded range before it enqueues accelerator work.
+
+        Returns:
+            ``None`` when the active L2 topology is unsupported. Otherwise,
+            the successfully loaded prefix keys and their temporary objects;
+            both lists are empty for a clean miss.
+
+        Notes:
+            Adapter selection takes a short operation lease. Runtime deletion
+            marks the adapter draining and waits for every lease to cover the
+            full lookup-through-unlock operation before closing it, while
+            concurrent restores can perform disk I/O in parallel.
+        """
+        leased_adapter = self._acquire_fused_raw_block_adapter()
+        if leased_adapter is None:
+            return None
+        adapter_id, adapter = leased_adapter
+        try:
+            if not keys:
+                return [], []
+
+            reserved_keys: list[ObjectKey] = []
+            handed_prefix_len = 0
+            operation_failed = False
+
+            try:
+                lookup_results = adapter.lookup_and_lock_sync(keys)
+                lookup_prefix_len = 0
+                for found in lookup_results[: len(keys)]:
+                    if not found:
+                        break
+                    lookup_prefix_len += 1
+                if lookup_prefix_len == 0:
+                    return [], []
+
+                prefix_keys = keys[:lookup_prefix_len]
+                reserve_results = self._l1_manager.reserve_write(
+                    keys=prefix_keys,
+                    is_temporary=[True] * len(prefix_keys),
+                    layout_desc=layout_desc,
+                    mode="new",
+                )
+                reserved_objects = {
+                    key: memory_obj
+                    for key in prefix_keys
+                    if (
+                        (result := reserve_results.get(key)) is not None
+                        and result[0] == L1Error.SUCCESS
+                        and (memory_obj := result[1]) is not None
+                    )
+                }
+                reserved_keys = list(reserved_objects)
+
+                load_keys: list[ObjectKey] = []
+                load_objects: list[MemoryObj] = []
+                for key in prefix_keys:
+                    memory_obj = reserved_objects.get(key)
+                    if memory_obj is None:
+                        break
+                    load_keys.append(key)
+                    load_objects.append(memory_obj)
+
+                non_prefix_reservations = reserved_keys[len(load_keys) :]
+                if non_prefix_reservations:
+                    self.finish_raw_block_restore(non_prefix_reservations)
+                reserved_keys = load_keys
+                if not load_keys:
+                    return [], []
+
+                def hand_loaded_batch(start: int, end: int) -> None:
+                    nonlocal handed_prefix_len
+                    if on_batch_loaded is None:
+                        return
+                    if (
+                        start != handed_prefix_len
+                        or start < 0
+                        or end <= start
+                        or end > len(load_keys)
+                    ):
+                        raise RuntimeError(
+                            "Raw-block completion callbacks must hand off one "
+                            "contiguous prefix"
+                        )
+                    batch_keys = load_keys[start:end]
+                    batch_objects = load_objects[start:end]
+                    # Ownership transfers before the callback can enqueue work
+                    # or raise. The final accelerator event now governs when
+                    # these temporary objects may be reclaimed.
+                    handed_prefix_len = end
+                    on_batch_loaded(
+                        start,
+                        end,
+                        batch_keys,
+                        batch_objects,
+                    )
+
+                load_kwargs = {}
+                if on_batch_loaded is not None:
+                    load_kwargs = {
+                        "completion_batch_size": completion_batch_size,
+                        "on_batch_loaded": hand_loaded_batch,
+                    }
+                load_results = adapter.load_sync(
+                    load_keys,
+                    load_objects,
+                    **load_kwargs,
+                )
+                loaded_prefix_len = 0
+                for loaded in load_results[: len(load_keys)]:
+                    if not loaded:
+                        break
+                    loaded_prefix_len += 1
+
+                failed_keys = load_keys[loaded_prefix_len:]
+                if failed_keys:
+                    self.finish_raw_block_restore(failed_keys)
+
+                successful_keys = load_keys[:loaded_prefix_len]
+                successful_objects = load_objects[:loaded_prefix_len]
+                reserved_keys = successful_keys
+                return successful_keys, successful_objects
+            except Exception:
+                operation_failed = True
+                cleanup_keys = reserved_keys[handed_prefix_len:]
+                if cleanup_keys:
+                    try:
+                        self.finish_raw_block_restore(cleanup_keys)
+                    except Exception:
+                        logger.exception(
+                            "Failed cleaning fused raw-block L1 reservations"
+                        )
+                raise
+            finally:
+                try:
+                    adapter.submit_unlock(keys)
+                except Exception:
+                    if not operation_failed:
+                        cleanup_keys = reserved_keys[handed_prefix_len:]
+                        if cleanup_keys:
+                            try:
+                                self.finish_raw_block_restore(cleanup_keys)
+                            except Exception:
+                                logger.exception(
+                                    "Failed cleaning fused raw-block L1 "
+                                    "reservations after unlock error"
+                                )
+                        raise
+                    logger.exception(
+                        "Failed unlocking raw-block keys after restore error"
+                    )
+        finally:
+            self._release_adapter_lease(adapter_id)
+
+    def finish_raw_block_restore(self, keys: list[ObjectKey]) -> None:
+        """Release temporary L1 objects after a fused accelerator restore.
+
+        Args:
+            keys: Write-locked temporary keys returned by
+                :meth:`load_raw_block_prefix`.
+        """
+        if not keys:
+            return
+        try:
+            self.finish_write(keys)
+        finally:
+            # The final accelerator event has completed before this callback.
+            # Force deletion also reclaims an object if finish_write itself
+            # failed and left its write lock held.
+            self.delete_l1_keys(keys, force=True)
 
     @contextmanager
     def read_prefetched_results(
@@ -915,6 +1143,8 @@ class StorageManager:
                 raise ValueError(f"No L2 adapter with id {adapter_id}")
 
             deadline = time.monotonic() + timeout
+            with self._adapter_lease_condition:
+                self._draining_adapter_ids.add(adapter_id)
             store_done = self._store_controller.request_remove_adapter(adapter_id)
             prefetch_done = self._prefetch_controller.request_remove_adapter(adapter_id)
             if not store_done.wait(timeout=max(0.0, deadline - time.monotonic())):
@@ -925,12 +1155,24 @@ class StorageManager:
                 raise LMCacheTimeoutError(
                     f"Timed out draining adapter {adapter_id} from prefetch controller"
                 )
+            with self._adapter_lease_condition:
+                while self._adapter_lease_counts.get(adapter_id, 0) > 0:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise LMCacheTimeoutError(
+                            f"Timed out waiting for adapter {adapter_id} "
+                            "operation leases"
+                        )
+                    self._adapter_lease_condition.wait(timeout=remaining)
 
             self._l2_eviction_controller.remove_adapter_state(adapter_id)
             with self._adapters_lock:
                 adapter = self._l2_adapters.pop(adapter_id)
                 self._adapter_descriptors.pop(adapter_id, None)
             adapter.close()
+            with self._adapter_lease_condition:
+                self._adapter_lease_counts.pop(adapter_id, None)
+                self._draining_adapter_ids.discard(adapter_id)
             logger.info("Deleted L2 adapter %d", adapter_id)
 
     def l2_adapters(self) -> list[tuple[AdapterDescriptor, L2AdapterInterface]]:
@@ -964,17 +1206,29 @@ class StorageManager:
         """
         Close the storage manager and release all resources.
         """
-        self._prefetch_controller.stop()
-        self._store_controller.stop()
-        self._eviction_controller.stop()
-        self._l2_eviction_controller.stop()
+        with self._lifecycle_lock:
+            adapter_ids = list(self._l2_adapters)
+            with self._adapter_lease_condition:
+                self._draining_adapter_ids.update(adapter_ids)
 
-        PeriodicEventNotifier.shutdown()
+            self._prefetch_controller.stop()
+            self._store_controller.stop()
+            self._eviction_controller.stop()
+            self._l2_eviction_controller.stop()
 
-        for adapter in self._l2_adapters.values():
-            adapter.close()
+            PeriodicEventNotifier.shutdown()
 
-        self._l1_manager.close()
+            with self._adapter_lease_condition:
+                while any(
+                    self._adapter_lease_counts.get(adapter_id, 0) > 0
+                    for adapter_id in adapter_ids
+                ):
+                    self._adapter_lease_condition.wait()
+
+            for adapter in self._l2_adapters.values():
+                adapter.close()
+
+            self._l1_manager.close()
 
     def report_status(self) -> dict:
         """Return a status dict aggregating all sub-component statuses."""
@@ -987,6 +1241,7 @@ class StorageManager:
         children = [l1, store, prefetch, l1_eviction, l2_eviction] + adapters
         return {
             "is_healthy": all(c["is_healthy"] for c in children),
+            "store_policy": self._store_policy_name,
             "l1_manager": l1,
             "store_controller": store,
             "prefetch_controller": prefetch,
@@ -1040,6 +1295,49 @@ class StorageManager:
         """Return whether any L2 adapter is currently active."""
         with self._adapters_lock:
             return bool(self._l2_adapters)
+
+    def _get_fused_raw_block_adapter(
+        self,
+    ) -> tuple[int, RawBlockL2Adapter] | None:
+        """Return the sole raw adapter for an explicit pure-L2 store policy."""
+        if self._store_policy_name != "skip_l1":
+            return None
+        adapters = self._snapshot_adapters()
+        if len(adapters) != 1:
+            return None
+        adapter_id, _descriptor, adapter = adapters[0]
+        if not isinstance(adapter, RawBlockL2Adapter):
+            return None
+        return adapter_id, adapter
+
+    def _acquire_fused_raw_block_adapter(
+        self,
+    ) -> tuple[int, RawBlockL2Adapter] | None:
+        """Lease the sole raw adapter without holding the lock during I/O."""
+        with self._lifecycle_lock:
+            entry = self._get_fused_raw_block_adapter()
+            if entry is None:
+                return None
+            adapter_id, adapter = entry
+            with self._adapter_lease_condition:
+                if adapter_id in self._draining_adapter_ids:
+                    return None
+                self._adapter_lease_counts[adapter_id] = (
+                    self._adapter_lease_counts.get(adapter_id, 0) + 1
+                )
+            return adapter_id, adapter
+
+    def _release_adapter_lease(self, adapter_id: int) -> None:
+        """Release one fused raw-adapter operation lease."""
+        with self._adapter_lease_condition:
+            lease_count = self._adapter_lease_counts.get(adapter_id, 0)
+            if lease_count <= 0:
+                raise RuntimeError(f"Adapter {adapter_id} operation lease is not held")
+            if lease_count == 1:
+                self._adapter_lease_counts.pop(adapter_id)
+            else:
+                self._adapter_lease_counts[adapter_id] = lease_count - 1
+            self._adapter_lease_condition.notify_all()
 
     def _build_l2_adapter(
         self,

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -6,7 +6,7 @@ Distributed multi-tier storage manager for MP mode
 # Standard
 from contextlib import contextmanager
 from dataclasses import replace
-from typing import Callable, Iterator, Literal, Optional
+from typing import Any, Callable, Iterator, Literal, Optional
 import threading
 import time
 
@@ -404,7 +404,7 @@ class StorageManager:
                         batch_objects,
                     )
 
-                load_kwargs = {}
+                load_kwargs: dict[str, Any] = {}
                 if on_batch_loaded is not None:
                     load_kwargs = {
                         "completion_batch_size": completion_batch_size,

--- a/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
@@ -33,7 +33,6 @@ class SGLANG_Detector(EngineDetector):
             and len(kv_caches) % 2 == 0
             and isinstance(kv_caches[0], torch.Tensor)
             and kv_caches[0].dim() == 3
-            and kv_caches[0].shape[1] > 1
             and "tokens_per_block" in layout_hints
         ):
             block_size = layout_hints["tokens_per_block"]

--- a/lmcache/v1/memory_allocators/lazy_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/lazy_memory_allocator.py
@@ -103,15 +103,21 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
 
         # Detect numa mapping
         if numa_mapping is not None:
+            self._base_buffer = None
             numa_id = get_numa_id(numa_mapping)
             ptr = lmc_ops.alloc_numa_ptr(self._final_size, numa_id)
             arr_type = ctypes.c_uint8 * self._final_size
             buf = arr_type.from_address(ptr)
             self._buffer = torch.frombuffer(buf, dtype=torch.uint8)
         else:
-            self._buffer = torch.empty(
-                self._final_size, dtype=torch.uint8, device="cpu", pin_memory=False
+            self._base_buffer = torch.empty(
+                self._final_size + align_bytes - 1,
+                dtype=torch.uint8,
+                device="cpu",
+                pin_memory=False,
             )
+            offset = (-self._base_buffer.data_ptr()) % align_bytes
+            self._buffer = self._base_buffer[offset : offset + self._final_size]
 
         # Pin the first `curr_size` bytes (aligned to the internal chunk size)
         self._pin_memory_chunk(0, self._curr_size)
@@ -275,8 +281,10 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         assert offset + size <= self._final_size, "Pinning exceeds buffer size"
 
         ptr = self._buffer.data_ptr() + offset
-        # Use flag: cudaHostRegisterMapped (0x02)
-        if not current_device_spec.pin_memory(ptr, size, 2):
+        # cudaHostRegisterPortable | cudaHostRegisterMapped. The daemon may
+        # serve TP workers whose CUDA contexts target different devices, so a
+        # mapped L1 allocation must be portable across every such context.
+        if not current_device_spec.pin_memory(ptr, size, 0x01 | 0x02):
             logger.warning(
                 "pin_memory failed for chunk at ptr=%#x size=%d; "
                 "DMA performance may be degraded",

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -2,7 +2,7 @@
 """LMCache-driven KV cache transfer operations for the MPCacheServer."""
 
 # Standard
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import islice
 from typing import Generator, Sequence
 import threading
@@ -59,6 +59,44 @@ logger = init_logger(__name__)
 _HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = hasattr(
     lmc_ops, "execute_object_group_transfer"
 )
+_FUSED_EVENT_SESSION_RESOURCE_KEY = "fused_raw_block_export_events"
+
+
+@dataclass(frozen=True)
+class _FusedDrainEvent:
+    """Server-side final event retained for a rank-specific drain RPC."""
+
+    backend: EventIPCBackend
+    event: object
+    device: object
+
+
+@dataclass
+class _FusedDrainState:
+    """Request state retained before a fused handler can enqueue writes."""
+
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    final_event: _FusedDrainEvent | None = None
+    terminal_safe: bool = False
+
+    def publish_final(self, final_event: _FusedDrainEvent) -> None:
+        """Publish the recorded final event for a later drain request."""
+        with self._lock:
+            self.final_event = final_event
+
+    def mark_terminal_safe(self) -> None:
+        """Record that the handler fenced any writes without an IPC event."""
+        with self._lock:
+            self.terminal_safe = True
+
+    def snapshot(self) -> tuple[_FusedDrainEvent | None, bool]:
+        """Return the final event and terminal-safety flag atomically."""
+        with self._lock:
+            return self.final_event, self.terminal_safe
+
+
+def _fused_event_session_resource_key(worker_id: int) -> str:
+    return f"{_FUSED_EVENT_SESSION_RESOURCE_KEY}.{worker_id}"
 
 
 def get_layout_desc(
@@ -576,6 +614,67 @@ def transfer_kv_per_object_group(
                 )
 
 
+def _launch_staged_h2d_batch(
+    cache_context: BaseCacheContext,
+    block_ids_gpu: list[torch.Tensor],
+    *,
+    object_group_id: int,
+    batch_len: int,
+    skip_first_n_tokens: int,
+) -> None:
+    """Launch paged KV copies for buffers whose H2D staging is already queued."""
+    if batch_len <= 0:
+        return
+    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
+    batch_end_token = batch_len * lmcache_chunk_size
+    if skip_first_n_tokens >= batch_end_token:
+        return
+
+    kv_groups_manager = cache_context.kv_layer_groups_manager
+    object_group = kv_groups_manager.object_groups[object_group_id]
+    skip_tokens = max(skip_first_n_tokens, 0)
+    for kernel_group_id in object_group.kernel_group_indices:
+        blocks_per_chunk = cache_context.calculate_num_blocks(
+            lmcache_chunk_size,
+            kernel_group_id,
+        )
+        tokens_per_window = min(
+            lmcache_chunk_size,
+            kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
+        )
+        blocks_per_window = cache_context.calculate_num_blocks(
+            tokens_per_window,
+            kernel_group_id,
+        )
+        block_count = batch_len * blocks_per_window
+        orig_skip_blocks = cache_context.calculate_num_blocks(
+            skip_tokens,
+            kernel_group_id,
+        )
+        recalculated_skip_blocks = _recalculate_blocks_to_skip(
+            blocks_per_chunk,
+            blocks_per_window,
+            orig_skip_blocks,
+        )
+        lmc_ops.multi_layer_block_kv_transfer(
+            cache_context.get_kernel_group_kv_pointers(kernel_group_id),
+            [
+                cache_context.get_temp_kernel_group_buffer(
+                    slot,
+                    kernel_group_id,
+                ).data_ptr()
+                for slot in range(batch_len)
+            ],
+            block_ids_gpu[kernel_group_id].narrow(0, 0, block_count),
+            cache_context.device,
+            lmc_ops.TransferDirection.H2D,
+            cache_context.get_shape_desc(kernel_group_id),
+            cache_context.get_slots_per_chunk_in_sw(kernel_group_id),
+            cache_context.get_engine_kv_format(kernel_group_id),
+            recalculated_skip_blocks,
+        )
+
+
 @dataclass
 class ContextEntry:
     """Registered cache context metadata for a single worker instance.
@@ -618,8 +717,14 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         ctx: The shared engine context.
     """
 
-    def __init__(self, ctx: MPCacheServerContext) -> None:
+    def __init__(
+        self,
+        ctx: MPCacheServerContext,
+        affinity_worker_count: int | None = None,
+    ) -> None:
         self._ctx = ctx
+        self._affinity_worker_count = affinity_worker_count
+        self._warned_affinity_world_sizes: set[int] = set()
         self._cache_contexts: dict[int, ContextEntry] = {}
         # Guards all reads/writes of _cache_contexts. The reaper mutates it
         # off the MQ main loop, so register/unregister/store/retrieve and
@@ -627,6 +732,11 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         # ops -- never across context creation, layout-registry calls, or
         # empty_cache (leaf-lock invariant: no thread holds two locks).
         self._lock = threading.Lock()
+        self._fused_counter_lock = threading.Lock()
+        self._fused_success_count = 0
+        self._fused_pipelined_count = 0
+        self._fused_staged_fallback_count = 0
+        self._fused_failure_count = 0
 
         # Route finish_write / finish_read_prefetched through a C++ host
         # callback so the driver thread doesn't acquire the GIL.
@@ -639,6 +749,11 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         self._device_host_func_dispatcher.register(
             "finish_read_prefetched",
             self._ctx.storage_manager.finish_read_prefetched,
+            payload_type=list[ObjectKey],
+        )
+        self._device_host_func_dispatcher.register(
+            "finish_raw_block_restore",
+            self._ctx.storage_manager.finish_raw_block_restore,
             payload_type=list[ObjectKey],
         )
         self._device_host_func_dispatcher.start()
@@ -797,6 +912,19 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 self.retrieve,
                 ThreadPoolType.AFFINITY,
             ),
+            HandlerSpec(
+                RequestType.FUSED_RAW_BLOCK_RETRIEVE,
+                self.fused_raw_block_retrieve,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.FUSED_RAW_BLOCK_DRAIN,
+                self.fused_raw_block_drain,
+                # The same client identity routes this behind its fused
+                # retrieve on one FIFO affinity queue. The final event is
+                # therefore retained before this handler can inspect it.
+                ThreadPoolType.AFFINITY,
+            ),
         ]
 
     def report_status(self) -> dict:
@@ -818,21 +946,77 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 "kv_cache_layout": ctx.report_status(),
             }
 
+        with self._fused_counter_lock:
+            fused_status = {
+                "success_count": self._fused_success_count,
+                "pipelined_count": self._fused_pipelined_count,
+                "staged_fallback_count": self._fused_staged_fallback_count,
+                "failure_count": self._fused_failure_count,
+            }
+        affinity_worker_count = getattr(
+            self,
+            "_affinity_worker_count",
+            None,
+        )
+        max_registered_world_size = max(
+            (entry.world_size for entry in self.context_entries_snapshot().values()),
+            default=0,
+        )
         return {
             "registered_gpu_ids": registered_gpu_ids,
             "cache_context_meta": cache_context_meta,
+            "fused_raw_block_retrieve": fused_status,
+            "affinity_pool": {
+                "worker_count": affinity_worker_count,
+                "max_registered_world_size": max_registered_world_size,
+                "undersubscribed": (
+                    affinity_worker_count is not None
+                    and max_registered_world_size > affinity_worker_count
+                ),
+            },
         }
 
     def close(self) -> None:
         """Release GPU resources owned by this module."""
-        # Stop the drain thread before storage_manager.close() so any
-        # in-flight completions reach a live storage manager.
+        with self._lock:
+            entries = list(self._cache_contexts.values())
+
+        # A fused response can outlive its handler while H2D work and the
+        # stream-ordered L1 cleanup remain pending. Fence retained final events,
+        # then each context stream, before stopping the dispatcher. Its final
+        # drain therefore observes every cleanup callback before StorageManager
+        # releases the registered L1 arena.
+        self._synchronize_retained_fused_events()
+        for entry in entries:
+            entry.cache_context.stream.synchronize()
         self._device_host_func_dispatcher.stop()
 
         with self._lock:
-            entries = list(self._cache_contexts.values())
             self._cache_contexts.clear()
         self._release_entries(entries)
+
+    def _synchronize_retained_fused_events(self) -> None:
+        """Fence fused final events still owned by active sessions."""
+        sessions = self._ctx.session_manager.sessions_snapshot()
+        for session in sessions:
+            resources = session.get_retained_resources_by_prefix(
+                f"{_FUSED_EVENT_SESSION_RESOURCE_KEY}."
+            )
+            for resource in resources:
+                if not isinstance(resource, _FusedDrainState):
+                    continue
+                drain_event, terminal_safe = resource.snapshot()
+                if drain_event is None:
+                    if not terminal_safe:
+                        raise RuntimeError(
+                            "Cannot close with an unfenced fused raw-block restore"
+                        )
+                    continue
+                with torch_dev.device(drain_event.device):
+                    drain_event.backend.synchronize_event(
+                        drain_event.event,
+                        drain_event.device,
+                    )
 
     def register_kv_cache(
         self,
@@ -903,6 +1087,22 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 last_seen=now,
                 has_liveness_signal=False,
                 event_backend=event_backend,
+            )
+
+        affinity_worker_count = getattr(self, "_affinity_worker_count", None)
+        if (
+            affinity_worker_count is not None
+            and world_size > affinity_worker_count
+            and world_size not in getattr(self, "_warned_affinity_world_sizes", set())
+        ):
+            self._warned_affinity_world_sizes.add(world_size)
+            logger.warning(
+                "Registered TP world_size=%d with only %d GPU affinity "
+                "workers; fused rank transfers will serialize. Start the "
+                "daemon with --max-gpu-workers=%d for rank-parallel reads.",
+                world_size,
+                affinity_worker_count,
+                world_size,
             )
 
         logger.info(
@@ -1145,6 +1345,430 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
 
     @_lmcache_nvtx_annotate
+    def fused_raw_block_drain(self, request_id: str, worker_id: int) -> bool:
+        """Synchronize retained final events for one fused TP worker."""
+        session = self._ctx.session_manager.get(request_id)
+        if session is None:
+            return False
+        resources = session.get_retained_resources(
+            _fused_event_session_resource_key(worker_id)
+        )
+        drain_states = [
+            resource for resource in resources if isinstance(resource, _FusedDrainState)
+        ]
+        if not drain_states:
+            return False
+        for drain_state in drain_states:
+            drain_event, terminal_safe = drain_state.snapshot()
+            if drain_event is None:
+                if not terminal_safe:
+                    return False
+                continue
+            with torch_dev.device(drain_event.device):
+                drain_event.backend.synchronize_event(
+                    drain_event.event,
+                    drain_event.device,
+                )
+        return True
+
+    @_lmcache_nvtx_annotate
+    def fused_raw_block_retrieve(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int = 0,
+    ) -> tuple[bytes, tuple[int, bool]]:
+        """Load a raw-block prefix and restore it directly into engine KV.
+
+        This SGLang MP path replaces the asynchronous L2-prefetch round trip
+        with one synchronous raw-block load into temporary L1 objects. It
+        submits every direct-I/O read before waiting, overlaps completed reads
+        with host-to-device staging, then launches the existing all-layer KV
+        transfer kernel.
+
+        Args:
+            key: Worker-specific key and chunk-aligned token range.
+            instance_id: Registered engine KV-cache instance.
+            gpu_block_ids: Destination block IDs indexed by engine group.
+            event_ipc_handle: Producer event that orders destination writes.
+            skip_first_n_tokens: Leading APC-shared tokens not to overwrite.
+
+        Returns:
+            A final completion-event handle and
+            ``(retrieved_tokens, success)``. A clean cache miss returns
+            ``(0, True)``.
+
+        Raises:
+            ValueError: If the registered instance no longer exists.
+            RuntimeError: If its event backend is unavailable.
+        """
+        if key.worker_id is None:
+            raise ValueError("Fused raw-block retrieve requires a worker ID")
+
+        # Establish the rank-specific drain state before fallible preflight or
+        # stream work. Both
+        # this request and FUSED_RAW_BLOCK_DRAIN use the same client-identity
+        # affinity FIFO, so the drain handler observes this state only after
+        # this handler has either published a recorded final event or fenced
+        # the stream and marked the state terminal-safe.
+        drain_state = _FusedDrainState()
+        self._ctx.session_manager.get_or_create(key.request_id).retain_resources(
+            _fused_event_session_resource_key(key.worker_id),
+            [drain_state],
+            owner_id=key.worker_id,
+        )
+        try:
+            entry = self.get_and_touch_context_entry(instance_id)
+            if entry is None:
+                raise ValueError(
+                    f"No GPU context registered for instance ID {instance_id}"
+                )
+            cache_context = entry.cache_context
+            event_backend = entry.event_backend
+            if event_backend is None:
+                raise RuntimeError("Registered cache context has no event backend")
+        except Exception:
+            # No device work can precede this point. Publishing terminal safety
+            # lets a same-affinity drain prove that destination slots are idle
+            # even though the failed handler cannot return a final event.
+            drain_state.mark_terminal_safe()
+            raise
+
+        restored_keys: list[ObjectKey] = []
+        retrieved_tokens = 0
+        retrieve_succeeded = False
+        total_bytes = 0
+        used_pipelined_staging = False
+        used_staged_fallback = False
+        final_event: object | None = None
+        final_recorded = False
+        cleanup_callback_submitted = False
+
+        try:
+            self._ctx.event_bus.publish(
+                Event(
+                    event_type=EventType.MP_RETRIEVE_SUBMITTED,
+                    session_id=key.request_id,
+                    metadata={"device": str(cache_context.device)},
+                )
+            )
+
+            with (
+                torch_dev.device(cache_context.device),
+                torch_dev.stream(cache_context.stream),
+            ):
+                final_event = event_backend.create_event(cache_context.device)
+                self._ctx.event_bus.publish_on_stream(
+                    cache_context.cupy_stream,
+                    Event(
+                        event_type=EventType.MP_RETRIEVE_START,
+                        session_id=key.request_id,
+                        metadata={
+                            "device": str(cache_context.device),
+                            "engine_id": instance_id,
+                            "model_name": entry.model_name,
+                        },
+                    ),
+                )
+                try:
+                    producer_event = event_backend.import_event(
+                        event_ipc_handle, cache_context.device
+                    )
+                    event_backend.wait_event(producer_event, cache_context.stream)
+
+                    if (
+                        key.start < 0
+                        or key.end <= key.start
+                        or key.end > len(key.token_ids)
+                        or key.start % self._ctx.chunk_size != 0
+                        or key.end % self._ctx.chunk_size != 0
+                    ):
+                        raise ValueError(
+                            "Invalid fused raw-block range "
+                            f"[{key.start}, {key.end}) for "
+                            f"{len(key.token_ids)} tokens"
+                        )
+                    if skip_first_n_tokens < 0:
+                        raise ValueError(
+                            "skip_first_n_tokens must be non-negative, got "
+                            f"{skip_first_n_tokens}"
+                        )
+
+                    groups = cache_context.kv_layer_groups_manager
+                    if groups.num_object_groups != 1 or groups.num_kernel_groups != 1:
+                        raise ValueError(
+                            "Fused raw-block retrieve requires one object and "
+                            "kernel group"
+                        )
+
+                    obj_keys = self._ctx.resolve_obj_keys(key, [0])[0]
+                    blocks_per_chunk = cache_context.calculate_num_blocks(
+                        self._ctx.chunk_size,
+                        0,
+                    )
+                    pipelined_block_ids_gpu: list[torch.Tensor] | None = None
+                    staged_window_start = 0
+                    staged_window_objects: list[MemoryObj] = []
+                    if obj_keys:
+                        candidate_required_blocks = len(obj_keys) * blocks_per_chunk
+                        if len(gpu_block_ids) != 1:
+                            raise ValueError(
+                                "Fused raw-block retrieve requires one block-ID group"
+                            )
+                        if len(gpu_block_ids[0]) < candidate_required_blocks:
+                            raise ValueError(
+                                "Fused raw-block retrieve needs "
+                                f"{candidate_required_blocks} candidate block "
+                                f"IDs, got {len(gpu_block_ids[0])}"
+                            )
+                        pipelined_block_ids_gpu = downsample_and_stage_block_ids(
+                            cache_context,
+                            [gpu_block_ids[0][:candidate_required_blocks]],
+                        )
+
+                    def flush_staged_window() -> None:
+                        nonlocal staged_window_start
+                        if not staged_window_objects:
+                            return
+                        assert pipelined_block_ids_gpu is not None
+                        batch_len = len(staged_window_objects)
+                        block_begin = staged_window_start * blocks_per_chunk
+                        block_count = batch_len * blocks_per_chunk
+                        batch_skip_tokens = min(
+                            max(
+                                skip_first_n_tokens
+                                - staged_window_start * self._ctx.chunk_size,
+                                0,
+                            ),
+                            batch_len * self._ctx.chunk_size,
+                        )
+                        _launch_staged_h2d_batch(
+                            cache_context,
+                            [
+                                pipelined_block_ids_gpu[0].narrow(
+                                    0,
+                                    block_begin,
+                                    block_count,
+                                )
+                            ],
+                            object_group_id=0,
+                            batch_len=batch_len,
+                            skip_first_n_tokens=batch_skip_tokens,
+                        )
+                        staged_window_start += batch_len
+                        staged_window_objects.clear()
+
+                    def enqueue_loaded_batch(
+                        start: int,
+                        end: int,
+                        batch_keys: list[ObjectKey],
+                        batch_objects: list[MemoryObj],
+                    ) -> None:
+                        nonlocal staged_window_start
+                        assert pipelined_block_ids_gpu is not None
+                        # Take ownership before CUDA enqueue can fail. The
+                        # final event then fences both successful and partial
+                        # batch writes before these objects are reclaimed.
+                        restored_keys.extend(batch_keys)
+                        if not staged_window_objects:
+                            staged_window_start = start
+                        for object_index, memory_obj in enumerate(
+                            batch_objects,
+                            start=start,
+                        ):
+                            object_skip_tokens = min(
+                                max(
+                                    skip_first_n_tokens
+                                    - object_index * self._ctx.chunk_size,
+                                    0,
+                                ),
+                                self._ctx.chunk_size,
+                            )
+                            if object_skip_tokens < self._ctx.chunk_size:
+                                lmcache_memcpy_async_h2d(
+                                    memory_obj,
+                                    cache_context.get_temp_object_group_buffer(
+                                        len(staged_window_objects),
+                                        0,
+                                    ),
+                                )
+                            staged_window_objects.append(memory_obj)
+                            if (
+                                len(staged_window_objects)
+                                == cache_context.max_batch_size
+                            ):
+                                flush_staged_window()
+
+                    loaded = self._ctx.storage_manager.load_raw_block_prefix(
+                        obj_keys,
+                        get_layout_desc(
+                            cache_context,
+                            object_group_id=0,
+                            num_tokens=self._ctx.chunk_size,
+                        ),
+                        completion_batch_size=(
+                            1 if pipelined_block_ids_gpu is not None else None
+                        ),
+                        on_batch_loaded=(
+                            enqueue_loaded_batch
+                            if pipelined_block_ids_gpu is not None
+                            else None
+                        ),
+                    )
+                    if loaded is None:
+                        # Capability discovery is cached while L2 adapters can
+                        # be deleted at runtime. No raw load means no writes.
+                        loaded = ([], [])
+
+                    loaded_keys, memory_objs = loaded
+                    loaded_keys = list(loaded_keys)
+                    memory_objs = list(memory_objs)
+                    if (
+                        len(loaded_keys) != len(memory_objs)
+                        or len(loaded_keys) > len(obj_keys)
+                        or loaded_keys != obj_keys[: len(loaded_keys)]
+                    ):
+                        raise RuntimeError(
+                            "Raw-block restore returned a non-prefix result"
+                        )
+                    pipeline_applied = bool(restored_keys)
+                    if pipeline_applied and restored_keys != loaded_keys:
+                        raise RuntimeError(
+                            "Pipelined raw-block handoff differs from the loaded prefix"
+                        )
+                    restored_keys = loaded_keys
+
+                    if not restored_keys:
+                        retrieve_succeeded = True
+                    else:
+                        required_blocks = len(restored_keys) * blocks_per_chunk
+                        if len(gpu_block_ids) != 1:
+                            raise ValueError(
+                                "Fused raw-block retrieve requires one block-ID group"
+                            )
+                        if len(gpu_block_ids[0]) < required_blocks:
+                            raise ValueError(
+                                "Fused raw-block retrieve needs "
+                                f"{required_blocks} block IDs, got "
+                                f"{len(gpu_block_ids[0])}"
+                            )
+
+                        if pipeline_applied:
+                            flush_staged_window()
+                            used_pipelined_staging = True
+                        else:
+                            assert pipelined_block_ids_gpu is not None
+                            block_ids_gpu = [
+                                pipelined_block_ids_gpu[0].narrow(
+                                    0,
+                                    0,
+                                    required_blocks,
+                                )
+                            ]
+                            transfer_kv_per_object_group(
+                                cache_context,
+                                block_ids_gpu,
+                                memory_objs,
+                                object_group_id=0,
+                                batch_size=cache_context.max_batch_size,
+                                skip_first_n_tokens=skip_first_n_tokens,
+                                direction=lmc_ops.TransferDirection.H2D,
+                            )
+                            used_staged_fallback = True
+
+                        retrieved_tokens = min(
+                            len(restored_keys) * self._ctx.chunk_size,
+                            key.end - key.start,
+                        )
+                        total_bytes = sum(
+                            memory_obj.get_size() for memory_obj in memory_objs
+                        )
+                        retrieve_succeeded = True
+                except Exception:
+                    logger.exception(
+                        "Cannot perform fused raw-block retrieve for request_id=%s",
+                        key.request_id,
+                    )
+                finally:
+                    event_backend.record_event(
+                        final_event,
+                        cache_context.stream,
+                    )
+                    final_recorded = True
+                    drain_state.publish_final(
+                        _FusedDrainEvent(
+                            backend=event_backend,
+                            event=final_event,
+                            device=cache_context.device,
+                        )
+                    )
+
+            final_event_handle = event_backend.export_event(
+                final_event, cache_context.device
+            )
+            self._ctx.event_bus.publish_on_stream(
+                cache_context.cupy_stream,
+                Event(
+                    event_type=EventType.MP_RETRIEVE_END,
+                    session_id=key.request_id,
+                    metadata={
+                        "retrieved_count": (
+                            len(restored_keys) if retrieve_succeeded else 0
+                        ),
+                        "device": str(cache_context.device),
+                        "engine_id": instance_id,
+                        "model_name": entry.model_name,
+                        "cache_salt": key.cache_salt,
+                        "total_bytes": total_bytes,
+                        "num_tokens": (retrieved_tokens if retrieve_succeeded else 0),
+                    },
+                ),
+            )
+            if restored_keys:
+                submit_callback_to_stream(
+                    cache_context.cupy_stream,
+                    "finish_raw_block_restore",
+                    restored_keys,
+                )
+                cleanup_callback_submitted = True
+
+            self._record_fused_result(
+                succeeded=retrieve_succeeded,
+                pipelined=used_pipelined_staging,
+                staged_fallback=used_staged_fallback,
+            )
+            return (
+                final_event_handle,
+                (retrieved_tokens, retrieve_succeeded),
+            )
+        except Exception:
+            # No response can safely authorize slot reuse. Fence every
+            # possible write and synchronously release temporary L1 objects if
+            # their callback was not successfully submitted.
+            if cleanup_callback_submitted:
+                cache_context.stream.synchronize()
+            elif final_recorded:
+                assert final_event is not None
+                event_backend.synchronize_event(
+                    final_event,
+                    cache_context.device,
+                )
+            elif final_event is not None:
+                cache_context.stream.synchronize()
+
+            if restored_keys and not cleanup_callback_submitted:
+                self._ctx.storage_manager.finish_raw_block_restore(restored_keys)
+            drain_state.mark_terminal_safe()
+            self._record_fused_result(
+                succeeded=False,
+                pipelined=used_pipelined_staging,
+                staged_fallback=used_staged_fallback,
+            )
+            raise
+
+    @_lmcache_nvtx_annotate
     def retrieve(
         self,
         key: IPCCacheServerKey,
@@ -1335,3 +1959,21 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             event_backend.export_event(event, cache_context.device),
             retrieve_succeeded,
         )
+
+    def _record_fused_result(
+        self,
+        *,
+        succeeded: bool,
+        pipelined: bool,
+        staged_fallback: bool,
+    ) -> None:
+        """Update cheap monotonic fused-path counters."""
+        with self._fused_counter_lock:
+            if succeeded:
+                self._fused_success_count += 1
+            else:
+                self._fused_failure_count += 1
+            if pipelined:
+                self._fused_pipelined_count += 1
+            if staged_fallback:
+                self._fused_staged_fallback_count += 1

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -516,18 +516,29 @@ class LookupModule:
                 metadata={"request_id": request_id},
             )
         )
-        session = self._ctx.session_manager.remove(request_id)
+        session, waiting_for_resource_owners = (
+            self._ctx.session_manager.release_for_end_session(request_id)
+        )
         self._ctx.event_bus.publish(
             Event(
                 event_type=EventType.MP_REQUEST_END,
                 session_id=request_id,
             )
         )
+        if waiting_for_resource_owners:
+            logger.debug(
+                "Session %s retains exporter events for other TP workers",
+                request_id,
+            )
+            return
         if session is None:
             logger.warning("Session %s not found, skipping touch", request_id)
             return
         if session.lookup_ipc_key is None:
-            logger.warning(
+            # STORE-only and fused raw-block sessions intentionally have no
+            # LOOKUP key. They still use END_SESSION to release request-scoped
+            # resources, so this is a normal no-touch path.
+            logger.debug(
                 "Session %s has no lookup ipc key, skipping touch",
                 request_id,
             )

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -16,6 +16,9 @@ from lmcache.v1.multiprocess.engine_module import (
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.protocols.engine import (
+    FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY,
+)
 from lmcache.v1.periodic_thread import (
     PeriodicThread,
     ThreadLevel,
@@ -182,10 +185,19 @@ class ManagementModule:
         server.
 
         Returns:
-            The enabled experimental intermediate tensor transfer types.
-            See ``lmcache.v1.multiprocess.modules.experimental.__init__``.
+            The enabled experimental intermediate tensor transfer types plus
+            exact versioned protocol capabilities supported by this server.
+            Unknown entries are safe for older clients to ignore.
         """
-        return list(self._experimental_transfer)
+        capabilities = list(self._experimental_transfer)
+        supports_fused = getattr(
+            self._ctx.storage_manager,
+            "supports_fused_raw_block_retrieve",
+            None,
+        )
+        if callable(supports_fused) and supports_fused() is True:
+            capabilities.append(FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY)
+        return capabilities
 
     def clear(self) -> None:
         """Clear all stored KV cache data from the storage manager."""

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -96,6 +96,10 @@ class RequestType(enum.Enum):
     # Experimental transfer intermediate tensor
     GET_EXPERIMENTAL = enum.auto()
 
+    # Appended to preserve every existing numeric wire value.
+    FUSED_RAW_BLOCK_RETRIEVE = enum.auto()
+    FUSED_RAW_BLOCK_DRAIN = enum.auto()
+
 
 @dataclass
 class ProtocolDefinition:

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -27,6 +27,8 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
 
+FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY = "lmcache.fused_raw_block_restore.v1"
+
 
 @dataclass
 class PrepareStoreResponse:
@@ -65,6 +67,8 @@ REQUEST_NAMES = [
     "STORE_Q",
     "STORE",
     "RETRIEVE",
+    "FUSED_RAW_BLOCK_RETRIEVE",
+    "FUSED_RAW_BLOCK_DRAIN",
     "LOOKUP",
     "QUERY_PREFETCH_STATUS",
     "WAIT_PREFETCH_STATUS",
@@ -185,6 +189,22 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         "RETRIEVE": ProtocolDefinition(
             payload_classes=[KeyType, int, list[list[int]], bytes, int],
             response_class=tuple[bytes, bool],
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Load a contiguous raw-block prefix and restore it into GPU KV.
+        # This request is sent only after GET_EXPERIMENTAL advertises the
+        # exact paired protocol capability above.
+        # Returns: tuple[final event handle, (retrieved tokens, success)]
+        "FUSED_RAW_BLOCK_RETRIEVE": ProtocolDefinition(
+            payload_classes=[KeyType, int, list[list[int]], bytes, int],
+            response_class=tuple[bytes, tuple[int, bool]],
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Synchronize a rank's retained final event when the fused response
+        # could not deliver/import its IPC handle.
+        "FUSED_RAW_BLOCK_DRAIN": ProtocolDefinition(
+            payload_classes=[str, int],
+            response_class=bool,
             handler_type=HandlerType.BLOCKING,
         ),
         # Submit a prefix lookup; job is tracked server-side by request_id

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -203,11 +203,21 @@ def _build_modules(
     # the InstanceLivenessTargets the reaper scans.
     transfer_modules: list[EngineModule] = []
     if mp_config.supported_transfer_mode == "lmcache_driven":
-        transfer_modules.append(LMCacheDrivenTransferModule(ctx))
+        transfer_modules.append(
+            LMCacheDrivenTransferModule(
+                ctx,
+                affinity_worker_count=mp_config.max_gpu_workers,
+            )
+        )
     elif mp_config.supported_transfer_mode == "engine_driven":
         transfer_modules.append(EngineDrivenTransferModule(ctx))
     elif mp_config.supported_transfer_mode == "auto":
-        transfer_modules.append(LMCacheDrivenTransferModule(ctx))
+        transfer_modules.append(
+            LMCacheDrivenTransferModule(
+                ctx,
+                affinity_worker_count=mp_config.max_gpu_workers,
+            )
+        )
         transfer_modules.append(EngineDrivenTransferModule(ctx))
     else:
         raise ValueError(

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -43,6 +43,7 @@ class Session:
     lookup_ipc_key: Optional[IPCCacheServerKey] = None
     extras: dict[str, Any] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _resource_owners: set[int] = field(default_factory=set, repr=False)
 
     def set_tokens(self, full_token_ids: list[int]) -> None:
         """Update the token sequence (idempotent, replaces not extends).
@@ -52,6 +53,73 @@ class Session:
         """
         with self._lock:
             self.token_ids = full_token_ids
+
+    def retain_resources(
+        self,
+        resource_key: str,
+        resources: list[Any],
+        *,
+        owner_id: int | None = None,
+    ) -> None:
+        """Keep request-scoped resources alive until the session is removed.
+
+        Args:
+            resource_key: Namespace used to group related resources.
+            resources: Strong references to append to that namespace.
+            owner_id: Optional rank-local owner. Sessions with owners are
+                removed only after one END_SESSION call per distinct owner.
+
+        Raises:
+            TypeError: If ``resource_key`` is already used for non-list data.
+        """
+        if not resources:
+            return
+        with self._lock:
+            retained = self.extras.setdefault(resource_key, [])
+            if not isinstance(retained, list):
+                raise TypeError(
+                    f"Session extra {resource_key!r} is not a resource list"
+                )
+            retained.extend(resources)
+            if owner_id is not None:
+                self._resource_owners.add(owner_id)
+
+    def release_one_resource_owner(self) -> bool:
+        """Consume one rank's END_SESSION and report whether owners remain.
+
+        Returns:
+            ``True`` when at least one retained-resource owner still needs to
+            end the shared session. ``False`` when the session can be removed.
+        """
+        with self._lock:
+            if not self._resource_owners:
+                return False
+            self._resource_owners.pop()
+            return bool(self._resource_owners)
+
+    def get_retained_resources(self, resource_key: str) -> list[Any]:
+        """Return a stable snapshot of one retained-resource namespace."""
+        with self._lock:
+            retained = self.extras.get(resource_key, [])
+            if not isinstance(retained, list):
+                raise TypeError(
+                    f"Session extra {resource_key!r} is not a resource list"
+                )
+            return list(retained)
+
+    def get_retained_resources_by_prefix(self, resource_prefix: str) -> list[Any]:
+        """Return retained resources from matching namespaces."""
+        resources: list[Any] = []
+        with self._lock:
+            for resource_key, retained in self.extras.items():
+                if not resource_key.startswith(resource_prefix):
+                    continue
+                if not isinstance(retained, list):
+                    raise TypeError(
+                        f"Session extra {resource_key!r} is not a resource list"
+                    )
+                resources.extend(retained)
+        return resources
 
     @overload
     def get_hashes(self, start: int, end: int) -> list: ...
@@ -179,6 +247,44 @@ class SessionManager:
                 logger.debug("Removed session for request_id=%s", request_id)
                 return session
             return None
+
+    def get(self, request_id: str) -> Optional[Session]:
+        """Return an active session without creating it."""
+        with self._lock:
+            return self._sessions.get(request_id)
+
+    def sessions_snapshot(self) -> list[Session]:
+        """Return strong references to every currently active session."""
+        with self._lock:
+            return list(self._sessions.values())
+
+    def release_for_end_session(
+        self,
+        request_id: str,
+    ) -> tuple[Optional[Session], bool]:
+        """Release one END_SESSION participant atomically.
+
+        A fused TP request stores exporter events from every worker in one
+        request-id Session. The first workers to finish must not remove that
+        shared owner. Ordinary sessions have no resource-owner count and retain
+        the historical remove-on-first-END behavior.
+
+        Args:
+            request_id: Unique request identifier.
+
+        Returns:
+            ``(removed_session, waiting_for_more_owners)``. While the second
+            value is ``True``, the session and its resources remain managed.
+        """
+        with self._lock:
+            session = self._sessions.get(request_id)
+            if session is None:
+                return None, False
+            if session.release_one_resource_owner():
+                return None, True
+            del self._sessions[request_id]
+            logger.debug("Removed session for request_id=%s", request_id)
+            return session, False
 
     def cleanup_expired(self) -> int:
         """Remove sessions that have exceeded their TTL.

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 import ctypes
 import json
 import os
@@ -43,6 +43,7 @@ _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
+IOURING_FIXED_BUFFER_MAX_BYTES = 1 << 30
 
 
 def round_up(x: int, align: int) -> int:
@@ -314,6 +315,10 @@ class RawBlockCore:
         self._data_base_offset: int = 0
 
         self._raw = None
+        self._fixed_buffer_count = 0
+        self._fixed_buffer_bytes = 0
+        self._batched_load_count = 0
+        self._batched_load_fallback_count = 0
         self._closed = False
 
         self._meta_seq: int = 0
@@ -446,6 +451,63 @@ class RawBlockCore:
         """
         self._raw = raw_device
 
+    def register_l1_fixed_buffers(self, ptr: int, size: int) -> bool:
+        """Register a stable L1 prefix with the io_uring device.
+
+        Linux limits each fixed-buffer entry to 1 GiB. Requests that cross an
+        entry boundary remain valid and use the ordinary io_uring path.
+        Registration is an optional startup optimization: unsupported kernels,
+        extensions, and resource limits leave ordinary reads enabled.
+
+        Args:
+            ptr: Base address of the stable L1 memory region.
+            size: Stable byte length starting at ``ptr``.
+
+        Returns:
+            True when all fixed-buffer entries were registered, otherwise false.
+        """
+        if (
+            self.io_engine != "io_uring"
+            or not self.use_odirect
+            or not self.enable_zero_copy
+            or size <= 0
+        ):
+            return False
+
+        ptr = int(ptr)
+        size = int(size)
+        size -= size % self.block_align
+        if ptr <= 0 or ptr % self.block_align != 0 or size <= 0:
+            logger.warning(
+                "RawBlockCore: skipping io_uring fixed-buffer registration "
+                "because the stable L1 range is not block aligned"
+            )
+            return False
+
+        buffer_ptrs: list[int] = []
+        buffer_sizes: list[int] = []
+        offset = 0
+        while offset < size:
+            chunk_size = min(IOURING_FIXED_BUFFER_MAX_BYTES, size - offset)
+            buffer_ptrs.append(ptr + offset)
+            buffer_sizes.append(chunk_size)
+            offset += chunk_size
+
+        try:
+            self._rawdev().register_fixed_buffers(buffer_ptrs, buffer_sizes)
+        except Exception as e:
+            logger.warning(
+                "RawBlockCore: io_uring fixed-buffer registration unavailable; "
+                "using ordinary reads: %s",
+                e,
+            )
+            return False
+
+        with self._lock:
+            self._fixed_buffer_count = len(buffer_ptrs)
+            self._fixed_buffer_bytes = size
+        return True
+
     def register_fixed_buffers_from_allocator(self, memory_allocator: Any) -> None:
         """Register allocator pages with io_uring when the allocator exposes them.
 
@@ -475,6 +537,9 @@ class RawBlockCore:
         buffer_ptrs = [buf.data_ptr() for buf in buffers]
         buffer_sizes = [buf.numel() * buf.element_size() for buf in buffers]
         self._rawdev().register_fixed_buffers(buffer_ptrs, buffer_sizes)
+        with self._lock:
+            self._fixed_buffer_count = len(buffer_ptrs)
+            self._fixed_buffer_bytes = sum(buffer_sizes)
         logger.info(
             "RawBlockCore: registered %d paged buffers for io_uring fixed I/O",
             len(buffers),
@@ -820,6 +885,233 @@ class RawBlockCore:
                 self._last_io_ts = time.monotonic()
         return results
 
+    def load_many_into_batched(
+        self,
+        encoded_keys: Sequence[str],
+        objs: Sequence[MemoryObj],
+        *,
+        raise_on_error: bool = False,
+        completion_batch_size: int | None = None,
+        on_batch_loaded: Callable[[int, int], None] | None = None,
+    ) -> list[bool]:
+        """Load eligible io_uring reads in one batch.
+
+        This method is reserved for synchronous MP retrieval. Unlike
+        :meth:`load_many_into`, it prepares all eligible destination buffers
+        before issuing one ``_read_buffers`` call. Buffers that require bounce
+        handling retain the existing one-at-a-time path.
+
+        Args:
+            encoded_keys: Ordered encoded raw-block keys to load.
+            objs: Destination memory objects. Buffers must remain valid until
+                this method returns.
+            raise_on_error: If true, re-raise the first load exception instead
+                of logging it and returning false for that key.
+            completion_batch_size: Number of logical objects whose completed
+                reads trigger one callback. Used only with ``on_batch_loaded``.
+            on_batch_loaded: Optional callback invoked with a half-open range
+                after that range's reads complete successfully. All groups are
+                submitted before the first wait so later I/O can overlap work
+                enqueued by the callback.
+
+        Returns:
+            A list of per-key load success booleans aligned with
+            ``encoded_keys``.
+
+        Raises:
+            ValueError: If either sequence is empty or the sequence lengths do
+                not match.
+            Exception: Re-raises load errors when ``raise_on_error`` is true.
+        """
+        if not encoded_keys or not objs:
+            raise ValueError("encoded_keys and objs must be non-empty")
+        if len(encoded_keys) != len(objs):
+            raise ValueError("encoded_keys and objs must have the same length")
+        if on_batch_loaded is not None and (
+            completion_batch_size is None or completion_batch_size <= 0
+        ):
+            raise ValueError(
+                "completion_batch_size must be positive with on_batch_loaded"
+            )
+
+        with self._lock:
+            items = [
+                (encoded_key, self._index.get(encoded_key))
+                for encoded_key in encoded_keys
+            ]
+            self._inflight_io_count += 1
+
+        results = [False] * len(encoded_keys)
+        batched_reads: list[tuple[int, str, _Entry, Any, int]] = []
+        fallback_reads: list[tuple[int, str, _Entry, Any, int, int]] = []
+        try:
+            for i, (encoded_key, entry) in enumerate(items):
+                if entry is None:
+                    continue
+                try:
+                    payload_len = int(entry.size)
+                    total_len = (
+                        round_up(payload_len, self.block_align)
+                        if self._requires_transfer_alignment
+                        else payload_len
+                    )
+                    buf = memoryview(objs[i].byte_array)
+                    try:
+                        buf = buf.cast("B")
+                    except Exception:
+                        pass
+
+                    direct_view = self._build_direct_odirect_view(
+                        memory_obj=objs[i],
+                        payload_len=payload_len,
+                        total_len=total_len,
+                        buffer_len=len(buf),
+                        zero_tail=False,
+                    )
+
+                    batch_buffer: Any | None = None
+                    if self.io_engine == "io_uring" and not self.use_uring_cmd:
+                        if self.use_odirect:
+                            if (
+                                direct_view is not None
+                                and len(direct_view) >= total_len
+                            ):
+                                batch_buffer = direct_view
+                        elif len(buf) >= total_len:
+                            batch_buffer = buf
+
+                    if batch_buffer is not None:
+                        batched_reads.append(
+                            (i, encoded_key, entry, batch_buffer, total_len)
+                        )
+                        continue
+
+                    read_buffer = direct_view if direct_view is not None else buf
+                    read_payload_len = (
+                        total_len
+                        if direct_view is not None and len(direct_view) >= total_len
+                        else payload_len
+                    )
+                    fallback_reads.append(
+                        (
+                            i,
+                            encoded_key,
+                            entry,
+                            read_buffer,
+                            read_payload_len,
+                            total_len,
+                        )
+                    )
+                except Exception as e:
+                    if raise_on_error:
+                        raise
+                    logger.error("RawBlockCore load failed for %s: %s", encoded_key, e)
+
+            pipeline_eligible = (
+                on_batch_loaded is not None
+                and len(batched_reads) == len(encoded_keys)
+                and not fallback_reads
+                and [item[0] for item in batched_reads]
+                == list(range(len(encoded_keys)))
+            )
+            if pipeline_eligible:
+                assert completion_batch_size is not None
+                with self._lock:
+                    self._batched_load_count += 1
+
+                def mark_batch_loaded(start: int, end: int) -> None:
+                    for position in range(start, end):
+                        i, _, entry, _, _ = batched_reads[position]
+                        objs[i].metadata.cached_positions = entry.meta.cached_positions
+                        results[i] = True
+                    assert on_batch_loaded is not None
+                    on_batch_loaded(start, end)
+
+                self._read_buffers_pipelined(
+                    [
+                        entry.offset + self.header_bytes
+                        for _, _, entry, _, _ in batched_reads
+                    ],
+                    [buf for _, _, _, buf, _ in batched_reads],
+                    [total_len for _, _, _, _, total_len in batched_reads],
+                    completion_batch_size=completion_batch_size,
+                    on_batch_loaded=mark_batch_loaded,
+                )
+                return results
+
+            if batched_reads:
+                with self._lock:
+                    self._batched_load_count += 1
+                try:
+                    self._read_buffers(
+                        [
+                            entry.offset + self.header_bytes
+                            for _, _, entry, _, _ in batched_reads
+                        ],
+                        [buf for _, _, _, buf, _ in batched_reads],
+                        [total_len for _, _, _, _, total_len in batched_reads],
+                        [total_len for _, _, _, _, total_len in batched_reads],
+                    )
+                    for i, _, entry, _, _ in batched_reads:
+                        objs[i].metadata.cached_positions = entry.meta.cached_positions
+                        results[i] = True
+                except Exception as e:
+                    if raise_on_error:
+                        raise
+                    with self._lock:
+                        self._batched_load_fallback_count += 1
+                    logger.warning(
+                        "RawBlockCore batched load failed; retrying reads "
+                        "one by one: %s",
+                        e,
+                    )
+                    raw_dev = self._rawdev()
+                    for i, encoded_key, entry, buf, total_len in batched_reads:
+                        try:
+                            raw_dev.pread_into(
+                                entry.offset + self.header_bytes,
+                                buf,
+                                total_len,
+                                total_len,
+                            )
+                            objs[
+                                i
+                            ].metadata.cached_positions = entry.meta.cached_positions
+                            results[i] = True
+                        except Exception as retry_error:
+                            logger.error(
+                                "RawBlockCore load failed for %s: %s",
+                                encoded_key,
+                                retry_error,
+                            )
+
+            for (
+                i,
+                encoded_key,
+                entry,
+                buf,
+                payload_len,
+                total_len,
+            ) in fallback_reads:
+                try:
+                    self._read_buffers(
+                        [entry.offset + self.header_bytes],
+                        [buf],
+                        [payload_len],
+                        [total_len],
+                    )
+                    objs[i].metadata.cached_positions = entry.meta.cached_positions
+                    results[i] = True
+                except Exception as e:
+                    if raise_on_error:
+                        raise
+                    logger.error("RawBlockCore load failed for %s: %s", encoded_key, e)
+        finally:
+            with self._lock:
+                self._inflight_io_count -= 1
+                self._last_io_ts = time.monotonic()
+        return results
+
     def unlock_many(self, encoded_keys: Sequence[str]) -> None:
         """Release L2 lock references for encoded keys.
 
@@ -908,6 +1200,19 @@ class RawBlockCore:
     def report_status(self) -> dict:
         """Return raw-block health, layout, metadata, and in-flight counters."""
         with self._lock:
+            fixed_read_submission_count = 0
+            nonfixed_read_submission_count = 0
+            if self._raw is not None:
+                fixed_read_counter = getattr(
+                    self._raw, "fixed_read_submission_count", None
+                )
+                nonfixed_read_counter = getattr(
+                    self._raw, "nonfixed_read_submission_count", None
+                )
+                if callable(fixed_read_counter):
+                    fixed_read_submission_count = int(fixed_read_counter())
+                if callable(nonfixed_read_counter):
+                    nonfixed_read_submission_count = int(nonfixed_read_counter())
             return {
                 "is_healthy": not self._closed,
                 "type": "RawBlockCore",
@@ -935,6 +1240,12 @@ class RawBlockCore:
                 "io_engine": self.io_engine,
                 "iouring_queue_depth": self.iouring_queue_depth,
                 "use_uring_cmd": self.use_uring_cmd,
+                "fixed_buffer_count": self._fixed_buffer_count,
+                "fixed_buffer_bytes": self._fixed_buffer_bytes,
+                "fixed_read_submission_count": fixed_read_submission_count,
+                "nonfixed_read_submission_count": nonfixed_read_submission_count,
+                "batched_load_count": self._batched_load_count,
+                "batched_load_fallback_count": self._batched_load_fallback_count,
             }
 
     def close(self) -> None:
@@ -1298,6 +1609,55 @@ class RawBlockCore:
         ):
             raw_dev.write_uring(int(offset), buf, int(payload_len), int(total_len))
 
+    def _read_buffers_pipelined(
+        self,
+        offsets: Sequence[int],
+        buffers: Sequence[Any],
+        total_lens: Sequence[int],
+        *,
+        completion_batch_size: int,
+        on_batch_loaded: Callable[[int, int], None],
+    ) -> None:
+        """Submit every read group, then publish completed groups in order."""
+        raw_dev = self._rawdev()
+        submissions: list[tuple[int, int, int]] = []
+        first_error: Exception | None = None
+        for start in range(0, len(offsets), completion_batch_size):
+            end = min(start + completion_batch_size, len(offsets))
+            try:
+                batch_offsets = [int(offset) for offset in offsets[start:end]]
+                batch_buffers = list(buffers[start:end])
+                batch_total_lens = [
+                    int(total_len) for total_len in total_lens[start:end]
+                ]
+                if not all(self._is_buffer_aligned(buf) for buf in batch_buffers):
+                    raise ValueError("Pipelined O_DIRECT reads require aligned buffers")
+                batch_id = raw_dev.batched_read(
+                    batch_offsets,
+                    batch_buffers,
+                    batch_total_lens,
+                )
+                submissions.append((batch_id, start, end))
+            except Exception as error:
+                first_error = error
+                break
+
+        for batch_id, start, end in submissions:
+            try:
+                raw_dev.wait_iouring(batch_id)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+            else:
+                if first_error is None:
+                    try:
+                        on_batch_loaded(start, end)
+                    except Exception as error:
+                        first_error = error
+
+        if first_error is not None:
+            raise first_error
+
     def _read_buffers(
         self,
         offsets: Sequence[int],
@@ -1333,13 +1693,16 @@ class RawBlockCore:
             int(payload_len) == int(total_len)
             for payload_len, total_len in zip(payload_lens, total_lens, strict=True)
         )
+        batch_offsets = [int(offset) for offset in offsets]
+        batch_buffers = list(buffers)
+        batch_total_lens = [int(total_len) for total_len in total_lens]
         # batched_read requires aligned buffers when O_DIRECT is enabled
         # Check alignment before using batched_read
-        if can_batch and all(self._is_buffer_aligned(buf) for buf in buffers):
+        if can_batch and all(self._is_buffer_aligned(buf) for buf in batch_buffers):
             batch_id = raw_dev.batched_read(
-                [int(offset) for offset in offsets],
-                list(buffers),
-                [int(total_len) for total_len in total_lens],
+                batch_offsets,
+                batch_buffers,
+                batch_total_lens,
             )
             raw_dev.wait_iouring(batch_id)
             return

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -213,6 +213,22 @@ fn round_up(x: usize, align: usize) -> usize {
     (x + align - 1) / align * align
 }
 
+fn registered_buffer_index(
+    buffers: &HashMap<usize, (u16, usize)>,
+    ptr: usize,
+    len: usize,
+) -> Option<u16> {
+    let end = ptr.checked_add(len)?;
+    buffers.iter().find_map(|(base, (index, size))| {
+        let registered_end = base.checked_add(*size)?;
+        if ptr >= *base && end <= registered_end {
+            Some(*index)
+        } else {
+            None
+        }
+    })
+}
+
 // Fetch errno for the last libc call on this thread.
 fn errno() -> i32 {
     // SAFETY: libc call.
@@ -895,11 +911,15 @@ struct RawBlockDevice {
     worker: Option<thread::JoinHandle<()>>,
     // Shutdown signal for worker thread
     shutdown: Option<Arc<AtomicBool>>,
-    // Map from buffer pointer address to registered fixed buffer index
-    // Used for zero-copy I/O with pre-registered buffers
+    // Map from registered buffer base address to (index, size).
+    // Individual I/O buffers may be subranges of these persistent regions.
     fixed_buffer_map: Arc<Mutex<HashMap<usize, (u16, usize)>>>,
     // Flag indicating if fixed buffers have been registered
     fixed_buffers_registered: Arc<AtomicBool>,
+    // Monotonic counts of regular ReadFixed and Read SQEs built by the
+    // io_uring worker. UringCmd80 operations are intentionally excluded.
+    fixed_read_submission_count: Arc<AtomicU64>,
+    nonfixed_read_submission_count: Arc<AtomicU64>,
     // Count of currently in-flight I/O operations (global)
     // Used for shutdown and cleanup
     in_flight_count: Arc<AtomicU64>,
@@ -1040,6 +1060,8 @@ impl RawBlockDevice {
             fd_size_bytes(fd)?
         };
 
+        let fixed_read_submission_count = Arc::new(AtomicU64::new(0));
+        let nonfixed_read_submission_count = Arc::new(AtomicU64::new(0));
         let (
             ring_opt,
             queue_opt,
@@ -1128,6 +1150,8 @@ impl RawBlockDevice {
             let in_flight_count_clone = Arc::clone(&in_flight_count);
             let in_flight_cvar_clone = Arc::clone(&in_flight_cvar);
             let batch_in_flight_clone = Arc::clone(&batch_in_flight);
+            let fixed_read_submission_count_clone = Arc::clone(&fixed_read_submission_count);
+            let nonfixed_read_submission_count_clone = Arc::clone(&nonfixed_read_submission_count);
             let ring_size = iouring_queue_depth;
 
             // Helper function to copy data from bounce buffer to original buffer
@@ -1241,8 +1265,12 @@ impl RawBlockDevice {
                 ring: &IoUringWrapper,
                 sub: &IoSubmission,
                 user_data: u64,
+                fixed_read_submission_count: &AtomicU64,
+                nonfixed_read_submission_count: &AtomicU64,
             ) -> Result<(), PyErr> {
                 let ptr = sub.ptr_addr as *mut u8;
+                let regular_read_uses_fixed_buffer = (sub.nvme_cmd_data.is_none() && !sub.is_write)
+                    .then_some(sub.fixed_buffer_idx.is_some());
 
                 // Check if this is an io_uring_cmd submission
                 if let Some(nvme_data) = &sub.nvme_cmd_data {
@@ -1334,6 +1362,14 @@ impl RawBlockDevice {
                         }
                     }
                 }
+                if let Some(uses_fixed_buffer) = regular_read_uses_fixed_buffer {
+                    let counter = if uses_fixed_buffer {
+                        fixed_read_submission_count
+                    } else {
+                        nonfixed_read_submission_count
+                    };
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
                 Ok(())
             }
 
@@ -1421,8 +1457,13 @@ impl RawBlockDevice {
                                             // Don't decrement in_flight_count since we're resubmitting
                                             in_flight.insert(user_data, sub.clone());
                                             // Push a new SQE for the remaining data
-                                            let _ =
-                                                build_and_submit_sqe(&ring_clone, &sub, user_data);
+                                            let _ = build_and_submit_sqe(
+                                                &ring_clone,
+                                                &sub,
+                                                user_data,
+                                                &fixed_read_submission_count_clone,
+                                                &nonfixed_read_submission_count_clone,
+                                            );
                                             let _ = match &ring_clone {
                                                 IoUringWrapper::Standard(ring) => {
                                                     let ring = ring.lock().unwrap();
@@ -1502,8 +1543,13 @@ impl RawBlockDevice {
                                             // Don't decrement in_flight_count since we're resubmitting
                                             in_flight.insert(user_data, sub.clone());
                                             // Push a new SQE for the remaining data
-                                            let _ =
-                                                build_and_submit_sqe(&ring_clone, &sub, user_data);
+                                            let _ = build_and_submit_sqe(
+                                                &ring_clone,
+                                                &sub,
+                                                user_data,
+                                                &fixed_read_submission_count_clone,
+                                                &nonfixed_read_submission_count_clone,
+                                            );
                                             let _ = match &ring_clone {
                                                 IoUringWrapper::Standard(ring) => {
                                                     let ring = ring.lock().unwrap();
@@ -1585,7 +1631,13 @@ impl RawBlockDevice {
                             for sub in batch.iter().take(to_submit_count) {
                                 let user_data = next_user_data;
                                 next_user_data = next_user_data.wrapping_add(1);
-                                match build_and_submit_sqe(&ring_clone, sub, user_data) {
+                                match build_and_submit_sqe(
+                                    &ring_clone,
+                                    sub,
+                                    user_data,
+                                    &fixed_read_submission_count_clone,
+                                    &nonfixed_read_submission_count_clone,
+                                ) {
                                     Ok(()) => {
                                         user_data_list.push(user_data);
                                         built_submissions.push(sub.clone());
@@ -1813,6 +1865,8 @@ impl RawBlockDevice {
             shutdown: shutdown_opt,
             fixed_buffer_map: Arc::new(Mutex::new(HashMap::new())),
             fixed_buffers_registered: Arc::new(AtomicBool::new(false)),
+            fixed_read_submission_count,
+            nonfixed_read_submission_count,
             in_flight_count: in_flight_count_opt.unwrap_or_else(|| Arc::new(AtomicU64::new(0))),
             in_flight_cvar: in_flight_cvar_opt.unwrap_or_else(|| Arc::new(Condvar::new())),
             batch_ready: batch_ready_opt,
@@ -1888,6 +1942,16 @@ impl RawBlockDevice {
         Ok(self.size)
     }
 
+    /// Number of regular io_uring ReadFixed SQEs submitted.
+    fn fixed_read_submission_count(&self) -> u64 {
+        self.fixed_read_submission_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of regular io_uring Read SQEs submitted.
+    fn nonfixed_read_submission_count(&self) -> u64 {
+        self.nonfixed_read_submission_count.load(Ordering::Relaxed)
+    }
+
     /// Get NVMe namespace ID (only available when use_uring_cmd=true)
     fn nvme_nsid(&self) -> PyResult<u32> {
         self.nvme_nsid.ok_or_else(|| {
@@ -1909,15 +1973,13 @@ impl RawBlockDevice {
         })
     }
 
-    /// Register fixed buffers for zero-copy io_uring operations.
+    /// Register fixed buffers for io_uring operations.
     ///
     /// - Pre-registering memory buffers with the kernel
     /// - Using indexed descriptors (instead of pointers) in I/O operations
-    /// - The kernel then does DMA directly from/to the registered buffers
+    /// - Reusing the same pinned page mappings across I/O operations
     ///
-    /// This is more efficient than regular I/O because:
-    /// - No buffer copying between user space and kernel
-    /// - The kernel can pin the memory pages for the duration of I/O
+    /// This avoids importing and pinning the same pages for every request.
     ///
     /// Registration must happen BEFORE any I/O using these buffers.
     /// The buffers must remain valid (not freed) until unregistered.
@@ -1940,47 +2002,68 @@ impl RawBlockDevice {
                 "at least one buffer must be provided",
             ));
         }
-
-        {
-            let mut map = self.fixed_buffer_map.lock().unwrap();
-            map.clear();
-            for (idx, (ptr, size)) in buffer_ptrs.iter().zip(buffer_sizes.iter()).enumerate() {
-                map.insert(*ptr, (idx as u16, *size));
-            }
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        if self.fixed_buffers_registered.load(Ordering::Acquire) {
+            return Err(PyRuntimeError::new_err(
+                "fixed buffers are already registered",
+            ));
+        }
+        if buffer_ptrs.len() > usize::from(u16::MAX) + 1 {
+            return Err(PyValueError::new_err("too many fixed buffers"));
         }
 
-        if let Some(ring) = &self.ring {
-            let mut iovecs: Vec<libc::iovec> = Vec::new();
-            for (ptr, size) in buffer_ptrs.iter().zip(buffer_sizes.iter()) {
-                iovecs.push(libc::iovec {
-                    iov_base: *ptr as *mut libc::c_void,
-                    iov_len: *size,
-                });
+        let mut new_map = HashMap::with_capacity(buffer_ptrs.len());
+        let mut ranges = Vec::with_capacity(buffer_ptrs.len());
+        for (idx, (ptr, size)) in buffer_ptrs.iter().zip(buffer_sizes.iter()).enumerate() {
+            if *ptr == 0 || *size == 0 {
+                return Err(PyValueError::new_err(
+                    "fixed-buffer pointers and sizes must be non-zero",
+                ));
             }
-            unsafe {
-                let result = match ring {
-                    IoUringWrapper::Standard(ring) => {
-                        let ring = ring.lock().unwrap();
-                        ring.submitter().register_buffers(&iovecs)
-                    }
-                    IoUringWrapper::Big(ring) => {
-                        let ring = ring.lock().unwrap();
-                        ring.submitter().register_buffers(&iovecs)
-                    }
-                };
-                match result {
-                    Ok(_) => {
-                        self.fixed_buffers_registered.store(true, Ordering::Relaxed);
-                    }
-                    Err(e) => {
-                        return Err(PyRuntimeError::new_err(format!(
-                            "register_buffers failed: {}",
-                            e
-                        )))
-                    }
+            let end = ptr
+                .checked_add(*size)
+                .ok_or_else(|| PyValueError::new_err("fixed-buffer range overflow"))?;
+            new_map.insert(*ptr, (idx as u16, *size));
+            ranges.push((*ptr, end));
+        }
+        ranges.sort_unstable_by_key(|(start, _)| *start);
+        if ranges.windows(2).any(|pair| pair[0].1 > pair[1].0) {
+            return Err(PyValueError::new_err(
+                "fixed-buffer ranges must not overlap",
+            ));
+        }
+
+        let ring = self
+            .ring
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("io_uring not initialized"))?;
+        let iovecs: Vec<libc::iovec> = buffer_ptrs
+            .iter()
+            .zip(buffer_sizes.iter())
+            .map(|(ptr, size)| libc::iovec {
+                iov_base: *ptr as *mut libc::c_void,
+                iov_len: *size,
+            })
+            .collect();
+        unsafe {
+            let result = match ring {
+                IoUringWrapper::Standard(ring) => {
+                    let ring = ring.lock().unwrap();
+                    ring.submitter().register_buffers(&iovecs)
                 }
-            }
+                IoUringWrapper::Big(ring) => {
+                    let ring = ring.lock().unwrap();
+                    ring.submitter().register_buffers(&iovecs)
+                }
+            };
+            result
+                .map_err(|e| PyRuntimeError::new_err(format!("register_buffers failed: {}", e)))?;
         }
+
+        *self.fixed_buffer_map.lock().unwrap() = new_map;
+        self.fixed_buffers_registered.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -2063,7 +2146,7 @@ impl RawBlockDevice {
         let use_odirect = self.use_odirect;
         let alignment = self.alignment;
         let use_uring_cmd = self.use_uring_cmd;
-        let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Acquire);
         // Clone the fixed buffer map before releasing GIL to avoid lock contention
         let fixed_buffer_map: HashMap<usize, (u16, usize)> = if fixed_buffers_registered {
             let map = self.fixed_buffer_map.lock().unwrap();
@@ -2104,8 +2187,8 @@ impl RawBlockDevice {
 
                 let comp = Arc::new(IoCompletion::new());
 
-                // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+                // Use the persistent registration when this I/O fits one range.
+                let fixed_idx = registered_buffer_index(&fixed_buffer_map, ptrs[i], total_len);
 
                 if use_odirect {
                     #[allow(clippy::manual_is_multiple_of)]
@@ -2370,12 +2453,12 @@ impl RawBlockDevice {
             true
         };
 
-        // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-        let use_fixed = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        // Use the persistent registration when this I/O fits one range.
+        let use_fixed = self.fixed_buffers_registered.load(Ordering::Acquire);
         let fixed_idx = if use_fixed && ptr_aligned {
             let map = self.fixed_buffer_map.lock().unwrap();
             let ptr_addr = ptr as usize;
-            map.get(&ptr_addr).map(|(idx, _)| *idx)
+            registered_buffer_index(&map, ptr_addr, total_len)
         } else {
             None
         };
@@ -2505,12 +2588,12 @@ impl RawBlockDevice {
             true
         };
 
-        // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-        let use_fixed = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        // Use the persistent registration when this I/O fits one range.
+        let use_fixed = self.fixed_buffers_registered.load(Ordering::Acquire);
         let fixed_idx = if use_fixed && ptr_aligned {
             let map = self.fixed_buffer_map.lock().unwrap();
             let ptr_addr = ptr as usize;
-            map.get(&ptr_addr).map(|(idx, _)| *idx)
+            registered_buffer_index(&map, ptr_addr, total_len)
         } else {
             None
         };
@@ -2673,7 +2756,7 @@ impl RawBlockDevice {
         let fd = self.fd;
         let use_odirect = self.use_odirect;
         let alignment = self.alignment;
-        let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Relaxed);
+        let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Acquire);
         // Clone the fixed buffer map before releasing GIL to avoid lock contention
         let fixed_buffer_map: HashMap<usize, (u16, usize)> = if fixed_buffers_registered {
             let map = self.fixed_buffer_map.lock().unwrap();
@@ -2729,8 +2812,8 @@ impl RawBlockDevice {
 
                 let comp = Arc::new(IoCompletion::new());
 
-                // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+                // Use the persistent registration when this I/O fits one range.
+                let fixed_idx = registered_buffer_index(&fixed_buffer_map, ptrs[i], total_len);
 
                 let sub = IoSubmission {
                     fd,
@@ -2750,32 +2833,32 @@ impl RawBlockDevice {
                 submissions.push((sub, comp));
             }
 
-            // Queue all submissions atomically. At this point no further errors can
-            // occur during queuing.
-            for (sub, comp) in submissions {
-                in_flight_count.fetch_add(1, Ordering::Relaxed);
-
-                // Increment per-batch in-flight count
-                {
-                    let batch_map = batch_in_flight.lock().unwrap();
-                    if let Some((batch_count, _)) = batch_map.get(&batch_id) {
-                        batch_count.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-
-                {
-                    let mut q = queue.lock().unwrap();
-                    q.push(sub);
-                }
-                batch_ready.signal_producer();
-
-                // Store completion for error checking in wait_iouring
-                {
-                    let mut completions = batched_completions.lock().unwrap();
-                    let batch_completions = completions.entry(batch_id).or_default();
-                    batch_completions.push(comp);
+            // Register the entire batch before exposing any submissions to the
+            // worker, which may complete requests as soon as the queue is unlocked.
+            let submission_count = submissions.len() as u64;
+            in_flight_count.fetch_add(submission_count, Ordering::Relaxed);
+            {
+                let batch_map = batch_in_flight.lock().unwrap();
+                if let Some((batch_count, _)) = batch_map.get(&batch_id) {
+                    batch_count.fetch_add(submission_count, Ordering::Relaxed);
                 }
             }
+            {
+                let mut completions = batched_completions.lock().unwrap();
+                let batch_completions = completions.entry(batch_id).or_default();
+                batch_completions.extend(
+                    submissions
+                        .iter()
+                        .map(|(_, completion)| Arc::clone(completion)),
+                );
+            }
+
+            // Queue the batch atomically and notify the worker once.
+            {
+                let mut q = queue.lock().unwrap();
+                q.extend(submissions.into_iter().map(|(submission, _)| submission));
+            }
+            batch_ready.signal_producer();
             Ok::<(), PyErr>(())
         });
 
@@ -3080,7 +3163,7 @@ impl RawBlockDevice {
                 guard = g;
             }
 
-            if self.fixed_buffers_registered.load(Ordering::Relaxed) {
+            if self.fixed_buffers_registered.load(Ordering::Acquire) {
                 if let Some(ring) = &self.ring {
                     let _ = match ring {
                         IoUringWrapper::Standard(ring) => {
@@ -3094,7 +3177,7 @@ impl RawBlockDevice {
                     };
                 }
                 self.fixed_buffers_registered
-                    .store(false, Ordering::Relaxed);
+                    .store(false, Ordering::Release);
                 self.fixed_buffer_map.lock().unwrap().clear();
             }
         }
@@ -3124,6 +3207,30 @@ impl Drop for RawBlockDevice {
         if !self.closed.load(Ordering::Relaxed) {
             let _ = self.do_close();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::registered_buffer_index;
+    use std::collections::HashMap;
+
+    #[test]
+    fn registered_buffer_index_accepts_contained_ranges() {
+        let buffers = HashMap::from([(0x10000, (7, 0x4000))]);
+
+        assert_eq!(registered_buffer_index(&buffers, 0x10000, 0x1000), Some(7));
+        assert_eq!(registered_buffer_index(&buffers, 0x12000, 0x1000), Some(7));
+        assert_eq!(registered_buffer_index(&buffers, 0x13000, 0x1000), Some(7));
+    }
+
+    #[test]
+    fn registered_buffer_index_rejects_out_of_range_and_overflow() {
+        let buffers = HashMap::from([(0x10000, (7, 0x4000))]);
+
+        assert_eq!(registered_buffer_index(&buffers, 0x0fff0, 0x1000), None);
+        assert_eq!(registered_buffer_index(&buffers, 0x13000, 0x1001), None);
+        assert_eq!(registered_buffer_index(&buffers, usize::MAX - 1, 4), None);
     }
 }
 

--- a/tests/v1/distributed/test_l1_memory_manager.py
+++ b/tests/v1/distributed/test_l1_memory_manager.py
@@ -409,6 +409,7 @@ class TestGetL1MemoryDesc:
 
         assert desc.size == basic_config.size_in_bytes
         assert desc.align_bytes == basic_config.align_bytes
+        assert desc.fixed_buffer_registration_size == 0
 
         manager.close()
 
@@ -422,6 +423,17 @@ class TestGetL1MemoryDesc:
         assert isinstance(desc, L1MemoryDesc)
         assert desc.ptr != 0
         assert desc.size == non_lazy_config.size_in_bytes
+        assert desc.fixed_buffer_registration_size == non_lazy_config.size_in_bytes
+
+        manager.close()
+
+    def test_fully_initialized_lazy_l1_is_safe_to_register(self, small_config):
+        """A lazy pool is stable when its initial size already equals its final size."""
+        manager = L1MemoryManager(small_config)
+
+        desc = manager.get_l1_memory_desc()
+
+        assert desc.fixed_buffer_registration_size == small_config.size_in_bytes
 
         manager.close()
 

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import os
 import select
 import tempfile
+import threading
 
 # Third Party
 import pytest
@@ -13,7 +14,7 @@ import torch
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import EvictionConfig
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
     RawBlockL2Adapter,
     RawBlockL2AdapterConfig,
@@ -204,6 +205,117 @@ def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
         RawBlockL2AdapterConfig.from_dict(_config_dict(iouring_queue_depth=0))
 
 
+def test_raw_block_l2_adapter_registers_stable_l1_fixed_buffers():
+    """Adapter startup offers only the descriptor's stable prefix to the core."""
+    config = RawBlockL2AdapterConfig.from_dict(
+        _config_dict(
+            use_odirect=True,
+            io_engine="io_uring",
+        )
+    )
+    l1_memory_desc = L1MemoryDesc(
+        ptr=0x1000_0000,
+        size=4 << 30,
+        align_bytes=4096,
+        fixed_buffer_registration_size=4 << 30,
+    )
+
+    with patch(
+        "lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter.RawBlockCore"
+    ) as core_cls:
+        core = core_cls.return_value
+        core.report_status.return_value = {"usable_capacity_bytes": 0}
+        core.snapshot_indexed_keys.return_value = []
+
+        adapter = RawBlockL2Adapter(config, l1_memory_desc)
+        try:
+            core.register_l1_fixed_buffers.assert_called_once_with(
+                l1_memory_desc.ptr,
+                l1_memory_desc.fixed_buffer_registration_size,
+            )
+        finally:
+            adapter.close()
+
+
+def test_raw_block_sync_loads_run_concurrently_and_close_waits():
+    """Synchronous MP reads do not serialize, and close waits for their buffers."""
+    config = RawBlockL2AdapterConfig.from_dict(_config_dict())
+    entered_lock = threading.Lock()
+    both_entered = threading.Event()
+    release_loads = threading.Event()
+    core_closed = threading.Event()
+    errors: list[BaseException] = []
+    entered = 0
+
+    def load_many_into_batched(
+        keys,
+        objects,
+        *,
+        completion_batch_size=None,
+        on_batch_loaded=None,
+    ):
+        nonlocal entered
+        del keys, objects
+        assert completion_batch_size is None
+        assert on_batch_loaded is None
+        with entered_lock:
+            entered += 1
+            if entered == 2:
+                both_entered.set()
+        if not release_loads.wait(timeout=5):
+            raise TimeoutError("test did not release synchronous loads")
+        return [False]
+
+    with patch(
+        "lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter.RawBlockCore"
+    ) as core_cls:
+        core = core_cls.return_value
+        core.report_status.return_value = {"usable_capacity_bytes": 0}
+        core.snapshot_indexed_keys.return_value = []
+        core.load_many_into_batched.side_effect = load_many_into_batched
+        core.close.side_effect = core_closed.set
+        adapter = RawBlockL2Adapter(config)
+
+        def run_load(chunk_id: int) -> None:
+            try:
+                adapter.load_sync(
+                    [_create_object_key(chunk_id)],
+                    [_create_memory_obj()],
+                )
+            except BaseException as error:
+                errors.append(error)
+
+        load_threads = [
+            threading.Thread(target=run_load, args=(chunk_id,)) for chunk_id in (1, 2)
+        ]
+        for thread in load_threads:
+            thread.start()
+
+        close_thread: threading.Thread | None = None
+        try:
+            assert both_entered.wait(timeout=2), (
+                "adapter mutex serialized synchronous disk reads"
+            )
+            close_thread = threading.Thread(target=adapter.close)
+            close_thread.start()
+            assert not core_closed.wait(timeout=0.2), (
+                "adapter closed fixed buffers while a synchronous read was active"
+            )
+        finally:
+            release_loads.set()
+            for thread in load_threads:
+                thread.join(timeout=5)
+            if close_thread is not None:
+                close_thread.join(timeout=5)
+            else:
+                adapter.close()
+
+        assert not errors
+        assert core_closed.is_set()
+        assert all(not thread.is_alive() for thread in load_threads)
+        assert close_thread is None or not close_thread.is_alive()
+
+
 @pytest.mark.parametrize("block_align", [0, -1, 3, 4095])
 def test_raw_block_l2_adapter_config_rejects_non_power_of_2_block_align(
     block_align: int,
@@ -272,6 +384,35 @@ def test_raw_block_l2_adapter_uring_cmd_rejects_regular_file():
                     use_uring_cmd=True,
                 )
             )
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_synchronous_lookup_load_roundtrip():
+    """The synchronous MP API locks hits and loads them into caller buffers."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        try:
+            hit_key = _create_object_key(1)
+            miss_key = _create_object_key(2)
+            stored = _create_memory_obj(fill_value=7.0)
+            assert _run_store(adapter, [hit_key], [stored]) is True
+
+            assert adapter.lookup_and_lock_sync([hit_key, miss_key]) == [True, False]
+
+            loaded = [
+                _create_memory_obj(fill_value=0.0),
+                _create_memory_obj(fill_value=0.0),
+            ]
+            assert adapter.load_sync([hit_key, miss_key], loaded) == [True, False]
+            assert torch.equal(loaded[0].tensor, stored.tensor)
+            assert torch.count_nonzero(loaded[1].tensor) == 0
+            adapter.submit_unlock([hit_key, miss_key])
+        finally:
+            adapter.close()
 
 
 @requires_raw_block_ext

--- a/tests/v1/distributed/test_report_status.py
+++ b/tests/v1/distributed/test_report_status.py
@@ -123,6 +123,7 @@ class TestStorageManagerReportStatus:
 
         # Top-level keys
         assert "is_healthy" in status
+        assert status["store_policy"] == "default"
         assert "l1_manager" in status
         assert "store_controller" in status
         assert "prefetch_controller" in status
@@ -146,6 +147,18 @@ class TestStorageManagerReportStatus:
         assert adapter_status["type"] == "MockL2Adapter"
         assert "stored_object_count" in adapter_status
         assert "max_capacity_bytes" in adapter_status
+
+    def test_report_status_exposes_configured_store_policy(self, basic_l1_config):
+        config = StorageManagerConfig(
+            l1_manager_config=basic_l1_config,
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+            store_policy="skip_l1",
+        )
+        storage_manager = StorageManager(config)
+        try:
+            assert storage_manager.report_status()["store_policy"] == "skip_l1"
+        finally:
+            storage_manager.close()
 
     def test_l1_manager_status_shape(self, storage_manager_no_l2):
         l1 = storage_manager_no_l2.report_status()["l1_manager"]

--- a/tests/v1/distributed/test_storage_manager_raw_block_restore.py
+++ b/tests/v1/distributed/test_storage_manager_raw_block_restore.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for StorageManager's fused raw-block restore path."""
+
+# Standard
+from unittest.mock import MagicMock, call, create_autospec, patch
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
+    RawBlockL2Adapter,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
+from lmcache.v1.memory_management import MemoryObj
+
+
+class _TestStorageManager(StorageManager):
+    """Minimal StorageManager harness without background controllers."""
+
+    def __init__(
+        self,
+        l1_manager: MagicMock,
+        adapters: list[L2AdapterInterface],
+        store_policy: str,
+    ) -> None:
+        self._l1_manager = l1_manager
+        self._event_bus = MagicMock()
+        self._store_policy_name = store_policy
+        self._lifecycle_lock = threading.Lock()
+        self._adapter_lease_condition = threading.Condition()
+        self._adapter_lease_counts = {}
+        self._draining_adapter_ids = set()
+        self._adapters_lock = threading.Lock()
+        self._l2_adapters = dict(enumerate(adapters))
+        self._adapter_descriptors = {
+            index: MagicMock(index=index) for index in self._l2_adapters
+        }
+
+
+def _make_key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test-model",
+        kv_rank=0,
+    )
+
+
+def _make_layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([16])],
+        dtypes=[torch.uint8],
+    )
+
+
+def _make_objects(count: int) -> list[MemoryObj]:
+    return [create_autospec(MemoryObj, instance=True) for _ in range(count)]
+
+
+def _make_raw_adapter() -> RawBlockL2Adapter:
+    return create_autospec(RawBlockL2Adapter, instance=True)
+
+
+def _make_manager(
+    adapters: list[L2AdapterInterface],
+    *,
+    store_policy: str = "skip_l1",
+) -> tuple[StorageManager, MagicMock]:
+    l1_manager = MagicMock()
+    l1_manager.finish_write.side_effect = lambda keys: {
+        key: L1Error.SUCCESS for key in keys
+    }
+    l1_manager.delete.side_effect = lambda keys, force=False: {
+        key: L1Error.SUCCESS for key in keys
+    }
+    manager = _TestStorageManager(l1_manager, adapters, store_policy)
+    return manager, l1_manager
+
+
+def _successful_reservations(
+    keys: list[ObjectKey],
+    objects: list[MemoryObj],
+) -> dict[ObjectKey, tuple[L1Error, MemoryObj]]:
+    return {
+        key: (L1Error.SUCCESS, memory_obj)
+        for key, memory_obj in zip(keys, objects, strict=True)
+    }
+
+
+def test_fused_raw_block_restore_loads_full_prefix_and_finishes_temps():
+    keys = [_make_key(i) for i in range(3)]
+    objects = _make_objects(len(keys))
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [True, True, True]
+    adapter.load_sync.return_value = [True, True, True]
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
+
+    assert manager.supports_fused_raw_block_retrieve() is True
+    assert manager.load_raw_block_prefix(keys, _make_layout()) == (keys, objects)
+    l1_manager.reserve_write.assert_called_once_with(
+        keys=keys,
+        is_temporary=[True, True, True],
+        layout_desc=_make_layout(),
+        mode="new",
+    )
+    adapter.load_sync.assert_called_once_with(keys, objects)
+    adapter.submit_unlock.assert_called_once_with(keys)
+    l1_manager.finish_write.assert_not_called()
+    l1_manager.delete.assert_not_called()
+
+    manager.finish_raw_block_restore(keys)
+    l1_manager.finish_write.assert_called_once_with(keys)
+    l1_manager.delete.assert_called_once_with(keys, force=True)
+
+
+def test_fused_raw_block_restore_returns_contiguous_load_prefix():
+    keys = [_make_key(i) for i in range(4)]
+    objects = _make_objects(len(keys))
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [True, True, True, True]
+    adapter.load_sync.return_value = [True, True, False, True]
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
+
+    assert manager.load_raw_block_prefix(keys, _make_layout()) == (
+        keys[:2],
+        objects[:2],
+    )
+    l1_manager.finish_write.assert_called_once_with(keys[2:])
+    l1_manager.delete.assert_called_once_with(keys[2:], force=True)
+    adapter.submit_unlock.assert_called_once_with(keys)
+
+
+def test_fused_raw_block_restore_zero_prefix_skips_allocation_and_load():
+    keys = [_make_key(i) for i in range(3)]
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [False, True, True]
+    manager, l1_manager = _make_manager([adapter])
+
+    assert manager.load_raw_block_prefix(keys, _make_layout()) == ([], [])
+    l1_manager.reserve_write.assert_not_called()
+    adapter.load_sync.assert_not_called()
+    adapter.submit_unlock.assert_called_once_with(keys)
+
+
+def test_fused_raw_block_restore_rejects_unsupported_adapter_topologies():
+    raw_adapter_0 = _make_raw_adapter()
+    raw_adapter_1 = _make_raw_adapter()
+    other_adapter = create_autospec(L2AdapterInterface, instance=True)
+
+    for adapters in (
+        [],
+        [other_adapter],
+        [raw_adapter_0, raw_adapter_1],
+    ):
+        manager, l1_manager = _make_manager(adapters)
+        assert manager.supports_fused_raw_block_retrieve() is False
+        assert manager.load_raw_block_prefix([_make_key(0)], _make_layout()) is None
+        l1_manager.reserve_write.assert_not_called()
+
+
+def test_fused_raw_block_restore_requires_explicit_skip_l1_policy():
+    adapter = _make_raw_adapter()
+    key = _make_key(0)
+    default_manager, default_l1 = _make_manager(
+        [adapter],
+        store_policy="default",
+    )
+
+    assert default_manager.supports_fused_raw_block_retrieve() is False
+    assert default_manager.load_raw_block_prefix([key], _make_layout()) is None
+    default_l1.reserve_write.assert_not_called()
+    adapter.lookup_and_lock_sync.assert_not_called()
+
+    skip_l1_manager, _ = _make_manager(
+        [_make_raw_adapter()],
+        store_policy="skip_l1",
+    )
+    assert skip_l1_manager.supports_fused_raw_block_retrieve() is True
+
+
+def test_fused_raw_block_restore_cleans_non_prefix_allocations():
+    keys = [_make_key(i) for i in range(3)]
+    objects = _make_objects(len(keys))
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [True, True, True]
+    adapter.load_sync.return_value = [True]
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = {
+        keys[0]: (L1Error.SUCCESS, objects[0]),
+        keys[1]: (L1Error.OUT_OF_MEMORY, None),
+        keys[2]: (L1Error.SUCCESS, objects[2]),
+    }
+
+    assert manager.load_raw_block_prefix(keys, _make_layout()) == (
+        keys[:1],
+        objects[:1],
+    )
+    adapter.load_sync.assert_called_once_with(keys[:1], objects[:1])
+    l1_manager.finish_write.assert_called_once_with(keys[2:])
+    l1_manager.delete.assert_called_once_with(keys[2:], force=True)
+    adapter.submit_unlock.assert_called_once_with(keys)
+
+
+def test_fused_raw_block_restore_cleans_all_reservations_on_load_error():
+    keys = [_make_key(i) for i in range(3)]
+    objects = _make_objects(len(keys))
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [True, True, True]
+    adapter.load_sync.side_effect = RuntimeError("load failed")
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        manager.load_raw_block_prefix(keys, _make_layout())
+    l1_manager.finish_write.assert_called_once_with(keys)
+    l1_manager.delete.assert_called_once_with(keys, force=True)
+    adapter.submit_unlock.assert_called_once_with(keys)
+
+
+@pytest.mark.parametrize("failure_source", ["callback", "later_load"])
+def test_pipelined_restore_error_preserves_handed_prefix_for_stream_cleanup(
+    failure_source: str,
+):
+    keys = [_make_key(i) for i in range(3)]
+    objects = _make_objects(len(keys))
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [True, True, True]
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
+    handed_keys: list[ObjectKey] = []
+    handed_objects: list[MemoryObj] = []
+
+    def take_loaded_batch(
+        start: int,
+        end: int,
+        batch_keys: list[ObjectKey],
+        batch_objects: list[MemoryObj],
+    ) -> None:
+        assert (start, end) == (0, 1)
+        handed_keys.extend(batch_keys)
+        handed_objects.extend(batch_objects)
+        if failure_source == "callback":
+            raise RuntimeError("CUDA enqueue failed")
+
+    def load_sync(load_keys, load_objects, **kwargs):
+        assert load_keys == keys
+        assert load_objects == objects
+        assert kwargs["completion_batch_size"] == 1
+        kwargs["on_batch_loaded"](0, 1)
+        raise RuntimeError("later read failed")
+
+    adapter.load_sync.side_effect = load_sync
+    expected_error = (
+        "CUDA enqueue failed" if failure_source == "callback" else "later read failed"
+    )
+    with pytest.raises(RuntimeError, match=expected_error):
+        manager.load_raw_block_prefix(
+            keys,
+            _make_layout(),
+            completion_batch_size=1,
+            on_batch_loaded=take_loaded_batch,
+        )
+
+    assert handed_keys == keys[:1]
+    assert handed_objects == objects[:1]
+    l1_manager.finish_write.assert_called_once_with(keys[1:])
+    l1_manager.delete.assert_called_once_with(keys[1:], force=True)
+    adapter.submit_unlock.assert_called_once_with(keys)
+    assert manager._adapter_lease_counts == {}
+
+    manager.finish_raw_block_restore(handed_keys)
+    assert l1_manager.finish_write.call_args_list == [
+        call(keys[1:]),
+        call(keys[:1]),
+    ]
+    assert l1_manager.delete.call_args_list == [
+        call(keys[1:], force=True),
+        call(keys[:1], force=True),
+    ]
+
+
+def test_fused_restore_cleans_successful_reservations_on_unlock_error():
+    keys = [_make_key(i) for i in range(2)]
+    objects = _make_objects(len(keys))
+    adapter = _make_raw_adapter()
+    adapter.lookup_and_lock_sync.return_value = [True, True]
+    adapter.load_sync.return_value = [True, True]
+    adapter.submit_unlock.side_effect = RuntimeError("unlock failed")
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
+
+    with pytest.raises(RuntimeError, match="unlock failed"):
+        manager.load_raw_block_prefix(keys, _make_layout())
+
+    l1_manager.finish_write.assert_called_once_with(keys)
+    l1_manager.delete.assert_called_once_with(keys, force=True)
+
+
+def test_fused_restore_leases_allow_concurrent_raw_block_loads():
+    keys = [_make_key(0)]
+    objects = _make_objects(2)
+    adapter = _make_raw_adapter()
+    load_barrier = threading.Barrier(2)
+    results: list[tuple[list[ObjectKey], list[MemoryObj]] | None] = []
+
+    def load_sync(_keys, _objects):
+        load_barrier.wait(timeout=5)
+        return [True]
+
+    adapter.lookup_and_lock_sync.return_value = [True]
+    adapter.load_sync.side_effect = load_sync
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.side_effect = [
+        _successful_reservations(keys, [objects[0]]),
+        _successful_reservations(keys, [objects[1]]),
+    ]
+
+    def load() -> None:
+        results.append(manager.load_raw_block_prefix(keys, _make_layout()))
+
+    load_threads = [
+        threading.Thread(target=load),
+        threading.Thread(target=load),
+    ]
+    for thread in load_threads:
+        thread.start()
+    for thread in load_threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in load_threads)
+    assert len(results) == 2
+    assert adapter.load_sync.call_count == 2
+    assert adapter.submit_unlock.call_count == 2
+    assert manager._adapter_lease_counts == {}
+
+
+def test_delete_raw_adapter_waits_for_restore_lease_through_unlock():
+    keys = [_make_key(0)]
+    objects = _make_objects(1)
+    adapter = _make_raw_adapter()
+    unlock_entered = threading.Event()
+    allow_unlock = threading.Event()
+    adapter_closed = threading.Event()
+
+    def submit_unlock(_keys):
+        unlock_entered.set()
+        assert allow_unlock.wait(timeout=5)
+
+    adapter.lookup_and_lock_sync.return_value = [True]
+    adapter.load_sync.return_value = [True]
+    adapter.submit_unlock.side_effect = submit_unlock
+    adapter.close.side_effect = adapter_closed.set
+    manager, l1_manager = _make_manager([adapter])
+    l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
+    drained = threading.Event()
+    drained.set()
+    deletion_started = threading.Event()
+    manager._store_controller = MagicMock()
+    manager._store_controller.request_remove_adapter.side_effect = lambda _adapter_id: (
+        deletion_started.set() or drained
+    )
+    manager._prefetch_controller = MagicMock()
+    manager._prefetch_controller.request_remove_adapter.return_value = drained
+    manager._l2_eviction_controller = MagicMock()
+
+    load_thread = threading.Thread(
+        target=manager.load_raw_block_prefix,
+        args=(keys, _make_layout()),
+    )
+    delete_thread = threading.Thread(target=manager.delete_l2_adapter, args=(0,))
+    load_thread.start()
+    assert unlock_entered.wait(timeout=5)
+    delete_thread.start()
+    assert deletion_started.wait(timeout=5)
+
+    # Deletion marks the adapter draining but cannot close it while submit_unlock
+    # is still covered by the restore operation's lease.
+    assert not adapter_closed.wait(timeout=0.05)
+    allow_unlock.set()
+    load_thread.join(timeout=5)
+    delete_thread.join(timeout=5)
+
+    assert not load_thread.is_alive()
+    assert not delete_thread.is_alive()
+    assert adapter_closed.is_set()
+    adapter.close.assert_called_once_with()
+    assert manager._l2_adapters == {}
+
+
+def test_finish_raw_block_restore_attempts_force_delete_when_finish_fails():
+    keys = [_make_key(0)]
+    manager, l1_manager = _make_manager([])
+    l1_manager.finish_write.side_effect = RuntimeError("finish failed")
+
+    with pytest.raises(RuntimeError, match="finish failed"):
+        manager.finish_raw_block_restore(keys)
+
+    l1_manager.delete.assert_called_once_with(keys, force=True)
+
+
+def test_storage_manager_closes_raw_adapter_before_l1_fixed_buffers():
+    manager = StorageManager.__new__(StorageManager)
+    manager._prefetch_controller = MagicMock()
+    manager._store_controller = MagicMock()
+    manager._eviction_controller = MagicMock()
+    manager._l2_eviction_controller = MagicMock()
+    adapter = MagicMock()
+    manager._l2_adapters = {0: adapter}
+    manager._lifecycle_lock = threading.Lock()
+    manager._adapter_lease_condition = threading.Condition()
+    manager._adapter_lease_counts = {}
+    manager._draining_adapter_ids = set()
+    manager._l1_manager = MagicMock()
+    close_order: list[str] = []
+    adapter.close.side_effect = lambda: close_order.append("adapter")
+    manager._l1_manager.close.side_effect = lambda: close_order.append("l1")
+
+    with patch("lmcache.v1.distributed.storage_manager.PeriodicEventNotifier.shutdown"):
+        manager.close()
+
+    assert close_order == ["adapter", "l1"]

--- a/tests/v1/distributed/test_storage_manager_raw_block_restore.py
+++ b/tests/v1/distributed/test_storage_manager_raw_block_restore.py
@@ -2,6 +2,7 @@
 """CPU-only tests for StorageManager's fused raw-block restore path."""
 
 # Standard
+from typing import cast
 from unittest.mock import MagicMock, call, create_autospec, patch
 import threading
 
@@ -231,7 +232,7 @@ def test_pipelined_restore_error_preserves_handed_prefix_for_stream_cleanup(
     keys = [_make_key(i) for i in range(3)]
     objects = _make_objects(len(keys))
     adapter = _make_raw_adapter()
-    adapter.lookup_and_lock_sync.return_value = [True, True, True]
+    cast(MagicMock, adapter.lookup_and_lock_sync).return_value = [True, True, True]
     manager, l1_manager = _make_manager([adapter])
     l1_manager.reserve_write.return_value = _successful_reservations(keys, objects)
     handed_keys: list[ObjectKey] = []
@@ -256,7 +257,7 @@ def test_pipelined_restore_error_preserves_handed_prefix_for_stream_cleanup(
         kwargs["on_batch_loaded"](0, 1)
         raise RuntimeError("later read failed")
 
-    adapter.load_sync.side_effect = load_sync
+    cast(MagicMock, adapter.load_sync).side_effect = load_sync
     expected_error = (
         "CUDA enqueue failed" if failure_source == "callback" else "later read failed"
     )
@@ -272,7 +273,7 @@ def test_pipelined_restore_error_preserves_handed_prefix_for_stream_cleanup(
     assert handed_objects == objects[:1]
     l1_manager.finish_write.assert_called_once_with(keys[1:])
     l1_manager.delete.assert_called_once_with(keys[1:], force=True)
-    adapter.submit_unlock.assert_called_once_with(keys)
+    cast(MagicMock, adapter.submit_unlock).assert_called_once_with(keys)
     assert manager._adapter_lease_counts == {}
 
     manager.finish_raw_block_restore(handed_keys)

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -15,6 +15,8 @@ import torch
 # First Party
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.kv_format import detect_format, extract_kv_cache_shapes
+from lmcache.v1.gpu_connector.utils import normalize_and_discover_per_layer_formats
+from lmcache.v1.kv_layer_groups import group_layers_by_identity
 import lmcache.c_ops as lmc_ops
 
 NB, NL, BS, NH, HS = 7, 5, 3, 2, 4
@@ -111,6 +113,36 @@ def test_sglang_mha_mp_reshape():
     # Canonical depth-2 [K_layers, V_layers], inner reshaped to 4-D.
     assert len(out) == 2 and len(out[0]) == NL
     assert tuple(out[0][0].shape) == (NB, BS, NH, HS)
+
+
+def test_sglang_mha_mp_one_head_registration_geometry():
+    # At TP == total KV heads, each rank has one head. The tokens_per_block
+    # hint still identifies the flat MP K/V wire layout, so NH == 1 must not
+    # be mistaken for SGLang's depth-1 fused MLA layout.
+    if not hasattr(F, "TWO_X_NL_X_NB_BS_NH_HS"):
+        pytest.skip("extension lacks TWO_X_NL_X_NB_BS_NH_HS")
+    flat = [_t(NB * BS, 1, HS) for _ in range(2 * NL)]
+
+    normalized, formats = normalize_and_discover_per_layer_formats(
+        flat,
+        layer_index_groups=[],
+        serving_engine=EngineType.SGLANG,
+        layout_hints={"tokens_per_block": BS},
+    )
+
+    assert formats == [F.TWO_X_NL_X_NB_BS_NH_HS] * NL
+    assert len(normalized) == 2 and len(normalized[0]) == NL
+    assert tuple(normalized[0][0].shape) == (NB, BS, 1, HS)
+
+    groups = group_layers_by_identity(normalized, formats)
+    assert len(groups) == 1
+    identity, layer_indices = groups[0]
+    assert identity.kv_size == 2
+    assert identity.num_heads == 1
+    assert identity.head_size == HS
+    assert identity.block_size == BS
+    assert identity.engine_kv_format == F.TWO_X_NL_X_NB_BS_NH_HS
+    assert layer_indices == list(range(NL))
 
 
 def test_trtllm_cross_layer_6d():

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -84,6 +84,9 @@ class _FakeStorageManager:
     def finish_read_prefetched(self, keys: list[object]) -> None:
         return None
 
+    def finish_raw_block_restore(self, keys: list[object]) -> None:
+        return None
+
     def reserve_write(
         self,
         keys: list[object],

--- a/tests/v1/multiprocess/test_fused_raw_block_retrieve.py
+++ b/tests/v1/multiprocess/test_fused_raw_block_retrieve.py
@@ -4,6 +4,7 @@
 # Standard
 from contextlib import nullcontext
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, call, patch
 import threading
 
@@ -12,16 +13,15 @@ import pytest
 import torch
 
 # First Party
-import lmcache.c_ops as lmc_ops
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.engine_module import ThreadPoolType
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     ContextEntry,
     LMCacheDrivenTransferModule,
+    _fused_event_session_resource_key,
     _FusedDrainEvent,
     _FusedDrainState,
-    _fused_event_session_resource_key,
     _launch_staged_h2d_batch,
 )
 from lmcache.v1.multiprocess.modules.management import ManagementModule
@@ -34,6 +34,7 @@ from lmcache.v1.multiprocess.protocols.base import HandlerType, RequestType
 from lmcache.v1.multiprocess.protocols.engine import (
     FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY,
 )
+import lmcache.c_ops as lmc_ops
 
 
 def _make_key() -> IPCCacheServerKey:
@@ -113,7 +114,11 @@ def _invoke(
     *,
     callback_side_effect: Exception | None = None,
 ) -> tuple[bytes, tuple[int, bool]]:
-    module.context.storage_manager.load_raw_block_prefix.return_value = loaded
+    load_raw_block_prefix = cast(
+        MagicMock,
+        module.context.storage_manager.load_raw_block_prefix,
+    )
+    load_raw_block_prefix.return_value = loaded
     with (
         patch(
             "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.device",

--- a/tests/v1/multiprocess/test_fused_raw_block_retrieve.py
+++ b/tests/v1/multiprocess/test_fused_raw_block_retrieve.py
@@ -1,0 +1,697 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the fused raw-block multiprocess retrieve path."""
+
+# Standard
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+import lmcache.c_ops as lmc_ops
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.engine_module import ThreadPoolType
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    ContextEntry,
+    LMCacheDrivenTransferModule,
+    _FusedDrainEvent,
+    _FusedDrainState,
+    _fused_event_session_resource_key,
+    _launch_staged_h2d_batch,
+)
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.protocol import (
+    get_handler_type,
+    get_payload_classes,
+    get_response_class,
+)
+from lmcache.v1.multiprocess.protocols.base import HandlerType, RequestType
+from lmcache.v1.multiprocess.protocols.engine import (
+    FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY,
+)
+
+
+def _make_key() -> IPCCacheServerKey:
+    return IPCCacheServerKey.from_token_ids(
+        model_name="test-model",
+        world_size=1,
+        worker_id=0,
+        token_ids=list(range(12)),
+        start=4,
+        end=12,
+        request_id="request-1",
+    )
+
+
+def _make_object_key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test-model",
+        kv_rank=0,
+    )
+
+
+def _make_module() -> tuple[
+    LMCacheDrivenTransferModule,
+    MagicMock,
+    MagicMock,
+    MagicMock,
+    MagicMock,
+]:
+    ctx = MagicMock()
+    ctx.chunk_size = 4
+    ctx.event_bus = MagicMock()
+    object_keys = [_make_object_key(0), _make_object_key(1)]
+    ctx.resolve_obj_keys.return_value = [object_keys]
+    session = MagicMock()
+    ctx.session_manager.get_or_create.return_value = session
+
+    cache_context = MagicMock()
+    cache_context.device = torch.device("cpu")
+    cache_context.stream = MagicMock()
+    cache_context.cupy_stream = object()
+    cache_context.max_batch_size = 1
+    cache_context.calculate_num_blocks.return_value = 2
+    groups = cache_context.kv_layer_groups_manager
+    groups.num_object_groups = 1
+    groups.num_kernel_groups = 1
+
+    event_backend = MagicMock()
+    final_event = object()
+    event_backend.create_event.return_value = final_event
+    event_backend.export_event.side_effect = lambda event, _device: {
+        final_event: b"final-event",
+    }.get(event, event)
+
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._ctx = ctx
+    module._lock = threading.Lock()
+    module._cache_contexts = {
+        7: ContextEntry(
+            cache_context=cache_context,
+            model_name="test-model",
+            world_size=1,
+            event_backend=event_backend,
+        )
+    }
+    module._fused_counter_lock = threading.Lock()
+    module._fused_success_count = 0
+    module._fused_pipelined_count = 0
+    module._fused_staged_fallback_count = 0
+    module._fused_failure_count = 0
+    return module, ctx, cache_context, event_backend, session
+
+
+def _invoke(
+    module: LMCacheDrivenTransferModule,
+    loaded: tuple[list[ObjectKey], list[MagicMock]] | None,
+    *,
+    callback_side_effect: Exception | None = None,
+) -> tuple[bytes, tuple[int, bool]]:
+    module.context.storage_manager.load_raw_block_prefix.return_value = loaded
+    with (
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.device",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.stream",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.get_layout_desc",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "downsample_and_stage_block_ids",
+            return_value=[MagicMock()],
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "transfer_kv_per_object_group"
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "submit_callback_to_stream",
+            side_effect=callback_side_effect,
+        ),
+    ):
+        return module.fused_raw_block_retrieve(
+            _make_key(),
+            7,
+            [list(range(4))],
+            b"producer-event",
+            0,
+        )
+
+
+def test_fused_raw_block_protocol_and_handler_routing():
+    assert (
+        RequestType.FUSED_RAW_BLOCK_RETRIEVE.value
+        == RequestType.GET_EXPERIMENTAL.value + 1
+    )
+    assert (
+        RequestType.FUSED_RAW_BLOCK_DRAIN.value
+        == RequestType.FUSED_RAW_BLOCK_RETRIEVE.value + 1
+    )
+    assert get_payload_classes(RequestType.FUSED_RAW_BLOCK_RETRIEVE) == [
+        IPCCacheServerKey,
+        int,
+        list[list[int]],
+        bytes,
+        int,
+    ]
+    assert (
+        get_response_class(RequestType.FUSED_RAW_BLOCK_RETRIEVE)
+        == tuple[bytes, tuple[int, bool]]
+    )
+    assert (
+        get_handler_type(RequestType.FUSED_RAW_BLOCK_RETRIEVE) is HandlerType.BLOCKING
+    )
+    assert get_payload_classes(RequestType.FUSED_RAW_BLOCK_DRAIN) == [str, int]
+    assert get_response_class(RequestType.FUSED_RAW_BLOCK_DRAIN) is bool
+    assert get_handler_type(RequestType.FUSED_RAW_BLOCK_DRAIN) is HandlerType.BLOCKING
+
+    module, _, _, _, _ = _make_module()
+    pools = {spec.request_type: spec.pool for spec in module.get_handlers()}
+    assert pools[RequestType.FUSED_RAW_BLOCK_RETRIEVE] is ThreadPoolType.AFFINITY
+    assert pools[RequestType.FUSED_RAW_BLOCK_DRAIN] is ThreadPoolType.AFFINITY
+
+
+def test_capability_requires_exact_supported_raw_block_topology():
+    ctx = MagicMock()
+    ctx.storage_manager.supports_fused_raw_block_retrieve.return_value = True
+    module = ManagementModule(ctx, experimental_transfer=["other-feature"])
+
+    assert module.get_experimental() == [
+        "other-feature",
+        FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY,
+    ]
+
+    ctx.storage_manager.supports_fused_raw_block_retrieve.return_value = False
+    assert module.get_experimental() == ["other-feature"]
+
+
+def test_status_reports_undersubscribed_affinity_pool():
+    module, _, _, _, _ = _make_module()
+    module._affinity_worker_count = 1
+    module._cache_contexts[7].world_size = 8
+
+    assert module.report_status()["affinity_pool"] == {
+        "worker_count": 1,
+        "max_registered_world_size": 8,
+        "undersubscribed": True,
+    }
+
+
+def test_fused_retrieve_returns_final_event_and_retains_exporter():
+    module, ctx, _, event_backend, session = _make_module()
+    object_keys = ctx.resolve_obj_keys.return_value[0]
+    memory_objs = [MagicMock(), MagicMock()]
+    for memory_obj in memory_objs:
+        memory_obj.get_size.return_value = 64
+
+    response = _invoke(module, (object_keys, memory_objs))
+
+    assert response[1] == (8, True)
+    assert response[0] == b"final-event"
+    event_backend.wait_event.assert_called_once_with(
+        event_backend.import_event.return_value,
+        module._cache_contexts[7].cache_context.stream,
+    )
+    event_backend.record_event.assert_called_once()
+    session.retain_resources.assert_called_once()
+    resource_key, resources = session.retain_resources.call_args.args
+    assert resource_key == _fused_event_session_resource_key(0)
+    assert len(resources) == 1
+    drain_event, terminal_safe = resources[0].snapshot()
+    assert drain_event == _FusedDrainEvent(
+        backend=event_backend,
+        event=event_backend.create_event.return_value,
+        device=module._cache_contexts[7].cache_context.device,
+    )
+    assert terminal_safe is False
+    assert session.retain_resources.call_args.kwargs == {"owner_id": 0}
+    assert module.report_status()["fused_raw_block_retrieve"] == {
+        "success_count": 1,
+        "pipelined_count": 0,
+        "staged_fallback_count": 1,
+        "failure_count": 0,
+    }
+
+
+def test_fused_retrieve_automatically_pipelines_loaded_objects():
+    module, ctx, cache_context, _, _ = _make_module()
+    object_keys = ctx.resolve_obj_keys.return_value[0]
+    memory_objs = [MagicMock(), MagicMock()]
+    for memory_obj in memory_objs:
+        memory_obj.get_size.return_value = 64
+    cache_context.max_batch_size = 4
+
+    def load_prefix(_keys, _layout, **kwargs):
+        assert kwargs["completion_batch_size"] == 1
+        callback = kwargs["on_batch_loaded"]
+        callback(0, 1, object_keys[:1], memory_objs[:1])
+        callback(1, 2, object_keys[1:], memory_objs[1:])
+        return object_keys, memory_objs
+
+    ctx.storage_manager.load_raw_block_prefix.side_effect = load_prefix
+    staged_block_ids = torch.arange(4)
+    with (
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.device",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.stream",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.get_layout_desc",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "downsample_and_stage_block_ids",
+            return_value=[staged_block_ids],
+        ),
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "lmcache_memcpy_async_h2d"
+        ) as stage_h2d,
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "_launch_staged_h2d_batch"
+        ) as launch,
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "transfer_kv_per_object_group"
+        ) as fallback,
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+            "submit_callback_to_stream"
+        ),
+    ):
+        response = module.fused_raw_block_retrieve(
+            _make_key(),
+            7,
+            [list(range(4))],
+            b"producer-event",
+            0,
+        )
+
+    assert response[1] == (8, True)
+    assert response[0] == b"final-event"
+    assert stage_h2d.call_args_list == [
+        call(
+            memory_objs[0],
+            cache_context.get_temp_object_group_buffer.return_value,
+        ),
+        call(
+            memory_objs[1],
+            cache_context.get_temp_object_group_buffer.return_value,
+        ),
+    ]
+    assert cache_context.get_temp_object_group_buffer.call_args_list == [
+        call(0, 0),
+        call(1, 0),
+    ]
+    launch.assert_called_once()
+    launch_args = launch.call_args
+    assert torch.equal(launch_args.args[1][0], staged_block_ids)
+    assert launch_args.kwargs == {
+        "object_group_id": 0,
+        "batch_len": 2,
+        "skip_first_n_tokens": 0,
+    }
+    fallback.assert_not_called()
+    assert module.report_status()["fused_raw_block_retrieve"] == {
+        "success_count": 1,
+        "pipelined_count": 1,
+        "staged_fallback_count": 0,
+        "failure_count": 0,
+    }
+
+
+def test_pipelined_stage_failure_records_final_event_and_cleans_handed_prefix():
+    module, ctx, _, event_backend, session = _make_module()
+    object_keys = ctx.resolve_obj_keys.return_value[0]
+    memory_objs = [MagicMock(), MagicMock()]
+
+    def load_prefix(_keys, _layout, **kwargs):
+        kwargs["on_batch_loaded"](0, 1, object_keys[:1], memory_objs[:1])
+        raise AssertionError("staging failure must escape the callback")
+
+    ctx.storage_manager.load_raw_block_prefix.side_effect = load_prefix
+
+    with patch(
+        "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+        "submit_callback_to_stream"
+    ) as submit_callback:
+        with (
+            patch(
+                "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+                "torch_dev.device",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+                "torch_dev.stream",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+                "get_layout_desc",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+                "downsample_and_stage_block_ids",
+                return_value=[torch.arange(4)],
+            ),
+            patch(
+                "lmcache.v1.multiprocess.modules.lmcache_driven_transfer."
+                "lmcache_memcpy_async_h2d",
+                side_effect=RuntimeError("staging failed"),
+            ),
+        ):
+            response = module.fused_raw_block_retrieve(
+                _make_key(),
+                7,
+                [list(range(4))],
+                b"producer-event",
+                0,
+            )
+
+    assert response[1] == (0, False)
+    assert response[0] == b"final-event"
+    event_backend.record_event.assert_called_once()
+    submit_callback.assert_called_once_with(
+        module._cache_contexts[7].cache_context.cupy_stream,
+        "finish_raw_block_restore",
+        object_keys[:1],
+    )
+    session.retain_resources.assert_called_once()
+    resource_key, resources = session.retain_resources.call_args.args
+    assert resource_key == _fused_event_session_resource_key(0)
+    assert len(resources) == 1
+    drain_event, terminal_safe = resources[0].snapshot()
+    assert drain_event == _FusedDrainEvent(
+        backend=event_backend,
+        event=event_backend.create_event.return_value,
+        device=module._cache_contexts[7].cache_context.device,
+    )
+    assert terminal_safe is False
+    assert session.retain_resources.call_args.kwargs == {"owner_id": 0}
+    assert module.report_status()["fused_raw_block_retrieve"]["failure_count"] == 1
+
+
+def test_fused_raw_block_clean_miss_is_success_without_transfer():
+    module, _, _, _, _ = _make_module()
+
+    response = _invoke(module, ([], []))
+
+    assert response[1] == (0, True)
+    assert response[0] == b"final-event"
+
+
+def test_cached_capability_after_adapter_deletion_becomes_clean_miss():
+    module, _, _, _, _ = _make_module()
+
+    response = _invoke(module, None)
+
+    assert response[1] == (0, True)
+    assert response[0] == b"final-event"
+    assert module.report_status()["fused_raw_block_retrieve"] == {
+        "success_count": 1,
+        "pipelined_count": 0,
+        "staged_fallback_count": 0,
+        "failure_count": 0,
+    }
+
+
+def test_response_construction_failure_drains_final_event_server_side():
+    module, _, _, event_backend, _ = _make_module()
+    event_backend.export_event.side_effect = RuntimeError("export failed")
+
+    with pytest.raises(RuntimeError, match="export failed"):
+        _invoke(module, ([], []))
+
+    event_backend.synchronize_event.assert_called_once_with(
+        event_backend.create_event.return_value,
+        module._cache_contexts[7].cache_context.device,
+    )
+    assert module.report_status()["fused_raw_block_retrieve"]["failure_count"] == 1
+
+
+def test_rank_specific_drain_synchronizes_retained_final_events():
+    module, ctx, cache_context, event_backend, session = _make_module()
+    final_events = [object(), object()]
+    drain_states = [_FusedDrainState(), _FusedDrainState()]
+    for state, final_event in zip(drain_states, final_events, strict=True):
+        state.publish_final(
+            _FusedDrainEvent(event_backend, final_event, cache_context.device),
+        )
+    session.get_retained_resources.return_value = [
+        drain_states[0],
+        object(),
+        drain_states[1],
+    ]
+    ctx.session_manager.get.return_value = session
+
+    with patch(
+        "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.device",
+        return_value=nullcontext(),
+    ):
+        assert module.fused_raw_block_drain("request-1", 3) is True
+
+    session.get_retained_resources.assert_called_once_with(
+        _fused_event_session_resource_key(3)
+    )
+    assert event_backend.synchronize_event.call_args_list == [
+        call(final_events[0], cache_context.device),
+        call(final_events[1], cache_context.device),
+    ]
+
+
+def test_rank_specific_drain_reports_missing_session():
+    module, ctx, _, _, _ = _make_module()
+    ctx.session_manager.get.return_value = None
+
+    assert module.fused_raw_block_drain("missing", 0) is False
+
+
+def test_record_event_failure_fences_stream_and_cleans_temporary_l1():
+    module, ctx, cache_context, event_backend, _ = _make_module()
+    object_keys = ctx.resolve_obj_keys.return_value[0]
+    memory_objs = [MagicMock(), MagicMock()]
+    event_backend.record_event.side_effect = RuntimeError("record failed")
+
+    with pytest.raises(RuntimeError, match="record failed"):
+        _invoke(module, (object_keys, memory_objs))
+
+    cache_context.stream.synchronize.assert_called_once_with()
+    ctx.storage_manager.finish_raw_block_restore.assert_called_once_with(object_keys)
+
+
+def test_end_event_publication_failure_fences_final_and_cleans_temporary_l1():
+    module, ctx, cache_context, event_backend, _ = _make_module()
+    object_keys = ctx.resolve_obj_keys.return_value[0]
+    memory_objs = [MagicMock(), MagicMock()]
+    ctx.event_bus.publish_on_stream.side_effect = [
+        None,
+        RuntimeError("end event failed"),
+    ]
+
+    with pytest.raises(RuntimeError, match="end event failed"):
+        _invoke(module, (object_keys, memory_objs))
+
+    event_backend.synchronize_event.assert_called_once_with(
+        event_backend.create_event.return_value,
+        cache_context.device,
+    )
+    ctx.storage_manager.finish_raw_block_restore.assert_called_once_with(object_keys)
+
+
+def test_cleanup_callback_failure_fences_final_and_cleans_temporary_l1():
+    module, ctx, cache_context, event_backend, _ = _make_module()
+    object_keys = ctx.resolve_obj_keys.return_value[0]
+    memory_objs = [MagicMock(), MagicMock()]
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        _invoke(
+            module,
+            (object_keys, memory_objs),
+            callback_side_effect=RuntimeError("callback failed"),
+        )
+
+    event_backend.synchronize_event.assert_called_once_with(
+        event_backend.create_event.return_value,
+        cache_context.device,
+    )
+    ctx.storage_manager.finish_raw_block_restore.assert_called_once_with(object_keys)
+
+
+def test_drain_state_retention_failure_occurs_before_any_stream_work():
+    module, ctx, _, event_backend, session = _make_module()
+    session.retain_resources.side_effect = RuntimeError("retain failed")
+
+    with pytest.raises(RuntimeError, match="retain failed"):
+        _invoke(module, ([], []))
+
+    ctx.storage_manager.load_raw_block_prefix.assert_not_called()
+    event_backend.create_event.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("failure", "error_type", "error_match"),
+    [
+        ("missing_context", ValueError, "No GPU context"),
+        ("missing_event_backend", RuntimeError, "no event backend"),
+    ],
+)
+def test_preflight_failure_publishes_terminal_safe_drain_state(
+    failure: str,
+    error_type: type[Exception],
+    error_match: str,
+):
+    module, ctx, _, event_backend, session = _make_module()
+    if failure == "missing_context":
+        module._cache_contexts.clear()
+    else:
+        module._cache_contexts[7].event_backend = None
+
+    with pytest.raises(error_type, match=error_match):
+        _invoke(module, ([], []))
+
+    session.retain_resources.assert_called_once()
+    resource_key, resources = session.retain_resources.call_args.args
+    assert resource_key == _fused_event_session_resource_key(0)
+    assert len(resources) == 1
+    drain_state = resources[0]
+    assert drain_state.snapshot() == (None, True)
+    assert session.retain_resources.call_args.kwargs == {"owner_id": 0}
+    event_backend.create_event.assert_not_called()
+    ctx.storage_manager.load_raw_block_prefix.assert_not_called()
+
+    ctx.session_manager.get.return_value = session
+    session.get_retained_resources.return_value = [drain_state]
+    assert module.fused_raw_block_drain("request-1", 0) is True
+    event_backend.synchronize_event.assert_not_called()
+
+
+def test_close_fences_retained_events_and_stream_before_dispatcher_teardown():
+    module, ctx, cache_context, event_backend, session = _make_module()
+    final_event = object()
+    drain_state = _FusedDrainState()
+    drain_state.publish_final(
+        _FusedDrainEvent(event_backend, final_event, cache_context.device)
+    )
+    ctx.session_manager.sessions_snapshot.return_value = [session]
+    session.get_retained_resources_by_prefix.return_value = [drain_state]
+    module._device_host_func_dispatcher = MagicMock()
+    call_order: list[str] = []
+    event_backend.synchronize_event.side_effect = lambda *_args: call_order.append(
+        "event"
+    )
+    cache_context.stream.synchronize.side_effect = lambda: call_order.append("stream")
+    module._device_host_func_dispatcher.stop.side_effect = lambda: call_order.append(
+        "dispatcher"
+    )
+
+    with (
+        patch(
+            "lmcache.v1.multiprocess.modules.lmcache_driven_transfer.torch_dev.device",
+            return_value=nullcontext(),
+        ),
+        patch.object(
+            module,
+            "_release_entries",
+            side_effect=lambda _entries: call_order.append("release"),
+        ),
+    ):
+        module.close()
+
+    assert call_order == ["event", "stream", "dispatcher", "release"]
+    session.get_retained_resources_by_prefix.assert_called_once_with(
+        "fused_raw_block_export_events."
+    )
+    event_backend.synchronize_event.assert_called_once_with(
+        final_event,
+        cache_context.device,
+    )
+    assert module.context_entries_snapshot() == {}
+
+
+def _make_staged_context() -> MagicMock:
+    cache_context = MagicMock()
+    cache_context.device = torch.device("cpu")
+    cache_context.lmcache_tokens_per_chunk = 4
+    groups = cache_context.kv_layer_groups_manager
+    groups.object_groups = [SimpleNamespace(kernel_group_indices=[0])]
+    groups.get_subchunk_sw_size_tokens.return_value = 4
+    cache_context.calculate_num_blocks.side_effect = (
+        lambda token_count, _kernel_group_id: token_count // 2
+    )
+    cache_context.get_kernel_group_kv_pointers.return_value = object()
+    cache_context.get_temp_kernel_group_buffer.side_effect = (
+        lambda slot, _kernel_group_id: SimpleNamespace(
+            data_ptr=lambda: 1000 + slot,
+        )
+    )
+    shape_desc = object()
+    cache_context.get_shape_desc.return_value = shape_desc
+    cache_context.get_slots_per_chunk_in_sw.return_value = 4
+    cache_context.get_engine_kv_format.return_value = object()
+    return cache_context
+
+
+def test_launch_staged_h2d_batch_uses_distinct_slots_and_prefix_skip():
+    cache_context = _make_staged_context()
+    block_ids = torch.arange(4)
+
+    with patch.object(lmc_ops, "multi_layer_block_kv_transfer") as transfer:
+        _launch_staged_h2d_batch(
+            cache_context,
+            [block_ids],
+            object_group_id=0,
+            batch_len=2,
+            skip_first_n_tokens=4,
+        )
+
+    transfer.assert_called_once()
+    args = transfer.call_args.args
+    assert args[0] is cache_context.get_kernel_group_kv_pointers.return_value
+    assert args[1] == [1000, 1001]
+    assert torch.equal(args[2], block_ids)
+    assert args[3] == cache_context.device
+    assert args[4] is lmc_ops.TransferDirection.H2D
+    assert args[5] is cache_context.get_shape_desc.return_value
+    assert args[6] == 4
+    assert args[7] is cache_context.get_engine_kv_format.return_value
+    assert args[8] == 2
+    assert cache_context.get_temp_kernel_group_buffer.call_args_list == [
+        call(0, 0),
+        call(1, 0),
+    ]
+
+
+def test_launch_staged_h2d_batch_skips_fully_covered_window():
+    cache_context = _make_staged_context()
+    with patch.object(lmc_ops, "multi_layer_block_kv_transfer") as transfer:
+        _launch_staged_h2d_batch(
+            cache_context,
+            [torch.arange(4)],
+            object_group_id=0,
+            batch_len=2,
+            skip_first_n_tokens=8,
+        )
+
+    transfer.assert_not_called()
+    cache_context.get_temp_kernel_group_buffer.assert_not_called()

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -2,8 +2,10 @@
 """Tests for Session and SessionManager."""
 
 # Standard
+import gc
 import threading
 import time
+import weakref
 
 # Third Party
 import pytest
@@ -99,6 +101,44 @@ class TestSession:
         assert store_hashes == all_hashes[1:]
         assert session.num_chunks_processed == 3  # no extra computation
 
+    def test_retain_resources_holds_strong_references_until_session_drop(
+        self,
+        session_manager: SessionManager,
+    ) -> None:
+        """Exporter-side IPC resources live for the request session."""
+
+        class _Resource:
+            pass
+
+        session = session_manager.get_or_create("req-resource")
+        resource = _Resource()
+        resource_ref = weakref.ref(resource)
+        session.retain_resources("ipc_events", [resource])
+
+        del resource
+        gc.collect()
+        assert resource_ref() is not None
+
+        removed = session_manager.remove("req-resource")
+        assert removed is session
+        del removed
+        del session
+        gc.collect()
+        assert resource_ref() is None
+
+    def test_retained_resource_prefix_snapshot(self, session: Session) -> None:
+        first = object()
+        second = object()
+        unrelated = object()
+        session.retain_resources("fused_events.0", [first])
+        session.retain_resources("fused_events.1", [second])
+        session.retain_resources("other", [unrelated])
+
+        assert session.get_retained_resources_by_prefix("fused_events.") == [
+            first,
+            second,
+        ]
+
 
 class TestSessionManager:
     def test_get_or_create_new(self, session_manager: SessionManager) -> None:
@@ -115,6 +155,15 @@ class TestSessionManager:
         s2 = session_manager.get_or_create("req-2")
         assert s1 is not s2
 
+    def test_sessions_snapshot_keeps_active_sessions(
+        self,
+        session_manager: SessionManager,
+    ) -> None:
+        first = session_manager.get_or_create("req-1")
+        second = session_manager.get_or_create("req-2")
+
+        assert session_manager.sessions_snapshot() == [first, second]
+
     def test_remove(self, session_manager: SessionManager) -> None:
         session_manager.get_or_create("req-1")
         removed = session_manager.remove("req-1")
@@ -128,6 +177,51 @@ class TestSessionManager:
         """Removing a non-existent session should return None."""
         result = session_manager.remove("does-not-exist")
         assert result is None
+
+    def test_fused_tp_resources_release_only_after_every_rank_ends(
+        self,
+        session_manager: SessionManager,
+    ) -> None:
+        """The first of N TP END_SESSION calls keeps all exporters alive."""
+
+        class _ExporterEvent:
+            pass
+
+        session = session_manager.get_or_create("req-tp")
+        rank_0_event = _ExporterEvent()
+        rank_1_event = _ExporterEvent()
+        rank_0_ref = weakref.ref(rank_0_event)
+        rank_1_ref = weakref.ref(rank_1_event)
+        session.retain_resources(
+            "fused_events",
+            [rank_0_event],
+            owner_id=0,
+        )
+        session.retain_resources(
+            "fused_events",
+            [rank_1_event],
+            owner_id=1,
+        )
+        del rank_0_event
+        del rank_1_event
+
+        removed, waiting = session_manager.release_for_end_session("req-tp")
+        assert removed is None
+        assert waiting is True
+        assert session_manager.active_count() == 1
+        gc.collect()
+        assert rank_0_ref() is not None
+        assert rank_1_ref() is not None
+
+        removed, waiting = session_manager.release_for_end_session("req-tp")
+        assert removed is session
+        assert waiting is False
+        assert session_manager.active_count() == 0
+        del removed
+        del session
+        gc.collect()
+        assert rank_0_ref() is None
+        assert rank_1_ref() is None
 
     def test_cleanup_expired(self, session_manager: SessionManager) -> None:
         """Sessions older than TTL should be cleaned up."""

--- a/tests/v1/storage_backend/test_raw_block_device.py
+++ b/tests/v1/storage_backend/test_raw_block_device.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 # Standard
+import ctypes
 import errno
+import mmap
 import os
 import platform
 
@@ -119,6 +121,104 @@ def test_raw_block_device_iouring_best_effort_roundtrip(tmp_path):
     finally:
         if dev is not None:
             dev.close()
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="O_DIRECT is Linux only")
+def test_raw_block_device_fixed_buffer_read_accepts_registered_subrange(tmp_path):
+    """A real O_DIRECT ReadFixed may target an aligned registered subrange."""
+    path = make_raw_block_file(tmp_path)
+    payload = bytes(index % 251 for index in range(RAW_BLOCK_CI_BLOCK_ALIGN))
+    with path.open("r+b", buffering=0) as f:
+        f.seek(RAW_BLOCK_CI_BLOCK_ALIGN)
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+
+    region = mmap.mmap(-1, 2 * RAW_BLOCK_CI_BLOCK_ALIGN)
+    output = memoryview(region)[RAW_BLOCK_CI_BLOCK_ALIGN : 2 * RAW_BLOCK_CI_BLOCK_ALIGN]
+    base = ctypes.addressof(ctypes.c_char.from_buffer(region))
+    dev = None
+    try:
+        assert base % RAW_BLOCK_CI_BLOCK_ALIGN == 0
+        dev = RawBlockDevice(
+            str(path),
+            writable=False,
+            use_odirect=True,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+        dev.register_fixed_buffers([base], [len(region)])
+        assert dev.fixed_read_submission_count() == 0
+        assert dev.nonfixed_read_submission_count() == 0
+        batch_id = dev.batched_read(
+            [RAW_BLOCK_CI_BLOCK_ALIGN],
+            [output],
+            [RAW_BLOCK_CI_BLOCK_ALIGN],
+        )
+        dev.wait_iouring(batch_id)
+        assert bytes(output) == payload
+        assert dev.fixed_read_submission_count() == 1
+        assert dev.nonfixed_read_submission_count() == 0
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"O_DIRECT io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+        output.release()
+        region.close()
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="O_DIRECT is Linux only")
+def test_raw_block_device_nonfixed_read_submission_is_observable(tmp_path):
+    """A batched O_DIRECT read without registration uses an ordinary Read SQE."""
+    path = make_raw_block_file(tmp_path)
+    payload = bytes(index % 251 for index in range(RAW_BLOCK_CI_BLOCK_ALIGN))
+    with path.open("r+b", buffering=0) as f:
+        f.seek(RAW_BLOCK_CI_BLOCK_ALIGN)
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+
+    region = mmap.mmap(-1, RAW_BLOCK_CI_BLOCK_ALIGN)
+    output = memoryview(region)
+    dev = None
+    try:
+        assert (
+            ctypes.addressof(ctypes.c_char.from_buffer(region))
+            % (RAW_BLOCK_CI_BLOCK_ALIGN)
+            == 0
+        )
+        dev = RawBlockDevice(
+            str(path),
+            writable=False,
+            use_odirect=True,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+        assert dev.fixed_read_submission_count() == 0
+        assert dev.nonfixed_read_submission_count() == 0
+        batch_id = dev.batched_read(
+            [RAW_BLOCK_CI_BLOCK_ALIGN],
+            [output],
+            [RAW_BLOCK_CI_BLOCK_ALIGN],
+        )
+        dev.wait_iouring(batch_id)
+        assert bytes(output) == payload
+        assert dev.fixed_read_submission_count() == 0
+        assert dev.nonfixed_read_submission_count() == 1
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"O_DIRECT io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+        output.release()
+        region.close()
 
 
 @pytest.mark.skipif(

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 # Standard
 from concurrent.futures import Future
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 import asyncio
 import os
@@ -146,8 +146,9 @@ def _install_deferred_batched_reads(
         ):
             out[:total_len] = device._data[offset : offset + total_len]
 
-    device.batched_read = batched_read
-    device.wait_iouring = wait_iouring
+    untyped_device = cast(Any, device)
+    untyped_device.batched_read = batched_read
+    untyped_device.wait_iouring = wait_iouring
     return trace
 
 

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -58,6 +58,11 @@ class _FakeRawBlockDevice:
     def __init__(self, path: str, *, size_bytes: int, **kwargs):
         del path, kwargs
         self._data = bytearray(size_bytes)
+        self.batched_read_calls: list[tuple[list[int], list[int]]] = []
+        self.wait_iouring_calls: list[int] = []
+        self.register_fixed_buffer_calls: list[tuple[list[int], list[int]]] = []
+        self._fixed_read_submission_count = 0
+        self._nonfixed_read_submission_count = 0
 
     def size_bytes(self):
         return len(self._data)
@@ -66,27 +71,107 @@ class _FakeRawBlockDevice:
         del total_len
         out[:payload_len] = self._data[offset : offset + payload_len]
 
+    def read_uring(self, offset, out, payload_len, total_len=None):
+        self.pread_into(offset, out, payload_len, total_len)
+
+    def batched_read(self, offsets, buffers, total_lens):
+        self.batched_read_calls.append((list(offsets), list(total_lens)))
+        for offset, out, total_len in zip(offsets, buffers, total_lens, strict=False):
+            out[:total_len] = self._data[offset : offset + total_len]
+        return len(self.batched_read_calls)
+
+    def wait_iouring(self, batch_id):
+        self.wait_iouring_calls.append(batch_id)
+
+    def register_fixed_buffers(self, buffer_ptrs, buffer_sizes):
+        self.register_fixed_buffer_calls.append((list(buffer_ptrs), list(buffer_sizes)))
+
+    def fixed_read_submission_count(self):
+        return self._fixed_read_submission_count
+
+    def nonfixed_read_submission_count(self):
+        return self._nonfixed_read_submission_count
+
     def pwrite_from_buffer(self, offset, data, payload_len=None, total_len=None):
         del total_len
         length = len(data) if payload_len is None else payload_len
         self._data[offset : offset + length] = bytes(memoryview(data)[:length])
 
+    def write_uring(self, offset, data, payload_len, total_len=None):
+        self.pwrite_from_buffer(offset, data, payload_len, total_len)
+
+    def batched_write(self, offsets, buffers, total_lens):
+        for offset, data, total_len in zip(offsets, buffers, total_lens, strict=False):
+            self._data[offset : offset + total_len] = bytes(
+                memoryview(data)[:total_len]
+            )
+        return 1
+
     def close(self):
         return None
 
 
-def _install_fake_raw_block_device(monkeypatch, *, size_bytes: int = 64 * 1024):
+def _install_deferred_batched_reads(
+    device: _FakeRawBlockDevice,
+    *,
+    wait_error_batch_id: int | None = None,
+) -> list[tuple]:
+    """Delay fake reads until wait_iouring to expose pipeline ordering."""
+    trace: list[tuple] = []
+    pending: dict[int, tuple[list[int], list[Any], list[int]]] = {}
+    next_batch_id = 1
+
+    def batched_read(offsets, buffers, total_lens):
+        nonlocal next_batch_id
+        batch_id = next_batch_id
+        next_batch_id += 1
+        pending[batch_id] = (
+            list(offsets),
+            list(buffers),
+            list(total_lens),
+        )
+        trace.append(("submit", batch_id))
+        return batch_id
+
+    def wait_iouring(batch_id):
+        trace.append(("wait", batch_id))
+        offsets, buffers, total_lens = pending.pop(batch_id)
+        if batch_id == wait_error_batch_id:
+            raise RuntimeError(f"wait failed for batch {batch_id}")
+        for offset, out, total_len in zip(
+            offsets,
+            buffers,
+            total_lens,
+            strict=True,
+        ):
+            out[:total_len] = device._data[offset : offset + total_len]
+
+    device.batched_read = batched_read
+    device.wait_iouring = wait_iouring
+    return trace
+
+
+def _install_fake_raw_block_device(
+    monkeypatch, *, size_bytes: int = 64 * 1024
+) -> list[_FakeRawBlockDevice]:
+    devices: list[_FakeRawBlockDevice] = []
+
     def create_fake_device(path: str, **kwargs):
-        return _FakeRawBlockDevice(path, size_bytes=size_bytes, **kwargs)
+        device = _FakeRawBlockDevice(path, size_bytes=size_bytes, **kwargs)
+        devices.append(device)
+        return device
 
     monkeypatch.setitem(
         sys.modules,
         "lmcache_rust_raw_block_io",
         types.SimpleNamespace(RawBlockDevice=create_fake_device),
     )
+    return devices
 
 
-def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
+def _make_raw_block_core(
+    *, use_odirect: bool = False, io_engine: str = "posix"
+) -> RawBlockCore:
     return RawBlockCore(
         RawBlockCoreConfig(
             device_path="/tmp/raw-block-boundary-test",
@@ -104,7 +189,7 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
             meta_enable_periodic=False,
             load_checkpoint_on_init=True,
             meta_verify_on_load=True,
-            io_engine="posix",
+            io_engine=io_engine,
             iouring_queue_depth=256,
         ),
         key_namespace="object",
@@ -234,6 +319,293 @@ def test_raw_block_core_non_odirect_rejects_payload_over_slot_capacity(monkeypat
         )
         assert too_large.results == [False]
         assert core.contains_key("too-large") is False
+    finally:
+        core.close()
+
+
+def test_raw_block_core_batches_only_explicit_batched_loads(monkeypatch):
+    """The new MP loader coalesces reads without changing the legacy loader."""
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        keys = [
+            RawBlockKeySpec(encoded="first", slot_identity=1),
+            RawBlockKeySpec(encoded="second", slot_identity=2),
+        ]
+        stored = [_make_byte_obj(4096), _make_byte_obj(4096)]
+        stored[0].tensor.fill_(17)
+        stored[1].tensor.fill_(23)
+        assert core.put_many(keys, stored).results == [True, True]
+
+        device = devices[0]
+        device.batched_read_calls.clear()
+        device.wait_iouring_calls.clear()
+
+        legacy_loaded = [_make_byte_obj(4096), _make_byte_obj(4096)]
+        assert core.load_many_into(["first", "second"], legacy_loaded) == [True, True]
+        assert len(device.batched_read_calls) == 2
+        assert all(len(offsets) == 1 for offsets, _ in device.batched_read_calls)
+        assert core.report_status()["batched_load_count"] == 0
+
+        device.batched_read_calls.clear()
+        device.wait_iouring_calls.clear()
+        batched_loaded = [_make_byte_obj(4096), _make_byte_obj(4096)]
+        assert core.load_many_into_batched(["first", "second"], batched_loaded) == [
+            True,
+            True,
+        ]
+
+        first_offset = core.entry_offset("first")
+        second_offset = core.entry_offset("second")
+        assert first_offset is not None
+        assert second_offset is not None
+        assert device.batched_read_calls == [
+            ([first_offset + 4096, second_offset + 4096], [4096, 4096])
+        ]
+        assert len(device.wait_iouring_calls) == 1
+        assert bytes(batched_loaded[0].byte_array) == bytes(stored[0].byte_array)
+        assert bytes(batched_loaded[1].byte_array) == bytes(stored[1].byte_array)
+        status = core.report_status()
+        assert status["batched_load_count"] == 1
+        assert status["batched_load_fallback_count"] == 0
+    finally:
+        core.close()
+
+
+def test_raw_block_core_pipeline_submits_all_reads_before_wait(monkeypatch):
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        key_specs = [
+            RawBlockKeySpec(encoded=f"key-{index}", slot_identity=index + 1)
+            for index in range(3)
+        ]
+        stored = [_make_byte_obj(4096) for _ in key_specs]
+        for index, memory_obj in enumerate(stored):
+            memory_obj.tensor.fill_(17 + index)
+        assert core.put_many(key_specs, stored).results == [True, True, True]
+
+        loaded = [_make_byte_obj(4096) for _ in key_specs]
+        trace = _install_deferred_batched_reads(devices[0])
+
+        def on_batch_loaded(start: int, end: int) -> None:
+            assert end == start + 1
+            assert bytes(loaded[start].byte_array) == bytes(stored[start].byte_array)
+            trace.append(("callback", start, end))
+
+        assert core.load_many_into_batched(
+            [key.encoded for key in key_specs],
+            loaded,
+            completion_batch_size=1,
+            on_batch_loaded=on_batch_loaded,
+        ) == [True, True, True]
+        assert trace == [
+            ("submit", 1),
+            ("submit", 2),
+            ("submit", 3),
+            ("wait", 1),
+            ("callback", 0, 1),
+            ("wait", 2),
+            ("callback", 1, 2),
+            ("wait", 3),
+            ("callback", 2, 3),
+        ]
+        assert core.report_status()["batched_load_count"] == 1
+    finally:
+        core.close()
+
+
+def test_raw_block_core_pipeline_callback_error_drains_without_retry(monkeypatch):
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        key_specs = [
+            RawBlockKeySpec(encoded=f"key-{index}", slot_identity=index + 1)
+            for index in range(3)
+        ]
+        stored = [_make_byte_obj(4096) for _ in key_specs]
+        assert core.put_many(key_specs, stored).results == [True, True, True]
+
+        loaded = [_make_byte_obj(4096) for _ in key_specs]
+        device = devices[0]
+        trace = _install_deferred_batched_reads(device)
+        retry_calls = 0
+
+        def reject_retry(*args, **kwargs):
+            nonlocal retry_calls
+            del args, kwargs
+            retry_calls += 1
+            raise AssertionError("pipeline callback errors must not retry reads")
+
+        def fail_first_callback(start: int, end: int) -> None:
+            trace.append(("callback", start, end))
+            raise RuntimeError("consumer enqueue failed")
+
+        device.pread_into = reject_retry
+        with pytest.raises(RuntimeError, match="consumer enqueue failed"):
+            core.load_many_into_batched(
+                [key.encoded for key in key_specs],
+                loaded,
+                completion_batch_size=1,
+                on_batch_loaded=fail_first_callback,
+            )
+
+        assert trace == [
+            ("submit", 1),
+            ("submit", 2),
+            ("submit", 3),
+            ("wait", 1),
+            ("callback", 0, 1),
+            ("wait", 2),
+            ("wait", 3),
+        ]
+        assert retry_calls == 0
+        status = core.report_status()
+        assert status["inflight_io_count"] == 0
+        assert status["batched_load_fallback_count"] == 0
+    finally:
+        core.close()
+
+
+def test_raw_block_core_pipeline_wait_error_drains_remaining_batches(monkeypatch):
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        key_specs = [
+            RawBlockKeySpec(encoded=f"key-{index}", slot_identity=index + 1)
+            for index in range(3)
+        ]
+        stored = [_make_byte_obj(4096) for _ in key_specs]
+        assert core.put_many(key_specs, stored).results == [True, True, True]
+
+        loaded = [_make_byte_obj(4096) for _ in key_specs]
+        device = devices[0]
+        trace = _install_deferred_batched_reads(
+            device,
+            wait_error_batch_id=2,
+        )
+        retry_calls = 0
+
+        def reject_retry(*args, **kwargs):
+            nonlocal retry_calls
+            del args, kwargs
+            retry_calls += 1
+            raise AssertionError("pipeline wait errors must not retry reads")
+
+        def on_batch_loaded(start: int, end: int) -> None:
+            trace.append(("callback", start, end))
+
+        device.pread_into = reject_retry
+        with pytest.raises(RuntimeError, match="wait failed for batch 2"):
+            core.load_many_into_batched(
+                [key.encoded for key in key_specs],
+                loaded,
+                completion_batch_size=1,
+                on_batch_loaded=on_batch_loaded,
+            )
+
+        assert trace == [
+            ("submit", 1),
+            ("submit", 2),
+            ("submit", 3),
+            ("wait", 1),
+            ("callback", 0, 1),
+            ("wait", 2),
+            ("wait", 3),
+        ]
+        assert retry_calls == 0
+        status = core.report_status()
+        assert status["inflight_io_count"] == 0
+        assert status["batched_load_fallback_count"] == 0
+    finally:
+        core.close()
+
+
+def test_raw_block_core_batched_load_failure_falls_back(monkeypatch):
+    """A failed io_uring batch retries safely and remains observable in status."""
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        keys = [
+            RawBlockKeySpec(encoded="first", slot_identity=1),
+            RawBlockKeySpec(encoded="second", slot_identity=2),
+        ]
+        stored = [_make_byte_obj(4096), _make_byte_obj(4096)]
+        assert core.put_many(keys, stored).results == [True, True]
+
+        def fail_batched_read(offsets, buffers, total_lens):
+            del offsets, buffers, total_lens
+            raise RuntimeError("batch unavailable")
+
+        devices[0].batched_read = fail_batched_read
+        loaded = [_make_byte_obj(4096), _make_byte_obj(4096)]
+
+        assert core.load_many_into_batched(["first", "second"], loaded) == [
+            True,
+            True,
+        ]
+        status = core.report_status()
+        assert status["batched_load_count"] == 1
+        assert status["batched_load_fallback_count"] == 1
+    finally:
+        core.close()
+
+
+def test_raw_block_core_registers_stable_l1_as_one_gib_fixed_buffers(monkeypatch):
+    """A stable L1 prefix is split into kernel-compatible fixed-buffer entries."""
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=True, io_engine="io_uring")
+    try:
+        base = 0x1000_0000
+        size = 4 << 30
+
+        assert core.register_l1_fixed_buffers(base, size) is True
+        assert devices[0].register_fixed_buffer_calls == [
+            (
+                [base + index * (1 << 30) for index in range(4)],
+                [1 << 30] * 4,
+            )
+        ]
+        status = core.report_status()
+        assert status["fixed_buffer_count"] == 4
+        assert status["fixed_buffer_bytes"] == size
+    finally:
+        core.close()
+
+
+def test_raw_block_core_fixed_buffer_registration_failure_falls_back(monkeypatch):
+    """Registration errors preserve startup and leave ordinary reads enabled."""
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=True, io_engine="io_uring")
+    try:
+
+        def fail_registration(buffer_ptrs, buffer_sizes):
+            del buffer_ptrs, buffer_sizes
+            raise RuntimeError("fixed buffers unsupported")
+
+        devices[0].register_fixed_buffers = fail_registration
+
+        assert core.register_l1_fixed_buffers(0x1000_0000, 1 << 30) is False
+        status = core.report_status()
+        assert status["fixed_buffer_count"] == 0
+        assert status["fixed_buffer_bytes"] == 0
+    finally:
+        core.close()
+
+
+def test_raw_block_core_reports_fixed_and_nonfixed_read_submissions(monkeypatch):
+    """Status exposes worker submission counters for benchmark phase deltas."""
+    devices = _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        device = core.raw_device()
+        assert device is devices[0]
+        device._fixed_read_submission_count = 7
+        device._nonfixed_read_submission_count = 3
+
+        status = core.report_status()
+        assert status["fixed_read_submission_count"] == 7
+        assert status["nonfixed_read_submission_count"] == 3
     finally:
         core.close()
 

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import MagicMock
 import threading
 import time
 
@@ -30,6 +31,34 @@ from lmcache.v1.memory_management import (
 from lmcache.v1.pin_monitor import PinMonitor
 
 HUGEPAGE_SIZE = 2 * 1024 * 1024  # MAP_HUGE_2MB
+
+
+def test_lazy_allocator_pins_chunks_as_portable_mapped(monkeypatch):
+    # First Party
+    from lmcache.v1.memory_allocators import lazy_memory_allocator as lazy_mod
+
+    allocator = object.__new__(lazy_mod.LazyMemoryAllocator)
+    allocator._buffer = MagicMock()
+    allocator._buffer.data_ptr.return_value = 0x10000000
+    allocator._final_size = lazy_mod.LazyMemoryAllocator.PIN_CHUNK_SIZE
+    allocator._pin_record = []
+    device_spec = MagicMock()
+    device_spec.pin_memory.return_value = True
+    monkeypatch.setattr(lazy_mod, "current_device_spec", device_spec)
+
+    allocator._pin_memory_chunk(
+        0,
+        lazy_mod.LazyMemoryAllocator.PIN_CHUNK_SIZE,
+    )
+
+    device_spec.pin_memory.assert_called_once_with(
+        0x10000000,
+        lazy_mod.LazyMemoryAllocator.PIN_CHUNK_SIZE,
+        0x01 | 0x02,
+    )
+    assert allocator._pin_record == [
+        (0x10000000, lazy_mod.LazyMemoryAllocator.PIN_CHUNK_SIZE)
+    ]
 
 
 def check_allocator(allocator, max_size):
@@ -660,6 +689,27 @@ class TestLazyMemoryAllocator:
         assert memory_obj.tensor.dtype == dtype
 
         allocator.close()
+
+    def test_underlying_buffer_honors_allocation_alignment(self, lazy_allocator_cls):
+        """The stable lazy arena and its allocations honor the requested alignment."""
+        alignment = 4096
+        allocator = lazy_allocator_cls(
+            init_size=self.INIT_SIZE,
+            final_size=self.FINAL_SIZE,
+            align_bytes=alignment,
+        )
+        try:
+            assert allocator.get_underlying_buffer().data_ptr() % alignment == 0
+
+            memory_objs = allocator.batched_allocate(
+                torch.Size([4096]),
+                torch.uint8,
+                batch_size=3,
+            )
+            assert memory_objs is not None
+            assert all(obj.data_ptr % alignment == 0 for obj in memory_objs)
+        finally:
+            allocator.close()
 
     def test_allocate_with_format(self, lazy_allocator_cls):
         """Test allocation with explicit memory format."""

--- a/tests/v1/test_mp_mem_kernels.py
+++ b/tests/v1/test_mp_mem_kernels.py
@@ -48,6 +48,7 @@ FMT_CROSS_LAYER = lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
 FMT_FLASH_INFER = lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS
 FMT_MLA = lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
 FMT_SGLANG_MHA = lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
+FMT_SGLANG_MP_MHA = lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS
 FMT_SGLANG_MLA = lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS
 FMT_NORMAL_HND = lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
 FMT_FLASH_INFER_HND = lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS
@@ -67,6 +68,7 @@ FORMAT_PARAMS = [
     (FMT_FLASH_INFER, 4, 8, 128, False),
     (FMT_MLA, 4, 1, 576, True),
     (FMT_SGLANG_MHA, 4, 8, 128, False),
+    (FMT_SGLANG_MP_MHA, 4, 8, 128, False),
     (FMT_SGLANG_MLA, 4, 1, 576, True),
     (FMT_NORMAL_HND, 4, 8, 128, False),
     (FMT_FLASH_INFER_HND, 4, 8, 128, False),
@@ -115,6 +117,9 @@ def create_vllm_tensors(
     elif engine_kv_format == FMT_SGLANG_MHA:
         shape = [nbbs, nh, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(2 * nl)]
+    elif engine_kv_format == FMT_SGLANG_MP_MHA:
+        shape = [nb, bs, nh, hs]
+        return [_create_random_tensor(shape, dtype, device) for _ in range(2 * nl)]
     elif engine_kv_format == FMT_SGLANG_MLA:
         shape = [nbbs, 1, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
@@ -158,6 +163,9 @@ def create_zero_vllm_tensors(
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
     elif engine_kv_format == FMT_SGLANG_MHA:
         shape = [nbbs, nh, hs]
+        return [_create_zero_tensor(shape, dtype, device) for _ in range(2 * nl)]
+    elif engine_kv_format == FMT_SGLANG_MP_MHA:
+        shape = [nb, bs, nh, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(2 * nl)]
     elif engine_kv_format == FMT_SGLANG_MLA:
         shape = [nbbs, 1, hs]
@@ -219,6 +227,10 @@ def get_block_data(
             ts, ed = block_idx * bs, (block_idx + 1) * bs
             k = vllm_tensors[layer_idx][ts:ed, :, :].clone()
             v = vllm_tensors[nl + layer_idx][ts:ed, :, :].clone()
+            results.append(torch.stack([k, v], dim=0))
+        elif engine_kv_format == FMT_SGLANG_MP_MHA:
+            k = vllm_tensors[layer_idx][block_idx, :, :, :].clone()
+            v = vllm_tensors[nl + layer_idx][block_idx, :, :, :].clone()
             results.append(torch.stack([k, v], dim=0))
         elif engine_kv_format == FMT_SGLANG_MLA:
             ts, ed = block_idx * bs, (block_idx + 1) * bs
@@ -296,6 +308,7 @@ TOTAL_BLOCKS = NUM_MEMORY_OBJECTS * BLOCKS_PER_OBJECT  # 64
         "flash_infer",
         "mla",
         "sglang_mha",
+        "sglang_mp_mha",
         "sglang_mla",
         "normal_hnd",
         "flash_infer_hnd",
@@ -403,6 +416,7 @@ def test_block_transfer_roundtrip(
         "flash_infer",
         "mla",
         "sglang_mha",
+        "sglang_mp_mha",
         "sglang_mla",
         "normal_hnd",
         "flash_infer_hnd",

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -7,6 +7,7 @@ returns a pollable future -- an already-completed one on the no-op paths
 completion future on the happy path -- and never blocks on the result."""
 
 # Standard
+from typing import cast
 import threading
 
 # Third Party
@@ -25,6 +26,7 @@ from lmcache.integration.sglang.multi_process_adapter import (
 )
 from lmcache.integration.sglang.sglang_adapter import StoreMetadata
 from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.platform.base.event_ipc import EventIPCBackend
 
 _CHUNK_SIZE = 256
 
@@ -41,7 +43,7 @@ def _make_connector(healthy: bool = True) -> LMCacheMPConnector:
         conn._health_event.set()
     conn._lmcache_chunk_size = _CHUNK_SIZE
     conn._mq_timeout = 5.0
-    conn._event_backend = _FakeEventBackend()
+    conn._event_backend = cast(EventIPCBackend, _FakeEventBackend())
     conn._daemon_session_ids = set()
     conn._pending_lookups_lock = threading.Lock()
     conn._fused_final_events = {}

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -41,6 +41,11 @@ def _make_connector(healthy: bool = True) -> LMCacheMPConnector:
         conn._health_event.set()
     conn._lmcache_chunk_size = _CHUNK_SIZE
     conn._mq_timeout = 5.0
+    conn._event_backend = _FakeEventBackend()
+    conn._daemon_session_ids = set()
+    conn._pending_lookups_lock = threading.Lock()
+    conn._fused_final_events = {}
+    conn._undrained_fused_requests = set()
     return conn
 
 
@@ -76,6 +81,9 @@ class _FakeRaw:
     def to_cuda_future(self, device=None) -> MessagingFuture:
         return self._future
 
+    def to_device_future(self, device=None) -> MessagingFuture:
+        return self._future
+
 
 class _FakeEvent:
     def __init__(self, interprocess: bool = False) -> None:
@@ -94,6 +102,17 @@ class _FakeTorchDev:
     @staticmethod
     def current_stream():
         return object()
+
+
+class _FakeEventBackend:
+    def create_event(self, device):
+        return _FakeEvent(interprocess=True)
+
+    def record_event(self, event, stream) -> None:
+        event.record(stream)
+
+    def export_event(self, event, device) -> bytes:
+        return event.ipc_handle()
 
 
 def test_completed_future_resolves_to_given_result() -> None:

--- a/tests/v1/test_sglang_mp_fused_adapter.py
+++ b/tests/v1/test_sglang_mp_fused_adapter.py
@@ -1,0 +1,522 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused unit tests for SGLang's fused raw-block MP retrieve client."""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+import threading
+
+# Third Party
+import pytest
+import torch
+
+pytest.importorskip("sglang", reason="SGLang is required for its MP adapter tests")
+
+# First Party
+from lmcache.integration.sglang import multi_process_adapter as adapter_mod
+from lmcache.integration.sglang.multi_process_adapter import (
+    CompletionEvent,
+    FusedRestoreUndrainedError,
+    LMCacheMPConnector,
+    _PendingLookup,
+)
+from lmcache.integration.sglang.sglang_adapter import LoadMetadata
+from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.protocols.engine import (
+    FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY,
+)
+
+
+@pytest.fixture
+def fused_connector(monkeypatch):
+    connector = object.__new__(LMCacheMPConnector)
+    connector.tp_size = 1
+    connector.worker_id = 0
+    connector.page_size = 1
+    connector.num_layers = 2
+    connector.device = torch.device("cpu")
+    connector.model_name = "test-model"
+    connector.instance_id = 123
+    connector.tp_group = "tp-group"
+    connector._mq_timeout = 5.0
+    connector._lmcache_chunk_size = 4
+    connector._supports_fused_raw_block_retrieve = True
+    connector._pending_lookups = {}
+    connector._daemon_session_ids = set()
+    connector._pending_lookups_lock = threading.Lock()
+    connector._fused_final_events = {}
+    connector._undrained_fused_requests = set()
+    connector._health_event = threading.Event()
+    connector._health_event.set()
+    connector._event_backend = MagicMock()
+    connector._test_final_event = object()
+    connector._event_backend.import_event.return_value = connector._test_final_event
+    connector._test_current_stream = object()
+    monkeypatch.setattr(
+        adapter_mod.torch_dev,
+        "current_stream",
+        MagicMock(return_value=connector._test_current_stream),
+    )
+    return connector
+
+
+def _metadata(request_id: str = "request-0") -> LoadMetadata:
+    return LoadMetadata(
+        token_ids=list(range(10)),
+        slot_mapping=torch.arange(8, dtype=torch.int64),
+        offset=0,
+        prefix_pad=0,
+        request_id=request_id,
+    )
+
+
+@pytest.mark.parametrize("retrieved_tokens", [8, 4, 0])
+def test_fused_retrieve_waits_completion_on_current_load_stream(
+    fused_connector,
+    retrieved_tokens,
+):
+    future = MagicMock()
+    future.result.return_value = (
+        b"final",
+        (retrieved_tokens, True),
+    )
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+
+    assert fused_connector.retrieve_kv(_metadata()) == retrieved_tokens
+
+    fused_connector._event_backend.wait_event.assert_called_once_with(
+        fused_connector._test_final_event,
+        fused_connector._test_current_stream,
+    )
+    fused_connector._event_backend.import_event.assert_called_once_with(
+        b"final",
+        fused_connector.device,
+    )
+    fused_connector._event_backend.synchronize_event.assert_not_called()
+    submitted = fused_connector._submit_fused_raw_block_retrieve.call_args.kwargs
+    assert submitted["offset"] == 0
+    assert submitted["aligned_end"] == 8
+    assert submitted["block_ids"] == list(range(8))
+    assert submitted["prefix_pad"] == 0
+
+
+def test_fused_retrieve_agrees_tp_before_retaining_and_waiting_completion(
+    fused_connector,
+):
+    trace: list[str] = []
+    future = MagicMock()
+    future.result.return_value = (
+        b"final",
+        (8, True),
+    )
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+    fused_connector._global_fused_result = MagicMock(
+        side_effect=lambda succeeded, tokens: (
+            trace.append("collective") or (succeeded, tokens)
+        )
+    )
+    fused_connector._event_backend.wait_event.side_effect = lambda _event, _stream: (
+        trace.append("wait")
+    )
+
+    assert fused_connector.retrieve_kv(_metadata()) == 8
+
+    assert trace == ["collective", "wait"]
+    fused_connector._event_backend.synchronize_event.assert_not_called()
+    retained = fused_connector._fused_final_events["request-0"]
+    assert len(retained) == 1
+    assert isinstance(retained[0], CompletionEvent)
+    assert retained[0]._event is fused_connector._test_final_event  # noqa: SLF001
+
+
+def test_end_session_synchronizes_final_before_releasing_exporters(
+    fused_connector,
+    monkeypatch,
+):
+    trace: list[tuple] = []
+    future = MagicMock()
+    future.result.return_value = (
+        b"final",
+        (8, True),
+    )
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+    fused_connector.mq_client = MagicMock()
+    fused_connector._event_backend.synchronize_event.side_effect = (
+        lambda event, device: trace.append(("synchronize", event, device))
+    )
+
+    def send_request(_client, request_type, payload):
+        trace.append(("send", request_type, payload))
+        return MagicMock()
+
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_request)
+
+    assert fused_connector.retrieve_kv(_metadata()) == 8
+    assert "request-0" in fused_connector._fused_final_events
+
+    fused_connector.end_session("request-0")
+
+    assert trace == [
+        (
+            "synchronize",
+            fused_connector._test_final_event,
+            fused_connector.device,
+        ),
+        ("send", RequestType.END_SESSION, ["request-0"]),
+    ]
+    assert "request-0" not in fused_connector._fused_final_events
+
+
+def test_tp_failure_synchronizes_local_completion(fused_connector):
+    future = MagicMock()
+    future.result.return_value = (
+        b"final",
+        (8, True),
+    )
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+    fused_connector._global_fused_result = MagicMock(return_value=(False, 0))
+
+    with pytest.raises(RuntimeError, match="another TP rank"):
+        fused_connector.retrieve_kv(_metadata())
+
+    fused_connector._event_backend.synchronize_event.assert_called_once_with(
+        fused_connector._test_final_event,
+        fused_connector.device,
+    )
+
+
+def test_completion_event_delegates_to_backend():
+    backend = MagicMock()
+    native_event = object()
+    device = torch.device("cpu")
+    stream = object()
+    event = CompletionEvent(backend, native_event, device)
+
+    event.wait_on_stream(stream)
+    event.synchronize()
+
+    backend.wait_event.assert_called_once_with(native_event, stream)
+    backend.synchronize_event.assert_called_once_with(native_event, device)
+
+
+def test_global_fused_result_reduces_success_and_token_bounds(
+    fused_connector,
+    monkeypatch,
+):
+    fused_connector.tp_size = 2
+
+    def reduce_result(result, *, op, group):
+        assert result.tolist() == [1, 8, -8]
+        assert op == torch.distributed.ReduceOp.MIN
+        assert group == "tp-group"
+        result.copy_(torch.tensor([1, 4, -8], dtype=torch.int32))
+
+    monkeypatch.setattr(adapter_mod.dist, "all_reduce", reduce_result)
+
+    assert fused_connector._global_fused_result(True, 8) == (False, 4)
+
+
+def test_asymmetric_capability_is_disabled_by_tp_min_agreement(
+    fused_connector,
+    monkeypatch,
+):
+    fused_connector.tp_size = 2
+
+    def reduce_capability(supported, *, op, group):
+        assert supported.tolist() == [1]
+        assert op == torch.distributed.ReduceOp.MIN
+        assert group == "tp-group"
+        # This process reached the exact capability, while a peer did not.
+        supported.zero_()
+
+    monkeypatch.setattr(adapter_mod.dist, "all_reduce", reduce_capability)
+
+    assert fused_connector._agree_fused_raw_block_capability(True) is False
+
+
+def test_timeout_drains_response_final_before_collective_and_raise(
+    fused_connector,
+):
+    trace: list[tuple] = []
+    future = MagicMock()
+
+    def get_result(timeout=None):
+        trace.append(("future", timeout))
+        raise TimeoutError("fused timed out")
+
+    future.result.side_effect = get_result
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+    fused_connector._global_fused_result = MagicMock(
+        side_effect=lambda succeeded, tokens: (
+            trace.append(("collective", succeeded, tokens)) or (False, 0)
+        )
+    )
+    fused_connector._drain_fused_raw_block_retrieve = MagicMock(
+        side_effect=lambda _request_id: trace.append(("drain",))
+    )
+
+    with pytest.raises(TimeoutError, match="fused timed out"):
+        fused_connector.retrieve_kv(_metadata())
+
+    assert future.result.call_args_list == [
+        call(timeout=fused_connector._mq_timeout),
+    ]
+    assert trace == [
+        ("future", fused_connector._mq_timeout),
+        ("drain",),
+        ("collective", False, 0),
+    ]
+
+
+def test_drain_timeout_surfaces_unsafe_error_and_tracks_request(
+    fused_connector,
+):
+    future = MagicMock()
+    future.result.side_effect = TimeoutError("fused timed out")
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+    fused_connector._drain_fused_raw_block_retrieve = MagicMock(
+        side_effect=TimeoutError("drain timed out")
+    )
+
+    with pytest.raises(FusedRestoreUndrainedError, match="server-side drain failed"):
+        fused_connector.retrieve_kv(_metadata())
+
+    assert fused_connector._undrained_fused_requests == {"request-0"}
+
+
+def test_unimportable_final_uses_rank_specific_server_drain_before_collective(
+    fused_connector,
+):
+    trace: list[str] = []
+    future = MagicMock()
+    future.result.return_value = (
+        b"final",
+        (8, True),
+    )
+    fused_connector._submit_fused_raw_block_retrieve = MagicMock(return_value=future)
+    fused_connector._event_backend.import_event.side_effect = RuntimeError(
+        "final import failed"
+    )
+    fused_connector._drain_fused_raw_block_retrieve = MagicMock(
+        side_effect=lambda _request_id: trace.append("drain")
+    )
+    fused_connector._global_fused_result = MagicMock(
+        side_effect=lambda *_args: trace.append("collective") or (False, 0)
+    )
+
+    with pytest.raises(RuntimeError, match="final import failed"):
+        fused_connector.retrieve_kv(_metadata())
+
+    assert trace == ["drain", "collective"]
+    fused_connector._drain_fused_raw_block_retrieve.assert_called_once_with("request-0")
+
+
+def test_rank_specific_server_drain_rpc_waits_without_timeout(
+    fused_connector,
+    monkeypatch,
+):
+    fused_connector.mq_client = MagicMock()
+    drain_future = MagicMock()
+    drain_future.result.return_value = True
+    send_mock = MagicMock(return_value=drain_future)
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_mock)
+
+    fused_connector._drain_fused_raw_block_retrieve("request-0")
+
+    send_mock.assert_called_once_with(
+        fused_connector.mq_client,
+        RequestType.FUSED_RAW_BLOCK_DRAIN,
+        ["request-0", fused_connector.worker_id],
+    )
+    drain_future.result.assert_called_once_with(timeout=fused_connector._mq_timeout)
+
+
+def test_submit_fused_retrieve_retains_producer_export_event(
+    fused_connector,
+    monkeypatch,
+):
+    fused_connector.mq_client = MagicMock()
+    producer_event = object()
+    fused_connector._event_backend.create_event.return_value = producer_event
+    fused_connector._event_backend.export_event.return_value = b"producer"
+    messaging_future = MagicMock()
+    send_mock = MagicMock(return_value=messaging_future)
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_mock)
+
+    result = fused_connector._submit_fused_raw_block_retrieve(
+        request_id="request-0",
+        token_ids=list(range(10)),
+        offset=0,
+        aligned_end=8,
+        block_ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        prefix_pad=2,
+    )
+
+    assert result is messaging_future
+    assert messaging_future._export_event is producer_event
+    request_type, payload = send_mock.call_args.args[1:]
+    assert request_type is RequestType.FUSED_RAW_BLOCK_RETRIEVE
+    key, instance_id, block_ids, event_handle, prefix_pad = payload
+    assert (key.start, key.end, key.request_id) == (0, 8, "request-0")
+    assert instance_id == fused_connector.instance_id
+    assert block_ids == [[0, 1, 2, 3, 4, 5, 6, 7]]
+    assert event_handle == b"producer"
+    assert prefix_pad == 2
+
+
+def test_reset_drains_all_final_events_and_ends_every_known_session(
+    fused_connector,
+    monkeypatch,
+):
+    fused_connector.mq_client = MagicMock()
+    fused_connector._pending_lookups["lookup"] = _PendingLookup(
+        token_ids=list(range(8)),
+        matched_token_num=8,
+        locks_held=True,
+    )
+    fused_connector._daemon_session_ids.update({"lookup", "store"})
+    final_events = [
+        CompletionEvent(
+            fused_connector._event_backend,
+            object(),
+            fused_connector.device,
+        ),
+        CompletionEvent(
+            fused_connector._event_backend,
+            object(),
+            fused_connector.device,
+        ),
+    ]
+    fused_connector._fused_final_events["fused"] = final_events
+    fused_connector._daemon_session_ids.add("fused")
+    fused_connector._free_lookup_locks = MagicMock()
+    sends: list[tuple[RequestType, list]] = []
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_lmcache_request",
+        lambda _client, request_type, payload: (
+            sends.append((request_type, payload)) or MagicMock()
+        ),
+    )
+
+    fused_connector.reset()
+
+    assert fused_connector._event_backend.synchronize_event.call_args_list == [
+        call(event._event, fused_connector.device)  # noqa: SLF001
+        for event in final_events
+    ]
+    fused_connector._free_lookup_locks.assert_called_once_with(
+        list(range(8)),
+        0,
+        8,
+        "lookup",
+    )
+    assert sends == [
+        (RequestType.END_SESSION, ["fused"]),
+        (RequestType.END_SESSION, ["lookup"]),
+        (RequestType.END_SESSION, ["store"]),
+    ]
+    assert fused_connector._pending_lookups == {}
+    assert fused_connector._daemon_session_ids == set()
+    assert fused_connector._fused_final_events == {}
+    assert fused_connector._undrained_fused_requests == set()
+
+
+def test_retaining_policy_same_prompt_hit_uses_generic_retrieve(fused_connector):
+    fused_connector._supports_fused_raw_block_retrieve = False
+    fused_connector._pending_lookups["request-0"] = _PendingLookup(
+        token_ids=list(range(8)),
+        matched_token_num=8,
+        locks_held=True,
+    )
+    fused_connector._free_lookup_locks = MagicMock()
+    future = MagicMock()
+    future.result.return_value = True
+    fused_connector._submit_retrieve = MagicMock(return_value=future)
+    fused_connector._retrieve_fused_raw_block = MagicMock()
+    metadata = _metadata()
+    metadata.slot_mapping = torch.tensor(
+        [-1, -1, 10, 11, 12, 13, 14, 15],
+        dtype=torch.int64,
+    )
+    metadata.prefix_pad = 2
+
+    assert fused_connector.retrieve_kv(metadata) == 8
+
+    generic_call = fused_connector._submit_retrieve.call_args.kwargs
+    assert generic_call["block_ids"] == [0, 0, 10, 11, 12, 13, 14, 15]
+    assert generic_call["skip_first_n_tokens"] == 2
+    fused_connector._retrieve_fused_raw_block.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected"),
+    [
+        ({FUSED_RAW_BLOCK_RETRIEVE_CAPABILITY}, True),
+        (set(), False),
+        ({"lmcache.unrelated.v1"}, False),
+    ],
+)
+def test_init_enables_fused_only_for_exact_paired_capability(
+    monkeypatch,
+    capabilities,
+    expected,
+):
+    fake_client = MagicMock()
+    monkeypatch.setattr(
+        adapter_mod,
+        "MessageQueueClient",
+        MagicMock(return_value=fake_client),
+    )
+    monkeypatch.setattr(
+        adapter_mod,
+        "get_lmcache_chunk_size",
+        MagicMock(return_value=4),
+    )
+    monkeypatch.setattr(
+        adapter_mod,
+        "get_experimental",
+        MagicMock(return_value=capabilities),
+    )
+    event_backend = MagicMock()
+    monkeypatch.setattr(
+        adapter_mod,
+        "get_event_ipc_backend",
+        MagicMock(return_value=event_backend),
+    )
+    monkeypatch.setattr(
+        adapter_mod,
+        "_wrap_sglang_kv_caches",
+        MagicMock(return_value=[]),
+    )
+    monkeypatch.setattr(adapter_mod.zmq.Context, "instance", MagicMock())
+    register_future = MagicMock()
+    register_future.result.return_value = None
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_lmcache_request",
+        MagicMock(return_value=register_future),
+    )
+    heartbeat = MagicMock()
+    monkeypatch.setattr(
+        adapter_mod,
+        "HeartbeatThread",
+        MagicMock(return_value=heartbeat),
+    )
+    kv_tensor = MagicMock()
+    kv_tensor.device = torch.device("cpu")
+
+    connector = LMCacheMPConnector(
+        sgl_config=SimpleNamespace(model_path="test-model"),
+        tp_size=1,
+        rank=0,
+        page_size=1,
+        host="127.0.0.1",
+        port=0,
+        k_pool=[kv_tensor],
+        v_pool=[kv_tensor],
+    )
+
+    assert connector.supports_fused_raw_block_retrieve() is expected
+    event_backend.check_event_support.assert_called_once_with(torch.device("cpu"))
+    heartbeat.start.assert_called_once_with()


### PR DESCRIPTION
## Summary

This PR improves read-side local-SSD offload for SGLang multi-process (MP) mode.

- batch raw-block `O_DIRECT` reads through fixed `io_uring` buffers and reuse aligned workspaces;
- register stable aligned L1 allocation subranges with the shared raw-block device;
- fuse raw-block lookup, batched reads, staged host-to-device copies, and the existing all-layer restore into one MP request;
- negotiate the fused capability explicitly and return the prefix that was actually restored;
- retain completion state and drain or fail-stop before staging memory, KV slots, sessions, or request IDs can be reused;
- recognize the one-KV-head-per-rank SGLang MP layout using the explicit tokens-per-block hint.

Unsupported connectors retain the existing generic lookup/retrieve path. Non-MP behavior and the raw-block write path are unchanged and intentionally out of scope.

## Companion SGLang change

This is paired with [sgl-project/sglang#32946](https://github.com/sgl-project/sglang/pull/32946), which consumes the capability, skips the redundant standalone lookup, reconciles the actual restored prefix, and enforces the matching drain contract.

## End-to-end local-SSD read performance

We compared LMCache raw-block restore with SGLang native HiCache across four matched ABBA launches per topology. CUDA graphs were enabled. Values are medians of the four launch-level p50s. The subtractive SSD TTFT penalty is `SSD-forced p50 - GPU-covered p50` in milliseconds.

| Topology and model | LMCache forced TTFT | HiCache forced TTFT | Lower latency | LMCache / HiCache SSD penalty | Lower penalty | Paired wins |
|:--|--:|--:|--:|--:|--:|:--|
| TP1 / DP1 / EP1 - `Qwen3-Coder-30B-A3B-Instruct` | 71.110 ms | 78.713 ms | **9.66%** | 17.058 / 23.162 ms | **26.36%** | 4/4 forced, 4/4 penalty |
| TP8 / DP1 / EP8 - `Qwen3-Coder-480B-A35B-Instruct-FP8` | 193.529 ms | 238.119 ms | **18.73%** | 44.946 / 68.826 ms | **34.70%** | 4/4 forced, 4/4 penalty |

SSD-forced end-to-end p50 was near parity and slightly favored HiCache: 123.020 versus 122.589 ms at TP1 and 388.979 versus 386.458 ms at TP8. The performance claim is therefore limited to restore/TTFT latency, not total end-to-end latency.

The workload used 769 input tokens, a 768-token aligned reusable prefix, 8 output tokens, and 256-token pages. Each independent launch ran three cycles with 16 requests per phase and discarded the first four samples per cycle. Requests were issued one at a time. Model revisions were `b2cff646eb4bb1d68355c01b18ae02e7cf42d120` for TP1 and `003f183a92fbe5b9a8325aaa8b2ae797c91dd90f` for TP8; both used BF16 KV cache. All measured outputs matched the cached-prefix reference.

These results cover Qwen3 MoE models with standard attention. They should not be generalized to recurrent or compressed-KV layouts, MLA, or unrelated workloads.

### Page-cache and physical-read proof

The forced phases were genuine storage reads rather than Linux page-cache hits:

| Topology | Expected reads per launch/backend | Actual reads | Formal page-cache snapshots |
|:--|--:|:--|:--|
| TP1 | 3,623,878,656 bytes | exact for LMCache and HiCache | zero resident pages in all snapshots (9 LMCache / 12 HiCache) |
| TP8 | 9,361,686,528 bytes | exact for LMCache and HiCache | zero resident pages in all snapshots (9 LMCache / 12 HiCache) |

`O_DIRECT` remained active without a buffered-I/O fallback. All 16 launches passed source, topology, runtime, correctness, physical-read, and page-residency gates.

## Validation

- runtime implementation focused validation: **270 passed, 45 skipped, 13 deselected**;
- final CI-only follow-up affected suite: **51 passed, 29 skipped**;
- the repository's all-files pre-commit gate passes, including isort, Ruff, formatting, codespell, mypy, clang-format, Rust formatting, and Clippy;
- Rust tests and BF16/FP8 CPU/GPU KV round trips passed;
- GitHub Test, CPU Device Tests, Code Quality, CodeQL, and Operator CI pass on the final head;
- a broader local GPU-kernel run still reproduces the pre-existing `test_block_transfer_skip_prefix` segmentation fault observed on clean `dev`; it is not introduced by this diff;
- the end-to-end measurements used the runtime implementation preserved at parent commit `3d40a8e0102149e54b676541969f35b6c9aeaf32` (tree `d6c9e55fcba01ab6088c0d2624a2e2fcf563ea67`); the final follow-up commit only adds static typing annotations/casts and import ordering, without changing runtime behavior.