### PR TITLE
[Operator] Emit the renamed coordinator event flags and rename the CRD fields to match

### DIFF
--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -1104,8 +1104,8 @@ explicit endpoint:
         ref:
           name: my-coordinator       # or: url: http://my-coordinator.default.svc:9300
         heartbeatInterval: 5          # seconds; must be > 0
-        l2EventReporting: false       # report L2 store/lookup events for fleet eviction
-        l2EventFlushInterval: 1       # seconds between event batch flushes; must be > 0
+        eventReporting: false         # report cache events for fleet-wide tracking/eviction
+        eventFlushInterval: 1         # seconds between event batch flushes; must be > 0
 
 .. list-table::
    :header-rows: 1
@@ -1122,25 +1122,26 @@ explicit endpoint:
      - ``5``
      - Seconds between server heartbeats to the coordinator; must be > 0.
        Emitted as ``--coordinator-heartbeat-interval``.
-   * - ``l2EventReporting``
+   * - ``eventReporting``
      - ``false``
      - Enable reporting cache events to the coordinator: the key directory's
        store/access/delete stream (fleet-wide placement tracking) and the L2
        usage stream (quota tracking and eviction).  When true, the operator
        emits ``--coordinator-event-reporting``.
-   * - ``l2EventFlushInterval``
+   * - ``eventFlushInterval``
      - ``1``
      - Seconds between cache-event batch flushes; must be > 0.  Emitted as
        ``--coordinator-event-flush-interval`` whenever a coordinator is
-       configured.
+       configured.  See :doc:`coordinator` for the flag semantics.
 
 .. note::
 
-   The CRD field names keep their ``l2Event*`` spelling for API
-   compatibility, but the server flags they map to have no ``l2-`` infix
-   (``--coordinator-event-reporting``, ``--coordinator-event-flush-interval``),
-   because the server reports the key directory's event stream alongside L2
-   usage.  See :doc:`coordinator` for the flag semantics.
+   These fields were previously named ``l2EventReporting`` /
+   ``l2EventFlushInterval``.  They were renamed (dropping the ``l2``
+   prefix, matching the server's flag rename) because event reporting
+   covers the key directory's event stream alongside L2 usage.  Manifests
+   using the old spellings must be updated: unknown CRD fields are pruned
+   silently, so the old names would quietly fall back to the defaults.
 
 Coordinator CRD Spec Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -1105,6 +1105,42 @@ explicit endpoint:
           name: my-coordinator       # or: url: http://my-coordinator.default.svc:9300
         heartbeatInterval: 5          # seconds; must be > 0
         l2EventReporting: false       # report L2 store/lookup events for fleet eviction
+        l2EventFlushInterval: 1       # seconds between event batch flushes; must be > 0
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Field
+     - Default
+     - Description
+   * - ``ref.name`` / ``url``
+     - --
+     - Exactly one must be set.  ``ref`` names an ``LMCacheCoordinator`` in
+       the same namespace; ``url`` is an explicit coordinator endpoint.
+   * - ``heartbeatInterval``
+     - ``5``
+     - Seconds between server heartbeats to the coordinator; must be > 0.
+       Emitted as ``--coordinator-heartbeat-interval``.
+   * - ``l2EventReporting``
+     - ``false``
+     - Enable reporting cache events to the coordinator: the key directory's
+       store/access/delete stream (fleet-wide placement tracking) and the L2
+       usage stream (quota tracking and eviction).  When true, the operator
+       emits ``--coordinator-event-reporting``.
+   * - ``l2EventFlushInterval``
+     - ``1``
+     - Seconds between cache-event batch flushes; must be > 0.  Emitted as
+       ``--coordinator-event-flush-interval`` whenever a coordinator is
+       configured.
+
+.. note::
+
+   The CRD field names keep their ``l2Event*`` spelling for API
+   compatibility, but the server flags they map to have no ``l2-`` infix
+   (``--coordinator-event-reporting``, ``--coordinator-event-flush-interval``),
+   because the server reports the key directory's event stream alongside L2
+   usage.  See :doc:`coordinator` for the flag semantics.
 
 Coordinator CRD Spec Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -573,15 +573,16 @@ The global-CacheBlend knobs (`blendChunkSize`, `blendProbeStride`) render into t
   what you are doing (e.g. the coordinator runs outside the cluster and must
   reach the server through a specific externally-routable address); an incorrect
   value silently breaks coordinator-to-server connectivity.
-- `heartbeatInterval`, `l2EventReporting`, `l2EventFlushInterval`. The two
-  event fields are emitted as `--coordinator-event-reporting` /
-  `--coordinator-event-flush-interval` — no `l2-` infix. The server renamed the
-  flags (#4292) when event reporting grew to cover the key directory's
-  store/access/delete stream alongside L2 usage; the CRD fields keep their
-  `l2Event*` names because renaming them is a breaking API change. The flag
-  spellings are a hard contract: an unknown flag makes `lmcache server` exit 2
-  and the DaemonSet crash-loop, so `coordinator_test.go` asserts the exact
-  strings.
+- `heartbeatInterval`, `eventReporting`, `eventFlushInterval`. The event
+  fields map to `--coordinator-event-reporting` /
+  `--coordinator-event-flush-interval`. Both the flags (#4292) and the CRD
+  fields (formerly `l2EventReporting` / `l2EventFlushInterval`) dropped the
+  `l2` prefix when event reporting grew to cover the key directory's
+  store/access/delete stream alongside L2 usage. The field rename is breaking:
+  unknown CRD fields are pruned silently, so manifests still using the old
+  spellings fall back to the defaults. The flag spellings are a hard contract:
+  an unknown flag makes `lmcache server` exit 2 and the DaemonSet crash-loop,
+  so `coordinator_test.go` asserts the exact strings.
 
 When `coordinator` is unset, the server emits no `--coordinator-url` and does not
 register (unchanged behavior).

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -573,7 +573,15 @@ The global-CacheBlend knobs (`blendChunkSize`, `blendProbeStride`) render into t
   what you are doing (e.g. the coordinator runs outside the cluster and must
   reach the server through a specific externally-routable address); an incorrect
   value silently breaks coordinator-to-server connectivity.
-- `heartbeatInterval`, `l2EventReporting`, `l2EventFlushInterval`.
+- `heartbeatInterval`, `l2EventReporting`, `l2EventFlushInterval`. The two
+  event fields are emitted as `--coordinator-event-reporting` /
+  `--coordinator-event-flush-interval` — no `l2-` infix. The server renamed the
+  flags (#4292) when event reporting grew to cover the key directory's
+  store/access/delete stream alongside L2 usage; the CRD fields keep their
+  `l2Event*` names because renaming them is a breaking API change. The flag
+  spellings are a hard contract: an unknown flag makes `lmcache server` exit 2
+  and the DaemonSet crash-loop, so `coordinator_test.go` asserts the exact
+  strings.
 
 When `coordinator` is unset, the server emits no `--coordinator-url` and does not
 register (unchanged behavior).

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -356,17 +356,17 @@ type CoordinatorConnectionSpec struct {
 	// +kubebuilder:default=5
 	HeartbeatInterval *float64 `json:"heartbeatInterval,omitempty"`
 
-	// l2EventReporting enables reporting L2 store/lookup events to the
-	// coordinator for fleet-wide usage tracking and eviction.
+	// eventReporting enables reporting cache events to the coordinator: the
+	// key directory's store/access/delete stream and the L2 usage stream.
 	// +optional
 	// +kubebuilder:default=false
-	L2EventReporting *bool `json:"l2EventReporting,omitempty"`
+	EventReporting *bool `json:"eventReporting,omitempty"`
 
-	// l2EventFlushInterval is the seconds between L2 event flush attempts; must
-	// be > 0.
+	// eventFlushInterval is the seconds between cache-event flush attempts;
+	// must be > 0.
 	// +optional
 	// +kubebuilder:default=1
-	L2EventFlushInterval *float64 `json:"l2EventFlushInterval,omitempty"`
+	EventFlushInterval *float64 `json:"eventFlushInterval,omitempty"`
 }
 
 // LMCacheEngineSpec defines the desired state of LMCacheEngine.

--- a/operator/api/v1alpha1/lmcacheengine_validation.go
+++ b/operator/api/v1alpha1/lmcacheengine_validation.go
@@ -69,8 +69,8 @@ func validateCoordinatorConnectionSpec(conn *CoordinatorConnectionSpec) field.Er
 	if conn.HeartbeatInterval != nil && *conn.HeartbeatInterval <= 0 {
 		errs = append(errs, field.Invalid(connPath.Child("heartbeatInterval"), *conn.HeartbeatInterval, "must be greater than 0"))
 	}
-	if conn.L2EventFlushInterval != nil && *conn.L2EventFlushInterval <= 0 {
-		errs = append(errs, field.Invalid(connPath.Child("l2EventFlushInterval"), *conn.L2EventFlushInterval, "must be greater than 0"))
+	if conn.EventFlushInterval != nil && *conn.EventFlushInterval <= 0 {
+		errs = append(errs, field.Invalid(connPath.Child("eventFlushInterval"), *conn.EventFlushInterval, "must be greater than 0"))
 	}
 
 	return errs

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -327,13 +327,13 @@ func (in *CoordinatorConnectionSpec) DeepCopyInto(out *CoordinatorConnectionSpec
 		*out = new(float64)
 		**out = **in
 	}
-	if in.L2EventReporting != nil {
-		in, out := &in.L2EventReporting, &out.L2EventReporting
+	if in.EventReporting != nil {
+		in, out := &in.EventReporting, &out.EventReporting
 		*out = new(bool)
 		**out = **in
 	}
-	if in.L2EventFlushInterval != nil {
-		in, out := &in.L2EventFlushInterval, &out.L2EventFlushInterval
+	if in.EventFlushInterval != nil {
+		in, out := &in.EventFlushInterval, &out.EventFlushInterval
 		*out = new(float64)
 		**out = **in
 	}

--- a/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1003,23 +1003,23 @@ spec:
                       reach the server through a specific externally-routable address. An
                       incorrect value silently breaks coordinator-to-server connectivity.
                     type: string
+                  eventFlushInterval:
+                    default: 1
+                    description: |-
+                      eventFlushInterval is the seconds between cache-event flush attempts;
+                      must be > 0.
+                    type: number
+                  eventReporting:
+                    default: false
+                    description: |-
+                      eventReporting enables reporting cache events to the coordinator: the
+                      key directory's store/access/delete stream and the L2 usage stream.
+                    type: boolean
                   heartbeatInterval:
                     default: 5
                     description: heartbeatInterval is the seconds between heartbeats;
                       must be > 0.
                     type: number
-                  l2EventFlushInterval:
-                    default: 1
-                    description: |-
-                      l2EventFlushInterval is the seconds between L2 event flush attempts; must
-                      be > 0.
-                    type: number
-                  l2EventReporting:
-                    default: false
-                    description: |-
-                      l2EventReporting enables reporting L2 store/lookup events to the
-                      coordinator for fleet-wide usage tracking and eviction.
-                    type: boolean
                   ref:
                     description: |-
                       ref names an LMCacheCoordinator in the same namespace. The operator

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -982,23 +982,23 @@ spec:
                       reach the server through a specific externally-routable address. An
                       incorrect value silently breaks coordinator-to-server connectivity.
                     type: string
+                  eventFlushInterval:
+                    default: 1
+                    description: |-
+                      eventFlushInterval is the seconds between cache-event flush attempts;
+                      must be > 0.
+                    type: number
+                  eventReporting:
+                    default: false
+                    description: |-
+                      eventReporting enables reporting cache events to the coordinator: the
+                      key directory's store/access/delete stream and the L2 usage stream.
+                    type: boolean
                   heartbeatInterval:
                     default: 5
                     description: heartbeatInterval is the seconds between heartbeats;
                       must be > 0.
                     type: number
-                  l2EventFlushInterval:
-                    default: 1
-                    description: |-
-                      l2EventFlushInterval is the seconds between L2 event flush attempts; must
-                      be > 0.
-                    type: number
-                  l2EventReporting:
-                    default: false
-                    description: |-
-                      l2EventReporting enables reporting L2 store/lookup events to the
-                      coordinator for fleet-wide usage tracking and eviction.
-                    type: boolean
                   ref:
                     description: |-
                       ref names an LMCacheCoordinator in the same namespace. The operator

--- a/operator/internal/resources/compute.go
+++ b/operator/internal/resources/compute.go
@@ -120,15 +120,11 @@ func BuildContainerArgs(spec *lmcachev1alpha1.LMCacheEngineSpec) []string {
 			args = append(args,
 				"--coordinator-heartbeat-interval", formatFloat(derefFloat64(c.HeartbeatInterval, 5.0)),
 			)
-			// Flag names have no "l2-" infix: the server reports the key
-			// directory's store/access/delete stream alongside L2 usage, so
-			// it spells these --coordinator-event-*. The CRD fields keep
-			// their l2Event* names for API compatibility.
-			if derefBool(c.L2EventReporting, false) {
+			if derefBool(c.EventReporting, false) {
 				args = append(args, "--coordinator-event-reporting")
 			}
 			args = append(args,
-				"--coordinator-event-flush-interval", formatFloat(derefFloat64(c.L2EventFlushInterval, 1.0)),
+				"--coordinator-event-flush-interval", formatFloat(derefFloat64(c.EventFlushInterval, 1.0)),
 			)
 		}
 	}

--- a/operator/internal/resources/compute.go
+++ b/operator/internal/resources/compute.go
@@ -120,11 +120,15 @@ func BuildContainerArgs(spec *lmcachev1alpha1.LMCacheEngineSpec) []string {
 			args = append(args,
 				"--coordinator-heartbeat-interval", formatFloat(derefFloat64(c.HeartbeatInterval, 5.0)),
 			)
+			// Flag names have no "l2-" infix: the server reports the key
+			// directory's store/access/delete stream alongside L2 usage, so
+			// it spells these --coordinator-event-*. The CRD fields keep
+			// their l2Event* names for API compatibility.
 			if derefBool(c.L2EventReporting, false) {
-				args = append(args, "--coordinator-l2-event-reporting")
+				args = append(args, "--coordinator-event-reporting")
 			}
 			args = append(args,
-				"--coordinator-l2-event-flush-interval", formatFloat(derefFloat64(c.L2EventFlushInterval, 1.0)),
+				"--coordinator-event-flush-interval", formatFloat(derefFloat64(c.L2EventFlushInterval, 1.0)),
 			)
 		}
 	}

--- a/operator/internal/resources/coordinator_test.go
+++ b/operator/internal/resources/coordinator_test.go
@@ -156,8 +156,34 @@ func TestBuildContainerArgs_CoordinatorURL(t *testing.T) {
 	if got := findArgValue(t, args, "--coordinator-heartbeat-interval"); got != "5" {
 		t.Errorf("--coordinator-heartbeat-interval = %q, want 5", got)
 	}
-	if !slices.Contains(args, "--coordinator-l2-event-reporting") {
-		t.Errorf("expected --coordinator-l2-event-reporting flag")
+	// Flag spellings are a contract with `lmcache server`: an unknown flag
+	// makes argparse exit 2, so every engine pod crash-loops. Assert the exact
+	// names (no "l2-" infix) rather than just their presence.
+	if !slices.Contains(args, "--coordinator-event-reporting") {
+		t.Errorf("expected --coordinator-event-reporting flag, got %v", args)
+	}
+	if got := findArgValue(t, args, "--coordinator-event-flush-interval"); got != "1" {
+		t.Errorf("--coordinator-event-flush-interval = %q, want 1", got)
+	}
+}
+
+func TestBuildContainerArgs_CoordinatorEventReportingDisabled(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.Coordinator = &lmcachev1alpha1.CoordinatorConnectionSpec{
+		URL: ptr("http://my-coordinator.default.svc:9300"),
+	}
+
+	args := BuildContainerArgs(&engine.Spec)
+
+	// --coordinator-event-reporting is store_true upstream, so it must be
+	// omitted (not passed a value) when reporting is off. The flush interval
+	// is still emitted: it carries a value and applies whenever the
+	// coordinator URL is set.
+	if slices.Contains(args, "--coordinator-event-reporting") {
+		t.Errorf("expected no --coordinator-event-reporting when disabled, got %v", args)
+	}
+	if got := findArgValue(t, args, "--coordinator-event-flush-interval"); got != "1" {
+		t.Errorf("--coordinator-event-flush-interval = %q, want 1", got)
 	}
 }
 

--- a/operator/internal/resources/coordinator_test.go
+++ b/operator/internal/resources/coordinator_test.go
@@ -144,8 +144,8 @@ func TestBuildContainerArgs_CoordinatorURL(t *testing.T) {
 	engine := minimalEngine()
 	url := "http://my-coordinator.default.svc:9300"
 	engine.Spec.Coordinator = &lmcachev1alpha1.CoordinatorConnectionSpec{
-		URL:              ptr(url),
-		L2EventReporting: ptr(true),
+		URL:            ptr(url),
+		EventReporting: ptr(true),
 	}
 
 	args := BuildContainerArgs(&engine.Spec)

--- a/operator/test/e2e/coordinator_registration_smoke_test.go
+++ b/operator/test/e2e/coordinator_registration_smoke_test.go
@@ -88,8 +88,8 @@ var _ = Describe("LMCacheCoordinator registration smoke (GPU)", Ordered, func() 
 		lmc, err := utils.NewLMCFromFixture("lmc_runtime.yaml", nsName, "coord-engine")
 		Expect(err).NotTo(HaveOccurred())
 		lmc.Spec.Coordinator = &lmcachev1alpha1.CoordinatorConnectionSpec{
-			Ref:              &corev1.LocalObjectReference{Name: coordinatorName},
-			L2EventReporting: boolPtr(true),
+			Ref:            &corev1.LocalObjectReference{Name: coordinatorName},
+			EventReporting: boolPtr(true),
 		}
 		Expect(utils.ApplyLMC(ctx, k8sClient, lmc)).To(Succeed())
 


### PR DESCRIPTION
## Problem

#4292 renamed two `lmcache server` flags, dropping the `l2-` infix now that the server reports the key directory's store/access/delete stream alongside L2 usage:

| before | after |
|---|---|
| `--coordinator-l2-event-reporting` | `--coordinator-event-reporting` |
| `--coordinator-l2-event-flush-interval` | `--coordinator-event-flush-interval` |

`operator/internal/resources/compute.go` was not updated, so the operator still emits the old spellings. Every engine it reconciles with a resolved coordinator URL is handed a flag `lmcache server` does not recognise — argparse rejects it and exits **2**.

The failure is total and not opt-in: `--coordinator-event-flush-interval` is emitted whenever the coordinator URL is set, independent of the reporting toggle. The cache-engine process dies before binding `:5555`, the TCP startup probe fails with `connection refused`, and the DaemonSet crash-loops indefinitely.

It also reads as a hang rather than a usage error, because `add_arguments` imports the CUDA-backed config modules *before* parsing — so the argparse failure lands ~12s into startup.

## Fix

Two parts:

1. **Emit the current flag names** (`compute.go`): `--coordinator-event-reporting` / `--coordinator-event-flush-interval`.
2. **Rename the CRD fields to match**: `l2EventReporting` / `l2EventFlushInterval` → `eventReporting` / `eventFlushInterval`, so the fields no longer misname what is reported (the event stream covers the key directory alongside L2 usage). CRD manifests and deepcopy are regenerated via `make generate manifests`.

The field rename is a **breaking CRD change**. Unknown fields are pruned silently by the structural schema, so manifests still using the old spellings do not error — they fall back to the defaults (`eventReporting: false`, `eventFlushInterval: 1`). The user docs and `DESIGN.md` call this out.

## Docs

- `docs/source/mp/operator.rst`: the engine `coordinator` block previously had no spec reference — added a field table (`ref`/`url`, `heartbeatInterval`, `eventReporting`, `eventFlushInterval`) including which server flag each field is emitted as, plus a migration note for the renamed fields (old spellings are silently pruned, not rejected). Sphinx build clean for the page.
- `operator/DESIGN.md`: records the field→flag mapping, the rename and its breaking-change semantics, and why the flag spellings are a hard contract.

## Tests

The existing test asserted only that the *reporting* flag was present, and nothing covered the flush-interval flag at all, which is exactly why a rename in the server's CLI passed straight through to a crash-looping DaemonSet. Now:

- `TestBuildContainerArgs_CoordinatorURL` asserts both flag names exactly, including the flush interval's value.
- `TestBuildContainerArgs_CoordinatorEventReportingDisabled` (new) covers the reporting-disabled path: the `store_true` flag must be omitted rather than passed a value, while the flush interval is still emitted.

Verified by mutation — restoring the old spellings fails both tests; `go build ./...`, `go vet ./...`, `gofmt`, and the full `go test ./...` are clean.
