### PR TITLE
[Fix][MP][Operator] Restore compat for renamed coordinator event flags

### DIFF
--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -12,6 +12,11 @@ import math
 import os
 import uuid
 
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
 
 @dataclass
 class MPServerConfig:
@@ -609,6 +614,24 @@ def add_coordinator_args(
         help="Seconds between cache-event flush attempts (must be > 0). "
         "Defaults to LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL, then 1.0.",
     )
+    # Deprecated pre-v0.5.3 aliases, hidden from --help. Released deployers
+    # (operator <= v0.5.2, charts) still render these names into server args,
+    # and rejecting them crashes the pod on startup. Remove once those
+    # deployers are out of the support matrix.
+    group.add_argument(
+        "--coordinator-l2-event-reporting",
+        dest="coordinator_l2_event_reporting",
+        action="store_true",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    group.add_argument(
+        "--coordinator-l2-event-flush-interval",
+        dest="coordinator_l2_event_flush_interval",
+        type=float,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
     return parser
 
 
@@ -620,6 +643,11 @@ def parse_args_to_coordinator_config(
     A flag value takes precedence over its environment variable. The heartbeat
     interval is validated here so a malformed value fails fast at startup
     (runtime best-effort only covers coordinator *reachability*, not config).
+
+    The event-reporting flags also accept their deprecated pre-v0.5.3
+    spellings (``--coordinator-l2-event-*``), logging a deprecation warning
+    when used. Precedence per setting: new flag > deprecated flag > env var
+    > default.
 
     Args:
         args: Parsed arguments from the argument parser.
@@ -661,15 +689,31 @@ def parse_args_to_coordinator_config(
             "coordinator heartbeat interval must be a finite number > 0, "
             "got %s" % heartbeat_interval
         )
+    # Deprecated pre-v0.5.3 flag spellings. Precedence within each setting:
+    # new flag > deprecated flag > env var > default.
+    deprecated_reporting = getattr(args, "coordinator_l2_event_reporting", None)
     if args.coordinator_event_reporting is not None:
         event_reporting = args.coordinator_event_reporting
+    elif deprecated_reporting is not None:
+        logger.warning(
+            "--coordinator-l2-event-reporting is deprecated, "
+            "use --coordinator-event-reporting instead"
+        )
+        event_reporting = deprecated_reporting
     else:
         event_reporting = os.getenv(
             "LMCACHE_COORDINATOR_EVENT_REPORTING", ""
         ).lower() in ("1", "true", "yes")
 
+    deprecated_flush = getattr(args, "coordinator_l2_event_flush_interval", None)
     if args.coordinator_event_flush_interval is not None:
         event_flush_interval = args.coordinator_event_flush_interval
+    elif deprecated_flush is not None:
+        logger.warning(
+            "--coordinator-l2-event-flush-interval is deprecated, "
+            "use --coordinator-event-flush-interval instead"
+        )
+        event_flush_interval = deprecated_flush
     else:
         raw = os.getenv("LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL")
         if raw:

--- a/operator/internal/resources/compute.go
+++ b/operator/internal/resources/compute.go
@@ -120,11 +120,14 @@ func BuildContainerArgs(spec *lmcachev1alpha1.LMCacheEngineSpec) []string {
 			args = append(args,
 				"--coordinator-heartbeat-interval", formatFloat(derefFloat64(c.HeartbeatInterval, 5.0)),
 			)
+			// Renamed from --coordinator-l2-event-* in lmcache v0.5.3; servers
+			// < v0.5.3 reject these spellings at argparse, so this operator
+			// requires lmcache >= v0.5.3 when a coordinator is configured.
 			if derefBool(c.L2EventReporting, false) {
-				args = append(args, "--coordinator-l2-event-reporting")
+				args = append(args, "--coordinator-event-reporting")
 			}
 			args = append(args,
-				"--coordinator-l2-event-flush-interval", formatFloat(derefFloat64(c.L2EventFlushInterval, 1.0)),
+				"--coordinator-event-flush-interval", formatFloat(derefFloat64(c.L2EventFlushInterval, 1.0)),
 			)
 		}
 	}

--- a/operator/internal/resources/coordinator_test.go
+++ b/operator/internal/resources/coordinator_test.go
@@ -156,8 +156,11 @@ func TestBuildContainerArgs_CoordinatorURL(t *testing.T) {
 	if got := findArgValue(t, args, "--coordinator-heartbeat-interval"); got != "5" {
 		t.Errorf("--coordinator-heartbeat-interval = %q, want 5", got)
 	}
-	if !slices.Contains(args, "--coordinator-l2-event-reporting") {
-		t.Errorf("expected --coordinator-l2-event-reporting flag")
+	if !slices.Contains(args, "--coordinator-event-reporting") {
+		t.Errorf("expected --coordinator-event-reporting flag")
+	}
+	if got := findArgValue(t, args, "--coordinator-event-flush-interval"); got != "1" {
+		t.Errorf("--coordinator-event-flush-interval = %q, want 1", got)
 	}
 }
 

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -8,6 +8,7 @@ pure config layer (no native extensions), so it runs without a CUDA build.
 
 # Standard
 import argparse
+import logging
 import uuid
 
 # Third Party
@@ -163,3 +164,59 @@ def test_event_reporting_env_fallback(monkeypatch):
 def test_event_flush_interval_rejects_nonpositive():
     with pytest.raises(ValueError):
         _parse(["--coordinator-event-flush-interval", "0"])
+
+
+# -- Deprecated pre-v0.5.3 aliases (operator <= v0.5.2 still emits these) -----
+
+
+def test_deprecated_l2_event_flags_are_accepted():
+    config = _parse(
+        [
+            "--coordinator-l2-event-reporting",
+            "--coordinator-l2-event-flush-interval",
+            "0.5",
+        ]
+    )
+    assert config.event_reporting is True
+    assert config.event_flush_interval == 0.5
+
+
+def test_new_flags_win_over_deprecated_aliases():
+    config = _parse(
+        [
+            "--coordinator-event-flush-interval",
+            "2.0",
+            "--coordinator-l2-event-flush-interval",
+            "0.5",
+        ]
+    )
+    assert config.event_flush_interval == 2.0
+
+
+def test_deprecated_flags_log_warning():
+    # lmcache's ``init_logger`` sets ``propagate = False``, so pytest's
+    # ``caplog`` (root-logger based) cannot see the records. Attach a local
+    # handler to the named logger instead (established pattern, see
+    # tests/v1/test_v1_adapter_state_desync.py).
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _ListHandler(level=logging.WARNING)
+    config_logger = logging.getLogger("lmcache.v1.multiprocess.config")
+    config_logger.addHandler(handler)
+    try:
+        _parse(["--coordinator-l2-event-flush-interval", "0.5"])
+    finally:
+        config_logger.removeHandler(handler)
+    messages = [r.getMessage() for r in records]
+    assert any(
+        "--coordinator-l2-event-flush-interval is deprecated" in m for m in messages
+    )
+
+
+def test_deprecated_flush_interval_flag_rejects_nonpositive():
+    with pytest.raises(ValueError):
+        _parse(["--coordinator-l2-event-flush-interval", "0"])


### PR DESCRIPTION
**What this PR does / why we need it**:

#4292 renamed `--coordinator-l2-event-{reporting,flush-interval}` to `--coordinator-event-{reporting,flush-interval}` with no back-compat. Released deployers (operator <= v0.5.2, charts) still render the old spellings into `lmcache server` args, so every engine pod crash-loops at argparse:

```
lmcache: error: unrecognized arguments: --coordinator-l2-event-flush-interval 1
```

This broke the tensormesh e2e pipeline (build 128: engine + cacheblend DaemonSet pods CrashLoopBackOff, readiness gate failed).
