### PR TITLE
[RFC][MP] Orchestration View: separate convergent from accumulative folds over a lossy event stream

### DIFF
--- a/lmcache/v1/distributed/orchestration/__init__.py
+++ b/lmcache/v1/distributed/orchestration/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache/v1/distributed/orchestration/view.py
+++ b/lmcache/v1/distributed/orchestration/view.py
@@ -79,9 +79,9 @@ class ViewField:
         self._fold_kind = fold_kind
         self._owner = owner
         self._values: dict[str, float] = {}
-        # Drop count at the last point this field is known to have matched
+        # Loss count at the last point this field is known to have matched
         # reality. A convergent field never consults it.
-        self._clean_at_drops = owner.dropped_events_seen
+        self._clean_at_loss = owner.loss_marks
 
     @property
     def name(self) -> str:
@@ -99,11 +99,11 @@ class ViewField:
 
         A convergent field is always trusted, since a dropped event only makes
         a key look older than it is. An accumulative field is trusted only
-        while no events have been dropped since its last reconciliation.
+        while no loss has been observed since its last reconciliation.
         """
         if self._fold_kind is FoldKind.CONVERGENT:
             return True
-        return self._owner.dropped_events_seen == self._clean_at_drops
+        return self._owner.loss_marks == self._clean_at_loss
 
     def set(self, key: str, value: float) -> None:
         """Assign a value for one key.
@@ -152,7 +152,7 @@ class ViewField:
                 here are removed.
         """
         self._values = dict(absolute_values)
-        self._clean_at_drops = self._owner.dropped_events_seen
+        self._clean_at_loss = self._owner.loss_marks
 
     def get(self, key: str) -> float:
         """Return the value for one key, or ``0.0`` when it is unknown.
@@ -215,6 +215,8 @@ class View:
         """Initialize an empty view with no observed drops."""
         self._fields: dict[str, ViewField] = {}
         self._dropped_events_seen: int = 0
+        self._sequence_gaps: int = 0
+        self._last_seq: dict[str, int] = {}
         self._reads: list[str] = []
         self._recording: bool = False
 
@@ -222,6 +224,23 @@ class View:
     def dropped_events_seen(self) -> int:
         """Total events the bus has reported dropping, as last observed."""
         return self._dropped_events_seen
+
+    @property
+    def sequence_gaps(self) -> int:
+        """Number of gaps seen in the per-instance batch sequence."""
+        return self._sequence_gaps
+
+    @property
+    def loss_marks(self) -> int:
+        """Every loss signal this view has observed, from either source.
+
+        The bus reports its own discards through a counter, and the
+        coordinator's forwarding layer advances its per-instance sequence
+        number before it attempts to publish, so a failed publish shows up
+        downstream as a gap rather than as silence. Both are folded here
+        because an accumulative field cannot tell them apart.
+        """
+        return self._dropped_events_seen + self._sequence_gaps
 
     @property
     def degraded(self) -> bool:
@@ -247,6 +266,42 @@ class View:
                 f"{self._dropped_events_seen} to {total_dropped}"
             )
         self._dropped_events_seen = total_dropped
