### PR TITLE
[Operator] Make hostIPC optional

### DIFF
--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -17,10 +17,10 @@ Why Use the Operator
 The manual DaemonSet approach works, but it has sharp edges the operator
 eliminates:
 
-- **Auto-injected pod settings** -- The operator always sets ``hostIPC: true``
-  and ``--host 0.0.0.0``.  Forgetting ``hostIPC`` in a hand-written manifest
-  causes silent CUDA IPC failures (``cudaErrorMapBufferObjectFailed``) that are
-  hard to debug.
+- **Auto-injected pod settings** -- The operator always mounts the host's
+  ``/dev/shm`` (hostPath) and sets ``--host 0.0.0.0``.  Forgetting the shared
+  ``/dev/shm`` in a hand-written manifest causes silent CUDA IPC failures
+  (``cudaErrorMapBufferObjectFailed``) that are hard to debug.
 - **Node-local service discovery** -- The operator creates a ClusterIP Service
   with ``internalTrafficPolicy=Local`` and a connection ConfigMap that vLLM
   pods simply mount.  No ``hostNetwork``, no Downward API, no shell variable
@@ -87,7 +87,8 @@ A minimal CR deploys a DaemonSet with 60 GB L1 cache on every GPU node:
 The operator automatically:
 
 - Creates a DaemonSet running one LMCache server pod per matched node
-- Sets ``hostIPC: true`` and passes ``--host 0.0.0.0`` to the server
+- Mounts the host's ``/dev/shm`` (hostPath) for CUDA IPC and passes
+  ``--host 0.0.0.0`` to the server
 - Creates a node-local ClusterIP Service for vLLM discovery
 - Creates a connection ConfigMap (``my-cache-connection``) with the
   ``kv-transfer-config`` JSON that vLLM needs
@@ -127,8 +128,6 @@ Mount it in your vLLM Deployment:
           labels:
             app: vllm
         spec:
-          # Required for CUDA IPC between vLLM and LMCache
-          hostIPC: true
           containers:
             - name: vllm
               image: lmcache/vllm-openai:latest
@@ -151,6 +150,10 @@ Mount it in your vLLM Deployment:
                 - name: kv-transfer-config
                   mountPath: /etc/lmcache
                   readOnly: true
+                # Required for CUDA IPC between vLLM and LMCache: both pods
+                # must see the same /dev/shm tmpfs
+                - name: lmcache-dev-shm
+                  mountPath: /dev/shm
               resources:
                 limits:
                   nvidia.com/gpu: "1"
@@ -158,11 +161,19 @@ Mount it in your vLLM Deployment:
             - name: kv-transfer-config
               configMap:
                 name: my-cache-connection  # <engine-name>-connection
+            - name: lmcache-dev-shm
+              hostPath:
+                path: /dev/shm
+                type: Directory
 
 Key requirements for vLLM pods:
 
-- **hostIPC: true** -- CUDA IPC (``cudaIpcOpenMemHandle``) needs a shared IPC
-  namespace between vLLM and LMCache.
+- **Shared /dev/shm** -- CUDA IPC (``cudaIpcOpenMemHandle``) needs vLLM and
+  LMCache to see the same ``/dev/shm`` tmpfs (PyTorch's CUDA IPC handles
+  reference a shared-memory ref-counter file there).  Mount the host's
+  ``/dev/shm`` via hostPath as above, or set ``spec.hostIPC: true`` on the
+  engine and ``hostIPC: true`` on the vLLM pod to share the host IPC
+  namespace instead.
 - **PYTHONHASHSEED=0** -- Ensures deterministic token hashing so vLLM and
   LMCache produce consistent cache keys.
 - **ConfigMap mount** -- The ``$(cat ...)`` pattern reads the connection JSON
@@ -188,13 +199,14 @@ the webhook mutates the pod at admission time to add:
 - ``--kv-transfer-config <JSON>`` -- the ``LMCacheMPConnector`` config, read
   verbatim from the engine's ``<engine>-connection`` ConfigMap and inlined onto
   the vLLM container's ``args`` (no volume mount needed);
-- ``hostIPC: true`` on the pod spec (CUDA IPC with the node-local server);
+- a hostPath mount of the host's ``/dev/shm`` (CUDA IPC with the node-local
+  server; ``hostIPC: true`` instead when the engine sets ``spec.hostIPC``);
 - ``PYTHONHASHSEED=0`` on the vLLM container env, **set-if-absent** -- it
   preserves a value you already set.
 
-Unlike the CacheBlend injector it does **not** consult the engine CR: the
-entire connector config lives in the connection ConfigMap, and
-``LMCacheEngine`` has no injection sub-spec.  It fails open
+The connector config lives in the connection ConfigMap; the webhook also
+reads the ``LMCacheEngine`` CR (when present) to mirror its ``spec.hostIPC``
+mode and its optional injection sub-spec.  It fails open
 (``failurePolicy: Ignore``) and is idempotent (re-admitted pods carrying the
 ``lmcache.ai/lmcache-injected`` stamp are allowed unchanged).
 
@@ -205,9 +217,10 @@ Prerequisites
   controller-only and disables the webhook via ``ENABLE_WEBHOOKS=false``) --
   same as the CacheBlend webhook; install once per cluster (see
   :ref:`mp-operator-cacheblend` "Additional Prerequisites").
-- **Pod Security Standards** -- the injected ``hostIPC`` is rejected by the
-  ``baseline`` / ``restricted`` PSS profiles, so the vLLM pod's namespace must
-  be labeled ``pod-security.kubernetes.io/enforce=privileged``.
+- **Pod Security Standards** -- the injected hostPath ``/dev/shm`` mount (and
+  ``hostIPC``, when the engine opts in) is rejected by the ``baseline`` /
+  ``restricted`` PSS profiles, so the vLLM pod's namespace must be labeled
+  ``pod-security.kubernetes.io/enforce=privileged``.
 - **Engine reconciled in the same namespace** -- the webhook reads the
   ``<engine>-connection`` ConfigMap directly, so the ``LMCacheEngine`` must
   already exist in the vLLM pod's namespace.
@@ -243,9 +256,9 @@ not reach ``vllm serve``):
             # lmcache.ai/lmcache-container: "vllm"
         spec:
           runtimeClassName: nvidia
-          # Do NOT set hostIPC here or mount an emptyDir at /dev/shm -- the
-          # webhook injects hostIPC=true; an emptyDir would shadow the host's
-          # /dev/shm and break cudaIpcOpenMemHandle.
+          # Do NOT mount an emptyDir at /dev/shm -- the webhook injects a
+          # hostPath mount of the host's /dev/shm; an emptyDir would shadow the
+          # host's /dev/shm and break cudaIpcOpenMemHandle.
           containers:
             - name: vllm
               image: lmcache/vllm-openai:latest
@@ -272,7 +285,7 @@ Deployment spec):
 .. code-block:: bash
 
     kubectl get pod -l app=vllm-lmcache -o yaml | \
-      grep -E "hostIPC|kv-transfer-config|lmcache-injected|lmcache-skip-reason"
+      grep -E "lmcache-dev-shm|hostIPC|kv-transfer-config|lmcache-injected|lmcache-skip-reason"
 
 If nothing was injected, check the pod's ``lmcache.ai/lmcache-skip-reason``
 annotation:
@@ -556,6 +569,15 @@ GPU & Security
      - ``nvidia``
      - GPU vendor: ``nvidia`` (uses the ``nvidia`` RuntimeClass) or ``amd``
        (runs on the default runtime).
+   * - ``hostIPC``
+     - ``false``
+     - Run the pod in the host IPC namespace instead of mounting the host's
+       ``/dev/shm`` via hostPath. Cross-pod CUDA IPC needs only the shared
+       ``/dev/shm`` tmpfs, so the default hostPath mount suffices on NVIDIA
+       clusters; set ``true`` where hostPath volumes are blocked by an
+       admission policy, or for ``gpuVendor: amd`` (the HIP IPC path is
+       unverified without it). The injection webhook mirrors this setting on
+       opted-in vLLM pods.
    * - ``privileged``
      - ``false``
      - Run the engine container in privileged mode. On most clusters
@@ -648,10 +670,14 @@ For example, ``l1.sizeGB: 60`` produces a 65 Gi request and 98 Gi limit.
 Auto-Injected Pod Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The operator always injects these into the pod spec (they are not configurable
-via the CRD):
+The operator always injects these into the pod spec:
 
-- **hostIPC: true** -- Required for CUDA IPC between LMCache and vLLM.
+- **Host /dev/shm mount (hostPath)** -- Required for CUDA IPC between LMCache
+  and vLLM: both processes must see the same ``/dev/shm`` tmpfs (PyTorch's CUDA
+  IPC handles reference a shared-memory ref-counter file there).  Set
+  ``spec.hostIPC: true`` to share the host IPC namespace instead (needed on
+  clusters that block hostPath volumes, and for ``gpuVendor: amd``); the mount
+  is then omitted.
 - **--host 0.0.0.0** -- Binds the server to all interfaces so the node-local
   Service can route to it.
 - **NVIDIA_VISIBLE_DEVICES=all** -- Ensures GPU access for IPC-based memory
@@ -662,9 +688,9 @@ via the CRD):
   and readiness (5s) probes on the server port.
 
 .. note::
-   The operator does **not** mount an emptyDir at ``/dev/shm``.  With
-   ``hostIPC: true``, the container sees the host's ``/dev/shm`` directly.
-   Mounting an emptyDir would shadow it with a private tmpfs and break CUDA IPC.
+   The operator never mounts an emptyDir at ``/dev/shm``.  Mounting an emptyDir
+   there would shadow the host's ``/dev/shm`` with a private tmpfs and break
+   CUDA IPC.
 
 Resources Created
 ~~~~~~~~~~~~~~~~~
@@ -968,8 +994,9 @@ It has two halves the operator runs together:
 
 - a GPU-resident CacheBlend V3 engine (``lmcache server --engine-type blend``),
   deployed as a DaemonSet with the **same GPU model as** ``LMCacheEngine``
-  (``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` + ``hostIPC``,
-  plus ``privileged`` when ``spec.privileged`` is set, and **no**
+  (``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` + the host
+  ``/dev/shm`` mount -- or ``hostIPC`` when ``spec.hostIPC`` is set -- plus
+  ``privileged`` when ``spec.privileged`` is set, and **no**
   ``nvidia.com/gpu`` claim) so it shares the vLLM GPU for same-device CUDA IPC;
   and
 - the vLLM-side plugin, injected into opted-in pods by the webhook.
@@ -989,9 +1016,10 @@ Beyond the operator prerequisites above:
 
 - **Deploy with the webhook** -- use ``make deploy`` (not ``make run``, which is
   controller-only and disables the webhook via ``ENABLE_WEBHOOKS=false``).
-- **Pod Security Standards** -- the webhook injects ``hostIPC``/``privileged``,
-  which the ``baseline``/``restricted`` profiles reject, so label the engine's
-  and the vLLM pod's namespaces ``pod-security.kubernetes.io/enforce=privileged``.
+- **Pod Security Standards** -- the webhook injects a hostPath ``/dev/shm``
+  mount (or ``hostIPC``/``privileged`` when the engine opts in), which the
+  ``baseline``/``restricted`` profiles reject, so label the engine's and the
+  vLLM pod's namespaces ``pod-security.kubernetes.io/enforce=privileged``.
 
 Deploying a CacheBlendEngine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1058,7 +1086,8 @@ not reach ``vllm serve``:
                 limits:
                   nvidia.com/gpu: "1"
 
-The webhook injects the plugin init container, ``PYTHONPATH``, ``hostIPC``, the
+The webhook injects the plugin init container, ``PYTHONPATH``, the ``/dev/shm``
+mount, the
 private-image pull secret, and the required CacheBlend vLLM flags
 (``--kv-transfer-config`` from the engine's connection ConfigMap,
 ``--pipeline-parallel-size 1``, ``--no-enable-chunked-prefill``,
@@ -1567,9 +1596,9 @@ Operator vs Manual Deployment
    * - Concern
      - Manual DaemonSet
      - LMCacheEngine Operator
-   * - hostIPC
+   * - ``/dev/shm`` sharing (CUDA IPC)
      - Must set manually
-     - Auto-injected
+     - Auto-injected (hostPath mount; ``spec.hostIPC`` opt-in)
    * - ``--host 0.0.0.0``
      - Must set manually
      - Auto-injected
@@ -1595,14 +1624,17 @@ Operator vs Manual Deployment
 Security Considerations
 -----------------------
 
-**hostIPC** exposes the host's IPC namespace (System V IPC, POSIX message
-queues) to the container.  Any process in the container can interact with IPC
-resources from other processes on the same host.
+The **hostPath /dev/shm mount** exposes the host's shared-memory tmpfs to the
+container -- a narrower grant than the whole host IPC namespace, but still
+host-level access.  ``spec.hostIPC: true`` (opt-in, default ``false``) instead
+exposes the host's IPC namespace (System V IPC, POSIX message queues): any
+process in the container can interact with IPC resources from other processes
+on the same host.
 
 - Deploy only in trusted environments.
 - Clusters using Pod Security Standards must allow the ``privileged`` profile
   for the LMCache namespace -- the ``baseline`` and ``restricted`` profiles
-  reject ``hostIPC``.
+  reject hostPath volumes and ``hostIPC`` alike.
 - ``spec.privileged`` defaults to ``false``. When enabled (required for
   ``gpuVendor: amd``), the engine container additionally runs privileged,
   granting it full device access -- enable it only where GPU visibility

--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -101,10 +101,11 @@ Both names point at the same image; only the hostnames differ.
 
 - **PodSecurity admission**: test namespaces are pre-labeled
   `pod-security.kubernetes.io/enforce=privileged` so the operator's
