### PR TITLE
feat(mp): add coordinator runtime policy fanout

### DIFF
--- a/docs/design/v1/distributed/runtime_policy.md
+++ b/docs/design/v1/distributed/runtime_policy.md
@@ -1,0 +1,92 @@
+# Runtime Management Policy
+
+This document describes the node-local Phase 1 implementation of RFC #4360.
+It covers only policies whose state can be reused after an update.
+
+## Control Flow
+
+```text
+HTTP /config/policies
+        |
+        v
+StorageManager
+  - version check
+  - full validation
+  - controller routing
+        |
+        +--> StoreController.update_policy()
+        +--> PrefetchController.update_policy()
+        +--> L1EvictionController.update_tunables()
+        `--> L2EvictionController.update_tunables()
+```
+
+`StorageManager` owns the monotonic runtime policy version. A request is
+validated completely before any controller is mutated. `expected_version`, when
+provided, implements optimistic concurrency and returns HTTP 409 on a stale
+write.
+
+## Phase 1 Contract
+
+The following changes are hot-updateable:
+
+| Field | Effective on |
+| --- | --- |
+| `store_policy` | Next store plan |
+| `prefetch_policy` | Next prefetch request |
+| `l1_eviction.tunables.trigger_watermark` | Next eviction loop tick |
+| `l1_eviction.tunables.eviction_ratio` | Next eviction loop tick |
+| `l2_eviction[].tunables.trigger_watermark` | Next eviction loop tick |
+| `l2_eviction[].tunables.eviction_ratio` | Next eviction loop tick |
+
+Store and prefetch tasks capture the policy instance when they enter their
+planning lifecycle. Updating the controller does not recompute an in-flight
+plan, and a store task uses its captured policy for the eventual L1 deletion
+decision.
+
+Eviction policy classes are stateful and are not replaced at runtime. A class
+change returns `state_migration_required`. Startup-only fields such as
+`chunk_size`, L1 capacity, serde, and adapter type return `restart_required`.
+
+## HTTP API
+
+`GET /config/policies` returns the current version, current policy names, and
+capability metadata. The `registered` lists are the source of truth for valid
+store and prefetch selectors.
+
+`POST /config/policies/validate` accepts the same body as `PATCH` and never
+mutates the process.
+
+`PATCH /config/policies` applies an update. The body uses stable L2 adapter IDs:
+
+```json
+{
+  "expected_version": 7,
+  "store_policy": "skip_l1",
+  "prefetch_policy": "retain",
+  "l1_eviction": {
+    "tunables": {
+      "trigger_watermark": 0.9,
+      "eviction_ratio": 0.1
+    }
+  },
+  "l2_eviction": [
+    {
+      "adapter_id": 0,
+      "tunables": {
+        "trigger_watermark": 0.85,
+        "eviction_ratio": 0.1
+      }
+    }
+  ]
+}
+```
+
+Successful updates increment the version and return the applied field list.
+Invalid policy names return 400, stale versions return 409, and unknown L2
+adapter IDs return 404. Validation errors never partially apply an update.
+
+## Future Extensions
+
+Coordinator fan-out can use the same versioned domain API without changing
+controller ownership. Stateful eviction policy migration remains a separate
+extension and requires an explicit snapshot/import compatibility contract.

--- a/docs/design/v1/mp_coordinator/runtime_policy.md
+++ b/docs/design/v1/mp_coordinator/runtime_policy.md
@@ -1,0 +1,91 @@
+# Runtime policy coordination
+
+## Scope
+
+This document describes the coordinator side of the runtime management-policy
+API from issue #4360. The node-local API is implemented by
+``multiprocess/http_apis/policy_api.py``. This phase adds a coordinator proxy
+and a fleet fan-out layer; it does not migrate cache state or change the
+configured storage topology.
+
+## Endpoints
+
+The coordinator exposes direct proxy endpoints for one registered MP server:
+
+| Method | Path | Semantics |
+| --- | --- | --- |
+| ``GET`` | ``/instances/{instance_id}/config/policies`` | Read node-local state |
+| ``POST`` | ``/instances/{instance_id}/config/policies/validate`` | Validate without applying |
+| ``PATCH`` | ``/instances/{instance_id}/config/policies`` | Apply node-local update |
+
+Fleet endpoints target every currently registered instance:
+
+| Method | Path | Semantics |
+| --- | --- | --- |
+| ``POST`` | ``/fleet/config/policies/validate`` | Validate all targets |
+| ``PATCH`` | ``/fleet/config/policies`` | Validate all, then apply all |
+
+Fleet requests wrap the node-local update because versions are node-local:
+
+```json
+{
+  "update": {
+    "store_policy": "lru",
+    "l1_eviction": {"tunables": {"eviction_ratio": 0.2}}
+  },
+  "expected_versions": {
+    "node-a": 4,
+    "node-b": 7
+  }
+}
+```
+
+The optional ``expected_versions`` map is keyed by registered instance id. A
+fleet request must not put ``expected_version`` inside ``update``. For a
+``PATCH`` that omits a node's version, the coordinator uses the version
+returned by that node's validation response as the apply precondition. This
+keeps the normal path protected against a concurrent update between validation
+and apply while still allowing a caller to provide explicit versions.
+
+## Fan-out semantics
+
+Fleet ``PATCH`` is a two-stage best-effort operation:
+
+1. The coordinator snapshots the registered instances and sends validation
+   requests concurrently to all of them.
+2. If any validation fails or a target is unreachable, no ``PATCH`` requests
+   are sent. The response is ``status: "rejected"`` with one result per target.
+3. If validation succeeds, the coordinator sends fenced ``PATCH`` requests
+   concurrently. It reports ``status: "updated"`` only when every target
+   succeeds. A failure after the barrier returns ``status: "partial"`` and
+   preserves each target's status code and response body.
+
+This is deliberately not an atomic distributed transaction. There is no
+rollback in this phase: a caller can inspect the result list and retry only
+the failed or stale targets. Version conflicts are reported as HTTP 409,
+transport failures as HTTP 502, and validation errors as HTTP 400 when no more
+specific status applies. An empty registry is HTTP 404.
+
+Every successful node-local validation response must contain its current
+``version``. A malformed response is treated as a coordinator-side validation
+failure, and no apply is attempted.
+
+## Ownership and lifecycle
+
+``InstanceRegistry`` remains the sole source of target addresses. The policy
+manager only translates an ``MPInstance`` into ``http://ip:http_port`` and
+does not cache membership or policy state. The router is auto-discovered by
+the coordinator's existing ``*_api.py`` convention.
+
+The coordinator's existing lifespan-owned ``httpx.AsyncClient`` is reused for
+all direct and fleet calls. Registration and heartbeat health checks can remove
+an instance after the target snapshot; an in-flight request still reports that
+target's result, while later calls use the new registry snapshot.
+
+## Deliberate non-goals
+
+- No cross-node atomic commit or rollback.
+- No durable policy desired-state store.
+- No automatic retry, quorum, or leader election.
+- No eviction-class replacement or L2 adapter migration; those remain
+  ``state_migration_required`` node-local errors until the later phase.

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -121,6 +121,17 @@ compatibility with the vLLM-embedded API server.
      - Enumerate the live cache adapters (``type_name``, ``tier``, ``primary``,
        ``reconfigurable``). Supersedes ``/reconfigure/backends``.
    * - GET
+     - ``/config/policies``
+     - Return runtime management-policy state, version, and hot-update
+       capabilities.
+   * - POST
+     - ``/config/policies/validate``
+     - Validate a runtime policy update without applying it.
+   * - PATCH
+     - ``/config/policies``
+     - Apply a node-local runtime update to store, prefetch, or eviction policy
+       settings.
+   * - GET
      - ``/version``
      - Combined version string (``"<version>-<commit_id>"``).
    * - GET
@@ -202,6 +213,39 @@ compatibility with the vLLM-embedded API server.
    * - POST
      - ``/reconfigure/{backend}/{operation}``
      - Apply one runtime reconfiguration operation to a backend adapter.
+
+**Runtime management policy**
+
+``GET /config/policies`` reports the current runtime policy version and the
+fields that can be updated without restarting the server. Phase 1 supports
+the registered ``store_policy`` and ``prefetch_policy`` selectors, plus the
+L1 and configured L2 eviction ``trigger_watermark`` and ``eviction_ratio``
+tunables. Eviction policy classes remain stateful and cannot be replaced at
+runtime.
+
+Use ``POST /config/policies/validate`` before ``PATCH /config/policies`` when
+an orchestrator wants to validate a change before applying it. Include the
+version returned by ``GET`` as ``expected_version`` to reject stale writes.
+Updates are not retroactive: store changes affect future store plans,
+prefetch changes affect future prefetch requests, and eviction tunables are
+read on the next eviction loop tick.
+
+Example:
+
+.. code-block:: bash
+
+   curl -s http://localhost:8080/config/policies
+
+   curl -s -X PATCH http://localhost:8080/config/policies \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "expected_version": 0,
+       "store_policy": "skip_l1",
+       "l1_eviction": {"tunables": {"eviction_ratio": 0.1}}
+     }'
+
+The update is node-local and process-local in Phase 1; it is not persisted
+across restarts and does not fan out through the MP coordinator.
 
 **Observability**
 

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -245,7 +245,65 @@ Example:
      }'
 
 The update is node-local and process-local in Phase 1; it is not persisted
-across restarts and does not fan out through the MP coordinator.
+across restarts. The coordinator fan-out endpoints below can now target the
+registered MP fleet.
+
+**Coordinator runtime management policy**
+
+The MP coordinator exposes direct proxies for a registered node:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 55 35
+
+   * - Method
+     - Path
+     - Purpose
+   * - GET
+     - ``/instances/{instance_id}/config/policies``
+     - Read one node's policy state.
+   * - POST
+     - ``/instances/{instance_id}/config/policies/validate``
+     - Validate one node's update without applying it.
+   * - PATCH
+     - ``/instances/{instance_id}/config/policies``
+     - Apply one node's update.
+
+Fleet operations address every currently registered node:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 45 45
+
+   * - Method
+     - Path
+     - Purpose
+   * - POST
+     - ``/fleet/config/policies/validate``
+     - Validate the update on every node; no update is applied.
+   * - PATCH
+     - ``/fleet/config/policies``
+     - Validate every node, then apply concurrently.
+
+Fleet bodies wrap the node-local update and can provide per-node optimistic
+versions because versions are local to each MP server:
+
+.. code-block:: json
+
+   {
+     "update": {
+       "store_policy": "skip_l1",
+       "l1_eviction": {"tunables": {"eviction_ratio": 0.1}}
+     },
+     "expected_versions": {"node-a": 4, "node-b": 7}
+   }
+
+Fleet ``PATCH`` is a validation barrier followed by best-effort apply. Any
+validation failure prevents all ``PATCH`` calls. A failure after validation
+returns ``status: "partial"`` with one result per node; there is no rollback
+or cross-node transaction in this phase. Transport failures are reported as
+``502`` and version conflicts as ``409``. A fleet request must use
+``expected_versions`` rather than the node-local ``update.expected_version``.
 
 **Observability**
 

--- a/lmcache/v1/distributed/runtime_policy.py
+++ b/lmcache/v1/distributed/runtime_policy.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Domain types for runtime management-policy updates in MP mode."""
+
+# Standard
+from dataclasses import dataclass
+from typing import Literal
+import math
+
+RuntimePolicyErrorCode = Literal[
+    "invalid_policy",
+    "invalid_value",
+    "version_conflict",
+    "restart_required",
+    "state_migration_required",
+    "unknown_l2_adapter",
+    "eviction_not_configured",
+    "duplicate_l2_adapter",
+    "invalid_update",
+    "unsupported_field",
+]
+
+_VALID_EVICTION_POLICIES = frozenset({"LRU", "IsolatedLRU", "noop"})
+
+
+@dataclass(frozen=True)
+class RuntimePolicyError(Exception):
+    """A structured validation failure for a runtime policy request."""
+
+    code: RuntimePolicyErrorCode
+    message: str
+    status_code: int = 400
+    field: str | None = None
+    current: object | None = None
+    requested: object | None = None
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
+
+    def as_dict(self) -> dict[str, object]:
+        """Return the stable JSON representation used by the HTTP API."""
+        result: dict[str, object] = {
+            "error": self.code,
+            "message": self.message,
+        }
+        if self.field is not None:
+            result["field"] = self.field
+        if self.current is not None:
+            result["current"] = self.current
+        if self.requested is not None:
+            result["requested"] = self.requested
+        return result
+
+
+@dataclass(frozen=True)
+class RuntimePolicyTunables:
+    """Mutable numeric knobs accepted by the Phase 1 runtime API."""
+
+    policy: str | None = None
+    trigger_watermark: float | None = None
+    eviction_ratio: float | None = None
+
+    def has_value(self) -> bool:
+        """Return whether the request carries at least one field."""
+        return any(
+            value is not None
+            for value in (
+                self.policy,
+                self.trigger_watermark,
+                self.eviction_ratio,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeL2EvictionUpdate:
+    """Runtime update addressed to one live L2 adapter."""
+
+    adapter_id: int
+    tunables: RuntimePolicyTunables
+
+
+@dataclass(frozen=True)
+class RuntimePolicyUpdate:
+    """A fully parsed node-local runtime policy update."""
+
+    expected_version: int | None = None
+    store_policy: str | None = None
+    prefetch_policy: str | None = None
+    l1_eviction: RuntimePolicyTunables | None = None
+    l2_eviction: tuple[RuntimeL2EvictionUpdate, ...] = ()
+    restart_required_fields: tuple[str, ...] = ()
+    unsupported_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RuntimePolicyValidation:
+    """Result of validating a policy update without applying it."""
+
+    version: int
+    changed_fields: tuple[str, ...]
+    effective_on: dict[str, str]
+
+
+@dataclass(frozen=True)
+class RuntimePolicyUpdateResult:
+    """Result of applying a validated runtime policy update."""
+
+    status: Literal["updated", "unchanged"]
+    version: int
+    applied: tuple[str, ...]
+    effective_on: dict[str, str]
+
+
+def validate_eviction_value(field: str, value: float | None) -> None:
+    """Validate a Phase 1 eviction value.
+
+    Args:
+        field: Fully qualified field name used in an error response.
+        value: Candidate value, or ``None`` when the field was omitted.
+
+    Raises:
+        RuntimePolicyError: If *value* is not finite or outside ``[0, 1]``.
+    """
+    if value is None:
+        return
+    if not math.isfinite(value):
+        raise RuntimePolicyError(
+            code="invalid_value",
+            field=field,
+            requested=value,
+            message=f"{field} must be a finite number between 0 and 1",
+        )
+    if not 0.0 <= value <= 1.0:
+        raise RuntimePolicyError(
+            code="invalid_value",
+            field=field,
+            requested=value,
+            message=f"{field} must be between 0 and 1",
+        )
+
+
+def validate_eviction_policy(field: str, policy: str | None) -> None:
+    """Validate an eviction policy selector without changing state."""
+    if policy is None or policy in _VALID_EVICTION_POLICIES:
+        return
+    raise RuntimePolicyError(
+        code="invalid_policy",
+        field=field,
+        requested=policy,
+        message=(
+            f"{field} must be one of {', '.join(sorted(_VALID_EVICTION_POLICIES))}"
+        ),
+    )

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -101,6 +101,7 @@ class L1EvictionController(EvictionController):
     ):
         super().__init__()
         self._eviction_config = eviction_config
+        self._config_lock = threading.Lock()
         self._eviction_policy = CreateEvictionPolicy(eviction_config)
         self._l1_manager = l1_manager
         self._listener = L1EvictionPolicy(self._eviction_policy)
@@ -109,13 +110,36 @@ class L1EvictionController(EvictionController):
         self._last_extra_log = time.monotonic()
 
     def report_status(self) -> dict:
+        with self._config_lock:
+            eviction_policy = self._eviction_config.eviction_policy
+            trigger_watermark = self._eviction_config.trigger_watermark
+            eviction_ratio = self._eviction_config.eviction_ratio
         return {
             "is_healthy": self._thread.is_alive(),
             "thread_alive": self._thread.is_alive(),
-            "eviction_policy": self._eviction_config.eviction_policy,
-            "trigger_watermark": self._eviction_config.trigger_watermark,
-            "eviction_ratio": self._eviction_config.eviction_ratio,
+            "eviction_policy": eviction_policy,
+            "trigger_watermark": trigger_watermark,
+            "eviction_ratio": eviction_ratio,
         }
+
+    def update_tunables(
+        self,
+        trigger_watermark: float | None,
+        eviction_ratio: float | None,
+    ) -> None:
+        """Update numeric L1 eviction tunables for future loop ticks.
+
+        Args:
+            trigger_watermark: New trigger watermark, or ``None`` to retain
+                the current value.
+            eviction_ratio: New eviction ratio, or ``None`` to retain the
+                current value.
+        """
+        with self._config_lock:
+            if trigger_watermark is not None:
+                self._eviction_config.trigger_watermark = trigger_watermark
+            if eviction_ratio is not None:
+                self._eviction_config.eviction_ratio = eviction_ratio
 
     def _publish_skipped(self, usage: float, watermark: float) -> None:
         """Publish a below-watermark loop tick (no eviction this cycle)."""
@@ -158,13 +182,14 @@ class L1EvictionController(EvictionController):
         )
 
     def eviction_loop(self):
-        watermark = self._eviction_config.trigger_watermark
-        eviction_ratio = self._eviction_config.eviction_ratio
-
         while not self._stop_flag.is_set():
             time.sleep(1)
+            with self._config_lock:
+                watermark = self._eviction_config.trigger_watermark
+                eviction_ratio = self._eviction_config.eviction_ratio
+                extra_logging_enabled = self._eviction_config.extra_logging_enabled
             used_bytes, total_bytes = self._l1_manager.get_memory_usage()
-            if self._eviction_config.extra_logging_enabled:
+            if extra_logging_enabled:
                 self._maybe_log_memory_usage(used_bytes, total_bytes)
             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
             if usage < watermark:
@@ -271,6 +296,45 @@ class L2EvictionController(StorageControllerInterface):
                 s for s in self._adapter_states if s.adapter_id != adapter_id
             ]
 
+    def update_tunables(
+        self,
+        adapter_id: int,
+        trigger_watermark: float | None,
+        eviction_ratio: float | None,
+    ) -> None:
+        """Update one adapter's eviction tunables for future loop ticks.
+
+        Args:
+            adapter_id: Stable StorageManager adapter id.
+            trigger_watermark: New watermark, or ``None`` to retain it.
+            eviction_ratio: New ratio, or ``None`` to retain it.
+
+        Raises:
+            KeyError: If the adapter has no active eviction state.
+        """
+        with self._states_lock:
+            for state in self._adapter_states:
+                if state.adapter_id != adapter_id:
+                    continue
+                if trigger_watermark is not None:
+                    state.eviction_config.trigger_watermark = trigger_watermark
+                if eviction_ratio is not None:
+                    state.eviction_config.eviction_ratio = eviction_ratio
+                return
+        raise KeyError(adapter_id)
+
+    def get_policy_status(self) -> dict[int, dict[str, object]]:
+        """Return current policy and tunable values keyed by adapter id."""
+        with self._states_lock:
+            return {
+                state.adapter_id: {
+                    "eviction_policy": state.eviction_config.eviction_policy,
+                    "trigger_watermark": state.eviction_config.trigger_watermark,
+                    "eviction_ratio": state.eviction_config.eviction_ratio,
+                }
+                for state in self._adapter_states
+            }
+
     def report_status(self) -> dict:
         # NOTE: ``usage.bytes_by_cache_salt`` is intentionally NOT
         # surfaced here. A deployment can have 10k+ salts, so embedding
@@ -280,14 +344,24 @@ class L2EvictionController(StorageControllerInterface):
         # ``StorageManager.get_usage_bytes_by_cache_salt``).
         adapter_statuses = []
         with self._states_lock:
-            states = list(self._adapter_states)
-        for state in states:
-            usage = state.adapter.get_usage()
+            states = [
+                (
+                    state.adapter_id,
+                    state.adapter,
+                    state.eviction_config.eviction_policy,
+                    state.eviction_config.trigger_watermark,
+                    state.eviction_config.eviction_ratio,
+                )
+                for state in self._adapter_states
+            ]
+        for adapter_id, adapter, eviction_policy, watermark, ratio in states:
+            usage = adapter.get_usage()
             adapter_statuses.append(
                 {
-                    "eviction_policy": state.eviction_config.eviction_policy,
-                    "trigger_watermark": state.eviction_config.trigger_watermark,
-                    "eviction_ratio": state.eviction_config.eviction_ratio,
+                    "adapter_id": adapter_id,
+                    "eviction_policy": eviction_policy,
+                    "trigger_watermark": watermark,
+                    "eviction_ratio": ratio,
                     "current_usage": usage.usage_fraction,
                     "total_bytes_used": usage.total_bytes_used,
                     "total_capacity_bytes": usage.total_capacity_bytes,

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -141,6 +141,9 @@ class InFlightPrefetchRequest:
     keys: list[ObjectKey]
     layout_desc: MemoryLayoutDesc
     phase: PrefetchPhase
+    prefetch_policy: PrefetchPolicy
+    """Policy captured when this request entered the lookup phase."""
+
     extra_count: int = 0
     """Extra read locks per key (on top of the default 1) to acquire when
     transitioning from write-locked to read-locked.  Must match the
@@ -226,6 +229,7 @@ class PrefetchController(StorageControllerInterface):
             desc.index: desc for desc in adapter_descriptors
         }
         self._policy = policy
+        self._policy_lock = threading.Lock()
         self._max_in_flight = max_in_flight
 
         # Adapters that are being drained and will be removed after all
@@ -452,6 +456,18 @@ class PrefetchController(StorageControllerInterface):
             "num_active_adapters": len(self._l2_adapters) - len(self._draining),
             "num_draining_adapters": len(self._draining),
         }
+
+    def update_policy(self, policy: PrefetchPolicy) -> None:
+        """Replace the policy used for future prefetch requests.
+
+        Requests that already entered the lookup phase retain their captured
+        policy through load planning and completion.
+
+        Args:
+            policy: New policy instance to use for future requests.
+        """
+        with self._policy_lock:
+            self._policy = policy
 
     def get_adapter_state_observations(
         self,
@@ -762,6 +778,7 @@ class PrefetchController(StorageControllerInterface):
             self._complete_request(request_id, Bitmap(len(spec.keys)))
             return
 
+        prefetch_policy = self._get_policy()
         pending_lookup_tasks: dict[int, L2TaskId] = {}
         for adapter_id, adapter in routing_adapters.items():
             task_id = adapter.submit_lookup_and_lock_task(spec.keys, spec.layout_desc)
@@ -772,6 +789,7 @@ class PrefetchController(StorageControllerInterface):
             keys=spec.keys,
             layout_desc=spec.layout_desc,
             phase=PrefetchPhase.LOOKUP,
+            prefetch_policy=prefetch_policy,
             extra_count=spec.extra_count,
             policy=spec.policy,
             attn_desc=spec.attn_desc,
@@ -811,7 +829,7 @@ class PrefetchController(StorageControllerInterface):
             for adapter_id, desc in self._adapter_descriptors.items()
             if adapter_id not in self._draining
         ]
-        load_plan = self._policy.select_load_plan(
+        load_plan = request.prefetch_policy.select_load_plan(
             request.keys,
             request.lookup_results,
             routing_descriptors,
@@ -849,7 +867,7 @@ class PrefetchController(StorageControllerInterface):
         if request.mode is PrefetchMode.WARM:
             retentions = [True] * len(keys_to_reserve)
         else:
-            retentions = self._policy.select_l1_retentions(
+            retentions = request.prefetch_policy.select_l1_retentions(
                 keys_to_reserve,
             )
         write_results = l1_mgr.reserve_write(
@@ -1214,3 +1232,8 @@ class PrefetchController(StorageControllerInterface):
                 len(request.keys),
             )
         self._in_flight_requests.clear()
+
+    def _get_policy(self) -> PrefetchPolicy:
+        """Return the current policy for a newly started request."""
+        with self._policy_lock:
+            return self._policy

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -183,6 +183,9 @@ class InFlightStoreTask:
     """The subset of keys for which reserve_read succeeded
     (i.e., keys holding an L1 read lock that must be released)."""
 
+    policy: StorePolicy
+    """Policy captured when this task was planned."""
+
     l2_store_result: bool | None = None
     """L2 outcome (True=success, False=failure, None=still in flight)."""
 
@@ -239,6 +242,7 @@ class StoreController(StorageControllerInterface):
             desc.index: desc for desc in adapter_descriptors
         }
         self._policy = policy
+        self._policy_lock = threading.Lock()
 
         # Adapters that are being drained and will be removed after all
         # the in-flight operations are done.
@@ -333,6 +337,19 @@ class StoreController(StorageControllerInterface):
             "num_active_adapters": len(self._l2_adapters) - num_draining,
             "num_draining_adapters": num_draining,
         }
+
+    def update_policy(self, policy: StorePolicy) -> None:
+        """Replace the policy used for future store planning.
+
+        In-flight tasks retain the policy instance captured when they were
+        submitted, so changing the controller policy does not change the L1
+        deletion decision for work already in progress.
+
+        Args:
+            policy: New policy instance to use for future store tasks.
+        """
+        with self._policy_lock:
+            self._policy = policy
 
     def add_adapter(
         self,
@@ -580,7 +597,9 @@ class StoreController(StorageControllerInterface):
             for adapter_id, desc in self._adapter_descriptors.items()
             if adapter_id not in self._draining
         ]
-        plan = self._policy.select_store_targets(keys, routing_descriptors)
+        with self._policy_lock:
+            policy = self._policy
+        plan = policy.select_store_targets(keys, routing_descriptors)
 
         l1_mgr = self._l1_manager
 
@@ -659,6 +678,7 @@ class StoreController(StorageControllerInterface):
                 adapter_index=adapter_index,
                 keys=successful_keys,
                 read_locked_keys=list(successful_keys),
+                policy=policy,
             )
             self._status_in_flight_count += 1
 
@@ -759,7 +779,7 @@ class StoreController(StorageControllerInterface):
                 adapter_index,
                 len(task.keys),
             )
-            delete_keys = self._policy.select_l1_deletions(task.keys)
+            delete_keys = task.policy.select_l1_deletions(task.keys)
             if delete_keys:
                 l1_mgr.delete(delete_keys)
         else:

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -6,7 +6,7 @@ Distributed multi-tier storage manager for MP mode
 # Standard
 from contextlib import contextmanager
 from dataclasses import replace
-from typing import Iterator, Literal, Optional
+from typing import Iterator, Literal, Optional, cast
 import threading
 import time
 
@@ -34,6 +34,14 @@ from lmcache.v1.distributed.l2_adapters.reconfiguration import (
 )
 from lmcache.v1.distributed.l2_adapters.serde_wrapper import SerdeL2AdapterWrapper
 from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.distributed.runtime_policy import (
+    RuntimePolicyError,
+    RuntimePolicyUpdate,
+    RuntimePolicyUpdateResult,
+    RuntimePolicyValidation,
+    validate_eviction_policy,
+    validate_eviction_value,
+)
 from lmcache.v1.distributed.serde import create_serde_processor
 from lmcache.v1.distributed.storage_controllers import (
     L1EvictionController,
@@ -44,10 +52,13 @@ from lmcache.v1.distributed.storage_controllers import (
 )
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     create_prefetch_policy,
+    get_registered_prefetch_policies,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    StorePolicy,
     create_store_policy,
+    get_registered_store_policies,
 )
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
@@ -68,6 +79,10 @@ class StorageManager:
     def __init__(self, config: StorageManagerConfig):
         self._l1_manager = L1Manager(config.l1_manager_config)
         self._event_bus = get_event_bus()
+        self._runtime_policy_lock = threading.Lock()
+        self._runtime_policy_version = 0
+        self._runtime_store_policy_name = config.store_policy
+        self._runtime_prefetch_policy_name = config.prefetch_policy
 
         # L1 eviction controller
         self._eviction_controller = L1EvictionController(
@@ -985,8 +1000,11 @@ class StorageManager:
         l2_eviction = self._l2_eviction_controller.report_status()
         adapters = [a.report_status() for _id, _desc, a in self._snapshot_adapters()]
         children = [l1, store, prefetch, l1_eviction, l2_eviction] + adapters
+        with self._runtime_policy_lock:
+            runtime_policy_version = self._runtime_policy_version
         return {
             "is_healthy": all(c["is_healthy"] for c in children),
+            "runtime_policy_version": runtime_policy_version,
             "l1_manager": l1,
             "store_controller": store,
             "prefetch_controller": prefetch,
@@ -995,6 +1013,179 @@ class StorageManager:
             "l2_adapters": adapters,
             "num_l2_adapters": len(adapters),
         }
+
+    def get_runtime_policy(self) -> dict[str, object]:
+        """Return runtime policy state and hot-update capabilities."""
+        with self._runtime_policy_lock:
+            return self._get_runtime_policy_locked()
+
+    def _get_runtime_policy_locked(self) -> dict[str, object]:
+        """Return runtime policy state and hot-update capabilities.
+
+        Returns:
+            A JSON-serializable mapping containing the monotonic runtime
+            policy version, current selector names, and capability metadata.
+        """
+        version = self._runtime_policy_version
+        store_policy = self._runtime_store_policy_name
+        prefetch_policy = self._runtime_prefetch_policy_name
+
+        l1_status = self._eviction_controller.report_status()
+        l2_status = self._l2_eviction_controller.get_policy_status()
+        l2_capabilities: list[dict[str, object]] = []
+        for adapter_id, descriptor, _adapter in self._snapshot_adapters():
+            eviction = l2_status.get(adapter_id)
+            if eviction is None:
+                l2_capabilities.append(
+                    {
+                        "adapter_id": adapter_id,
+                        "adapter_name": descriptor.type_name,
+                        "eviction_enabled": False,
+                        "policy": None,
+                        "policy_hot_swappable": False,
+                        "stateful": True,
+                        "runtime_tunables": {},
+                    }
+                )
+                continue
+            l2_capabilities.append(
+                {
+                    "adapter_id": adapter_id,
+                    "adapter_name": descriptor.type_name,
+                    "eviction_enabled": True,
+                    "policy": eviction["eviction_policy"],
+                    "policy_hot_swappable": False,
+                    "stateful": True,
+                    "runtime_tunables": self._eviction_tunable_capabilities(
+                        cast(float, eviction["trigger_watermark"]),
+                        cast(float, eviction["eviction_ratio"]),
+                    ),
+                }
+            )
+
+        return {
+            "version": version,
+            "capabilities": {
+                "store_policy": {
+                    "current": store_policy,
+                    "registered": get_registered_store_policies(),
+                    "hot_swappable": True,
+                    "stateful": False,
+                    "effective_on": "next_store_plan",
+                },
+                "prefetch_policy": {
+                    "current": prefetch_policy,
+                    "registered": get_registered_prefetch_policies(),
+                    "hot_swappable": True,
+                    "stateful": False,
+                    "effective_on": "next_prefetch_request",
+                },
+                "l1_eviction": {
+                    "policy": l1_status["eviction_policy"],
+                    "policy_hot_swappable": False,
+                    "stateful": True,
+                    "runtime_tunables": self._eviction_tunable_capabilities(
+                        float(l1_status["trigger_watermark"]),
+                        float(l1_status["eviction_ratio"]),
+                    ),
+                },
+                "l2_eviction": l2_capabilities,
+            },
+        }
+
+    def validate_runtime_policy_update(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyValidation:
+        """Validate a runtime policy update without mutating controllers.
+
+        Args:
+            update: Parsed node-local policy update.
+
+        Returns:
+            The current version, changed field names, and effective-on
+            semantics for the update.
+
+        Raises:
+            RuntimePolicyError: If the update is invalid or unsafe to apply.
+        """
+        with self._runtime_policy_lock:
+            with self._lifecycle_lock:
+                return self._validate_runtime_policy_update_locked(update)
+
+    def update_runtime_policy(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyUpdateResult:
+        """Atomically apply a validated node-local runtime policy update.
+
+        Args:
+            update: Parsed node-local policy update.
+
+        Returns:
+            The new runtime version and the fields that were applied.
+
+        Raises:
+            RuntimePolicyError: If the update is invalid or unsafe to apply.
+        """
+        with self._runtime_policy_lock:
+            with self._lifecycle_lock:
+                validation = self._validate_runtime_policy_update_locked(update)
+                if not validation.changed_fields:
+                    return RuntimePolicyUpdateResult(
+                        status="unchanged",
+                        version=self._runtime_policy_version,
+                        applied=(),
+                        effective_on={},
+                    )
+
+                store_policy: StorePolicy | None = None
+                if update.store_policy is not None:
+                    store_policy = create_store_policy(update.store_policy)
+                prefetch_policy = None
+                if update.prefetch_policy is not None:
+                    prefetch_policy = create_prefetch_policy(update.prefetch_policy)
+
+                if store_policy is not None:
+                    self._store_controller.update_policy(store_policy)
+                    self._runtime_store_policy_name = str(update.store_policy)
+                if prefetch_policy is not None:
+                    self._prefetch_controller.update_policy(prefetch_policy)
+                    self._runtime_prefetch_policy_name = str(update.prefetch_policy)
+
+                l1_eviction = update.l1_eviction
+                if l1_eviction is not None:
+                    self._eviction_controller.update_tunables(
+                        l1_eviction.trigger_watermark,
+                        l1_eviction.eviction_ratio,
+                    )
+
+                for l2_update in update.l2_eviction:
+                    self._l2_eviction_controller.update_tunables(
+                        l2_update.adapter_id,
+                        l2_update.tunables.trigger_watermark,
+                        l2_update.tunables.eviction_ratio,
+                    )
+
+                old_version = self._runtime_policy_version
+                self._runtime_policy_version += 1
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.RUNTIME_POLICY_UPDATED,
+                        metadata={
+                            "old_version": old_version,
+                            "new_version": self._runtime_policy_version,
+                            "changed_fields": list(validation.changed_fields),
+                            "source": "http",
+                        },
+                    )
+                )
+                return RuntimePolicyUpdateResult(
+                    status="updated",
+                    version=self._runtime_policy_version,
+                    applied=validation.changed_fields,
+                    effective_on=validation.effective_on,
+                )
 
     def register_l2_listener(self, listener: L2AdapterListener) -> None:
         """Register a listener on all current and future L2 adapters.
@@ -1019,6 +1210,207 @@ class StorageManager:
             True if memory is consistent, False otherwise.
         """
         return self._l1_manager.memcheck()
+
+    def _validate_runtime_policy_update_locked(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyValidation:
+        """Validate *update* while ``_runtime_policy_lock`` is held."""
+        if (
+            update.expected_version is not None
+            and update.expected_version != self._runtime_policy_version
+        ):
+            raise RuntimePolicyError(
+                code="version_conflict",
+                status_code=409,
+                field="expected_version",
+                current=self._runtime_policy_version,
+                requested=update.expected_version,
+                message=(
+                    "runtime policy version changed; read the current policy "
+                    "and retry the update"
+                ),
+            )
+        if update.restart_required_fields:
+            field = update.restart_required_fields[0]
+            raise RuntimePolicyError(
+                code="restart_required",
+                field=field,
+                message=f"{field} affects startup-only storage semantics",
+            )
+        if update.unsupported_fields:
+            field = update.unsupported_fields[0]
+            raise RuntimePolicyError(
+                code="unsupported_field",
+                field=field,
+                message=f"runtime policy does not support field {field!r}",
+            )
+
+        changed_fields: list[str] = []
+        effective_on: dict[str, str] = {}
+
+        def record(field: str, effective: str) -> None:
+            changed_fields.append(field)
+            effective_on[field] = effective
+
+        if update.store_policy is not None:
+            try:
+                create_store_policy(update.store_policy)
+            except ValueError as exc:
+                raise RuntimePolicyError(
+                    code="invalid_policy",
+                    field="store_policy",
+                    requested=update.store_policy,
+                    message=str(exc),
+                ) from exc
+            if update.store_policy != self._runtime_store_policy_name:
+                record("store_policy", "next_store_plan")
+
+        if update.prefetch_policy is not None:
+            try:
+                create_prefetch_policy(update.prefetch_policy)
+            except ValueError as exc:
+                raise RuntimePolicyError(
+                    code="invalid_policy",
+                    field="prefetch_policy",
+                    requested=update.prefetch_policy,
+                    message=str(exc),
+                ) from exc
+            if update.prefetch_policy != self._runtime_prefetch_policy_name:
+                record("prefetch_policy", "next_prefetch_request")
+
+        l1_status = self._eviction_controller.report_status()
+        if update.l1_eviction is not None:
+            tunables = update.l1_eviction
+            if not tunables.has_value():
+                raise RuntimePolicyError(
+                    code="invalid_update",
+                    field="l1_eviction",
+                    message="l1_eviction must contain a policy or tunable",
+                )
+            current_policy = str(l1_status["eviction_policy"])
+            validate_eviction_policy("l1_eviction.policy", tunables.policy)
+            if tunables.policy is not None and tunables.policy != current_policy:
+                raise RuntimePolicyError(
+                    code="state_migration_required",
+                    field="l1_eviction.policy",
+                    current=current_policy,
+                    requested=tunables.policy,
+                    message=(
+                        "changing the eviction policy class requires a policy "
+                        "snapshot/import contract"
+                    ),
+                )
+            validate_eviction_value(
+                "l1_eviction.trigger_watermark", tunables.trigger_watermark
+            )
+            validate_eviction_value(
+                "l1_eviction.eviction_ratio", tunables.eviction_ratio
+            )
+            if (
+                tunables.trigger_watermark is not None
+                and tunables.trigger_watermark != float(l1_status["trigger_watermark"])
+            ):
+                record("l1_eviction.trigger_watermark", "next_eviction_loop_tick")
+            if tunables.eviction_ratio is not None and tunables.eviction_ratio != float(
+                l1_status["eviction_ratio"]
+            ):
+                record("l1_eviction.eviction_ratio", "next_eviction_loop_tick")
+
+        active_adapter_ids = {
+            adapter_id
+            for adapter_id, _descriptor, _adapter in self._snapshot_adapters()
+        }
+        l2_status = self._l2_eviction_controller.get_policy_status()
+        seen_adapter_ids: set[int] = set()
+        for l2_update in update.l2_eviction:
+            adapter_id = l2_update.adapter_id
+            if adapter_id in seen_adapter_ids:
+                raise RuntimePolicyError(
+                    code="duplicate_l2_adapter",
+                    field=f"l2_eviction[{adapter_id}]",
+                    requested=adapter_id,
+                    message=f"adapter id {adapter_id} appears more than once",
+                )
+            seen_adapter_ids.add(adapter_id)
+            if adapter_id not in active_adapter_ids:
+                raise RuntimePolicyError(
+                    code="unknown_l2_adapter",
+                    status_code=404,
+                    field=f"l2_eviction[{adapter_id}]",
+                    requested=adapter_id,
+                    message=f"L2 adapter {adapter_id} is not active",
+                )
+            current = l2_status.get(adapter_id)
+            if current is None:
+                raise RuntimePolicyError(
+                    code="eviction_not_configured",
+                    field=f"l2_eviction[{adapter_id}]",
+                    requested=adapter_id,
+                    message=f"L2 adapter {adapter_id} has no eviction policy",
+                )
+            tunables = l2_update.tunables
+            if not tunables.has_value():
+                raise RuntimePolicyError(
+                    code="invalid_update",
+                    field=f"l2_eviction[{adapter_id}]",
+                    message="the adapter update must contain a policy or tunable",
+                )
+            current_policy = str(current["eviction_policy"])
+            policy_field = f"l2_eviction[{adapter_id}].policy"
+            validate_eviction_policy(policy_field, tunables.policy)
+            if tunables.policy is not None and tunables.policy != current_policy:
+                raise RuntimePolicyError(
+                    code="state_migration_required",
+                    field=policy_field,
+                    current=current_policy,
+                    requested=tunables.policy,
+                    message=(
+                        "changing the eviction policy class requires a policy "
+                        "snapshot/import contract"
+                    ),
+                )
+            watermark_field = f"l2_eviction[{adapter_id}].trigger_watermark"
+            ratio_field = f"l2_eviction[{adapter_id}].eviction_ratio"
+            validate_eviction_value(watermark_field, tunables.trigger_watermark)
+            validate_eviction_value(ratio_field, tunables.eviction_ratio)
+            if (
+                tunables.trigger_watermark is not None
+                and tunables.trigger_watermark
+                != cast(float, current["trigger_watermark"])
+            ):
+                record(watermark_field, "next_eviction_loop_tick")
+            if tunables.eviction_ratio is not None and tunables.eviction_ratio != cast(
+                float, current["eviction_ratio"]
+            ):
+                record(ratio_field, "next_eviction_loop_tick")
+
+        return RuntimePolicyValidation(
+            version=self._runtime_policy_version,
+            changed_fields=tuple(changed_fields),
+            effective_on=effective_on,
+        )
+
+    @staticmethod
+    def _eviction_tunable_capabilities(
+        trigger_watermark: float,
+        eviction_ratio: float,
+    ) -> dict[str, dict[str, object]]:
+        """Build capability metadata for the two Phase 1 eviction knobs."""
+        return {
+            "trigger_watermark": {
+                "current": trigger_watermark,
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "effective_on": "next_eviction_loop_tick",
+            },
+            "eviction_ratio": {
+                "current": eviction_ratio,
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "effective_on": "next_eviction_loop_tick",
+            },
+        }
 
     def _snapshot_adapters(
         self,

--- a/lmcache/v1/mp_coordinator/cache_control/policy_manager.py
+++ b/lmcache/v1/mp_coordinator/cache_control/policy_manager.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator-side proxy for node-local runtime policy APIs."""
+
+# Standard
+from typing import Any
+
+# Third Party
+import httpx
+
+# First Party
+from lmcache.v1.mp_coordinator.registry import MPInstance
+
+
+class RuntimePolicyManager:
+    """Send runtime-policy requests to registered MP servers."""
+
+    async def request(
+        self,
+        target: MPInstance,
+        http_client: httpx.AsyncClient,
+        method: str,
+        body: dict[str, Any] | None = None,
+    ) -> tuple[int, Any]:
+        """Proxy one policy request and decode its JSON response.
+
+        Args:
+            target: The registered MP server to call.
+            http_client: Coordinator-owned outbound HTTP client.
+            method: HTTP method for the node-local policy endpoint.
+            body: Optional JSON request body.
+
+        Returns:
+            The node's status code and decoded JSON body.
+
+        Raises:
+            httpx.HTTPError: If the coordinator cannot reach the target.
+        """
+        url = f"http://{target.ip}:{target.http_port}/config/policies"
+        response = await http_client.request(method, url, json=body)
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {"detail": response.text}
+        return response.status_code, payload

--- a/lmcache/v1/mp_coordinator/cache_control/policy_manager.py
+++ b/lmcache/v1/mp_coordinator/cache_control/policy_manager.py
@@ -20,6 +20,7 @@ class RuntimePolicyManager:
         http_client: httpx.AsyncClient,
         method: str,
         body: dict[str, Any] | None = None,
+        endpoint: str = "/config/policies",
     ) -> tuple[int, Any]:
         """Proxy one policy request and decode its JSON response.
 
@@ -28,6 +29,7 @@ class RuntimePolicyManager:
             http_client: Coordinator-owned outbound HTTP client.
             method: HTTP method for the node-local policy endpoint.
             body: Optional JSON request body.
+            endpoint: Node-local policy endpoint path.
 
         Returns:
             The node's status code and decoded JSON body.
@@ -35,7 +37,7 @@ class RuntimePolicyManager:
         Raises:
             httpx.HTTPError: If the coordinator cannot reach the target.
         """
-        url = f"http://{target.ip}:{target.http_port}/config/policies"
+        url = f"http://{target.ip}:{target.http_port}{endpoint}"
         response = await http_client.request(method, url, json=body)
         try:
             payload = response.json()

--- a/lmcache/v1/mp_coordinator/http_apis/policy_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/policy_api.py
@@ -124,6 +124,7 @@ async def _proxy_direct(
     instance_id: str,
     method: str,
     body: dict[str, Any] | None = None,
+    endpoint: str = "/config/policies",
 ) -> JSONResponse:
     """Proxy one node-local request through the registry."""
     ctx = get_context(request)
@@ -135,7 +136,7 @@ async def _proxy_direct(
         )
     try:
         status_code, payload = await _policy_manager.request(
-            target, _client_or_503(request), method, body
+            target, _client_or_503(request), method, body, endpoint
         )
     except httpx.HTTPError as error:
         raise HTTPException(
@@ -153,7 +154,7 @@ async def _validate_target(
     """Validate one target and turn transport errors into result records."""
     try:
         status_code, payload = await _policy_manager.request(
-            target, client, "POST", body
+            target, client, "POST", body, "/config/policies/validate"
         )
     except httpx.HTTPError as error:
         return _error_result(target.instance_id, error)
@@ -210,7 +211,7 @@ async def _apply_target(
     """Apply one target after the fleet validation barrier."""
     try:
         status_code, payload = await _policy_manager.request(
-            target, client, "PATCH", body
+            target, client, "PATCH", body, "/config/policies"
         )
     except httpx.HTTPError as error:
         return _error_result(target.instance_id, error)
@@ -228,7 +229,13 @@ async def validate_instance_policies(
     instance_id: str, body: RuntimePolicyUpdateRequest, request: Request
 ) -> JSONResponse:
     """Proxy node-local policy validation through the coordinator."""
-    return await _proxy_direct(request, instance_id, "POST", _direct_body(body))
+    return await _proxy_direct(
+        request,
+        instance_id,
+        "POST",
+        _direct_body(body),
+        "/config/policies/validate",
+    )
 
 
 @router.patch("/instances/{instance_id}/config/policies", response_model=None)

--- a/lmcache/v1/mp_coordinator/http_apis/policy_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/policy_api.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator proxy and fleet fan-out for runtime management policies."""
+
+# Standard
+from typing import Annotated, Any
+import asyncio
+
+# Third Party
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+import httpx
+
+# First Party
+from lmcache.v1.mp_coordinator.cache_control.policy_manager import (
+    RuntimePolicyManager,
+)
+from lmcache.v1.mp_coordinator.http_apis.dependencies import (
+    CoordinatorContext,
+    get_context,
+    get_outbound_client,
+)
+from lmcache.v1.mp_coordinator.registry import MPInstance
+from lmcache.v1.multiprocess.http_apis.policy_api import RuntimePolicyUpdateRequest
+
+router = APIRouter()
+_policy_manager = RuntimePolicyManager()
+
+
+class FleetRuntimePolicyUpdateRequest(BaseModel):
+    """Body for coordinator fleet policy validation and updates.
+
+    ``expected_versions`` is keyed by instance id because policy versions are
+    node-local. When a key is omitted from a PATCH request, the coordinator
+    uses the version observed during its all-target validation pass as the
+    precondition for that node.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    update: RuntimePolicyUpdateRequest
+    expected_versions: dict[str, Annotated[int, Field(ge=0)]] = Field(
+        default_factory=dict
+    )
+
+    @field_validator("expected_versions")
+    @classmethod
+    def _validate_instance_ids(cls, value: dict[str, int]) -> dict[str, int]:
+        """Reject blank instance ids in the optimistic version map."""
+        if any(not instance_id.strip() for instance_id in value):
+            raise ValueError("expected_versions contains a blank instance_id")
+        return value
+
+
+def _target_result(instance_id: str, status_code: int, body: Any) -> dict[str, Any]:
+    """Build one stable per-instance fan-out result."""
+    return {
+        "instance_id": instance_id,
+        "status_code": status_code,
+        "body": body,
+    }
+
+
+def _error_result(instance_id: str, error: Exception) -> dict[str, Any]:
+    """Represent an unreachable target without leaking an exception."""
+    return _target_result(
+        instance_id,
+        502,
+        {"error": "instance_unreachable", "detail": str(error)},
+    )
+
+
+def _all_succeeded(results: list[dict[str, Any]]) -> bool:
+    """Return whether every target completed with a 2xx response."""
+    return all(200 <= result["status_code"] < 300 for result in results)
+
+
+def _aggregate_error_status(results: list[dict[str, Any]]) -> int:
+    """Choose an actionable HTTP status for a failed fleet operation."""
+    codes = [result["status_code"] for result in results]
+    if 502 in codes:
+        return 502
+    if 409 in codes:
+        return 409
+    if 503 in codes:
+        return 503
+    if any(400 <= code < 500 for code in codes):
+        return 400
+    return 502
+
+
+def _instances(
+    ctx: CoordinatorContext,
+    expected_versions: dict[str, int],
+) -> list[MPInstance]:
+    """Snapshot and validate the fleet targets for one request."""
+    targets = sorted(ctx.registry.all_instances(), key=lambda item: item.instance_id)
+    if not targets:
+        raise HTTPException(status_code=404, detail="no MP servers are registered")
+    unknown = sorted(set(expected_versions) - {item.instance_id for item in targets})
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"expected_versions contains unknown instance(s): {unknown}",
+        )
+    return targets
+
+
+def _client_or_503(request: Request) -> httpx.AsyncClient:
+    """Resolve the lifespan-bound client with a stable API error."""
+    try:
+        return get_outbound_client(request)
+    except RuntimeError as error:
+        raise HTTPException(status_code=503, detail=str(error)) from None
+
+
+def _direct_body(body: RuntimePolicyUpdateRequest) -> dict[str, Any]:
+    """Serialize a validated node-local policy request."""
+    return body.model_dump(exclude_unset=True)
+
+
+async def _proxy_direct(
+    request: Request,
+    instance_id: str,
+    method: str,
+    body: dict[str, Any] | None = None,
+) -> JSONResponse:
+    """Proxy one node-local request through the registry."""
+    ctx = get_context(request)
+    target = ctx.registry.get(instance_id)
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no MP server registered with instance_id={instance_id!r}",
+        )
+    try:
+        status_code, payload = await _policy_manager.request(
+            target, _client_or_503(request), method, body
+        )
+    except httpx.HTTPError as error:
+        raise HTTPException(
+            status_code=502,
+            detail=f"policy request to {instance_id!r} failed: {error}",
+        ) from None
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+async def _validate_target(
+    target: MPInstance,
+    client: httpx.AsyncClient,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate one target and turn transport errors into result records."""
+    try:
+        status_code, payload = await _policy_manager.request(
+            target, client, "POST", body
+        )
+    except httpx.HTTPError as error:
+        return _error_result(target.instance_id, error)
+    return _target_result(target.instance_id, status_code, payload)
+
+
+def _validation_response(results: list[dict[str, Any]]) -> JSONResponse:
+    """Build the fleet validation response without applying any update."""
+    succeeded = _all_succeeded(results)
+    return JSONResponse(
+        status_code=200 if succeeded else _aggregate_error_status(results),
+        content={
+            "phase": "validate",
+            "status": "valid" if succeeded else "rejected",
+            "results": results,
+        },
+    )
+
+
+async def _validate_fleet(
+    request: Request,
+    body: FleetRuntimePolicyUpdateRequest,
+) -> tuple[list[MPInstance], list[dict[str, Any]]]:
+    """Run the all-target validation barrier used by validate and PATCH."""
+    if body.update.expected_version is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "fleet requests must use expected_versions; "
+                "update.expected_version is node-local"
+            ),
+        )
+    ctx = get_context(request)
+    targets = _instances(ctx, body.expected_versions)
+    client = _client_or_503(request)
+    update = body.update.model_dump(exclude_unset=True)
+
+    async def _one(target: MPInstance) -> dict[str, Any]:
+        target_update = dict(update)
+        expected_version = body.expected_versions.get(target.instance_id)
+        if expected_version is not None:
+            target_update["expected_version"] = expected_version
+        return await _validate_target(target, client, target_update)
+
+    results = list(await asyncio.gather(*(_one(target) for target in targets)))
+    return targets, results
+
+
+async def _apply_target(
+    target: MPInstance,
+    client: httpx.AsyncClient,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply one target after the fleet validation barrier."""
+    try:
+        status_code, payload = await _policy_manager.request(
+            target, client, "PATCH", body
+        )
+    except httpx.HTTPError as error:
+        return _error_result(target.instance_id, error)
+    return _target_result(target.instance_id, status_code, payload)
+
+
+@router.get("/instances/{instance_id}/config/policies", response_model=None)
+async def get_instance_policies(instance_id: str, request: Request) -> JSONResponse:
+    """Proxy a node-local policy snapshot through the coordinator."""
+    return await _proxy_direct(request, instance_id, "GET")
+
+
+@router.post("/instances/{instance_id}/config/policies/validate", response_model=None)
+async def validate_instance_policies(
+    instance_id: str, body: RuntimePolicyUpdateRequest, request: Request
+) -> JSONResponse:
+    """Proxy node-local policy validation through the coordinator."""
+    return await _proxy_direct(request, instance_id, "POST", _direct_body(body))
+
+
+@router.patch("/instances/{instance_id}/config/policies", response_model=None)
+async def update_instance_policies(
+    instance_id: str, body: RuntimePolicyUpdateRequest, request: Request
+) -> JSONResponse:
+    """Proxy a node-local policy update through the coordinator."""
+    return await _proxy_direct(request, instance_id, "PATCH", _direct_body(body))
+
+
+@router.post("/fleet/config/policies/validate", response_model=None)
+async def validate_fleet_policies(
+    body: FleetRuntimePolicyUpdateRequest, request: Request
+) -> JSONResponse:
+    """Validate one policy update against every registered MP server."""
+    _, results = await _validate_fleet(request, body)
+    return _validation_response(results)
+
+
+@router.patch("/fleet/config/policies", response_model=None)
+async def update_fleet_policies(
+    body: FleetRuntimePolicyUpdateRequest, request: Request
+) -> JSONResponse:
+    """Validate all targets, then fan out a fenced update concurrently.
+
+    The validation barrier prevents known-invalid updates from reaching any
+    node. The apply phase is intentionally best-effort: a transport failure or
+    version race after validation can leave a partial fleet update, which is
+    reported per instance for the caller to reconcile.
+    """
+    targets, validation_results = await _validate_fleet(request, body)
+    if not _all_succeeded(validation_results):
+        return JSONResponse(
+            status_code=_aggregate_error_status(validation_results),
+            content={
+                "phase": "validate",
+                "status": "rejected",
+                "results": validation_results,
+            },
+        )
+
+    versions: dict[str, int] = {}
+    for result in validation_results:
+        payload = result["body"]
+        version = payload.get("version") if isinstance(payload, dict) else None
+        if not isinstance(version, int) or isinstance(version, bool):
+            result["status_code"] = 502
+            result["body"] = {
+                "error": "invalid_validation_response",
+                "detail": "successful validation response did not include version",
+            }
+            return JSONResponse(
+                status_code=502,
+                content={
+                    "phase": "validate",
+                    "status": "rejected",
+                    "results": validation_results,
+                },
+            )
+        versions[result["instance_id"]] = version
+
+    client = _client_or_503(request)
+    update = body.update.model_dump(exclude_unset=True)
+
+    async def _one(target: MPInstance) -> dict[str, Any]:
+        target_update = dict(update)
+        target_update["expected_version"] = body.expected_versions.get(
+            target.instance_id, versions[target.instance_id]
+        )
+        return await _apply_target(target, client, target_update)
+
+    results = list(await asyncio.gather(*(_one(target) for target in targets)))
+    succeeded = _all_succeeded(results)
+    return JSONResponse(
+        status_code=200 if succeeded else _aggregate_error_status(results),
+        content={
+            "phase": "apply",
+            "status": "updated" if succeeded else "partial",
+            "results": results,
+        },
+    )

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -37,6 +37,7 @@ class EventType(Enum):
     SM_READ_PREFETCHED_FINISHED = "sm.read.prefetched_finished"
     SM_WRITE_RESERVED = "sm.write.reserved"
     SM_WRITE_FINISHED = "sm.write.finished"
+    RUNTIME_POLICY_UPDATED = "runtime.policy.updated"
 
     # L2 Store Controller events
     L2_STORE_SUBMITTED = "l2.store.submitted"

--- a/lmcache/v1/multiprocess/http_apis/policy_api.py
+++ b/lmcache/v1/multiprocess/http_apis/policy_api.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP API for node-local runtime management-policy updates."""
+
+# Standard
+from typing import Protocol, cast
+
+# Third Party
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+# First Party
+from lmcache.v1.distributed.runtime_policy import (
+    RuntimeL2EvictionUpdate,
+    RuntimePolicyError,
+    RuntimePolicyTunables,
+    RuntimePolicyUpdate,
+    RuntimePolicyUpdateResult,
+    RuntimePolicyValidation,
+)
+
+router = APIRouter()
+
+_RESTART_REQUIRED_FIELDS = frozenset(
+    {
+        "chunk_size",
+        "l1_size",
+        "l1_size_gb",
+        "l1_memory",
+        "memory_layout",
+        "serde",
+        "l2_adapter",
+        "l2_adapter_type",
+    }
+)
+
+
+class EvictionTunablesRequest(BaseModel):
+    """Wire model for numeric eviction knobs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trigger_watermark: float | None = Field(default=None, ge=0.0, le=1.0)
+    eviction_ratio: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class EvictionUpdateRequest(BaseModel):
+    """Wire model for one eviction policy plane."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    policy: str | None = None
+    tunables: EvictionTunablesRequest | None = None
+
+
+class L2EvictionUpdateRequest(EvictionUpdateRequest):
+    """Wire model for a stable-id addressed L2 eviction update."""
+
+    adapter_id: int = Field(ge=0)
+
+
+class RuntimePolicyUpdateRequest(BaseModel):
+    """Wire model shared by ``validate`` and ``PATCH`` policy endpoints."""
+
+    model_config = ConfigDict(extra="allow")
+
+    expected_version: int | None = Field(default=None, ge=0)
+    store_policy: str | None = None
+    prefetch_policy: str | None = None
+    l1_eviction: EvictionUpdateRequest | None = None
+    l2_eviction: list[L2EvictionUpdateRequest] = Field(default_factory=list)
+
+
+class _StorageManagerLike(Protocol):
+    def get_runtime_policy(self) -> dict[str, object]: ...
+
+    def validate_runtime_policy_update(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyValidation: ...
+
+    def update_runtime_policy(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyUpdateResult: ...
+
+
+class _EngineLike(Protocol):
+    storage_manager: _StorageManagerLike
+
+
+def _get_storage_manager(request: Request) -> _StorageManagerLike | JSONResponse:
+    """Resolve the live StorageManager or return the standard 503 response."""
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None:
+        return JSONResponse(
+            status_code=503,
+            content={"error": "engine not initialized"},
+        )
+    return cast(_EngineLike, engine).storage_manager
+
+
+def _to_tunables(
+    request: EvictionUpdateRequest,
+) -> RuntimePolicyTunables:
+    """Convert one HTTP eviction model to a domain update."""
+    tunables = request.tunables
+    return RuntimePolicyTunables(
+        policy=request.policy,
+        trigger_watermark=(
+            tunables.trigger_watermark if tunables is not None else None
+        ),
+        eviction_ratio=tunables.eviction_ratio if tunables is not None else None,
+    )
+
+
+def _to_runtime_update(body: RuntimePolicyUpdateRequest) -> RuntimePolicyUpdate:
+    """Convert the validated HTTP body to a transport-independent update."""
+    extras = tuple(body.model_extra or {})
+    return RuntimePolicyUpdate(
+        expected_version=body.expected_version,
+        store_policy=body.store_policy,
+        prefetch_policy=body.prefetch_policy,
+        l1_eviction=(
+            _to_tunables(body.l1_eviction) if body.l1_eviction is not None else None
+        ),
+        l2_eviction=tuple(
+            RuntimeL2EvictionUpdate(
+                adapter_id=entry.adapter_id,
+                tunables=_to_tunables(entry),
+            )
+            for entry in body.l2_eviction
+        ),
+        restart_required_fields=tuple(
+            sorted(field for field in extras if field in _RESTART_REQUIRED_FIELDS)
+        ),
+        unsupported_fields=tuple(
+            sorted(field for field in extras if field not in _RESTART_REQUIRED_FIELDS)
+        ),
+    )
+
+
+def _error_response(error: RuntimePolicyError) -> JSONResponse:
+    """Convert a domain validation error to its stable HTTP response."""
+    return JSONResponse(status_code=error.status_code, content=error.as_dict())
+
+
+@router.get("/config/policies", response_model=None)
+async def get_policies(request: Request) -> dict[str, object] | JSONResponse:
+    """Return current runtime policy state and update capabilities."""
+    storage_manager = _get_storage_manager(request)
+    if isinstance(storage_manager, JSONResponse):
+        return storage_manager
+    return storage_manager.get_runtime_policy()
+
+
+@router.post("/config/policies/validate", response_model=None)
+async def validate_policies(
+    body: RuntimePolicyUpdateRequest,
+    request: Request,
+) -> dict[str, object] | JSONResponse:
+    """Validate a policy update without changing runtime state."""
+    storage_manager = _get_storage_manager(request)
+    if isinstance(storage_manager, JSONResponse):
+        return storage_manager
+    try:
+        validation = storage_manager.validate_runtime_policy_update(
+            _to_runtime_update(body)
+        )
+    except RuntimePolicyError as error:
+        return _error_response(error)
+    return {
+        "status": "valid",
+        "version": validation.version,
+        "changed": list(validation.changed_fields),
+        "effective_on": validation.effective_on,
+    }
+
+
+@router.patch("/config/policies", response_model=None)
+async def update_policies(
+    body: RuntimePolicyUpdateRequest,
+    request: Request,
+) -> dict[str, object] | JSONResponse:
+    """Apply a fully validated node-local runtime policy update."""
+    storage_manager = _get_storage_manager(request)
+    if isinstance(storage_manager, JSONResponse):
+        return storage_manager
+    try:
+        result = storage_manager.update_runtime_policy(_to_runtime_update(body))
+    except RuntimePolicyError as error:
+        return _error_response(error)
+    return {
+        "status": result.status,
+        "version": result.version,
+        "applied": list(result.applied),
+        "effective_on": result.effective_on,
+    }

--- a/tests/v1/distributed/test_runtime_policy.py
+++ b/tests/v1/distributed/test_runtime_policy.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for StorageManager runtime policy updates."""
+
+# Standard
+from typing import cast
+
+# Third Party
+import pytest
+
+pytest.importorskip("sortedcontainers")
+
+# First Party
+from lmcache import torch_dev, torch_device_type
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.runtime_policy import (
+    RuntimeL2EvictionUpdate,
+    RuntimePolicyError,
+    RuntimePolicyTunables,
+    RuntimePolicyUpdate,
+)
+from tests.v1.distributed.utils import should_use_lazy_alloc
+
+try:
+    # First Party
+    from lmcache.v1.distributed.storage_manager import StorageManager
+except ImportError:
+    pytest.skip(
+        "Skipping because StorageManager cannot be imported", allow_module_level=True
+    )
+
+if not torch_dev.is_available():
+    pytest.skip(
+        f"Requires available {torch_device_type} runtime",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture
+def basic_l1_config() -> L1ManagerConfig:
+    return L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(
+            size_in_bytes=128 * 1024 * 1024,
+            use_lazy=should_use_lazy_alloc(),
+            init_size_in_bytes=64 * 1024 * 1024,
+            align_bytes=0x1000,
+        ),
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+
+
+@pytest.fixture
+def storage_manager(basic_l1_config: L1ManagerConfig):
+    manager = StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=basic_l1_config,
+            eviction_config=EvictionConfig(
+                eviction_policy="LRU",
+                trigger_watermark=0.8,
+                eviction_ratio=0.2,
+            ),
+        )
+    )
+    yield manager
+    manager.close()
+
+
+@pytest.fixture
+def storage_manager_with_l2(basic_l1_config: L1ManagerConfig):
+    adapter_config = MockL2AdapterConfig(
+        max_size_gb=0.01,
+        mock_bandwidth_gb=10.0,
+    )
+    adapter_config.eviction_config = EvictionConfig(
+        eviction_policy="LRU",
+        trigger_watermark=0.7,
+        eviction_ratio=0.3,
+    )
+    manager = StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=basic_l1_config,
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+            l2_adapter_config=L2AdaptersConfig(adapters=[adapter_config]),
+        )
+    )
+    yield manager
+    manager.close()
+
+
+def _capability(
+    policy: dict[str, object],
+    name: str,
+) -> dict[str, object]:
+    """Return one capability entry from the JSON-shaped status mapping."""
+    capabilities = cast(dict[str, object], policy["capabilities"])
+    return cast(dict[str, object], capabilities[name])
+
+
+def _tunable(
+    capability: dict[str, object],
+    name: str,
+) -> dict[str, object]:
+    """Return one eviction tunable from a capability entry."""
+    tunables = cast(dict[str, object], capability["runtime_tunables"])
+    return cast(dict[str, object], tunables[name])
+
+
+def test_runtime_policy_reports_capabilities(storage_manager: StorageManager) -> None:
+    policy = storage_manager.get_runtime_policy()
+
+    assert policy["version"] == 0
+    assert _capability(policy, "store_policy")["current"] == "default"
+    assert _capability(policy, "prefetch_policy")["current"] == "default"
+    assert _capability(policy, "l1_eviction")["policy"] == "LRU"
+    assert (
+        _tunable(_capability(policy, "l1_eviction"), "eviction_ratio")["current"] == 0.2
+    )
+
+
+def test_runtime_policy_update_changes_selectors_and_l1_tunables(
+    storage_manager: StorageManager,
+) -> None:
+    result = storage_manager.update_runtime_policy(
+        RuntimePolicyUpdate(
+            expected_version=0,
+            store_policy="skip_l1",
+            prefetch_policy="retain",
+            l1_eviction=RuntimePolicyTunables(
+                trigger_watermark=0.9,
+                eviction_ratio=0.1,
+            ),
+        )
+    )
+
+    assert result.status == "updated"
+    assert result.version == 1
+    assert result.applied == (
+        "store_policy",
+        "prefetch_policy",
+        "l1_eviction.trigger_watermark",
+        "l1_eviction.eviction_ratio",
+    )
+
+    policy = storage_manager.get_runtime_policy()
+    assert policy["version"] == 1
+    assert _capability(policy, "store_policy")["current"] == "skip_l1"
+    assert _capability(policy, "prefetch_policy")["current"] == "retain"
+    assert (
+        _tunable(_capability(policy, "l1_eviction"), "trigger_watermark")["current"]
+        == 0.9
+    )
+    assert storage_manager.report_status()["runtime_policy_version"] == 1
+
+
+def test_runtime_policy_rejects_stale_version_without_mutation(
+    storage_manager: StorageManager,
+) -> None:
+    storage_manager.update_runtime_policy(RuntimePolicyUpdate(store_policy="skip_l1"))
+
+    with pytest.raises(RuntimePolicyError, match="version changed") as exc_info:
+        storage_manager.update_runtime_policy(
+            RuntimePolicyUpdate(
+                expected_version=0,
+                prefetch_policy="retain",
+            )
+        )
+
+    assert exc_info.value.code == "version_conflict"
+    assert exc_info.value.status_code == 409
+    assert storage_manager.get_runtime_policy()["version"] == 1
+    assert (
+        _capability(storage_manager.get_runtime_policy(), "prefetch_policy")["current"]
+        == "default"
+    )
+
+
+def test_runtime_policy_rejects_eviction_policy_class_change(
+    storage_manager: StorageManager,
+) -> None:
+    with pytest.raises(RuntimePolicyError) as exc_info:
+        storage_manager.update_runtime_policy(
+            RuntimePolicyUpdate(
+                l1_eviction=RuntimePolicyTunables(policy="noop"),
+            )
+        )
+
+    assert exc_info.value.code == "state_migration_required"
+    assert storage_manager.get_runtime_policy()["version"] == 0
+
+
+def test_runtime_policy_updates_configured_l2_tunables(
+    storage_manager_with_l2: StorageManager,
+) -> None:
+    result = storage_manager_with_l2.update_runtime_policy(
+        RuntimePolicyUpdate(
+            l2_eviction=(
+                RuntimeL2EvictionUpdate(
+                    adapter_id=0,
+                    tunables=RuntimePolicyTunables(
+                        trigger_watermark=0.95,
+                        eviction_ratio=0.05,
+                    ),
+                ),
+            ),
+        )
+    )
+
+    assert result.version == 1
+    assert result.applied == (
+        "l2_eviction[0].trigger_watermark",
+        "l2_eviction[0].eviction_ratio",
+    )
+    capabilities = cast(
+        dict[str, object], storage_manager_with_l2.get_runtime_policy()["capabilities"]
+    )
+    l2 = cast(list[dict[str, object]], capabilities["l2_eviction"])[0]
+    assert l2["adapter_id"] == 0
+    assert _tunable(l2, "trigger_watermark")["current"] == 0.95
+    assert _tunable(l2, "eviction_ratio")["current"] == 0.05
+
+
+def test_runtime_policy_rejects_startup_only_field(
+    storage_manager: StorageManager,
+) -> None:
+    with pytest.raises(RuntimePolicyError) as exc_info:
+        storage_manager.update_runtime_policy(
+            RuntimePolicyUpdate(restart_required_fields=("chunk_size",))
+        )
+
+    assert exc_info.value.code == "restart_required"
+    assert exc_info.value.field == "chunk_size"

--- a/tests/v1/distributed/test_runtime_policy_types.py
+++ b/tests/v1/distributed/test_runtime_policy_types.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for transport-independent runtime policy validation types."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.runtime_policy import (
+    RuntimePolicyError,
+    validate_eviction_policy,
+    validate_eviction_value,
+)
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, float("nan"), float("inf")])
+def test_eviction_value_must_be_finite_and_bounded(value: float) -> None:
+    with pytest.raises(RuntimePolicyError) as exc_info:
+        validate_eviction_value("l1_eviction.eviction_ratio", value)
+
+    assert exc_info.value.code == "invalid_value"
+    assert exc_info.value.field == "l1_eviction.eviction_ratio"
+
+
+def test_error_serialization_is_stable() -> None:
+    error = RuntimePolicyError(
+        code="version_conflict",
+        status_code=409,
+        field="expected_version",
+        current=4,
+        requested=3,
+        message="stale version",
+    )
+
+    assert error.as_dict() == {
+        "error": "version_conflict",
+        "message": "stale version",
+        "field": "expected_version",
+        "current": 4,
+        "requested": 3,
+    }
+
+
+def test_eviction_policy_must_be_registered() -> None:
+    with pytest.raises(RuntimePolicyError, match="must be one of") as exc_info:
+        validate_eviction_policy("l1_eviction.policy", "unknown")
+
+    assert exc_info.value.code == "invalid_policy"

--- a/tests/v1/mp_coordinator/test_policy_api.py
+++ b/tests/v1/mp_coordinator/test_policy_api.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for coordinator runtime-policy proxy and fleet fan-out APIs."""
+
+# Standard
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+import httpx
+
+# First Party
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+
+def _client() -> TestClient:
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        enable_startup_resync=False,
+    )
+    return TestClient(create_app(config))
+
+
+def _register(client: TestClient, *instance_ids: str) -> None:
+    for index, instance_id in enumerate(instance_ids, start=1):
+        response = client.post(
+            "/instances",
+            json={
+                "instance_id": instance_id,
+                "ip": "10.0.0.1",
+                "http_port": 8000 + index,
+            },
+        )
+        assert response.status_code == 200, response.text
+
+
+def _update() -> dict:
+    return {
+        "store_policy": "lru",
+        "l1_eviction": {"tunables": {"eviction_ratio": 0.2}},
+    }
+
+
+def _mock_client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_direct_policy_proxy_preserves_node_response() -> None:
+    """Direct GET/PATCH/validate calls retain target status and payload."""
+    calls: list[tuple[str, str, dict | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content) if request.content else None
+        calls.append((request.method, request.url.path, payload))
+        if request.method == "GET":
+            return httpx.Response(200, json={"version": 3, "store_policy": "lru"})
+        if request.method == "POST":
+            return httpx.Response(409, json={"error": "version_conflict"})
+        return httpx.Response(200, json={"status": "updated", "version": 4})
+
+    with _client() as client:
+        _register(client, "node-a")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+
+        assert client.get("/instances/node-a/config/policies").json()["version"] == 3
+        conflict = client.post(
+            "/instances/node-a/config/policies/validate",
+            json={"expected_version": 2, **_update()},
+        )
+        assert conflict.status_code == 409
+        assert conflict.json() == {"error": "version_conflict"}
+        patched = client.patch("/instances/node-a/config/policies", json=_update())
+        assert patched.status_code == 200
+        assert patched.json()["version"] == 4
+
+    assert calls[0][0:2] == ("GET", "/config/policies")
+    validation_body = calls[1][2]
+    patch_body = calls[2][2]
+    assert validation_body is not None
+    assert patch_body is not None
+    assert validation_body["expected_version"] == 2
+    assert patch_body["store_policy"] == "lru"
+
+
+def test_direct_policy_proxy_maps_unreachable_target_to_502() -> None:
+    """A coordinator transport failure is distinct from a node response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    with _client() as client:
+        _register(client, "node-a")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+        response = client.get("/instances/node-a/config/policies")
+        assert response.status_code == 502
+        assert "connection refused" in response.json()["detail"]
+
+
+def test_direct_policy_proxy_unknown_instance_returns_404() -> None:
+    with _client() as client:
+        response = client.get("/instances/missing/config/policies")
+        assert response.status_code == 404
+
+
+def test_fleet_validate_is_all_target_and_does_not_apply() -> None:
+    """Validation fans out to all nodes and never sends PATCH requests."""
+    calls: list[tuple[str, str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        calls.append((request.method, request.url.path, payload))
+        return httpx.Response(
+            200,
+            json={
+                "status": "valid",
+                "version": {"node-a": 4, "node-b": 7}.get(
+                    "node-a" if request.url.port == 8001 else "node-b", 4
+                ),
+            },
+        )
+
+    with _client() as client:
+        _register(client, "node-a", "node-b")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+        response = client.post(
+            "/fleet/config/policies/validate", json={"update": _update()}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "valid"
+        assert len(response.json()["results"]) == 2
+
+    assert [method for method, _, _ in calls] == ["POST", "POST"]
+
+
+def test_fleet_patch_uses_validation_barrier_and_per_node_versions() -> None:
+    """A successful validation pass fences each concurrent apply call."""
+    calls: list[tuple[str, str, dict]] = []
+    versions = {8001: 4, 8002: 7}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        calls.append((request.method, request.url.path, payload))
+        if request.method == "POST":
+            return httpx.Response(
+                200, json={"status": "valid", "version": versions[request.url.port]}
+            )
+        return httpx.Response(
+            200, json={"status": "updated", "version": payload["expected_version"] + 1}
+        )
+
+    with _client() as client:
+        _register(client, "node-a", "node-b")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+        response = client.patch("/fleet/config/policies", json={"update": _update()})
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "updated"
+
+    patch_bodies = {
+        body["expected_version"] for method, _, body in calls if method == "PATCH"
+    }
+    assert patch_bodies == {4, 7}
+    assert len([method for method, _, _ in calls if method == "PATCH"]) == 2
+
+
+def test_fleet_patch_forwards_explicit_expected_versions() -> None:
+    """Caller-provided versions override the versions observed at validation."""
+    calls: list[tuple[str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        calls.append((request.method, payload))
+        if request.method == "POST":
+            return httpx.Response(200, json={"status": "valid", "version": 20})
+        return httpx.Response(200, json={"status": "updated", "version": 21})
+
+    with _client() as client:
+        _register(client, "node-a", "node-b")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+        response = client.patch(
+            "/fleet/config/policies",
+            json={
+                "update": _update(),
+                "expected_versions": {"node-a": 8, "node-b": 9},
+            },
+        )
+        assert response.status_code == 200
+
+    assert {
+        payload["expected_version"] for method, payload in calls if method == "PATCH"
+    } == {8, 9}
+
+
+def test_fleet_validation_failure_prevents_all_apply_calls() -> None:
+    """A rejected target stops the fleet before any PATCH is sent."""
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.method)
+        if request.method == "POST" and request.url.port == 8002:
+            return httpx.Response(409, json={"error": "version_conflict"})
+        return httpx.Response(200, json={"status": "valid", "version": 1})
+
+    with _client() as client:
+        _register(client, "node-a", "node-b")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+        response = client.patch("/fleet/config/policies", json={"update": _update()})
+        assert response.status_code == 409
+        assert response.json()["status"] == "rejected"
+
+    assert calls == ["POST", "POST"]
+
+
+def test_fleet_apply_reports_partial_failure() -> None:
+    """Apply failures after validation are visible per target."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(200, json={"status": "valid", "version": 1})
+        if request.url.port == 8002:
+            raise httpx.ConnectError("node disappeared", request=request)
+        return httpx.Response(200, json={"status": "updated", "version": 2})
+
+    with _client() as client:
+        _register(client, "node-a", "node-b")
+        client.app.state.ctx.outbound_client = _mock_client(handler)
+        response = client.patch("/fleet/config/policies", json={"update": _update()})
+        assert response.status_code == 502
+        assert response.json()["status"] == "partial"
+        assert {item["status_code"] for item in response.json()["results"]} == {
+            200,
+            502,
+        }
+
+
+def test_fleet_without_registered_instances_returns_404() -> None:
+    with _client() as client:
+        response = client.post(
+            "/fleet/config/policies/validate", json={"update": _update()}
+        )
+        assert response.status_code == 404

--- a/tests/v1/mp_coordinator/test_policy_api.py
+++ b/tests/v1/mp_coordinator/test_policy_api.py
@@ -75,6 +75,8 @@ def test_direct_policy_proxy_preserves_node_response() -> None:
         assert patched.json()["version"] == 4
 
     assert calls[0][0:2] == ("GET", "/config/policies")
+    assert calls[1][0:2] == ("POST", "/config/policies/validate")
+    assert calls[2][0:2] == ("PATCH", "/config/policies")
     validation_body = calls[1][2]
     patch_body = calls[2][2]
     assert validation_body is not None
@@ -131,6 +133,10 @@ def test_fleet_validate_is_all_target_and_does_not_apply() -> None:
         assert len(response.json()["results"]) == 2
 
     assert [method for method, _, _ in calls] == ["POST", "POST"]
+    assert [path for _, path, _ in calls] == [
+        "/config/policies/validate",
+        "/config/policies/validate",
+    ]
 
 
 def test_fleet_patch_uses_validation_barrier_and_per_node_versions() -> None:
@@ -161,6 +167,12 @@ def test_fleet_patch_uses_validation_barrier_and_per_node_versions() -> None:
     }
     assert patch_bodies == {4, 7}
     assert len([method for method, _, _ in calls if method == "PATCH"]) == 2
+    assert {path for method, path, _ in calls if method == "POST"} == {
+        "/config/policies/validate"
+    }
+    assert {path for method, path, _ in calls if method == "PATCH"} == {
+        "/config/policies"
+    }
 
 
 def test_fleet_patch_forwards_explicit_expected_versions() -> None:

--- a/tests/v1/multiprocess/http_apis/test_policy_api.py
+++ b/tests/v1/multiprocess/http_apis/test_policy_api.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MP runtime management-policy HTTP API."""
+
+# Standard
+from dataclasses import dataclass, field
+
+# Third Party
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# First Party
+from lmcache.v1.distributed.runtime_policy import (
+    RuntimePolicyError,
+    RuntimePolicyUpdate,
+    RuntimePolicyUpdateResult,
+    RuntimePolicyValidation,
+)
+from lmcache.v1.multiprocess.http_apis.policy_api import router
+
+
+@dataclass
+class _FakeStorageManager:
+    calls: list[RuntimePolicyUpdate] = field(default_factory=list)
+    runtime_policy: dict[str, object] = field(
+        default_factory=lambda: {"version": 3, "capabilities": {}}
+    )
+    validation_error: RuntimePolicyError | None = None
+
+    def get_runtime_policy(self) -> dict[str, object]:
+        return self.runtime_policy
+
+    def validate_runtime_policy_update(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyValidation:
+        if self.validation_error is not None:
+            raise self.validation_error
+        self.calls.append(update)
+        return RuntimePolicyValidation(
+            version=3,
+            changed_fields=("store_policy",),
+            effective_on={"store_policy": "next_store_plan"},
+        )
+
+    def update_runtime_policy(
+        self,
+        update: RuntimePolicyUpdate,
+    ) -> RuntimePolicyUpdateResult:
+        if self.validation_error is not None:
+            raise self.validation_error
+        self.calls.append(update)
+        return RuntimePolicyUpdateResult(
+            status="updated",
+            version=4,
+            applied=("store_policy",),
+            effective_on={"store_policy": "next_store_plan"},
+        )
+
+
+@dataclass
+class _FakeEngine:
+    storage_manager: _FakeStorageManager
+
+
+def _client(storage_manager: _FakeStorageManager | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    if storage_manager is not None:
+        app.state.engine = _FakeEngine(storage_manager)
+    return TestClient(app)
+
+
+def test_get_policies_returns_runtime_capabilities() -> None:
+    storage_manager = _FakeStorageManager()
+
+    response = _client(storage_manager).get("/config/policies")
+
+    assert response.status_code == 200
+    assert response.json() == {"version": 3, "capabilities": {}}
+
+
+def test_validate_does_not_apply_and_converts_nested_update() -> None:
+    storage_manager = _FakeStorageManager()
+
+    response = _client(storage_manager).post(
+        "/config/policies/validate",
+        json={
+            "expected_version": 3,
+            "store_policy": "skip_l1",
+            "l1_eviction": {
+                "tunables": {
+                    "trigger_watermark": 0.9,
+                    "eviction_ratio": 0.1,
+                }
+            },
+            "l2_eviction": [
+                {
+                    "adapter_id": 7,
+                    "tunables": {"eviction_ratio": 0.2},
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "valid",
+        "version": 3,
+        "changed": ["store_policy"],
+        "effective_on": {"store_policy": "next_store_plan"},
+    }
+    assert len(storage_manager.calls) == 1
+    update = storage_manager.calls[0]
+    assert update.expected_version == 3
+    assert update.store_policy == "skip_l1"
+    assert update.l1_eviction is not None
+    assert update.l1_eviction.trigger_watermark == 0.9
+    assert update.l2_eviction[0].adapter_id == 7
+
+
+def test_patch_returns_new_version_and_applied_fields() -> None:
+    storage_manager = _FakeStorageManager()
+
+    response = _client(storage_manager).patch(
+        "/config/policies",
+        json={"store_policy": "skip_l1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "updated",
+        "version": 4,
+        "applied": ["store_policy"],
+        "effective_on": {"store_policy": "next_store_plan"},
+    }
+
+
+def test_restart_only_fields_have_structured_error() -> None:
+    storage_manager = _FakeStorageManager(
+        validation_error=RuntimePolicyError(
+            code="restart_required",
+            field="chunk_size",
+            message="chunk_size affects startup-only storage semantics",
+        )
+    )
+
+    response = _client(storage_manager).patch(
+        "/config/policies",
+        json={"chunk_size": 512},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": "restart_required",
+        "message": "chunk_size affects startup-only storage semantics",
+        "field": "chunk_size",
+    }
+
+
+def test_invalid_numeric_shape_is_rejected_by_http_schema() -> None:
+    response = _client(_FakeStorageManager()).patch(
+        "/config/policies",
+        json={"l1_eviction": {"tunables": {"eviction_ratio": 2.0}}},
+    )
+
+    assert response.status_code == 422
+
+
+def test_uninitialized_engine_returns_503() -> None:
+    response = _client().get("/config/policies")
+
+    assert response.status_code == 503
+    assert response.json() == {"error": "engine not initialized"}


### PR DESCRIPTION
## What this PR does / why we need it

The node-local runtime policy API in #4382 is sufficient for one MP server, but operators of a registered MP fleet still need to address nodes individually and coordinate version checks themselves. This PR adds the coordinator control-plane layer for RFC #4360 and roadmap item #4025.

**Dependency:** this PR is based on `codex/runtime-policy-config` and depends on #4382. Because the upstream base branch is `dev`, GitHub currently shows the foundation commit together with this coordinator delta; after #4382 lands, this branch should be rebased so the remaining diff is coordinator-only.

### Phase 1-3 support matrix

The rows marked **Phase 1** are supplied by #4382; this PR adds the coordinator and fleet columns.

| Capability or setting | Node-local API | Coordinator direct proxy | Fleet API | Runtime semantics |
| --- | --- | --- | --- | --- |
| `store_policy` | Supported | Supported | Supported | Next store plan. |
| `prefetch_policy` | Supported | Supported | Supported | Next prefetch request. |
| L1 eviction `trigger_watermark` | Supported | Supported | Supported | Next eviction-loop tick. |
| L1 eviction `eviction_ratio` | Supported | Supported | Supported | Next eviction-loop tick. |
| Configured L2 eviction tunables | Supported | Supported | Supported | Next eviction-loop tick. |
| Eviction policy class replacement | Rejected | Proxied rejection | Rejected by every target | `state_migration_required`; no live state migration. |
| `chunk_size` | Rejected | Proxied rejection | Validation barrier rejects | `restart_required`. |
| L1 capacity or memory layout | Rejected | Proxied rejection | Validation barrier rejects | `restart_required`. |
| Serde type | Rejected | Proxied rejection | Validation barrier rejects | `restart_required`. |
| L2 adapter type or topology | Rejected | Proxied rejection | Validation barrier rejects | No storage-topology change in this phase. |
| Policy persistence across restart | Not available | Not available | Not available | State is process-local; restart resets it. |
| Cross-node transaction or rollback | Not applicable | Not applicable | Not available | Fleet apply is best-effort and may return `partial`. |

### Coordinator API

For one registered MP server, the coordinator provides direct proxies:

| Method | Endpoint | Semantics |
| --- | --- | --- |
| `GET` | `/instances/{instance_id}/config/policies` | Read node-local policy state. |
| `POST` | `/instances/{instance_id}/config/policies/validate` | Validate without applying. |
| `PATCH` | `/instances/{instance_id}/config/policies` | Apply to one node. |

For fleet operations:

| Method | Endpoint | Semantics |
| --- | --- | --- |
| `POST` | `/fleet/config/policies/validate` | Validate every currently registered node. |
| `PATCH` | `/fleet/config/policies` | Validate every node, then apply concurrently. |

Fleet requests wrap the node-local update and use a per-instance version map:

```json
{
  "update": {
    "store_policy": "skip_l1",
    "l1_eviction": {"tunables": {"eviction_ratio": 0.1}}
  },
  "expected_versions": {
    "node-a": 4,
    "node-b": 7
  }
}
```

### Apply protocol

1. Snapshot the currently registered instances.
2. Send validation requests concurrently to every target.
3. If any target rejects the update or is unreachable, send no apply requests and return one result per target.
4. On a successful validation barrier, fence each apply with the version observed for that node, unless the caller supplied an explicit `expected_versions` entry.
5. Return the individual status and response for every target.

The coordinator uses the existing lifespan-owned `httpx.AsyncClient` and the registry as the sole source of target addresses. It does not cache membership or policy state.

## Concurrency and failure semantics

- Direct node updates use the node-local optimistic version contract from #4382.
- Concurrent direct writers with the same stale version produce one successful update and `409 Conflict` responses for the losers.
- Concurrent fleet writers can produce a successful apply and a `partial` response with per-node `409` conflicts.
- Transport failures are reported as `502` for the affected node.
- There is no cross-node transaction, automatic rollback, quorum, retry, or persistence in this phase. Callers reconcile failed or stale targets using the result list.

## Compatibility and scope

- The coordinator routes are additive and do not change existing membership, quota, cache, or data-plane APIs.
- The node-local API remains the authority for validation and mutation; the coordinator only proxies and coordinates requests.
- Stateful eviction-policy migration, durable desired state, and cross-node rollback remain future work.

## Validation

Remote validation on `root@134.199.199.149` using the Phase 1 wheel and the Phase 2 source:

- Focused coordinator policy tests: `9 passed`.
- Full `tests/v1/mp_coordinator`: `234 passed`.
- Real single-host HTTP E2E with one coordinator and two independent MP server containers:
  - Registrar registration and heartbeat.
  - Direct GET/validate/PATCH and fleet validate/PATCH.
  - Validation-barrier rejection of restart-only fields.
  - Version conflict, hard-killed-node `502`, and no healthy-node apply.
  - Restart, re-registration, and state reset behavior.
- Real concurrent HTTP E2E:
  - Eight direct PATCH requests with `expected_version=0`: exactly `1 x 200` and `7 x 409`.
  - Two concurrent fleet PATCH requests: exactly one logical apply per node, fenced conflicts for the competing request, and verified final versions/tunables.
- Touched-file `pre-commit` suite passed, including SPDX, isort, ruff, ruff-format, codespell, and mypy.
- `python -m compileall` and `git diff --check` passed.

During the real E2E run, validation routing exposed and fixed a defect where coordinator POST requests were sent to `/config/policies` instead of `/config/policies/validate`. The fix and outbound-path regression assertions are included here.

Refs #4025
Refs #4360

## Checklist

- [x] This PR contains user-facing changes; documentation is included.
- [x] This PR contains unit and integration tests.