+
+    def observe_batch(self, instance_id: str, seq: int) -> int:
+        """Record a forwarded batch and report how many were missed.
+
+        The coordinator stamps each outgoing batch with a per-instance
+        sequence number and advances that number before it attempts to
+        publish, so a batch lost on the way here leaves a hole rather than
+        going unnoticed. Feeding batches through this method turns that hole
+        into the same loss signal a bus discard produces.
+
+        Args:
+            instance_id: Node the batch came from.
+            seq: Sequence number carried by the batch.
+
+        Returns:
+            How many batches were missed immediately before this one, zero
+            when the sequence is contiguous or this is the first batch seen
+            from that instance.
+
+        Raises:
+            ValueError: If the sequence repeats or moves backwards for an
+                instance, which no ordered forwarder should produce.
+        """
+        previous = self._last_seq.get(instance_id)
+        if previous is None:
+            self._last_seq[instance_id] = seq
+            return 0
+        if seq <= previous:
+            raise ValueError(
+                f"instance '{instance_id}' sequence went from {previous} "
+                f"to {seq}"
+            )
+        missed = seq - previous - 1
+        self._last_seq[instance_id] = seq
+        self._sequence_gaps += missed
+        return missed
 
     def declare(self, name: str, fold_kind: FoldKind) -> ViewField:
         """Create a field on this view.

--- a/lmcache/v1/distributed/orchestration/view.py
+++ b/lmcache/v1/distributed/orchestration/view.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed cluster view state for KV cache orchestration (see #4291).
+
+The orchestration layer builds a global picture of the cluster by folding the
+event stream published by each node. That stream is lossy on purpose. When the
+event bus queue is full, ``publish()`` drops the event and only bumps a
+counter, so the fold sees a stream that thins out exactly when the cluster is
+busy.
+
+Losing an event costs different amounts depending on how the state is folded,
+and this module makes that difference part of the type rather than something
+each policy author has to rediscover.
+
+A :attr:`FoldKind.CONVERGENT` field assigns a value per key, so a dropped
+event leaves the key holding an older value until the next event for that key
+repairs it. The error is bounded and self healing, which is why an LRU view
+can be folded from a lossy stream safely.
+
+A :attr:`FoldKind.ACCUMULATIVE` field adds and subtracts, so a dropped event
+is a permanent offset that nothing in the system corrects. A quota view folded
+this way drifts silently, and since the matching action deletes keys, acting
+on a drifted total deletes a tenant's cache over quota it is not using.
+
+:class:`View` therefore tracks how many events the bus reported dropping, and
+:meth:`View.evaluate` records which fields a trigger read so an accumulative
+read taken while the view is degraded can be reported rather than acted on.
+"""
+
+# Standard
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+
+__all__ = [
+    "FoldKind",
+    "ViewField",
+    "View",
+    "TriggerVerdict",
+    "ViewFieldError",
+]
+
+
+class ViewFieldError(ValueError):
+    """Raised when a field is used in a way its fold kind does not allow."""
+
+
+class FoldKind(Enum):
+    """How a view field combines the events folded into it.
+
+    Attributes:
+        CONVERGENT: Assignment per key, last writer wins. A dropped event
+            leaves a stale value that the next event for the same key
+            repairs, so the field tolerates a lossy stream.
+        ACCUMULATIVE: Running total per key. A dropped event shifts the total
+            permanently, so the field is only trustworthy while no drops have
+            occurred since its last reconciliation.
+    """
+
+    CONVERGENT = "convergent"
+    ACCUMULATIVE = "accumulative"
+
+
+class ViewField:
+    """One named piece of cluster state, folded according to its kind.
+
+    A field is created through :meth:`View.declare` rather than directly, so
+    that it stays attached to the drop accounting of its owning view.
+    """
+
+    def __init__(self, name: str, fold_kind: FoldKind, owner: "View") -> None:
+        """Initialize the field.
+
+        Args:
+            name: Identifier used when reporting untrusted reads.
+            fold_kind: How events combine into this field.
+            owner: The view that owns the drop accounting for this field.
+        """
+        self._name = name
+        self._fold_kind = fold_kind
+        self._owner = owner
+        self._values: dict[str, float] = {}
+        # Drop count at the last point this field is known to have matched
+        # reality. A convergent field never consults it.
+        self._clean_at_drops = owner.dropped_events_seen
+
+    @property
+    def name(self) -> str:
+        """Identifier of this field."""
+        return self._name
+
+    @property
+    def fold_kind(self) -> FoldKind:
+        """How events combine into this field."""
+        return self._fold_kind
+
+    @property
+    def trusted(self) -> bool:
+        """Whether the current contents can be acted on.
+
+        A convergent field is always trusted, since a dropped event only makes
+        a key look older than it is. An accumulative field is trusted only
+        while no events have been dropped since its last reconciliation.
+        """
+        if self._fold_kind is FoldKind.CONVERGENT:
+            return True
+        return self._owner.dropped_events_seen == self._clean_at_drops
+
+    def set(self, key: str, value: float) -> None:
+        """Assign a value for one key.
+
+        Args:
+            key: Key the value belongs to.
+            value: New value, replacing any previous one.
+
+        Raises:
+            ViewFieldError: If the field is accumulative, where assignment
+                would silently discard the running total.
+        """
+        if self._fold_kind is not FoldKind.CONVERGENT:
+            raise ViewFieldError(
+                f"field '{self._name}' is accumulative, use add() or reconcile()"
+            )
+        self._values[key] = value
+
+    def add(self, key: str, delta: float) -> None:
+        """Add a signed delta to one key's running total.
+
+        Args:
+            key: Key the delta belongs to.
+            delta: Amount to add, negative to subtract.
+
+        Raises:
+            ViewFieldError: If the field is convergent, where a delta has no
+                defined meaning.
+        """
+        if self._fold_kind is not FoldKind.ACCUMULATIVE:
+            raise ViewFieldError(
+                f"field '{self._name}' is convergent, use set()"
+            )
+        self._values[key] = self._values.get(key, 0.0) + delta
+
+    def reconcile(self, absolute_values: Mapping[str, float]) -> None:
+        """Replace the contents with values taken from an authoritative source.
+
+        This is how an accumulative field recovers from dropped events. The
+        caller supplies absolute values rather than deltas, for example an
+        occupancy figure reported by each node, and the field is marked
+        trustworthy as of the current drop count.
+
+        Args:
+            absolute_values: Complete mapping of key to value. Keys absent
+                here are removed.
+        """
+        self._values = dict(absolute_values)
+        self._clean_at_drops = self._owner.dropped_events_seen
+
+    def get(self, key: str) -> float:
+        """Return the value for one key, or ``0.0`` when it is unknown.
+
+        Args:
+            key: Key to read.
+
+        Returns:
+            The folded value, defaulting to ``0.0``.
+        """
+        return self._values.get(key, 0.0)
+
+    def items(self) -> list[tuple[str, float]]:
+        """Return every key and value currently folded into this field.
+
+        Returns:
+            Key and value pairs in insertion order.
+        """
+        return list(self._values.items())
+
+
+@dataclass(frozen=True)
+class TriggerVerdict:
+    """Outcome of evaluating a trigger against the view.
+
+    Attributes:
+        fired: What the trigger returned.
+        untrusted_fields: Names of accumulative fields the trigger read while
+            the view was degraded. Empty when every read was trustworthy.
+    """
+
+    fired: bool
+    untrusted_fields: tuple[str, ...] = field(default=())
+
+    @property
+    def trustworthy(self) -> bool:
+        """Whether every field the trigger read could be relied on.
+
+        Independent of :attr:`fired`, because a trigger that stays quiet on
+        drifted state is no more informative than one that fires on it.
+        """
+        return not self.untrusted_fields
+
+    @property
+    def actionable(self) -> bool:
+        """Whether the caller may run the action for this verdict."""
+        return self.fired and self.trustworthy
+
+
+class View:
+    """A global picture of the cluster, folded from the node event stream.
+
+    The view owns its fields and the drop accounting they consult. Feed it the
+    bus counter with :meth:`observe_dropped_events` as events are folded, then
+    evaluate triggers through :meth:`evaluate` so that reads of accumulative
+    state taken after a drop are reported instead of acted on.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty view with no observed drops."""
+        self._fields: dict[str, ViewField] = {}
+        self._dropped_events_seen: int = 0
+        self._reads: list[str] = []
+        self._recording: bool = False
+
+    @property
+    def dropped_events_seen(self) -> int:
+        """Total events the bus has reported dropping, as last observed."""
+        return self._dropped_events_seen
+
+    @property
+    def degraded(self) -> bool:
+        """Whether any accumulative field has become untrustworthy."""
+        return any(not f.trusted for f in self._fields.values())
+
+    def observe_dropped_events(self, total_dropped: int) -> None:
+        """Record the bus drop counter.
+
+        Pass ``EventBus.dropped_events_count`` here whenever events are
+        folded. The counter is cumulative, so it never decreases.
+
+        Args:
+            total_dropped: Cumulative number of events the bus discarded.
+
+        Raises:
+            ValueError: If the counter moves backwards, which would mean two
+                different buses are being folded into one view.
+        """
+        if total_dropped < self._dropped_events_seen:
+            raise ValueError(
+                "drop counter went backwards, from "
+                f"{self._dropped_events_seen} to {total_dropped}"
+            )
+        self._dropped_events_seen = total_dropped
+
+    def declare(self, name: str, fold_kind: FoldKind) -> ViewField:
+        """Create a field on this view.
+
+        Args:
+            name: Identifier for the field.
+            fold_kind: How events combine into it.
+
+        Returns:
+            The newly created field.
+
+        Raises:
+            ViewFieldError: If a field of that name already exists.
+        """
+        if name in self._fields:
+            raise ViewFieldError(f"field '{name}' is already declared")
+        created = ViewField(name, fold_kind, self)
+        self._fields[name] = created
+        return created
+
+    def field(self, name: str) -> ViewField:
+        """Return a declared field, recording the read while evaluating.
+
+        Args:
+            name: Identifier of the field.
+
+        Returns:
+            The field.
+
+        Raises:
+            ViewFieldError: If no field of that name was declared.
+        """
+        if name not in self._fields:
+            raise ViewFieldError(f"field '{name}' is not declared")
+        if self._recording:
+            self._reads.append(name)
+        return self._fields[name]
+
+    def evaluate(self, trigger: Callable[["View"], bool]) -> TriggerVerdict:
+        """Run a trigger and report whether its reads can be acted on.
+
+        Every field the trigger reaches through :meth:`field` is recorded, and
+        any accumulative field that has seen a drop since its last
+        reconciliation is named in the verdict. A trigger that fires on
+        untrusted state is reported rather than suppressed, so the caller can
+        log it, reconcile, and evaluate again.
+
+        Args:
+            trigger: Predicate over this view.
+
+        Returns:
+            The trigger result together with the untrusted fields it read.
+        """
+        self._reads = []
+        self._recording = True
+        try:
+            fired = trigger(self)
+        finally:
+            self._recording = False
+        untrusted = tuple(
+            dict.fromkeys(
+                name for name in self._reads if not self._fields[name].trusted
+            )
+        )
+        return TriggerVerdict(fired=fired, untrusted_fields=untrusted)

