### PR TITLE
[core][bugfix] connector: guarantee exactly one completion per submitted future_id

### DIFF
--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -291,6 +291,7 @@ class ConnectorBase : public IStorageConnector {
 
     if (need_shared) {
       workers_.reserve(static_cast<size_t>(num_workers_));
+      shared_live_workers_.store(num_workers_, std::memory_order_relaxed);
       for (int i = 0; i < num_workers_; i++) {
         workers_.emplace_back([this]() { this->worker_loop(); });
       }
@@ -370,6 +371,12 @@ class ConnectorBase : public IStorageConnector {
     std::condition_variable cv;
     std::queue<Request> requests;
     std::vector<std::thread> workers;
+    // Number of worker threads still running on this lane. Set before the
+    // threads are spawned so it is never observed too low.
+    std::atomic<int> live_workers{0};
+    // Set by the last worker to leave, under mu, after it has drained the
+    // queue. Guards enqueue_request against handing work to nobody.
+    bool drained = false;
   };
 
   void validate_batch_inputs(const std::vector<std::string>& keys,
@@ -435,17 +442,35 @@ class ConnectorBase : public IStorageConnector {
     if (it != lanes_.end()) {
       {
         std::lock_guard<std::mutex> lk(it->second->mu);
-        it->second->requests.push(std::move(req));
+        if (!it->second->drained) {
+          it->second->requests.push(std::move(req));
+          it->second->cv.notify_one();
+          return;
+        }
       }
-      it->second->cv.notify_one();
+      fail_unservable_request(req);
       return;
     }
 
     {
       std::lock_guard<std::mutex> lk(req_mu_);
-      requests_.push(std::move(req));
+      if (!shared_drained_) {
+        requests_.push(std::move(req));
+        req_cv_.notify_one();
+        return;
+      }
     }
-    req_cv_.notify_one();
+    fail_unservable_request(req);
+  }
+
+  // Reached when every worker for this queue has already exited and drained.
+  // Queueing here would strand the future_id forever, so it fails now.
+  void fail_unservable_request(const Request& req) {
+    Completion comp;
+    comp.future_id = req.future_id;
+    comp.ok = false;
+    comp.error = "connector has no live worker for this operation";
+    handle_tile_completion(req, comp);
   }
 
   void push_completion(Completion&& c) {
@@ -496,10 +521,12 @@ class ConnectorBase : public IStorageConnector {
   void start_lane_workers(WorkerLane& lane, int num_workers) {
     lane.workers.reserve(static_cast<size_t>(num_workers));
     WorkerLane* lane_ptr = &lane;
+    lane.live_workers.store(num_workers, std::memory_order_relaxed);
     for (int i = 0; i < num_workers; i++) {
       lane.workers.emplace_back([this, lane_ptr]() {
         this->worker_loop_for_queue(lane_ptr->mu, lane_ptr->cv,
-                                    lane_ptr->requests);
+                                    lane_ptr->requests, lane_ptr->live_workers,
+                                    lane_ptr->drained);
       });
     }
   }
@@ -519,11 +546,42 @@ class ConnectorBase : public IStorageConnector {
     }
   }
 
-  void worker_loop() { worker_loop_for_queue(req_mu_, req_cv_, requests_); }
+  void worker_loop() {
+    worker_loop_for_queue(req_mu_, req_cv_, requests_, shared_live_workers_,
+                          shared_drained_);
+  }
+
+  // Fails every request still sitting in a queue whose workers have all gone.
+  // Each one already owns a future_id on the Python side, so it must produce a
+  // completion rather than be dropped.
+  void fail_orphaned_requests(std::mutex& req_mu,
+                              std::queue<Request>& requests, bool& drained) {
+    for (;;) {
+      Request req;
+      {
+        std::lock_guard<std::mutex> lk(req_mu);
+        if (requests.empty()) {
+          // Publish the flag under the same mutex that enqueue_request takes,
+          // so no request can be queued after the final drain.
+          drained = true;
+          return;
+        }
+        req = std::move(requests.front());
+        requests.pop();
+      }
+
+      Completion comp;
+      comp.future_id = req.future_id;
+      comp.ok = false;
+      comp.error = "connector worker exited before the request was executed";
+      handle_tile_completion(req, comp);
+    }
+  }
 
   void worker_loop_for_queue(std::mutex& req_mu,
                              std::condition_variable& req_cv,
-                             std::queue<Request>& requests) {
+                             std::queue<Request>& requests,
+                             std::atomic<int>& live_workers, bool& drained) {
     try {
       // create connection (derived class specific)
       ConnectionType conn = create_connection();
@@ -546,6 +604,7 @@ class ConnectorBase : public IStorageConnector {
 
         Completion comp;
         comp.future_id = req.future_id;
+        bool stopping = false;
 
         // 2. execute the requested operation
         try {
@@ -574,18 +633,35 @@ class ConnectorBase : public IStorageConnector {
           comp.ok = false;
           comp.error = e.what();
           // if shutting down, errors are expected
-          if (stop_.load(std::memory_order_acquire)) {
-            break;  // exit without pushing completion
-          }
+          stopping = stop_.load(std::memory_order_acquire);
+        } catch (...) {
+          // An unknown exception must fail this tile only. Letting it unwind
+          // would kill the worker and orphan every future_id behind it.
+          comp.ok = false;
+          comp.error = "unknown exception in connector worker";
+          stopping = stop_.load(std::memory_order_acquire);
         }
 
-        // 3. update shared batch state and push completion when done
+        // 3. update shared batch state and push completion when done.
+        // Runs on every path, including shutdown, so the batch that owns this
+        // tile always reaches zero remaining tiles and reports.
         handle_tile_completion(req, comp);
+
+        if (stopping) {
+          break;
+        }
       }
     } catch (const std::exception& e) {
       fprintf(stderr, "[LMCache Connector Worker Error] %s\n", e.what());
     } catch (...) {
       fprintf(stderr, "[LMCache Connector Worker Error] Unknown exception\n");
+    }
+
+    // The last worker to leave this queue owns whatever is still in it. Until
+    // then the surviving workers are still draining, so stealing their work
+    // here would be wrong.
+    if (live_workers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      fail_orphaned_requests(req_mu, requests, drained);
     }
   }
 
@@ -642,6 +718,10 @@ class ConnectorBase : public IStorageConnector {
   std::mutex req_mu_;
   std::condition_variable req_cv_;
   std::queue<Request> requests_;
+
+  // Shared-pool counterparts of WorkerLane::live_workers and ::drained.
+  std::atomic<int> shared_live_workers_{0};
+  bool shared_drained_ = false;
 
   // completion queue (CQ)
   std::mutex comp_mu_;

--- a/tests/v1/storage_backends/__init__.py
+++ b/tests/v1/storage_backends/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/storage_backends/csrc/CMakeLists.txt
+++ b/tests/v1/storage_backends/csrc/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+project(connector_completion_contract LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(connector_completion_contract connector_completion_contract.cpp)
+
+target_include_directories(connector_completion_contract
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../csrc/storage_backends)
+
+find_package(Threads REQUIRED)
+target_link_libraries(connector_completion_contract PRIVATE Threads::Threads)

--- a/tests/v1/storage_backends/csrc/connector_completion_contract.cpp
+++ b/tests/v1/storage_backends/csrc/connector_completion_contract.cpp
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression test for the ConnectorBase completion contract (see #4342).
+//
+// ConnectorBase hands every submitted batch a future_id and the L2 adapter
+// keeps that id in its pending maps until a completion arrives. A worker that
+// leaves worker_loop_for_queue without completing the requests it owns strands
+// the id forever, and for stores it also pins the L1 read locks the task holds.
+//
+// Each case below drives one of the paths a worker can leave on and asserts
+// that exactly one completion still comes back.
+
+#include "connector_base.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <vector>
+
+using lmcache::connector::Completion;
+using lmcache::connector::ConnectorBase;
+
+namespace {
+
+constexpr int kPollAttempts = 200;
+constexpr auto kPollInterval = std::chrono::milliseconds(10);
+
+// Collects completions until at least one arrives or the budget runs out.
+std::vector<Completion> await_completions(ConnectorBase<int>& connector) {
+  for (int attempt = 0; attempt < kPollAttempts; ++attempt) {
+    std::vector<Completion> completions = connector.drain_completions();
+    if (!completions.empty()) {
+      return completions;
+    }
+    std::this_thread::sleep_for(kPollInterval);
+  }
+  return {};
+}
+
+// Minimal connector: every operation succeeds unless a subclass says otherwise.
+class TestConnector : public ConnectorBase<int> {
+ public:
+  explicit TestConnector(int num_workers) : ConnectorBase(num_workers) {}
+  ~TestConnector() override { close(); }
+
+ protected:
+  int create_connection() override { return 0; }
+  void do_single_get(int&, const std::string&, void*, size_t,
+                     size_t) override {}
+  void do_single_set(int&, const std::string&, const void*, size_t,
+                     size_t) override {}
+  bool do_single_exists(int&, const std::string&) override { return true; }
+};
+
+// Path 1: create_connection() throws, so no worker ever reaches the request
+// loop and the queue is left with nobody to drain it.
+class UnreachableConnector : public TestConnector {
+ public:
+  UnreachableConnector() : TestConnector(2) { start_workers(); }
+
+ protected:
+  int create_connection() override {
+    throw std::runtime_error("connection refused");
+  }
+};
+
+// Path 2: a non-std::exception escapes the per-tile handler. It must fail the
+// tile without killing the worker, so later requests are still served.
+class ThrowsNonStandardOnce : public TestConnector {
+ public:
+  ThrowsNonStandardOnce() : TestConnector(1) { start_workers(); }
+
+ protected:
+  bool do_single_exists(int&, const std::string&) override {
+    if (!already_threw_.exchange(true)) {
+      throw 42;  // deliberately not derived from std::exception
+    }
+    return true;
+  }
+
+ private:
+  std::atomic<bool> already_threw_{false};
+};
+
+bool expect_single_completion(const std::vector<Completion>& completions,
+                              uint64_t future_id, bool expected_ok,
+                              const char* case_name) {
+  if (completions.size() != 1) {
+    fprintf(stderr, "[%s] expected 1 completion, got %zu\n", case_name,
+            completions.size());
+    return false;
+  }
+  if (completions[0].future_id != future_id) {
+    fprintf(stderr, "[%s] completion carried future_id %llu, expected %llu\n",
+            case_name,
+            static_cast<unsigned long long>(completions[0].future_id),
+            static_cast<unsigned long long>(future_id));
+    return false;
+  }
+  if (completions[0].ok != expected_ok) {
+    fprintf(stderr, "[%s] completion ok=%d, expected %d (error: %s)\n",
+            case_name, static_cast<int>(completions[0].ok),
+            static_cast<int>(expected_ok), completions[0].error.c_str());
+    return false;
+  }
+  return true;
+}
+
+// A batch submitted to a connector whose workers all died still completes.
+bool dead_workers_still_complete_the_batch() {
+  UnreachableConnector connector;
+  // Let both workers fail create_connection() before anything is submitted.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  const std::vector<std::string> keys{"a", "b", "c"};
+  const uint64_t future_id = connector.submit_batch_exists(keys);
+
+  return expect_single_completion(await_completions(connector), future_id,
+                                  false, "dead_workers");
+}
+
+// An unknown exception fails its own batch and leaves the worker able to serve
+// the next one.
+bool unknown_exception_fails_only_its_batch() {
+  ThrowsNonStandardOnce connector;
+
+  const std::vector<std::string> keys{"a"};
+  const uint64_t failing_id = connector.submit_batch_exists(keys);
+  if (!expect_single_completion(await_completions(connector), failing_id, false,
+                                "unknown_exception/first")) {
+    return false;
+  }
+
+  const uint64_t following_id = connector.submit_batch_exists(keys);
+  return expect_single_completion(await_completions(connector), following_id,
+                                  true, "unknown_exception/second");
+}
+
+struct TestCase {
+  const char* name;
+  bool (*run)();
+};
+
+}  // namespace
+
+int main() {
+  const TestCase cases[] = {
+      {"dead_workers_still_complete_the_batch",
+       dead_workers_still_complete_the_batch},
+      {"unknown_exception_fails_only_its_batch",
+       unknown_exception_fails_only_its_batch},
+  };
+
+  int failures = 0;
+  for (const TestCase& test_case : cases) {
+    const bool passed = test_case.run();
+    printf("%s: %s\n", passed ? "PASS" : "FAIL", test_case.name);
+    if (!passed) {
+      ++failures;
+    }
+  }
+
+  return failures == 0 ? 0 : 1;
+}

--- a/tests/v1/storage_backends/test_connector_completion_contract.py
+++ b/tests/v1/storage_backends/test_connector_completion_contract.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runs the ConnectorBase completion-contract regression test (see #4342).
+
+``ConnectorBase`` promises exactly one completion for every submitted
+``future_id``. The C++ cases in ``csrc/connector_completion_contract.cpp``
+drive the paths on which a worker can leave its loop and assert that the
+promise still holds. This module builds and runs that binary.
+"""
+
+# Standard
+import os
+import subprocess
+
+# Third Party
+import pytest
+
+_CSRC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "csrc")
+_BUILD_DIR = os.path.join(_CSRC_DIR, "build")
+_BINARY_NAME = "connector_completion_contract"
+_BUILD_TIMEOUT_SECONDS = 300
+_RUN_TIMEOUT_SECONDS = 120
+
+
+def _build_test_binary() -> str:
+    """Build the completion-contract test binary with CMake.
+
+    Returns:
+        Absolute path to the built binary.
+
+    Raises:
+        pytest.skip.Exception: If CMake or a C++ compiler is unavailable, or
+            the build fails.
+    """
+    os.makedirs(_BUILD_DIR, exist_ok=True)
+    binary_path = os.path.join(_BUILD_DIR, _BINARY_NAME)
+
+    try:
+        subprocess.check_call(
+            ["cmake", ".."],
+            cwd=_BUILD_DIR,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_BUILD_TIMEOUT_SECONDS,
+        )
+        subprocess.check_call(
+            ["cmake", "--build", "."],
+            cwd=_BUILD_DIR,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_BUILD_TIMEOUT_SECONDS,
+        )
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ):
+        pytest.skip(
+            f"Could not build {_BINARY_NAME}. "
+            "Ensure cmake and a C++ compiler are available."
+        )
+
+    if not os.path.isfile(binary_path):
+        pytest.skip(f"{_BINARY_NAME} was not produced by the build.")
+
+    return binary_path
+
+
+def test_every_submitted_future_id_gets_a_completion() -> None:
+    """A worker that dies still completes the requests it owns.
+
+    Covers two paths: ``create_connection()`` throwing so no worker reaches
+    the request loop, and a non-``std::exception`` escaping the per-tile
+    handler. Both used to leave the ``future_id`` pending forever, which for
+    stores also pinned the L1 read locks the task held.
+    """
+    binary_path = _build_test_binary()
+
+    result = subprocess.run(
+        [binary_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=_RUN_TIMEOUT_SECONDS,
+    )
+
+    assert result.returncode == 0, (
+        f"completion contract violated:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4342.

`ConnectorBase` hands every submitted batch a `future_id`, and
`NativeConnectorL2Adapter` keeps that id in `_pending_ops` until a completion
arrives. A worker that leaves `worker_loop_for_queue` without completing the
requests it owns strands the id for the life of the process. For stores that
also pins the L1 read locks the task holds, so those chunks can never be
evicted.

Reading the loop turned up four ways to leave without completing, two of which
were not in the original report:

1. `create_connection()` throws, so no worker reaches the request loop and the
   queue is left with nobody to drain it.
2. A non-`std::exception` escapes the per-tile `catch`, unwinds to `catch (...)`
   and kills the worker. That tile never reaches `handle_tile_completion`.
3. On shutdown the per-tile `catch` breaks out of the loop *before* the
   completion step. The existing comment says so: `// exit without pushing
   completion`.
4. A request submitted after the last worker has exited joins a queue that will
   never be drained again.

The cost is amplified by the batch accounting: `handle_tile_completion` only
emits when `remaining_tiles` reaches zero, so a single orphaned tile takes down
the completion for its entire batch.

**Changes**

- Widen the per-tile handler with `catch (...)` so an unknown exception fails
  one tile instead of the worker.
- Always call `handle_tile_completion`, including on the shutdown path, and
  break afterwards rather than instead.
- Track live workers per queue. The **last** worker out drains what is left and
  fails it. Draining on every worker death would be wrong, because surviving
  workers on the same queue are still serving and their work would be stolen.
- Publish the `drained` flag under the same mutex `enqueue_request` takes, and
  fail requests that arrive after it. Without this, a request queued one
  instruction after the final drain is orphaned exactly as before.

**Special notes for your reviewers**:

- This is my first PR to LMCache.
- Scope is deliberately the completion contract only. The issue also suggests
  routing worker death through the logger and a metric; `csrc/` has no logger
  today (11 `fprintf(stderr, ...)` call sites), so that belongs in its own PR.
- The test lives in `tests/v1/storage_backends/csrc/` to mirror
  `csrc/storage_backends/`, following the `tests/v1/shm_allocator/csrc` pattern.
  Happy to move it under the existing `tests/v1/storage_backend/` if you prefer
  the singular name.
- Verified in both directions. With the patched header both cases pass. With
  `csrc/storage_backends/connector_base.h` restored from `dev` both fail, and
  the failure messages match the diagnosis:

  ```
  [dead_workers] expected 1 completion, got 0
  [LMCache Connector Worker Error] Unknown exception
  [unknown_exception/first] expected 1 completion, got 0
  FAIL: dead_workers_still_complete_the_batch
  FAIL: unknown_exception_fails_only_its_batch
  ```

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
