### PR TITLE
Add Ascend NPU (torch_npu) support

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -275,6 +275,18 @@ def create_lmcache_metadata(
     chunk_size = config.chunk_size
     num_kv_head = model_cfg.get_num_kv_heads(parallel_cfg)
     head_size = model_cfg.get_head_size()
+    if use_mla:
+        from lmcache import torch_device_type
+        if torch_device_type == "npu":
+            # vLLM-Ascend caches only the compressed MLA latent
+            # (kv_lora_rank); size the pool to it so it matches the
+            # on-device KV cache tensor.
+            for _cfg in (getattr(model_cfg, "hf_text_config", None),
+                         getattr(model_cfg, "hf_config", None)):
+                _lora = getattr(_cfg, "kv_lora_rank", None)
+                if _lora:
+                    head_size = _lora
+                    break
     kv_shape = (num_layer, 1 if use_mla else 2, chunk_size, num_kv_head, head_size)
 
     # Extract engine_id and kv_connector_extra_config from vllm_config if available

--- a/lmcache/integration/vllm/vllm_service_factory.py
+++ b/lmcache/integration/vllm/vllm_service_factory.py
@@ -100,6 +100,18 @@ class VllmServiceFactory(BaseServiceFactory):
         chunk_size = self.lmcache_config.chunk_size
         num_kv_head = model_config.get_num_kv_heads(parallel_config)
         head_size = model_config.get_head_size()
+        if use_mla:
+            from lmcache import torch_device_type
+            if torch_device_type == "npu":
+                # vLLM-Ascend caches only the compressed MLA latent
+                # (kv_lora_rank); size the pool to it so it matches the
+                # on-device KV cache tensor.
+                for _cfg in (getattr(model_config, "hf_text_config", None),
+                             getattr(model_config, "hf_config", None)):
+                    _lora = getattr(_cfg, "kv_lora_rank", None)
+                    if _lora:
+                        head_size = _lora
+                        break
         kv_shape = (
             num_layer,
             1 if use_mla else 2,

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -228,6 +228,13 @@ def CreateGPUConnector(
             )
 
             return VLLMPagedMemHPUConnectorV2.from_metadata(metadata, use_gpu, device)
+        elif torch_device_type == "npu":
+            # First Party
+            from lmcache.v1.gpu_connector.npu_connector import (
+                VLLMPagedMemNPUConnectorV2,
+            )
+
+            return VLLMPagedMemNPUConnectorV2.from_metadata(metadata, use_gpu, device)
         else:
             raise RuntimeError(f"No supported {torch_device_type} connector found.")
 

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -67,4 +67,15 @@ class VLLM_Detector(EngineDetector):
                 return lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, kv_caches
         if list_depth == 1 and tensor_ndim == 3:  # MLA
             return lmc_ops.EngineKVFormat.NL_X_NB_BS_HS, kv_caches
+        # Ascend vLLM MLA: a depth-2 list whose leaves are rank-4
+        # [num_blocks, block_size, num_kv_head=1, head_size] latent caches.
+        # Take each layer's first leaf (mirrors the connector's _mla_latent)
+        # and drop the singleton head axis so it matches the canonical
+        # rank-3 MLA layout (NL_X_NB_BS_HS). Flattening every leaf would
+        # inflate the layer count when a layer exposes >1 cache tensor.
+        if list_depth == 2 and tensor_ndim == 4 and first_tensor.shape[2] == 1:
+            latents = [sub[0] if isinstance(sub, (list, tuple)) else sub
+                       for sub in kv_caches]
+            reshaped = [t.reshape(t.shape[0], t.shape[1], t.shape[3]) for t in latents]
+            return lmc_ops.EngineKVFormat.NL_X_NB_BS_HS, reshaped
         return None, kv_caches

--- a/lmcache/v1/gpu_connector/npu_connector.py
+++ b/lmcache/v1/gpu_connector/npu_connector.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024-2026 LMCache Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard
+from typing import List, Optional
+
+# Third Party
+import torch_npu  # noqa: F401
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector import GPUConnectorInterface
+from lmcache.v1.gpu_connector.utils import (
+    get_block_size,
+    get_dtype,
+    get_head_size,
+    get_hidden_dim_size,
+    get_num_blocks,
+    get_num_heads,
+    get_num_layers,
+    get_page_buffer_size,
+    is_mla,
+    normalize_kv_and_discover_format,
+)
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
+
+logger = init_logger(__name__)
+
+
+def _mla_latent(kvcache) -> torch.Tensor:
+    """vLLM-Ascend exposes each MLA layer's latent KV cache as a 1-tuple.
+
+    Unwrap it so callers get the underlying tensor; pass plain tensors through.
+    """
+    return kvcache[0] if isinstance(kvcache, (tuple, list)) else kvcache
+
+
+class VLLMPagedMemNPUConnectorV2(GPUConnectorInterface):
+    """
+    The GPU KV cache should be a nested tuple of K and V tensors.
+    More specifically, we have:
+    - GPUTensor = Tuple[KVLayer, ...]
+    - KVLayer = Tuple[Tensor, Tensor]
+    - Tensor: [num_blocks, block_size, num_heads, head_size]
+    It will produce / consume memory object with KV_2LTD format
+    """
+
+    def __init__(
+        self,
+        use_gpu: bool = False,
+        **kwargs,
+    ):
+        self._attributes_initialized = False
+        self.kvcaches: Optional[List[torch.Tensor]] = None
+        self.use_gpu = use_gpu
+
+    @classmethod
+    def from_metadata(
+        cls,
+        metadata: LMCacheMetadata,
+        use_gpu: bool = False,
+        device: Optional[torch.device] = None,
+    ) -> "VLLMPagedMemNPUConnectorV2":
+        """Create a connector from LMCacheMetadata.
+        Args:
+            metadata: The LMCache engine metadata containing model configuration.
+            use_gpu: Whether to use GPU intermediate buffer.
+            device: The device to use for the connector.
+        Returns:
+            A new instance of VLLMPagedMemNPUConnectorV2.
+        """
+        return cls(
+            use_gpu=use_gpu,
+        )
+
+    def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
+        The kvcaches should correspond to the "WHOLE token sequence".
+
+        Note:
+          1. This function expects the 'slot_mapping' is a "full slot mapping"
+             where it's length is the same as the whole token sequence.
+          2. In the case that there is prefix caching, slot_mapping will starts
+             with -1s until the end of the matched prefix. The start and end
+             should NEVER overlap with the prefix caching (which means the
+             underlying kernel will never see -1 in slot_mapping)
+
+
+        :raises ValueError: If 'kvcaches' is not provided in kwargs,
+        :raises AssertionError: If the memory object does not have a tensor.
+        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        """
+        assert memory_obj.tensor is not None
+
+        self.initialize_kvcaches_ptr(**kwargs)
+
+        assert self.kvcaches is not None, (
+            "kvcaches should be provided in kwargs or initialized beforehand."
+        )
+
+        if "slot_mapping" not in kwargs:
+            raise ValueError("'slot_mapping' should be provided in kwargs.")
+
+        slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+        slices = slot_mapping[start:end]
+        self._initialize_attributes(self.kvcaches)
+        self._validate_memory_format(memory_obj)
+
+        if self.use_mla:
+            tmp = memory_obj.tensor[0].to(slot_mapping.device)
+            total_blocks = self.num_blocks * self.block_size
+            for i, kvcache in enumerate(self.kvcaches):
+                _mla_latent(kvcache).view(total_blocks, self.head_size).index_copy_(
+                    0, slices, tmp[i]
+                )
+        else:
+            tmp_k = memory_obj.tensor[0].to(slot_mapping.device)
+            tmp_v = memory_obj.tensor[1].to(slot_mapping.device)
+            total_blocks = self.num_blocks * self.block_size
+            d = self.num_heads * self.head_size
+            for i, (kcache, vcache) in enumerate(self.kvcaches):
+                kcache.view(total_blocks, d).index_copy_(0, slices, tmp_k[i])
+                vcache.view(total_blocks, d).index_copy_(0, slices, tmp_v[i])
+
+        torch.npu.synchronize()
+
+    def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
+        The kvcaches should correspond to the "WHOLE token sequence".
+
+        Will set the memory_obj.metadata.fmt to MemoryFormat.KV_MLA_FMT
+        if use_mla is True.
+
+        Note:
+          1. This function expects the 'slot_mapping' is a "full slot mapping"
+             where it's length is the same as the whole token sequence.
+          2. In the case that there is prefix caching, slot_mapping will starts
+             with -1s until the end of the matched prefix. The start and end
+             should NEVER overlap with the prefix caching (which means the
+             underlying kernel will never see -1 in slot_mapping)
+
+        :raises ValueError: If 'kvcaches' is not provided in kwargs,
+        :raises AssertionError: If the memory object does not have a tensor.
+        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        """
+        assert memory_obj.tensor is not None
+
+        self.initialize_kvcaches_ptr(**kwargs)
+        assert self.kvcaches is not None, (
+            "kvcaches should be provided in kwargs or initialized beforehand."
+        )
+
+        if "slot_mapping" not in kwargs:
+            raise ValueError("'slot_mapping' should be provided in kwargs.")
+
+        slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+        slices = slot_mapping[start:end]
+        self._initialize_attributes(self.kvcaches)
+        self._validate_memory_format(memory_obj)
+
+        if self.use_mla:
+            total_blocks = self.num_blocks * self.block_size
+            tmp = torch.stack(
+                [
+                    _mla_latent(kvcache)
+                    .view(total_blocks, self.head_size)
+                    .index_select(0, slices)
+                    for kvcache in self.kvcaches
+                ]
+            )
+        else:
+            total_blocks = self.num_blocks * self.block_size
+            d = self.num_heads * self.head_size
+            tmp_k = torch.stack(
+                [
+                    kvcache[0].view(total_blocks, d).index_select(0, slices)
+                    for kvcache in self.kvcaches
+                ]
+            )
+            tmp_v = torch.stack(
+                [
+                    kvcache[1].view(total_blocks, d).index_select(0, slices)
+                    for kvcache in self.kvcaches
+                ]
+            )
+            tmp = torch.stack([tmp_k, tmp_v])
+        memory_obj.tensor.copy_(tmp, non_blocking=True)
+
+        torch.npu.synchronize()
+
+        if self.use_mla:
+            memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
+
+    def batched_to_gpu(self, memory_objs, starts, ends, **kwargs):
+        for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
+            self.to_gpu(memory_obj, start, end, **kwargs)
+
+    def batched_from_gpu(self, memory_objs, starts, ends, **kwargs):
+        for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
+            self.from_gpu(memory_obj, start, end, **kwargs)
+
+    def get_shape(self, num_tokens: int) -> torch.Size:
+        """Get the shape of the data given the number of tokens.
+
+        Args:
+            num_tokens: The number of tokens in the data.
+
+        Returns:
+            The shape of the KV cache data.
+
+        Raises:
+            RuntimeError: If attributes have not been initialized yet
+                (i.e., no kv_caches have been seen).
+        """
+        if not self._attributes_initialized:
+            raise RuntimeError(
+                "Cannot determine shape before attributes are initialized. "
+                "Call to_gpu or from_gpu first so that _initialize_attributes "
+                "can discover the KV cache layout."
+            )
+        kv_size = 1 if self.use_mla else 2
+        return torch.Size([kv_size, self.num_layers, num_tokens, self.hidden_dim_size])
+
+    def initialize_kvcaches_ptr(self, **kwargs) -> None:
+        """Initialize the kvcaches pointers if not already initialized."""
+        if "kvcaches" in kwargs:
+            self.kvcaches = kwargs["kvcaches"]
+
+    def _validate_memory_format(self, memory_obj: MemoryObj) -> None:
+        """Validate that the memory object has the expected format.
+
+        Args:
+            memory_obj: The memory object to validate.
+
+        Raises:
+            ValueError: If the memory format does not match the expected
+                format based on whether MLA is in use.
+        """
+        if self.use_mla:
+            if memory_obj.metadata.fmt != MemoryFormat.KV_MLA_FMT:
+                raise ValueError(
+                    "The memory object should be in KV_MLA_FMT format in"
+                    " order to be processed by VLLMPagedMemNPUConnectorV2"
+                )
+        else:
+            if memory_obj.metadata.fmt != MemoryFormat.KV_2LTD:
+                raise ValueError(
+                    "The memory object should be in KV_2LTD format in"
+                    " order to be processed by VLLMPagedMemNPUConnectorV2"
+                )
+
+    def _initialize_attributes(self, kv_caches: List[torch.Tensor]):
+        if self._attributes_initialized or not kv_caches:
+            return
+
+        first = kv_caches[0]
+        if isinstance(first, torch.Tensor):
+            self.device = first.device
+        else:
+            self.device = first[0].device
+        assert self.device.type == "npu", "The device should be NPU."
+
+        # NPU vLLM provides kv_caches as List[TensorTuple(k_tensor, v_tensor)],
+        # where each TensorTuple contains two 4D tensors of shape
+        # (num_blocks, block_size, num_heads, head_size).
+        # We create a lightweight proxy List[Tensor(2, ...)] to match the
+        # standard vLLM format (NL_X_TWO_NB_BS_NH_HS) for format discovery.
+        if (
+            isinstance(kv_caches, (list, tuple))
+            and len(kv_caches) > 0
+            and len(kv_caches[0]) == 2
+            and not isinstance(kv_caches[0], torch.Tensor)
+            and isinstance(kv_caches[0][0], torch.Tensor)
+            and isinstance(kv_caches[0][1], torch.Tensor)
+        ):
+            # kv_caches[i][0].shape = (num_blocks, block_size, num_heads, head_size)
+            # We need shape (2, num_blocks, block_size, num_heads, head_size)
+            inner_shape = kv_caches[0][0].shape
+            fake_shape = (2, *inner_shape)
+            kv_caches = [
+                torch.empty(fake_shape, dtype=kv_caches[0][0].dtype, device="meta")
+                for _ in range(len(kv_caches))
+            ]
+            logger.info(
+                "NPU: created lightweight kv_caches proxy with shape %s "
+                "for format discovery",
+                fake_shape,
+            )
+
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
+            kv_caches, EngineType.VLLM
+        )
+        self.num_layers = get_num_layers(kv_caches, self.engine_kv_format)
+        self.num_blocks = get_num_blocks(kv_caches, self.engine_kv_format)
+        self.block_size = get_block_size(kv_caches, self.engine_kv_format)
+        self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
+        self.hidden_dim_size = get_hidden_dim_size(kv_caches, self.engine_kv_format)
+        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
+        self.use_mla = is_mla(self.engine_kv_format)
+        self.dtype = get_dtype(kv_caches, self.engine_kv_format)
+        self.num_heads = (
+            1 if self.use_mla else get_num_heads(kv_caches, self.engine_kv_format)
+        )
+
+        self._attributes_initialized = True
+        logger.info(
+            "NPU: attributes initialized - format: %s, "
+            "num_layers: %d, num_blocks: %d, block_size: %d, "
+            "page_buffer_size: %d, hidden_dim_size: %d, head_size: %d, "
+            "use_mla: %s, dtype: %s, num_heads: %d",
+            self.engine_kv_format,
+            self.num_layers,
+            self.num_blocks,
+            self.block_size,
+            self.page_buffer_size,
+            self.hidden_dim_size,
+            self.head_size,
+            self.use_mla,
+            self.dtype,
+            self.num_heads,
+        )

--- a/lmcache/v1/platform/npu/__init__.py
+++ b/lmcache/v1/platform/npu/__init__.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NPU (Huawei Ascend) platform helpers."""
+
+# Future
+from __future__ import annotations
+
+# First Party
+from lmcache.v1.platform.base.device_ops import DeviceOps
+from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.npu.device_ops import NpuDeviceOps
+
+# ---------------------------------------------------------------------------
+# Device detection registry entry
+# ---------------------------------------------------------------------------
+
+
+class NpuDeviceSpec(DeviceSpec):
+    """NPU device specification for the detection registry."""
+
+    @property
+    def device_type(self) -> str:
+        return "npu"
+
+    @property
+    def torch_module_name(self) -> str:
+        return "npu"
+
+    @property
+    def ops_cls(self) -> type[DeviceOps]:
+        return NpuDeviceOps
+
+    def is_available(self) -> bool:
+        """Check NPU availability without importing lmcache.__init__."""
+        try:
+            # Third Party
+            import torch
+
+            return hasattr(torch, "npu") and torch.npu.is_available()
+        except Exception:
+            return False

--- a/lmcache/v1/platform/npu/device_ops.py
+++ b/lmcache/v1/platform/npu/device_ops.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NPU ops backend: inherit the torch baseline unchanged.
+
+:class:`NpuDeviceOps` gives the registry a ``device_type="npu"`` entry.
+All ops are inherited from :class:`DeviceOps` via MRO.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# First Party
+from lmcache.v1.platform.base.device_ops import DeviceOps
+
+
+class NpuDeviceOps(DeviceOps):
+    device_type: ClassVar[str] = "npu"


### PR DESCRIPTION
## What

Add Huawei Ascend NPU (`torch_npu`) support to LMCache, so KV cache can be
offloaded from vLLM-Ascend to any LMCache backend on Ascend hardware.

## Changes

- **`platform/npu`**: an `NpuDeviceSpec`/`NpuDeviceOps` plugin so the device
  registry auto-discovers Ascend (`torch.npu`) as `"npu"`, mirroring the
  existing `hpu` plugin. No change to the detection core.
- **`CreateGPUConnector`**: dispatch `VLLMPagedMemNPUConnectorV2` for `npu`.
- **`npu_connector.py`**: an NPU paged-mem KV connector. Device-agnostic
  `.to()` copies, `torch.npu.synchronize()`, eager mode (no `mark_step`).
  Each MLA layer's latent cache arrives as a 1-tuple, unwrapped before
  `.view()`.
- **KV-format detector**: recognize the Ascend MLA layout — a depth-2 list of
  rank-4 `[num_blocks, block_size, 1, head_size]` latent caches — and
  normalize it to the canonical rank-3 `NL_X_NB_BS_HS` format.
- **metadata head_size**: vLLM-Ascend caches only the compressed MLA latent
  (`kv_lora_rank`), not `kv_lora_rank + qk_rope_head_dim`. Size the memory
  pool to the latent on NPU so it matches the on-device cache tensor. Gated
  on the `npu` device, so CUDA MLA (which caches the full dim) is unaffected.

## Testing

Verified end-to-end on a Huawei Ascend 910B host (CANN, `torch_npu`) with
vLLM-Ascend serving a GLM-style MLA model, `LMCacheConnectorV1`,
`--tensor-parallel-size 16 --enforce-eager`:

- **store**: `Stored 1536 out of total 1536` tokens to the remote backend.
- **remote read**: after a full server restart (local CPU cache empty), the
  same prompt yields `External prefix cache hit rate: 91.4%` — the hit can
  only come from the remote backend.
- no crashes across repeated store/retrieve requests.

The `head_size` change is the key fix: without it, `memory_obj.tensor.copy_`
fails with a `576 vs 512` shape mismatch (`kv_lora_rank + rope` vs the
latent-only on-device cache).