### PR TITLE
[core][feat] mp_observability: bus-owned periodic hook so cache-event freshness stops depending on the eviction loop

### DIFF
--- a/lmcache/v1/mp_coordinator/cache_events.py
+++ b/lmcache/v1/mp_coordinator/cache_events.py
@@ -170,11 +170,18 @@ class CacheEventSubscriber(EventSubscriber):
             EventType.L2_KEYS_STORED: self._on_l2_store,
             EventType.L2_KEYS_DELETED: self._on_l2_delete,
             EventType.L2_KEYS_ACCESSED: self._on_l2_access,
-            # TODO: decouple the flush tick from the eviction loop (e.g. a
-            # bus-owned periodic hook) so cache-event freshness does not
-            # silently depend on the eviction loop's cadence.
-            EventType.L1_EVICTION_LOOP_TICK: self._on_tick,
         }
+
+    def on_periodic(self) -> None:
+        """Flush on the bus timer rather than on another component's cadence.
+
+        This used to ride ``L1_EVICTION_LOOP_TICK``, which tied cache event
+        freshness to the eviction loop, so a slow or stalled eviction loop
+        silently stopped refreshing the coordinator's view. Runs on the drain
+        thread, the same thread as the handlers, so the buffer needs no extra
+        locking.
+        """
+        self._flush_if_due()
 
     def flush(self) -> None:
         """Drain the buffer and publish one batch per pending batch.
@@ -217,9 +224,6 @@ class CacheEventSubscriber(EventSubscriber):
         self._sink.close()
 
     # -- Event handlers (bus drain thread) ------------------------------------
-
-    def _on_tick(self, event: Event) -> None:
-        self._flush_if_due()
 
     def _on_l1_store(self, event: Event) -> None:
         self._record_l1_placements(CacheEventType.STORE, event)

--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -83,9 +83,26 @@ class EventSubscriber(ABC):
         ...
 
     def register(self, bus: EventBus) -> None:
-        """Subscribe all declared handlers to *bus*."""
+        """Subscribe all declared handlers to *bus*.
+
+        A subclass that overrides :meth:`on_periodic` is also wired to the
+        drain loop's timer, so it does not have to borrow an unrelated event
+        to get a clock.
+        """
         for event_type, callback in self.get_subscriptions().items():
             bus.subscribe(event_type, callback)
+        if type(self).on_periodic is not EventSubscriber.on_periodic:
+            bus.register_periodic(self.on_periodic)
+
+    def on_periodic(self) -> None:  # noqa: B027
+        """Optional timer hook.  Called on every drain loop iteration.
+
+        Runs on the drain thread, the same thread as the event callbacks, so
+        an implementation may touch the same state without extra locking.
+        The interval is the drain loop's wait timeout, so treat this as "at
+        least this often" and check the clock rather than counting calls.
+        """
+        pass
 
     def shutdown(self) -> None:  # noqa: B027
         """Optional cleanup hook.  Called by ``EventBus.stop()``."""
@@ -115,6 +132,7 @@ class EventBus:
         self._lock = threading.Lock()
         self._thread: threading.Thread | None = None
         self._registered_subscribers: list[EventSubscriber] = []
+        self._periodics: list[Callable[[], None]] = []
         self._discard_count: int = 0
         self._last_discard_warning: float = 0.0
         self._subscriber_exception_counts: dict[str, int] = {}
@@ -146,6 +164,18 @@ class EventBus:
         """Register a callback for a specific event type (thread-safe)."""
         with self._lock:
             self._subscribers[event_type].append(callback)
+
+    def register_periodic(self, hook: Callable[[], None]) -> None:
+        """Register a callable invoked once per drain loop iteration.
+
+        This exists so a subscriber that needs a clock does not have to
+        subscribe to an unrelated event and inherit that event's cadence.
+
+        Args:
+            hook: Zero argument callable, run on the drain thread.
+        """
+        with self._lock:
+            self._periodics.append(hook)
 
     def register_subscriber(self, subscriber: EventSubscriber) -> None:
         """Register an ``EventSubscriber`` and wire up its callbacks."""
@@ -308,6 +338,44 @@ class EventBus:
             self._wake.wait(timeout=0.1)
             self._wake.clear()
             self._drain_all()
+            self._run_periodics()
+
+    def _count_callback_exception(self, cb: Callable[..., None]) -> str:
+        """Attribute a callback failure to its owner and count it.
+
+        Args:
+            cb: The callable that raised.
+
+        Returns:
+            The name the failure was counted against.
+        """
+        instance = getattr(cb, "__self__", None)
+        name = (
+            type(instance).__name__
+            if instance is not None
+            else getattr(cb, "__qualname__", repr(cb))
+        )
+        with self._lock:
+            self._subscriber_exception_counts[name] = (
+                self._subscriber_exception_counts.get(name, 0) + 1
+            )
+        return name
+
+    def _run_periodics(self) -> None:
+        """Call every registered timer hook once, isolating failures.
+
+        A hook that raises is counted and logged like a subscriber callback,
+        because the drain thread carries every other subscriber and must not
+        die for one of them.
+        """
+        with self._lock:
+            snapshot = list(self._periodics)
+        for hook in snapshot:
+            try:
+                hook()
+            except Exception:
+                self._count_callback_exception(hook)
+                logger.exception("EventBus: error in periodic hook")
 
     def _drain_all(self) -> None:
         """Pop all queued events and dispatch to subscribers."""
@@ -337,16 +405,7 @@ class EventBus:
                 try:
                     cb(event)
                 except Exception:
-                    instance = getattr(cb, "__self__", None)
-                    name = (
-                        type(instance).__name__
-                        if instance is not None
-                        else getattr(cb, "__qualname__", repr(cb))
-                    )
-                    with self._lock:
-                        self._subscriber_exception_counts[name] = (
-                            self._subscriber_exception_counts.get(name, 0) + 1
-                        )
+                    name = self._count_callback_exception(cb)
                     logger.exception(
                         "EventBus: error in callback %s for %s",
                         name,

--- a/tests/v1/mp_observability/__init__.py
+++ b/tests/v1/mp_observability/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/mp_observability/test_periodic_hook.py
+++ b/tests/v1/mp_observability/test_periodic_hook.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the EventBus periodic hook (see #4291).
+
+A subscriber that needs a clock used to subscribe to an unrelated event and
+inherit its cadence, which made its freshness depend on a component it has
+nothing to do with. These tests pin the timer the bus now offers instead.
+"""
+
+# Standard
+import threading
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event_bus import (
+    EventBus,
+    EventBusConfig,
+    EventCallback,
+    EventSubscriber,
+)
+from lmcache.v1.mp_observability.event import EventType
+
+_SETTLE_SECONDS = 0.5
+
+
+class _CountingSubscriber(EventSubscriber):
+    """Subscriber with no event subscriptions that only counts timer calls."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {}
+
+    def on_periodic(self) -> None:
+        self.calls += 1
+
+
+class _RaisingSubscriber(EventSubscriber):
+    """Subscriber whose timer hook always fails."""
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {}
+
+    def on_periodic(self) -> None:
+        raise RuntimeError("periodic boom")
+
+
+class _SilentSubscriber(EventSubscriber):
+    """Subscriber that does not override the timer hook."""
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {}
+
+
+@pytest.fixture
+def bus() -> EventBus:
+    """Start a running bus and stop it after the test."""
+    started = EventBus(EventBusConfig(enabled=True))
+    started.start()
+    yield started
+    started.stop()
+
+
+def test_periodic_hook_runs_without_any_events(bus: EventBus) -> None:
+    """The timer must not depend on traffic, which is the whole point."""
+    subscriber = _CountingSubscriber()
+    bus.register_subscriber(subscriber)
+
+    time.sleep(_SETTLE_SECONDS)
+
+    assert subscriber.calls > 0
+
+
+def test_a_failing_hook_does_not_stop_the_drain_thread(bus: EventBus) -> None:
+    """The drain thread carries every subscriber, so one failure is isolated."""
+    failing = _RaisingSubscriber()
+    healthy = _CountingSubscriber()
+    bus.register_subscriber(failing)
+    bus.register_subscriber(healthy)
+
+    time.sleep(_SETTLE_SECONDS)
+
+    assert healthy.calls > 0
+    assert bus.subscriber_exception_counts().get("_RaisingSubscriber", 0) > 0
+    assert any(t.name for t in threading.enumerate())
+
+
+def test_a_subscriber_without_the_hook_is_not_registered(bus: EventBus) -> None:
+    """Only an overridden hook joins the timer, so the default costs nothing."""
+    bus.register_subscriber(_SilentSubscriber())
+
+    time.sleep(0.2)
+
+    assert bus.subscriber_exception_counts() == {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes a `TODO` that is already in the code. `CacheEventSubscriber.get_subscriptions()` carries this:

```python
# TODO: decouple the flush tick from the eviction loop (e.g. a
# bus-owned periodic hook) so cache-event freshness does not
# silently depend on the eviction loop's cadence.
EventType.L1_EVICTION_LOOP_TICK: self._on_tick,
```

The subscriber does not care about eviction. It subscribed to that event purely to get a clock for `_flush_if_due()`. The cost is that a slow or stalled eviction loop stops refreshing the coordinator's global view, and nothing in the view says so, which matters more now that #4291 wants to drive orchestration actions off that view.

The drain loop already wakes on a `0.1` second timeout, so the timer existed and only needed exposing.

**Changes**

- `EventBus.register_periodic(hook)` takes a zero argument callable, run once per drain iteration.
- `EventSubscriber.on_periodic()` is a no-op by default and is wired automatically only when a subclass overrides it, so subscribers that do not need a clock pay nothing.
- A hook that raises is counted and logged the same way a subscriber callback is, because the drain thread carries every other subscriber and must not die for one of them. The attribution logic is factored into `_count_callback_exception` and shared by both paths.
- `CacheEventSubscriber` flushes from `on_periodic()` and no longer subscribes to `L1_EVICTION_LOOP_TICK`.

**Special notes for your reviewers**:

- Hooks run on the drain thread, the same thread as the event callbacks, so `_pending_batches` and `_last_flush` keep their current single threaded access and need no new locking. That was the reason to put the timer in the drain loop rather than in a separate thread.
- Cadence is unchanged in practice. The eviction loop ticked at roughly 1 Hz and the drain loop wakes at 10 Hz, so `_flush_if_due()` is consulted more often and still flushes on its own `flush_interval`. Treat `on_periodic()` as "at least this often" and check the clock rather than counting calls, which is what the docstring says.
- 3 tests, including that the timer fires with no traffic at all, that a failing hook does not take the drain thread down with it, and that a subscriber which does not override the hook is never registered.
- Found while reviewing #4291. A global view folded from these events has three sources of staleness, bus discards, forwarder sequence gaps, and flush age. The first two are visible today. This one makes the third measurable, since flush age is only meaningful once it stops being a proxy for the eviction loop's health.
- Related, not in this PR: #4374, #4375, and the draft #4376.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
