### PR TITLE
[good-first-issue] config: add missing env_converter for store_location and retrieve_locations (#4379)

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -156,8 +156,12 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
     "blend_min_tokens": {"type": int, "default": 256, "env_converter": int},
     "blend_special_str": {"type": str, "default": " # # ", "env_converter": str},
-    "retrieve_locations": {"type": Optional[list[str]], "default": None},
-    "store_location": {"type": Optional[str], "default": None},
+    "retrieve_locations": {
+        "type": Optional[list[str]],
+        "default": None,
+        "env_converter": _to_str_list,
+    },
+    "store_location": {"type": Optional[str], "default": None, "env_converter": str},
     # P2P configurations
     "enable_p2p": {
         "type": bool,

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -1051,3 +1051,61 @@ class TestNixlUseHugepagesDeprecation:
         }
         config.validate()
         assert config.local_cpu_use_hugepages is True
+
+
+class TestStoreAndRetrieveLocationEnvConversion:
+    """``store_location`` and ``retrieve_locations`` must convert from the
+    environment like every other config option.
+
+    Both options were registered without an ``env_converter``, which made the
+    env-var and dict-import paths raise ``KeyError`` and left
+    ``retrieve_locations`` typed as ``str`` instead of ``list[str]``.
+    """
+
+    def test_update_config_from_env_accepts_store_location(self, monkeypatch):
+        """``LMCACHE_STORE_LOCATION`` is applied instead of raising."""
+        monkeypatch.setenv("LMCACHE_STORE_LOCATION", "LocalDiskBackend")
+        config = LMCacheEngineConfig.from_defaults()
+        config.update_config_from_env()
+        assert config.store_location == "LocalDiskBackend"
+
+    def test_update_config_from_env_accepts_retrieve_locations(self, monkeypatch):
+        """``LMCACHE_RETRIEVE_LOCATIONS`` is applied instead of raising."""
+        monkeypatch.setenv(
+            "LMCACHE_RETRIEVE_LOCATIONS", "LocalCPUBackend,LocalDiskBackend"
+        )
+        config = LMCacheEngineConfig.from_defaults()
+        config.update_config_from_env()
+        assert config.retrieve_locations == ["LocalCPUBackend", "LocalDiskBackend"]
+
+    def test_from_env_parses_retrieve_locations_as_list(self, monkeypatch):
+        """A comma-separated env value becomes ``list[str]``, not ``str``.
+
+        Without conversion the value stays a string, so membership tests match
+        on substrings and report backends that were never configured.
+        """
+        monkeypatch.setenv(
+            "LMCACHE_RETRIEVE_LOCATIONS", "LocalCPUBackend,LocalDiskBackend"
+        )
+        config = LMCacheEngineConfig.from_env()
+        assert config.retrieve_locations == ["LocalCPUBackend", "LocalDiskBackend"]
+        assert "LocalCPU" not in (config.retrieve_locations or [])
+
+    def test_from_env_parses_store_location_as_str(self, monkeypatch):
+        """``store_location`` round-trips through the environment as ``str``."""
+        monkeypatch.setenv("LMCACHE_STORE_LOCATION", "LocalDiskBackend")
+        config = LMCacheEngineConfig.from_env()
+        assert config.store_location == "LocalDiskBackend"
+
+    def test_from_dict_round_trip_preserves_both_options(self):
+        """``to_dict``/``from_dict`` round-trips instead of raising.
+
+        ``load_ec_engine_config`` clones a config through this path, so the
+        failure surfaced for any deployment setting either option.
+        """
+        config = LMCacheEngineConfig.from_defaults()
+        config.retrieve_locations = ["LocalCPUBackend"]
+        config.store_location = "LocalDiskBackend"
+        restored = LMCacheEngineConfig.from_dict(config.to_dict())
+        assert restored.retrieve_locations == ["LocalCPUBackend"]
+        assert restored.store_location == "LocalDiskBackend"


### PR DESCRIPTION
**What this PR does and why we need it**:

Closes #4379
Refs #3372

`_CONFIG_DEFINITIONS` registers 114 config options, and exactly two of them were
missing the `env_converter` key: `retrieve_locations` and `store_location`. Two
code paths index `config["env_converter"]` unconditionally instead of going
through `_apply_env_converter_safely`, so both options raise an uncaught
`KeyError: 'env_converter'` rather than being applied:

- `lmcache/v1/config.py:1028` (`_update_config_from_env`) — the enclosing `try`
  catches `(ValueError, json.JSONDecodeError)`, which does not cover `KeyError`.
- `lmcache/v1/config_base.py:436` (`_from_dict`) — no `try` at all.

This crashes engine startup when `LMCACHE_STORE_LOCATION` is set alongside
`LMCACHE_CONFIG_FILE`, and crashes `load_ec_engine_config()` for any config
setting `retrieve_locations` (it clones via `from_dict` in
`_clone_lmcache_engine_config`). Separately, `from_env()` reaches
`_apply_env_converter_safely`, which falls back to the raw string when no
converter is registered — so `retrieve_locations`, declared
`Optional[list[str]]` and consumed as a list, silently arrives as `str` and
membership tests match on substrings (`"LocalCPU" in ...` returns `True` for a
backend that was never configured).

The fix registers the converters already used by each option's direct
type-siblings: `_to_str_list` for `Optional[list[str]]` (as `nixl_backends`,
`storage_plugins`, `remote_storage_plugins` do) and `str` for `Optional[str]`
(as `p2p_host`, `mp_host`, `pd_role` do).

**Special notes for your reviewers**:

- This my first PR here yo yo
- Verified the tests fail for the right reason before the fix: reverting only
  the `config.py` change and keeping the new tests gives 4 failures — three
  `KeyError: 'env_converter'` at the call sites above, and one
  `assert 'LocalCPUBackend,LocalDiskBackend' == ['LocalCPUBackend', 'LocalDiskBackend']`
  demonstrating the string-vs-list corruption. With the fix: 5 passed.
- `pytest tests/v1/test_config.py` → 175 passed, 1 skipped, 1 xpassed
  (baseline before this change was 170 passed).
- Lint clean on both files: `ruff check`, `ruff format --check`, `isort`,
  `codespell`, SPDX header check, and `mypy --config-file=pyproject.toml`.
- Tested on a CPU-only machine using `NO_NATIVE_EXT=1` (no GPU, no CUDA
  toolchain), which is why the run above is scoped to the affected test files.
- Scope is deliberately limited to the two missing `env_converter` entries plus
  their regression tests; no incidental cleanup.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
