### PR TITLE
docs: daily drift check — multi-process mode (2026-07-31)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -128,6 +128,13 @@ Source: ``lmcache/v1/multiprocess/config.py``
        ``--no-separate-object-groups`` to keep all layers in a single
        full-attention object group. Transparent to correctness; a non-hybrid
        model always resolves to one object group. See :doc:`/mp/hybrid_models`.
+   * - ``--enable NAME [NAME ...]``
+     - ``[]``
+     - Zero or more experimental transfer modules to enable in the MP
+       server. Currently the only recognized option is ``transfer_query``,
+       which loads the query-tensor transfer module used by the KV-cache
+       SDK (see :doc:`/mp/sdk`). Modules are registered in
+       ``lmcache/v1/multiprocess/modules/experimental/__init__.py``.
 
 Lookup Hash Logging
 -------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current `dev`
code (`upstream/dev` HEAD [`9c0bcd88`](https://github.com/LMCache/LMCache/commit/9c0bcd882d33d751d4144e64fe39c370fd1432a3)),
focused on the multi-process mode. One drift item today, introduced by
[#4042](https://github.com/LMCache/LMCache/pull/4042) (commit [`8dcd94f2`](https://github.com/LMCache/LMCache/commit/8dcd94f2e39f6cc0be24ebe181f168a5bb6295ec),
*"Get query tensor v2"*, 2026-07-29), which added a new MP server CLI
flag but did not add it to the canonical multi-process configuration
reference.

Prior open drift-check PRs still track their own items and do not
overlap this one:

- [#4304](https://github.com/LMCache/LMCache/pull/4304) — `/directory/*`
  endpoints missing from `docs/source/mp/coordinator.rst` and
  `docs/design/v1/mp_coordinator/README.md`.
- [#4285](https://github.com/LMCache/LMCache/pull/4285) — `TransferContext`
  method-count mismatch in `docs/design/v1/multiprocess/engine_driven_transfer_design.md`
  and L2-adapter factory description in `docs/source/mp/index.rst`.
- [#4269](https://github.com/LMCache/LMCache/pull/4269) — `--runtime-plugin-config`
  env-var description in `docs/source/mp/configuration.rst`.
- Older PRs (#4249, #4236, #4199) continue to track their earlier items.

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/configuration.rst`** — the "MP Server" argument
  table is the canonical reference for the ``lmcache server`` CLI: the
  page opens by declaring itself the doc that *"documents every CLI
  argument accepted by the LMCache multiprocess server"*
  ([lines 1-14](https://github.com/LMCache/LMCache/blob/9c0bcd882d33d751d4144e64fe39c370fd1432a3/docs/source/mp/configuration.rst#L1-L14)),
  and the "MP Server" table at
  [lines 16-130](https://github.com/LMCache/LMCache/blob/9c0bcd882d33d751d4144e64fe39c370fd1432a3/docs/source/mp/configuration.rst#L16-L130)
  lists every other argument added by `add_mp_server_args()` in
  `lmcache/v1/multiprocess/config.py`. Since [#4042](https://github.com/LMCache/LMCache/pull/4042)
  landed the new `--enable NAME [NAME ...]` flag has been part of the
  MP-server argument group (see [`config.py:382-390`](https://github.com/LMCache/LMCache/blob/9c0bcd882d33d751d4144e64fe39c370fd1432a3/lmcache/v1/multiprocess/config.py#L382-L390),
  with the corresponding field at [`config.py:98-100`](https://github.com/LMCache/LMCache/blob/9c0bcd882d33d751d4144e64fe39c370fd1432a3/lmcache/v1/multiprocess/config.py#L98-L100)),
  but the table does not list it. The flag is only mentioned in passing
  in `docs/source/mp/sdk.rst`
  ([lines 57-71](https://github.com/LMCache/LMCache/blob/9c0bcd882d33d751d4144e64fe39c370fd1432a3/docs/source/mp/sdk.rst#L57-L71))
  as part of the query-tensor SDK walkthrough — a reader looking for
  the canonical list of MP server flags will not find it there.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/mp/configuration.rst` — "MP Server" table ([lines 16-130](https://github.com/LMCache/LMCache/blob/9c0bcd882d33d751d4144e64fe39c370fd1432a3/docs/source/mp/configuration.rst#L16-L130)) | Table ends at ``--separate-object-groups`` / ``--no-separate-object-groups``. No `--enable` row. | Adds a row for ``--enable NAME [NAME ...]`` (default ``[]``) describing the experimental transfer-module opt-in, with pointers to `mp/sdk.rst` for the intended use case and to `lmcache/v1/multiprocess/modules/experimental/__init__.py` for the recognized option set. |

### `docs/design/`

None today.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One
file touched:

- `docs/source/mp/configuration.rst`

## Code bugs surfaced (not fixed here)

None new from today's check. (Pre-existing items from earlier drift
checks — the `lmcache_mp_connector_0180.py` docstring inversion
flagged by [#4199](https://github.com/LMCache/LMCache/pull/4199), the
`--runtime-plugin-config` help-string mismatch flagged by
[#4269](https://github.com/LMCache/LMCache/pull/4269) — remain open;
this PR does not re-flag them.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLE3pzd3tmaWAbUxNmC1zD)_