### PR TITLE
fix(fs_l2_adapter): fall back to buffered I/O when O_DIRECT is rejected (#4386)

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -571,6 +571,29 @@ class FSL2Adapter(L2AdapterInterface):
                 except OSError:
                     pass
 
+    def _disable_odirect(self, exc: BaseException) -> None:
+        """Permanently degrade this adapter to buffered I/O.
+
+        Whether O_DIRECT is usable depends on the file system, the
+        device stack and the alignment of the buffers handed to us --
+        none of which we can check up front.  When the first direct
+        I/O call is rejected we drop O_DIRECT for the rest of the
+        process instead of failing every subsequent store, which
+        would leave the L2 tier permanently dead while the server
+        keeps reporting no fatal error.
+        """
+        if not self._use_odirect:
+            return
+        self._use_odirect = False
+        self._os_disk_bs = 0
+        logger.warning(
+            "O_DIRECT is not usable under base_path=%s (%s: %s); "
+            "falling back to buffered I/O for the rest of this process.",
+            self._base_path,
+            type(exc).__name__,
+            exc,
+        )
+
     # ---- store ----------------------------------------------------------
 
     async def _execute_store(
@@ -608,13 +631,21 @@ class FSL2Adapter(L2AdapterInterface):
                             do_odirect = False
 
                     if do_odirect:
-                        await self._loop.run_in_executor(
-                            None,
-                            self._write_with_odirect,
-                            tmp_path,
-                            buf,
-                        )
-                    else:
+                        try:
+                            await self._loop.run_in_executor(
+                                None,
+                                self._write_with_odirect,
+                                tmp_path,
+                                buf,
+                            )
+                        except OSError as e:
+                            # O_DIRECT rejected by the kernel: turn it off
+                            # and retry this chunk buffered, rather than
+                            # failing this store and every one after it.
+                            self._disable_odirect(e)
+                            do_odirect = False
+
+                    if not do_odirect:
                         async with aiofiles.open(tmp_path, "wb") as f:
                             await f.write(buf)
 

--- a/tests/v1/distributed/test_fs_l2_adapter_odirect.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_odirect.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for FSL2Adapter's O_DIRECT fallback.
+
+Whether ``O_DIRECT`` is usable depends on the file system, the device
+stack and the alignment of the buffers handed to the adapter, none of
+which can be checked up front.  When a direct write is rejected the
+adapter must degrade to buffered I/O instead of failing that store and
+every store after it, which would leave the L2 tier permanently dead
+while the server keeps reporting no fatal error.
+"""
+
+# Standard
+from collections.abc import Iterator
+from pathlib import Path
+from typing import cast
+import errno
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+
+class _Buf:
+    """Minimal MemoryObj stand-in: just the ``byte_array`` the FS
+    adapter's store path reads."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = bytearray(data)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._data)
+
+
+def _key(h: bytes) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=h,
+        model_name="llama",
+        kv_rank=42,
+        cache_salt="alice",
+    )
+
+
+@pytest.fixture
+def odirect_adapter(tmp_path: Path) -> Iterator[FSL2Adapter]:
+    adp = FSL2Adapter(FSL2AdapterConfig(base_path=str(tmp_path), use_odirect=True))
+    try:
+        yield adp
+    finally:
+        adp.close()
+
+
+def _store_and_wait(
+    adp: FSL2Adapter, keys: list[ObjectKey], payloads: list[bytes]
+) -> None:
+    """Submit a store and poll until its result is available."""
+    objs = cast("list[MemoryObj]", [_Buf(p) for p in payloads])
+    task_id = adp.submit_store_task(keys, objs)
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        completed = adp.pop_completed_store_tasks()
+        if task_id in completed:
+            # L2StoreResult is an int: >= 0 success, -1 failure.
+            assert int(completed[task_id]) >= 0
+            return
+        time.sleep(0.01)
+    pytest.fail("store task did not complete within 5s")
+
+
+class TestODirectFallback:
+    def test_rejected_odirect_write_falls_back_to_buffered(
+        self, odirect_adapter: FSL2Adapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A kernel that refuses the direct write must not kill the tier.
+
+        The chunk is retried buffered, O_DIRECT is dropped for the rest
+        of the process, and later chunks never attempt it again.
+        """
+        adp = odirect_adapter
+        # Keep the payload block-aligned so the size check does not
+        # opt out of O_DIRECT before the write is even attempted.
+        block = adp._os_disk_bs or 4096
+        payload_a = b"a" * (block * 2)
+        payload_b = b"b" * (block * 2)
+
+        attempts: list[Path] = []
+
+        def _reject(file_path: Path, buf: bytes) -> None:
+            attempts.append(file_path)
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+        monkeypatch.setattr(adp, "_write_with_odirect", _reject)
+
+        k1 = _key(b"\x01")
+        k2 = _key(b"\x02")
+        _store_and_wait(adp, [k1], [payload_a])
+        _store_and_wait(adp, [k2], [payload_b])
+
+        assert adp._key_to_path(k1).read_bytes() == payload_a
+        assert adp._key_to_path(k2).read_bytes() == payload_b
+        # Only the first chunk pays for the failed attempt.
+        assert len(attempts) == 1
+        assert adp._use_odirect is False
+
+    def test_successful_odirect_write_keeps_odirect_enabled(
+        self, odirect_adapter: FSL2Adapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fallback must not fire when direct I/O works."""
+        adp = odirect_adapter
+        block = adp._os_disk_bs or 4096
+        payload = b"c" * (block * 2)
+
+        calls: list[Path] = []
+        original = adp._write_with_odirect
+
+        def _record(file_path: Path, buf: bytes) -> None:
+            calls.append(file_path)
+            original(file_path, buf)
+
+        monkeypatch.setattr(adp, "_write_with_odirect", _record)
+
+        k = _key(b"\x03")
+        _store_and_wait(adp, [k], [payload])
+
+        assert adp._key_to_path(k).read_bytes() == payload
+        assert len(calls) == 1
+        assert adp._use_odirect is True


### PR DESCRIPTION
## Problem

Closes #4386.

With the `fs` L2 adapter and `use_odirect: true`, a single rejected direct write kills the whole disk tier. `_write_with_odirect` re-raises, `_execute_store` marks the chunk failed, and nothing about the adapter's state changes — so the next chunk takes the same path and fails the same way. The result is what the issue reports: nothing is ever persisted to L2, the server keeps running and reports no fatal error, and the log fills with one `FSL2Adapter failed to store <path>` line per chunk for the lifetime of the process.

Whether `O_DIRECT` is usable depends on the file system, the device stack, and the alignment of the buffers handed to the adapter. None of that can be checked up front — `statvfs().f_bsize` at construction only tells us the block size to size-align against, not whether the kernel will accept the call.

## Fix

Catch `OSError` around the direct write, drop `O_DIRECT` for the rest of the process, and retry that chunk buffered:

- The adapter already has a buffered write path — it is used when the object size is not block-aligned — so this reuses it rather than adding one.
- Clearing `_use_odirect` also covers the load path, which reads the same flag (`_execute_load`), so reads stop attempting direct I/O too.
- The one-shot warning names the base path and the concrete errno, so an operator can tell `EINVAL` from `EACCES` without reading LMCache's source. `_write_with_odirect`'s existing `logger.exception` still emits the full traceback once.

Only the first chunk pays for the failed attempt; every store after it goes straight to buffered I/O.

This is deliberately about the *degradation*, not about which errno the reporter's md-RAID0 stack returns — the adapter should not depend on that being knowable to keep working.

## Tests

New `tests/v1/distributed/test_fs_l2_adapter_odirect.py`:

- `test_rejected_odirect_write_falls_back_to_buffered` — a rejected direct write (`OSError(EINVAL)`) still stores the chunk with the right bytes, later chunks store too, `O_DIRECT` is attempted exactly once, and `_use_odirect` ends up `False`.
- `test_successful_odirect_write_keeps_odirect_enabled` — the fallback does not fire when direct I/O works.

Verified on Linux against the real adapter:

```
# before the fix
1 failed, 1 passed

# after the fix (new file + existing tests/v1/distributed/test_fs_l2_adapter_delete.py)
11 passed
```

`ruff==0.11.7` (check + format), `isort==6.0.1`, `mypy==1.17.1 --config-file=pyproject.toml`, and the SPDX header check are all clean on both files; `mypy` was also green on the unmodified file beforehand, so nothing new was introduced.

> **Note on the base commit:** my fork's `dev` cannot be fast-forwarded (the sync touches `.github/workflows/*`, which my token is not scoped for), so this branch is cut from my fork's `dev` tip rather than upstream's. The diff against upstream `dev` is exactly the two files above and merges cleanly — happy to rebase if you'd prefer a fresher base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
