### PR TITLE
[core][bugfix] fs connector: classify O_DIRECT refusals and check buffer alignment

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -2,12 +2,88 @@
 
 #include "connector.h"
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <stdexcept>
 #include <string>
 
 namespace lmcache {
 namespace connector {
+
+namespace {
+
+// Carries the errno alongside the message. A caller cannot classify an
+// O_DIRECT refusal from strerror text alone.
+struct IoError : std::runtime_error {
+  IoError(const std::string& what, int errnum)
+      : std::runtime_error(what), err(errnum) {}
+  int err;
+};
+
+// Errnos meaning this file or filesystem will not serve direct I/O.
+// open() is documented to answer EINVAL, a filesystem may answer
+// EOPNOTSUPP, and EPERM is reachable under policy. None of them says the
+// data is unavailable, so each should degrade to buffered I/O rather than
+// fail the request.
+bool is_direct_io_refusal(int err) {
+  if (err == EINVAL || err == EPERM) return true;
+#ifdef EOPNOTSUPP
+  if (err == EOPNOTSUPP) return true;
+#endif
+#ifdef ENOTSUP
+  if (err == ENOTSUP) return true;
+#endif
+  return false;
+}
+
+// O_DIRECT constrains the file offset, the transfer length and the buffer
+// address. Every transfer here starts at offset zero, so the other two are
+// checked. Length alone is not enough, because a pinned host allocator can
+// return a block sized region at an address that is not block aligned.
+bool odirect_alignment_ok(size_t block_size, size_t len, const void* buf) {
+  if (block_size == 0) return false;
+  if (len % block_size != 0) return false;
+  return reinterpret_cast<uintptr_t>(buf) % block_size == 0;
+}
+
+// Opens with O_DIRECT when asked, and falls back to a buffered open when the
+// flag is refused. Reports which one the caller got, since that decides
+// whether the transfer has to stay aligned.
+int open_maybe_direct(const char* path, int flags, mode_t mode,
+                      bool want_direct, bool* opened_direct) {
+  *opened_direct = false;
+#ifdef O_DIRECT
+  if (want_direct) {
+    int fd = ::open(path, flags | O_DIRECT, mode);
+    if (fd >= 0) {
+      *opened_direct = true;
+      return fd;
+    }
+    if (!is_direct_io_refusal(errno)) {
+      return -1;
+    }
+  }
+#else
+  (void)want_direct;
+#endif
+  return ::open(path, flags, mode);
+}
+
+bool odirect_already_refused(const WorkerFSConn& conn) {
+  return conn.odirect_refused != nullptr &&
+         conn.odirect_refused->load(std::memory_order_relaxed);
+}
+
+void note_odirect_refused(WorkerFSConn& conn) {
+  if (conn.odirect_refused == nullptr) return;
+  if (!conn.odirect_refused->exchange(true, std::memory_order_relaxed)) {
+    fprintf(stderr,
+            "[LMCache FS] O_DIRECT refused on this path, continuing with "
+            "buffered I/O\n");
+  }
+}
+
+}  // namespace
 
 // ---------------------------------------------------------------
 // Helpers
@@ -95,7 +171,7 @@ static void write_all(int fd, const void* data, size_t len) {
     ssize_t n = ::write(fd, ptr + written, len - written);
     if (n < 0) {
       if (errno == EINTR) continue;
-      throw std::runtime_error("write failed: " + std::string(strerror(errno)));
+      throw IoError("write failed: " + std::string(strerror(errno)), errno);
     }
     if (n == 0) {
       throw std::runtime_error("write returned 0");
@@ -111,12 +187,39 @@ static size_t read_all(int fd, void* buf, size_t len) {
     ssize_t n = ::read(fd, ptr + total, len - total);
     if (n < 0) {
       if (errno == EINTR) continue;
-      throw std::runtime_error("read failed: " + std::string(strerror(errno)));
+      throw IoError("read failed: " + std::string(strerror(errno)), errno);
     }
     if (n == 0) break;  // EOF
     total += static_cast<size_t>(n);
   }
   return total;
+}
+
+// Reads exactly len bytes, optionally issuing a small leading read first so
+// the filesystem starts reading ahead. Shared by the direct and the buffered
+// attempt so both paths behave identically.
+static void read_whole_file(int fd, void* buf, size_t len,
+                            size_t read_ahead_size,
+                            const std::string& file_path) {
+  size_t n;
+  if (read_ahead_size > 0 && len > read_ahead_size) {
+    size_t n_head = read_all(fd, buf, read_ahead_size);
+    if (n_head < read_ahead_size) {
+      n = n_head;  // short read on the head, treat as incomplete
+    } else {
+      size_t n_tail =
+          read_all(fd, static_cast<char*>(buf) + read_ahead_size,
+                   len - read_ahead_size);
+      n = n_head + n_tail;
+    }
+  } else {
+    n = read_all(fd, buf, len);
+  }
+  if (n != len) {
+    throw std::runtime_error("incomplete read for " + file_path + ": expected " +
+                             std::to_string(len) + ", got " +
+                             std::to_string(n));
+  }
 }
 
 // ---------------------------------------------------------------
@@ -163,6 +266,7 @@ WorkerFSConn FSConnector::create_connection() {
   conn.use_odirect = use_odirect_;
   conn.disk_block_size = disk_block_size_;
   conn.read_ahead_size = read_ahead_size_;
+  conn.odirect_refused = &odirect_refused_;
   return conn;
 }
 
@@ -171,48 +275,45 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
   std::string filename = key_to_filename(key);
   auto file_path = conn.base_path / filename;
 
-  int flags = O_RDONLY;
-  bool do_odirect = conn.use_odirect;
-  if (do_odirect) {
-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
-    if (aligned) {
-#ifdef O_DIRECT
-      flags |= O_DIRECT;
-#endif
-    } else {
-      do_odirect = false;
-    }
-  }
+  const int flags = O_RDONLY;
+  bool want_odirect =
+      conn.use_odirect && !odirect_already_refused(conn) &&
+      odirect_alignment_ok(conn.disk_block_size, len, buf);
 
-  int fd = ::open(file_path.c_str(), flags);
+  bool opened_direct = false;
+  int fd = open_maybe_direct(file_path.c_str(), flags, 0, want_odirect,
+                             &opened_direct);
   if (fd < 0) {
     throw std::runtime_error("open for read failed: " + file_path.string() +
                              ": " + strerror(errno));
   }
+  if (want_odirect && !opened_direct) {
+    note_odirect_refused(conn);
+  }
 
   try {
-    size_t n;
-    if (conn.read_ahead_size > 0 && len > conn.read_ahead_size) {
-      // Trigger filesystem readahead with a small initial
-      // read, then read the remainder.
-      size_t ra = conn.read_ahead_size;
-      size_t n_head = read_all(fd, buf, ra);
-      if (n_head < ra) {
-        // Short read on the head portion — treat as
-        // incomplete
-        n = n_head;
-      } else {
-        size_t n_tail = read_all(fd, static_cast<char*>(buf) + ra, len - ra);
-        n = n_head + n_tail;
-      }
-    } else {
-      n = read_all(fd, buf, len);
+    read_whole_file(fd, buf, len, conn.read_ahead_size, file_path.string());
+  } catch (const IoError& e) {
+    ::close(fd);
+    // O_DIRECT accepted at open() and refused at read() is reachable on
+    // mainstream filesystems, so retry buffered once before failing the key.
+    if (!opened_direct || !is_direct_io_refusal(e.err)) {
+      throw;
     }
-    if (n != len) {
-      throw std::runtime_error("incomplete read for " + file_path.string() +
-                               ": expected " + std::to_string(len) + ", got " +
-                               std::to_string(n));
+    note_odirect_refused(conn);
+    fd = ::open(file_path.c_str(), flags);
+    if (fd < 0) {
+      throw std::runtime_error("open for buffered read failed: " +
+                               file_path.string() + ": " + strerror(errno));
     }
+    try {
+      read_whole_file(fd, buf, len, conn.read_ahead_size, file_path.string());
+    } catch (...) {
+      ::close(fd);
+      throw;
+    }
+    ::close(fd);
+    return;
   } catch (...) {
     ::close(fd);
     throw;
@@ -240,27 +341,47 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
     tmp_path.replace_extension(TMP_EXT);
   }
 
-  int flags = O_CREAT | O_WRONLY | O_TRUNC;
-  bool do_odirect = conn.use_odirect;
-  if (do_odirect) {
-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
-    if (aligned) {
-#ifdef O_DIRECT
-      flags |= O_DIRECT;
-#endif
-    } else {
-      do_odirect = false;
-    }
-  }
+  const int flags = O_CREAT | O_WRONLY | O_TRUNC;
+  bool want_odirect = conn.use_odirect && !odirect_already_refused(conn) &&
+                      odirect_alignment_ok(conn.disk_block_size, len, buf);
 
-  int fd = ::open(tmp_path.c_str(), flags, 0644);
+  bool opened_direct = false;
+  int fd = open_maybe_direct(tmp_path.c_str(), flags, 0644, want_odirect,
+                             &opened_direct);
   if (fd < 0) {
     throw std::runtime_error("open for write failed: " + tmp_path.string() +
                              ": " + strerror(errno));
   }
+  if (want_odirect && !opened_direct) {
+    note_odirect_refused(conn);
+  }
 
   try {
     write_all(fd, buf, len);
+  } catch (const IoError& e) {
+    ::close(fd);
+    // O_DIRECT accepted at open() and refused at write() is the live failure
+    // on XFS with a host buffer that is length aligned but not address
+    // aligned. Without this branch every store fails and the tier stays empty
+    // while reporting healthy, so retry buffered once before giving up.
+    if (!opened_direct || !is_direct_io_refusal(e.err)) {
+      std::filesystem::remove(tmp_path);
+      throw;
+    }
+    note_odirect_refused(conn);
+    fd = ::open(tmp_path.c_str(), flags, 0644);
+    if (fd < 0) {
+      std::filesystem::remove(tmp_path);
+      throw std::runtime_error("open for buffered write failed: " +
+                               tmp_path.string() + ": " + strerror(errno));
+    }
+    try {
+      write_all(fd, buf, len);
+    } catch (...) {
+      ::close(fd);
+      std::filesystem::remove(tmp_path);
+      throw;
+    }
   } catch (...) {
     ::close(fd);
     // Clean up temp file on failure

--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -40,6 +40,16 @@ bool is_direct_io_refusal(int err) {
 // address. Every transfer here starts at offset zero, so the other two are
 // checked. Length alone is not enough, because a pinned host allocator can
 // return a block sized region at an address that is not block aligned.
+//
+// block_size reaches here as statvfs f_bsize, which is the filesystem's block
+// size and not the device logical_block_size the kernel actually enforces for
+// O_DIRECT. On mainstream setups f_bsize is a multiple of that sector size, so
+// this check is the conservative side and anything it accepts the kernel
+// accepts too. The gap only bites in the other direction, when choosing a
+// deliberately misaligned address for a test: a buffer off an f_bsize boundary
+// can still be a legal O_DIRECT address on a device with a smaller sector, and
+// the O_DIRECT regression test passed with and without the fix for exactly
+// that reason until its skew was changed.
 bool odirect_alignment_ok(size_t block_size, size_t len, const void* buf) {
   if (block_size == 0) return false;
   if (len % block_size != 0) return false;

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <unistd.h>
+#include <atomic>
 #include <cstring>
 #include <filesystem>
 #include <string>
@@ -30,6 +31,10 @@ struct WorkerFSConn {
   // If > 0, trigger filesystem readahead by issuing a small
   // initial read of this many bytes before reading the rest.
   size_t read_ahead_size = 0;
+  // Shared with the owning FSConnector. Latched the first time any worker
+  // learns this path refuses O_DIRECT, so the other workers stop paying for
+  // an attempt that is known to fail. Set once, never cleared.
+  std::atomic<bool>* odirect_refused = nullptr;
 };
 
 class FSConnector : public ConnectorBase<WorkerFSConn> {
@@ -74,6 +79,8 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   bool use_odirect_;
   size_t disk_block_size_;
   size_t read_ahead_size_;
+  // See WorkerFSConn::odirect_refused.
+  std::atomic<bool> odirect_refused_{false};
 };
 
 }  // namespace connector

--- a/tests/v1/storage_backends/__init__.py
+++ b/tests/v1/storage_backends/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/storage_backends/csrc/CMakeLists.txt
+++ b/tests/v1/storage_backends/csrc/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(fs_odirect_fallback LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(LMCACHE_CSRC ${CMAKE_CURRENT_SOURCE_DIR}/../../../../csrc/storage_backends)
+
+find_package(Threads REQUIRED)
+
+add_executable(fs_odirect_fallback
+    fs_odirect_fallback.cpp
+    ${LMCACHE_CSRC}/fs/connector.cpp)
+target_include_directories(fs_odirect_fallback PRIVATE ${LMCACHE_CSRC})
+target_link_libraries(fs_odirect_fallback PRIVATE Threads::Threads)

--- a/tests/v1/storage_backends/csrc/fs_odirect_fallback.cpp
+++ b/tests/v1/storage_backends/csrc/fs_odirect_fallback.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression test for O_DIRECT handling in the native fs connector (#4364).
+//
+// O_DIRECT constrains the file offset, the transfer length and the buffer
+// address. The connector used to gate only on length, so a host buffer that
+// was length aligned but not address aligned passed the gate, open() accepted
+// O_DIRECT and write() then answered EINVAL. Nothing classified that errno, so
+// every store failed and the L2 tier stayed empty while reporting healthy.
+//
+// This test drives exactly that shape, a length aligned buffer at a
+// deliberately unaligned address, and asserts the store still lands and reads
+// back byte identical.
+
+#include "fs/connector.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+using lmcache::connector::Completion;
+using lmcache::connector::FSConnector;
+
+namespace {
+
+constexpr size_t kAlign = 4096;
+constexpr size_t kPayload = 8192;  // multiple of kAlign, so the length gate passes
+constexpr size_t kSkew = 512;      // shifts the address off a kAlign boundary
+constexpr int kPollAttempts = 300;
+
+std::vector<Completion> await_completion(FSConnector& connector) {
+  for (int attempt = 0; attempt < kPollAttempts; ++attempt) {
+    std::vector<Completion> completions = connector.drain_completions();
+    if (!completions.empty()) {
+      return completions;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  return {};
+}
+
+// Returns a pointer that is kSkew bytes past a kAlign boundary.
+char* skewed_buffer(std::vector<char>* backing) {
+  backing->assign(kPayload + 2 * kAlign, 0);
+  auto base = reinterpret_cast<uintptr_t>(backing->data());
+  uintptr_t aligned = (base + kAlign - 1) & ~(uintptr_t)(kAlign - 1);
+  return reinterpret_cast<char*>(aligned + kSkew);
+}
+
+std::string make_temp_dir() {
+  std::string tmpl =
+      (std::filesystem::temp_directory_path() / "lmc_odirect_XXXXXX").string();
+  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  buf.push_back('\0');
+  const char* dir = ::mkdtemp(buf.data());
+  if (dir == nullptr) {
+    throw std::runtime_error("mkdtemp failed");
+  }
+  return std::string(dir);
+}
+
+bool unaligned_address_still_stores_and_loads() {
+  const std::string base = make_temp_dir();
+
+  std::vector<char> store_backing;
+  char* store_buf = skewed_buffer(&store_backing);
+  for (size_t i = 0; i < kPayload; ++i) {
+    store_buf[i] = static_cast<char>(i % 251);
+  }
+
+  if (reinterpret_cast<uintptr_t>(store_buf) % kAlign == 0) {
+    fprintf(stderr, "test setup failed, buffer came out aligned\n");
+    return false;
+  }
+
+  const std::vector<std::string> keys{"m@00000000@abcdef"};
+  const std::vector<size_t> lens{kPayload};
+
+  {
+    FSConnector connector(base, 2, "", /*use_odirect=*/true, 0);
+    std::vector<void*> bufs{store_buf};
+    const uint64_t store_id = connector.submit_batch_set(keys, bufs, lens, 0);
+
+    std::vector<Completion> done = await_completion(connector);
+    if (done.size() != 1 || done[0].future_id != store_id) {
+      fprintf(stderr, "store produced %zu completions\n", done.size());
+      return false;
+    }
+    if (!done[0].ok) {
+      fprintf(stderr, "store failed: %s\n", done[0].error.c_str());
+      return false;
+    }
+  }
+
+  std::vector<char> load_backing;
+  char* load_buf = skewed_buffer(&load_backing);
+  {
+    FSConnector connector(base, 2, "", /*use_odirect=*/true, 0);
+    std::vector<void*> bufs{load_buf};
+    const uint64_t load_id = connector.submit_batch_get(keys, bufs, lens, 0);
+
+    std::vector<Completion> done = await_completion(connector);
+    if (done.size() != 1 || done[0].future_id != load_id) {
+      fprintf(stderr, "load produced %zu completions\n", done.size());
+      return false;
+    }
+    if (!done[0].ok) {
+      fprintf(stderr, "load failed: %s\n", done[0].error.c_str());
+      return false;
+    }
+  }
+
+  if (std::memcmp(store_buf, load_buf, kPayload) != 0) {
+    fprintf(stderr, "payload came back different\n");
+    return false;
+  }
+
+  std::error_code ec;
+  std::filesystem::remove_all(base, ec);
+  return true;
+}
+
+}  // namespace
+
+int main() {
+#ifndef O_DIRECT
+  // The round trip still runs, it just cannot exercise the refusal path, so
+  // say so rather than reporting a pass that proves less than it looks like.
+  printf("NOTE: no O_DIRECT on this platform, buffered path only\n");
+#endif
+  const bool passed = unaligned_address_still_stores_and_loads();
+  printf("%s: unaligned_address_still_stores_and_loads\n",
+         passed ? "PASS" : "FAIL");
+  return passed ? 0 : 1;
+}

--- a/tests/v1/storage_backends/csrc/fs_odirect_fallback.cpp
+++ b/tests/v1/storage_backends/csrc/fs_odirect_fallback.cpp
@@ -11,6 +11,16 @@
 // This test drives exactly that shape, a length aligned buffer at a
 // deliberately unaligned address, and asserts the store still lands and reads
 // back byte identical.
+//
+// What this test does NOT cover: the runtime refusal path. odirect_alignment_ok
+// is evaluated before open(), so a misaligned buffer is caught there and
+// is_direct_io_refusal / note_odirect_refused / the IoError retry branches are
+// never entered. Reaching those needs open() or write() to refuse O_DIRECT on a
+// filesystem that accepted it, which no skew value can force and which tmpfs no
+// longer produces on current kernels. Covering them deterministically means
+// interposing open/write/read to return a chosen errno, the same approach #4359
+// took on the Python side. Until that exists those branches are reviewed rather
+// than exercised.
 
 #include "fs/connector.h"
 
@@ -30,7 +40,19 @@ namespace {
 
 constexpr size_t kAlign = 4096;
 constexpr size_t kPayload = 8192;  // multiple of kAlign, so the length gate passes
-constexpr size_t kSkew = 512;      // shifts the address off a kAlign boundary
+// The skew has to be misaligned against the DEVICE's logical sector size, not
+// merely against kAlign. The connector checks alignment against statvfs
+// f_bsize, but the kernel enforces O_DIRECT against the device's
+// logical_block_size, and the two differ. On the #4364 reproduction host
+// (XFS on NVMe RAID-0) f_bsize is 4096 while logical_block_size is 512, so a
+// skew of 512 sits off a 4096 boundary and is still a legal O_DIRECT address:
+// open() and write() both succeed and the test passes with and without the
+// fix. That was measured on that host, PASS on both trees, before this value
+// was changed.
+// Every real logical_block_size is a power of two, and an odd offset is never
+// a multiple of a power of two greater than one, so an odd skew is misaligned
+// on any device rather than only on the ones that happened to be tried.
+constexpr size_t kSkew = 1;
 constexpr int kPollAttempts = 300;
 
 std::vector<Completion> await_completion(FSConnector& connector) {

--- a/tests/v1/storage_backends/test_fs_odirect_fallback.py
+++ b/tests/v1/storage_backends/test_fs_odirect_fallback.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runs the native fs connector O_DIRECT regression test (see #4364).
+
+O_DIRECT constrains the file offset, the transfer length and the buffer
+address. The connector gated on length alone, so a host buffer that was
+length aligned at an unaligned address passed the gate, ``open()`` accepted
+the flag and ``write()`` answered ``EINVAL``. Nothing classified that errno,
+so every store failed while the tier kept reporting healthy.
+
+The C++ case in ``csrc/fs_odirect_fallback.cpp`` drives that exact shape.
+"""
+
+# Standard
+import os
+import subprocess
+
+# Third Party
+import pytest
+
+_CSRC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "csrc")
+_BUILD_DIR = os.path.join(_CSRC_DIR, "build")
+_BINARY_NAME = "fs_odirect_fallback"
+_BUILD_TIMEOUT_SECONDS = 300
+_RUN_TIMEOUT_SECONDS = 120
+
+
+def _build_test_binary() -> str:
+    """Build the O_DIRECT regression binary with CMake.
+
+    Returns:
+        Absolute path to the built binary.
+
+    Raises:
+        pytest.skip.Exception: If CMake or a C++ compiler is unavailable, or
+            the build fails.
+    """
+    os.makedirs(_BUILD_DIR, exist_ok=True)
+    binary_path = os.path.join(_BUILD_DIR, _BINARY_NAME)
+
+    try:
+        subprocess.check_call(
+            ["cmake", ".."],
+            cwd=_BUILD_DIR,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_BUILD_TIMEOUT_SECONDS,
+        )
+        subprocess.check_call(
+            ["cmake", "--build", "."],
+            cwd=_BUILD_DIR,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_BUILD_TIMEOUT_SECONDS,
+        )
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ):
+        pytest.skip(
+            f"Could not build {_BINARY_NAME}. "
+            "Ensure cmake and a C++ compiler are available."
+        )
+
+    if not os.path.isfile(binary_path):
+        pytest.skip(f"{_BINARY_NAME} was not produced by the build.")
+
+    return binary_path
+
+
+def test_odirect_falls_back_when_the_buffer_address_is_unaligned() -> None:
+    """A length aligned buffer at an unaligned address must still store.
+
+    Stores and loads one 8 KiB payload through a buffer placed 512 bytes past
+    a 4096 byte boundary, then compares the bytes. On platforms without
+    O_DIRECT this still exercises the buffered round trip.
+    """
+    binary_path = _build_test_binary()
+
+    result = subprocess.run(
+        [binary_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=_RUN_TIMEOUT_SECONDS,
+    )
+
+    assert result.returncode == 0, (
+        f"O_DIRECT fallback failed:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #4364. This is site 9 of the nine O_DIRECT implementations listed there,
`csrc/storage_backends/fs/connector.cpp`, which drives the MP `fs_native`
adapter. The issue notes a Python helper is not applicable to this file, so
this is the C++ counterpart. It does not touch the other eight sites.

Two defects from that report are present here:

1. **No errno classification.** The connector asks the platform with
   `#ifdef O_DIRECT` and then opens. Nothing inspects `EINVAL`,
   `EOPNOTSUPP`, `ENOTSUP` or `EPERM`, so a refusal becomes a
   `std::runtime_error` and the key fails. None of those errnos means the data
   is unavailable, so each should degrade to buffered I/O.

2. **Alignment gated on length only.**

   ```cpp
   bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
   ```

   O_DIRECT also constrains the buffer address. A length aligned host buffer at
   an unaligned address passes this gate, `open()` accepts the flag, and
   `write()` answers `EINVAL`. That is the shape reproduced on XFS in
   https://github.com/LMCache/LMCache/issues/4364#issuecomment-5146560980, where
   57 stores failed and the L2 tier held 0 files while reporting healthy.

**Changes**

- Check the buffer address as well as the transfer length before requesting
  O_DIRECT.
- Classify the four refusal errnos and fall back to buffered I/O rather than
  failing the key, both when `open()` refuses the flag and when the first
  `read()` or `write()` refuses it after a successful open.
- Latch the refusal on the connector so the other workers stop paying for an
  attempt known to fail on this path, and log it once instead of per file.
- Carry `errno` on I/O errors so a refusal can be told apart from a real fault.

**Special notes for your reviewers**:

- Scope is this file only. I have not touched the block size question, which is
  the third defect in #4364. This still uses `statvfs` `f_bsize` rather than the
  device logical block size. Using the larger value costs a missed O_DIRECT
  rather than an `EINVAL`, so it is a separate change.
- **The O_DIRECT path itself is not verified on my machine.** I develop on
  macOS, which has no `O_DIRECT`, so locally the new test exercises only the
  buffered round trip and says so in its output. The refusal branches are
  reasoned from the reproduction in the issue, not observed here. @xiangping-chen,
  you have the XFS over NVMe host and already reproduced the write time
  `EINVAL`, would you be willing to run this branch against it?
- The test places an 8 KiB payload in a buffer 512 bytes past a 4096 byte
  boundary, so the length gate passes and the address gate does not. It follows
  the `tests/v1/shm_allocator/csrc` pattern, CMake builds the binary and pytest
  runs it, skipping when no toolchain is present.
- I have a separate PR open on the shared connector base, #4374. The two do not
  overlap.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