--- a/tests/v1/distributed/orchestration/__init__.py
+++ b/tests/v1/distributed/orchestration/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/distributed/orchestration/test_view.py
+++ b/tests/v1/distributed/orchestration/test_view.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the typed cluster view used by KV cache orchestration (#4291).
+
+The event stream the view folds is lossy, so these tests pin the difference
+between state that heals after a dropped event and state that does not.
+"""
+
+# Standard
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.orchestration.view import (
+    FoldKind,
+    View,
+    ViewFieldError,
+)
+
+
+def test_convergent_field_stays_trusted_after_drops() -> None:
+    """A dropped event only leaves a stale value, which the next one fixes."""
+    view = View()
+    accessed = view.declare("accessed_at", FoldKind.CONVERGENT)
+    accessed.set("key-a", 100.0)
+
+    view.observe_dropped_events(42)
+
+    assert accessed.trusted
+    assert not view.degraded
+
+
+def test_accumulative_field_loses_trust_after_a_drop() -> None:
+    """A dropped delta is a permanent offset, so the total is not usable."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+    used_bytes.add("tenant-a", 4096.0)
+
+    assert used_bytes.trusted
+
+    view.observe_dropped_events(1)
+
+    assert not used_bytes.trusted
+    assert view.degraded
+
+
+def test_reconcile_with_absolute_values_restores_trust() -> None:
+    """Absolute values from an authoritative source clear the drift."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+    used_bytes.add("tenant-a", 4096.0)
+    view.observe_dropped_events(3)
+
+    used_bytes.reconcile({"tenant-a": 2048.0})
+
+    assert used_bytes.trusted
+    assert not view.degraded
+    assert used_bytes.get("tenant-a") == 2048.0
+
+
+def test_reconcile_drops_keys_absent_from_the_snapshot() -> None:
+    """Reconciliation replaces the contents rather than merging into them."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+    used_bytes.add("tenant-a", 4096.0)
+    used_bytes.add("tenant-b", 8192.0)
+
+    used_bytes.reconcile({"tenant-a": 4096.0})
+
+    assert used_bytes.get("tenant-b") == 0.0
+
+
+def test_trigger_over_convergent_state_stays_actionable_while_degraded() -> None:
+    """An LRU style policy is safe to run even after events were dropped."""
+    view = View()
+    accessed = view.declare("accessed_at", FoldKind.CONVERGENT)
+    view.declare("used_bytes", FoldKind.ACCUMULATIVE).add("tenant-a", 1.0)
+    accessed.set("key-a", 10.0)
+    view.observe_dropped_events(5)
+
+    verdict = view.evaluate(lambda v: v.field("accessed_at").get("key-a") < 50.0)
+
+    assert verdict.fired
+    assert verdict.untrusted_fields == ()
+    assert verdict.actionable
+
+
+def test_trigger_over_accumulative_state_is_flagged_while_degraded() -> None:
+    """A quota style policy must not delete keys off a drifted total."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+    used_bytes.add("tenant-a", 9000.0)
+    view.observe_dropped_events(1)
+
+    verdict = view.evaluate(lambda v: v.field("used_bytes").get("tenant-a") > 8192.0)
+
+    assert verdict.fired
+    assert verdict.untrusted_fields == ("used_bytes",)
+    assert not verdict.actionable
+
+
+def test_a_dropped_decrement_is_what_makes_the_quota_trigger_wrong() -> None:
+    """The failure this guard exists for, written out end to end."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+
+    used_bytes.add("tenant-a", 8192.0)  # key entered L1
+    view.observe_dropped_events(1)  # the matching eviction event was dropped
+
+    over_quota = view.evaluate(
+        lambda v: v.field("used_bytes").get("tenant-a") > 4096.0
+    )
+
+    # The total still says the tenant is over quota and the action attached to
+    # this trigger deletes their keys, so firing here would delete a cache the
+    # tenant is no longer filling.
+    assert over_quota.fired
+    assert not over_quota.actionable
+
+    used_bytes.reconcile({"tenant-a": 0.0})
+    after = view.evaluate(lambda v: v.field("used_bytes").get("tenant-a") > 4096.0)
+
+    assert not after.fired
+    assert after.trustworthy
+    assert not after.actionable
+
+
+def test_each_untrusted_field_is_named_once() -> None:
+    """Repeated reads of the same field do not repeat in the verdict."""
+    view = View()
+    view.declare("used_bytes", FoldKind.ACCUMULATIVE).add("tenant-a", 1.0)
+    view.observe_dropped_events(1)
+
+    def trigger(v: View) -> bool:
+        left = v.field("used_bytes").get("tenant-a")
+        right = v.field("used_bytes").get("tenant-b")
+        return left > right
+
+    verdict = view.evaluate(trigger)
+
+    assert verdict.untrusted_fields == ("used_bytes",)
+
+
+def test_assignment_on_an_accumulative_field_is_rejected() -> None:
+    """Assigning would silently discard the running total."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+
+    with pytest.raises(ViewFieldError):
+        used_bytes.set("tenant-a", 1.0)
+
+
+def test_delta_on_a_convergent_field_is_rejected() -> None:
+    """A delta has no defined meaning against a last writer wins field."""
+    view = View()
+    accessed = view.declare("accessed_at", FoldKind.CONVERGENT)
+
+    with pytest.raises(ViewFieldError):
+        accessed.add("key-a", 1.0)
+
+
+def test_drop_counter_may_not_move_backwards() -> None:
+    """A decreasing counter means two buses are folded into one view."""
+    view = View()
+    view.observe_dropped_events(10)
+
+    with pytest.raises(ValueError):
+        view.observe_dropped_events(9)
+
+
+def test_declaring_the_same_field_twice_is_rejected() -> None:
+    """Two owners of one name would disagree about its fold kind."""
+    view = View()
+    view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+
+    with pytest.raises(ViewFieldError):
+        view.declare("used_bytes", FoldKind.CONVERGENT)
+
+
+def test_reading_an_undeclared_field_is_rejected() -> None:
+    """A typo in a trigger should fail loudly rather than read empty state."""
+    view = View()
+
+    with pytest.raises(ViewFieldError):
+        view.field("used_byte")

--- a/tests/v1/distributed/orchestration/test_view.py
+++ b/tests/v1/distributed/orchestration/test_view.py
@@ -183,3 +183,68 @@ def test_reading_an_undeclared_field_is_rejected() -> None:
 
     with pytest.raises(ViewFieldError):
         view.field("used_byte")
+
+
+def test_first_batch_from_an_instance_is_never_a_gap() -> None:
+    """There is nothing to compare the first sequence number against."""
+    view = View()
+
+    assert view.observe_batch("node-a", 41) == 0
+    assert view.sequence_gaps == 0
+
+
+def test_contiguous_batches_report_no_loss() -> None:
+    """A forwarder that lands every batch leaves the view trusted."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+
+    view.observe_batch("node-a", 1)
+    view.observe_batch("node-a", 2)
+    view.observe_batch("node-a", 3)
+
+    assert view.sequence_gaps == 0
+    assert used_bytes.trusted
+
+
+def test_a_sequence_gap_costs_trust_the_same_as_a_bus_drop() -> None:
+    """The coordinator advances seq before publishing, so loss leaves a hole."""
+    view = View()
+    used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)
+    view.observe_batch("node-a", 1)
+
+    missed = view.observe_batch("node-a", 4)
+
+    assert missed == 2
+    assert view.sequence_gaps == 2
+    assert view.loss_marks == 2
+    assert not used_bytes.trusted
+
+
+def test_sequences_are_tracked_per_instance() -> None:
+    """Two nodes number their batches independently."""
+    view = View()
+    view.observe_batch("node-a", 7)
+    view.observe_batch("node-b", 1)
+
+    assert view.observe_batch("node-a", 8) == 0
+    assert view.observe_batch("node-b", 2) == 0
+    assert view.sequence_gaps == 0
+
+
+def test_a_repeated_sequence_number_is_rejected() -> None:
+    """An ordered forwarder never emits the same number twice."""
+    view = View()
+    view.observe_batch("node-a", 5)
+
+    with pytest.raises(ValueError):
+        view.observe_batch("node-a", 5)
+
+
+def test_both_loss_sources_add_up() -> None:
+    """A bus discard and a lost batch are the same kind of damage."""
+    view = View()
+    view.observe_dropped_events(3)
+    view.observe_batch("node-a", 1)
+    view.observe_batch("node-a", 3)
+
+    assert view.loss_marks == 4


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #4291. Opening as a **draft for discussion**, not a merge request. The
`View` programming API block in that RFC is empty and this is a concrete
proposal for it, built around one property of the stream it would fold.