-  DaemonSet (which always sets `hostIPC=true`, and `privileged=true` only
-  when `spec.privileged` is enabled) is accepted at admission time.
-  `hostIPC=true` alone is rejected by the `baseline`/`restricted` profiles,
-  so the label is required regardless of `privileged`. Harmless on clusters
+  DaemonSet (which mounts the host's `/dev/shm` via hostPath by default, sets
+  `hostIPC=true` only when `spec.hostIPC` is enabled, and `privileged=true`
+  only when `spec.privileged` is enabled) is accepted at admission time.
+  The hostPath volume alone is rejected by the `baseline`/`restricted`
+  profiles, so the label is required regardless of `hostIPC`/`privileged`. Harmless on clusters
   that don't enforce PodSecurity.
 - **SCC (Security Context Constraints)**: M1 smokes never wait for
   DaemonSet pods to schedule, so SCC isn't a blocker. If you need pods
@@ -251,8 +252,8 @@ from `/etc/nvidia-container-runtime/config.toml`.
 
 Single-node is intentional: the LMCache DaemonSet and the test-side
 vLLM Deployment both schedule onto the same (only) worker, which is
-what the kv-cache transfer needs anyway (hostIPC + cudaIPC require
-colocation).
+what the kv-cache transfer needs anyway (the shared /dev/shm + cudaIPC
+require colocation).
 
 **Side effect of step 2 to be aware of**: after the flip, every
 docker container on the host — not just Kind workers — starts

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-LMCache multiprocess mode runs as a separate server process that vLLM instances connect to for KV cache offloading. Today this is deployed manually via raw K8s manifests (a DaemonSet for LMCache + a Deployment for vLLM). A K8s operator would automate lifecycle management, enforce best practices (`hostIPC`, resource sizing), and expose connection info for vLLM discovery.
+LMCache multiprocess mode runs as a separate server process that vLLM instances connect to for KV cache offloading. Today this is deployed manually via raw K8s manifests (a DaemonSet for LMCache + a Deployment for vLLM). A K8s operator would automate lifecycle management, enforce best practices (`/dev/shm` sharing for CUDA IPC, resource sizing), and expose connection info for vLLM discovery.
 
 ### Current Pain Points the Operator Solves
 
-- Manual `hostIPC` setup and node-local service discovery
+- Manual `/dev/shm`-sharing setup and node-local service discovery
 - No automated connection info propagation to vLLM
 - No Prometheus ServiceMonitor integration
 - No validation of configuration parameters
@@ -15,7 +15,7 @@ LMCache multiprocess mode runs as a separate server process that vLLM instances 
 
 The operator introduces a single CRD (`LMCacheEngine`) that declaratively captures the full LMCache server configuration. The controller reconciles this CR into the underlying K8s resources (DaemonSet, Service, ConfigMap, ServiceMonitor), automatically injecting the required pod-level settings that are easy to forget in hand-written manifests.
 
-**Auto-injected pod settings eliminate manual boilerplate.** The controller always sets `hostIPC: true` and `--host 0.0.0.0` — settings that the current `lmcache-daemonset.yaml` requires users to specify by hand. Getting any of these wrong (e.g., forgetting `hostIPC`) causes silent connectivity failures or CUDA IPC errors that are hard to debug.
+**Auto-injected pod settings eliminate manual boilerplate.** The controller always mounts the host's `/dev/shm` (hostPath) and sets `--host 0.0.0.0` — settings that the current `lmcache-daemonset.yaml` requires users to specify by hand. Getting any of these wrong (e.g., forgetting the `/dev/shm` mount) causes silent connectivity failures or CUDA IPC errors that are hard to debug.
 
 **A node-local Service with connection ConfigMap provides a stable discovery contract for vLLM.** The operator creates a ClusterIP Service with `internalTrafficPolicy=Local`, which ensures kube-proxy routes traffic only to the LMCache pod on the same node. A ConfigMap (`<name>-connection`) contains the `kv-transfer-config` JSON pointing to this service's cluster DNS name. vLLM deployments simply mount the ConfigMap — no downward API or shell substitution needed. When the LMCache CR changes, the ConfigMap updates automatically and vLLM pods pick up the new values on restart.
 
@@ -135,8 +135,8 @@ spec:
 
   # -- Connection-injection webhook defaults (optional) --
   # Read by the LMCache mutating webhook for pods bound to this engine. When
-  # unset, the webhook wires only the connection (--kv-transfer-config, hostIPC,
-  # PYTHONHASHSEED). Set injection.payloadImage to ALSO stage an lmcache code
+  # unset, the webhook wires only the connection (--kv-transfer-config, the
+  # /dev/shm sharing, PYTHONHASHSEED). Set injection.payloadImage to ALSO stage an lmcache code
   # tree into the vLLM container (emptyDir + init container + readOnly mount +
   # PYTHONPATH=/lmcache-payload), reusing the CacheBlend payload-staging
   # mechanism so the vLLM client and the engine server run one lmcache build.
@@ -178,6 +178,12 @@ spec:
   priorityClassName: string
 
   # -- Security --
+  hostIPC: bool               # default: false; run the pod in the host IPC
+                              # namespace instead of mounting the host's
+                              # /dev/shm via hostPath. Needed only where the
+                              # hostPath mount is unavailable or for AMD (HIP
+                              # IPC is unverified without it) — see
+                              # "Auto-managed Pod Settings" below.
   privileged: bool            # default: false; run the engine container in
                               # privileged mode. Needed only on clusters where
                               # the engine cannot see the node GPUs otherwise
@@ -193,15 +199,15 @@ spec:
 
 The operator always injects these into the pod spec:
 
-- **`hostIPC: true`** — **required for CUDA IPC between LMCache and vLLM.** LMCache uses `CudaIPCWrapper` which calls PyTorch's `_share_cuda_()` to get a GPU driver-level IPC handle. The handle is serialized and sent over ZMQ TCP. The receiving process reconstructs the tensor via `cudaIpcOpenMemHandle` at the driver level. This call requires both processes to share the same IPC namespace — without `hostIPC: true`, `cudaIpcOpenMemHandle` fails with `cudaErrorMapBufferObjectFailed`. **Both the LMCache pods and vLLM pods must have `hostIPC: true`.**
+- **Host `/dev/shm` mount (hostPath, volume `lmcache-dev-shm`)** — **required for CUDA IPC between LMCache and vLLM.** The CUDA IPC handles that carry KV tensors across pods are opened via files the driver and PyTorch create in `/dev/shm`, so both pods must see the same `/dev/shm` tmpfs; without it, `cudaIpcOpenMemHandle` fails with `cudaErrorMapBufferObjectFailed`. A shared IPC namespace is **not** required — only the shared `/dev/shm` tmpfs is. The injection webhook mirrors the mount onto opted-in vLLM pods. `spec.hostIPC: true` restores the legacy host-IPC-namespace mode — for clusters that block hostPath volumes, or for `gpuVendor: amd` (unverified without it). A user-supplied `/dev/shm` mount suppresses the injection.
 - **`runtimeClassName: nvidia`** — uses the NVIDIA container runtime, which injects the host's NVIDIA driver libraries and device files into the container. This is required for CUDA to function inside the pod.
 - **`NVIDIA_VISIBLE_DEVICES=all`** — gives the engine access to all GPUs on the node for CUDA IPC and custom data transfer kernels without claiming any via `nvidia.com/gpu` resource requests (which would make those GPUs unavailable to the serving engine). The combination of `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` lets the container see all GPUs without consuming device-plugin resources, so the serving engine (e.g., vLLM) can still request all GPUs on the node. On most clusters this is sufficient; on some, the engine cannot see the GPUs unless the pod is also privileged — set `spec.privileged: true` to run the engine container privileged (default `false`).
 - **`NVIDIA_VISIBLE_DEVICES=all`** and **`NVIDIA_DRIVER_CAPABILITIES=all`** — env vars that instruct the NVIDIA container runtime to expose all GPUs and all driver capabilities to the container.
 - **`--host 0.0.0.0`** — always passed as a container arg. The server defaults to `--host localhost` which only binds to loopback; the server must bind to all interfaces so the node-local Service can route traffic to it.
 - **No `hostNetwork`** — the operator does **not** use `hostNetwork`. Instead, it creates a ClusterIP Service with `internalTrafficPolicy=Local`. kube-proxy ensures that traffic to the service is routed only to the LMCache pod on the same node. This avoids occupying host ports and reduces the privileged surface area.
-- **No `/dev/shm` emptyDir mount** — the operator intentionally does *not* mount an emptyDir at `/dev/shm`. With `hostIPC: true`, the container already sees the host's `/dev/shm`. Mounting an emptyDir would shadow the host's `/dev/shm` with a private tmpfs, breaking CUDA IPC (`cudaIpcOpenMemHandle` fails because IPC handles written by one pod are invisible to others). If your workload needs a larger `/dev/shm` for non-IPC purposes, add it via `spec.volumes` / `spec.volumeMounts`.
+- **No `/dev/shm` emptyDir mount** — the operator intentionally never mounts an emptyDir at `/dev/shm`. It would shadow the host's `/dev/shm` with a private tmpfs, breaking CUDA IPC (`cudaIpcOpenMemHandle` fails because IPC handles written by one pod are invisible to others).
 
-> **Security implications:** The LMCache pods run with `hostIPC: true` (required for CUDA IPC), which exposes the host's IPC namespace. When `spec.privileged: true` is set they additionally run privileged, granting full device access to the container. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace whenever `hostIPC`/`privileged` are in use — the `baseline` and `restricted` profiles reject these settings.
+> **Security implications:** The LMCache pods mount the host's `/dev/shm` (hostPath), which exposes the host's shared-memory tmpfs — a narrower grant than the whole host IPC namespace, but still host-level access. With `spec.hostIPC: true` they instead join the host IPC namespace, and with `spec.privileged: true` they additionally run privileged, granting full device access. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace — hostPath volumes, `hostIPC`, and `privileged` are all rejected by the `baseline` and `restricted` profiles.
 
 ---
 
@@ -261,7 +267,7 @@ spec:
     sizeGB: 60
 ```
 
-This deploys a DaemonSet with 60GB L1 cache, LRU eviction, blake3 hashing, port 5555, auto-computed 65Gi memory request / 98Gi limit, Prometheus on 9090, and a connection ConfigMap for vLLM. The operator auto-injects `hostIPC` and `--host 0.0.0.0`, and creates a node-local Service for vLLM discovery.
+This deploys a DaemonSet with 60GB L1 cache, LRU eviction, blake3 hashing, port 5555, auto-computed 65Gi memory request / 98Gi limit, Prometheus on 9090, and a connection ConfigMap for vLLM. The operator auto-injects the `/dev/shm` hostPath mount and `--host 0.0.0.0`, and creates a node-local Service for vLLM discovery.
 
 ### Production Deployment (all GPU nodes)
 
@@ -343,7 +349,7 @@ The ConfigMap uses the lookup Service's cluster DNS name. Because the Service ha
 
 ## Auto-injected Pod Template Details
 
-In addition to the auto-managed pod settings above (`hostIPC`, `--host 0.0.0.0`),
+In addition to the auto-managed pod settings above (the `/dev/shm` mount, `--host 0.0.0.0`),
 the operator injects:
 
 - Container command: `/opt/venv/bin/lmcache server`
@@ -367,7 +373,7 @@ OnEvent(LMCacheEngine create/update/delete):
    - memoryLimit = ceil(memoryRequest * 1.5) Gi
    - containerArgs from all spec fields
 3. RECONCILE DaemonSet (CreateOrUpdate, ownerRef)
-   - Always inject: hostIPC, runtimeClassName: nvidia, NVIDIA_VISIBLE_DEVICES=all, --host 0.0.0.0 (privileged only when spec.privileged=true)
+   - Always inject: the lmcache-dev-shm hostPath mount (or hostIPC when spec.hostIPC=true), runtimeClassName: nvidia, NVIDIA_VISIBLE_DEVICES=all, --host 0.0.0.0 (privileged only when spec.privileged=true)
 4. RECONCILE node-local lookup Service (internalTrafficPolicy=Local)
 5. RECONCILE headless Service for metrics
 6. RECONCILE connection ConfigMap
@@ -439,8 +445,9 @@ l2Backend, scheduling, overrides, imagePullSecrets) and adds:
 DaemonSet running `lmcache server --engine-type blend` (plus
 `--l1-align-bytes 16777216`), a node-local lookup Service, a metrics Service, and
 a `<name>-connection` ConfigMap. **GPU model is identical to `LMCacheEngine`**:
-`runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` + `hostIPC: true` (and
-`privileged` when `spec.privileged=true`), with **no `nvidia.com/gpu`
+`runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` + the lmcache-dev-shm hostPath
+mount (or `hostIPC` when `spec.hostIPC=true`; `privileged` when
+`spec.privileged=true`), with **no `nvidia.com/gpu`
 device-plugin claim** — the engine
 *shares* the vLLM GPU rather than reserving one, because the blend server scatters
 re-RoPE'd KV directly into vLLM's paged KV over **same-device CUDA IPC**. The
@@ -481,7 +488,7 @@ webhook then applies:
 
 | Mutation | What |
 |---|---|
-| pod `hostIPC: true` | required for CUDA IPC with the node-local engine |
+| host `/dev/shm` mount (or `hostIPC: true` when the engine opts in) | required for CUDA IPC with the node-local engine |
 | `cb-plugin` emptyDir + payload init container | the busybox payload `cp -a`'s the pure-Python plugin tree onto the shared volume |
 | readOnly mount + `PYTHONPATH=/cb-plugin` on the vLLM container | vLLM discovers the plugin via its `vllm.general_plugins` entry point |
 | append required vLLM args | `--kv-transfer-config <from the connection ConfigMap>`, `--pipeline-parallel-size 1`, `--no-enable-chunked-prefill`, `--enforce-eager` (or the configured cudagraph) |
@@ -518,9 +525,10 @@ a user-supplied `--flag=value`.
 - **`make deploy`, not `make run`** — `make run` sets `ENABLE_WEBHOOKS=false` and
   installs no `MutatingWebhookConfiguration`; it is controller-only. The webhook
   needs the operator running as an in-cluster pod.
-- **Pod Security Standards** — the injected `hostIPC`/`privileged` is rejected by
-  the `baseline`/`restricted` profiles, so the engine's and the vLLM pod's
-  namespaces must be labeled `pod-security.kubernetes.io/enforce=privileged`.
+- **Pod Security Standards** — the injected hostPath `/dev/shm` mount (and
+  `hostIPC`/`privileged` when opted in) is rejected by the `baseline`/`restricted`
+  profiles, so the engine's and the vLLM pod's namespaces must be labeled
+  `pod-security.kubernetes.io/enforce=privileged`.
 
 ### Resources created (for a `CacheBlendEngine` named `cb`)
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -19,6 +19,9 @@ See [DESIGN.md](DESIGN.md) for architecture details, reconciliation logic, and C
 > On AMD ROCm clusters, `spec.gpuVendor: amd` omits `runtimeClassName` and skips NVIDIA-specific env vars.
 
 > [!WARNING]
+> **Upgrade note:** earlier operator versions always set `hostIPC: true` on engine pods and webhook-injected vLLM pods. `spec.hostIPC` now defaults to `false`; the host's `/dev/shm` is shared via a hostPath mount instead (the CUDA IPC requirement). Upgrading restarts the engine pods once (the DaemonSet pod template changes). Already-running vLLM pods keep working without a restart: a pod using `hostIPC` and a pod using the hostPath mount see the same host `/dev/shm`. If your cluster blocks hostPath volumes, set `spec.hostIPC: true` on existing CRs **before** upgrading.
+
+> [!WARNING]
 > **Upgrade note:** earlier operator versions always ran the engine container privileged. `spec.privileged` now defaults to `false`. Upgrading rewrites the DaemonSet pod template (forcing a rolling pod replacement), and on any cluster where privileged was load-bearing for GPU visibility the engine pods will come back up **without** GPU access. If your cluster relied on privileged mode (always the case for `gpuVendor: amd`), set `spec.privileged: true` on existing CRs before upgrading.
 
 ## Quick Start
@@ -56,7 +59,7 @@ The minimal CR just needs `l1.sizeGB`. Apply the sample (a fully-commented field
 kubectl apply -f config/samples/lmcache_v1alpha1_lmcacheengine.yaml
 ```
 
