### PR TITLE
[Fix][Disk] Guard load_bytes_from_disk against concurrent-eviction TOCTOU

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -714,7 +714,17 @@ class LocalDiskBackend(StorageBackendInterface):
 
         # TODO(Jiayi): Please recover the metadata in a more
         # elegant way in the future.
-        cached_positions = self.dict[key].cached_positions
+        # The disk read above runs without disk_lock (by design — see
+        # the comment in get_blocking). A concurrent remove(force=True)
+        # can evict this key during that unlocked window; re-acquire the
+        # lock only for the brief dict lookup and treat an evicted key as
+        # a cache miss so the caller sees None instead of a KeyError.
+        with self.disk_lock:
+            disk_meta = self.dict.get(key)
+            if disk_meta is None:
+                memory_obj.ref_count_down()
+                return None
+            cached_positions = disk_meta.cached_positions
         memory_obj.metadata.cached_positions = cached_positions
 
         return memory_obj

--- a/tests/v1/storage_backend/test_local_disk_backend_toctou.py
+++ b/tests/v1/storage_backend/test_local_disk_backend_toctou.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from unittest.mock import patch
+import asyncio
+import os
+import shutil
+import tempfile
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryFormat
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
+
+_SHAPE = torch.Size([28, 2, 256, 8, 128])
+_DTYPE = torch.bfloat16
+
+
+def _make_backend(memory_allocator) -> tuple[LocalDiskBackend, str]:
+    temp_dir = tempfile.mkdtemp()
+    cfg = LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        local_disk=temp_dir,
+        max_local_disk_size=1.0,
+        lmcache_instance_id="toctou",
+    )
+    cpu = LocalCPUBackend(
+        LMCacheEngineConfig.from_legacy(chunk_size=256),
+        memory_allocator=memory_allocator,
+    )
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    backend = LocalDiskBackend(
+        config=cfg,
+        loop=loop,
+        local_cpu_backend=cpu,
+        dst_device="cuda:0",
+    )
+    return backend, temp_dir
+
+
+def _key(key_id: int) -> CacheEngineKey:
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=_DTYPE,
+    )
+
+
+def test_get_blocking_concurrent_evict_returns_none(memory_allocator) -> None:
+    """A concurrent remove(force=True) during the unlocked disk read must
+    not crash get_blocking; it should surface as a cache miss (None).
+
+    The disk read in load_bytes_from_disk runs without disk_lock (by
+    design). A barrier is injected into read_file -- a dependency, not the
+    function under fix -- so the eviction lands in the window between the
+    membership check and the self.dict[key] access. On the unfixed code
+    that access raises KeyError out of get_blocking; on the fixed code it
+    returns None.
+    """
+    backend, temp_dir = _make_backend(memory_allocator)
+    try:
+        key = _key(500)
+        path = backend._key_to_path(key)
+        nbytes = _DTYPE.itemsize
+        for s in _SHAPE:
+            nbytes *= s
+        with open(path, "wb") as f:
+            f.write(os.urandom(nbytes))
+        backend.insert_key(
+            key,
+            size=nbytes,
+            shape=_SHAPE,
+            dtype=_DTYPE,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+
+        entered_read = threading.Event()
+        evicted = threading.Event()
+        original_read_file = backend.read_file
+
+        def delaying_read_file(k, buffer, p):
+            entered_read.set()
+            evicted.wait(timeout=5)
+            return original_read_file(k, buffer, p)
+
+        holder: dict = {}
+
+        def reader():
+            try:
+                holder["res"] = backend.get_blocking(key)
+            except Exception as exc:
+                holder["err"] = exc
+
+        with patch.object(backend, "read_file", side_effect=delaying_read_file):
+            t = threading.Thread(target=reader)
+            t.start()
+            assert entered_read.wait(timeout=5), "reader never reached read_file"
+            backend.remove(key, force=True)
+            evicted.set()
+            t.join(timeout=10)
+
+        assert "err" not in holder, f"get_blocking raised: {holder['err']!r}"
+        assert holder.get("res") is None
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
  ## Problem

  `LocalDiskBackend.get_blocking` checks key membership and reads metadata under
  `disk_lock`, then **releases the lock** before calling `load_bytes_from_disk`
  (the unlocked disk read is intentional — see the comment in `get_blocking`;
  holding `disk_lock` across the read would deadlock concurrent insert/evict).

  Inside `load_bytes_from_disk`, the post-read line
  `cached_positions = self.dict[key].cached_positions` accesses `self.dict`
  **without holding the lock**. A concurrent `remove(force=True)` — which pops
  `self.dict[key]` and `os.remove`s the file under `disk_lock` — can evict the
  key during that unlocked window:

  1. `get_blocking` confirms `key in self.dict` under the lock and reads
     metadata, then releases the lock.
  2. The concurrent `remove(force=True)` pops the key and deletes the file.
  3. `read_file` catches `FileNotFoundError`, pops the key, and returns early
     **without filling the buffer**.
  4. `load_bytes_from_disk` then does `self.dict[key]` → **`KeyError`** (the key
     was just popped) → propagates out of `get_blocking` (no `try/except`) →
     **`EngineCore` crash**.

  This race class was partially addressed by #3149, which added the tail
  re-check in `get_blocking`, but the unguarded `self.dict[key]` access inside
  `load_bytes_from_disk` was left open.

  ## Fix

  Re-acquire `disk_lock` **only for the brief dict lookup** (the disk read
  itself stays outside the lock — the unlocked-read design is preserved), use
  `self.dict.get(key)`, and if the key was evicted during the unlocked read, free
  the already-allocated `memory_obj` via `ref_count_down()` and return `None` so
  the caller treats it as a cache miss instead of crashing. This mirrors the
  existing guard in `_load_chunk_into_memory` (same file, same idiom).

  The `None` return is already handled by `get_blocking`'s tail re-check
  (it skips `update_on_hit` on a failed load, per its docstring contract), and
  by the existing test `test_no_phantom_hit_when_load_fails`.

  Refs #3149 (prior scoped-disk-bugfix for the same race class).

  ## Test

  `tests/v1/storage_backend/test_local_disk_backend_toctou.py` reproduces the
  race deterministically. A `threading.Event` barrier is injected into
  `read_file` (a *dependency*, not the function under fix) so a concurrent
  `remove(force=True)` lands between the membership check and the dict access:

  - **RED on `dev`**: `KeyError(CacheEngineKey(...))` propagates out of
    `get_blocking`, plus a ref-count leak warning from the orphaned allocation.
  - **GREEN on this branch**: `get_blocking` returns `None`, no exception, no
    leak.

  The barrier targets `read_file` (a dependency), never `load_bytes_from_disk`
  or `get_blocking` (the functions under fix), so the reproduction exercises the
  real code path.

branch: fix/local-disk-backend-get-blocking-toctou
base: dev
