### PR TITLE
fix(mp): release L1 read locks after store submission failure

### DIFF
--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -653,7 +653,11 @@ class StoreController(StorageControllerInterface):
                 continue
 
             adapter = self._l2_adapters[adapter_index]
-            task_id = adapter.submit_store_task(successful_keys, successful_objs)
+            try:
+                task_id = adapter.submit_store_task(successful_keys, successful_objs)
+            except Exception:
+                l1_mgr.finish_read(successful_keys)
+                raise
 
             self._in_flight_tasks[(adapter_index, task_id)] = InFlightStoreTask(
                 adapter_index=adapter_index,

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -10,6 +10,7 @@ the full integration without mocking internals.
 """
 
 # Standard
+from unittest.mock import patch
 import select
 import time
 
@@ -355,6 +356,56 @@ class TestStoreControllerSingleAdapter:
 
         ctrl.stop()
         adapter.close()
+
+    def test_read_lock_released_when_store_submission_raises(self, l1_manager):
+        """A failed L2 submission should release its L1 read lock."""
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        adapter = make_adapter()
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+
+        try:
+            with (
+                patch.object(
+                    adapter,
+                    "submit_store_task",
+                    side_effect=RuntimeError("injected submit failure"),
+                ) as submit_store_task,
+                patch.object(
+                    l1_manager,
+                    "finish_read",
+                    wraps=l1_manager.finish_read,
+                ) as finish_read,
+            ):
+                with pytest.raises(RuntimeError, match="injected submit failure"):
+                    ctrl._submit_store_for_single_shape(keys)
+
+            submit_store_task.assert_called_once()
+            finish_read.assert_called_once_with(keys)
+            assert ctrl._in_flight_tasks == {}
+            assert ctrl._status_in_flight_count == 0
+
+            result = l1_manager.reserve_write(
+                keys=keys,
+                is_temporary=[False],
+                layout_desc=layout,
+                mode="update",
+            )
+            assert result[keys[0]][1] is not None, (
+                "Key should be updatable after a failed L2 store submission"
+            )
+            l1_manager.finish_write(keys)
+        finally:
+            ctrl.stop()
+            adapter.close()
 
     def test_multiple_concurrent_requests_same_adapter(self, l1_manager):
         """Each L1-write batch produces an independent in-flight store request.


### PR DESCRIPTION
## What this PR does / why we need it

`StoreController` reserves L1 read access before submitting an asynchronous L2 store task.

If `submit_store_task()` raises, no task ID is returned and no entry is added to `_in_flight_tasks`. The normal completion path therefore cannot release the read locks acquired for that submission. The affected L1 entries remain read-locked until the lock TTL expires or the process is cleaned up, unnecessarily blocking updates and eviction during that interval.

This change releases the read locks acquired for the failed submission and then re-raises the original exception, preserving the existing error-reporting behavior.

Successful submissions are unchanged: their read locks remain held until the normal asynchronous completion path releases them.

## Tests

Added a focused regression test that injects an exception from `submit_store_task()` and verifies that:

* the original submission exception is propagated;
* the store submission is attempted exactly once;
* the acquired L1 read lock is released exactly once;
* no in-flight store task is recorded;
* the in-flight task counter remains unchanged;
* the affected L1 entry can immediately be reserved for update again.

Validation performed locally:

* deterministic failure-path fault injection: passed
* deterministic successful-submission control: passed
* `ruff check`: passed
* `ruff format --check`: passed
* Python compilation: passed
* `git diff --check`: passed

The focused pytest file could not be collected in the local CPU-only environment because the LMCache import chain requires the CUDA-built `lmcache.c_ops` extension. The regression test is included for execution in upstream CI.

## Special notes for reviewers

The change is limited to rollback of controller-owned L1 read locks when L2 task submission fails before returning a task ID. The normal asynchronous submission and completion paths are unchanged.

* [ ] this PR contains user-facing changes - docs added
* [x] this PR contains unit tests