-The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `NVIDIA_VISIBLE_DEVICES=all`; set `spec.privileged: true` if your cluster also needs privileged mode), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
+The operator automatically handles `/dev/shm` sharing for CUDA IPC (a hostPath mount; set `spec.hostIPC: true` to use the host IPC namespace instead), GPU visibility (`runtimeClassName: nvidia`, `NVIDIA_VISIBLE_DEVICES=all`; set `spec.privileged: true` if your cluster also needs privileged mode), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
 
 ### 3. Connect vLLM to LMCache
 
@@ -64,7 +67,7 @@ The operator creates a ConfigMap named `<engine-name>-connection` with the `kv-t
 
 Key points for vLLM pods:
 
-- **`hostIPC: true` is required** — CUDA IPC (`cudaIpcOpenMemHandle`) needs a shared IPC namespace between vLLM and LMCache. Without this, GPU memory mapping fails.
+- **A shared `/dev/shm` is required** — CUDA IPC needs both pods to see the same `/dev/shm` tmpfs: PyTorch's CUDA IPC handles reference a shared-memory ref-counter file there. Mount the host's `/dev/shm` via hostPath on the vLLM pod (the injection webhook does this for you), or set `spec.hostIPC: true` on the engine to use the host IPC namespace instead. Without a shared `/dev/shm`, GPU memory mapping fails.
 - **ConfigMap mount** — the `$(cat ...)` pattern reads the connection JSON and passes it inline to `--kv-transfer-config`. The ConfigMap name is always `<LMCacheEngine name>-connection`.
 - **External LMCache connector required** — the operator-generated config now sets `kv_connector_module_path=lmcache.integration.vllm.lmcache_mp_connector` so vLLM loads the external LMCache MP connector instead of silently resolving a vendored builtin path.
 - **No `hostNetwork` needed** — the operator creates a ClusterIP Service with `internalTrafficPolicy=Local`. kube-proxy routes traffic to the LMCache pod on the same node automatically. The ConfigMap points to the service DNS name, so neither LMCache nor vLLM pods need `hostNetwork`.
@@ -73,7 +76,7 @@ Key points for vLLM pods:
 > Use a pinned vLLM image that is new enough to honor `kv_connector_module_path` for KV connector loading. In practice, that means a build that includes the external-module selection fix from vLLM PR #38301 (merged April 7, 2026). Builds that also include vLLM PR #42596 (merged May 15, 2026) are preferred because they default LMCache MP to the external connector with builtin fallback. If your existing vLLM build predates those changes or you are unsure, upgrade it before enabling this operator path.
 
 > [!WARNING]
-> **Do NOT mount an emptyDir at `/dev/shm`** on either LMCache or vLLM pods. With `hostIPC: true`, both pods share the host's `/dev/shm`. Mounting an emptyDir (even with `medium: Memory`) shadows it with a private tmpfs, breaking CUDA IPC — `cudaIpcOpenMemHandle` fails because IPC handles from one pod become invisible to the other.
+> **Do NOT mount an emptyDir at `/dev/shm`** on either LMCache or vLLM pods. Both pods must share the host's `/dev/shm` (via the default hostPath mount, or via `hostIPC: true`). Mounting an emptyDir (even with `medium: Memory`) shadows it with a private tmpfs, breaking CUDA IPC — `cudaIpcOpenMemHandle` fails because IPC handles from one pod become invisible to the other.
 
 ### 4. Verify the Deployment
 
@@ -115,7 +118,7 @@ Every scenario has a ready-to-edit manifest under [`config/samples/`](config/sam
 Notes:
 
 - **GPU targeting** — `nodeSelector: {nvidia.com/gpu.present: "true"}` runs LMCache only on GPU nodes; new GPU nodes auto-get a pod.
-- **AMD (ROCm)** — `spec.gpuVendor: amd` omits `runtimeClassName` and the NVIDIA env vars; vLLM connects via HIP IPC over `hostIPC` the same way (`PYTHONHASHSEED=0` still required). Supply a `nodeSelector` matching your platform's AMD label and a ROCm-built `spec.image`. AMD has no RuntimeClass-based device injection, so set `spec.privileged: true` to let the engine reach `/dev/kfd`/`/dev/dri` (see the [AMD sample](config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml)).
+- **AMD (ROCm)** — `spec.gpuVendor: amd` omits `runtimeClassName` and the NVIDIA env vars; vLLM connects via HIP IPC over `hostIPC` the same way (`PYTHONHASHSEED=0` still required); the HIP IPC path is unverified with only the hostPath `/dev/shm` mount, so set `spec.hostIPC: true` for AMD. Supply a `nodeSelector` matching your platform's AMD label and a ROCm-built `spec.image`. AMD has no RuntimeClass-based device injection, so set `spec.privileged: true` to let the engine reach `/dev/kfd`/`/dev/dri` (see the [AMD sample](config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml)).
 - **Custom port** — set `server.port`; the connection ConfigMap updates automatically and vLLM picks it up on restart.
 - **L2 adapters** — only one at a time today. Redis/Valkey is natively typed; cross-namespace auth Secrets are copied automatically and injected via env (never in args or `kubectl describe`). Other types (`nixl_store`, `fs`, `mock`, `raw_block`) use the `raw` escape hatch — see the commented blocks in the minimal sample. For `raw_block` with `use_odirect: true`, `--l1-align-bytes` must be ≥ `block_align`.
 - **Resources** auto-compute from `l1.sizeGB`; override with `resourceOverrides`.
@@ -134,7 +137,9 @@ CREATE the webhook injects, reading the engine's `<engine>-connection` ConfigMap
 
 - `--kv-transfer-config <JSON>` — the `LMCacheMPConnector` config, inlined onto
   the vLLM container args (no volume mount needed);
-- `hostIPC: true` — CUDA IPC with the node-local LMCache server;
+- a hostPath mount of the host's `/dev/shm` — CUDA IPC with the node-local
+  LMCache server (or `hostIPC: true` instead, when the engine sets
+  `spec.hostIPC: true`);
 - `PYTHONHASHSEED=0` — deterministic prefix hashing (only if you didn't set it).
 
 ### Optional: code-payload staging
@@ -163,12 +168,13 @@ Editable sample: [`config/samples/vllm_lmcache_deployment.yaml`](config/samples/
 > [!IMPORTANT]
 > The webhook needs `make deploy` (not `make run`) + cert-manager, and the vLLM
 > pod's namespace labeled `pod-security.kubernetes.io/enforce=privileged` (the
-> injected `hostIPC` is rejected by `baseline`/`restricted`). The engine must
+> injected hostPath `/dev/shm` mount — and `hostIPC`, if the engine opts in —
+> is rejected by `baseline`/`restricted`). The engine must
 > already be reconciled in the same namespace (its `<engine>-connection`
 > ConfigMap must exist — the webhook reads it).
 
 The webhook mutates **Pods**, not the Deployment, so verify on a pod
-(`kubectl get pod -l app=vllm-lmcache -o yaml | grep -E "hostIPC|kv-transfer-config|lmcache-injected"`).
+(`kubectl get pod -l app=vllm-lmcache -o yaml | grep -E "lmcache-dev-shm|hostIPC|kv-transfer-config|lmcache-injected"`).
 If nothing was injected, check the pod's `lmcache.ai/lmcache-skip-reason`
 annotation (`command-override`, `kv-transfer-config-present`, `engine-not-found`,
 or `target-container-not-found`).
@@ -195,7 +201,8 @@ image ENTRYPOINT — a `sh -c` wrapper is skipped). Editable samples:
 > (`kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml`).
 > If Pod Security Standards are enforced, label the engine's and the vLLM pod's
 > namespaces `pod-security.kubernetes.io/enforce=privileged` — the webhook injects
-> `hostIPC`/`privileged`, which `baseline`/`restricted` reject.
+> a hostPath `/dev/shm` mount (or `hostIPC` when the engine opts in), which
+> `baseline`/`restricted` reject.
 
 > [!IMPORTANT]
 > CacheBlend is still in early stage development and under heavy testing. Its

--- a/operator/api/v1alpha1/cacheblendengine_types.go
+++ b/operator/api/v1alpha1/cacheblendengine_types.go
@@ -204,6 +204,22 @@ type CacheBlendEngineSpec struct {
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
+	// hostIPC runs the pod in the host's IPC namespace. Cross-pod CUDA IPC does
+	// not require it on NVIDIA stacks: the operator instead mounts the host's
+	// /dev/shm into the engine pod (hostPath), which is the requirement —
+	// PyTorch's CUDA IPC handles reference a shared-memory ref-counter file in
+	// /dev/shm that both processes must open by name. It therefore defaults to
+	// false. Set it to true only where the hostPath /dev/shm mount is
+	// unavailable (e.g. blocked by an admission policy) or where the GPU stack
+	// still needs a shared IPC namespace; the AMD (ROCm) HIP IPC path is
+	// unverified without hostIPC, so gpuVendor "amd" deployments should set it
+	// to true. When true, the /dev/shm hostPath mount is omitted (the shared
+	// namespace already exposes the host's /dev/shm). The injection webhook
+	// mirrors this setting on opted-in vLLM pods. Default: false.
+	// +optional
+	// +kubebuilder:default=false
+	HostIPC *bool `json:"hostIPC,omitempty"`
+
 	// privileged runs the engine container in privileged mode. On some clusters
 	// this is required for the engine to see all node GPUs (for CUDA IPC) without
 	// claiming any via the nvidia.com/gpu device plugin; on many clusters

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -524,6 +524,22 @@ type LMCacheEngineSpec struct {
 	// +kubebuilder:default=false
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
 
+	// hostIPC runs the pod in the host's IPC namespace. Cross-pod CUDA IPC does
+	// not require it on NVIDIA stacks: the operator instead mounts the host's
+	// /dev/shm into the engine pod (hostPath), which is the requirement —
+	// PyTorch's CUDA IPC handles reference a shared-memory ref-counter file in
+	// /dev/shm that both processes must open by name. It therefore defaults to
+	// false. Set it to true only where the hostPath /dev/shm mount is
+	// unavailable (e.g. blocked by an admission policy) or where the GPU stack
+	// still needs a shared IPC namespace; the AMD (ROCm) HIP IPC path is
+	// unverified without hostIPC, so gpuVendor "amd" deployments should set it
+	// to true. When true, the /dev/shm hostPath mount is omitted (the shared
+	// namespace already exposes the host's /dev/shm). The injection webhook
+	// mirrors this setting on opted-in vLLM pods. Default: false.
+	// +optional
+	// +kubebuilder:default=false
+	HostIPC *bool `json:"hostIPC,omitempty"`
+
 	// privileged runs the engine container in privileged mode. On some clusters
 	// this is required for the engine to see all node GPUs (for CUDA IPC) without
 	// claiming any via the nvidia.com/gpu device plugin; on many clusters

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -260,6 +260,11 @@ func (in *CacheBlendEngineSpec) DeepCopyInto(out *CacheBlendEngineSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.HostIPC != nil {
+		in, out := &in.HostIPC, &out.HostIPC
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Privileged != nil {
 		in, out := &in.Privileged, &out.Privileged
 		*out = new(bool)
@@ -955,6 +960,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 	}
 	if in.HostNetwork != nil {
 		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
+	if in.HostIPC != nil {
+		in, out := &in.HostIPC, &out.HostIPC
 		*out = new(bool)
 		**out = **in
 	}

--- a/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1246,6 +1246,22 @@ spec:
                 - nvidia
                 - amd
                 type: string
+              hostIPC:
+                default: false
+                description: |-
+                  hostIPC runs the pod in the host's IPC namespace. Cross-pod CUDA IPC does
+                  not require it on NVIDIA stacks: the operator instead mounts the host's
+                  /dev/shm into the engine pod (hostPath), which is the requirement —
+                  PyTorch's CUDA IPC handles reference a shared-memory ref-counter file in
+                  /dev/shm that both processes must open by name. It therefore defaults to
+                  false. Set it to true only where the hostPath /dev/shm mount is
+                  unavailable (e.g. blocked by an admission policy) or where the GPU stack
+                  still needs a shared IPC namespace; the AMD (ROCm) HIP IPC path is
+                  unverified without hostIPC, so gpuVendor "amd" deployments should set it
+                  to true. When true, the /dev/shm hostPath mount is omitted (the shared
+                  namespace already exposes the host's /dev/shm). The injection webhook
+                  mirrors this setting on opted-in vLLM pods. Default: false.
+                type: boolean
               image:
                 description: |-
                   image defines the container image to use for the blend_v3 engine. This

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1216,6 +1216,22 @@ spec:
                 - nvidia
                 - amd
                 type: string
+              hostIPC:
+                default: false
+                description: |-
+                  hostIPC runs the pod in the host's IPC namespace. Cross-pod CUDA IPC does
+                  not require it on NVIDIA stacks: the operator instead mounts the host's
+                  /dev/shm into the engine pod (hostPath), which is the requirement —
+                  PyTorch's CUDA IPC handles reference a shared-memory ref-counter file in
+                  /dev/shm that both processes must open by name. It therefore defaults to
+                  false. Set it to true only where the hostPath /dev/shm mount is
+                  unavailable (e.g. blocked by an admission policy) or where the GPU stack
+                  still needs a shared IPC namespace; the AMD (ROCm) HIP IPC path is
+                  unverified without hostIPC, so gpuVendor "amd" deployments should set it
+                  to true. When true, the /dev/shm hostPath mount is omitted (the shared
+                  namespace already exposes the host's /dev/shm). The injection webhook
+                  mirrors this setting on opted-in vLLM pods. Default: false.
+                type: boolean
               hostNetwork:
                 default: false
                 description: |-

--- a/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
@@ -81,7 +81,8 @@ spec:
 # ---------------------------------------------------------------------------
 # To enable CacheBlend on a vLLM pod, label it for the webhook and annotate it
 # with this engine's name. The pod (and this engine) must run in a namespace
-# labeled `pod-security.kubernetes.io/enforce=privileged` (hostIPC is injected).
+# labeled `pod-security.kubernetes.io/enforce=privileged` (a hostPath /dev/shm
+# mount is injected).
 #
 #   metadata:
 #     labels:

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
@@ -91,7 +91,7 @@ spec:
 
   # -- Connection-injection webhook defaults (optional) --
   # The mutating webhook always wires opted-in vLLM pods to this engine
-  # (--kv-transfer-config, hostIPC, PYTHONHASHSEED). Set injection.payloadImage to
+  # (--kv-transfer-config, the /dev/shm sharing, PYTHONHASHSEED). Set injection.payloadImage to
   # ALSO stage an lmcache code tree into the vLLM container (emptyDir + init
   # container + read-only mount + PYTHONPATH), pinning vLLM's lmcache to a
   # specific build so client and server match. Leave unset for connection-only.

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine_injection.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine_injection.yaml
@@ -1,6 +1,6 @@
 # LMCacheEngine that pins injected vLLM pods to a specific lmcache build.
 #
-# On top of the usual connection wiring (--kv-transfer-config, hostIPC,
+# On top of the usual connection wiring (--kv-transfer-config, /dev/shm sharing,
 # PYTHONHASHSEED), spec.injection.payloadImage makes the webhook stage an lmcache
 # payload into every opted-in vLLM pod (emptyDir + init container + read-only
 # mount + PYTHONPATH=/lmcache-payload), so vLLM imports THAT lmcache instead of

--- a/operator/config/samples/vllm_cacheblend_deployment.yaml
+++ b/operator/config/samples/vllm_cacheblend_deployment.yaml
@@ -3,7 +3,8 @@
 # The mutating webhook injects everything CacheBlend needs at pod CREATE — you
 # only supply the two highlighted bits below (the opt-in label + the engine
 # annotation) and a normal, args-only vLLM launch. After admission the webhook
-# adds: pod hostIPC=true; the `cb-plugin` emptyDir + payload init container;
+# adds: a hostPath mount of the host's /dev/shm; the `cb-plugin` emptyDir +
+# payload init container;
 # a readOnly mount + PYTHONPATH on the vLLM container; the required vLLM flags
 # (--kv-transfer-config <node-local engine>, --pipeline-parallel-size 1,
 # --no-enable-chunked-prefill, --enforce-eager); and the private-payload
@@ -13,7 +14,7 @@
 #   1. A CacheBlendEngine named below exists IN THIS NAMESPACE and is reconciled
 #      (its `<name>-connection` ConfigMap exists — the webhook reads it).
 #   2. This namespace is labeled pod-security.kubernetes.io/enforce=privileged
-#      (the injected hostIPC/privileged is rejected by baseline/restricted PSS).
+#      (the injected hostPath /dev/shm mount is rejected by baseline/restricted PSS).
 #   3. The vLLM container launches via the image ENTRYPOINT (["vllm","serve"])
 #      with args ONLY. Do NOT use `command: ["/bin/sh","-c", ...]` — a command
 #      override makes the webhook SKIP injection (appended args can't reach
@@ -23,7 +24,7 @@
 #      the annotation below).
 #
 # Verify after creation:
-#   kubectl get pod -l app=vllm-cacheblend -o yaml | grep -E "hostIPC|cb-plugin|PYTHONPATH|kv-transfer-config|cacheblend-injected"
+#   kubectl get pod -l app=vllm-cacheblend -o yaml | grep -E "lmcache-dev-shm|hostIPC|cb-plugin|PYTHONPATH|kv-transfer-config|cacheblend-injected"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,8 +55,8 @@ spec:
       # The blend engine shares THIS pod's GPU via CUDA IPC (it does not claim
       # its own), so the engine + this pod must land on the same GPU node.
       runtimeClassName: nvidia
-      # NOTE: do NOT set hostIPC here or mount an emptyDir at /dev/shm — the
-      # webhook injects hostIPC=true, which shares the host's /dev/shm for CUDA
+      # NOTE: do NOT mount an emptyDir at /dev/shm — the webhook injects a
+      # hostPath mount of the host's /dev/shm for CUDA
       # IPC; an emptyDir would shadow it and break cudaIpcOpenMemHandle.
       containers:
         - name: vllm

--- a/operator/config/samples/vllm_lmcache_deployment.yaml
+++ b/operator/config/samples/vllm_lmcache_deployment.yaml
@@ -3,7 +3,8 @@
 # The webhook-injected alternative to vllm_deployment.yaml (which wires vLLM to
 # the engine by hand). You supply only the opt-in label + engine annotation and a
 # normal, args-only vLLM launch; at pod CREATE the webhook adds:
-#   - pod hostIPC=true (CUDA IPC with the node-local LMCache server);
+#   - a hostPath mount of the host's /dev/shm (CUDA IPC with the node-local
+#     LMCache server; hostIPC instead when the engine sets spec.hostIPC);
 #   - --kv-transfer-config <inline JSON> on the vLLM container (read verbatim from
 #     the engine's <name>-connection ConfigMap — injected inline, no volume mount);
 #   - PYTHONHASHSEED=0 env (deterministic prefix hashing, set only if you didn't).
@@ -17,14 +18,14 @@
 #      (its `<name>-connection` ConfigMap exists — the webhook reads it).
 #   2. The webhook is deployed: `make deploy` (not `make run`) + cert-manager.
 #   3. This namespace is labeled pod-security.kubernetes.io/enforce=privileged
-#      (the injected hostIPC is rejected by baseline/restricted PSS).
+#      (the injected hostPath /dev/shm mount is rejected by baseline/restricted PSS).
 #   4. The vLLM container launches via the image ENTRYPOINT (["vllm","serve"])
 #      with args ONLY. Do NOT use `command: ["/bin/sh","-c", ...]` — a command
 #      override makes the webhook SKIP injection (appended args can't reach
 #      `vllm serve`); it stamps lmcache.ai/lmcache-skip-reason=command-override.
 #
 # Verify after creation (the webhook mutates the POD, not the Deployment):
-#   kubectl get pod -l app=vllm-lmcache -o yaml | grep -E "hostIPC|kv-transfer-config|lmcache-injected|lmcache-payload|PYTHONPATH"
+#   kubectl get pod -l app=vllm-lmcache -o yaml | grep -E "lmcache-dev-shm|hostIPC|kv-transfer-config|lmcache-injected|lmcache-payload|PYTHONPATH"
 # If nothing was injected, check lmcache.ai/lmcache-skip-reason on the pod
 # (command-override, kv-transfer-config-present, engine-not-found, or
 # target-container-not-found).
@@ -54,8 +55,8 @@ spec:
     spec:
       # Needed for GPU access unless `nvidia` is the default containerd runtime.
       runtimeClassName: nvidia
-      # NOTE: do NOT set hostIPC here or mount an emptyDir at /dev/shm — the
-      # webhook injects hostIPC=true, which shares the host's /dev/shm for CUDA
+      # NOTE: do NOT mount an emptyDir at /dev/shm — the webhook injects a
+      # hostPath mount of the host's /dev/shm for CUDA
       # IPC; an emptyDir would shadow it and break cudaIpcOpenMemHandle.
       containers:
         - name: vllm

--- a/operator/config/samples/vllm_lmcache_injection_deployment.yaml
+++ b/operator/config/samples/vllm_lmcache_injection_deployment.yaml
@@ -4,7 +4,7 @@
 #
 # Because that engine sets spec.injection.payloadImage, the webhook does TWO
 # things to this pod at CREATE:
-#   1. Connection wiring (as in vllm_lmcache_deployment.yaml): hostIPC=true,
+#   1. Connection wiring (as in vllm_lmcache_deployment.yaml): the /dev/shm mount,
 #      --kv-transfer-config on the vLLM container, PYTHONHASHSEED=0.
 #   2. Payload staging: a `lmcache-payload` emptyDir + an init container that
 #      copies the payload image's lmcache tree in, a readOnly mount, and
@@ -17,7 +17,7 @@
 #      reconciled (its `<name>-connection` ConfigMap exists — the webhook reads it).
 #   2. The webhook is deployed: `make deploy` (not `make run`) + cert-manager.
 #   3. This namespace is labeled pod-security.kubernetes.io/enforce=privileged
-#      (the injected hostIPC is rejected by baseline/restricted PSS).
+#      (the injected hostPath /dev/shm mount is rejected by baseline/restricted PSS).
 #   4. The vLLM container launches via the image ENTRYPOINT (["vllm","serve"])
 #      with args ONLY. Do NOT use `command: ["/bin/sh","-c", ...]` — a command
 #      override makes the webhook SKIP injection (it stamps
@@ -25,7 +25,7 @@
 #
 # Verify the swap after creation (the webhook mutates the POD, not the Deployment):
 #   kubectl get pod -l app=vllm-lmcache-versioned -o yaml \
-#     | grep -E "hostIPC|kv-transfer-config|lmcache-injected|lmcache-payload|PYTHONPATH"
+#     | grep -E "lmcache-dev-shm|hostIPC|kv-transfer-config|lmcache-injected|lmcache-payload|PYTHONPATH"
 #   # runtime proof — which lmcache the pod actually imports vs the baked-in one:
 #   POD=$(kubectl get pod -l app=vllm-lmcache-versioned -o name | head -1)
 #   kubectl exec $POD -c vllm -- python3 -c "import lmcache; print(lmcache.__version__, lmcache.__file__)"
@@ -61,8 +61,8 @@ spec:
     spec:
       # Needed for GPU access unless `nvidia` is the default containerd runtime.
       runtimeClassName: nvidia
-      # NOTE: do NOT set hostIPC here or mount an emptyDir at /dev/shm — the
-      # webhook injects hostIPC=true, which shares the host's /dev/shm for CUDA
+      # NOTE: do NOT mount an emptyDir at /dev/shm — the webhook injects a
+      # hostPath mount of the host's /dev/shm for CUDA
       # IPC; an emptyDir would shadow it and break cudaIpcOpenMemHandle.
       containers:
         - name: vllm

--- a/operator/internal/controller/cacheblendengine_controller_test.go
+++ b/operator/internal/controller/cacheblendengine_controller_test.go
@@ -131,7 +131,7 @@ var _ = Describe("CacheBlendEngine Controller", func() {
 			Expect(ownedBy(ds.OwnerReferences)).To(BeTrue())
 
 			podSpec := ds.Spec.Template.Spec
-			Expect(podSpec.HostIPC).To(BeTrue())
+			Expect(podSpec.HostIPC).To(BeFalse())
 			Expect(podSpec.Containers).To(HaveLen(1))
 			engineContainer := podSpec.Containers[0]
 

--- a/operator/internal/resources/cacheblend_engine.go
+++ b/operator/internal/resources/cacheblend_engine.go
@@ -84,6 +84,7 @@ func cbSpecToEngineSpec(spec *lmcachev1alpha1.CacheBlendEngineSpec) *lmcachev1al
 		PodLabels:          spec.PodLabels,
 		ServiceAccountName: spec.ServiceAccountName,
 		PriorityClassName:  spec.PriorityClassName,
+		HostIPC:            spec.HostIPC,
 		Privileged:         spec.Privileged,
 		ExtraArgs:          spec.ExtraArgs,
 	}
@@ -110,10 +111,12 @@ func BuildCBEngineArgs(spec *lmcachev1alpha1.CacheBlendEngineSpec) []string {
 
 // BuildCBEngineDaemonSet constructs the DaemonSet for the blend_v3 engine of the
 // given CacheBlendEngine. It reuses the shared GPU/security pod-template
-// scaffolding (hostIPC, runtimeClassName=nvidia, NVIDIA_VISIBLE_DEVICES=all,
-// privileged only when spec.privileged=true (default false), CPU+memory-only
-// resources with no nvidia.com/gpu claim) so the engine shares the node's GPU
-// via CUDA IPC, and adds the blend-specific server args.
+// scaffolding (host /dev/shm sharing for CUDA IPC — hostPath mount by default,
+// host IPC namespace when spec.hostIPC=true — runtimeClassName=nvidia,
+// NVIDIA_VISIBLE_DEVICES=all, privileged only when spec.privileged=true
+// (default false), CPU+memory-only resources with no nvidia.com/gpu claim) so
+// the engine shares the node's GPU via CUDA IPC, and adds the blend-specific
+// server args.
 func BuildCBEngineDaemonSet(engine *lmcachev1alpha1.CacheBlendEngine) *appsv1.DaemonSet {
 	engineSpec := cbSpecToEngineSpec(&engine.Spec)
 	return buildDaemonSetCore(

--- a/operator/internal/resources/cacheblend_engine_test.go
+++ b/operator/internal/resources/cacheblend_engine_test.go
@@ -111,9 +111,19 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 
 	podSpec := ds.Spec.Template.Spec
 
-	// hostIPC required for CUDA IPC with the node-local engine.
-	if !podSpec.HostIPC {
-		t.Fatal("expected HostIPC=true")
+	// CUDA IPC with the node-local engine is wired via the /dev/shm hostPath
+	// mount by default; hostIPC is opt-in via spec.hostIPC.
+	if podSpec.HostIPC {
+		t.Fatal("expected HostIPC=false by default")
+	}
+	foundShm := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == devShmVolumeName && v.HostPath != nil && v.HostPath.Path == devShmPath {
+			foundShm = true
+		}
+	}
+	if !foundShm {
+		t.Fatal("expected the lmcache-dev-shm hostPath volume by default")
 	}
 	// runtimeClassName=nvidia for the default (nvidia) vendor.
 	if podSpec.RuntimeClassName == nil || *podSpec.RuntimeClassName != nvidiaRuntimeClass {
@@ -216,10 +226,13 @@ func TestBuildCBEngineDaemonSet_AMDNoRuntimeClass(t *testing.T) {
 	if podSpec.RuntimeClassName != nil {
 		t.Fatalf("expected nil RuntimeClassName for AMD, got %q", *podSpec.RuntimeClassName)
 	}
-	// hostIPC is still injected for AMD (privileged stays at its default false
-	// here since the fixture does not opt in).
-	if !podSpec.HostIPC {
-		t.Fatal("expected HostIPC=true even for AMD")
+	// The HIP IPC path is unverified without a shared IPC namespace, so AMD
+	// deployments opt into hostIPC explicitly (privileged stays at its default
+	// false here since the fixture does not opt in).
+	engine.Spec.HostIPC = ptr(true)
+	ds = BuildCBEngineDaemonSet(engine)
+	if !ds.Spec.Template.Spec.HostIPC {
+		t.Fatal("expected HostIPC=true when spec.hostIPC=true for AMD")
 	}
 }
 

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -66,10 +66,11 @@ func BuildDaemonSet(engine *lmcachev1alpha1.LMCacheEngine) *appsv1.DaemonSet {
 
 // buildDaemonSetCore constructs the DaemonSet shared by the LMCacheEngine and
 // CacheBlendEngine controllers. It is the single source of truth for the
-// GPU/security pod-template scaffolding (hostIPC, runtimeClassName, optional
-// privileged (default false, via spec.Privileged), NVIDIA_VISIBLE_DEVICES,
-// resources without a device-plugin GPU claim) so those settings cannot drift
-// between the two engines.
+// GPU/security pod-template scaffolding (host /dev/shm sharing for CUDA IPC —
+// a hostPath mount by default, or the host IPC namespace when spec.HostIPC is
+// true — runtimeClassName, optional privileged (default false, via
+// spec.Privileged), NVIDIA_VISIBLE_DEVICES, resources without a device-plugin
+// GPU claim) so those settings cannot drift between the two engines.
 //
 // Parameters:
 //   - name, namespace: the owning object's identity, used for labels and metadata.
@@ -97,6 +98,7 @@ func buildDaemonSetCore(
 		runtimeClassName = &rc
 	}
 	privileged := derefBool(spec.Privileged, false)
+	hostIPC := derefBool(spec.HostIPC, false)
 
 	serverPort := derefInt32(getServerPort(spec), 5555)
 	imgRepo := defaultImageRepo
@@ -185,11 +187,19 @@ func buildDaemonSetCore(
 	}
 	envVars = append(envVars, spec.Env...)
 
-	// No emptyDir /dev/shm mount — hostIPC: true exposes the host's /dev/shm
-	// directly. An emptyDir mount would shadow it and break CUDA IPC between
-	// LMCache and vLLM pods (cudaIpcOpenMemHandle requires shared /dev/shm).
+	// Cross-pod CUDA IPC needs the engine and vLLM pods to share the host's
+	// /dev/shm tmpfs (PyTorch CUDA IPC handles reference a ref-counter file
+	// there). By default that is a hostPath mount; with spec.hostIPC=true the
+	// shared IPC namespace already exposes the host's /dev/shm, so the mount is
+	// omitted. Never mount an emptyDir at /dev/shm — it would shadow the host's
+	// tmpfs and break CUDA IPC (cudaIpcOpenMemHandle fails with
+	// cudaErrorMapBufferObjectFailed).
 	volumes := append([]corev1.Volume{}, spec.Volumes...)
 	volumeMounts := append([]corev1.VolumeMount{}, spec.VolumeMounts...)
+	if !hostIPC && !HasDevShmMount(volumeMounts) && !HasDevShmVolume(volumes) {
+		volumes = append(volumes, BuildDevShmVolume())
+		volumeMounts = append(volumeMounts, BuildDevShmVolumeMount())
+	}
 
 	// Mount the L2 encryption master key (user-created Secret in the engine's
 	// namespace) read-only at the path the serde config references. Only the
@@ -298,7 +308,7 @@ func buildDaemonSetCore(
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					HostIPC:            true,
+					HostIPC:            hostIPC,
 					HostNetwork:        derefBool(spec.HostNetwork, false),
 					RuntimeClassName:   runtimeClassName,
 					ServiceAccountName: spec.ServiceAccountName,

--- a/operator/internal/resources/devshm.go
+++ b/operator/internal/resources/devshm.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file holds the host /dev/shm wiring shared by the engine DaemonSet
+// builder (buildDaemonSetCore) and the pod-injection webhooks
+// (webhook.applyIPCSharing): the hostPath volume/mount that gives two
+// same-node pods the shared /dev/shm tmpfs cross-pod CUDA IPC needs, plus
+// the guards that keep the injection away from user-supplied wiring.
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// devShmVolumeName is the pod volume name for the host /dev/shm mount used
+	// for cross-pod CUDA IPC when hostIPC is disabled (the default).
+	devShmVolumeName = "lmcache-dev-shm"
+
+	// devShmPath is both the hostPath source and the in-container mount path of
+	// the shared /dev/shm tmpfs.
+	devShmPath = "/dev/shm"
+)
+
+// BuildDevShmVolume returns the hostPath volume exposing the host's /dev/shm
+// tmpfs to the pod. Sharing this tmpfs is what cross-pod CUDA IPC actually
+// needs: PyTorch's CUDA IPC handles reference a shared-memory ref-counter file
+// in /dev/shm that the receiving process opens by name. Mounting the host's
+// /dev/shm (rather than sharing the whole host IPC namespace via hostIPC) is
+// the narrower grant. Also consumed by the injection webhooks so the engine
+// and vLLM pods always share the same tmpfs.
+func BuildDevShmVolume() corev1.Volume {
+	hostPathType := corev1.HostPathDirectory
+	return corev1.Volume{
+		Name: devShmVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: devShmPath,
+				Type: &hostPathType,
+			},
+		},
+	}
+}
+
+// BuildDevShmVolumeMount returns the container mount for BuildDevShmVolume,
+// mounting the host's /dev/shm at /dev/shm.
+func BuildDevShmVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      devShmVolumeName,
+		MountPath: devShmPath,
+	}
+}
+
+// HasDevShmMount reports whether mounts already contains a mount at /dev/shm
+// (any volume name). Callers use it to avoid double-mounting when the user
+// supplies their own /dev/shm volume.
+func HasDevShmMount(mounts []corev1.VolumeMount) bool {
+	for i := range mounts {
+		if mounts[i].MountPath == devShmPath {
+			return true
+		}
+	}
+	return false
+}
+
+// HasDevShmVolume reports whether volumes already contains a volume named
+// "lmcache-dev-shm" (regardless of its source). Callers skip the default injection in
+// that case: appending a same-named volume would make the pod spec invalid,
+// and mounting a user-owned volume of unknown source at /dev/shm could
+// silently shadow the host tmpfs.
+func HasDevShmVolume(volumes []corev1.Volume) bool {
+	for i := range volumes {
+		if volumes[i].Name == devShmVolumeName {
+			return true
+		}
+	}
+	return false
+}

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -612,9 +612,10 @@ func TestBuildDaemonSet_Minimal(t *testing.T) {
 		t.Fatal("expected HostNetwork=false")
 	}
 
-	// Should have HostIPC=true (required for CUDA IPC)
-	if !ds.Spec.Template.Spec.HostIPC {
-		t.Fatal("expected HostIPC=true")
+	// Should NOT have HostIPC by default — CUDA IPC is wired via the /dev/shm
+	// hostPath mount instead (opt back in via spec.hostIPC).
+	if ds.Spec.Template.Spec.HostIPC {
+		t.Fatal("expected HostIPC=false by default")
 	}
 
 	// Should have exactly 1 container
@@ -644,21 +645,28 @@ func TestBuildDaemonSet_Minimal(t *testing.T) {
 		t.Fatal("missing readiness probe")
 	}
 
-	// Should NOT have emptyDir /dev/shm volume (hostIPC provides host's /dev/shm)
+	// Should NOT have emptyDir /dev/shm volume (it would shadow the host's
+	// /dev/shm and break CUDA IPC)
 	for _, v := range ds.Spec.Template.Spec.Volumes {
 		if v.Name == "dshm" {
 			t.Fatal("dshm emptyDir volume should not be present — it shadows host /dev/shm and breaks CUDA IPC")
 		}
 	}
 
-	// Should have no volumes by default (no user-specified volumes)
-	if len(ds.Spec.Template.Spec.Volumes) != 0 {
-		t.Fatalf("expected 0 volumes, got %d", len(ds.Spec.Template.Spec.Volumes))
+	// Should have exactly the lmcache-dev-shm hostPath volume by default (shares the
+	// host's /dev/shm tmpfs for CUDA IPC without hostIPC)
+	if len(ds.Spec.Template.Spec.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(ds.Spec.Template.Spec.Volumes))
+	}
+	shm := ds.Spec.Template.Spec.Volumes[0]
+	if shm.Name != devShmVolumeName || shm.HostPath == nil || shm.HostPath.Path != devShmPath {
+		t.Fatalf("expected lmcache-dev-shm hostPath volume at /dev/shm, got %+v", shm)
 	}
 
-	// Should have no volume mounts by default
-	if len(c.VolumeMounts) != 0 {
-		t.Fatalf("expected 0 volume mounts, got %d", len(c.VolumeMounts))
+	// Should mount the lmcache-dev-shm volume at /dev/shm
+	if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].Name != devShmVolumeName ||
+		c.VolumeMounts[0].MountPath != devShmPath {
+		t.Fatalf("expected a single lmcache-dev-shm mount at /dev/shm, got %+v", c.VolumeMounts)
 	}
 
 	// Should have LMCACHE_LOG_LEVEL env var
@@ -755,14 +763,25 @@ func TestBuildDaemonSet_CustomEnvAndVolumes(t *testing.T) {
 		t.Fatalf("expected 4 env vars, got %d", len(c.Env))
 	}
 
-	// Should have only user-specified extra-vol (no built-in dshm)
-	if len(ds.Spec.Template.Spec.Volumes) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(ds.Spec.Template.Spec.Volumes))
+	// Should have the user-specified extra-vol plus the default lmcache-dev-shm
+	// hostPath volume (the user mount is not at /dev/shm, so the default is
+	// still injected)
+	if len(ds.Spec.Template.Spec.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(ds.Spec.Template.Spec.Volumes))
+	}
+	foundExtra := false
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		if v.Name == "extra-vol" {
+			foundExtra = true
+		}
+	}
+	if !foundExtra {
+		t.Fatal("missing user-specified extra-vol volume")
 	}
 
-	// Should have only user-specified extra mount
-	if len(c.VolumeMounts) != 1 {
-		t.Fatalf("expected 1 volume mount, got %d", len(c.VolumeMounts))
+	// Should have the user-specified extra mount plus the lmcache-dev-shm mount
+	if len(c.VolumeMounts) != 2 {
+		t.Fatalf("expected 2 volume mounts, got %d", len(c.VolumeMounts))
 	}
 }
 
@@ -1475,6 +1494,95 @@ func TestBuildDaemonSet_PrivilegedEnabled(t *testing.T) {
 
 	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
 		t.Fatal("expected privileged=true when spec.privileged=true")
+	}
+}
+
+func TestBuildDaemonSet_HostIPCEnabled(t *testing.T) {
+	// spec.hostIPC=true restores the legacy shared-IPC-namespace mode: the pod
+	// joins the host IPC namespace and the /dev/shm hostPath mount is omitted
+	// (the namespace already exposes the host's /dev/shm).
+	engine := minimalEngine()
+	engine.Spec.HostIPC = ptr(true)
+
+	ds := BuildDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	if !podSpec.HostIPC {
+		t.Fatal("expected HostIPC=true when spec.hostIPC=true")
+	}
+	for _, v := range podSpec.Volumes {
+		if v.Name == devShmVolumeName {
+			t.Fatal("lmcache-dev-shm hostPath volume must be omitted when hostIPC=true")
+		}
+	}
+}
+
+func TestBuildDaemonSet_UserDevShmMountWins(t *testing.T) {
+	// A user-supplied /dev/shm mount (any volume name) suppresses the default
+	// lmcache-dev-shm hostPath injection so the pod never gets two mounts at one path.
+	engine := minimalEngine()
+	engine.Spec.Volumes = []corev1.Volume{{
+		Name: "my-shm",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: devShmPath},
+		},
+	}}
+	engine.Spec.VolumeMounts = []corev1.VolumeMount{{
+		Name:      "my-shm",
+		MountPath: devShmPath,
+	}}
+
+	ds := BuildDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	for _, v := range podSpec.Volumes {
+		if v.Name == devShmVolumeName {
+			t.Fatal("default lmcache-dev-shm volume must not be added when the user already mounts /dev/shm")
+		}
+	}
+	mounts := 0
+	for _, m := range podSpec.Containers[0].VolumeMounts {
+		if m.MountPath == devShmPath {
+			mounts++
+		}
+	}
+	if mounts != 1 {
+		t.Fatalf("expected exactly 1 mount at /dev/shm, got %d", mounts)
+	}
+}
+
+func TestBuildDaemonSet_UserDevShmVolumeNameCollision(t *testing.T) {
+	// A user volume that collides with the injected volume name (even if not mounted at
+	// /dev/shm) suppresses the default injection: appending a second volume
+	// with the same name would make the pod spec invalid.
+	engine := minimalEngine()
+	engine.Spec.Volumes = []corev1.Volume{{
+		Name: devShmVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}}
+	engine.Spec.VolumeMounts = []corev1.VolumeMount{{
+		Name:      devShmVolumeName,
+		MountPath: "/custom",
+	}}
+
+	ds := BuildDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	seen := 0
+	for _, v := range podSpec.Volumes {
+		if v.Name == devShmVolumeName {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("expected exactly 1 volume named lmcache-dev-shm, got %d (duplicate names are invalid)", seen)
+	}
+	for _, m := range podSpec.Containers[0].VolumeMounts {
+		if m.MountPath == devShmPath {
+			t.Fatal("must not mount the user's lmcache-dev-shm volume at /dev/shm")
+		}
 	}
 }
 

--- a/operator/internal/webhook/cacheblend_pod_injector.go
+++ b/operator/internal/webhook/cacheblend_pod_injector.go
@@ -144,8 +144,9 @@ func (p *CacheBlendPodInjector) Handle(ctx context.Context, req admission.Reques
 
 	// --- Apply mutations M0–M7 ---
 
-	// M0: pod hostIPC for CUDA IPC with the node-local engine.
-	pod.Spec.HostIPC = true
+	// M0: share the host's /dev/shm for CUDA IPC with the node-local engine,
+	// mirroring the engine's spec.hostIPC mode (hostPath mount by default).
+	applyIPCSharing(pod, target, derefBool(engine.Spec.HostIPC))
 
 	// M1: shared emptyDir volume.
 	pod.Spec.Volumes = appendVolumeIfAbsent(pod.Spec.Volumes, BuildCBPluginVolume())
@@ -275,6 +276,14 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// derefBool returns the value pointed to by b, or false if b is nil.
+func derefBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
 }
 
 // resolvePayloadImage builds the "<repository>:<tag>" reference and pull policy

--- a/operator/internal/webhook/cacheblend_pod_injector_envtest_test.go
+++ b/operator/internal/webhook/cacheblend_pod_injector_envtest_test.go
@@ -45,7 +45,7 @@ var _ = Describe("CacheBlendPodInjector webhook (envtest)", Ordered, func() {
 		Expect(k8sClient.Create(envtestCtx, resources.BuildCBConnectionConfigMap(engine))).To(Succeed())
 	})
 
-	It("injects the plugin, flags, hostIPC, and private-image pull secret into an annotated pod", func() {
+	It("injects the plugin, flags, /dev/shm sharing, and private-image pull secret into an annotated pod", func() {
 		pod := vllmPod(func(p *corev1.Pod) {
 			p.Name = "vllm-injected"
 			if p.Labels == nil {
@@ -62,8 +62,9 @@ var _ = Describe("CacheBlendPodInjector webhook (envtest)", Ordered, func() {
 		By("the idempotency annotation is stamped")
 		Expect(got.Annotations).To(HaveKeyWithValue(AnnotationInjected, valueTrue))
 
-		By("M0: hostIPC is set on the pod")
-		Expect(got.Spec.HostIPC).To(BeTrue())
+		By("M0: the host's /dev/shm is shared via hostPath (no hostIPC by default)")
+		Expect(got.Spec.HostIPC).To(BeFalse())
+		Expect(findVolume(got, testDevShmVolumeName)).NotTo(BeNil())
 
 		By("M1/M2: the cb-plugin emptyDir volume and payload init container are present")
 		Expect(hasPluginVolume(got)).To(BeTrue())
@@ -146,7 +147,7 @@ var _ = Describe("CacheBlendPodInjector webhook (envtest)", Ordered, func() {
 
 		By("the pod is injected using the engine + ConfigMap from the engine's namespace")
 		Expect(got.Annotations).To(HaveKeyWithValue(AnnotationInjected, valueTrue))
-		Expect(got.Spec.HostIPC).To(BeTrue())
+		Expect(findVolume(got, testDevShmVolumeName)).NotTo(BeNil())
 		Expect(hasPluginVolume(got)).To(BeTrue())
 		Expect(got.Spec.InitContainers).NotTo(BeEmpty())
 		c := findContainer(got, "vllm")

--- a/operator/internal/webhook/cacheblend_pod_injector_test.go
+++ b/operator/internal/webhook/cacheblend_pod_injector_test.go
@@ -538,6 +538,23 @@ var _ = Describe("CacheBlendPodInjector", func() {
 			Expect(out.Spec.HostIPC).To(BeTrue())
 			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
+
+		It("preserves the pod's hostIPC opt-in without mounting /dev/shm", func() {
+			engine := newTestEngine(nil)
+			injector := newPodInjector(engine, true)
+			pod := vllmPod(func(p *corev1.Pod) {
+				p.Spec.HostIPC = true
+			})
+
+			resp := injector.Handle(ctx, makeRequest(pod))
+			out := applyResponse(pod, resp)
+
+			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
+			vllm := findContainer(out, "vllm")
+			Expect(findVolumeMount(vllm, testDevShmVolumeName)).To(BeNil())
+			Expect(out.Annotations[AnnotationInjected]).To(Equal(valueTrue))
+		})
 	})
 
 	Describe("cudagraph modes", func() {

--- a/operator/internal/webhook/cacheblend_pod_injector_test.go
+++ b/operator/internal/webhook/cacheblend_pod_injector_test.go
@@ -208,8 +208,12 @@ var _ = Describe("CacheBlendPodInjector", func() {
 			resp := injector.Handle(ctx, makeRequest(pod))
 			out := applyResponse(pod, resp)
 
-			By("M0: hostIPC")
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			By("M0: /dev/shm hostPath sharing (no hostIPC by default)")
+			Expect(out.Spec.HostIPC).To(BeFalse())
+			shmVol := findVolume(out, testDevShmVolumeName)
+			Expect(shmVol).NotTo(BeNil())
+			Expect(shmVol.HostPath).NotTo(BeNil())
+			Expect(shmVol.HostPath.Path).To(Equal("/dev/shm"))
 
 			By("M1: cb-plugin emptyDir volume")
 			var vol *corev1.Volume
@@ -327,6 +331,7 @@ var _ = Describe("CacheBlendPodInjector", func() {
 			Expect(out.Annotations[AnnotationSkipReason]).To(Equal(SkipReasonEngineNotFound))
 			Expect(out.Annotations).NotTo(HaveKey(AnnotationInjected))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 			Expect(out.Spec.InitContainers).To(BeEmpty())
 		})
 
@@ -343,6 +348,7 @@ var _ = Describe("CacheBlendPodInjector", func() {
 
 			Expect(out.Annotations[AnnotationSkipReason]).To(Equal(SkipReasonEngineNotFound))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
 
 		It("allows an already-injected pod as a no-op", func() {
@@ -370,6 +376,7 @@ var _ = Describe("CacheBlendPodInjector", func() {
 			Expect(out.Annotations[AnnotationSkipReason]).To(Equal(SkipReasonCommandOverride))
 			Expect(out.Annotations).NotTo(HaveKey(AnnotationInjected))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 			Expect(out.Spec.InitContainers).To(BeEmpty())
 		})
 	})
@@ -428,7 +435,7 @@ var _ = Describe("CacheBlendPodInjector", func() {
 			By("the skip reason is stamped but the rest of the injection still applies")
 			Expect(out.Annotations[AnnotationSkipReason]).To(Equal(SkipReasonKVTransferConfigPresent))
 			Expect(out.Annotations[AnnotationInjected]).To(Equal(valueTrue))
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).NotTo(BeNil())
 		})
 
 		It("prepends to a pre-existing PYTHONPATH", func() {
@@ -508,10 +515,28 @@ var _ = Describe("CacheBlendPodInjector", func() {
 			Expect(out.Annotations[AnnotationSkipReason]).To(Equal(SkipReasonTargetContainerNotFound))
 			Expect(out.Annotations).NotTo(HaveKey(AnnotationInjected))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 			Expect(out.Spec.InitContainers).To(BeEmpty())
 			By("the original vLLM container is left untouched")
 			vllm := findContainer(out, "vllm")
 			Expect(envValue(vllm, pythonPathEnvName)).To(BeEmpty())
+		})
+	})
+
+	Describe("hostIPC opt-in", func() {
+		It("mirrors the engine's hostIPC opt-in instead of mounting /dev/shm", func() {
+			hostIPC := true
+			engine := newTestEngine(func(e *lmcachev1alpha1.CacheBlendEngine) {
+				e.Spec.HostIPC = &hostIPC
+			})
+			injector := newPodInjector(engine, true)
+			pod := vllmPod(nil)
+
+			resp := injector.Handle(ctx, makeRequest(pod))
+			out := applyResponse(pod, resp)
+
+			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
 	})
 

--- a/operator/internal/webhook/lmcache_pod_injector.go
+++ b/operator/internal/webhook/lmcache_pod_injector.go
@@ -74,7 +74,8 @@ var lmCacheKeys = injectionKeys{
 
 // LMCachePodInjector is the mutating admission handler that wires an opted-in
 // vLLM pod to an LMCacheEngine so the user no longer has to hand-write the
-// --kv-transfer-config flag, hostIPC, and PYTHONHASHSEED. It is gated by the
+// --kv-transfer-config flag, the /dev/shm sharing for CUDA IPC, and
+// PYTHONHASHSEED. It is gated by the
 // engine's connection ConfigMap: it mutates a pod only when the pod's
 // lmcache.ai/lmcache-engine annotation names an engine whose <engine>-connection
 // ConfigMap exists. It fails open (failurePolicy: Ignore) and is idempotent.
@@ -95,7 +96,7 @@ type LMCachePodInjector struct {
 }
 
 // Handle implements admission.Handler. It applies the LMCache connection
-// mutations (hostIPC, --kv-transfer-config, PYTHONHASHSEED) to an opted-in pod
+// mutations (/dev/shm sharing, --kv-transfer-config, PYTHONHASHSEED) to an opted-in pod
 // whose named LMCacheEngine connection ConfigMap exists, optionally followed by
 // code-payload staging when the engine's injection.payloadImage is set, then
 // returns a JSON patch. It short-circuits to an unchanged Allowed response for
@@ -111,11 +112,13 @@ func (p *LMCachePodInjector) Handle(ctx context.Context, req admission.Request) 
 	}
 
 	// Read the engine CR for its optional injection defaults (payload staging +
-	// target-container default). Fail open: a missing CR or absent injection
-	// sub-spec just means connection-only injection — the connection ConfigMap
-	// (read below) remains the real gate, so existing behavior is unchanged.
+	// target-container default) and its IPC-sharing mode (spec.hostIPC). Fail
+	// open: a missing CR or absent injection sub-spec just means connection-only
+	// injection — the connection ConfigMap (read below) remains the real gate,
+	// so existing behavior is unchanged.
 	engine := &lmcachev1alpha1.LMCacheEngine{}
 	var targetDefault *string
+	engineHostIPC := false
 	if err := p.Client.Get(ctx, types.NamespacedName{Name: engineName, Namespace: namespace}, engine); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return admission.Errored(http.StatusInternalServerError, err)
@@ -127,6 +130,7 @@ func (p *LMCachePodInjector) Handle(ctx context.Context, req admission.Request) 
 		if engine.Spec.Injection != nil {
 			targetDefault = engine.Spec.Injection.TargetContainer
 		}
+		engineHostIPC = derefBool(engine.Spec.HostIPC)
 	}
 
 	// Read the connection ConfigMap (existence gate), resolve the target
@@ -147,8 +151,9 @@ func (p *LMCachePodInjector) Handle(ctx context.Context, req admission.Request) 
 
 	// --- Connection wiring (always applied) ---
 
-	// M0: pod hostIPC for CUDA IPC with the node-local engine.
-	pod.Spec.HostIPC = true
+	// M0: share the host's /dev/shm for CUDA IPC with the node-local engine,
+	// mirroring the engine's spec.hostIPC mode (hostPath mount by default).
+	applyIPCSharing(pod, target, engineHostIPC)
 
 	// Args: inject --kv-transfer-config unless the user already supplied one.
 	kvForArgs := kvTransferConfigJSON

--- a/operator/internal/webhook/lmcache_pod_injector_test.go
+++ b/operator/internal/webhook/lmcache_pod_injector_test.go
@@ -41,6 +41,9 @@ const (
 	testPayloadRepo = "registry.example.com/lmcache/lmcache-payload"
 	// testPayloadPullSecret is the engine's default payload pull secret name.
 	testPayloadPullSecret = "lmcache-payload-pull"
+	// testDevShmVolumeName is the injected /dev/shm volume name (mirrors the
+	// unexported resources constant; drift would fail the assertions below).
+	testDevShmVolumeName = "lmcache-dev-shm"
 )
 
 // newLMCacheInjector returns an LMCachePodInjector backed by a fake client,
@@ -145,18 +148,27 @@ var _ = Describe("LMCachePodInjector", func() {
 	ctx := context.Background()
 
 	Describe("full injection", func() {
-		It("injects hostIPC, --kv-transfer-config, and PYTHONHASHSEED for an opted-in pod", func() {
+		It("injects the /dev/shm mount, --kv-transfer-config, and PYTHONHASHSEED for an opted-in pod", func() {
 			injector := newLMCacheInjector(true)
 			pod := lmcachePod(nil)
 
 			resp := injector.Handle(ctx, makeRequest(pod))
 			out := applyResponse(pod, resp)
 
-			By("hostIPC")
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			By("no hostIPC by default; the host's /dev/shm is shared via hostPath")
+			Expect(out.Spec.HostIPC).To(BeFalse())
+			shm := findVolume(out, testDevShmVolumeName)
+			Expect(shm).NotTo(BeNil())
+			Expect(shm.HostPath).NotTo(BeNil())
+			Expect(shm.HostPath.Path).To(Equal("/dev/shm"))
 
 			c := findContainer(out, testContainerVLLM)
 			Expect(c).NotTo(BeNil())
+
+			By("the lmcache-dev-shm volume is mounted at /dev/shm")
+			shmMount := findVolumeMount(c, testDevShmVolumeName)
+			Expect(shmMount).NotTo(BeNil())
+			Expect(shmMount.MountPath).To(Equal("/dev/shm"))
 
 			By("--kv-transfer-config carries LMCacheMPConnector + tcp:// host")
 			kv := argsFlagValue(c.Args, lmcFlagKVTransferConfig)
@@ -188,6 +200,68 @@ var _ = Describe("LMCachePodInjector", func() {
 			c := findContainer(out, testContainerVLLM)
 
 			Expect(envValue(c, pythonHashSeedEnvName)).To(Equal("42"))
+		})
+
+		It("mirrors the engine's hostIPC opt-in instead of mounting /dev/shm", func() {
+			hostIPC := true
+			engine := lmcacheEngineWithInjection("")
+			engine.Spec.HostIPC = &hostIPC
+			injector := newLMCacheInjectorForEngine(engine)
+			pod := lmcachePod(nil)
+
+			resp := injector.Handle(ctx, makeRequest(pod))
+			out := applyResponse(pod, resp)
+
+			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
+		})
+
+		It("leaves a user-supplied /dev/shm mount untouched", func() {
+			injector := newLMCacheInjector(true)
+			pod := lmcachePod(func(p *corev1.Pod) {
+				p.Spec.Volumes = []corev1.Volume{{
+					Name: "my-shm",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Path: "/dev/shm"},
+					},
+				}}
+				p.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+					Name:      "my-shm",
+					MountPath: "/dev/shm",
+				}}
+			})
+
+			resp := injector.Handle(ctx, makeRequest(pod))
+			out := applyResponse(pod, resp)
+
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
+			c := findContainer(out, testContainerVLLM)
+			Expect(findVolumeMount(c, "my-shm")).NotTo(BeNil())
+		})
+
+		It("does not mount a user volume that is merely named lmcache-dev-shm", func() {
+			injector := newLMCacheInjector(true)
+			pod := lmcachePod(func(p *corev1.Pod) {
+				p.Spec.Volumes = []corev1.Volume{{
+					Name: testDevShmVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}}
+			})
+
+			resp := injector.Handle(ctx, makeRequest(pod))
+			out := applyResponse(pod, resp)
+
+			By("the injection still proceeds (connection wiring)")
+			Expect(out.Annotations[LMCacheAnnotationInjected]).To(Equal(valueTrue))
+
+			By("but the user's lmcache-dev-shm volume is not mounted at /dev/shm")
+			c := findContainer(out, testContainerVLLM)
+			for _, m := range c.VolumeMounts {
+				Expect(m.MountPath).NotTo(Equal("/dev/shm"))
+			}
+			Expect(out.Spec.Volumes).To(HaveLen(1))
 		})
 	})
 
@@ -224,6 +298,7 @@ var _ = Describe("LMCachePodInjector", func() {
 			Expect(out.Annotations[LMCacheAnnotationSkipReason]).To(Equal(SkipReasonEngineNotFound))
 			Expect(out.Annotations).NotTo(HaveKey(LMCacheAnnotationInjected))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
 
 		It("skips + stamps command-override when the target container overrides command", func() {
@@ -238,6 +313,7 @@ var _ = Describe("LMCachePodInjector", func() {
 			Expect(out.Annotations[LMCacheAnnotationSkipReason]).To(Equal(SkipReasonCommandOverride))
 			Expect(out.Annotations).NotTo(HaveKey(LMCacheAnnotationInjected))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
 
 		It("skips + stamps target-container-not-found for an unknown container name", func() {
@@ -252,11 +328,12 @@ var _ = Describe("LMCachePodInjector", func() {
 			Expect(out.Annotations[LMCacheAnnotationSkipReason]).To(Equal(SkipReasonTargetContainerNotFound))
 			Expect(out.Annotations).NotTo(HaveKey(LMCacheAnnotationInjected))
 			Expect(out.Spec.HostIPC).To(BeFalse())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
 	})
 
 	Describe("user-supplied --kv-transfer-config", func() {
-		It("skips + stamps but still applies hostIPC + PYTHONHASHSEED", func() {
+		It("skips + stamps but still applies /dev/shm sharing + PYTHONHASHSEED", func() {
 			injector := newLMCacheInjector(true)
 			pod := lmcachePod(func(p *corev1.Pod) {
 				p.Spec.Containers[0].Args = []string{"--kv-transfer-config", `{"kv_connector":"Other"}`}
@@ -273,7 +350,7 @@ var _ = Describe("LMCachePodInjector", func() {
 			By("the skip reason is stamped but the rest of the injection still applies")
 			Expect(out.Annotations[LMCacheAnnotationSkipReason]).To(Equal(SkipReasonKVTransferConfigPresent))
 			Expect(out.Annotations[LMCacheAnnotationInjected]).To(Equal(valueTrue))
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).NotTo(BeNil())
 			Expect(envValue(c, pythonHashSeedEnvName)).To(Equal(pythonHashSeedValue))
 		})
 	})
@@ -345,7 +422,7 @@ var _ = Describe("LMCachePodInjector", func() {
 			Expect(out.Spec.ImagePullSecrets).To(ContainElement(corev1.LocalObjectReference{Name: testPayloadPullSecret}))
 
 			By("connection wiring still applied")
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).NotTo(BeNil())
 			Expect(argsFlagValue(c.Args, lmcFlagKVTransferConfig)).To(ContainSubstring("LMCacheMPConnector"))
 			Expect(envValue(c, pythonHashSeedEnvName)).To(Equal(pythonHashSeedValue))
 			Expect(out.Annotations[LMCacheAnnotationInjected]).To(Equal(valueTrue))
@@ -364,7 +441,7 @@ var _ = Describe("LMCachePodInjector", func() {
 			Expect(envValue(c, pythonPathEnvName)).To(BeEmpty())
 
 			By("connection wiring still applied")
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).NotTo(BeNil())
 			Expect(argsFlagValue(c.Args, lmcFlagKVTransferConfig)).To(ContainSubstring("LMCacheMPConnector"))
 		})
 
@@ -377,7 +454,7 @@ var _ = Describe("LMCachePodInjector", func() {
 
 			Expect(out.Spec.InitContainers).To(BeEmpty())
 			Expect(findVolume(out, lmcPayloadVolumeName)).To(BeNil())
-			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).NotTo(BeNil())
 			Expect(out.Annotations[LMCacheAnnotationInjected]).To(Equal(valueTrue))
 		})
 
@@ -467,7 +544,10 @@ var _ = Describe("LMCachePodInjector", func() {
 			resp := injector.Handle(ctx, makeRequest(pod))
 			out := applyResponse(pod, resp)
 
-			Expect(out.Spec.Volumes).To(HaveLen(1))
+			By("the pre-staged payload volume is not duplicated (only lmcache-dev-shm is added)")
+			Expect(out.Spec.Volumes).To(HaveLen(2))
+			names := []string{out.Spec.Volumes[0].Name, out.Spec.Volumes[1].Name}
+			Expect(names).To(ConsistOf(lmcPayloadVolumeName, testDevShmVolumeName))
 			Expect(out.Spec.InitContainers).To(HaveLen(1))
 		})
 	})

--- a/operator/internal/webhook/lmcache_pod_injector_test.go
+++ b/operator/internal/webhook/lmcache_pod_injector_test.go
@@ -216,6 +216,22 @@ var _ = Describe("LMCachePodInjector", func() {
 			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
 		})
 
+		It("preserves the pod's hostIPC opt-in without mounting /dev/shm", func() {
+			injector := newLMCacheInjector(true)
+			pod := lmcachePod(func(p *corev1.Pod) {
+				p.Spec.HostIPC = true
+			})
+
+			resp := injector.Handle(ctx, makeRequest(pod))
+			out := applyResponse(pod, resp)
+
+			Expect(out.Spec.HostIPC).To(BeTrue())
+			Expect(findVolume(out, testDevShmVolumeName)).To(BeNil())
+			c := findContainer(out, testContainerVLLM)
+			Expect(findVolumeMount(c, testDevShmVolumeName)).To(BeNil())
+			Expect(out.Annotations[LMCacheAnnotationInjected]).To(Equal(valueTrue))
+		})
+
 		It("leaves a user-supplied /dev/shm mount untouched", func() {
 			injector := newLMCacheInjector(true)
 			pod := lmcachePod(func(p *corev1.Pod) {

--- a/operator/internal/webhook/pod_inject_common.go
+++ b/operator/internal/webhook/pod_inject_common.go
@@ -184,7 +184,8 @@ func prepareInjection(
 // CUDA IPC requirement is that both processes see the same /dev/shm
 // tmpfs (PyTorch's CUDA IPC handles reference a ref-counter file there). When
 // the engine opts into hostIPC, the pod instead joins the host IPC namespace,
-// which exposes the host's /dev/shm without a mount. User-supplied wiring is
+// which exposes the host's /dev/shm without a mount. A pod that already has
+// hostIPC enabled also needs no /dev/shm mount. Other user-supplied wiring is
 // left untouched: an existing mount at /dev/shm or an existing volume named
 // "lmcache-dev-shm" suppresses the injection.
 //
@@ -195,6 +196,8 @@ func prepareInjection(
 func applyIPCSharing(pod *corev1.Pod, target *corev1.Container, hostIPC bool) {
 	if hostIPC {
 		pod.Spec.HostIPC = true
+	}
+	if pod.Spec.HostIPC {
 		return
 	}
 	// Leave user-supplied wiring untouched: an existing mount at /dev/shm, or

--- a/operator/internal/webhook/pod_inject_common.go
+++ b/operator/internal/webhook/pod_inject_common.go
@@ -178,6 +178,37 @@ func prepareInjection(
 	return kvJSON, idx, admission.Response{}, true
 }
 
+// applyIPCSharing wires the pod for cross-pod CUDA IPC with the node-local
+// engine, mirroring the engine's spec.hostIPC mode. By default (hostIPC=false)
+// it mounts the host's /dev/shm into the target container via hostPath — the
+// CUDA IPC requirement is that both processes see the same /dev/shm
+// tmpfs (PyTorch's CUDA IPC handles reference a ref-counter file there). When
+// the engine opts into hostIPC, the pod instead joins the host IPC namespace,
+// which exposes the host's /dev/shm without a mount. User-supplied wiring is
+// left untouched: an existing mount at /dev/shm or an existing volume named
+// "lmcache-dev-shm" suppresses the injection.
+//
+// Parameters:
+//   - pod: the decoded pod (mutated in place: hostIPC or volumes).
+//   - target: the resolved vLLM container (mutated in place: volume mount).
+//   - hostIPC: the engine's resolved spec.hostIPC value.
+func applyIPCSharing(pod *corev1.Pod, target *corev1.Container, hostIPC bool) {
+	if hostIPC {
+		pod.Spec.HostIPC = true
+		return
+	}
+	// Leave user-supplied wiring untouched: an existing mount at /dev/shm, or
+	// an existing volume named "lmcache-dev-shm" (whatever its source — mounting a
+	// volume of unknown source at /dev/shm could silently shadow the host
+	// tmpfs, and appending a same-named volume would be invalid).
+	if resources.HasDevShmMount(target.VolumeMounts) ||
+		resources.HasDevShmVolume(pod.Spec.Volumes) {
+		return
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, resources.BuildDevShmVolume())
+	target.VolumeMounts = append(target.VolumeMounts, resources.BuildDevShmVolumeMount())
+}
+
 // stampInjected stamps the idempotency guard (and the kv-transfer-config-present
 // skip reason when the user supplied their own --kv-transfer-config), then
 // returns the success patch response. Callers apply their mutations first.

--- a/operator/test/e2e/cacheblend_integration_smoke_test.go
+++ b/operator/test/e2e/cacheblend_integration_smoke_test.go
@@ -47,7 +47,7 @@ import (
 //  2. A vLLM Deployment opts in to CacheBlend injection (label + engine
 //     annotation). The mutating webhook injects the CacheBlend vLLM flags
 //     (--kv-transfer-config <engine>, etc.), the cb-plugin init container,
-//     hostIPC, and the private payload's pull secret.
+//     the /dev/shm hostPath mount, and the private payload's pull secret.
 //  3. vLLM comes up on the CUSTOM attention backend (asserted on its own
 //     startup banner), starts, and serves /v1/models.
 //  4. A completion request drives a forward pass, which makes vLLM's connector

--- a/operator/test/e2e/crd_smoke_test.go
+++ b/operator/test/e2e/crd_smoke_test.go
@@ -160,14 +160,16 @@ var _ = Describe("LMCacheEngine smoke (no-GPU)", Ordered, func() {
 })
 
 // assertDaemonSetShape verifies the operator's auto-injected pod-level
-// settings: hostIPC, runtimeClassName=nvidia, a container security context
-// that is non-privileged by default (privileged is opt-in via spec.privileged),
-// --host 0.0.0.0 always present in container args, and the absence of any
-// /dev/shm volume mount that would shadow the host's /dev/shm and break CUDA IPC.
+// settings: the /dev/shm hostPath mount for CUDA IPC (hostIPC is opt-in via
+// spec.hostIPC and defaults to false), runtimeClassName=nvidia, a container
+// security context that is non-privileged by default (privileged is opt-in via
+// spec.privileged), --host 0.0.0.0 always present in container args, and the
+// absence of any emptyDir /dev/shm volume that would shadow the host's
+// /dev/shm and break CUDA IPC.
 func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
 	GinkgoHelper()
 	pod := ds.Spec.Template.Spec
-	Expect(pod.HostIPC).To(BeTrue(), "pod.hostIPC must be true")
+	Expect(pod.HostIPC).To(BeFalse(), "pod.hostIPC must default to false (opt-in via spec.hostIPC)")
 	Expect(pod.RuntimeClassName).NotTo(BeNil(), "pod.runtimeClassName must be set")
 	Expect(*pod.RuntimeClassName).To(Equal("nvidia"))
 	Expect(pod.Containers).To(HaveLen(1))
@@ -180,24 +182,28 @@ func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
 	Expect(c.Args).To(ContainElements("--host", "0.0.0.0"))
 	Expect(argValue(c.Args, "--port")).To(Equal(fmt.Sprintf("%d", expectedServerPort)))
 
-	// /dev/shm is left to the host via hostIPC=true. An emptyDir mount
-	// would shadow it and break cudaIpcOpenMemHandle between LMCache
-	// and vLLM pods. Verify both sides: no volume mount AND no volume.
-	for _, vm := range c.VolumeMounts {
-		Expect(vm.MountPath).NotTo(Equal("/dev/shm"),
-			"unexpected /dev/shm volumeMount on lmcache container")
-	}
-	for _, v := range pod.Volumes {
-		// Some helm charts call this volume "shm" or "dshm"; rather
-		// than enumerate names we check for any volume mounted at
-		// /dev/shm via the loop above. This loop catches a different
-		// mistake: an emptyDir/Volume named after /dev/shm with no
-		// matching mount, which is harmless but unexpected.
-		if v.EmptyDir != nil {
-			Expect(v.Name).NotTo(Or(Equal("shm"), Equal("dshm"), Equal("dev-shm")),
-				"unexpected /dev/shm-style emptyDir volume present")
+	// The host's /dev/shm is shared into the container via a hostPath mount —
+	// that (not the IPC namespace) is what cudaIpcOpenMemHandle between the
+	// LMCache and vLLM pods needs. An emptyDir there would shadow
+	// the host tmpfs and break CUDA IPC.
+	var shmMount *corev1.VolumeMount
+	for i, vm := range c.VolumeMounts {
+		if vm.MountPath == "/dev/shm" {
+			shmMount = &c.VolumeMounts[i]
 		}
 	}
+	Expect(shmMount).NotTo(BeNil(), "missing /dev/shm volume mount on lmcache container")
+	var shmVol *corev1.Volume
+	for i, v := range pod.Volumes {
+		Expect(v.EmptyDir).To(BeNil(),
+			"unexpected emptyDir volume %q — an emptyDir at /dev/shm shadows the host tmpfs", v.Name)
+		if v.Name == shmMount.Name {
+			shmVol = &pod.Volumes[i]
+		}
+	}
+	Expect(shmVol).NotTo(BeNil(), "no volume backs the /dev/shm mount")
+	Expect(shmVol.HostPath).NotTo(BeNil(), "/dev/shm volume must be a hostPath")
+	Expect(shmVol.HostPath.Path).To(Equal("/dev/shm"))
 }
 
 // assertLookupServiceShape checks the node-local discovery Service has

--- a/operator/test/e2e/lmcache_injection_smoke_test.go
+++ b/operator/test/e2e/lmcache_injection_smoke_test.go
@@ -65,7 +65,7 @@ var _ = Describe("LMCacheEngine injection webhook smoke", func() {
 		// namespace, cleaned up by the namespace's DeferCleanup. No teardown.
 	})
 
-	It("stamps the vLLM pod and injects --kv-transfer-config + hostIPC + PYTHONHASHSEED", func() {
+	It("stamps the vLLM pod and injects --kv-transfer-config + /dev/shm sharing + PYTHONHASHSEED", func() {
 		By("applying a minimal LMCacheEngine")
 		lmc, err := utils.NewLMCFromFixture("lmc_minimal.yaml", nsName, "inject-smoke")
 		Expect(err).NotTo(HaveOccurred())
@@ -102,7 +102,8 @@ var _ = Describe("LMCacheEngine injection webhook smoke", func() {
 			g.Expect(pod.Annotations).To(HaveKeyWithValue("lmcache.ai/lmcache-injected", "true"),
 				"webhook did not stamp lmcache-injected=true; injection did not fire "+
 					"(skip-reason=%q)", pod.Annotations["lmcache.ai/lmcache-skip-reason"])
-			g.Expect(pod.Spec.HostIPC).To(BeTrue(), "webhook did not inject hostIPC=true")
+			g.Expect(pod.Spec.HostIPC).To(BeFalse(), "webhook must not inject hostIPC by default")
+			g.Expect(podHasDevShmHostPath(pod)).To(BeTrue(), "webhook did not inject the /dev/shm hostPath volume")
 
 			args := vllmContainerArgs(pod)
 			g.Expect(argValue(args, "--kv-transfer-config")).To(ContainSubstring("LMCacheMPConnector"),
@@ -195,7 +196,7 @@ var _ = Describe("LMCacheEngine injection webhook smoke", func() {
 			g.Expect(pod.Spec.ImagePullSecrets).To(ContainElement(corev1.LocalObjectReference{Name: pullSecret}))
 
 			By("connection wiring still applied alongside staging")
-			g.Expect(pod.Spec.HostIPC).To(BeTrue())
+			g.Expect(podHasDevShmHostPath(pod)).To(BeTrue())
 			g.Expect(argValue(vllmContainerArgs(pod), "--kv-transfer-config")).To(ContainSubstring("LMCacheMPConnector"))
 		}, 60*time.Second, 2*time.Second).Should(Succeed())
 

--- a/operator/test/e2e/smoke_helpers_test.go
+++ b/operator/test/e2e/smoke_helpers_test.go
@@ -351,3 +351,15 @@ func vllmContainerArgs(pod *corev1.Pod) []string {
 	}
 	return nil
 }
+
+// podHasDevShmHostPath reports whether the pod carries a hostPath volume for
+// /dev/shm — the webhook's default CUDA IPC wiring (hostIPC is opt-in).
+func podHasDevShmHostPath(pod *corev1.Pod) bool {
+	for i := range pod.Spec.Volumes {
+		hp := pod.Spec.Volumes[i].HostPath
+		if hp != nil && hp.Path == "/dev/shm" {
+			return true
+		}
+	}
+	return false
+}

--- a/operator/test/utils/fixtures/vllm_cacheblend_deployment.yaml
+++ b/operator/test/utils/fixtures/vllm_cacheblend_deployment.yaml
@@ -4,11 +4,11 @@
 # to CacheBlend dependency injection via the mutating webhook. The webhook
 # appends the CacheBlend vLLM flags (--kv-transfer-config <engine>,
 # --pipeline-parallel-size 1, --no-enable-chunked-prefill, --enforce-eager), the
-# cb-plugin init container + emptyDir + PYTHONPATH, hostIPC=true, and the
-# engine's payload imagePullSecrets.
+# cb-plugin init container + emptyDir + PYTHONPATH, the /dev/shm hostPath mount,
+# and the engine's payload imagePullSecrets.
 #
 # Placeholders substituted by the spec (substituteVLLMPlaceholders):
-#   __NAMESPACE__    — engine namespace (PSS-privileged; webhook injects hostIPC)
+#   __NAMESPACE__    — engine namespace (PSS-privileged; webhook injects a hostPath volume)
 #   __ENGINE_NAME__  — CacheBlendEngine metadata.name (bound via annotation)
 #   __MODEL__        — Hugging Face model id
 #   __VLLM_IMAGE__   — container image (default lmcache/vllm-openai:latest)
@@ -45,8 +45,8 @@ spec:
       runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.present: "true"
-      # NOTE: do NOT set hostIPC here or mount an emptyDir at /dev/shm — the
-      # webhook injects hostIPC=true (shared host /dev/shm for CUDA IPC); an
+      # NOTE: do NOT mount an emptyDir at /dev/shm — the webhook injects a
+      # hostPath mount of the host's /dev/shm (for CUDA IPC); an
       # emptyDir would shadow it and break cudaIpcOpenMemHandle.
       containers:
         - name: vllm

--- a/operator/test/utils/fixtures/vllm_deployment.yaml
+++ b/operator/test/utils/fixtures/vllm_deployment.yaml
@@ -14,7 +14,7 @@
 #
 # Requirements baked in (matching the operator's LMCache pod template
 # and the constraints of cudaIpcOpenMemHandle-based KV handoff):
-#   - hostIPC: true                — share /dev/shm with the LMCache pod
+#   - hostPath /dev/shm volume     — share /dev/shm with the LMCache pod
 #   - runtimeClassName: nvidia     — same as LMCache so they co-schedule
 #                                    on GPU nodes
 #   - nodeSelector: gpu.present    — pin to a GPU node so the service's
@@ -45,7 +45,6 @@ spec:
       labels:
         app: vllm-smoke
     spec:
-      hostIPC: true
       runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.present: "true"
@@ -110,7 +109,13 @@ spec:
             - name: lmcache-connection
               mountPath: /etc/lmcache
               readOnly: true
+            - name: dev-shm
+              mountPath: /dev/shm
       volumes:
+        - name: dev-shm
+          hostPath:
+            path: /dev/shm
+            type: Directory
         - name: lmcache-connection
           configMap:
             # __ENGINE_NAME__-connection is owned by the LMCacheEngine

--- a/operator/test/utils/fixtures/vllm_lmcache_injection_deployment.yaml
+++ b/operator/test/utils/fixtures/vllm_lmcache_injection_deployment.yaml
@@ -3,7 +3,7 @@
 # Unlike vllm_deployment.yaml (the e2e_gpu round-trip, which mounts the
 # connection ConfigMap and uses a `sh -c` wrapper), this pod OPTS IN to
 # LMCacheEngine dependency injection via the mutating webhook. The webhook
-# appends --kv-transfer-config <inline JSON>, sets hostIPC=true, and adds
+# appends --kv-transfer-config <inline JSON>, mounts the host's /dev/shm, and adds
 # PYTHONHASHSEED=0.
 #
 # The spec asserts the admission mutation directly off the pod object, so the
@@ -11,7 +11,7 @@
 # avoids a multi-GB vLLM image pull on the Kind worker.
 #
 # Placeholders substituted by the spec:
-#   __NAMESPACE__    — engine namespace (PSS-privileged; webhook injects hostIPC)
+#   __NAMESPACE__    — engine namespace (PSS-privileged; webhook injects a hostPath volume)
 #   __ENGINE_NAME__  — LMCacheEngine metadata.name (bound via annotation)
 #
 # CRITICAL: launch args-only (no `command:` override) or the webhook SKIPs with


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4394. Part of the Q3 roadmap (#4025, §5): remove the hostIPC & privileged mode requirement from the operator (the privileged half was done in #3943).

Cross-pod CUDA IPC between the engine and vLLM needs both pods to see the same `/dev/shm` tmpfs, because the CUDA IPC handles are opened via files the driver and PyTorch create there. A shared host IPC namespace is not required. The operator previously hardcoded `hostIPC: true` on engine DaemonSet pods, and both injection webhooks forced it onto opted-in vLLM pods.

Following the #3943 pattern, this PR adds `spec.hostIPC` (`*bool`, default `false`) to `LMCacheEngine` and `CacheBlendEngine`:

- **Default (`false`)**: the engine DaemonSet mounts the host's `/dev/shm` via hostPath (volume `lmcache-dev-shm`), and the injection webhooks mirror the mount onto opted-in vLLM pods. This narrows the host-level grant from the whole host IPC namespace to a single tmpfs mount, and makes the `/dev/shm` dependency explicit in the pod spec.
- Opt-in (`true`): legacy behavior, kept for clusters that block hostPath volumes.
- A user-supplied mount at `/dev/shm`, or a volume already named `lmcache-dev-shm`, suppresses the injection.

**Verification** (NVIDIA L40S, EKS, separate lmcache-server / vLLM pods):
- With the modified operator, the e2e suite passes against a real cluster: CRD/lifecycle/field-coverage/auth smokes, the GPU vLLM integration round-trip, and both injection-webhook smokes. 

**Special notes for your reviewers**:

- **Upgrade impact**: the default flips, so upgrading restarts engine pods once. Running vLLM pods need no coordinated restart, since a hostIPC pod and a hostPath pod see the same host `/dev/shm`. AMD and hostPath-blocked clusters should set `spec.hostIPC: true` before upgrading.
- This does not reach PSS `baseline` compliance by itself, since hostPath volumes are also rejected by `baseline`/`restricted`, but it is a strictly narrower grant.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
