### PR TITLE
fix(mp): handle prefetch load submission failures

### DIFF
--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -923,15 +923,25 @@ class PrefetchController(StorageControllerInterface):
             return
 
         ## Step 7: submit load tasks per adapter
+        submitted_keys: list[ObjectKey] = []
         for adapter_idx, bitmap in trimmed_plan.items():
             per_adapter_keys = bitmap.gather(request.keys)
             per_adapter_objs = [
                 request.write_reserved_objs[key] for key in per_adapter_keys
             ]
-            task_id = self._l2_adapters[adapter_idx].submit_load_task(
-                per_adapter_keys, per_adapter_objs
-            )
+            try:
+                task_id = self._l2_adapters[adapter_idx].submit_load_task(
+                    per_adapter_keys, per_adapter_objs
+                )
+            except Exception:
+                logger.exception(
+                    "Prefetch request %d: failed to submit load task to adapter %d",
+                    request.request_id,
+                    adapter_idx,
+                )
+                continue
             request.pending_load_tasks[adapter_idx] = task_id
+            submitted_keys.extend(per_adapter_keys)
             # Per-adapter byte accounting for L2_LOAD_TASK_* throughput
             # events.  Uniform layout per chunk -> size * count.
             total_bytes = (
@@ -972,11 +982,9 @@ class PrefetchController(StorageControllerInterface):
                 event_type=EventType.L2_PREFETCH_LOAD_SUBMITTED,
                 metadata={
                     "request_id": request.request_id,
-                    "key_count": len(reserved_key_set),
-                    "adapter_count": len(trimmed_plan),
-                    "key_count_per_salt": Counter(
-                        k.cache_salt for k in reserved_key_set
-                    ),
+                    "key_count": len(submitted_keys),
+                    "adapter_count": len(request.pending_load_tasks),
+                    "key_count_per_salt": Counter(k.cache_salt for k in submitted_keys),
                 },
             )
         )
@@ -984,9 +992,12 @@ class PrefetchController(StorageControllerInterface):
         logger.debug(
             "Prefetch request %d: submitted load tasks to %d adapters for %d keys",
             request.request_id,
-            len(trimmed_plan),
-            len(reserved_key_set),
+            len(request.pending_load_tasks),
+            len(submitted_keys),
         )
+
+        if request.all_loads_done():
+            self._finalize_load(request)
 
     def _update_lookup_results(
         self, request_id: PrefetchRequestId, prefix_hit_count: int

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -442,6 +442,99 @@ class TestSingleAdapterPrefetch:
 class TestMultiAdapterPrefetch:
     """Test PrefetchController with multiple MockL2Adapters."""
 
+    def test_load_submission_failure_releases_resources(self, l1_manager, monkeypatch):
+        """A failed load submission completes and releases L1/L2 locks."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        store_keys_in_l2(adapter, keys, layout)
+        submit_calls = 0
+
+        def fail_submit_load(keys, objects):
+            nonlocal submit_calls
+            submit_calls += 1
+            raise RuntimeError("injected load submission failure")
+
+        monkeypatch.setattr(adapter, "submit_load_task", fail_submit_load)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        try:
+            req_id = ctrl.submit_prefetch_request(PrefetchRequestSpec(keys, layout))
+            result = wait_for_prefetch_result(ctrl, req_id)
+
+            assert result == 0
+            assert submit_calls == 1
+            assert ctrl.report_status()["in_flight_request_count"] == 0
+            assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+
+            write_results = l1_manager.reserve_write(
+                keys=keys,
+                is_temporary=[False],
+                layout_desc=layout,
+                mode="new",
+            )
+            assert write_results[keys[0]][0] == L1Error.SUCCESS
+            l1_manager.finish_write(keys)
+            l1_manager.delete(keys)
+        finally:
+            ctrl.stop()
+            adapter.close()
+
+    def test_partial_load_submission_failure_completes(self, l1_manager, monkeypatch):
+        """Other adapters finish when one adapter rejects load submission."""
+        adapters = [make_adapter(), make_adapter()]
+        descriptors = [make_descriptor(i) for i in range(2)]
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(2)]
+        store_keys_in_l2(adapters[0], keys[:1], layout)
+        store_keys_in_l2(adapters[1], keys[1:], layout)
+
+        def fail_submit_load(keys, objects):
+            raise RuntimeError("injected load submission failure")
+
+        monkeypatch.setattr(adapters[1], "submit_load_task", fail_submit_load)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=adapters,
+            adapter_descriptors=descriptors,
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        try:
+            req_id = ctrl.submit_prefetch_request(PrefetchRequestSpec(keys, layout))
+            result = wait_for_prefetch_result(ctrl, req_id)
+
+            assert result == 1
+            assert ctrl.report_status()["in_flight_request_count"] == 0
+            for adapter in adapters:
+                assert wait_for_condition(
+                    lambda adapter=adapter: adapter.debug_get_locked_key_count() == 0
+                )
+
+            assert l1_manager.unsafe_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
+            l1_manager.finish_read([keys[0]])
+
+            write_results = l1_manager.reserve_write(
+                keys=[keys[1]],
+                is_temporary=[False],
+                layout_desc=layout,
+                mode="new",
+            )
+            assert write_results[keys[1]][0] == L1Error.SUCCESS
+            l1_manager.finish_write([keys[1]])
+            l1_manager.delete([keys[1]])
+        finally:
+            ctrl.stop()
+            for adapter in adapters:
+                adapter.close()
+
     def test_disjoint_adapters(self, l1_manager):
         """Adapter 0 has {0,1}, adapter 1 has {2,3} → full prefix of 4."""
         adapters = [make_adapter(), make_adapter()]


### PR DESCRIPTION
## What this PR does / why we need it

`PrefetchController` reserves L1 write buffers before submitting asynchronous L2 load tasks.

If `submit_load_task()` raises, no task ID is recorded for that adapter. When no other load task is pending, no completion event can advance the request. The request therefore remains stuck in the load phase, its result is never published, and its L1 write reservations and L2 lookup locks are retained until controller shutdown.

This change handles load submission failures per adapter:

* successfully submitted load tasks continue through the existing asynchronous completion path;
* adapters whose submission failed are treated as load failures;
* if no load task was successfully submitted, the request is finalized immediately;
* L1 reservations and L2 locks are released through the existing finalization path;
* submission metrics count only successfully submitted adapters and keys.

Successful submissions are otherwise unchanged.

## Tests

Added focused regression coverage for:

* a single adapter whose load submission raises, verifying that the request completes, the in-flight count returns to zero, the L1 key can immediately be reserved for writing again, and the L2 lock is released;
* a multi-adapter request where one submission succeeds and another raises, verifying that the successful load completes normally while the failed key and all L2 locks are cleaned up.

Validation performed locally:

* deterministic all-submissions-failed fault injection: passed
* deterministic partial-submission-failure fault injection: passed
* `ruff check`: passed
* `ruff format --check`: passed
* Python compilation: passed
* `git diff --check`: passed

The focused pytest module was not rerun in the local CPU-only environment because its module-level runtime requirement depends on the CUDA-enabled LMCache environment. The regression tests are included for execution in upstream CI.

## Special notes for reviewers

The failure handling follows the existing adapter contract assumption: if `submit_load_task()` raises without returning a task ID, it has not transferred ownership of the provided buffers to a trackable asynchronous task.

* [ ] this PR contains user-facing changes - docs added
* [x] this PR contains unit tests