**The event stream is lossy by design.** `EventBusConfig.max_queue_size`
defaults to `10_000`, `publish()` appends to a deque on the hot path, and the
docstring says that when the queue is full new events are "silently dropped
with a rate-limited warning". `dropped_events_count` already exists for it. So
`get_view(events, view_checkpoint)` folds a stream that thins out exactly when
the cluster is busy.

That sorts the two example policies in the RFC onto opposite sides of a line:

- **LRU** writes `view[l1][key] = timestamp`, last writer wins per key. A
  dropped access event only makes a key look colder than it is and the next
  access repairs it. Bounded error, self healing.
- **Quota** does `+= size` and `-= size`. One dropped event is a permanent
  offset that nothing corrects, the trigger fires on an absolute threshold,
  and the action deletes every key belonging to that `cache_salt`. A dropped
  decrement eventually deletes a tenant's cache over quota they are not using.

This PR makes that difference part of the type rather than something each
policy author rediscovers.

**API**

```python
view = View()
accessed = view.declare("accessed_at", FoldKind.CONVERGENT)
used_bytes = view.declare("used_bytes", FoldKind.ACCUMULATIVE)

accessed.set("key-a", timestamp)      # add() rejected on a convergent field
used_bytes.add("tenant-a", nbytes)    # set() rejected on an accumulative one

view.observe_dropped_events(bus.dropped_events_count)

verdict = view.evaluate(lambda v: v.field("used_bytes").get("tenant-a") > limit)
verdict.fired             # what the trigger returned
verdict.untrusted_fields  # ("used_bytes",) once a drop has been observed
verdict.actionable        # fired and trustworthy

used_bytes.reconcile({"tenant-a": occupancy})   # absolute, not a delta
```

