### PR TITLE
docs: daily drift check — multi-process mode (2026-08-01)

### DIFF
--- a/docs/source/cli/describe.rst
+++ b/docs/source/cli/describe.rst
@@ -216,3 +216,8 @@ The ``engine_kv_shape`` field uses short names from the ``EngineKVFormat`` enum:
      - head_size
    * - PBS
      - page_buffer_size (NB × BS)
+   * - BSxVALS
+     - block_size (DSA indexer cache: per-block fp8 values region;
+       ``NL_X_NB_BSV_BSS`` renders as ``NL x [NB, BSxVALS, BSxSCALES]``)
+   * - BSxSCALES
+     - block_size (DSA indexer cache: per-block fp32 scales region)


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current `dev`
code (`upstream/dev` HEAD [`0427938a`](https://github.com/LMCache/LMCache/commit/0427938a40955a7e44128d64aabf55f35383cab1)),
focused on the multi-process mode. One drift item today, introduced by
[#4351](https://github.com/LMCache/LMCache/pull/4351) (commit [`0427938a`](https://github.com/LMCache/LMCache/commit/0427938a40955a7e44128d64aabf55f35383cab1),
*"add NL_X_NB_BSV_BSS format for CB"*, 2026-07-31), which added a new
`EngineKVFormat` used on the MP path but did not update the CLI
abbreviation table that documents the tokens users see in
`lmcache describe kvcache` output.

Prior open drift-check PRs still track their own items and do not
overlap this one:

- [#4361](https://github.com/LMCache/LMCache/pull/4361) — `--enable` MP-server
  flag missing from the `docs/source/mp/configuration.rst` table.
- [#4304](https://github.com/LMCache/LMCache/pull/4304) — `/directory/*`
  endpoints missing from `docs/source/mp/coordinator.rst` and
  `docs/design/v1/mp_coordinator/README.md`.
- [#4285](https://github.com/LMCache/LMCache/pull/4285) — `TransferContext`
  method-count mismatch in `docs/design/v1/multiprocess/engine_driven_transfer_design.md`
  and L2-adapter factory description in `docs/source/mp/index.rst`.
- [#4269](https://github.com/LMCache/LMCache/pull/4269) — `--runtime-plugin-config`
  env-var description in `docs/source/mp/configuration.rst`.
- Older PRs (#4249, #4236, #4199) continue to track their earlier items.

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/cli/describe.rst`** — the "Engine KV Shape Abbreviations"
  table
  ([lines 196-218](https://github.com/LMCache/LMCache/blob/0427938a40955a7e44128d64aabf55f35383cab1/docs/source/cli/describe.rst#L196-L218))
  opens by declaring itself the list of short names that appear in the
  `engine_kv_shape` field emitted by `lmcache describe kvcache` for each
  registered kernel group (this is the CLI surface for MP-server
  operators to inspect a running engine). Since [#4351](https://github.com/LMCache/LMCache/pull/4351)
  landed, the DSA indexer k-cache format `NL_X_NB_BSV_BSS` renders as
  `NL x [NB, BSxVALS, BSxSCALES]` — see the two new labels added to
  `_LABELS` in
  [`lmcache/v1/gpu_connector/kv_format/specs/base.py:38-42`](https://github.com/LMCache/LMCache/blob/0427938a40955a7e44128d64aabf55f35383cab1/lmcache/v1/gpu_connector/kv_format/specs/base.py#L38-L42)
  and the new spec at
  [`lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py`](https://github.com/LMCache/LMCache/blob/0427938a40955a7e44128d64aabf55f35383cab1/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py),
  registered on the MP block-axis map at
  [`lmcache/v1/multiprocess/http_apis/cache_api.py:151-158`](https://github.com/LMCache/LMCache/blob/0427938a40955a7e44128d64aabf55f35383cab1/lmcache/v1/multiprocess/http_apis/cache_api.py#L151-L158) —
  but the table lists only `NB / NL / BS / NH / HS / PBS`. A reader
  looking at the `engine_kv_shape` output for an MLA engine that carries
  the DSA indexer cache (e.g. DeepSeek-V4-Flash) will see two undocumented
  tokens.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/cli/describe.rst` — "Engine KV Shape Abbreviations" table ([lines 199-218](https://github.com/LMCache/LMCache/blob/0427938a40955a7e44128d64aabf55f35383cab1/docs/source/cli/describe.rst#L199-L218)) | Table ends at ``PBS`` / ``page_buffer_size (NB × BS)``. No ``BSxVALS`` / ``BSxSCALES`` rows. | Adds rows for ``BSxVALS`` and ``BSxSCALES`` (each sized by ``block_size``, matching the ``_ACCESSORS`` map in ``kv_format/specs/base.py``), and cross-references the ``NL_X_NB_BSV_BSS`` format that produces them. |

### `docs/design/`

None today. (The new format has no dedicated design doc under
`docs/design/v1/gpu_connector/` or `docs/design/v1/multiprocess/`, and
the CB v3 payload change in `blend_v3.py` — the added `group_rot`
parameter to `CB_REGISTER_ROPE_V3` — is not described at the
payload-schema level in any design doc, so there is nothing to update
there.)

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One
file touched:

- `docs/source/cli/describe.rst`

## Code bugs surfaced (not fixed here)

None new from today's check. (Pre-existing items from earlier drift
checks — the `lmcache_mp_connector_0180.py` docstring inversion
flagged by [#4199](https://github.com/LMCache/LMCache/pull/4199), the
`--runtime-plugin-config` help-string mismatch flagged by
[#4269](https://github.com/LMCache/LMCache/pull/4269) — remain open;
this PR does not re-flag them.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMTwfsuNd6qsUAExLHLqo)_