### PR TITLE
[core] Per-lane CUDA streams for concurrent KV retrieves

### DIFF
--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -694,3 +694,17 @@ def parse_args_to_coordinator_config(
         event_reporting=event_reporting,
         event_flush_interval=event_flush_interval,
     )
+
+
+def resolve_retrieve_lanes(*env_names: str, default: int = 2) -> int:
+    """Retrieve scatter-lane count from the first set env var, clamped >= 1.
+
+    Policy for BaseCacheContext's lane API: ``LMCACHE_RETRIEVE_LANES``
+    governs every retrieve path; blend also passes ``CB_RETRIEVE_LANES`` as
+    an alias. 1 = stock single-stream behavior.
+    """
+    for name in env_names:
+        raw = os.getenv(name)
+        if raw is not None:
+            return max(1, int(raw))
+    return default

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -42,6 +42,7 @@ from lmcache.v1.gpu_connector.gpu_ops import lmcache_memcpy_async_h2d
 from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.mp_coordinator.blend_client import PENDING
 from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.multiprocess.config import resolve_retrieve_lanes
 from lmcache.v1.multiprocess.custom_types import (
     CBMatchResult,
     CBUnifiedLookupResult,
@@ -65,7 +66,10 @@ from lmcache.v1.multiprocess.token_hasher import (
     rolling_hash_windows_numba,
     update_table_id_numba,
 )
-from lmcache.v1.platform.base.cache_context import BaseCacheContext
+from lmcache.v1.platform.base.cache_context import (
+    BaseCacheContext,
+    TransferLane,
+)
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -91,6 +95,14 @@ _TORCH_TO_AT_SCALAR = {
 # Default for cb_register_rope's wire-typed group_rot parameter (legacy: no
 # declared windows). Never mutated — the handler only iterates it.
 _EMPTY_GROUP_ROT: list[list[int]] = []
+
+# Retrieve scatter lanes (context-provisioned; see
+# BaseCacheContext.next_retrieve_lane): private streams so concurrent
+# retrieves overlap instead of serializing on the one context stream.
+# 1 = stock behavior. CB_RETRIEVE_LANES is blend's alias.
+_CB_RETRIEVE_LANES = resolve_retrieve_lanes(
+    "LMCACHE_RETRIEVE_LANES", "CB_RETRIEVE_LANES"
+)
 
 
 @dataclass
@@ -557,18 +569,17 @@ class BlendV3Module(InstanceLivenessTarget):
         # key must include the worker or later ranks skip work they never did.
         self._cb_applied_match_ranges: "OrderedDict[tuple[str, int | None], set[tuple[bytes, int, int]]]" = OrderedDict()  # noqa: E501
 
-        # Request-invariant retrieve-plan specs per GPU context (entries die
-        # with the context). The cached tuple holds the rope_state it was
-        # resolved against so a re-registration invalidates by identity.
-        self._cb_plan_invariants: "weakref.WeakKeyDictionary[Any, tuple]" = (
+        # Request-invariant retrieve-plan specs, ctx -> {lane_idx: tuple}
+        # (specs embed a lane's staging pointers; entries die with the
+        # context). The cached rope_state doubles as the validity check.
+        self._cb_plan_invariants: "weakref.WeakKeyDictionary[Any, dict[int, tuple]]" = (
             weakref.WeakKeyDictionary()
-        )
-        # Persistent pinned + device slot-mapping staging per GPU context,
+        )  # noqa: E501
+        # Pinned + device slot-mapping staging, ctx -> {lane_idx: entry},
         # grown on demand (see _cb_slot_buffers).
-        self._cb_slot_staging: "weakref.WeakKeyDictionary[Any, tuple]" = (
+        self._cb_slot_staging: "weakref.WeakKeyDictionary[Any, dict[int, list]]" = (
             weakref.WeakKeyDictionary()
         )
-
         # Non-blocking cb_unified_lookup poll state (submit-once, poll-on-recall)
         # so the handler never holds a worker thread across the L2->L1 loads.
         self._cb_jobs: dict[str, _CBUnifiedJob] = {}
@@ -789,27 +800,46 @@ class BlendV3Module(InstanceLivenessTarget):
             "legacy" if not norm_rot else str(norm_rot),
         )
 
-        # Pre-warm the retrieve-plan invariants + slot-mapping staging for
-        # this instance, off the retrieve critical path.
+        # Pre-warm every lane's staging + plan invariants off the retrieve
+        # critical path.
         try:
             entry = self._transfer_module.get_and_touch_context_entry(instance_id)
             ctx = entry.cache_context if entry is not None else None
             if ctx is not None:
-                self._cb_slot_buffers(
-                    ctx, ctx.kv_layer_groups_manager.num_kernel_groups, 1 << 16
-                )
                 rope_state = self._cb_rope_state[instance_id]
                 max_batch = ctx.max_batch_size
-                if self._cb_plan_invariants.get(ctx) is None:
-                    resolved = self._resolve_cb_plan_invariants(
-                        ctx, rope_state, max_batch
+                num_groups = ctx.kv_layer_groups_manager.num_kernel_groups
+                lanes, created = ctx.prewarm_retrieve_lanes(_CB_RETRIEVE_LANES)
+                per_lane = self._cb_plan_invariants.setdefault(ctx, {})
+                extra_bytes = 0
+                for lane in lanes:
+                    slot_entry = self._cb_slot_buffers(
+                        ctx, num_groups, 1 << 16, lane.index
                     )
-                    if resolved is not None:
-                        self._cb_plan_invariants[ctx] = (
-                            rope_state,
-                            max_batch,
-                            resolved,
+                    # Idempotent registrations: don't re-resolve warm lanes.
+                    if per_lane.get(lane.index) is None:
+                        resolved = self._resolve_cb_plan_invariants(
+                            ctx, rope_state, max_batch, buffers=lane.buffers
                         )
+                        if resolved is not None:
+                            per_lane[lane.index] = (rope_state, max_batch, resolved)
+                    if lane.index > 0:  # lane 0 rides the context's staging
+                        assert lane.buffers is not None
+                        assert lane.block_ids_buffer is not None
+                        extra_bytes += (
+                            int(lane.buffers.buffer.nbytes)
+                            + int(lane.block_ids_buffer.nbytes)
+                            + int(slot_entry[0].nbytes)
+                            + int(slot_entry[2].nbytes)
+                        )
+                if created:
+                    logger.info(
+                        "CB retrieve: pre-warmed %d scatter lane(s) for "
+                        "instance %d (%.1f MiB extra staging beyond lane 0)",
+                        len(lanes),
+                        instance_id,
+                        extra_bytes / (1 << 20),
+                    )
         except Exception:
             logger.debug("CB plan pre-warm skipped", exc_info=True)
 
@@ -1698,6 +1728,7 @@ class BlendV3Module(InstanceLivenessTarget):
         rope_state: _CBRopeState,
         batch_len: int,
         slots_to_rope: list[tuple[int, int, int]],
+        buffers: Any = None,
     ) -> None:
         """Re-RoPE the given tmp-pool slots in place (K-only, per kernel group).
 
@@ -1708,6 +1739,8 @@ class BlendV3Module(InstanceLivenessTarget):
             slots_to_rope (list[tuple[int, int, int]]): ``(slot_idx, old_st,
                 cur_st)`` per shifted slot — re-RoPE K from stored position
                 ``old_st`` to new position ``cur_st``.
+            buffers: Temp-buffer provider (a scatter lane's private staging);
+                None => the context's own buffers.
 
         Raises:
             RuntimeError: On a compressed (compress_ratio != 1) layout, a
@@ -1716,11 +1749,13 @@ class BlendV3Module(InstanceLivenessTarget):
         """
         if not slots_to_rope:
             return
+        if buffers is None:
+            buffers = gpu_context
         num_groups = gpu_context.kv_layer_groups_manager.num_kernel_groups
         for group_idx in range(num_groups):
             group = gpu_context.kv_layer_groups_manager.kernel_groups[group_idx]
             all_slots = [
-                gpu_context.get_temp_kernel_group_buffer(slot_idx, group_idx)
+                buffers.get_temp_kernel_group_buffer(slot_idx, group_idx)
                 for slot_idx in range(batch_len)
             ]
             rot = rope_state.rot_for_group(group.engine_group_idx, all_slots[0].dtype)
@@ -1808,6 +1843,7 @@ class BlendV3Module(InstanceLivenessTarget):
         resolved_groups: "list[tuple[torch.Tensor, int]]",
         batch: "list[tuple[CBMatchResult, Any]]",
         head_size: int,
+        buffers: Any = None,
     ) -> None:
         """Scatter one tmp-slot batch into the paged KV, one launch per
         (kernel group, tmp slot), straight from each slot's contiguous buffer
@@ -1820,7 +1856,11 @@ class BlendV3Module(InstanceLivenessTarget):
             resolved_groups: Per kernel group ``(block_ids, block_size)``.
             batch: ``(match, memory_obj)`` pairs; slot ``i`` holds ``batch[i]``.
             head_size: RoPE head size forwarded to the kernel.
+            buffers: Temp-buffer provider (a scatter lane's private staging);
+                None => the context's own buffers.
         """
+        if buffers is None:
+            buffers = gpu_context
         kgm = gpu_context.kv_layer_groups_manager
         tok_counts = [int(r.cur_ed - r.cur_st) for (r, _) in batch]
         pos = torch.cat(
@@ -1844,9 +1884,7 @@ class BlendV3Module(InstanceLivenessTarget):
             page_buffer_size = kgm.kernel_groups[group_idx].shape_desc.nb * group_bs
             tok_off = 0
             for slot_idx, n_tok in enumerate(tok_counts):
-                key_value = gpu_context.get_temp_kernel_group_buffer(
-                    slot_idx, group_idx
-                )
+                key_value = buffers.get_temp_kernel_group_buffer(slot_idx, group_idx)
                 if n_tok < key_value.shape[2]:
                     # Partial chunk: narrow to the real token count (the
                     # kernel scatters size(2) tokens). Slicing dim 2 breaks
@@ -1866,11 +1904,22 @@ class BlendV3Module(InstanceLivenessTarget):
                 tok_off += n_tok
 
     def _cb_slot_buffers(
-        self, gpu_context: BaseCacheContext, num_groups: int, n_pos: int
-    ) -> "tuple[torch.Tensor, Any, torch.Tensor]":
-        """Return ``(pinned, pinned_np, device)`` slot-mapping staging of at
-        least ``(num_groups, n_pos)``, reused across requests per context."""
-        entry = self._cb_slot_staging.get(gpu_context)
+        self,
+        gpu_context: BaseCacheContext,
+        num_groups: int,
+        n_pos: int,
+        lane_idx: int = 0,
+    ) -> "list":
+        """Return ``[pinned, pinned_np, device, h2d_guard]`` slot-mapping
+        staging of at least ``(num_groups, n_pos)``, reused across requests
+        per (context, lane) — per-lane so one lane's queued H2D is safe from
+        another's rebuild. ``h2d_guard`` (event or None, stamped by the plan
+        builder at lanes > 1) guards same-lane pinned reuse."""
+        lanes = self._cb_slot_staging.get(gpu_context)
+        if lanes is None:
+            lanes = {}
+            self._cb_slot_staging[gpu_context] = lanes
+        entry = lanes.get(lane_idx)
         if entry is None or entry[0].shape[0] < num_groups or entry[0].shape[1] < n_pos:
             cap = max(n_pos, 1 << 16)
             if entry is not None:
@@ -1884,8 +1933,8 @@ class BlendV3Module(InstanceLivenessTarget):
             dev = torch.empty(
                 (num_groups, cap), dtype=torch.int64, device=gpu_context.device
             )
-            entry = (pinned, pinned.numpy(), dev)
-            self._cb_slot_staging[gpu_context] = entry
+            entry = [pinned, pinned.numpy(), dev, None]
+            lanes[lane_idx] = entry
         return entry
 
     def _resolve_cb_plan_invariants(
@@ -1893,19 +1942,25 @@ class BlendV3Module(InstanceLivenessTarget):
         gpu_context: BaseCacheContext,
         rope_state: _CBRopeState,
         max_batch: int,
+        buffers: Any = None,
     ) -> "tuple[list[Any], list[torch.Tensor]] | None":
-        """Resolve the request-invariant plan half (cached per context in
-        ``_cb_plan_invariants``).
+        """Resolve the request-invariant plan half (cached per (context,
+        scatter lane) in ``_cb_plan_invariants``).
+
+        ``buffers`` is the temp-buffer provider whose pointers the specs
+        embed — a lane's private staging, or None for the context's own.
 
         Returns ``(group_specs, object_group_buffers)`` with slot-mapping
         fields as placeholders for the per-request stamp, or ``None`` on an
         unsupported layout (compressed / kv_size / dtype / head geometry).
         """
+        if buffers is None:
+            buffers = gpu_context
         kgm = gpu_context.kv_layer_groups_manager
         group_specs: list[Any] = []
         for group_idx in range(kgm.num_kernel_groups):
             group = kgm.kernel_groups[group_idx]
-            buf0 = gpu_context.get_temp_kernel_group_buffer(0, group_idx)
+            buf0 = buffers.get_temp_kernel_group_buffer(0, group_idx)
             num_layers, slot_tokens, hidden_dim = (
                 int(buf0.shape[1]),
                 int(buf0.shape[2]),
@@ -1917,7 +1972,7 @@ class BlendV3Module(InstanceLivenessTarget):
                     group_idx
                 ).data_ptr(),
                 temp_buffer_ptrs=[
-                    gpu_context.get_temp_kernel_group_buffer(slot, group_idx).data_ptr()
+                    buffers.get_temp_kernel_group_buffer(slot, group_idx).data_ptr()
                     for slot in range(max_batch)
                 ],
                 num_layers=num_layers,
@@ -1983,8 +2038,7 @@ class BlendV3Module(InstanceLivenessTarget):
                 )
             )
         object_group_buffers = [
-            gpu_context.get_temp_object_group_buffer(slot, 0)
-            for slot in range(max_batch)
+            buffers.get_temp_object_group_buffer(slot, 0) for slot in range(max_batch)
         ]
         return group_specs, object_group_buffers
 
@@ -1995,11 +2049,15 @@ class BlendV3Module(InstanceLivenessTarget):
         cpu_block_tables: "list[tuple[np.ndarray, int]]",
         runs: "list[list[tuple[CBMatchResult, Any]]]",
         max_batch: int,
+        lane: "TransferLane | None" = None,
     ) -> "tuple[list[Any], tuple[Any, Any, Any, Any], list[torch.Tensor]] | None":
         """Build the whole native retrieve plan: eligibility gates, cached
         invariant specs stamped with this request's slot mappings, and the
         numpy-vectorized int64 work tables for
         ``execute_cb_retrieve_plan_flat`` (layouts in the pybind docstring).
+
+        ``lane`` selects the scatter lane whose staging the plan embeds
+        (None => lane 0 / the context's own buffers).
 
         Returns:
             ``(group_specs, (staging, ropes, scatters, step_offsets),
@@ -2015,24 +2073,29 @@ class BlendV3Module(InstanceLivenessTarget):
             if not isinstance(memory_obj.parent(), LazyMemoryAllocator):
                 return None
 
+        lane_idx = 0 if lane is None else lane.index
+        lane_buffers = None if lane is None else lane.buffers
+
         # Specs are invariant per paged registration except the slot-mapping
-        # fields: cache them per context, re-stamp per request (the full
-        # resolve costs dozens of torch-view creations under the shared GIL).
+        # fields: cache them per (context, lane) — they embed the lane's
+        # staging pointers — and re-stamp per request (the full resolve
+        # costs dozens of torch-view creations under the shared GIL).
         # The cached rope_state reference doubles as the validity check: a
         # re-registration swaps the object, so identity comparison is sound.
-        cached = self._cb_plan_invariants.get(gpu_context)
+        per_lane = self._cb_plan_invariants.setdefault(gpu_context, {})
+        cached = per_lane.get(lane_idx)
         if cached is not None and not (
             cached[0] is rope_state and cached[1] == max_batch
         ):
             cached = None
         if cached is None:
             resolved = self._resolve_cb_plan_invariants(
-                gpu_context, rope_state, max_batch
+                gpu_context, rope_state, max_batch, buffers=lane_buffers
             )
             if resolved is None:
                 return None
             cached = (rope_state, max_batch, resolved)
-            self._cb_plan_invariants[gpu_context] = cached
+            per_lane[lane_idx] = cached
         group_specs, object_group_buffers = cached[2]
         num_groups = len(group_specs)
         wave = max_batch // 2
@@ -2087,9 +2150,16 @@ class BlendV3Module(InstanceLivenessTarget):
                 ]
             )
         n_pos = int(pos_np.shape[0])
-        pinned, pinned_np, dev_buf = self._cb_slot_buffers(
-            gpu_context, num_groups, n_pos
-        )
+        slot_entry = self._cb_slot_buffers(gpu_context, num_groups, n_pos, lane_idx)
+        pinned, pinned_np, dev_buf = slot_entry[0], slot_entry[1], slot_entry[2]
+        if slot_entry[3] is not None:
+            # Same-lane pinned reuse guard (armed only at lanes > 1): the
+            # previous request's H2D of these pinned rows queues behind its
+            # vllm_event wait, so rewriting them before it executes would
+            # corrupt that request's slot mappings — wait for it (cheap: it
+            # precedes the lane's bulk copies).
+            slot_entry[3].synchronize()
+            slot_entry[3] = None
         div_mod: "dict[int, tuple[np.ndarray, np.ndarray]]" = {}
         for gi, ((block_ids_np, group_bs), spec) in enumerate(
             zip(cpu_block_tables, group_specs, strict=True)
@@ -2107,6 +2177,12 @@ class BlendV3Module(InstanceLivenessTarget):
             # copies spec contents at call time.
             spec.slot_mapping_base = int(dev_buf[gi].data_ptr())
             spec.slot_mapping_capacity = n_pos
+        if lane is not None and lane.guarded:
+            # Arm the reuse guard for this lane's next request (records on
+            # the ambient stream = the lane's; see synchronize() above).
+            guard = torch_dev.Event()
+            guard.record()
+            slot_entry[3] = guard
         # The device staging must outlive the native call.
         keepalive = [dev_buf]
 
@@ -2225,6 +2301,11 @@ class BlendV3Module(InstanceLivenessTarget):
         rope_state = self._cb_rope_state[instance_id]
         chunk_size = self._ctx.chunk_size
 
+        # This request's scatter lane (see _CB_RETRIEVE_LANES): its stream +
+        # staging so concurrent retrieves overlap instead of serializing.
+        lane = gpu_context.next_retrieve_lane(_CB_RETRIEVE_LANES)
+        lane_buffers = gpu_context if lane.buffers is None else lane.buffers
+
         _retrieve_t0 = time.perf_counter()
 
         def _noop_success(reason: str = "?") -> tuple[bytes, bool]:
@@ -2250,7 +2331,7 @@ class BlendV3Module(InstanceLivenessTarget):
                 )
             with (
                 torch_dev.device(gpu_context.device),
-                torch_dev.stream(gpu_context.stream),
+                torch_dev.stream(lane.stream),
             ):
                 check_interprocess_event_support()
                 done_event = torch_dev.Event(interprocess=True)
@@ -2355,13 +2436,17 @@ class BlendV3Module(InstanceLivenessTarget):
 
         with (
             torch_dev.device(gpu_context.device),
-            torch_dev.stream(gpu_context.stream),
+            torch_dev.stream(lane.stream),
         ):
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
             # One staged block-id tensor per engine group, indexed by group.
-            block_ids_per_group_gpu = gpu_context.stage_block_ids(gpu_block_ids)
+            # Lanes >= 1 stage into their private buffer: the shared one may
+            # still be read by kernels queued on another lane's stream.
+            block_ids_per_group_gpu = gpu_context.stage_block_ids(
+                gpu_block_ids, out=lane.block_ids_buffer
+            )
 
             # Resolve each kernel group's block table + block size once. Select
             # by engine_group_idx (kernel groups may share one, e.g. MiniMax-M3).
@@ -2388,7 +2473,7 @@ class BlendV3Module(InstanceLivenessTarget):
                 cpu_block_tables.append((block_ids_np[eg_idx], group_bs))
 
             self._event_bus.publish_on_stream(
-                gpu_context.cupy_stream,
+                lane.cupy_stream,
                 Event(
                     event_type=EventType.CB_RETRIEVE_START,
                     session_id=key.request_id,
@@ -2408,7 +2493,8 @@ class BlendV3Module(InstanceLivenessTarget):
             vllm_event = torch_dev.Event.from_ipc_handle(
                 gpu_context.device, event_ipc_handle
             )
-            vllm_event.wait(stream=gpu_context.stream)
+            # Order this lane's scatter after the caller's forward event.
+            vllm_event.wait(stream=lane.stream)
 
             # Stage marks for the scatter_ms log line (CPU enqueue wall time):
             # fetch = L1 prefetched read, plan = flat-plan table build,
@@ -2453,7 +2539,7 @@ class BlendV3Module(InstanceLivenessTarget):
                     # applied match. Re-RoPE is folded in (n_shifted) — it is
                     # interleaved per-batch, so not a separate span.
                     self._event_bus.publish_on_stream(
-                        gpu_context.cupy_stream,
+                        lane.cupy_stream,
                         Event(
                             event_type=EventType.CB_SCATTER_START,
                             session_id=key.request_id,
@@ -2488,7 +2574,12 @@ class BlendV3Module(InstanceLivenessTarget):
                     # c_ops, non-lazy objects, max_batch < 2, or size mismatch).
                     _stage_t = time.perf_counter()
                     native_flat = self._build_cb_retrieve_plan_flat(
-                        gpu_context, rope_state, cpu_block_tables, runs, max_batch
+                        gpu_context,
+                        rope_state,
+                        cpu_block_tables,
+                        runs,
+                        max_batch,
+                        lane=lane,
                     )
                     _stage_ms["plan"] = (time.perf_counter() - _stage_t) * 1000
                     if native_flat is not None:
@@ -2508,10 +2599,11 @@ class BlendV3Module(InstanceLivenessTarget):
                             batch = run[batch_start : batch_start + max_batch]
                             batch_len = len(batch)
 
-                            # (a) H2D fill into per-chunk tmp slots.
+                            # (a) H2D fill into per-chunk tmp slots (the
+                            # lane's own, so lanes never share slots).
                             for slot_idx, (_, memory_obj) in enumerate(batch):
                                 # Single object group => object_group_idx=0.
-                                flat_slot = gpu_context.get_temp_object_group_buffer(
+                                flat_slot = lane_buffers.get_temp_object_group_buffer(
                                     slot_idx, 0
                                 )
                                 lmcache_memcpy_async_h2d(memory_obj, flat_slot)
@@ -2523,7 +2615,11 @@ class BlendV3Module(InstanceLivenessTarget):
                                 if r.old_st != r.cur_st
                             ]
                             self._apply_cb_rope_batched(
-                                gpu_context, rope_state, batch_len, slots_to_rope
+                                gpu_context,
+                                rope_state,
+                                batch_len,
+                                slots_to_rope,
+                                buffers=lane_buffers,
                             )
 
                             # (c) Per-token slot scatter: partial vLLM blocks
@@ -2533,12 +2629,13 @@ class BlendV3Module(InstanceLivenessTarget):
                                 resolved_groups,
                                 batch,
                                 rope_state.head_size,
+                                buffers=lane_buffers,
                             )
 
                     applied_now = {(r.hash, r.cur_st, r.cur_ed) for r, _ in pairs}
 
                     self._event_bus.publish_on_stream(
-                        gpu_context.cupy_stream,
+                        lane.cupy_stream,
                         Event(
                             event_type=EventType.CB_SCATTER_END,
                             session_id=key.request_id,
@@ -2547,7 +2644,7 @@ class BlendV3Module(InstanceLivenessTarget):
             except Exception:
                 logger.exception("Error during retrieving prefetched results")
                 self._event_bus.publish_on_stream(
-                    gpu_context.cupy_stream,
+                    lane.cupy_stream,
                     Event(
                         event_type=EventType.CB_RETRIEVE_END,
                         session_id=key.request_id,
@@ -2555,7 +2652,7 @@ class BlendV3Module(InstanceLivenessTarget):
                     ),
                 )
                 self._event_bus.publish_on_stream(
-                    gpu_context.cupy_stream,
+                    lane.cupy_stream,
                     Event(
                         event_type=EventType.CB_REQUEST_END,
                         session_id=key.request_id,
@@ -2568,7 +2665,7 @@ class BlendV3Module(InstanceLivenessTarget):
 
             event.record()
             self._event_bus.publish_on_stream(
-                gpu_context.cupy_stream,
+                lane.cupy_stream,
                 Event(
                     event_type=EventType.CB_RETRIEVE_END,
                     session_id=key.request_id,
@@ -2597,7 +2694,7 @@ class BlendV3Module(InstanceLivenessTarget):
             {k: round(v, 1) for k, v in _stage_ms.items()},
         )
         self._event_bus.publish_on_stream(
-            gpu_context.cupy_stream,
+            lane.cupy_stream,
             Event(
                 event_type=EventType.CB_REQUEST_END,
                 session_id=key.request_id,

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -4,7 +4,7 @@
 # Standard
 from dataclasses import dataclass
 from itertools import islice
-from typing import Generator, Sequence
+from typing import Any, Generator, Sequence
 import threading
 import time
 
@@ -31,6 +31,7 @@ from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.memory_management import GDSMemoryObject, MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.multiprocess.config import resolve_retrieve_lanes
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
@@ -59,6 +60,12 @@ logger = init_logger(__name__)
 _HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = hasattr(
     lmc_ops, "execute_object_group_transfer"
 )
+
+# Retrieve scatter lanes (context-provisioned; see
+# BaseCacheContext.next_retrieve_lane): concurrent retrieves otherwise
+# serialize on the single per-context stream, each request's completion
+# event draining behind the previous requests' copies. 1 = stock behavior.
+_RETRIEVE_LANES = resolve_retrieve_lanes("LMCACHE_RETRIEVE_LANES")
 
 
 def get_layout_desc(
@@ -134,9 +141,12 @@ def batched_iteration_with_skip(
 def downsample_and_stage_block_ids(
     cache_context: BaseCacheContext,
     block_ids: list[list[int]],
+    out: "torch.Tensor | None" = None,
 ) -> list[torch.Tensor]:
     """Cut the block id lists to skip the unneeded blocks in a chunk and
-    stage it into GPU tensors for later use.
+    stage it into GPU tensors for later use. ``out`` is a caller-owned
+    staging destination (retrieve scatter lanes); None => the context's
+    shared buffer.
 
     This mainly targets the case where a portion of the blocks are not
     needed for every chunk, such as deepseek v4's swa cache.
@@ -204,7 +214,7 @@ def downsample_and_stage_block_ids(
         block_ids[kernel_group_id] = new_block_ids
 
     # Stage the cut block ids into GPU tensors
-    block_ids_gpu = cache_context.stage_block_ids(block_ids)
+    block_ids_gpu = cache_context.stage_block_ids(block_ids, out=out)
     return block_ids_gpu
 
 
@@ -246,6 +256,7 @@ def _run_object_group_transfer_plan(
     batch_size: int,
     skip_first_n_tokens: int,
     direction: "lmc_ops.TransferDirection",
+    buffers: Any = None,
 ) -> None:
     """Plan and execute one object group's transfer in a single native call.
 
@@ -268,11 +279,15 @@ def _run_object_group_transfer_plan(
         batch_size: Number of memory objects per batched copy.
         skip_first_n_tokens: Tokens to skip writing at the start of the range.
         direction: H2D (retrieve) or D2H (store).
+        buffers: Temp-buffer provider (a retrieve scatter lane's private
+            staging); None => the context's own buffers.
 
     Raises:
         ValueError: If a None entry is found in memory_objs when direction is
             H2D, or if an object's size does not match its GPU staging buffer.
     """
+    if buffers is None:
+        buffers = cache_context
     lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
     kv_groups_manager = cache_context.kv_layer_groups_manager
     object_group = kv_groups_manager.object_groups[object_group_id]
@@ -302,7 +317,7 @@ def _run_object_group_transfer_plan(
         paged_ptrs = cache_context.get_kernel_group_kv_pointers(kernel_group_id)
         block_ids_tensor = block_ids_gpu[kernel_group_id]
         temp_buffers = [
-            cache_context.get_temp_kernel_group_buffer(slot, kernel_group_id)
+            buffers.get_temp_kernel_group_buffer(slot, kernel_group_id)
             for slot in range(max_batch_size)
         ]
 
@@ -321,7 +336,7 @@ def _run_object_group_transfer_plan(
 
     # Temp object-group staging buffers (reused per batch slot, like above).
     object_group_buffers = [
-        cache_context.get_temp_object_group_buffer(slot, object_group_id)
+        buffers.get_temp_object_group_buffer(slot, object_group_id)
         for slot in range(max_batch_size)
     ]
 
@@ -417,6 +432,7 @@ def transfer_kv_per_object_group(
     batch_size: int,
     skip_first_n_tokens: int,
     direction: "lmc_ops.TransferDirection",
+    buffers: Any = None,
 ) -> None:
     """Helper function to transfer memory objects of a single object group
     to/from GPU, with batching support.
@@ -437,6 +453,8 @@ def transfer_kv_per_object_group(
             the retrieve range. This avoids overwriting APC-shared GPU blocks that
             may be read concurrently by other requests.
         direction: The transfer direction, H2D (retrieve) or D2H (store).
+        buffers: Temp-buffer provider (a retrieve scatter lane's private
+            staging); None => the context's own buffers.
 
     Raises:
         ValueError: If it founds None entry in memory_objs when direction is H2D.
@@ -444,6 +462,8 @@ def transfer_kv_per_object_group(
         This function expects the caller to stage the block ids (list[list[int]])
         into GPU tensors and pass them in as `block_ids_gpu`.
     """
+    if buffers is None:
+        buffers = cache_context
     if _HAS_NATIVE_OBJECT_GROUP_TRANSFER and not any(
         isinstance(mo, GDSMemoryObject) for mo in memory_objs
     ):
@@ -455,6 +475,7 @@ def transfer_kv_per_object_group(
             batch_size,
             skip_first_n_tokens,
             direction,
+            buffers=buffers,
         )
         return
 
@@ -504,9 +525,7 @@ def transfer_kv_per_object_group(
             for chunk_idx, memory_obj in enumerate(memory_object_batch):
                 lmcache_memcpy_async_h2d(
                     memory_obj,
-                    cache_context.get_temp_object_group_buffer(
-                        chunk_idx, object_group_id
-                    ),
+                    buffers.get_temp_object_group_buffer(chunk_idx, object_group_id),
                 )
 
         # Do paged KV copy
@@ -548,9 +567,7 @@ def transfer_kv_per_object_group(
                 kernel_group_id
             )
             tmp_gpu_buffers_batched = [
-                cache_context.get_temp_kernel_group_buffer(
-                    i, kernel_group_id
-                ).data_ptr()
+                buffers.get_temp_kernel_group_buffer(i, kernel_group_id).data_ptr()
                 for i in range(batch_len)
             ]
             lmc_ops.multi_layer_block_kv_transfer(
@@ -569,9 +586,7 @@ def transfer_kv_per_object_group(
         if not is_h2d:
             for chunk_idx, memory_obj in enumerate(memory_object_batch):
                 lmcache_memcpy_async_d2h(
-                    cache_context.get_temp_object_group_buffer(
-                        chunk_idx, object_group_id
-                    ),
+                    buffers.get_temp_object_group_buffer(chunk_idx, object_group_id),
                     memory_obj,
                 )
 
@@ -905,6 +920,18 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 event_backend=event_backend,
             )
 
+        # Pre-warm retrieve lanes off the retrieve critical path.
+        try:
+            _, created = cache_context.prewarm_retrieve_lanes(_RETRIEVE_LANES)
+            if created > 1:
+                logger.info(
+                    "Pre-warmed %d retrieve scatter lane(s) for instance %d",
+                    created,
+                    instance_id,
+                )
+        except Exception:
+            logger.debug("retrieve-lane pre-warm skipped", exc_info=True)
+
         logger.info(
             "Registered KV cache for GPU ID %d with %d layers",
             instance_id,
@@ -1193,6 +1220,12 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
         num_chunks = len(obj_keys_per_obj_group[0])
 
+        # This request's scatter lane (see _RETRIEVE_LANES): its own stream +
+        # staging, so concurrent retrieves overlap instead of serializing on
+        # the context stream. Lane 0 == the context's stream/buffers.
+        lane = cache_context.next_retrieve_lane(_RETRIEVE_LANES)
+        lane_buffers = cache_context if lane.buffers is None else lane.buffers
+
         # CPU-synchronous sentinel: a GPU retrieve is about to be enqueued.
         # Must be published via publish() (not publish_on_stream) so the
         # drain thread sees it before MP_REQUEST_END can race MP_RETRIEVE_END.
@@ -1205,7 +1238,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
 
         self._ctx.event_bus.publish_on_stream(
-            cache_context.cupy_stream,
+            lane.cupy_stream,
             Event(
                 event_type=EventType.MP_RETRIEVE_START,
                 session_id=key.request_id,
@@ -1226,7 +1259,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
 
         with (
             torch_dev.device(cache_context.device),
-            torch_dev.stream(cache_context.stream),
+            torch_dev.stream(lane.stream),
         ):
             event = event_backend.create_event(cache_context.device)
 
@@ -1249,17 +1282,20 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     num_chunks,
                     blocks_per_chunk,
                 )
-                event_backend.record_event(event, cache_context.stream)
+                event_backend.record_event(event, lane.stream)
                 return event_backend.export_event(event, cache_context.device), False
 
-            # Cut and stage all block_ids to GPU once before the transfer
+            # Cut and stage all block_ids to GPU once before the transfer.
+            # Lanes >= 1 stage into their private buffer: the shared one may
+            # still be read by kernels queued on another lane's stream.
             block_ids_per_group_gpu = downsample_and_stage_block_ids(
-                cache_context, gpu_block_ids
+                cache_context, gpu_block_ids, out=lane.block_ids_buffer
             )
             producer_event = event_backend.import_event(
                 event_ipc_handle, cache_context.device
             )
-            event_backend.wait_event(producer_event, cache_context.stream)
+            # Order this lane's transfer after the caller's forward event.
+            event_backend.wait_event(producer_event, lane.stream)
 
             prefetched_keys: list[ObjectKey] = []
             total_bytes = 0
@@ -1285,6 +1321,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                             batch_size=cache_context.max_batch_size,
                             skip_first_n_tokens=skip_first_n_tokens,
                             direction=lmc_ops.TransferDirection.H2D,
+                            buffers=lane_buffers,
                         )
                         # Extend only after the copy is enqueued: on exception,
                         # read_prefetched_results releases this group's locks
@@ -1294,10 +1331,11 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 logger.exception("Cannot retrieve keys due to exception")
                 retrieve_succeeded = False
             finally:
-                event_backend.record_event(event, cache_context.stream)
+                event_backend.record_event(event, lane.stream)
                 if prefetched_keys:
+                    # Release read locks when THIS lane's copies complete.
                     submit_callback_to_stream(
-                        cache_context.cupy_stream,
+                        lane.cupy_stream,
                         "finish_read_prefetched",
                         prefetched_keys,
                     )
@@ -1307,7 +1345,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     else 0
                 )
                 self._ctx.event_bus.publish_on_stream(
-                    cache_context.cupy_stream,
+                    lane.cupy_stream,
                     Event(
                         event_type=EventType.MP_RETRIEVE_END,
                         session_id=key.request_id,

--- a/lmcache/v1/platform/base/cache_context.py
+++ b/lmcache/v1/platform/base/cache_context.py
@@ -33,6 +33,38 @@ if TYPE_CHECKING:
     import lmcache.c_ops as lmc_ops
 
 
+class TransferLane:
+    """One retrieve transfer queue on a cache context: a stream + private
+    staging. Lane 0 aliases the context's own stream/buffers (``buffers`` /
+    ``block_ids_buffer`` None => use the context). ``guarded`` (context
+    runs >1 lanes) arms consumers' same-lane staging reuse guards."""
+
+    __slots__ = (
+        "index",
+        "stream",
+        "cupy_stream",
+        "buffers",
+        "block_ids_buffer",
+        "guarded",
+    )
+
+    def __init__(
+        self,
+        index: int,
+        stream: Any,
+        cupy_stream: Any,
+        buffers: Any = None,
+        block_ids_buffer: "torch.Tensor | None" = None,
+        guarded: bool = False,
+    ) -> None:
+        self.index = index
+        self.stream = stream
+        self.cupy_stream = cupy_stream
+        self.buffers = buffers
+        self.block_ids_buffer = block_ids_buffer
+        self.guarded = guarded
+
+
 class BaseCacheContext(ABC):
     """Abstract base for GPU and CPU cache contexts.
 
@@ -67,6 +99,12 @@ class BaseCacheContext(ABC):
         self.kv_layer_groups_manager_ = kv_layer_groups_manager
         self.block_ids_buffer_ = block_ids_buffer
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
+        # Retrieve scatter lanes (see next_retrieve_lane); the count is
+        # resolved once at first use, lanes created lazily or by
+        # prewarm_retrieve_lanes.
+        self.retrieve_lanes_: "list[TransferLane | None]" = []
+        self.retrieve_lane_next_ = 0
+        self.retrieve_lane_count_: "int | None" = None
 
     # ------------------------------------------------------------------
     # Abstract -- subclasses MUST implement
@@ -243,12 +281,18 @@ class BaseCacheContext(ABC):
         )
 
     def stage_block_ids(
-        self, block_ids_per_group: list[list[int]]
+        self,
+        block_ids_per_group: list[list[int]],
+        out: "torch.Tensor | None" = None,
     ) -> list[torch.Tensor]:
-        """Stage per-group block IDs into the shared staging buffer.
+        """Stage per-group block IDs into the shared staging buffer, or into
+        ``out``: retrieve lanes pass their private buffer so one lane's
+        staging cannot overwrite block IDs another lane's queued kernels
+        still read.
 
         Returns one non-overlapping view per LMCache group.
         """
+        buffer = self.block_ids_buffer_ if out is None else out
         offsets = [0]
         flat: array.array = array.array("q")
         for view_block_ids in block_ids_per_group:
@@ -256,19 +300,88 @@ class BaseCacheContext(ABC):
             offsets.append(len(flat))
 
         total = offsets[-1]
-        if total > self.block_ids_buffer_.shape[0]:
+        if total > buffer.shape[0]:
             raise ValueError(
                 "block ID total %d exceeds the pre-allocated buffer "
-                "size %d" % (total, self.block_ids_buffer_.shape[0])
+                "size %d" % (total, buffer.shape[0])
             )
         if total:
             cpu_tensor = torch.frombuffer(flat, dtype=torch.long)
-            self.block_ids_buffer_[:total].copy_(cpu_tensor, non_blocking=True)
+            buffer[:total].copy_(cpu_tensor, non_blocking=True)
 
         return [
-            self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
-            for i in range(len(block_ids_per_group))
+            buffer[offsets[i] : offsets[i + 1]] for i in range(len(block_ids_per_group))
         ]
+
+    # ------------------------------------------------------------------
+    # Retrieve scatter lanes
+    # ------------------------------------------------------------------
+    # Concurrent retrieves serialize on the single per-context stream:
+    # request N's completion event drains behind requests 1..N-1. Lanes are
+    # extra transfer streams, each with private staging, so requests'
+    # copies overlap; per-lane stream ordering keeps staging reuse safe
+    # without locks. 1 lane = stock behavior.
+
+    def supports_retrieve_lanes(self) -> bool:
+        """Whether this platform can provision extra transfer streams +
+        staging. Base: single-lane only (lane 0 is always safe)."""
+        return False
+
+    def _make_retrieve_lane(self, index: int, guarded: bool) -> TransferLane:
+        """Build lane ``index``. Lane 0 aliases the context's own stream and
+        staging (nothing allocated); platforms answering True to
+        :meth:`supports_retrieve_lanes` must provision lanes >= 1."""
+        if index == 0:
+            return TransferLane(0, self.stream, self.cupy_stream, guarded=guarded)
+        raise NotImplementedError(
+            f"{type(self).__name__} does not provision retrieve lanes >= 1"
+        )
+
+    def _retrieve_lane_slots(self, num_lanes: int) -> int:
+        """Resolve the lane count once per context (first provisioning
+        wins) and size the slot list, so consumers with different resolved
+        counts share one stable round-robin modulus."""
+        if self.retrieve_lane_count_ is None:
+            self.retrieve_lane_count_ = (
+                max(1, num_lanes) if self.supports_retrieve_lanes() else 1
+            )
+            self.retrieve_lanes_ = [None] * self.retrieve_lane_count_
+        return self.retrieve_lane_count_
+
+    def next_retrieve_lane(self, num_lanes: int) -> TransferLane:
+        """Round-robin the next retrieve lane, creating it on first use.
+
+        ``num_lanes`` is the consumer-resolved count (policy lives with the
+        consumers); 1 => always lane 0, i.e. the stock single-stream
+        behavior. A context's transfers run on its one affinity thread, so
+        the counter needs no lock.
+        """
+        n = self._retrieve_lane_slots(num_lanes)
+        idx = self.retrieve_lane_next_ % n
+        self.retrieve_lane_next_ = (idx + 1) % n
+        lane = self.retrieve_lanes_[idx]
+        if lane is None:
+            lane = self._make_retrieve_lane(idx, guarded=n > 1)
+            self.retrieve_lanes_[idx] = lane
+        return lane
+
+    def prewarm_retrieve_lanes(
+        self, num_lanes: int
+    ) -> "tuple[list[TransferLane], int]":
+        """Create every lane now, off the retrieve critical path. Leaves
+        the round-robin counter untouched.
+
+        Returns:
+            ``(lanes, created)``: all lanes in index order and how many this
+            call created (0 => already warm, e.g. a re-registration).
+        """
+        n = self._retrieve_lane_slots(num_lanes)
+        created = 0
+        for idx in range(n):
+            if self.retrieve_lanes_[idx] is None:
+                self.retrieve_lanes_[idx] = self._make_retrieve_lane(idx, guarded=n > 1)
+                created += 1
+        return [lane for lane in self.retrieve_lanes_ if lane is not None], created
 
     # ------------------------------------------------------------------
     # Derived properties (pure helpers)

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -36,7 +36,7 @@ from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
     engine_group_layer_indices,
 )
-from lmcache.v1.platform.base.cache_context import BaseCacheContext
+from lmcache.v1.platform.base.cache_context import BaseCacheContext, TransferLane
 
 logger = init_logger(__name__)
 
@@ -409,6 +409,9 @@ class GPUCacheContext(BaseCacheContext):
             device=self.device_,
             max_batch_size=4,
         )
+        # Extra staging buffers handed out via clone_temp_buffer() (retrieve
+        # scatter lanes); tracked so close() deregisters them.
+        self._temp_buffer_clones: list[_TempGPUBuffer] = []
 
         # GPU streams
         self.cuda_stream_ = torch_dev.Stream(device=self.device_)
@@ -435,10 +438,87 @@ class GPUCacheContext(BaseCacheContext):
 
     def close(self) -> None:
         """
-        Deregister this context's GDS staging buffer (reverse of __init__).
+        Deregister this context's GDS staging buffer (reverse of __init__),
+        plus any scatter-lane clones handed out by clone_temp_buffer().
         """
         with torch_dev.stream(self.cuda_stream_):
             get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
+            for clone in self._temp_buffer_clones:
+                get_gds_context().deregister_gpu_buffer(clone.buffer)
+        self._temp_buffer_clones.clear()
+
+    def supports_retrieve_lanes(self) -> bool:
+        """CUDA contexts can provision extra transfer streams + staging."""
+        return True
+
+    def _make_retrieve_lane(self, index: int, guarded: bool) -> TransferLane:
+        """Provision retrieve lane ``index``: lane 0 aliases the context's
+        stream/staging; lanes >= 1 get their own stream, a staging clone
+        (GDS-registered on the lane stream, deregistered in close()), and a
+        private block-id buffer sized like the shared one."""
+        if index == 0:
+            return super()._make_retrieve_lane(index, guarded)
+        # Third Party
+        import cupy
+
+        with torch_dev.device(self.device_):
+            stream = torch_dev.Stream(device=self.device_)
+            cupy_stream = cupy.cuda.ExternalStream(
+                stream.cuda_stream, self.device_.index
+            )
+            with torch_dev.stream(stream):
+                buffers = self.clone_temp_buffer()
+                block_ids_buffer = torch.empty(
+                    self.block_ids_buffer_.shape[0],
+                    dtype=torch.long,
+                    device=self.device_,
+                )
+                self._warm_retrieve_lane(buffers, block_ids_buffer)
+            stream.synchronize()
+        return TransferLane(
+            index, stream, cupy_stream, buffers, block_ids_buffer, guarded=guarded
+        )
+
+    def _warm_retrieve_lane(
+        self, buffers: _TempGPUBuffer, block_ids_buffer: torch.Tensor
+    ) -> None:
+        """Exercise a fresh lane once on the ambient (lane) stream: CUDA
+        lazy module loading makes the first launch of a not-yet-loaded
+        kernel serialize against all in-flight work in the process, so no
+        first-launch (or first pinned-alloc / IPC-event init) may remain
+        once traffic starts."""
+        buffers.buffer[:4096].fill_(0)
+        for kg_idx in range(self.kv_layer_groups_manager_.num_kernel_groups):
+            buffers.get_temp_kernel_group_buffer(0, kg_idx).view(-1)[:1024].fill_(0)
+        pinned = torch.zeros(4096, dtype=torch.uint8, pin_memory=True)
+        buffers.buffer[:4096].copy_(pinned, non_blocking=True)
+        self.stage_block_ids([[0]], out=block_ids_buffer)
+        event = torch_dev.Event(interprocess=True)
+        event.record()
+        event.ipc_handle()
+        event.query()
+
+    def clone_temp_buffer(self) -> _TempGPUBuffer:
+        """Allocate an extra staging buffer with the context's exact
+        geometry, exposing the same get_temp_*_buffer surface. Used for
+        retrieve lanes' private staging; GDS-registered on the caller's
+        current stream and deregistered in close()."""
+        clone = _TempGPUBuffer(
+            kv_layer_groups_manager=self.kv_layer_groups_manager_,
+            lmcache_tokens_per_chunk=self.lmcache_tokens_per_chunk,
+            device=self.device_,
+            max_batch_size=self._temp_buffer.max_batch_size,
+        )
+        get_gds_context().register_gpu_buffer(clone.buffer)
+        self._temp_buffer_clones.append(clone)
+        logger.info(
+            "Allocated temp-buffer clone #%d (%.1f MiB) on %s for a retrieve "
+            "scatter lane",
+            len(self._temp_buffer_clones),
+            clone.buffer.nbytes / (1 << 20),
+            str(self.device_),
+        )
+        return clone
 
     @property
     def stream(self) -> Any:

--- a/tests/v1/multiprocess/test_batched_iteration_with_skip.py
+++ b/tests/v1/multiprocess/test_batched_iteration_with_skip.py
@@ -110,3 +110,101 @@ def test_returns_tuples_not_lists():
         batched_iteration_with_skip([1, 2, 3, 4], batch_size=2, skip_count=0)
     )
     assert isinstance(batch, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Retrieve scatter lanes: lane staging plumbed through the transfer helpers.
+# ---------------------------------------------------------------------------
+
+
+def test_downsample_and_stage_forwards_lane_buffer():
+    """downsample_and_stage_block_ids passes the lane's private buffer to
+    stage_block_ids; None (lane 0) keeps the stock call."""
+    # Standard
+    from unittest.mock import MagicMock
+
+    # Third Party
+    import torch
+
+    # First Party
+    from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+        downsample_and_stage_block_ids,
+    )
+
+    ctx = MagicMock()
+    ctx.kv_layer_groups_manager.num_kernel_groups = 1
+    ctx.kv_layer_groups_manager.get_subchunk_sw_size_tokens.return_value = 128
+    ctx.lmcache_tokens_per_chunk = 128
+    ctx.calculate_num_blocks.return_value = 2
+
+    lane_buf = torch.zeros(8, dtype=torch.long)
+    downsample_and_stage_block_ids(ctx, [[1, 2]], out=lane_buf)
+    assert ctx.stage_block_ids.call_args.kwargs["out"] is lane_buf
+
+    downsample_and_stage_block_ids(ctx, [[1, 2]])
+    assert ctx.stage_block_ids.call_args.kwargs["out"] is None
+
+
+def test_transfer_fallback_uses_lane_buffers():
+    """The Python fallback of transfer_kv_per_object_group stages H2D into
+    the provided lane buffers (not the context's); buffers=None (lane 0) is
+    the stock context-buffer path."""
+    # Standard
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, patch
+
+    # Third Party
+    import torch
+
+    # First Party
+    from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as mod
+
+    ctx = MagicMock()
+    ctx.lmcache_tokens_per_chunk = 4
+    ctx.kv_layer_groups_manager.object_groups = [
+        SimpleNamespace(kernel_group_indices=[0])
+    ]
+    attn = ctx.kv_layer_groups_manager.get_attn_desc.return_value
+    attn.is_full_attention.return_value = True
+    ctx.calculate_num_blocks.return_value = 1
+    ctx.kv_layer_groups_manager.get_subchunk_sw_size_tokens.return_value = 4
+
+    lane_bufs = MagicMock()
+    memory_objs = [MagicMock()]
+    block_ids_gpu = [torch.tensor([0], dtype=torch.long)]
+
+    with (
+        patch.object(mod, "_HAS_NATIVE_OBJECT_GROUP_TRANSFER", False),
+        patch.object(mod, "lmcache_memcpy_async_h2d") as h2d,
+        patch.object(mod, "lmc_ops") as ops,
+    ):
+        ops.TransferDirection.H2D = "H2D"
+        mod.transfer_kv_per_object_group(
+            ctx,
+            block_ids_gpu,
+            memory_objs,
+            object_group_id=0,
+            batch_size=2,
+            skip_first_n_tokens=0,
+            direction="H2D",
+            buffers=lane_bufs,
+        )
+        # Staging + kernel temp buffers come from the lane, not the context.
+        lane_bufs.get_temp_object_group_buffer.assert_called_once_with(0, 0)
+        lane_bufs.get_temp_kernel_group_buffer.assert_called_once_with(0, 0)
+        ctx.get_temp_object_group_buffer.assert_not_called()
+        ctx.get_temp_kernel_group_buffer.assert_not_called()
+        assert h2d.call_count == 1
+
+        # Lane 0 (buffers=None): stock context buffers.
+        mod.transfer_kv_per_object_group(
+            ctx,
+            block_ids_gpu,
+            memory_objs,
+            object_group_id=0,
+            batch_size=2,
+            skip_first_n_tokens=0,
+            direction="H2D",
+        )
+        ctx.get_temp_object_group_buffer.assert_called_once_with(0, 0)
+        ctx.get_temp_kernel_group_buffer.assert_called_once_with(0, 0)

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -1023,3 +1023,90 @@ def test_native_plan_falls_back_for_compressed_group():
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# Scatter lanes: blend consumes the cache context's lane API. Pool-mechanics
+# coverage (round-robin, pre-warm, lanes=1 passthrough, degrade) lives in
+# tests/v1/platform/test_gpu_cache_context.py; here we pin blend's per-lane
+# plan-invariant isolation.
+# ---------------------------------------------------------------------------
+
+
+@native_retrieve_plan_required
+def test_native_plan_invariants_are_per_lane():
+    """Two lanes on one context cache separate invariant specs (each lane's
+    specs embed that lane's staging pointers) and separate slot-mapping
+    staging; the plan's staging table targets the lane's own buffers."""
+    # Third Party
+    import numpy as np
+
+    # First Party
+    from lmcache.v1.platform.base.cache_context import TransferLane
+
+    eng, gpu_context, rope_state, obj_bytes = _build_plan_engine_and_context()
+
+    # A second, lane-private buffer provider with identical geometry.
+    # Third Party
+    import torch
+
+    lane_kv = {
+        (slot, group): torch.zeros_like(gpu_context.get_temp_kernel_group_buffer(0, 0))
+        for slot in range(2)
+        for group in range(2)
+    }
+    lane_obj = [torch.zeros(obj_bytes, dtype=torch.uint8) for _ in range(2)]
+    lane_bufs = MagicMock()
+    lane_bufs.get_temp_kernel_group_buffer.side_effect = lambda s, g: lane_kv[(s, g)]
+    lane_bufs.get_temp_object_group_buffer.side_effect = lambda s, og: lane_obj[s]
+    lane1 = TransferLane(
+        1, stream=None, cupy_stream=None, buffers=lane_bufs, guarded=False
+    )
+
+    def pair(cur_st, cur_ed, old_st):
+        return (
+            SimpleNamespace(cur_st=cur_st, cur_ed=cur_ed, old_st=old_st),
+            _lazy_memory_obj(obj_bytes, address=cur_st * 1000),
+        )
+
+    cpu_block_tables = [
+        (np.array([10, 11, 12], dtype=np.int64), 4),
+        (np.array([20, 21, 22], dtype=np.int64), 4),
+    ]
+
+    plan0 = eng._build_cb_retrieve_plan_flat(
+        gpu_context, rope_state, cpu_block_tables, [[pair(0, 4, 100)]], max_batch=2
+    )
+    plan1 = eng._build_cb_retrieve_plan_flat(
+        gpu_context,
+        rope_state,
+        cpu_block_tables,
+        [[pair(0, 4, 100)]],
+        max_batch=2,
+        lane=lane1,
+    )
+    assert plan0 is not None and plan1 is not None
+    specs0, (staging0, *_), keep0 = plan0
+    specs1, (staging1, *_), keep1 = plan1
+
+    # Separate invariant caches per lane: distinct spec objects, and lane 1's
+    # temp pointers come from the lane's private buffers.
+    assert specs1[0] is not specs0[0]
+    assert staging1[0, 0] == lane_obj[0].data_ptr()
+    assert staging0[0, 0] == gpu_context.get_temp_object_group_buffer(0, 0).data_ptr()
+
+    # Separate slot-mapping staging per lane (distinct device buffers).
+    assert keep1[0] is not keep0[0]
+    assert specs1[0].slot_mapping_base == keep1[0][0].data_ptr()
+
+    # Lane identity is stable: rebuilding on lane 1 reuses its own cache.
+    plan1b = eng._build_cb_retrieve_plan_flat(
+        gpu_context,
+        rope_state,
+        cpu_block_tables,
+        [[pair(4, 8, 200)]],
+        max_batch=2,
+        lane=lane1,
+    )
+    assert plan1b is not None
+    assert plan1b[0][0] is specs1[0]

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -211,7 +211,8 @@ def test_server_store_and_retrieve_delegate_event_ordering(
     monkeypatch.setattr(
         lmcache_driven_transfer,
         "downsample_and_stage_block_ids",
-        lambda cache_context, block_ids: block_ids,
+        # out= is the retrieve scatter lanes' private staging destination.
+        lambda cache_context, block_ids, out=None: block_ids,
     )
     monkeypatch.setattr(
         lmcache_driven_transfer,
@@ -251,6 +252,16 @@ def test_server_store_and_retrieve_delegate_event_ordering(
         device=torch.device("cpu"),
         stream="transfer-stream",
         cupy_stream="cupy-stream",
+        # Retrieve scatter lanes: this double always hands out lane 0 (the
+        # context's own stream), i.e. the stock single-lane behavior.
+        next_retrieve_lane=lambda num_lanes: SimpleNamespace(
+            index=0,
+            stream="transfer-stream",
+            cupy_stream="cupy-stream",
+            buffers=None,
+            block_ids_buffer=None,
+            guarded=False,
+        ),
         max_batch_size=1,
         kv_layer_groups_manager=SimpleNamespace(
             num_object_groups=1,

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -546,5 +546,160 @@ class TestGPUCacheContextReportStatus:
             assert 0 <= group["object_group_idx"] < manager.num_object_groups
 
 
+# ---------------------------------------------------------------------------
+# Retrieve scatter lanes: the context provisions N transfer streams + staging
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveLanes:
+    def test_resolve_retrieve_lanes_env_contract(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """LMCACHE_RETRIEVE_LANES governs every path; a consumer-passed
+        alias (blend's CB_RETRIEVE_LANES) applies only where passed; default
+        2; clamped >= 1."""
+        # First Party
+        from lmcache.v1.multiprocess.config import resolve_retrieve_lanes
+
+        both = ("LMCACHE_RETRIEVE_LANES", "CB_RETRIEVE_LANES")
+        monkeypatch.delenv("LMCACHE_RETRIEVE_LANES", raising=False)
+        monkeypatch.delenv("CB_RETRIEVE_LANES", raising=False)
+        assert resolve_retrieve_lanes("LMCACHE_RETRIEVE_LANES") == 2
+        assert resolve_retrieve_lanes(*both) == 2
+
+        monkeypatch.setenv("CB_RETRIEVE_LANES", "4")
+        assert resolve_retrieve_lanes(*both) == 4  # alias reaches blend...
+        assert resolve_retrieve_lanes("LMCACHE_RETRIEVE_LANES") == 2  # ...only
+
+        monkeypatch.setenv("LMCACHE_RETRIEVE_LANES", "3")
+        assert resolve_retrieve_lanes(*both) == 3  # primary wins
+
+        monkeypatch.setenv("LMCACHE_RETRIEVE_LANES", "0")
+        assert resolve_retrieve_lanes(*both) == 1  # clamped: 1 = stock
+
+    def test_lanes1_is_passthrough(self) -> None:
+        """num_lanes=1 hands out lane 0 forever: the context's own stream
+        and staging (buffers None), unguarded, nothing allocated — the
+        stock single-stream behavior."""
+        ctx = _make_context(_SINGLE_GROUP)
+        lane = ctx.next_retrieve_lane(1)
+        assert lane.index == 0
+        assert lane.stream is ctx.stream
+        assert lane.cupy_stream is ctx.cupy_stream
+        assert lane.buffers is None and lane.block_ids_buffer is None
+        assert lane.guarded is False
+        assert ctx._temp_buffer_clones == []  # no staging clone allocated
+        for _ in range(3):
+            assert ctx.next_retrieve_lane(1) is lane
+
+    def test_multi_lane_round_robin_and_provisioning(self) -> None:
+        """num_lanes=2: lanes alternate 0,1,0,1 (same objects reused); lane 1
+        owns a real stream distinct from the context's plus staging with the
+        context's exact geometry; both lanes are guarded."""
+        ctx = _make_context(_SINGLE_GROUP)
+        lane0 = ctx.next_retrieve_lane(2)
+        lane1 = ctx.next_retrieve_lane(2)
+        assert (lane0.index, lane1.index) == (0, 1)
+        assert ctx.next_retrieve_lane(2) is lane0
+        assert ctx.next_retrieve_lane(2) is lane1
+        assert lane0.guarded and lane1.guarded
+
+        assert lane1.stream is not ctx.stream
+        assert lane1.stream.cuda_stream != ctx.stream.cuda_stream
+        # Private staging: identical geometry, distinct memory, GDS-tracked
+        # for close() deregistration.
+        assert lane1.buffers is ctx._temp_buffer_clones[0]
+        assert lane1.buffers.buffer.nbytes == ctx._temp_buffer.buffer.nbytes
+        assert lane1.buffers.buffer.data_ptr() != ctx._temp_buffer.buffer.data_ptr()
+        assert (
+            lane1.buffers.get_temp_kernel_group_buffer(0, 0).shape
+            == ctx.get_temp_kernel_group_buffer(0, 0).shape
+        )
+        assert lane1.block_ids_buffer is not None
+        assert lane1.block_ids_buffer.shape == ctx.block_ids_buffer_.shape
+        assert lane1.block_ids_buffer.data_ptr() != ctx.block_ids_buffer_.data_ptr()
+
+    def test_prewarm_creates_all_then_reuses(self) -> None:
+        """prewarm_retrieve_lanes creates every lane up front without moving
+        the round-robin counter; next_retrieve_lane reuses the pre-warmed
+        objects; re-pre-warming creates 0."""
+        ctx = _make_context(_SINGLE_GROUP)
+        lanes, created = ctx.prewarm_retrieve_lanes(2)
+        assert created == 2
+        assert [lane.index for lane in lanes] == [0, 1]
+        # Counter untouched: assignment starts at lane 0, reusing objects.
+        assert ctx.next_retrieve_lane(2) is lanes[0]
+        assert ctx.next_retrieve_lane(2) is lanes[1]
+        lanes2, created2 = ctx.prewarm_retrieve_lanes(2)
+        assert created2 == 0
+        assert lanes2[0] is lanes[0] and lanes2[1] is lanes[1]
+        assert len(ctx._temp_buffer_clones) == 1  # only lane 1 allocated
+
+    def test_base_class_degrades_to_single_lane(self) -> None:
+        """A platform whose context does not support multi-lane transfer
+        (BaseCacheContext default) always runs lane 0, whatever the
+        requested count."""
+        # First Party
+        from lmcache.v1.platform.base.cache_context import BaseCacheContext
+
+        class _SingleLaneCtx:
+            supports_retrieve_lanes = BaseCacheContext.supports_retrieve_lanes
+            _make_retrieve_lane = BaseCacheContext._make_retrieve_lane
+            _retrieve_lane_slots = BaseCacheContext._retrieve_lane_slots
+            next_retrieve_lane = BaseCacheContext.next_retrieve_lane
+            prewarm_retrieve_lanes = BaseCacheContext.prewarm_retrieve_lanes
+
+            def __init__(self) -> None:
+                self.retrieve_lanes_: list = []
+                self.retrieve_lane_next_ = 0
+                self.retrieve_lane_count_: int | None = None
+                self.stream = object()
+                self.cupy_stream = object()
+
+        ctx = _SingleLaneCtx()
+        lane = ctx.next_retrieve_lane(4)  # type: ignore[misc]
+        assert lane.index == 0
+        assert lane.stream is ctx.stream
+        assert lane.guarded is False
+        assert ctx.next_retrieve_lane(4) is lane  # type: ignore[misc]
+        lanes, created = ctx.prewarm_retrieve_lanes(4)  # type: ignore[misc]
+        assert created == 0 and lanes == [lane]
+
+    def test_lane_count_is_sticky_per_context(self) -> None:
+        """The first provisioning call fixes the lane count; a later caller
+        with a different resolved count (blend alias vs standard path) does
+        not re-shape the round-robin modulus mid-flight."""
+        ctx = _make_context(_SINGLE_GROUP)
+        lane0 = ctx.next_retrieve_lane(2)
+        lane1 = ctx.next_retrieve_lane(2)
+        # A later, larger request keeps the 2-lane modulus and objects.
+        assert ctx.next_retrieve_lane(4) is lane0
+        assert ctx.next_retrieve_lane(4) is lane1
+        lanes, created = ctx.prewarm_retrieve_lanes(4)
+        assert created == 0
+        assert len(lanes) == 2
+        assert len(ctx._temp_buffer_clones) == 1  # still only lane 1's clone
+
+    def test_stage_block_ids_out_targets_caller_buffer(self) -> None:
+        """The out= seam lanes use for private block-id staging: views alias
+        the caller's buffer; omitting it keeps the shared one (stock)."""
+        ctx = _make_context(_SINGLE_GROUP)
+        lane_buf = torch.zeros(8, dtype=torch.long, device=_DEVICE)
+        views = ctx.stage_block_ids([[3, 1], [7, 5, 9]], out=lane_buf)
+        torch.cuda.synchronize()
+        assert [v.tolist() for v in views] == [[3, 1], [7, 5, 9]]
+        assert lane_buf[:5].tolist() == [3, 1, 7, 5, 9]
+
+        views = ctx.stage_block_ids([[2, 4]])
+        torch.cuda.synchronize()
+        assert views[0].tolist() == [2, 4]
+        assert ctx.block_ids_buffer_[:2].tolist() == [2, 4]
+
+        with pytest.raises(ValueError, match="exceeds the pre-allocated buffer"):
+            ctx.stage_block_ids(
+                [[1, 2, 3]], out=torch.zeros(2, dtype=torch.long, device=_DEVICE)
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Concurrent retrieves on a rank serialize on the single per-context CUDA stream: request N's completion event fires only after all earlier requests' transfers drain, inflating warm TTFT linearly with in-flight depth. Give each cache context a small pool of retrieve lanes (stream + private staging), assigned round-robin per retrieve, so transfers overlap and each request's event depends only on its own work.

- BaseCacheContext/GPUCacheContext: TransferLane, next_retrieve_lane, prewarm_retrieve_lanes; lanes >= 1 clone the temp staging (GDS-registered, freed in close()) and stage block ids into a private buffer (stage_block_ids(out=)).
- Lanes are warmed at provisioning: CUDA lazy module loading serializes a first kernel launch against all in-flight work in the process, which would cross-join the lanes.
- Consumers: the standard retrieve (lmcache_driven_transfer) and CacheBlend v3; both pre-warm lanes at registration.
- LMCACHE_RETRIEVE_LANES (default 2) governs both paths; CB_RETRIEVE_LANES is a read-compat alias for blend. lanes=1 is bit-for-bit the previous single-stream behavior.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
