### PR TITLE
docs: daily drift check — multi-process mode (2026-08-03)

### DIFF
--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -139,6 +139,7 @@ an `EngineKVFormat`. Nothing else may index raw shapes.
 | `NL_X_TWO_NB_NH_BS_HS` | vLLM flash-attn | HND | `NL × [2, NB, NH, BS, HS]` |
 | `NL_X_NB_TWO_NH_BS_HS` | vLLM flash-infer | HND | `NL × [NB, 2, NH, BS, HS]` |
 | `NL_X_NB_BS_HS` | vLLM MLA | — | `NL × [NB, BS, HS]` |
+| `NL_X_NB_BSV_BSS` | vLLM MLA (DSA indexer k-cache) | — | `NL × [NB, BS, 132]` uint8; physical page fuses `[BSxVALS][BSxSCALES]` (per-block fp8 values then fp32 scales). `c_ops` transfer path only. |
 | `TWO_X_NL_X_NBBS_NH_HS` | SGLang MHA | NHD | `[K_list, V_list]`, each `NL × [PBS, NH, HS]` |
 | `TWO_X_NL_X_NB_BS_NH_HS` | SGLang MHA via MP daemon | NHD | `[K_list, V_list]`, each `NL × [NB, BS, NH, HS]` |
 | `NL_X_NBBS_ONE_HS` | SGLang MLA | — | `NL × [PBS, 1, HS]` |


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current `dev`
code (`upstream/dev` HEAD [`dc6f4335`](https://github.com/LMCache/LMCache/commit/dc6f4335152364e8e609d39fb71f7a8ce30efbf8)),
focused on the multi-process mode.

One drift item today, in `docs/design/`. It is not caused by the three
commits landed since the last drift check (2026-08-01, PR
[#4378](https://github.com/LMCache/LMCache/pull/4378), base
[`0427938a`](https://github.com/LMCache/LMCache/commit/0427938a40955a7e44128d64aabf55f35383cab1)) —
those touched `.gitignore` ([#4398](https://github.com/LMCache/LMCache/pull/4398)),
a non-CUDA `_use_fp8_e4b15` device-capability handling fix
([#4303](https://github.com/LMCache/LMCache/pull/4303), which also
exported `NL_X_NB_BSV_BSS` in the SYCL/XPU pybind), and a config
`env_converter` bug fix ([#4380](https://github.com/LMCache/LMCache/pull/4380)),
none of which contradict any doc claim. Rather, this is a design-doc row
that PR [#4351](https://github.com/LMCache/LMCache/pull/4351)
(the `NL_X_NB_BSV_BSS` enum addition, 2026-07-31) did not update and
that the previous drift check
([#4378](https://github.com/LMCache/LMCache/pull/4378), 2026-08-01)
explicitly declined to file — its exception note said "The new format
has no dedicated design doc under `docs/design/v1/gpu_connector/` or
`docs/design/v1/multiprocess/`". That is true of a *dedicated* per-format
doc, but the shared enumeration in
[`docs/design/v1/gpu_connector/layout-invariant.md`](https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/docs/design/v1/gpu_connector/layout-invariant.md#L131-L148) —
the "Format → engine map" table that the surrounding text presents as
the enumeration of every `EngineKVFormat` value — was overlooked.

Prior open drift-check PRs still track their own items and do not
overlap this one:

- [#4378](https://github.com/LMCache/LMCache/pull/4378) — `NL_X_NB_BSV_BSS`
  abbreviations (`BSxVALS`, `BSxSCALES`) missing from the "Engine KV
  Shape Abbreviations" table in `docs/source/cli/describe.rst`.
  (Different file, different table — the CLI-side rows are for the
  physical-page axis tokens, not the enum-level format row addressed
  here.)
- [#4361](https://github.com/LMCache/LMCache/pull/4361) — `--enable`
  MP-server flag missing from the `docs/source/mp/configuration.rst`
  table.
- [#4304](https://github.com/LMCache/LMCache/pull/4304) — `/directory/*`
  endpoints missing from `docs/source/mp/coordinator.rst` and
  `docs/design/v1/mp_coordinator/README.md`.
- [#4285](https://github.com/LMCache/LMCache/pull/4285) — `TransferContext`
  method-count mismatch in `docs/design/v1/multiprocess/engine_driven_transfer_design.md`
  and L2-adapter factory description in `docs/source/mp/index.rst`.
- [#4269](https://github.com/LMCache/LMCache/pull/4269) —
  `--runtime-plugin-config` env-var description in
  `docs/source/mp/configuration.rst`.
- Older PRs ([#4249](https://github.com/LMCache/LMCache/pull/4249),
  [#4236](https://github.com/LMCache/LMCache/pull/4236),
  [#4199](https://github.com/LMCache/LMCache/pull/4199)) continue to
  track their earlier items.

Docs-only. No code touched.

## Drift items

### `docs/source/`

None today. (The `env_converter` addition in
[#4380](https://github.com/LMCache/LMCache/pull/4380) for
`store_location` / `retrieve_locations` brings the code into line with
what `docs/source/api_reference/configurations.rst`
[lines 93-98](https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/docs/source/api_reference/configurations.rst#L93-L98)
already documents about `LMCACHE_STORE_LOCATION` and
`LMCACHE_RETRIEVE_LOCATIONS`, so no doc edit is needed. The turboquant
`_use_fp8_e4b15` fix in
[#4303](https://github.com/LMCache/LMCache/pull/4303) affects only
non-CUDA `torch.<device>.get_device_capability` fallbacks, which are not
described as a claim in `docs/source/mp/serde.rst` or elsewhere.)

### `docs/design/`

- **`docs/design/v1/gpu_connector/layout-invariant.md`** — the
  "Format → engine map" table
  ([lines 131-148](https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/docs/design/v1/gpu_connector/layout-invariant.md#L131-L148))
  is presented in that section (and reinforced by the earlier
  paragraph "The C++ `EngineKVFormat` enum is the one authority for
  which formats exist") as the enumeration of every value in the
  `EngineKVFormat` enum, alongside the engine, HND/NHD layout, and
  logical structure of each. Since [#4351](https://github.com/LMCache/LMCache/pull/4351)
  the enum has 15 members (see
  [`lmcache/v1/platform/ops_types.py:43-105`](https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/lmcache/v1/platform/ops_types.py#L43-L105)),
  but the table lists only 14 — `NL_X_NB_BSV_BSS` (value `14`, used
  for the vLLM DSA indexer k-cache and registered on the MP diagnostics
  block-axis map at
  [`lmcache/v1/multiprocess/http_apis/cache_api.py:151-158`](https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/lmcache/v1/multiprocess/http_apis/cache_api.py#L151-L158))
  is missing. A reader auditing which formats the MP transfer path
  currently accepts sees a 14-row list against a 15-member enum.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/design/v1/gpu_connector/layout-invariant.md` — "Format → engine map" table ([lines 131-148](https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/docs/design/v1/gpu_connector/layout-invariant.md#L131-L148)) | 14 rows, ending at `NL_X_NB_BS_NH_CS`. No `NL_X_NB_BSV_BSS` row. | Adds a row for `NL_X_NB_BSV_BSS`, using the geometry documented in the spec ([`kv_format/specs/nl_x_nb_bsv_bss.py:1-24`](``https://github.com/LMCache/LMCache/blob/dc6f4335152364e8e609d39fb71f7a8ce30efbf8/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py#L1-L24)):`` logical `NL × [NB, BS, 132]` uint8, per-block physical page `[BSxVALS][BSxSCALES]` (fp8 values then fp32 scales); `attention_backends = ("vLLM MLA",)`; c_ops-only transfer path. |

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One file
touched:

- `docs/design/v1/gpu_connector/layout-invariant.md`

## Code bugs surfaced (not fixed here)

None new from today's check. (Pre-existing items from earlier drift
checks — the `lmcache_mp_connector_0180.py` docstring inversion flagged
by [#4199](https://github.com/LMCache/LMCache/pull/4199), the
`--runtime-plugin-config` help-string mismatch flagged by
[#4269](https://github.com/LMCache/LMCache/pull/4269) — remain open;
this PR does not re-flag them.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review."
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_017geK6guA6HqSNMmZEqc6Do)_