- A convergent field is always trusted. An accumulative field loses trust the
  moment the bus reports a drop and regains it only through `reconcile()`,
  which takes absolute values from an authoritative source rather than deltas.
- `evaluate()` records every field the trigger reached through `field()` and
  names the untrusted ones. A trigger firing on drifted state is **reported,
  not suppressed**, so the caller can log it, reconcile, and re-evaluate.
- `trustworthy` is separate from `fired`, because a trigger staying quiet on
  drifted state is no more informative than one firing on it.

**Special notes for your reviewers**:

- 13 tests, no new dependencies, nothing wired into the MP server yet. The
  module is standalone on purpose so the API can be argued about before
  anything depends on it.
- One test writes out the end to end shape of the failure this guards against,
  a store followed by a dropped eviction event leaving the tenant apparently
  over quota.
- Two smaller points from reading #4291 that are not in this PR. The event
  names in the RFC examples do not exist yet, the vocabulary in
  `lmcache/v1/mp_observability/event.py` is `L1_KEYS_ACCESSED`,
  `L1_KEYS_EVICTED`, `L1_WRITE_FINISHED` and friends. And `Event.timestamp` is
  `time.time()` from the publishing process, so ordering events from several
  nodes assumes their clocks agree.
- @KuntaiDu, if the direction is wrong I would rather find out at this size.
  Happy to reshape it around whichever ownership model you land on.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
