### PR TITLE
[MP] fix: handle object_group_id in FSConnector::key_to_filename

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -27,22 +27,22 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Unsalted:
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   Salted  :
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+  //   Unsalted:
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>.data
   //   Salted  :
-  //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
-  //
-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
-  // format, so existing cache directories remain valid.
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>.data
   //
   // NOTE: both model_name and cache_salt are forbidden from containing
   // '@' (invariant enforced on the Python side), so splitting on '@'
   // is unambiguous — no marker, no rsplit.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Split on '@' — must yield 4 (unsalted) or 5 (salted) fields.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -51,29 +51,33 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() != 4 && parts.size() != 5) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 4 or 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+  const std::string& object_group_id_hex = parts[2];
+  const std::string& chunk_hash = parts[3];
+  const std::string cache_salt = parts.size() == 5 ? parts[4] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
   // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
+  // matches what fs_l2_adapter.py._object_key_to_filename writes.
   std::string result;
-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+  result.reserve(safe_model.size() + kv_rank_hex.size() +
+                 object_group_id_hex.size() + chunk_hash.size() +
                  cache_salt.size() + 32);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
+  result += KEY_SEP;
+  result += object_group_id_hex;
   result += KEY_SEP;
   result += chunk_hash;
   if (!cache_salt.empty()) {

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -52,12 +52,12 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   // Build the filesystem-safe filename from a serialized key string.
   //
   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
+  //   Unsalted: "{model}@{kv_rank:08x}@{object_group_id:x}@{hash.hex()}"
+  //   Salted  : "{model}@{kv_rank:08x}@{object_group_id:x}@{hash.hex()}@{cache_salt}"
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
+  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{object_group_id:x}@{hash.hex()}.data"
+  //   Salted  : "{safe_model}@{kv_rank:#010x}@{object_group_id:x}@{hash.hex()}@{cache_salt}.data"
   //
   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
   // gains a '0x' prefix, and '.data' is appended. Both model_name and

--- a/tests/v1/distributed/test_fs_native_connector_filename.py
+++ b/tests/v1/distributed/test_fs_native_connector_filename.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the C++ FS connector filename encoding.
+
+These exercise the real pybind-wrapped ``LMCacheFSClient`` to keep
+``FSConnector::key_to_filename`` in sync with the Python serialization in
+``native_connector_l2_adapter._object_key_to_string`` (its input) and
+``fs_l2_adapter._object_key_to_filename`` (the filename it must produce).
+
+They require the C++ extension to be built and are skipped otherwise.
+"""
+
+# Standard
+import os
+import select
+import shutil
+import tempfile
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    _object_key_to_filename,
+)
+from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+    _object_key_to_string,
+)
+from lmcache.v1.platform import consume_fd
+
+# Skipped entirely when the native FS extension is not built.
+lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
+LMCacheFSClient = lmcache_fs.LMCacheFSClient
+
+
+def _drain_one_completion(client, expected_fid, timeout=5.0):
+    """Block until the completion for *expected_fid* is drained.
+
+    Returns the ``(ok, error)`` pair reported by the C++ connector. A
+    ``set`` whose ``key_to_filename`` throws surfaces here as
+    ``ok=False`` with the exception text in *error* — that is exactly
+    the regression this module guards against.
+    """
+    poll = select.poll()
+    poll.register(client.event_fd(), select.POLLIN)
+    deadline_remaining = timeout
+    while deadline_remaining > 0:
+        events = poll.poll(int(deadline_remaining * 1000))
+        if not events:
+            break  # timed out
+        try:
+            consume_fd(client.event_fd())
+        except BlockingIOError:
+            pass
+        for fid, ok, error, _result in client.drain_completions():
+            if fid == expected_fid:
+                return ok, error
+        deadline_remaining = timeout  # event consumed; keep waiting
+    raise AssertionError(
+        f"timed out waiting for completion of future_id={expected_fid}"
+    )
+
+
+@pytest.fixture
+def fs_client(tmp_path):
+    """A real ``LMCacheFSClient`` rooted at a per-test temp directory."""
+    base = tmp_path / "fs_root"
+    base.mkdir()
+    client = LMCacheFSClient(str(base), 1)
+    yield client, str(base)
+    client.close()
+    shutil.rmtree(base, ignore_errors=True)
+
+
+class TestFSConnectorFilenameEncoding:
+    """The C++ connector must accept the current ``_object_key_to_string``
+    wire format (4 fields unsalted / 5 salted) and emit filenames that
+    match ``_object_key_to_filename``."""
+
+    def test_unsalted_key_filename_matches_python(self, fs_client):
+        client, base = fs_client
+        key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+            object_group_id=5,
+        )
+        key_str = _object_key_to_string(key)
+        assert key_str == "llama@000000ff@5@00010203"
+
+        buf = memoryview(bytearray(16))
+        fid = client.submit_batch_set([key_str], [buf])
+        ok, error = _drain_one_completion(client, fid)
+        assert ok, f"set failed (key_to_filename rejected the key): {error}"
+
+        assert os.listdir(base) == [_object_key_to_filename(key)]
+        assert os.listdir(base) == ["llama@0x000000ff@5@00010203.data"]
+
+    def test_salted_key_filename_matches_python(self, fs_client):
+        client, base = fs_client
+        key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+            object_group_id=0,
+            cache_salt="alice",
+        )
+        key_str = _object_key_to_string(key)
+        assert key_str == "llama@000000ff@0@00010203@alice"
+
+        buf = memoryview(bytearray(16))
+        fid = client.submit_batch_set([key_str], [buf])
+        ok, error = _drain_one_completion(client, fid)
+        assert ok, f"set failed (key_to_filename rejected the key): {error}"
+
+        assert os.listdir(base) == [_object_key_to_filename(key)]
+        assert os.listdir(base) == ["llama@0x000000ff@0@00010203@alice.data"]
+
+    def test_model_name_slash_is_escaped(self, fs_client):
+        client, base = fs_client
+        key = ObjectKey(
+            chunk_hash=b"\xab\xcd",
+            model_name="org/model",
+            kv_rank=1,
+            object_group_id=2,
+        )
+        key_str = _object_key_to_string(key)
+
+        buf = memoryview(bytearray(8))
+        fid = client.submit_batch_set([key_str], [buf])
+        ok, error = _drain_one_completion(client, fid)
+        assert ok, f"set failed: {error}"
+
+        # '/' in model_name becomes '-SEP-' on disk, matching the
+        # Python adapter.
+        assert os.listdir(base) == [_object_key_to_filename(key)]
+        assert os.listdir(base)[0].startswith("org-SEP-model@")


### PR DESCRIPTION
  What this PR does / why we need it:
  pr: https://github.com/LMCache/LMCache/pull/3042 Add cache_salt to ObjectKey for cache isolation.

  FSConnector::key_to_filename rejecting salted keys, which made the MP-mode FS native L2
  backend unusable whenever cache_salt was set.

  _object_key_to_string (native_connector_l2_adapter.py) serializes an ObjectKey as 4 @-fields
  unsalted / 5 salted (model@rank@gid@hash[@salt]). The C++ FSConnector::key_to_filename
  (csrc/storage_backends/fs/connector.cpp) still validated for the older 3/4-field shape, so every
  salted key threw inside the worker:

  FSConnector: malformed key (expected 3 or 4 '@'-separated fields): llama@000000ff@0@00010203@alice

  Unsalted keys (4 fields) happened to still produce the correct filename by coincidence; only
  salted keys (5 fields) hit the throw.

  The cap wasn't raised when object_group_id was added to the wire format (#3608); the C++ side was
  missed (it was last touched for cache_salt in #3042).

  Changes:
  - csrc/storage_backends/fs/connector.cpp — key_to_filename now accepts 4 (unsalted) / 5 (salted)
  fields, parses object_group_id from parts[2], and emits it in the filename so the result is
  bit-identical to fs_l2_adapter._object_key_to_filename:
  <safe_model>@0x<rank>@<gid>@<hash>[@salt].data. kv_rank handling unchanged; object_group_id /
  chunk_hash passed through.
  - csrc/storage_backends/fs/connector.h — synced the stale format comment.
  - tests/v1/distributed/test_fs_native_connector_filename.py — regression tests driving the real
  LMCacheFSClient, asserting the on-disk filename equals _object_key_to_filename for unsalted,
  salted, and model_name-with-/ keys. Skipped when the C++ extension isn't built.

  If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests