### PR TITLE
style: replace f-string logging with %-format for deferred string evaluation

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1620,7 +1620,7 @@ class LMCacheEngine:
                 logger.info("Closing hidden_state_store...")
                 self.hidden_state_store.close()
             except Exception as e:
-                logger.error(f"Error closing hidden_state_store: {e}")
+                logger.error("Error closing hidden_state_store: %s", e)
 
         if self.lmcache_worker is not None:
             try:

--- a/lmcache/v1/compute/models/utils.py
+++ b/lmcache/v1/compute/models/utils.py
@@ -47,7 +47,7 @@ class VLLMModelTracker:
         """
         Register a vllm model by instance_id.
         """
-        logger.info(f"Registering vllm model for {instance_id}")
+        logger.info("Registering vllm model for %s", instance_id)
         if instance_id not in cls._vllm_models:
             cls._vllm_models[instance_id] = vllm_model
         else:

--- a/lmcache/v1/offload_server/zmq_server.py
+++ b/lmcache/v1/offload_server/zmq_server.py
@@ -66,10 +66,10 @@ class ZMQOffloadServer(OffloadServerInterface):
                     if not self.running:
                         logger.info("ZMQ socket closed, exiting offload server thread")
                         break
-                    logger.error(f"ZMQ error in offload server: {e}")
+                    logger.error("ZMQ error in offload server: %s", e)
                     break
                 except Exception as e:
-                    logger.error(f"Unexpected error in offload server: {e}")
+                    logger.error("Unexpected error in offload server: %s", e)
                     if not self.running:
                         break
 
@@ -103,7 +103,7 @@ class ZMQOffloadServer(OffloadServerInterface):
             self.socket.close(linger=0)
             logger.info("ZMQ socket closed")
         except Exception as e:
-            logger.warning(f"Error closing ZMQ socket: {e}")
+            logger.warning("Error closing ZMQ socket: %s", e)
 
         # Wait for thread with timeout to prevent deadlock
         if self.thread.is_alive():


### PR DESCRIPTION
Fixes none - part of onboarding #3372

**What this PR does / why it needs it:**

Replace f-string logging calls with %-format strings in 3 files. Using %-style avoids unnecessary string interpolation when the log level is disabled, which improves performance as recommended by maintainers (see https://github.com/LMCache/LMCache/issues/3372#issuecomment-2954065831).

**Files changed:**
- `lmcache/v1/offload_server/zmq_server.py` (3 calls)
- `lmcache/v1/cache_engine.py` (1 call)
- `lmcache/v1/compute/models/utils.py` (1 call)

**Special notes for reviewers:**
- This is my first PR to LMCache 🙇 please be gentle.
- Only error/warning/info logging calls with f-strings were changed.
- No functional changes — pure style fix for log performance.