### PR TITLE
fix(p2p): retry adapter removal after drain failure

### DIFF
--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -477,10 +477,10 @@ class P2PController:
                 if self._add_adapter(inst):
                     added += 1
             elif self._peer_changed(current, inst):
-                self._remove_adapter(peer_id)
-                removed += 1
-                if self._add_adapter(inst):
-                    added += 1
+                if self._remove_adapter(peer_id):
+                    removed += 1
+                    if self._add_adapter(inst):
+                        added += 1
             else:
                 current.consecutive_misses = 0
 
@@ -489,8 +489,9 @@ class P2PController:
                 continue
             adapter = self._adapters[peer_id]
             adapter.consecutive_misses += 1
-            if adapter.consecutive_misses > _MAX_MISSES:
-                self._remove_adapter(peer_id)
+            if adapter.consecutive_misses > _MAX_MISSES and self._remove_adapter(
+                peer_id
+            ):
                 removed += 1
         return added, removed
 
@@ -546,22 +547,28 @@ class P2PController:
         )
         return True
 
-    def _remove_adapter(self, peer_id: str) -> None:
+    def _remove_adapter(self, peer_id: str) -> bool:
         """Drain and remove the peer L2 adapter for ``peer_id``.
 
         Args:
             peer_id: Instance id of the peer whose adapter to remove.
+
+        Returns:
+            ``True`` if the adapter was removed, otherwise ``False``.
         """
         with self._orch_lock:
-            adapter = self._adapters.pop(peer_id, None)
+            adapter = self._adapters.get(peer_id)
         if adapter is None:
-            return
+            return False
         try:
             self._ctx.storage_manager.delete_l2_adapter(adapter.adapter_id)
         except Exception:
             logger.exception("Failed to remove P2P adapter for peer %s", peer_id)
-            return
+            return False
+        with self._orch_lock:
+            self._adapters.pop(peer_id, None)
         logger.debug("Removed P2P adapter for peer %s", peer_id)
+        return True
 
     def _active_job_count(self) -> int:
         """Return the number of active P2P lookup jobs (thread-safe)."""

--- a/tests/v1/multiprocess/test_p2p_controller.py
+++ b/tests/v1/multiprocess/test_p2p_controller.py
@@ -16,6 +16,7 @@ from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey, TrimPolicy
 from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
+from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
 from lmcache.v1.multiprocess.config import CoordinatorConfig, P2PConfig
 from lmcache.v1.multiprocess.modules.p2p_controller import (
     _MAX_MISSES,
@@ -370,6 +371,34 @@ def test_reconcile_removes_peer_after_grace():
     assert controller.report_status()["p2p_peers"] == []
 
 
+def test_reconcile_retries_removal_after_timeout():
+    """A timed-out removal stays tracked and is retried next cycle."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+    ctx.storage_manager.delete_l2_adapter.side_effect = [
+        LMCacheTimeoutError("boom"),
+        None,
+    ]
+
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA")})
+    for _ in range(_MAX_MISSES):
+        controller._apply_state(_P2PState.REGISTERED, {})
+
+    failed = controller._apply_state(_P2PState.REGISTERED, {})
+
+    assert failed.message.endswith("added=0 removed=0")
+    assert controller.report_status()["p2p_peers"] == ["peerA"]
+    ctx.storage_manager.delete_l2_adapter.assert_called_once_with(7)
+
+    retried = controller._apply_state(_P2PState.REGISTERED, {})
+
+    assert retried.message.endswith("added=0 removed=1")
+    assert [
+        call.args[0] for call in ctx.storage_manager.delete_l2_adapter.call_args_list
+    ] == [7, 7]
+    assert controller.report_status()["p2p_peers"] == []
+
+
 def test_reconcile_readds_on_url_change():
     """A peer whose advertised url changes is removed and re-added."""
     controller, ctx = _make_controller()
@@ -382,6 +411,27 @@ def test_reconcile_readds_on_url_change():
     assert ctx.storage_manager.add_l2_adapter.call_count == 2
     latest = ctx.storage_manager.add_l2_adapter.call_args.args[0]
     assert latest.peer_transfer_channel_server_url == "b:2"
+
+
+def test_reconcile_does_not_replace_changed_peer_after_removal_timeout():
+    """A changed peer is not replaced until its old adapter is removed."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+    ctx.storage_manager.delete_l2_adapter.side_effect = LMCacheTimeoutError("boom")
+
+    controller._apply_state(
+        _P2PState.REGISTERED,
+        {"peerA": _peer("peerA", url="a:1")},
+    )
+    failed = controller._apply_state(
+        _P2PState.REGISTERED,
+        {"peerA": _peer("peerA", url="b:2")},
+    )
+
+    assert failed.message.endswith("added=0 removed=0")
+    ctx.storage_manager.delete_l2_adapter.assert_called_once_with(7)
+    assert ctx.storage_manager.add_l2_adapter.call_count == 1
+    assert controller.report_status()["p2p_peers"] == ["peerA"]
 
 
 def test_close_removes_all_adapters():


### PR DESCRIPTION
## What this PR does / why we need it

`P2PController._remove_adapter()` previously removed the peer from its local bookkeeping before calling `StorageManager.delete_l2_adapter()`.

However, `delete_l2_adapter()` can time out while draining in-flight work and leave the adapter active so that the caller can retry. In that case, the controller had already forgotten the adapter:

* later reconciliation cycles could not retry the deletion;
* `report_status()` incorrectly reported that the peer was gone;
* a changed peer could receive a replacement adapter even though deletion of the old adapter had failed;
* reconciliation counted the failed deletion as a successful removal.

This PR retains the `_PeerAdapter` entry until storage deletion succeeds.

It also makes `_remove_adapter()` report success so reconciliation:

* retries failed removals on later cycles;
* counts only successful removals;
* adds a replacement adapter only after the old adapter is removed.

The normal successful removal path and public P2P interfaces are unchanged.

Refs #4041

## Tests

Added focused regression coverage for:

* retaining peer bookkeeping when adapter deletion times out;
* retrying deletion during the next reconciliation cycle;
* removing the peer after a successful retry;
* not installing a replacement adapter when deletion of a changed peer fails;
* reporting `removed=0` for failed deletions.

Validation performed locally:

* `ruff check`: passed
* `ruff format --check`: passed
* `git diff --check`: passed
* Python syntax compilation: passed

The focused pytest file could not be collected in the local CPU-only source environment because the LMCache import chain requires the CUDA-built `lmcache.c_ops` extension. No CUDA environment was available locally.

## Special notes for reviewers

The change intentionally keeps the scope limited to adapter lifecycle bookkeeping and retry semantics. It does not modify the P2P protocol, timeouts, or transfer path.

* [ ] this PR contains user facing changes - docs added
* [x] this PR contains unit tests
