### PR TITLE
[ROCm] Fix wheel build: mark bind-mounted repo as git safe.directory

### DIFF
--- a/.github/scripts/build_rocm_wheel.sh
+++ b/.github/scripts/build_rocm_wheel.sh
@@ -29,6 +29,11 @@ apt-get install -y -q --no-install-recommends \
     python3.12 python3.12-dev python3.12-venv
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
 
+# The repo is bind-mounted from the CI runner (owned by a non-root UID) while
+# this container runs as root, so git refuses to operate on it. setup.py's
+# version/git introspection runs during the wheel build, so mark it safe.
+git config --global --add safe.directory /work/LMCache
+
 PY=python3.12
 $PY --version
 


### PR DESCRIPTION
## Summary

Follow-up fix for #4273 (merged). The **Build ROCm wheel** job in `publish.yml` fails on push to `dev`:

```
fatal: detected dubious ownership in repository at '/work/LMCache'
git introspection failed: fatal: detected dubious ownership in repository at '/work/LMCache'
```
(failing run: https://github.com/LMCache/LMCache/actions/runs/30573891302/job/90977401591)

## Root cause

`build_rocm_wheel.sh` runs inside the `rocm/dev-ubuntu-22.04` container **as root**, with the repo **bind-mounted** from the CI runner (owned by a non-root UID). Git refuses to operate on a repo owned by a different user, and `setup.py`'s version/git introspection runs during `bdist_wheel`, so the build aborts. (This only manifests in CI — local/node builds used a root-owned checkout, same UID as the container.)

## Fix

Add one line in `build_rocm_wheel.sh`, after git is installed and before the build:

```sh
git config --global --add safe.directory /work/LMCache
```

## Validation

Reproduced in `rocm/dev-ubuntu-22.04:7.2.3-complete` with a **non-root-owned** bind mount:
- **Without** the config: `fatal: detected dubious ownership in repository at '/work/LMCache'`
- **With** the config: `git describe` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)