### PR TITLE
[Feat][MP] Engine-driven multi-group transfers via KVLayerGroupsManager

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -200,6 +200,49 @@ steps:
         plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]
 
+      # Engine-driven HMA verifies both transport backends end-to-end. Both
+      # matrix entries use the dshm pod: pickle remains lazy and ignores the
+      # mount, while SHM disables lazy L1 allocation and maps the pool.
+      - label: ":electric_plug: hma_lm_eval_gemma4_engine_driven / {{matrix.transport}}"
+        command: |
+          export LMCACHE_MP_TRANSFER_MODE="engine_driven"
+          export ENGINE_DRIVEN_TRANSPORT="{{matrix.transport}}"
+          case "{{matrix.transport}}" in
+            pickle)
+              export L1_USE_LAZY="true"
+              # Pickle sends complete hybrid KV payloads through one MQ
+              # connection. Limit this correctness-only job's request
+              # concurrency so queued payloads do not exhaust the RPC budget;
+              # the SHM matrix entry retains the regular 50-way stress load.
+              export NUM_CONCURRENT="4"
+              export LIMIT="30"
+              export STORE_DRAIN_SECONDS="180"
+              export LMCACHE_MQ_TIMEOUT="300"
+              ;;
+            shm)
+              export L1_USE_LAZY="false"
+              ;;
+          esac
+          .buildkite/k3_tests/multiprocess/run.sh hma_lm_eval_gemma4_engine_driven
+        matrix:
+          setup:
+            transport:
+              - "pickle"
+              - "shm"
+        timeout_in_minutes: 60
+        retry: *flaky-retry
+        env:
+          MODEL: "google/gemma-4-31B-it"
+          SCORE_TOLERANCE: "0.03"
+          ATTENTION_BACKEND: "auto"
+          GPU_MEMORY_UTILIZATION: "0.85"
+          MAX_WAIT_SECONDS: "600"
+          LIMIT: "100"
+          CPU_BUFFER_SIZE: "80"
+        agents: { queue: "k8s" }
+        plugins: [{ kubernetes: { podSpec: *pod-1gpu-dshm } }]
+        artifact_paths: ["*.log"]
+
       - label: ":compression: fault_tolerance"
         command: .buildkite/k3_tests/multiprocess/run.sh fault_tolerance
         timeout_in_minutes: 30

--- a/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
@@ -14,6 +14,7 @@ vllm_port="${VLLM_PORT:-8000}"
 vllm_baseline_port="${VLLM_BASELINE_PORT:-9000}"
 CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-80}"
 MAX_WORKERS="${MAX_WORKERS:-4}"
+LMCACHE_MQ_TIMEOUT="${LMCACHE_MQ_TIMEOUT:-10}"
 MODEL="${MODEL:-Qwen/Qwen3-14B}"
 BUILD_ID="${BUILD_ID:-local_$$}"
 
@@ -152,7 +153,7 @@ VLLM_SERVER_DEV_MODE=1 \
 VLLM_BATCH_INVARIANT=${BATCH_INVARIANT} \
 PYTHONHASHSEED=0 \
 vllm serve "$MODEL" \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": $LMCACHE_MQ_TIMEOUT}}" \
     $ATTENTION_BACKEND_ARG \
     --port "$vllm_port" \
     --no-async-scheduling \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-hma-lm-eval-engine-driven.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-hma-lm-eval-engine-driven.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Engine-driven HMA (hybrid memory allocator) correctness test.
+#
+# Identical to run-hma-lm-eval.sh in flow and coverage, but forces the
+# multiprocess transfer path to Engine-driven (not the default LMCache-driven
+# / AUTO selection). This ensures the Engine-driven path is exercised on CUDA
+# workers with a real hybrid model.
+#
+# Forced via LMCACHE_MP_TRANSFER_MODE=engine_driven (environment variable
+# respected by TransferContextFactory before AUTO detection runs).  The CI
+# pipeline also sets lmcache.mp.mp_transfer_mode=engine_driven in
+# kv_connector_extra_config for belt-and-suspenders coverage.
+#
+# Models (selected by run-single-test.sh):
+#   - google/gemma-4-31B-it: sliding-window + full-attention hybrid whose full
+#     layers have a larger head_dim, exercising per-group HMA store/retrieve
+#     via Engine-driven path.
+#   - Qwen/Qwen3.5-0.8B: Mamba/GDN + full-attention hybrid; exercising the
+#     registration-time cache re-views (kv_cache_group_edits.py).
+#
+# Flow (single GPU, no baseline server):
+#   1. Sanity-check the LMCache server log to confirm Engine-driven context was
+#      created (not LMCache-driven).
+#   2. vLLM run: lm_eval (gsm8k) against vLLM+LMCache, populating LMCache.
+#   3. Reset vLLM's *local* prefix cache (APC) only, leaving LMCache intact, via
+#      the dev-mode endpoint POST /reset_prefix_cache.
+#   4. LMCache retrieve run: re-run lm_eval; vLLM APC misses → LMCache serves KV.
+#   5. Assert the two runs' gsm8k scores match.
+#   6. Assert LMCache actually served retrieves in the retrieve run (non-vacuous).
+#
+# The reset endpoint requires VLLM_SERVER_DEV_MODE=1 (set by launch-processes.sh).
+# The LMCACHE_MP_TRANSFER_MODE and ENGINE_DRIVEN_TRANSPORT must be set before
+# launching the servers (already done by the pipeline matrix command).
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+
+# Configuration
+VLLM_PORT="${VLLM_PORT:-8000}"
+MODEL="${MODEL:-google/gemma-4-31B-it}"
+NUM_CONCURRENT="${NUM_CONCURRENT:-50}"
+LIMIT="${LIMIT:-100}"
+SCORE_TOLERANCE="${SCORE_TOLERANCE:-0}"
+STORE_DRAIN_SECONDS="${STORE_DRAIN_SECONDS:-20}"
+BUILD_ID="${BUILD_ID:-local_$$}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/lmcache_ci_results_${BUILD_ID}}"
+LMCACHE_LOG="${LMCACHE_LOG:-/tmp/build_${BUILD_ID}_lmcache.log}"
+
+# Must be set: Engine-driven transfer path override.
+LMCACHE_MP_TRANSFER_MODE="${LMCACHE_MP_TRANSFER_MODE:-engine_driven}"
+ENGINE_DRIVEN_TRANSPORT="${ENGINE_DRIVEN_TRANSPORT:-pickle}"
+case "$ENGINE_DRIVEN_TRANSPORT" in
+    pickle|shm) ;;
+    *)
+        echo "ERROR: ENGINE_DRIVEN_TRANSPORT must be 'pickle' or 'shm', got '$ENGINE_DRIVEN_TRANSPORT'"
+        exit 1
+        ;;
+esac
+
+HMA_ED_DIR="$RESULTS_DIR/hma_lm_eval_engine_driven"
+VLLM_RUN_DIR="$HMA_ED_DIR/vllm_run"
+RETRIEVE_RUN_DIR="$HMA_ED_DIR/retrieve_run"
+
+echo "=== Engine-driven HMA lm_eval correctness test ==="
+echo "Model: $MODEL"
+echo "Transfer mode: $LMCACHE_MP_TRANSFER_MODE"
+echo "Engine-driven transport: $ENGINE_DRIVEN_TRANSPORT"
+echo "vLLM (LMCache) port: $VLLM_PORT"
+echo "Concurrent requests: $NUM_CONCURRENT"
+echo "Limit: $LIMIT"
+echo "Score tolerance: $SCORE_TOLERANCE"
+echo "Results dir: $HMA_ED_DIR"
+echo ""
+
+mkdir -p "$VLLM_RUN_DIR" "$RETRIEVE_RUN_DIR"
+
+# ---------------------------------------------------------------------------
+# Verify Engine-driven context selected the expected transport.
+#
+# The strategy is selected while registering the Engine-driven context. Fail
+# fast so the matrix cannot pass with the wrong transport.
+# ---------------------------------------------------------------------------
+assert_engine_driven_transport_active() {
+    echo "=== Asserting Engine-driven $ENGINE_DRIVEN_TRANSPORT transport is active ==="
+    local marker
+    case "$ENGINE_DRIVEN_TRANSPORT" in
+        pickle) marker="Using pickle non-GPU transfer strategy" ;;
+        shm) marker="Using shm non-GPU transfer strategy" ;;
+    esac
+    local max_wait=30
+    local elapsed=0
+    while [ "$elapsed" -lt "$max_wait" ]; do
+        if [ -f "$LMCACHE_LOG" ] && grep -qi "$marker" "$LMCACHE_LOG" 2>/dev/null; then
+            echo "Engine-driven $ENGINE_DRIVEN_TRANSPORT transport confirmed in LMCache log."
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo ""
+    echo "ERROR: LMCache log did not contain '$marker' after ${max_wait}s."
+    echo "       Ensure LMCACHE_MP_TRANSFER_MODE=engine_driven and"
+    echo "       ENGINE_DRIVEN_TRANSPORT=$ENGINE_DRIVEN_TRANSPORT are set before startup."
+    echo "       Log tail (last 20 lines):"
+    tail -20 "$LMCACHE_LOG" 2>/dev/null || true
+    return 1
+}
+
+# Run one lm_eval gsm8k pass against a vLLM OpenAI-compatible server.
+run_lm_eval() {
+    local port="$1"
+    local output_dir="$2"
+    local run_name="$3"
+
+    echo "=== Running lm_eval ($run_name) on port $port ==="
+    lm_eval --model local-completions --tasks gsm8k \
+        --model_args "model=${MODEL},base_url=http://127.0.0.1:${port}/v1/completions,num_concurrent=${NUM_CONCURRENT},max_retries=3,tokenized_requests=False" \
+        --limit "$LIMIT" \
+        --seed 0 \
+        -s --output_path "$output_dir" \
+        --gen_kwargs '{"temperature": 0.0}'
+    echo "$run_name completed"
+    echo ""
+}
+
+# Reset a vLLM server's local prefix cache (APC) while preserving LMCache.
+reset_vllm_prefix_cache() {
+    local port="$1"
+    echo "=== Resetting vLLM local prefix cache on port $port (LMCache preserved) ==="
+    local code
+    code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "http://127.0.0.1:${port}/reset_prefix_cache")
+    if [ "$code" != "200" ]; then
+        echo "Failed to reset prefix cache (HTTP $code). Is VLLM_SERVER_DEV_MODE=1?"
+        return 1
+    fi
+    echo "vLLM prefix cache reset."
+    echo ""
+}
+
+# Count completed LMCache retrieves in the server log.
+count_retrieves() {
+    [ -f "$LMCACHE_LOG" ] || { echo 0; return; }
+    grep -c "Retrieved" "$LMCACHE_LOG" 2>/dev/null || true
+}
+
+# ── 0. Assert Engine-driven is active before any evaluation ─
+assert_engine_driven_transport_active
+
+# ── 1. vLLM run: compute from scratch, populating LMCache ───
+run_lm_eval "$VLLM_PORT" "$VLLM_RUN_DIR" "vLLM run (Engine-driven)"
+
+# Let async stores drain to the LMCache server before invalidating the APC.
+echo "Waiting ${STORE_DRAIN_SECONDS}s for LMCache stores to drain..."
+sleep "$STORE_DRAIN_SECONDS"
+
+retrieves_before=$(count_retrieves)
+
+# ── 2. Invalidate vLLM's local prefix cache (keep LMCache) ──
+reset_vllm_prefix_cache "$VLLM_PORT"
+
+# ── 3. Retrieve run: vLLM APC misses → LMCache serves the KV ─
+run_lm_eval "$VLLM_PORT" "$RETRIEVE_RUN_DIR" "LMCache Engine-driven retrieve run"
+
+retrieves_after=$(count_retrieves)
+
+# ── 4. Compare scores and verify LMCache was actually used ──
+echo "============================================"
+echo "=== Verifying Engine-driven HMA store/retrieve correctness ==="
+echo "============================================"
+echo "LMCache retrieves logged: before=${retrieves_before}, after=${retrieves_after}"
+
+python3 - "$VLLM_RUN_DIR" "$RETRIEVE_RUN_DIR" \
+    "$SCORE_TOLERANCE" "$retrieves_before" "$retrieves_after" <<'PYEOF'
+import glob
+import json
+import os
+import sys
+
+vllm_run_dir, retrieve_run_dir, tol_s, before_s, after_s = sys.argv[1:6]
+tol = float(tol_s)
+retrieves_before = int(before_s)
+retrieves_after = int(after_s)
+
+
+def gsm8k_score_and_stderr(results_dir: str) -> tuple[float, float]:
+    """Return the gsm8k (exact_match, stderr) from an lm_eval results directory.
+
+    Prefers the strict-match variant; falls back to any non-stderr
+    ``exact_match`` metric key paired with its ``exact_match_stderr`` twin.
+
+    Args:
+        results_dir: Directory passed to ``lm_eval --output_path``. Searched
+            recursively for the newest ``results_*.json``.
+
+    Returns:
+        ``(score, stderr)``: the gsm8k ``exact_match`` accuracy in
+        ``[0.0, 1.0]`` and its reported sampling stderr (0.0 if absent).
+
+    Raises:
+        SystemExit: If no ``results_*.json`` exists or the newest one has no
+            ``exact_match`` metric for the gsm8k task.
+    """
+    files = glob.glob(os.path.join(results_dir, "**", "results_*.json"), recursive=True)
+    if not files:
+        raise SystemExit(f"No results_*.json under {results_dir}")
+    latest = max(files, key=os.path.getmtime)
+    with open(latest) as f:
+        data = json.load(f)
+    metrics = data["results"]["gsm8k"]
+    preferred = "exact_match,strict-match"
+    if preferred in metrics:
+        stderr = float(metrics.get("exact_match_stderr,strict-match", 0.0))
+        return float(metrics[preferred]), stderr
+    for key, value in metrics.items():
+        if key.startswith("exact_match,") and "stderr" not in key:
+            variant = key.split(",", 1)[1]
+            stderr = float(metrics.get(f"exact_match_stderr,{variant}", 0.0))
+            return float(value), stderr
+    raise SystemExit(f"No exact_match metric in {latest}: {sorted(metrics)}")
+
+
+s_vllm, e_vllm = gsm8k_score_and_stderr(vllm_run_dir)
+s_retrieve, e_retrieve = gsm8k_score_and_stderr(retrieve_run_dir)
+
+print(f"  vLLM run (Engine-driven)   gsm8k exact_match = {s_vllm:.4f} +/- {e_vllm:.4f}")
+print(f"  Engine-driven retrieve run gsm8k exact_match = {s_retrieve:.4f} +/- {e_retrieve:.4f}")
+print(f"  tolerance = {tol}")
+
+failures = []
+if abs(s_vllm - s_retrieve) > tol:
+    failures.append(
+        f"score drift between runs: |{s_vllm:.4f} - {s_retrieve:.4f}| = "
+        f"{abs(s_vllm - s_retrieve):.4f} > {tol}"
+    )
+if retrieves_after <= retrieves_before:
+    failures.append(
+        "Engine-driven LMCache served no retrieves during the retrieve run "
+        f"(before={retrieves_before}, after={retrieves_after})"
+    )
+
+if failures:
+    print("\nFAILED:")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+
+print(
+    f"\nPASS: vLLM and Engine-driven LMCache-retrieve gsm8k scores match (tol={tol}); "
+    f"LMCache served {retrieves_after - retrieves_before} retrieves."
+)
+PYEOF
+
+echo ""
+echo "============================================"
+echo "=== Engine-driven HMA lm_eval correctness test passed ==="
+echo "============================================"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Orchestrator for a single multiprocessing test (native, no Docker).
 # Usage: run-single-test.sh <test_name>
-#   test_name: lm_eval | lm_eval_preemption | hma_lm_eval_gemma4 | vllm_bench
+#   test_name: lm_eval | lm_eval_preemption | hma_lm_eval_gemma4
+#              | hma_lm_eval_gemma4_engine_driven | vllm_bench
 #              | long_doc_qa | long_doc_qa_l2 | fault_tolerance | deadlock
 #              | restart_recovery | gds_smoke_test
 #
@@ -41,6 +42,12 @@ if [ "$TEST_NAME" = "hma_lm_eval_gemma4" ]; then
     # pipeline sets ATTENTION_BACKEND=auto; its ~63GB of weights also need a
     # higher GPU_MEMORY_UTILIZATION than the default (all set in pipeline.yml).
     export MODEL="${MODEL:-google/gemma-4-31B-it}"
+elif [ "$TEST_NAME" = "hma_lm_eval_gemma4_engine_driven" ]; then
+    # Same model as hma_lm_eval_gemma4 but forces the Engine-driven multiprocess
+    # transfer path via LMCACHE_MP_TRANSFER_MODE.  This ensures the Engine-driven
+    # code path is exercised end-to-end with per-group HMA KV caches on CUDA.
+    export MODEL="${MODEL:-google/gemma-4-31B-it}"
+    export LMCACHE_MP_TRANSFER_MODE="${LMCACHE_MP_TRANSFER_MODE:-engine_driven}"
 elif [ "$TEST_NAME" = "hma_lm_eval_qwen3_5" ]; then
     # Qwen3.5-0.8B is a Mamba/GDN + full-attention hybrid (caches re-viewed at
     # registration; see lmcache/integration/vllm/kv_cache_group_edits.py).
@@ -140,6 +147,9 @@ case "$TEST_NAME" in
     hma_lm_eval_gemma4)
         exec_script="${SCRIPT_DIR}/run-hma-lm-eval.sh"
         ;;
+    hma_lm_eval_gemma4_engine_driven)
+        exec_script="${SCRIPT_DIR}/run-hma-lm-eval-engine-driven.sh"
+        ;;
     hma_lm_eval_qwen3_5)
         exec_script="${SCRIPT_DIR}/run-hma-lm-eval.sh"
         ;;
@@ -178,7 +188,7 @@ case "$TEST_NAME" in
         ;;
     *)
         echo "Unknown test: $TEST_NAME"
-        echo "Valid tests: lm_eval, lm_eval_preemption, hma_lm_eval_gemma4, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery, cache_stats, http_api, gds_smoke_test, p2p, kimi_linear_tp"
+        echo "Valid tests: lm_eval, lm_eval_preemption, hma_lm_eval_gemma4, hma_lm_eval_gemma4_engine_driven, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery, cache_stats, http_api, gds_smoke_test, p2p, kimi_linear_tp"
         exit 1
         ;;
 esac

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -120,6 +120,24 @@ class IPCCacheServerKey:
 KVCache = list[DeviceIPCWrapper]
 
 
+class GroupLayout(msgspec.Struct):
+    """Per-LMCache-group layout for multi-group engine-driven registration.
+
+    Attributes:
+        num_layers: Number of KV layers in this group.
+        hidden_dim_size: Flattened hidden dimension per token for this group.
+        dtype_str: Torch dtype name for this group's KV tensors.
+        tokens_per_block: Tokens covered by one paged block of this group
+            (``EngineGroupInfo.tokens_per_block``; falls back to the engine
+            ``block_size`` when the engine reported ``0``).
+    """
+
+    num_layers: int
+    hidden_dim_size: int
+    dtype_str: str
+    tokens_per_block: int
+
+
 class RegisterEngineDrivenContextPayload(msgspec.Struct):
     """Payload for the REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT protocol message.
 
@@ -132,6 +150,10 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
         hidden_dim_size: Flattened hidden dimension per token.
         dtype_str: Torch dtype name (e.g. ``"float16"``).
         use_mla: Whether the worker KV format is MLA.
+        group_layouts: Per-group layouts for multi-group (hybrid-KV) workers,
+            in protocol group order. Empty means legacy single-group; the
+            top-level ``num_layers``/``hidden_dim_size``/``dtype_str`` then
+            describe the sole group.
     """
 
     instance_id: int
@@ -142,6 +164,7 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
     hidden_dim_size: int
     dtype_str: str
     use_mla: bool
+    group_layouts: list[GroupLayout] = []
 
 
 @dataclass

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -130,12 +130,18 @@ class GroupLayout(msgspec.Struct):
         tokens_per_block: Tokens covered by one paged block of this group
             (``EngineGroupInfo.tokens_per_block``; falls back to the engine
             ``block_size`` when the engine reported ``0``).
+        window_tokens: Tokens stored per LMCache chunk for this group. Equals
+            the full chunk token count for full-attention groups; for a
+            sliding-window group it is ``min(chunk_tokens, sw_size_tokens)`` so
+            the server sizes each per-chunk object to the window. ``0`` means
+            "full chunk" (legacy workers that predate SW support).
     """
 
     num_layers: int
     hidden_dim_size: int
     dtype_str: str
     tokens_per_block: int
+    window_tokens: int = 0
 
 
 class RegisterEngineDrivenContextPayload(msgspec.Struct):

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -297,6 +297,30 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
         non-GPU transfers."""
         return self._ctx.resolve_obj_keys(key, [0])[0]
 
+    def _resolve_obj_keys_by_group(
+        self, key: IPCCacheServerKey, num_groups: int
+    ) -> list[list[ObjectKey]]:
+        """Resolve object keys for every LMCache group, group-major.
+
+        Args:
+            key: Cache key for the token range.
+            num_groups: Number of LMCache groups the worker registered.
+
+        Returns:
+            ``keys[g][c]`` is chunk ``c``'s key in group ``g``
+            (``ObjectKey.object_group_id == g``).
+        """
+        return self._ctx.resolve_obj_keys(key, list(range(num_groups)))
+
+    def _group_keys_for(
+        self, entry: "EngineDrivenContextEntry", key: IPCCacheServerKey
+    ) -> "list[list[ObjectKey]] | None":
+        """Group-major keys when ``entry`` registered multi-group, else None."""
+        layouts = entry.metadata.group_layouts
+        if not layouts or len(layouts) < 2:
+            return None
+        return self._resolve_obj_keys_by_group(key, len(layouts))
+
     def register_kv_cache_engine_driven_context(
         self,
         payload: RegisterEngineDrivenContextPayload,
@@ -345,10 +369,33 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             )
         )
         layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+        group_layouts: list[MemoryLayoutDesc] | None = None
+        if payload.group_layouts:
+            group_layouts = []
+            for gl in payload.group_layouts:
+                g_dtype = getattr(torch, gl.dtype_str, None)
+                if g_dtype is None or not isinstance(g_dtype, torch.dtype):
+                    raise ValueError(
+                        f"Invalid group dtype_str '{gl.dtype_str}' in "
+                        "engine-driven registration"
+                    )
+                g_shape = (
+                    torch.Size(
+                        [gl.num_layers, self._ctx.chunk_size, gl.hidden_dim_size]
+                    )
+                    if payload.use_mla
+                    else torch.Size(
+                        [2, gl.num_layers, self._ctx.chunk_size, gl.hidden_dim_size]
+                    )
+                )
+                group_layouts.append(
+                    MemoryLayoutDesc(shapes=[g_shape], dtypes=[g_dtype])
+                )
         metadata = EngineDrivenContextMetadata(
             layout_desc=layout_desc,
             block_size=payload.block_size,
             use_mla=payload.use_mla,
+            group_layouts=group_layouts,
         )
         # Build the entry and strategy outside the lock, then insert the pair
         # atomically so a concurrent reap can never strand one without the
@@ -428,6 +475,7 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             instance_id=instance_id,
             context=entry.metadata,
             resolve_obj_keys=self._resolve_single_group_obj_keys,
+            group_keys=self._group_keys_for(entry, key),
         )
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.extras["store_start_time"] = time.perf_counter()
@@ -494,11 +542,12 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             ValueError: If no non-GPU context is registered for the given
                 instance ID.
         """
-        _, strategy = self._resolve_for_transfer(instance_id)
+        entry, strategy = self._resolve_for_transfer(instance_id)
         response = strategy.prepare_retrieve(
             key=key,
             instance_id=instance_id,
             resolve_obj_keys=self._resolve_single_group_obj_keys,
+            group_keys=self._group_keys_for(entry, key),
         )
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.extras["retrieve_start_time"] = time.perf_counter()

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -379,14 +379,14 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
                         f"Invalid group dtype_str '{gl.dtype_str}' in "
                         "engine-driven registration"
                     )
+                # Sliding-window groups store a reduced token window per chunk;
+                # size the per-chunk object to that window (fall back to the full
+                # chunk when the worker didn't report one, e.g. legacy payloads).
+                g_tokens = gl.window_tokens or self._ctx.chunk_size
                 g_shape = (
-                    torch.Size(
-                        [gl.num_layers, self._ctx.chunk_size, gl.hidden_dim_size]
-                    )
+                    torch.Size([gl.num_layers, g_tokens, gl.hidden_dim_size])
                     if payload.use_mla
-                    else torch.Size(
-                        [2, gl.num_layers, self._ctx.chunk_size, gl.hidden_dim_size]
-                    )
+                    else torch.Size([2, gl.num_layers, g_tokens, gl.hidden_dim_size])
                 )
                 group_layouts.append(
                     MemoryLayoutDesc(shapes=[g_shape], dtypes=[g_dtype])

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -3,8 +3,7 @@
 
 # Standard
 from dataclasses import dataclass
-from itertools import islice
-from typing import Generator, Sequence
+from typing import Callable, Sequence, cast
 import threading
 import time
 
@@ -47,6 +46,17 @@ from lmcache.v1.multiprocess.native_completion import (
     submit_callback_to_stream,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.transfer_plan import (
+    KernelGroupGeometry,
+    ObjectGroupGeometry,
+    TransferPlanStep,
+)
+from lmcache.v1.multiprocess.transfer_plan import (
+    batched_iteration_with_skip as batched_iteration_with_skip,
+)
+from lmcache.v1.multiprocess.transfer_plan import (
+    build_object_group_transfer_plan,
+)
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
 from lmcache.v1.platform.base.event_ipc import (
     EventIPCBackend,
@@ -89,46 +99,6 @@ def get_layout_desc(
     ]
     shapes, dtypes = zip(*shapes_and_dtypes, strict=False)
     return MemoryLayoutDesc(shapes=list(shapes), dtypes=list(dtypes))
-
-
-def batched_iteration_with_skip(
-    lst: Sequence,
-    batch_size: int,
-    skip_count: int,
-) -> Generator[tuple[int, tuple], None, None]:
-    """Utility function to iterate over a list in batches with an initial skip.
-
-    Args:
-        lst: The list to iterate over.
-        batch_size: The size of each batch.
-        skip_count: The number of items to skip at the start of the list.
-
-    Yields:
-        Tuples of (batch_start_idx, batch) where batch is a tuple of items
-        from the list, and batch_start_idx is the "original" index of the first
-        item in the batch.
-
-    Raises:
-        ValueError: If batch_size is less than 1 or skip_count is negative.
-
-    Note:
-        Batch_idx is the index of the batch in the original list, accounting
-        for the skipped items. For example, if skip_count is 10 and batch_size
-        is 5, the first yielded batch will have batch_start_idx=10.
-    """
-    if batch_size < 1:
-        raise ValueError("batch size must be at least one")
-    if skip_count < 0:
-        raise ValueError("skip_count must be non-negative")
-
-    it = iter(lst)
-    # Skip the initial items
-    for _ in range(skip_count):
-        next(it, None)
-    batch_start_idx = skip_count
-    while batch := tuple(islice(it, batch_size)):
-        yield batch_start_idx, batch
-        batch_start_idx += len(batch)
 
 
 def downsample_and_stage_block_ids(
@@ -208,34 +178,91 @@ def downsample_and_stage_block_ids(
     return block_ids_gpu
 
 
-def _recalculate_blocks_to_skip(
-    blocks_per_chunk: int,
-    blocks_per_window: int,
-    blocks_to_skip: int,
-) -> int:
-    """Re-calculate the number of blocks to skip for a batch of chunks based
-    on the blocks per chunk and blocks per sliding window WHEN the window
-    size is smaller than the lmcache chunk size.
+def _tokens_to_blocks_fn(
+    cache_context: BaseCacheContext, kernel_group_id: int
+) -> Callable[[int], int]:
+    """Bind a kernel group's token->block map for the transfer planner."""
+    return lambda tokens: cache_context.calculate_num_blocks(tokens, kernel_group_id)
+
+
+def _object_group_geometry(
+    cache_context: BaseCacheContext,
+    object_group_id: int,
+) -> ObjectGroupGeometry:
+    """Build one object group's transfer-plan geometry from a cache context.
 
     Args:
-        blocks_per_chunk: The total number of blocks in one chunk for the
-            current group.
-        blocks_per_window: The number of blocks in the sliding window
-            for the current group. Should be less than or equal to
-            blocks_per_chunk.
-        blocks_to_skip: The number of blocks to skip.
+        cache_context: The cache context containing the KV cache information.
+        object_group_id: Index of the object group whose geometry to build.
 
     Returns:
-        The re-calculated number of blocks to skip for the current batch of
-        chunks.
+        The geometry consumed by ``build_object_group_transfer_plan``, with
+        kernel groups in the object group's declared layout order.
     """
-    if blocks_per_chunk == blocks_per_window:
-        return blocks_to_skip
+    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
+    kv_groups_manager = cache_context.kv_layer_groups_manager
+    kernel_groups = []
+    for kernel_group_id in kv_groups_manager.object_groups[
+        object_group_id
+    ].kernel_group_indices:
+        tokens_per_window = min(
+            lmcache_chunk_size,
+            kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
+        )
+        kernel_groups.append(
+            KernelGroupGeometry(
+                kernel_group_id=kernel_group_id,
+                blocks_per_chunk=cache_context.calculate_num_blocks(
+                    lmcache_chunk_size, kernel_group_id
+                ),
+                blocks_per_window=cache_context.calculate_num_blocks(
+                    tokens_per_window, kernel_group_id
+                ),
+                tokens_to_blocks=_tokens_to_blocks_fn(cache_context, kernel_group_id),
+            )
+        )
+    return ObjectGroupGeometry(
+        object_group_id=object_group_id,
+        kernel_groups=tuple(kernel_groups),
+        tokens_per_chunk=lmcache_chunk_size,
+        num_chunks_in_sw=kv_groups_manager.get_attn_desc().num_chunks_in_sw[
+            object_group_id
+        ],
+    )
 
-    full_windows_to_skip = blocks_to_skip // blocks_per_chunk
-    tail_blocks = blocks_to_skip % blocks_per_chunk
-    tail_blocks_to_skip = tail_blocks - (blocks_per_chunk - blocks_per_window)
-    return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
+
+def _plan_object_group_transfer(
+    cache_context: BaseCacheContext,
+    memory_objs: Sequence[MemoryObj | None],
+    object_group_id: int,
+    batch_size: int,
+    skip_first_n_tokens: int,
+    is_h2d: bool,
+) -> tuple[ObjectGroupGeometry, list[TransferPlanStep]]:
+    """Build the transfer plan for one object group's memory objects.
+
+    Args:
+        cache_context: The cache context containing the KV cache information.
+        memory_objs: The MemoryObj instances to copy; None entries mark
+            objects the storage layer declined (D2H skips their batch, H2D
+            raises).
+        object_group_id: Index of the object group being copied.
+        batch_size: Number of memory objects per batched copy.
+        skip_first_n_tokens: Tokens to skip writing at the start of the range.
+        is_h2d: True for retrieve (H2D), False for store (D2H).
+
+    Returns:
+        The group's geometry together with its plan steps.
+    """
+    geometry = _object_group_geometry(cache_context, object_group_id)
+    plan = build_object_group_transfer_plan(
+        geometry,
+        present=[mo is not None for mo in memory_objs],
+        batch_size=batch_size,
+        skip_first_n_tokens=skip_first_n_tokens,
+        is_h2d=is_h2d,
+    )
+    return geometry, plan
 
 
 def _run_object_group_transfer_plan(
@@ -249,12 +276,15 @@ def _run_object_group_transfer_plan(
 ) -> None:
     """Plan and execute one object group's transfer in a single native call.
 
-    This is the fast path of :func:`transfer_kv_per_object_group`: it runs the
-    same batched-iteration / skip logic, but instead of issuing each staging
-    copy and kernel launch immediately (each a GIL release/re-acquire), it
-    resolves every argument to plain pointers/scalars (the "planner", GIL held
-    throughout) and hands the whole plan to ``execute_object_group_transfer``,
-    which issues all of it on the stream within a single GIL release.
+    This is the native fast path invoked by
+    :func:`transfer_kv_per_object_group` when the native
+    ``execute_object_group_transfer`` op is available and no object is
+    GDS-backed. It consumes the same shared transfer plan as the per-launch
+    fallback in that function, but instead of issuing each staging copy and
+    kernel launch immediately (each a GIL release/re-acquire), it resolves every
+    plan step to plain pointers/scalars (GIL held throughout) and hands the whole
+    batch to ``execute_object_group_transfer``, which issues all of it on the
+    stream within a single GIL release.
 
     Requires every object to be non-GDS (staged through the lazy-allocator
     path); the caller skips groups that contain any GDS-backed object.
@@ -273,32 +303,24 @@ def _run_object_group_transfer_plan(
         ValueError: If a None entry is found in memory_objs when direction is
             H2D, or if an object's size does not match its GPU staging buffer.
     """
-    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
-    kv_groups_manager = cache_context.kv_layer_groups_manager
-    object_group = kv_groups_manager.object_groups[object_group_id]
-    kernel_group_ids = object_group.kernel_group_indices
     is_h2d = direction == lmc_ops.TransferDirection.H2D
     max_batch_size = cache_context.max_batch_size
+    geometry, plan = _plan_object_group_transfer(
+        cache_context,
+        memory_objs,
+        object_group_id,
+        batch_size,
+        skip_first_n_tokens,
+        is_h2d,
+    )
+    if not plan:
+        return
 
     # --- Per-kernel-group invariants, resolved once (vs. every batch before) ---
     kernel_group_specs: list["lmc_ops.KernelGroupSpec"] = []
     spec_index_by_kg: dict[int, int] = {}
-    blocks_per_chunk_by_kg: dict[int, int] = {}
-    blocks_per_window_by_kg: dict[int, int] = {}
-    for kernel_group_id in kernel_group_ids:
-        blocks_per_chunk = cache_context.calculate_num_blocks(
-            lmcache_chunk_size, kernel_group_id
-        )
-        tokens_per_window = min(
-            lmcache_chunk_size,
-            kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
-        )
-        blocks_per_window = cache_context.calculate_num_blocks(
-            tokens_per_window, kernel_group_id
-        )
-        blocks_per_chunk_by_kg[kernel_group_id] = blocks_per_chunk
-        blocks_per_window_by_kg[kernel_group_id] = blocks_per_window
-
+    for kernel_group in geometry.kernel_groups:
+        kernel_group_id = kernel_group.kernel_group_id
         paged_ptrs = cache_context.get_kernel_group_kv_pointers(kernel_group_id)
         block_ids_tensor = block_ids_gpu[kernel_group_id]
         temp_buffers = [
@@ -325,80 +347,26 @@ def _run_object_group_transfer_plan(
         for slot in range(max_batch_size)
     ]
 
-    attn_desc = kv_groups_manager.get_attn_desc()
-    num_objects_to_skip = 0
-    if not attn_desc.is_full_attention(object_group_id) and is_h2d:
-        sw_size_chunks = attn_desc.num_chunks_in_sw[object_group_id]
-        num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
-        logger.debug(
-            "Detected sliding window for object group %d: "
-            "skipping the first %d objects in the batch",
-            object_group_id,
-            num_objects_to_skip,
-        )
-
-    # --- Walk the batches in order, emitting staging + launch work per step ---
+    # --- Materialize the plan: staging + launch work per step ---
     batch_steps: list["lmc_ops.BatchStep"] = []
-    for start_object_idx, memory_object_batch in batched_iteration_with_skip(
-        memory_objs, batch_size, skip_count=num_objects_to_skip
-    ):
-        if any(mo is None for mo in memory_object_batch):
-            if is_h2d:
-                raise ValueError(
-                    "MemoryObj is None for some objects in the batch, cannot "
-                    "perform H2D copy. memory_object_batch: "
-                    f"{memory_object_batch}"
-                )
-            else:
-                continue
-
-        batch_len = len(memory_object_batch)
-        batch_start_token = start_object_idx * lmcache_chunk_size
-        batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
-
-        effective_start = max(batch_start_token, skip_first_n_tokens)
-        if effective_start >= batch_end_token:
-            continue
-
-        skip_tokens_in_chunk = effective_start - batch_start_token
-
+    for step in plan:
+        batch_len = len(step.object_indices)
         staging = build_staging_copies(
-            memory_object_batch,
+            [cast(MemoryObj, memory_objs[i]) for i in step.object_indices],
             object_group_buffers[:batch_len],
             is_h2d,
         )
-
-        launches: list["lmc_ops.LaunchVar"] = []
-        for kernel_group_id in kernel_group_ids:
-            blocks_per_chunk = blocks_per_chunk_by_kg[kernel_group_id]
-            blocks_per_window = blocks_per_window_by_kg[kernel_group_id]
-
-            start_block_pos = start_object_idx * blocks_per_window
-            end_block_pos = (start_object_idx + batch_len) * blocks_per_window
-
-            orig_skip_blocks = cache_context.calculate_num_blocks(
-                skip_tokens_in_chunk, kernel_group_id
+        launches = [
+            lmc_ops.LaunchVar(
+                spec_index_by_kg[launch.kernel_group_id],
+                launch.start_block_pos,
+                launch.num_blocks,
+                batch_len,
+                launch.skip_blocks,
             )
-            recalculated_skip_blocks = _recalculate_blocks_to_skip(
-                blocks_per_chunk,
-                blocks_per_window,
-                orig_skip_blocks,
-            )
-
-            launches.append(
-                lmc_ops.LaunchVar(
-                    spec_index_by_kg[kernel_group_id],
-                    start_block_pos,
-                    end_block_pos - start_block_pos,
-                    batch_len,
-                    recalculated_skip_blocks,
-                )
-            )
-
+            for launch in step.launches
+        ]
         batch_steps.append(lmc_ops.BatchStep(staging, launches))
-
-    if not batch_steps:
-        return
 
     lmc_ops.execute_object_group_transfer(
         direction,
@@ -458,95 +426,35 @@ def transfer_kv_per_object_group(
         )
         return
 
-    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
-    kv_groups_manager = cache_context.kv_layer_groups_manager
-    object_group = kv_groups_manager.object_groups[object_group_id]
-    kernel_group_ids = object_group.kernel_group_indices
     is_h2d = direction == lmc_ops.TransferDirection.H2D
+    _, plan = _plan_object_group_transfer(
+        cache_context,
+        memory_objs,
+        object_group_id,
+        batch_size,
+        skip_first_n_tokens,
+        is_h2d,
+    )
 
-    attn_desc = kv_groups_manager.get_attn_desc()
-    num_objects_to_skip = 0
-    if not attn_desc.is_full_attention(object_group_id) and is_h2d:
-        sw_size_chunks = attn_desc.num_chunks_in_sw[object_group_id]
-        num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
-        logger.debug(
-            "Detected sliding window for object group %d: "
-            "skipping the first %d objects in the batch",
-            object_group_id,
-            num_objects_to_skip,
-        )
-
-    for start_object_idx, memory_object_batch in batched_iteration_with_skip(
-        memory_objs, batch_size, skip_count=num_objects_to_skip
-    ):
-        if any(mo is None for mo in memory_object_batch):
-            if is_h2d:
-                raise ValueError(
-                    "MemoryObj is None for some objects in the batch, cannot "
-                    "perform H2D copy. memory_object_batch: "
-                    f"{memory_object_batch}"
-                )
-            else:
-                continue
-
-        batch_len = len(memory_object_batch)
-        batch_start_token = start_object_idx * lmcache_chunk_size
-        batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
-
-        effective_start = max(batch_start_token, skip_first_n_tokens)
-        if effective_start >= batch_end_token:
-            continue
-
-        skip_tokens_in_chunk = effective_start - batch_start_token
+    for step in plan:
+        batch_len = len(step.object_indices)
 
         # For H2D, copy from CPU to GPU tmp buffers before the kernel launch
         if is_h2d:
-            for chunk_idx, memory_obj in enumerate(memory_object_batch):
+            for chunk_idx, object_idx in enumerate(step.object_indices):
                 lmcache_memcpy_async_h2d(
-                    memory_obj,
+                    cast(MemoryObj, memory_objs[object_idx]),
                     cache_context.get_temp_object_group_buffer(
                         chunk_idx, object_group_id
                     ),
                 )
 
         # Do paged KV copy
-        for kernel_group_id in kernel_group_ids:
-            blocks_per_chunk = cache_context.calculate_num_blocks(
-                lmcache_chunk_size, kernel_group_id
-            )
-            tokens_per_window = min(
-                lmcache_chunk_size,
-                kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
-            )
-            blocks_per_window = cache_context.calculate_num_blocks(
-                tokens_per_window, kernel_group_id
-            )
-
-            # Get the block ids for this chunk
-            start_block_pos = start_object_idx * blocks_per_window
-            end_block_pos = (start_object_idx + batch_len) * blocks_per_window
-
+        for launch in step.launches:
+            kernel_group_id = launch.kernel_group_id
             block_ids_curr_batch = block_ids_gpu[kernel_group_id][
-                start_block_pos:end_block_pos
+                launch.start_block_pos : launch.start_block_pos + launch.num_blocks
             ]
-
-            # Re-calculate the skip blocks for this kernel group
-            orig_skip_blocks = cache_context.calculate_num_blocks(
-                skip_tokens_in_chunk, kernel_group_id
-            )
-            recalculated_skip_blocks = _recalculate_blocks_to_skip(
-                blocks_per_chunk,
-                blocks_per_window,
-                orig_skip_blocks,
-            )
-
-            # Launch kernel
-            group_kv_pointers = cache_context.get_kernel_group_kv_pointers(
-                kernel_group_id
-            )
-            group_lmcache_chunk_size = cache_context.get_slots_per_chunk_in_sw(
-                kernel_group_id
-            )
             tmp_gpu_buffers_batched = [
                 cache_context.get_temp_kernel_group_buffer(
                     i, kernel_group_id
@@ -554,25 +462,25 @@ def transfer_kv_per_object_group(
                 for i in range(batch_len)
             ]
             lmc_ops.multi_layer_block_kv_transfer(
-                group_kv_pointers,
+                cache_context.get_kernel_group_kv_pointers(kernel_group_id),
                 tmp_gpu_buffers_batched,
                 block_ids_curr_batch,
                 cache_context.device,
                 direction,
                 cache_context.get_shape_desc(kernel_group_id),
-                group_lmcache_chunk_size,
+                cache_context.get_slots_per_chunk_in_sw(kernel_group_id),
                 cache_context.get_engine_kv_format(kernel_group_id),
-                recalculated_skip_blocks,
+                launch.skip_blocks,
             )
 
         # For D2H, copy from GPU tmp buffers to CPU after the kernel launch
         if not is_h2d:
-            for chunk_idx, memory_obj in enumerate(memory_object_batch):
+            for chunk_idx, object_idx in enumerate(step.object_indices):
                 lmcache_memcpy_async_d2h(
                     cache_context.get_temp_object_group_buffer(
                         chunk_idx, object_group_id
                     ),
-                    memory_obj,
+                    cast(MemoryObj, memory_objs[object_idx]),
                 )
 
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -50,11 +50,6 @@ from lmcache.v1.multiprocess.transfer_plan import (
     KernelGroupGeometry,
     ObjectGroupGeometry,
     TransferPlanStep,
-)
-from lmcache.v1.multiprocess.transfer_plan import (
-    batched_iteration_with_skip as batched_iteration_with_skip,
-)
-from lmcache.v1.multiprocess.transfer_plan import (
     build_object_group_transfer_plan,
 )
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
@@ -279,8 +274,9 @@ def _run_object_group_transfer_plan(
     This is the native fast path invoked by
     :func:`transfer_kv_per_object_group` when the native
     ``execute_object_group_transfer`` op is available and no object is
-    GDS-backed. It consumes the same shared transfer plan as the per-launch
-    fallback in that function, but instead of issuing each staging copy and
+    GDS-backed. It consumes the same shared
+    :func:`build_object_group_transfer_plan` output as the per-launch fallback in
+    that function, but instead of issuing each staging copy and
     kernel launch immediately (each a GIL release/re-acquire), it resolves every
     plan step to plain pointers/scalars (GIL held throughout) and hands the whole
     batch to ``execute_object_group_transfer``, which issues all of it on the

--- a/lmcache/v1/multiprocess/modules/server_transfer.py
+++ b/lmcache/v1/multiprocess/modules/server_transfer.py
@@ -92,6 +92,7 @@ class TransferStrategy(abc.ABC):
         instance_id: int,
         context: EngineDrivenContextMetadata,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareStoreResponse:
         """Prepare destination resources for a store request.
 
@@ -100,6 +101,8 @@ class TransferStrategy(abc.ABC):
             instance_id: Worker instance identifier.
             context: Non-GPU transfer metadata for the instance.
             resolve_obj_keys: Callable that resolves object keys from ``key``.
+            group_keys: Group-major object keys for multi-group workers;
+                ``None`` for single-group.
 
         Returns:
             Transport-specific store preparation response.
@@ -133,6 +136,7 @@ class TransferStrategy(abc.ABC):
         key: IPCCacheServerKey,
         instance_id: int,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareRetrieveResponse:
         """Prepare source resources for a retrieve request.
 
@@ -140,6 +144,8 @@ class TransferStrategy(abc.ABC):
             key: Cache key identifying the requested token range.
             instance_id: Worker instance identifier.
             resolve_obj_keys: Callable that resolves object keys from ``key``.
+            group_keys: Group-major object keys for multi-group workers;
+                ``None`` for single-group.
 
         Returns:
             Transport-specific retrieve preparation response.
@@ -188,11 +194,16 @@ class PickleTransferStrategy(TransferStrategy):
         instance_id: int,
         context: EngineDrivenContextMetadata,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareStoreResponse:
         """Return empty store context for pickle mode.
 
         Pickle transport does not pre-allocate SHM slots during prepare.
         """
+        if group_keys is not None and len(group_keys) > 1:
+            raise RuntimeError(
+                "pickle transport does not support multi-group transfers"
+            )
         return PrepareStoreResponse(context={})
 
     def commit_store(
@@ -239,8 +250,13 @@ class PickleTransferStrategy(TransferStrategy):
         key: IPCCacheServerKey,
         instance_id: int,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareRetrieveResponse:
         """Read prefetched objects and return serialized pickle payload."""
+        if group_keys is not None and len(group_keys) > 1:
+            raise RuntimeError(
+                "pickle transport does not support multi-group transfers"
+            )
         obj_keys = resolve_obj_keys(key)
         prefetched_keys: list[ObjectKey] = []
         try:
@@ -315,49 +331,73 @@ class ShmTransferStrategy(TransferStrategy):
         instance_id: int,
         context: EngineDrivenContextMetadata,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareStoreResponse:
         """Reserve SHM-backed objects and return slot descriptors.
 
+        Args:
+            group_keys: Group-major object keys for multi-group workers
+                (``group_keys[g][c]`` is chunk ``c``'s key in group ``g``).
+                ``None`` means single-group via ``resolve_obj_keys``.
+
         Returns:
-            Context with ``slots`` and ``chunk_indices``.
+            Context with ``slots`` and ``chunk_indices``. Multi-group
+            responses additionally carry ``group_ids`` parallel to ``slots``.
         """
-        obj_keys = resolve_obj_keys(key)
-        reserved = self._storage_manager.reserve_write(
-            obj_keys, context.layout_desc, "new"
-        )
+        if group_keys is None:
+            group_layouts = [context.layout_desc]
+            group_keys = [resolve_obj_keys(key)]
+        else:
+            assert context.group_layouts is not None
+            group_layouts = context.group_layouts
+        multi_group = len(group_keys) > 1
+
         slots: list[dict[str, Any]] = []
         chunk_indices: list[int] = []
+        group_ids: list[int] = []
         reserved_keys: list[ObjectKey] = []
-        try:
-            for idx, obj_key in enumerate(obj_keys):
-                memory_obj = reserved.get(obj_key)
-                if memory_obj is None or memory_obj.tensor is None:
-                    continue
-                slots.append(
-                    ShmSlotDescriptor(
-                        offset=memory_obj.shm_offset,
-                        length=memory_obj.shm_byte_length,
-                        shape=list(memory_obj.tensor.shape),
-                        dtype=_dtype_to_name(memory_obj.tensor.dtype),
-                    ).to_dict()
-                )
-                chunk_indices.append(idx)
-                reserved_keys.append(obj_key)
-        finally:
-            reserved_keys_set = set(reserved_keys)
-            unused_keys = [
-                obj_key for obj_key in reserved if obj_key not in reserved_keys_set
-            ]
-            if unused_keys:
-                self._storage_manager.finish_write(unused_keys)
+        for gid, (g_keys, g_layout) in enumerate(
+            zip(group_keys, group_layouts, strict=True)
+        ):
+            reserved = self._storage_manager.reserve_write(g_keys, g_layout, "new")
+            g_reserved: list[ObjectKey] = []
+            try:
+                for idx, obj_key in enumerate(g_keys):
+                    memory_obj = reserved.get(obj_key)
+                    if memory_obj is None or memory_obj.tensor is None:
+                        continue
+                    slots.append(
+                        ShmSlotDescriptor(
+                            offset=memory_obj.shm_offset,
+                            length=memory_obj.shm_byte_length,
+                            shape=list(memory_obj.tensor.shape),
+                            dtype=_dtype_to_name(memory_obj.tensor.dtype),
+                        ).to_dict()
+                    )
+                    chunk_indices.append(idx)
+                    group_ids.append(gid)
+                    g_reserved.append(obj_key)
+            finally:
+                g_reserved_set = set(g_reserved)
+                unused_keys = [
+                    obj_key for obj_key in reserved if obj_key not in g_reserved_set
+                ]
+                if unused_keys:
+                    self._storage_manager.finish_write(unused_keys)
+            reserved_keys.extend(g_reserved)
+
         if not reserved_keys:
-            return PrepareStoreResponse(context={"slots": [], "chunk_indices": []})
+            empty: dict[str, Any] = {"slots": [], "chunk_indices": []}
+            if multi_group:
+                empty["group_ids"] = []
+            return PrepareStoreResponse(context=empty)
         transfer_key = self._transfer_key_factory(key, instance_id)
         with self._pending_lock:
             self._pending_writes[transfer_key] = reserved_keys
-        return PrepareStoreResponse(
-            context={"slots": slots, "chunk_indices": chunk_indices}
-        )
+        ctx: dict[str, Any] = {"slots": slots, "chunk_indices": chunk_indices}
+        if multi_group:
+            ctx["group_ids"] = group_ids
+        return PrepareStoreResponse(context=ctx)
 
     def commit_store(
         self,
@@ -394,37 +434,57 @@ class ShmTransferStrategy(TransferStrategy):
         key: IPCCacheServerKey,
         instance_id: int,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareRetrieveResponse:
-        """Read SHM objects and return slot descriptors for worker access."""
-        obj_keys = resolve_obj_keys(key)
-        shm_prefetched_keys, shm_memory_objs = self._storage_manager.unsafe_read(
-            obj_keys
-        )
-        if (
-            not shm_memory_objs
-            or len(shm_prefetched_keys) != len(obj_keys)
-            or len(shm_memory_objs) != len(obj_keys)
-        ):
-            if shm_prefetched_keys:
-                self._storage_manager.finish_read_prefetched(shm_prefetched_keys)
-            return PrepareRetrieveResponse(success=False, data=b"", context={})
+        """Read SHM objects and return slot descriptors for worker access.
+
+        Args:
+            group_keys: Group-major object keys for multi-group workers.
+                A retrieve is a miss unless EVERY group has every chunk
+                (uniform coverage). ``None`` means single-group.
+        """
+        if group_keys is None:
+            group_keys = [resolve_obj_keys(key)]
+        multi_group = len(group_keys) > 1
+
+        all_prefetched: list[ObjectKey] = []
         slots: list[dict[str, Any]] = []
-        for memory_obj in shm_memory_objs:
-            if memory_obj.tensor is None:
-                self._storage_manager.finish_read_prefetched(shm_prefetched_keys)
-                return PrepareRetrieveResponse(success=False, data=b"", context={})
-            slots.append(
-                ShmSlotDescriptor(
-                    offset=memory_obj.shm_offset,
-                    length=memory_obj.shm_byte_length,
-                    shape=list(memory_obj.tensor.shape),
-                    dtype=_dtype_to_name(memory_obj.tensor.dtype),
-                ).to_dict()
-            )
+        group_ids: list[int] = []
+
+        def _miss() -> PrepareRetrieveResponse:
+            if all_prefetched:
+                self._storage_manager.finish_read_prefetched(all_prefetched)
+            return PrepareRetrieveResponse(success=False, data=b"", context={})
+
+        for gid, g_keys in enumerate(group_keys):
+            prefetched, memory_objs = self._storage_manager.unsafe_read(g_keys)
+            all_prefetched.extend(prefetched)
+            if (
+                not memory_objs
+                or len(prefetched) != len(g_keys)
+                or len(memory_objs) != len(g_keys)
+            ):
+                return _miss()
+            for memory_obj in memory_objs:
+                if memory_obj.tensor is None:
+                    return _miss()
+                slots.append(
+                    ShmSlotDescriptor(
+                        offset=memory_obj.shm_offset,
+                        length=memory_obj.shm_byte_length,
+                        shape=list(memory_obj.tensor.shape),
+                        dtype=_dtype_to_name(memory_obj.tensor.dtype),
+                    ).to_dict()
+                )
+                group_ids.append(gid)
+
         transfer_key = self._transfer_key_factory(key, instance_id)
         with self._pending_lock:
-            self._pending_reads[transfer_key] = shm_prefetched_keys
-        return PrepareRetrieveResponse(success=True, data=b"", context={"slots": slots})
+            self._pending_reads[transfer_key] = all_prefetched
+        ctx: dict[str, Any] = {"slots": slots}
+        if multi_group:
+            ctx["group_ids"] = group_ids
+        return PrepareRetrieveResponse(success=True, data=b"", context=ctx)
 
     def commit_retrieve(
         self,

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -190,6 +190,12 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                 "Engine-driven transfer context is not registered. "
                 "Call register() before submit_store()."
             )
+        if self._group_states:
+            # Multi-group stores take the synchronous per-group path for now;
+            # the wait-for-forward-event + copy-stream pipelining below is
+            # single-group. TODO: pipeline the grouped gather as well.
+            _event.wait()
+            return self._submit_store_multigroup(key, instance_id, kv_caches, block_ids)
         completion: MessagingFuture[bool] = MessagingFuture()
         engine_driven_context = self._engine_driven_context
         commit_executor = self._commit_executor

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -110,14 +110,18 @@ class EngineDrivenContextMetadata:
     """Non-GPU context layout metadata for non-CUDA workers.
 
     Attributes:
-        layout_desc: Memory layout descriptor used to interpret chunk payloads.
+        layout_desc: Memory layout descriptor used to interpret chunk payloads
+            (group 0's layout for multi-group workers).
         block_size: Number of tokens per paged block.
         use_mla: Whether the worker KV format is MLA.
+        group_layouts: Per-LMCache-group layouts for multi-group (hybrid-KV)
+            workers, in protocol group order. ``None`` means single-group.
     """
 
     layout_desc: MemoryLayoutDesc
     block_size: int
     use_mla: bool
+    group_layouts: "list[MemoryLayoutDesc] | None" = None
 
 
 class EngineDrivenContext(ABC):
@@ -188,6 +192,33 @@ class EngineDrivenContext(ABC):
     def commit_retrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
         """Commit retrieve. Pickle: no-op. Shm: release read locks."""
         ...
+
+    def prepare_store_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int], list[int]] | None:
+        """Multi-group store prepare (SHM transport only).
+
+        Returns:
+            Parallel per-slot ``(tensors, chunk_indices, group_ids)`` lists,
+            ``([], [], [])`` when fully cached, or ``None`` on a malformed
+            response.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support multi-group transfers"
+        )
+
+    def prepare_retrieve_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int]] | None:
+        """Multi-group retrieve prepare (SHM transport only).
+
+        Returns:
+            Parallel per-slot ``(tensors, group_ids)`` lists, or ``None`` on
+            a miss.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support multi-group transfers"
+        )
 
     @abstractmethod
     def close(self) -> None:

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -36,6 +36,7 @@ from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transfer_plan import (
     KernelGroupGeometry,
     ObjectGroupGeometry,
+    _recalculate_blocks_to_skip,
     build_object_group_transfer_plan,
 )
 
@@ -350,16 +351,21 @@ def compute_kv_layout(
     )
 
 
-def _uniform_object_group_geometry(
+def _object_group_geometry(
     blocks_per_chunk: int,
+    blocks_per_window: int,
     block_size: int,
     tokens_per_chunk: int,
 ) -> ObjectGroupGeometry:
     """Geometry for the engine-driven path's single native gather/scatter.
 
     One ``multi_layer_block_kv_transfer`` covers every layer of one LMCache
-    group in a single call, so the object group has exactly one kernel group
-    with full-attention coverage (window == chunk) and no sliding window.
+    group in a single call, so the object group has exactly one kernel group.
+    ``blocks_per_window == blocks_per_chunk`` for full attention; a sliding-
+    window group passes a smaller window so the planner keeps only the trailing
+    blocks of each chunk. Object-level skipping stays off (``num_chunks_in_sw
+    == -1``): the SW reduction is purely within each chunk, matching the
+    lmcache-driven ``downsample_and_stage_block_ids``.
     """
     return ObjectGroupGeometry(
         object_group_id=0,
@@ -367,7 +373,7 @@ def _uniform_object_group_geometry(
             KernelGroupGeometry(
                 kernel_group_id=0,
                 blocks_per_chunk=blocks_per_chunk,
-                blocks_per_window=blocks_per_chunk,
+                blocks_per_window=blocks_per_window,
                 tokens_to_blocks=lambda tokens: tokens // block_size,
             ),
         ),
@@ -384,6 +390,7 @@ def gather_paged_kv_to_cpu(
     engine_kv_format: "lmc_ops.EngineKVFormat" | None = None,
     out: list[torch.Tensor] | None = None,
     chunk_indices: list[int] | None = None,
+    blocks_per_window: int | None = None,
 ) -> list[torch.Tensor]:
     """Gather paged KV blocks into CPU chunk tensors.
 
@@ -443,6 +450,11 @@ def gather_paged_kv_to_cpu(
     num_blocks = get_num_blocks(normalized, engine_kv_format)
     num_chunks = len(block_ids) // blocks_per_chunk
     chunk_tokens = blocks_per_chunk * block_size
+    # Sliding-window groups store only the trailing window of each chunk; for
+    # full attention bpw == blocks_per_chunk so window_tokens == chunk_tokens
+    # and every branch below collapses to the full-coverage behaviour.
+    bpw = blocks_per_chunk if blocks_per_window is None else blocks_per_window
+    window_tokens = bpw * block_size
 
     shape_desc = make_page_buffer_shape_desc(
         normalized,
@@ -527,9 +539,12 @@ def gather_paged_kv_to_cpu(
 
     selected_block_ids: list[int] = []
     for chunk_idx in iter_indices:
-        selected_block_ids.extend(
-            block_ids[chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk]
-        )
+        chunk = block_ids[
+            chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk
+        ]
+        # Keep only the trailing window blocks of the chunk (whole chunk when
+        # bpw == blocks_per_chunk), matching downsample_and_stage_block_ids.
+        selected_block_ids.extend(chunk[-bpw:])
 
     if selected_block_ids:
         if _LMC_OPS_BLOCK_TRANSFER_ACCEPTS_TENSOR:
@@ -546,7 +561,7 @@ def gather_paged_kv_to_cpu(
                 tensors[0].device,
                 lmc_ops.TransferDirection.D2H,
                 shape_desc,
-                chunk_tokens,
+                window_tokens,
                 engine_kv_format,
                 0,
             )
@@ -573,8 +588,8 @@ def gather_paged_kv_to_cpu(
             # writes every gathered chunk, so skip_first_n_tokens is 0 and no
             # block is skipped.
             MAX_OBJECTS = 4
-            geometry = _uniform_object_group_geometry(
-                blocks_per_chunk, block_size, chunk_tokens
+            geometry = _object_group_geometry(
+                blocks_per_chunk, bpw, block_size, chunk_tokens
             )
             plan = build_object_group_transfer_plan(
                 geometry,
@@ -596,7 +611,7 @@ def gather_paged_kv_to_cpu(
                     tensors[0].device,
                     lmc_ops.TransferDirection.D2H,
                     shape_desc,
-                    chunk_tokens,
+                    window_tokens,
                     engine_kv_format,
                     launch.skip_blocks,
                 )
@@ -635,6 +650,7 @@ def scatter_cpu_to_paged_kv(
     skip_first_n_tokens: int = 0,
     layout_hints: LayoutHints | None = None,
     engine_kv_format: "lmc_ops.EngineKVFormat" | None = None,
+    blocks_per_window: int | None = None,
 ) -> None:
     """Scatter CPU chunk tensors back into paged KV tensors.
 
@@ -690,6 +706,8 @@ def scatter_cpu_to_paged_kv(
     num_layers = get_num_layers(normalized, engine_kv_format)
     num_blocks = get_num_blocks(normalized, engine_kv_format)
     chunk_tokens = blocks_per_chunk * block_size
+    bpw = blocks_per_chunk if blocks_per_window is None else blocks_per_window
+    window_tokens = bpw * block_size
 
     # Block-level transfer can only skip whole blocks. A non-aligned prefix is
     # rounded down to the nearest block (matching the lmcache-driven path in
@@ -704,6 +722,14 @@ def scatter_cpu_to_paged_kv(
             skip_first_n_tokens // block_size,
         )
     skip_prefix_n_blocks = skip_first_n_tokens // block_size
+    # For a sliding-window group the leading blocks of each chunk were dropped
+    # by the trailing-keep, so an APC skip-prefix expressed in full-chunk blocks
+    # must be re-expressed in window blocks. No-op when window == chunk. (The
+    # planner already does this for the compiled/plan branch; this covers the
+    # single-shot Python-fallback branch below.)
+    skip_prefix_window = _recalculate_blocks_to_skip(
+        blocks_per_chunk, bpw, skip_prefix_n_blocks
+    )
 
     shape_desc = make_page_buffer_shape_desc(
         normalized,
@@ -716,9 +742,11 @@ def scatter_cpu_to_paged_kv(
 
     selected_block_ids: list[int] = []
     for chunk_idx in range(len(chunks)):
-        selected_block_ids.extend(
-            block_ids[chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk]
-        )
+        chunk = block_ids[
+            chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk
+        ]
+        # Trailing window blocks only (whole chunk when bpw == blocks_per_chunk).
+        selected_block_ids.extend(chunk[-bpw:])
 
     if not selected_block_ids:
         return
@@ -736,9 +764,9 @@ def scatter_cpu_to_paged_kv(
             tensors[0].device,
             lmc_ops.TransferDirection.H2D,
             shape_desc,
-            chunk_tokens,
+            window_tokens,
             engine_kv_format,
-            skip_prefix_n_blocks,
+            skip_prefix_window,
         )
     else:
         # assuming this is c ops path which requires pin memory
@@ -774,8 +802,8 @@ def scatter_cpu_to_paged_kv(
         # on the straddling batch, so a skip spanning more than one batch is
         # honored per batch (the earlier code skipped only the first batch).
         MAX_OBJECTS = 4
-        geometry = _uniform_object_group_geometry(
-            blocks_per_chunk, block_size, chunk_tokens
+        geometry = _object_group_geometry(
+            blocks_per_chunk, bpw, block_size, chunk_tokens
         )
         plan = build_object_group_transfer_plan(
             geometry,
@@ -797,7 +825,7 @@ def scatter_cpu_to_paged_kv(
                 tensors[0].device,
                 lmc_ops.TransferDirection.H2D,
                 shape_desc,
-                chunk_tokens,
+                window_tokens,
                 engine_kv_format,
                 launch.skip_blocks,
             )

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -33,6 +33,11 @@ from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.transfer_plan import (
+    KernelGroupGeometry,
+    ObjectGroupGeometry,
+    build_object_group_transfer_plan,
+)
 
 if TYPE_CHECKING:
     # First Party
@@ -345,6 +350,32 @@ def compute_kv_layout(
     )
 
 
+def _uniform_object_group_geometry(
+    blocks_per_chunk: int,
+    block_size: int,
+    tokens_per_chunk: int,
+) -> ObjectGroupGeometry:
+    """Geometry for the engine-driven path's single native gather/scatter.
+
+    One ``multi_layer_block_kv_transfer`` covers every layer of one LMCache
+    group in a single call, so the object group has exactly one kernel group
+    with full-attention coverage (window == chunk) and no sliding window.
+    """
+    return ObjectGroupGeometry(
+        object_group_id=0,
+        kernel_groups=(
+            KernelGroupGeometry(
+                kernel_group_id=0,
+                blocks_per_chunk=blocks_per_chunk,
+                blocks_per_window=blocks_per_chunk,
+                tokens_to_blocks=lambda tokens: tokens // block_size,
+            ),
+        ),
+        tokens_per_chunk=tokens_per_chunk,
+        num_chunks_in_sw=-1,
+    )
+
+
 def gather_paged_kv_to_cpu(
     kv_caches: dict[str, torch.Tensor],
     block_ids: list[int],
@@ -536,22 +567,28 @@ def gather_paged_kv_to_cpu(
                 selected_block_ids, dtype=torch.int64, device=tensors[0].device
             )
 
-            # Split transfer to respect CUDA kernel's object count limitation
+            # The native kernel caps each call at MAX_OBJECTS objects. Plan the
+            # batched walk with the shared transfer planner so the engine-driven
+            # store batches identically to the lmcache-driven path. A store
+            # writes every gathered chunk, so skip_first_n_tokens is 0 and no
+            # block is skipped.
             MAX_OBJECTS = 4
-            req_blocks_per_obj = blocks_per_chunk
-            total_objects = len(objs_arg)
-
-            for i in range(0, total_objects, MAX_OBJECTS):
-                # Slice object pointers and corresponding block IDs
-                batch_objs_ptrs = objs_arg[i : i + MAX_OBJECTS]
-
-                start_block = i * req_blocks_per_obj
-                end_block = min(
-                    (i + MAX_OBJECTS) * req_blocks_per_obj, len(selected_block_ids)
-                )
-                batch_blocks = block_ids_arg[start_block:end_block]
-
-                # Execute batched transfer
+            geometry = _uniform_object_group_geometry(
+                blocks_per_chunk, block_size, chunk_tokens
+            )
+            plan = build_object_group_transfer_plan(
+                geometry,
+                present=[True] * len(objs_arg),
+                batch_size=MAX_OBJECTS,
+                skip_first_n_tokens=0,
+                is_h2d=False,
+            )
+            for step in plan:
+                batch_objs_ptrs = [objs_arg[k] for k in step.object_indices]
+                launch = step.launches[0]
+                batch_blocks = block_ids_arg[
+                    launch.start_block_pos : launch.start_block_pos + launch.num_blocks
+                ]
                 lmc_ops.multi_layer_block_kv_transfer(
                     paged_arg,
                     batch_objs_ptrs,
@@ -561,7 +598,7 @@ def gather_paged_kv_to_cpu(
                     shape_desc,
                     chunk_tokens,
                     engine_kv_format,
-                    0,
+                    launch.skip_blocks,
                 )
 
     # --- Final reconciliation ---
@@ -731,24 +768,28 @@ def scatter_cpu_to_paged_kv(
             selected_block_ids, dtype=torch.int64, device=tensors[0].device
         )
 
-        # Batched transfer to satisfy cuda's limitation (max 4 objects)
+        # The native kernel caps each call at MAX_OBJECTS objects. Plan the
+        # batched walk with the shared transfer planner: it drops batches that
+        # fall wholly inside skip_first_n_tokens and carries the residual skip
+        # on the straddling batch, so a skip spanning more than one batch is
+        # honored per batch (the earlier code skipped only the first batch).
         MAX_OBJECTS = 4
-        req_blocks_per_obj = (
-            blocks_per_chunk  # Each chunk corresponds to one object's blocks
+        geometry = _uniform_object_group_geometry(
+            blocks_per_chunk, block_size, chunk_tokens
         )
-        total_chunks = len(chunks)
-
-        for i in range(0, total_chunks, MAX_OBJECTS):
-            # Slice objects and block IDs for this batch
-            batch_objs_ptrs = objs_arg[i : i + MAX_OBJECTS]
-
-            start_block = i * req_blocks_per_obj
-            end_block = min(
-                (i + MAX_OBJECTS) * req_blocks_per_obj, len(selected_block_ids)
-            )
-            batch_blocks = block_ids_arg[start_block:end_block]
-
-            # Execute transfer for this batch
+        plan = build_object_group_transfer_plan(
+            geometry,
+            present=[True] * len(chunks),
+            batch_size=MAX_OBJECTS,
+            skip_first_n_tokens=skip_first_n_tokens,
+            is_h2d=True,
+        )
+        for step in plan:
+            batch_objs_ptrs = [objs_arg[k] for k in step.object_indices]
+            launch = step.launches[0]
+            batch_blocks = block_ids_arg[
+                launch.start_block_pos : launch.start_block_pos + launch.num_blocks
+            ]
             lmc_ops.multi_layer_block_kv_transfer(
                 paged_arg,
                 batch_objs_ptrs,
@@ -758,7 +799,7 @@ def scatter_cpu_to_paged_kv(
                 shape_desc,
                 chunk_tokens,
                 engine_kv_format,
-                skip_prefix_n_blocks if i == 0 else 0,
+                launch.skip_blocks,
             )
     # Fast path: The async GPU copy might still be in progress.
     # We intentionally omit synchronization here for performance.

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -184,6 +184,65 @@ class EngineDrivenContextShm(EngineDrivenContext):
         chunk_indices: list[int] = context["chunk_indices"]
         return self._build_slot_tensors(slots), chunk_indices
 
+    def prepare_store_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int], list[int]] | None:
+        """Multi-group prepare: per-slot tensors, chunk indices, group ids.
+
+        Returns:
+            ``None`` on a malformed response; ``([], [], [])`` when every
+            chunk is already cached in every group; otherwise three parallel
+            per-slot lists ``(tensors, chunk_indices, group_ids)``.
+        """
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_STORE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_STORE),
+        )
+        if not future.wait(timeout=self.mq_timeout):
+            raise LMCacheTimeoutError(
+                f"PREPARE_STORE timed out for instance_id={instance_id} "
+                f"after {self.mq_timeout}s",
+                session_id=key.request_id,
+            )
+        response = future.result()
+        context = response.context if isinstance(response.context, dict) else {}
+        slots = context.get("slots")
+        group_ids = context.get("group_ids")
+        if not isinstance(slots, list) or not isinstance(group_ids, list):
+            return None
+        if not slots:
+            return [], [], []
+        chunk_indices: list[int] = context["chunk_indices"]
+        return self._build_slot_tensors(slots), chunk_indices, group_ids
+
+    def prepare_retrieve_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int]] | None:
+        """Multi-group retrieve prepare: per-slot tensors + group ids.
+
+        Returns:
+            ``None`` on a miss; otherwise parallel per-slot
+            ``(tensors, group_ids)`` covering every chunk of every group.
+        """
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_RETRIEVE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_RETRIEVE),
+        )
+        try:
+            response = future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            return None
+        if not response.success:
+            return None
+        context = response.context if isinstance(response.context, dict) else {}
+        slots = context.get("slots", [])
+        group_ids = context.get("group_ids")
+        if not slots or not isinstance(group_ids, list):
+            return None
+        return self._build_slot_tensors(slots), group_ids
+
     def commit_store(
         self, key: IPCCacheServerKey, instance_id: int, _chunks: list[torch.Tensor]
     ) -> bool:

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -192,12 +192,18 @@ class _GroupState:
         engine_kv_format: Detected KV format for this group's tensors.
         blocks_in_chunk: Paged blocks of THIS group per LMCache chunk
             (``chunk_tokens / tokens_per_block``).
+        blocks_per_window: Paged blocks of THIS group actually stored per
+            chunk. Equals ``blocks_in_chunk`` for full-attention groups; for a
+            sliding-window group it is ``window_tokens / tokens_per_block``, so
+            only the trailing ``blocks_per_window`` blocks of each chunk are
+            gathered / scattered.
         layout_desc: Chunk layout for this group's objects.
     """
 
     layer_names: list[str]
     engine_kv_format: "lmc_ops.EngineKVFormat"
     blocks_in_chunk: int
+    blocks_per_window: int
     layout_desc: MemoryLayoutDesc
 
 
@@ -734,14 +740,6 @@ class EngineDrivenTransferContext(TransferContext):
         if len(engine_group_infos) > 1:
             layer_names = list(kv_caches)
             for gid, group in enumerate(engine_group_infos):
-                if group.sw_size_tokens >= 0:
-                    raise RuntimeError(
-                        "engine-driven multi-group transfer only supports "
-                        "uniform-coverage groups; group "
-                        f"{gid} is sliding-window "
-                        f"(sw_size_tokens={group.sw_size_tokens}). Run with "
-                        "a unified KV cache manager instead."
-                    )
                 subset = {
                     layer_names[i]: kv_caches[layer_names[i]]
                     for i in group.layer_indices
@@ -760,11 +758,24 @@ class EngineDrivenTransferContext(TransferContext):
                         f"group {gid} tokens_per_block={tokens_per_block} does "
                         f"not divide the chunk size ({chunk_tokens} tokens)"
                     )
+                # Sliding-window groups store only the trailing window of each
+                # chunk. sw_size_tokens < 0 (or >= chunk) means full attention:
+                # window == chunk, so blocks_per_window == blocks_in_chunk and
+                # everything below collapses to the full-coverage behaviour.
+                sw = group.sw_size_tokens
+                window_tokens = chunk_tokens if sw < 0 or sw >= chunk_tokens else sw
+                if window_tokens % tokens_per_block != 0:
+                    raise RuntimeError(
+                        f"group {gid} sliding-window size ({window_tokens} "
+                        f"tokens) is not a multiple of tokens_per_block "
+                        f"({tokens_per_block})"
+                    )
+                blocks_per_window = window_tokens // tokens_per_block
                 g_mla = g_kv_size == 1
                 g_shape = (
-                    torch.Size([g_num_layers, chunk_tokens, g_hidden])
+                    torch.Size([g_num_layers, window_tokens, g_hidden])
                     if g_mla
-                    else torch.Size([2, g_num_layers, chunk_tokens, g_hidden])
+                    else torch.Size([2, g_num_layers, window_tokens, g_hidden])
                 )
                 group_layouts.append(
                     GroupLayout(
@@ -772,6 +783,7 @@ class EngineDrivenTransferContext(TransferContext):
                         hidden_dim_size=g_hidden,
                         dtype_str=g_dtype_str,
                         tokens_per_block=tokens_per_block,
+                        window_tokens=window_tokens,
                     )
                 )
                 group_states.append(
@@ -779,6 +791,7 @@ class EngineDrivenTransferContext(TransferContext):
                         layer_names=[layer_names[i] for i in group.layer_indices],
                         engine_kv_format=g_format,
                         blocks_in_chunk=chunk_tokens // tokens_per_block,
+                        blocks_per_window=blocks_per_window,
                         layout_desc=MemoryLayoutDesc(
                             shapes=[g_shape],
                             dtypes=[getattr(torch, g_dtype_str)],
@@ -995,6 +1008,7 @@ class EngineDrivenTransferContext(TransferContext):
                 engine_kv_format=state.engine_kv_format,
                 out=out_g,
                 chunk_indices=chunks_g,
+                blocks_per_window=state.blocks_per_window,
             )
         # SHM writes are async device->CPU copies; complete them before commit.
         torch_dev.synchronize()
@@ -1034,6 +1048,7 @@ class EngineDrivenTransferContext(TransferContext):
                         skip_first_n_tokens=skip_first_n_tokens,
                         layout_hints=self._layout_hints,
                         engine_kv_format=state.engine_kv_format,
+                        blocks_per_window=state.blocks_per_window,
                     )
             except (RuntimeError, ValueError, TypeError, IndexError):
                 logger.exception("Failed to scatter retrieved CPU context chunks")

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -4,8 +4,9 @@
 # Standard
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 import os
 
 # Third Party
@@ -16,7 +17,10 @@ from lmcache import torch_dev
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints
-from lmcache.v1.multiprocess.custom_types import RegisterEngineDrivenContextPayload
+from lmcache.v1.multiprocess.custom_types import (
+    GroupLayout,
+    RegisterEngineDrivenContextPayload,
+)
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.mq import MessageQueueClient
@@ -36,6 +40,10 @@ from lmcache.v1.platform.base.event_ipc import (
     get_event_ipc_backend,
 )
 from lmcache.v1.platform.kv_wrap import wrap_kv_caches
+
+if TYPE_CHECKING:
+    # First Party
+    import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 
@@ -172,6 +180,25 @@ class IPCEvent(Protocol):
 
 
 SendRequest = Callable[[MessageQueueClient, RequestType, list[object]], MessagingFuture]
+
+
+@dataclass
+class _GroupState:
+    """Worker-side per-LMCache-group transfer state (multi-group registration).
+
+    Attributes:
+        layer_names: KV cache dict keys belonging to this group, in group
+            layer order — selects the gather/scatter tensor subset.
+        engine_kv_format: Detected KV format for this group's tensors.
+        blocks_in_chunk: Paged blocks of THIS group per LMCache chunk
+            (``chunk_tokens / tokens_per_block``).
+        layout_desc: Chunk layout for this group's objects.
+    """
+
+    layer_names: list[str]
+    engine_kv_format: "lmc_ops.EngineKVFormat"
+    blocks_in_chunk: int
+    layout_desc: MemoryLayoutDesc
 
 
 def _single_group_block_ids(block_ids: list[list[int]]) -> list[int]:
@@ -642,6 +669,7 @@ class EngineDrivenTransferContext(TransferContext):
         self._engine_driven_context: EngineDrivenContext | None = None
         self._layout_hints: LayoutHints | None = None
         self._engine_kv_format: Any = None
+        self._group_states: list[_GroupState] = []
 
     @property
     def engine_driven_context(self) -> EngineDrivenContext:
@@ -672,16 +700,19 @@ class EngineDrivenTransferContext(TransferContext):
     ) -> None:
         """Register KV caches with the non-GPU context server.
 
-        ``engine_group_infos`` and ``engine_type`` are accepted to satisfy
-        the base interface but are currently a no-op: the non-GPU transfer
-        path does not support hybrid KV cache groups and rejects multi-
-        group transfers at store / retrieve time (see
-        ``_single_group_block_ids``).
+        With multiple ``engine_group_infos`` (hybrid-KV models), each group's
+        layers are described by their own layout and gathered/scattered with
+        that group's block-id list (uniform coverage: every group stores and
+        retrieves every chunk). Sliding-window groups are rejected because
+        uniform coverage is only correct when every group holds blocks for the
+        full token range, and multi-group transfer requires the SHM transport
+        (pickle mode is rejected). Single-group registration keeps the legacy
+        path (see ``_single_group_block_ids``).
         """
         del engine_type  # unused on the engine-driven path
-        # TODO: per-group compression (EngineGroupInfo.tokens_per_block vs
-        # the tensor-detected slot count, e.g. DeepSeek V4) is only handled
-        # on the CUDA path. The non-CUDA path is yet to be implemented.
+        # TODO: per-group compression (EngineGroupInfo.tokens_per_block vs the
+        # tensor-detected slot count, e.g. DeepSeek V4) is checked to divide the
+        # chunk at register but not yet threaded through gather/scatter sizing.
         (
             block_size,
             num_layers,
@@ -696,15 +727,79 @@ class EngineDrivenTransferContext(TransferContext):
         # The wire field is named use_mla but only drives the object plane
         # count: single-plane (kv_size == 1) covers MLA and fused-K/V formats.
         use_mla_flag = kv_size == 1
-        shape = (
-            torch.Size([num_layers, blocks_in_chunk * block_size, hidden_dim_size])
-            if use_mla_flag
-            else torch.Size(
-                [2, num_layers, blocks_in_chunk * block_size, hidden_dim_size]
+        chunk_tokens = blocks_in_chunk * block_size
+
+        group_layouts: list[GroupLayout] = []
+        group_states: list[_GroupState] = []
+        if len(engine_group_infos) > 1:
+            layer_names = list(kv_caches)
+            for gid, group in enumerate(engine_group_infos):
+                if group.sw_size_tokens >= 0:
+                    raise RuntimeError(
+                        "engine-driven multi-group transfer only supports "
+                        "uniform-coverage groups; group "
+                        f"{gid} is sliding-window "
+                        f"(sw_size_tokens={group.sw_size_tokens}). Run with "
+                        "a unified KV cache manager instead."
+                    )
+                subset = {
+                    layer_names[i]: kv_caches[layer_names[i]]
+                    for i in group.layer_indices
+                }
+                (
+                    g_block_size,
+                    g_num_layers,
+                    g_hidden,
+                    g_dtype_str,
+                    g_format,
+                    g_kv_size,
+                ) = compute_kv_layout(subset, layout_hints=layout_hints)
+                tokens_per_block = group.tokens_per_block or g_block_size
+                if chunk_tokens % tokens_per_block != 0:
+                    raise RuntimeError(
+                        f"group {gid} tokens_per_block={tokens_per_block} does "
+                        f"not divide the chunk size ({chunk_tokens} tokens)"
+                    )
+                g_mla = g_kv_size == 1
+                g_shape = (
+                    torch.Size([g_num_layers, chunk_tokens, g_hidden])
+                    if g_mla
+                    else torch.Size([2, g_num_layers, chunk_tokens, g_hidden])
+                )
+                group_layouts.append(
+                    GroupLayout(
+                        num_layers=g_num_layers,
+                        hidden_dim_size=g_hidden,
+                        dtype_str=g_dtype_str,
+                        tokens_per_block=tokens_per_block,
+                    )
+                )
+                group_states.append(
+                    _GroupState(
+                        layer_names=[layer_names[i] for i in group.layer_indices],
+                        engine_kv_format=g_format,
+                        blocks_in_chunk=chunk_tokens // tokens_per_block,
+                        layout_desc=MemoryLayoutDesc(
+                            shapes=[g_shape],
+                            dtypes=[getattr(torch, g_dtype_str)],
+                        ),
+                    )
+                )
+            # Group 0's layout doubles as the legacy top-level layout so
+            # single-group readers of the payload keep working.
+            shape = group_states[0].layout_desc.shapes[0]
+            layout_desc = MemoryLayoutDesc(
+                shapes=[shape], dtypes=group_states[0].layout_desc.dtypes
             )
-        )
-        dtype = getattr(torch, dtype_str)
-        layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+        else:
+            shape = (
+                torch.Size([num_layers, chunk_tokens, hidden_dim_size])
+                if use_mla_flag
+                else torch.Size([2, num_layers, chunk_tokens, hidden_dim_size])
+            )
+            dtype = getattr(torch, dtype_str)
+            layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+        self._group_states = group_states
 
         future = send_request(
             mq_client,
@@ -719,6 +814,7 @@ class EngineDrivenTransferContext(TransferContext):
                     hidden_dim_size=hidden_dim_size,
                     dtype_str=dtype_str,
                     use_mla=use_mla_flag,
+                    group_layouts=group_layouts,
                 )
             ],
         )
@@ -742,10 +838,18 @@ class EngineDrivenTransferContext(TransferContext):
             pool_size=pool_size,
         )
         supported_transfer_mode = "SHM" if shm_name and pool_size > 0 else "pickle"
+        if self._group_states and supported_transfer_mode != "SHM":
+            raise RuntimeError(
+                "engine-driven multi-group transfer requires the SHM "
+                "transport, but the server returned no SHM pool (pickle "
+                "mode). Enable a non-lazy L1 pool on the MP server."
+            )
         logger.info(
-            "Worker non-GPU transfer context registered (instance_id=%d, mode=%s)",
+            "Worker non-GPU transfer context registered "
+            "(instance_id=%d, mode=%s, groups=%d)",
             instance_id,
             supported_transfer_mode,
+            max(1, len(self._group_states)),
         )
 
     def submit_store(
@@ -763,6 +867,9 @@ class EngineDrivenTransferContext(TransferContext):
                 "Engine-driven transfer context is not registered. "
                 "Call register() before submit_store()."
             )
+
+        if self._group_states:
+            return self._submit_store_multigroup(key, instance_id, kv_caches, block_ids)
 
         torch_dev.synchronize()
         result = self._engine_driven_context.prepare_store(key, instance_id)
@@ -807,6 +914,11 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
+        if self._group_states:
+            return self._submit_retrieve_multigroup(
+                key, instance_id, kv_caches, block_ids, skip_first_n_tokens
+            )
+
         src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
         ok = src_buffers is not None
         if src_buffers is not None:
@@ -829,6 +941,106 @@ class EngineDrivenTransferContext(TransferContext):
         self._engine_driven_context.commit_retrieve(key, instance_id)
 
         future: MessagingFuture[bool] = MessagingFuture()
+        future.set_result(ok)
+        return future
+
+    def _group_slots(
+        self,
+        tensors: list[torch.Tensor],
+        per_slot_group_ids: list[int],
+        gid: int,
+        chunk_indices: "list[int] | None" = None,
+    ) -> "tuple[list[torch.Tensor], list[int] | None]":
+        """Select group ``gid``'s slot tensors (and chunk indices) in order."""
+        idxs = [i for i, g in enumerate(per_slot_group_ids) if g == gid]
+        picked = [tensors[i] for i in idxs]
+        if chunk_indices is None:
+            return picked, None
+        return picked, [chunk_indices[i] for i in idxs]
+
+    def _submit_store_multigroup(
+        self,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+    ) -> MessagingFuture:
+        """Uniform-coverage store: gather every group's chunks into its slots."""
+        ctx = self._engine_driven_context
+        assert ctx is not None
+        future: MessagingFuture[bool] = MessagingFuture()
+        if len(block_ids) != len(self._group_states):
+            raise RuntimeError(
+                f"got {len(block_ids)} block-id lists for "
+                f"{len(self._group_states)} registered groups"
+            )
+        torch_dev.synchronize()
+        result = ctx.prepare_store_grouped(key, instance_id)
+        if result is None:
+            future.set_result(False)
+            return future
+        tensors, chunk_indices, group_ids = result
+        if not tensors:
+            future.set_result(True)
+            return future
+        for gid, state in enumerate(self._group_states):
+            out_g, chunks_g = self._group_slots(tensors, group_ids, gid, chunk_indices)
+            if not out_g:
+                continue
+            gather_paged_kv_to_cpu(
+                {name: kv_caches[name] for name in state.layer_names},
+                block_ids[gid],
+                state.blocks_in_chunk,
+                layout_hints=self._layout_hints,
+                engine_kv_format=state.engine_kv_format,
+                out=out_g,
+                chunk_indices=chunks_g,
+            )
+        # SHM writes are async device->CPU copies; complete them before commit.
+        torch_dev.synchronize()
+        ok = ctx.commit_store(key, instance_id, [])
+        future.set_result(ok)
+        return future
+
+    def _submit_retrieve_multigroup(
+        self,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        skip_first_n_tokens: int,
+    ) -> MessagingFuture:
+        """Uniform-coverage retrieve: scatter every group's chunks from its slots."""
+        ctx = self._engine_driven_context
+        assert ctx is not None
+        future: MessagingFuture[bool] = MessagingFuture()
+        if len(block_ids) != len(self._group_states):
+            raise RuntimeError(
+                f"got {len(block_ids)} block-id lists for "
+                f"{len(self._group_states)} registered groups"
+            )
+        result = ctx.prepare_retrieve_grouped(key, instance_id)
+        ok = result is not None
+        if result is not None:
+            tensors, group_ids = result
+            try:
+                for gid, state in enumerate(self._group_states):
+                    src_g, _ = self._group_slots(tensors, group_ids, gid)
+                    scatter_cpu_to_paged_kv(
+                        {name: kv_caches[name] for name in state.layer_names},
+                        block_ids[gid],
+                        src_g,
+                        state.blocks_in_chunk,
+                        skip_first_n_tokens=skip_first_n_tokens,
+                        layout_hints=self._layout_hints,
+                        engine_kv_format=state.engine_kv_format,
+                    )
+            except (RuntimeError, ValueError, TypeError, IndexError):
+                logger.exception("Failed to scatter retrieved CPU context chunks")
+                ok = False
+            # Complete device writes before the server may reuse the slots.
+            torch_dev.synchronize()
+        ctx.commit_retrieve(key, instance_id)
         future.set_result(ok)
         return future
 

--- a/lmcache/v1/multiprocess/transfer_plan.py
+++ b/lmcache/v1/multiprocess/transfer_plan.py
@@ -15,6 +15,11 @@ from dataclasses import dataclass
 from itertools import islice
 from typing import Callable, Generator, Sequence
 
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
 __all__ = [
     "KernelGroupGeometry",
     "ObjectGroupGeometry",
@@ -217,6 +222,14 @@ def build_object_group_transfer_plan(
     num_objects_to_skip = 0
     if geometry.num_chunks_in_sw >= 0 and is_h2d:
         num_objects_to_skip = max(0, num_objects - geometry.num_chunks_in_sw)
+        if num_objects_to_skip > 0:
+            logger.debug(
+                "Sliding window: skipping the first %d of %d leading objects "
+                "(H2D, window covers %d trailing chunks)",
+                num_objects_to_skip,
+                num_objects,
+                geometry.num_chunks_in_sw,
+            )
 
     tokens_per_chunk = geometry.tokens_per_chunk
     steps: list[TransferPlanStep] = []

--- a/lmcache/v1/multiprocess/transfer_plan.py
+++ b/lmcache/v1/multiprocess/transfer_plan.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Driven-path-agnostic KV transfer planning.
+
+This module owns the "what to copy" step of a multiprocess KV transfer: given
+one object group's geometry and the set of memory objects to move, it produces
+an ordered list of :class:`TransferPlanStep` describing every batched copy and
+per-kernel-group kernel launch. The plan contains only indices, block
+positions, and counts -- no tensors, pointers, streams, or IPC state -- so any
+transfer path (LMCache-driven or engine-driven) can build a plan the same way
+and materialize it with its own source/destination resolution and copy engine.
+"""
+
+# Standard
+from dataclasses import dataclass
+from itertools import islice
+from typing import Callable, Generator, Sequence
+
+__all__ = [
+    "KernelGroupGeometry",
+    "ObjectGroupGeometry",
+    "KernelGroupLaunch",
+    "TransferPlanStep",
+    "batched_iteration_with_skip",
+    "build_object_group_transfer_plan",
+]
+
+
+@dataclass(frozen=True)
+class KernelGroupGeometry:
+    """Per-kernel-group block geometry needed to plan a transfer.
+
+    Args:
+        kernel_group_id: Index of the kernel group in the layer-groups manager.
+        blocks_per_chunk: Number of paged blocks holding one full LMCache
+            chunk for this group.
+        blocks_per_window: Number of paged blocks holding one chunk's worth of
+            retained tokens for this group. Equal to ``blocks_per_chunk`` for
+            full-attention groups; smaller when the group's sliding window is
+            narrower than the chunk.
+        tokens_to_blocks: Maps a token count to this group's block count.
+            Supplied by the owner of the block-geometry math (e.g.
+            ``BaseCacheContext.calculate_num_blocks``) so the planner never
+            duplicates per-group slot/compression rules.
+    """
+
+    kernel_group_id: int
+    blocks_per_chunk: int
+    blocks_per_window: int
+    tokens_to_blocks: Callable[[int], int]
+
+
+@dataclass(frozen=True)
+class ObjectGroupGeometry:
+    """Geometry of one object group, the planning unit of a transfer.
+
+    Args:
+        object_group_id: Index of the object group in the layer-groups manager.
+        kernel_groups: Geometry of every kernel group backing this object
+            group, in the group's declared layout order.
+        tokens_per_chunk: LMCache chunk size in tokens.
+        num_chunks_in_sw: Number of trailing prefix chunks a sliding-window
+            group must retrieve; negative for full-attention groups (retrieve
+            everything).
+    """
+
+    object_group_id: int
+    kernel_groups: tuple[KernelGroupGeometry, ...]
+    tokens_per_chunk: int
+    num_chunks_in_sw: int
+
+
+@dataclass(frozen=True)
+class KernelGroupLaunch:
+    """One kernel group's slice of a batched copy.
+
+    Args:
+        kernel_group_id: Index of the kernel group to launch for.
+        start_block_pos: Offset of the batch's first block in the group's
+            (window-downsampled) block-id list.
+        num_blocks: Number of block ids the launch consumes from
+            ``start_block_pos``.
+        skip_blocks: Leading blocks within the batch whose writes must be
+            skipped (protects APC-shared GPU blocks under a retrieve).
+    """
+
+    kernel_group_id: int
+    start_block_pos: int
+    num_blocks: int
+    skip_blocks: int
+
+
+@dataclass(frozen=True)
+class TransferPlanStep:
+    """One batched copy: which objects move and how each kernel group runs.
+
+    Args:
+        start_object_idx: Index of the batch's first memory object in the
+            original (pre-skip) object sequence.
+        object_indices: Indices of the memory objects in this batch, in copy
+            order.
+        launches: One :class:`KernelGroupLaunch` per kernel group in the
+            object group, in the group's declared layout order.
+    """
+
+    start_object_idx: int
+    object_indices: tuple[int, ...]
+    launches: tuple[KernelGroupLaunch, ...]
+
+
+def batched_iteration_with_skip(
+    lst: Sequence,
+    batch_size: int,
+    skip_count: int,
+) -> Generator[tuple[int, tuple], None, None]:
+    """Utility function to iterate over a list in batches with an initial skip.
+
+    Args:
+        lst: The list to iterate over.
+        batch_size: The size of each batch.
+        skip_count: The number of items to skip at the start of the list.
+
+    Yields:
+        Tuples of (batch_start_idx, batch) where batch is a tuple of items
+        from the list, and batch_start_idx is the "original" index of the first
+        item in the batch.
+
+    Raises:
+        ValueError: If batch_size is less than 1 or skip_count is negative.
+
+    Note:
+        Batch_idx is the index of the batch in the original list, accounting
+        for the skipped items. For example, if skip_count is 10 and batch_size
+        is 5, the first yielded batch will have batch_start_idx=10.
+    """
+    if batch_size < 1:
+        raise ValueError("batch size must be at least one")
+    if skip_count < 0:
+        raise ValueError("skip_count must be non-negative")
+
+    it = iter(lst)
+    # Skip the initial items
+    for _ in range(skip_count):
+        next(it, None)
+    batch_start_idx = skip_count
+    while batch := tuple(islice(it, batch_size)):
+        yield batch_start_idx, batch
+        batch_start_idx += len(batch)
+
+
+def _recalculate_blocks_to_skip(
+    blocks_per_chunk: int,
+    blocks_per_window: int,
+    blocks_to_skip: int,
+) -> int:
+    """Re-calculate the number of blocks to skip for a batch of chunks based
+    on the blocks per chunk and blocks per sliding window WHEN the window
+    size is smaller than the lmcache chunk size.
+
+    Args:
+        blocks_per_chunk: The total number of blocks in one chunk for the
+            current group.
+        blocks_per_window: The number of blocks in the sliding window
+            for the current group. Should be less than or equal to
+            blocks_per_chunk.
+        blocks_to_skip: The number of blocks to skip.
+
+    Returns:
+        The re-calculated number of blocks to skip for the current batch of
+        chunks.
+    """
+    if blocks_per_chunk == blocks_per_window:
+        return blocks_to_skip
+
+    full_windows_to_skip = blocks_to_skip // blocks_per_chunk
+    tail_blocks = blocks_to_skip % blocks_per_chunk
+    tail_blocks_to_skip = tail_blocks - (blocks_per_chunk - blocks_per_window)
+    return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
+
+
+def build_object_group_transfer_plan(
+    geometry: ObjectGroupGeometry,
+    present: Sequence[bool],
+    batch_size: int,
+    skip_first_n_tokens: int,
+    is_h2d: bool,
+) -> list[TransferPlanStep]:
+    """Plan one object group's transfer as a list of batched copy steps.
+
+    Sliding-window groups retrieve only their trailing ``num_chunks_in_sw``
+    chunks, so on H2D the leading objects beyond the window are skipped
+    entirely. Batches that fall wholly before ``skip_first_n_tokens`` are
+    dropped; the batch straddling it carries per-kernel-group ``skip_blocks``
+    so the copy engine leaves the already-populated leading blocks untouched.
+
+    Args:
+        geometry: The object group's geometry.
+        present: Availability of each memory object, in object order; the
+            plan covers ``len(present)`` objects. On D2H a batch containing
+            an absent object is skipped (the storage layer declined those
+            keys); on H2D an absent object is an error.
+        batch_size: Number of memory objects per batched copy.
+        skip_first_n_tokens: Tokens to skip writing at the start of the
+            transfer range (H2D APC protection; pass 0 for stores).
+        is_h2d: True for retrieve (H2D), False for store (D2H).
+
+    Returns:
+        The plan steps in copy order; empty when nothing needs to move.
+
+    Raises:
+        ValueError: If ``is_h2d`` and any planned batch contains an absent
+            object, or if ``batch_size``/``skip_first_n_tokens`` is invalid.
+    """
+    if skip_first_n_tokens < 0:
+        raise ValueError("skip_first_n_tokens must be non-negative")
+
+    num_objects = len(present)
+    num_objects_to_skip = 0
+    if geometry.num_chunks_in_sw >= 0 and is_h2d:
+        num_objects_to_skip = max(0, num_objects - geometry.num_chunks_in_sw)
+
+    tokens_per_chunk = geometry.tokens_per_chunk
+    steps: list[TransferPlanStep] = []
+    for start_object_idx, index_batch in batched_iteration_with_skip(
+        range(num_objects), batch_size, skip_count=num_objects_to_skip
+    ):
+        if not all(present[i] for i in index_batch):
+            if is_h2d:
+                raise ValueError(
+                    "MemoryObj is None for some objects in the batch, cannot "
+                    f"perform H2D copy. object indices: {index_batch}"
+                )
+            continue
+
+        batch_len = len(index_batch)
+        batch_start_token = start_object_idx * tokens_per_chunk
+        batch_end_token = batch_start_token + batch_len * tokens_per_chunk
+
+        effective_start = max(batch_start_token, skip_first_n_tokens)
+        if effective_start >= batch_end_token:
+            continue
+
+        skip_tokens_in_chunk = effective_start - batch_start_token
+
+        launches = tuple(
+            KernelGroupLaunch(
+                kernel_group_id=kg.kernel_group_id,
+                start_block_pos=start_object_idx * kg.blocks_per_window,
+                num_blocks=batch_len * kg.blocks_per_window,
+                skip_blocks=_recalculate_blocks_to_skip(
+                    kg.blocks_per_chunk,
+                    kg.blocks_per_window,
+                    kg.tokens_to_blocks(skip_tokens_in_chunk),
+                ),
+            )
+            for kg in geometry.kernel_groups
+        )
+        steps.append(
+            TransferPlanStep(
+                start_object_idx=start_object_idx,
+                object_indices=index_batch,
+                launches=launches,
+            )
+        )
+    return steps

--- a/tests/v1/multiprocess/test_batched_iteration_with_skip.py
+++ b/tests/v1/multiprocess/test_batched_iteration_with_skip.py
@@ -5,7 +5,7 @@
 import pytest
 
 # First Party
-from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+from lmcache.v1.multiprocess.transfer_plan import (
     batched_iteration_with_skip,
 )
 

--- a/tests/v1/multiprocess/test_engine_driven_multigroup.py
+++ b/tests/v1/multiprocess/test_engine_driven_multigroup.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for engine-driven multi-group (uniform coverage) transfers.
+"""
+
+# Standard
+from typing import Any
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.multiprocess.custom_types import (
+    GroupLayout,
+    IPCCacheServerKey,
+    RegisterEngineDrivenContextPayload,
+)
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.transfer_context import worker_transfer
+from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContextMetadata
+from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
+    EngineDrivenTransferContext,
+)
+
+
+def _obj_key(chunk_hash: int, group: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_hash),
+        model_name="m",
+        kv_rank=0,
+        object_group_id=group,
+    )
+
+
+def _group_metadata(chunk_tokens: int = 8) -> EngineDrivenContextMetadata:
+    layouts = [
+        MemoryLayoutDesc(
+            shapes=[torch.Size([2, 2, chunk_tokens, 16])], dtypes=[torch.float32]
+        ),
+        MemoryLayoutDesc(
+            shapes=[torch.Size([2, 1, chunk_tokens, 4])], dtypes=[torch.float32]
+        ),
+    ]
+    return EngineDrivenContextMetadata(
+        layout_desc=layouts[0],
+        block_size=4,
+        use_mla=False,
+        group_layouts=layouts,
+    )
+
+
+def test_shm_strategy_multigroup_store_and_retrieve_roundtrip() -> None:
+    """Per-group reserve on store; retrieve misses until every group commits."""
+    pytest.importorskip(
+        "lmcache.native_storage_ops",
+        reason="real StorageManager requires compiled native storage ops",
+    )
+    # First Party
+    from lmcache.v1.distributed.config import (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+    )
+    from lmcache.v1.distributed.storage_manager import StorageManager
+    from lmcache.v1.multiprocess.modules.server_transfer import (
+        PickleTransferStrategy,
+        ShmTransferStrategy,
+    )
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    config = StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=8 * 1024 * 1024,
+                use_lazy=False,
+                shm_name="lmcache_test_multigroup_pool",
+            ),
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+    )
+    sm = StorageManager(config)
+    try:
+        strategy = ShmTransferStrategy(
+            storage_manager=sm,
+            pending_writes={},
+            pending_reads={},
+            pending_lock=__import__("threading").Lock(),
+            transfer_key_factory=lambda key, iid: (iid, key),
+            fallback_strategy=PickleTransferStrategy(sm),
+        )
+        metadata = _group_metadata()
+        key = IPCCacheServerKey.from_token_ids(
+            "m", 1, 0, [1] * 16, start=0, end=16, request_id="req-mg"
+        )
+        group_keys = [
+            [_obj_key(1, 0), _obj_key(2, 0)],
+            [_obj_key(1, 1), _obj_key(2, 1)],
+        ]
+
+        prep = strategy.prepare_store(
+            key=key,
+            instance_id=7,
+            context=metadata,
+            resolve_obj_keys=lambda _k: group_keys[0],
+            group_keys=group_keys,
+        )
+        ctx = prep.context
+        assert len(ctx["slots"]) == 4
+        assert ctx["group_ids"] == [0, 0, 1, 1]
+        assert ctx["chunk_indices"] == [0, 1, 0, 1]
+        # Group layouts differ: slot shapes must match each group's layout.
+        assert ctx["slots"][0]["shape"] == [2, 2, 8, 16]
+        assert ctx["slots"][2]["shape"] == [2, 1, 8, 4]
+
+        assert (
+            strategy.commit_store(
+                key=key,
+                instance_id=7,
+                cpu_data=b"",
+                context=metadata,
+                resolve_obj_keys=lambda _k: group_keys[0],
+            )
+            is True
+        )
+
+        # prepare_retrieve reads already read-locked objects (unsafe_read); in
+        # production the connector's lookup reserve-reads the matching keys
+        # first. Simulate that prefetch per group before retrieving.
+        for g_keys in group_keys:
+            sm._l1_manager.reserve_read(g_keys)
+
+        ret = strategy.prepare_retrieve(
+            key=key,
+            instance_id=7,
+            resolve_obj_keys=lambda _k: group_keys[0],
+            group_keys=group_keys,
+        )
+        assert ret.success is True
+        assert ret.context["group_ids"] == [0, 0, 1, 1]
+        assert strategy.commit_retrieve(key=key, instance_id=7) is True
+
+        # A key range where group 1 has nothing must be a miss overall.
+        partial_keys = [
+            [_obj_key(1, 0), _obj_key(2, 0)],
+            [_obj_key(9, 1), _obj_key(10, 1)],
+        ]
+        ret_miss = strategy.prepare_retrieve(
+            key=key,
+            instance_id=7,
+            resolve_obj_keys=lambda _k: partial_keys[0],
+            group_keys=partial_keys,
+        )
+        assert ret_miss.success is False
+        # No leaked read locks after the miss.
+        status = sm.report_status()["l1_manager"]
+        assert status["read_locked_count"] == 0
+    finally:
+        sm.close()
+
+
+class _FakeGroupedContext:
+    """Grouped-context fake capturing commit calls."""
+
+    def __init__(self, tensors, chunk_indices, group_ids):
+        self._prep = (tensors, chunk_indices, group_ids)
+        self.committed = False
+
+    def prepare_store_grouped(self, _key, _iid):
+        return self._prep
+
+    def prepare_retrieve_grouped(self, _key, _iid):
+        tensors, _, group_ids = self._prep
+        return tensors, group_ids
+
+    def commit_store(self, _key, _iid, _chunks):
+        self.committed = True
+        return True
+
+    def commit_retrieve(self, _key, _iid):
+        return True
+
+    def close(self) -> None:
+        return None
+
+
+def _fanout_ctx(monkeypatch) -> tuple[EngineDrivenTransferContext, list[dict]]:
+    """Worker context with two registered groups and a capturing gather."""
+    ctx = EngineDrivenTransferContext()
+    ctx._group_states = [
+        worker_transfer._GroupState(
+            layer_names=["layer_0", "layer_1"],
+            engine_kv_format=MagicMock(),
+            blocks_in_chunk=2,
+            layout_desc=MagicMock(),
+        ),
+        worker_transfer._GroupState(
+            layer_names=["layer_2"],
+            engine_kv_format=MagicMock(),
+            blocks_in_chunk=1,
+            layout_desc=MagicMock(),
+        ),
+    ]
+    calls: list[dict] = []
+
+    def _fake_gather(kv_caches, block_ids, blocks_in_chunk, **kwargs: Any):
+        calls.append(
+            {
+                "layers": sorted(kv_caches),
+                "block_ids": block_ids,
+                "blocks_in_chunk": blocks_in_chunk,
+                "out": kwargs.get("out"),
+                "chunk_indices": kwargs.get("chunk_indices"),
+            }
+        )
+        return kwargs.get("out")
+
+    monkeypatch.setattr(worker_transfer, "gather_paged_kv_to_cpu", _fake_gather)
+    monkeypatch.setattr(
+        worker_transfer, "scatter_cpu_to_paged_kv", lambda *a, **k: None
+    )
+    return ctx, calls
+
+
+def test_submit_store_multigroup_fans_out_per_group(monkeypatch) -> None:
+    ctx, calls = _fanout_ctx(monkeypatch)
+    t = [torch.zeros(1) for _ in range(4)]
+    fake = _FakeGroupedContext(t, [0, 1, 0, 1], [0, 0, 1, 1])
+    ctx._engine_driven_context = fake
+
+    kv = {name: torch.zeros(1) for name in ("layer_0", "layer_1", "layer_2")}
+    future = ctx.submit_store(
+        "req", MagicMock(), 1, kv, [[1, 2, 3, 4], [5, 6]], MagicMock(), 2
+    )
+
+    assert future.result(timeout=1) is True
+    assert fake.committed
+    assert len(calls) == 2
+    assert calls[0]["layers"] == ["layer_0", "layer_1"]
+    assert calls[0]["block_ids"] == [1, 2, 3, 4]
+    assert calls[0]["blocks_in_chunk"] == 2
+    assert calls[0]["out"] == [t[0], t[1]]
+    assert calls[0]["chunk_indices"] == [0, 1]
+    assert calls[1]["layers"] == ["layer_2"]
+    assert calls[1]["block_ids"] == [5, 6]
+    assert calls[1]["blocks_in_chunk"] == 1
+    assert calls[1]["out"] == [t[2], t[3]]
+
+
+def test_submit_store_multigroup_group_count_mismatch(monkeypatch) -> None:
+    ctx, _ = _fanout_ctx(monkeypatch)
+    ctx._engine_driven_context = _FakeGroupedContext([], [], [])
+    with pytest.raises(RuntimeError, match="block-id lists"):
+        ctx.submit_store("req", MagicMock(), 1, {}, [[1, 2]], MagicMock(), 2)
+
+
+def test_register_rejects_sliding_window_groups() -> None:
+    ctx = EngineDrivenTransferContext()
+    kv = {f"layer_{i}": torch.zeros(2, 4, 4, 2, 8) for i in range(2)}
+    with pytest.raises(RuntimeError, match="sliding-window"):
+        ctx.register(
+            instance_id=1,
+            kv_caches=kv,
+            model_name="m",
+            world_size=1,
+            blocks_in_chunk=2,
+            mq_client=MagicMock(),
+            mq_timeout=1.0,
+            send_request=MagicMock(),
+            engine_group_infos=[
+                EngineGroupInfo(engine_group_id=0, layer_indices=(0,)),
+                EngineGroupInfo(
+                    engine_group_id=1, layer_indices=(1,), sw_size_tokens=128
+                ),
+            ],
+        )
+
+
+def test_register_payload_carries_group_layouts() -> None:
+    """Two full-attention groups produce per-group layouts in the payload."""
+    ctx = EngineDrivenTransferContext()
+    kv = {f"layer_{i}": torch.zeros(2, 6, 4, 2, 8) for i in range(3)}
+
+    # First Party
+    from lmcache.v1.multiprocess.protocols.engine import (
+        RegisterEngineDrivenContextResponse,
+    )
+
+    sent: list[Any] = []
+
+    def _send(_mq, _rt, args):
+        sent.append(args[0])
+        future = MagicMock()
+        future.result.return_value = RegisterEngineDrivenContextResponse(
+            shm_name="lmcache_l1_pool_x", pool_size=4096
+        )
+        return future
+
+    ctx.register(
+        instance_id=1,
+        kv_caches=kv,
+        model_name="m",
+        world_size=1,
+        blocks_in_chunk=2,
+        mq_client=MagicMock(),
+        mq_timeout=1.0,
+        send_request=_send,
+        engine_group_infos=[
+            EngineGroupInfo(engine_group_id=0, layer_indices=(0, 1)),
+            EngineGroupInfo(engine_group_id=1, layer_indices=(2,)),
+        ],
+    )
+    payload: RegisterEngineDrivenContextPayload = sent[0]
+    assert len(payload.group_layouts) == 2
+    assert payload.group_layouts[0].num_layers == 2
+    assert payload.group_layouts[1].num_layers == 1
+    assert isinstance(payload.group_layouts[0], GroupLayout)
+    assert len(ctx._group_states) == 2
+    assert ctx._group_states[1].layer_names == ["layer_2"]

--- a/tests/v1/multiprocess/test_engine_driven_multigroup.py
+++ b/tests/v1/multiprocess/test_engine_driven_multigroup.py
@@ -231,7 +231,7 @@ def test_submit_store_multigroup_fans_out_per_group(monkeypatch) -> None:
     ctx, calls = _fanout_ctx(monkeypatch)
     t = [torch.zeros(1) for _ in range(4)]
     fake = _FakeGroupedContext(t, [0, 1, 0, 1], [0, 0, 1, 1])
-    ctx._engine_driven_context = fake
+    ctx._engine_driven_context = fake  # type: ignore[assignment]
 
     kv = {name: torch.zeros(1) for name in ("layer_0", "layer_1", "layer_2")}
     future = ctx.submit_store(
@@ -254,7 +254,7 @@ def test_submit_store_multigroup_fans_out_per_group(monkeypatch) -> None:
 
 def test_submit_store_multigroup_group_count_mismatch(monkeypatch) -> None:
     ctx, _ = _fanout_ctx(monkeypatch)
-    ctx._engine_driven_context = _FakeGroupedContext([], [], [])
+    ctx._engine_driven_context = _FakeGroupedContext([], [], [])  # type: ignore[assignment]
     with pytest.raises(RuntimeError, match="block-id lists"):
         ctx.submit_store("req", MagicMock(), 1, {}, [[1, 2]], MagicMock(), 2)
 

--- a/tests/v1/multiprocess/test_engine_driven_multigroup.py
+++ b/tests/v1/multiprocess/test_engine_driven_multigroup.py
@@ -197,12 +197,14 @@ def _fanout_ctx(monkeypatch) -> tuple[EngineDrivenTransferContext, list[dict]]:
             layer_names=["layer_0", "layer_1"],
             engine_kv_format=MagicMock(),
             blocks_in_chunk=2,
+            blocks_per_window=1,  # sliding-window group: keeps 1 of 2 blocks/chunk
             layout_desc=MagicMock(),
         ),
         worker_transfer._GroupState(
             layer_names=["layer_2"],
             engine_kv_format=MagicMock(),
             blocks_in_chunk=1,
+            blocks_per_window=1,  # full attention (window == chunk)
             layout_desc=MagicMock(),
         ),
     ]
@@ -214,6 +216,7 @@ def _fanout_ctx(monkeypatch) -> tuple[EngineDrivenTransferContext, list[dict]]:
                 "layers": sorted(kv_caches),
                 "block_ids": block_ids,
                 "blocks_in_chunk": blocks_in_chunk,
+                "blocks_per_window": kwargs.get("blocks_per_window"),
                 "out": kwargs.get("out"),
                 "chunk_indices": kwargs.get("chunk_indices"),
             }
@@ -242,13 +245,17 @@ def test_submit_store_multigroup_fans_out_per_group(monkeypatch) -> None:
     assert fake.committed
     assert len(calls) == 2
     assert calls[0]["layers"] == ["layer_0", "layer_1"]
+    # Raw (full) per-group block list is passed through; the sliding-window
+    # trailing-keep happens inside gather, driven by blocks_per_window.
     assert calls[0]["block_ids"] == [1, 2, 3, 4]
     assert calls[0]["blocks_in_chunk"] == 2
+    assert calls[0]["blocks_per_window"] == 1
     assert calls[0]["out"] == [t[0], t[1]]
     assert calls[0]["chunk_indices"] == [0, 1]
     assert calls[1]["layers"] == ["layer_2"]
     assert calls[1]["block_ids"] == [5, 6]
     assert calls[1]["blocks_in_chunk"] == 1
+    assert calls[1]["blocks_per_window"] == 1
     assert calls[1]["out"] == [t[2], t[3]]
 
 
@@ -259,26 +266,51 @@ def test_submit_store_multigroup_group_count_mismatch(monkeypatch) -> None:
         ctx.submit_store("req", MagicMock(), 1, {}, [[1, 2]], MagicMock(), 2)
 
 
-def test_register_rejects_sliding_window_groups() -> None:
+def test_register_accepts_sliding_window_groups() -> None:
+    """A sliding-window group registers (window < chunk) instead of raising; the
+    SW group keeps fewer blocks per chunk than its full-attention sibling, and
+    the payload carries the reduced per-group window."""
     ctx = EngineDrivenTransferContext()
     kv = {f"layer_{i}": torch.zeros(2, 4, 4, 2, 8) for i in range(2)}
-    with pytest.raises(RuntimeError, match="sliding-window"):
-        ctx.register(
-            instance_id=1,
-            kv_caches=kv,
-            model_name="m",
-            world_size=1,
-            blocks_in_chunk=2,
-            mq_client=MagicMock(),
-            mq_timeout=1.0,
-            send_request=MagicMock(),
-            engine_group_infos=[
-                EngineGroupInfo(engine_group_id=0, layer_indices=(0,)),
-                EngineGroupInfo(
-                    engine_group_id=1, layer_indices=(1,), sw_size_tokens=128
-                ),
-            ],
+
+    # First Party
+    from lmcache.v1.multiprocess.protocols.engine import (
+        RegisterEngineDrivenContextResponse,
+    )
+
+    sent: list[Any] = []
+
+    def _send(_mq, _rt, args):
+        sent.append(args[0])
+        future = MagicMock()
+        future.result.return_value = RegisterEngineDrivenContextResponse(
+            shm_name="lmcache_l1_pool_x", pool_size=4096
         )
+        return future
+
+    ctx.register(
+        instance_id=1,
+        kv_caches=kv,
+        model_name="m",
+        world_size=1,
+        blocks_in_chunk=2,
+        mq_client=MagicMock(),
+        mq_timeout=1.0,
+        send_request=_send,
+        engine_group_infos=[
+            EngineGroupInfo(engine_group_id=0, layer_indices=(0,)),
+            EngineGroupInfo(engine_group_id=1, layer_indices=(1,), sw_size_tokens=4),
+        ],
+    )
+    # chunk_tokens = blocks_in_chunk(2) * block_size(4) = 8; group 1's 4-token
+    # window is 1 of 2 blocks per chunk. Group 0 (full attention) keeps both.
+    full, sw = ctx._group_states
+    assert full.blocks_per_window == full.blocks_in_chunk == 2
+    assert sw.blocks_in_chunk == 2
+    assert sw.blocks_per_window == 1
+    payload: RegisterEngineDrivenContextPayload = sent[0]
+    assert payload.group_layouts[0].window_tokens == 8  # full attention
+    assert payload.group_layouts[1].window_tokens == 4  # sliding window
 
 
 def test_register_payload_carries_group_layouts() -> None:
@@ -320,5 +352,9 @@ def test_register_payload_carries_group_layouts() -> None:
     assert payload.group_layouts[0].num_layers == 2
     assert payload.group_layouts[1].num_layers == 1
     assert isinstance(payload.group_layouts[0], GroupLayout)
+    # Full-attention groups carry the full chunk as their window
+    # (blocks_in_chunk 2 * block_size 4 = 8 tokens).
+    assert payload.group_layouts[0].window_tokens == 8
+    assert payload.group_layouts[1].window_tokens == 8
     assert len(ctx._group_states) == 2
     assert ctx._group_states[1].layer_names == ["layer_2"]

--- a/tests/v1/multiprocess/test_transfer_plan.py
+++ b/tests/v1/multiprocess/test_transfer_plan.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``build_object_group_transfer_plan``."""
+
+# Standard
+from typing import Callable
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.transfer_plan import (
+    KernelGroupGeometry,
+    ObjectGroupGeometry,
+    build_object_group_transfer_plan,
+)
+
+
+def _linear_tokens_to_blocks(
+    blocks_per_chunk: int, tokens_per_chunk: int
+) -> Callable[[int], int]:
+    """Return a linear token->block map for one kernel group."""
+    return lambda tokens: tokens * blocks_per_chunk // tokens_per_chunk
+
+
+def _geometry(
+    kernel_groups: list[tuple[int, int, int]],
+    tokens_per_chunk: int = 256,
+    num_chunks_in_sw: int = -1,
+) -> ObjectGroupGeometry:
+    """Geometry with linear token->block math (block size = tpc / bpc)."""
+    return ObjectGroupGeometry(
+        object_group_id=0,
+        kernel_groups=tuple(
+            KernelGroupGeometry(
+                kernel_group_id=kg_id,
+                blocks_per_chunk=bpc,
+                blocks_per_window=bpw,
+                tokens_to_blocks=_linear_tokens_to_blocks(bpc, tokens_per_chunk),
+            )
+            for kg_id, bpc, bpw in kernel_groups
+        ),
+        tokens_per_chunk=tokens_per_chunk,
+        num_chunks_in_sw=num_chunks_in_sw,
+    )
+
+
+def test_full_attention_batches_cover_all_objects():
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 8)]),
+        present=[True] * 5,
+        batch_size=2,
+        skip_first_n_tokens=0,
+        is_h2d=True,
+    )
+    assert [s.object_indices for s in plan] == [(0, 1), (2, 3), (4,)]
+    assert [s.start_object_idx for s in plan] == [0, 2, 4]
+    launches = [s.launches[0] for s in plan]
+    assert [(x.start_block_pos, x.num_blocks) for x in launches] == [
+        (0, 16),
+        (16, 16),
+        (32, 8),
+    ]
+    assert all(x.skip_blocks == 0 for x in launches)
+
+
+def test_sliding_window_skips_leading_objects_on_h2d():
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 8)], num_chunks_in_sw=2),
+        present=[True] * 5,
+        batch_size=1,
+        skip_first_n_tokens=0,
+        is_h2d=True,
+    )
+    assert [s.object_indices for s in plan] == [(3,), (4,)]
+    assert [s.launches[0].start_block_pos for s in plan] == [24, 32]
+
+
+def test_sliding_window_does_not_skip_on_d2h():
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 8)], num_chunks_in_sw=2),
+        present=[True] * 5,
+        batch_size=5,
+        skip_first_n_tokens=0,
+        is_h2d=False,
+    )
+    assert [s.object_indices for s in plan] == [(0, 1, 2, 3, 4)]
+
+
+def test_skip_first_n_tokens_drops_and_clamps_batches():
+    # tokens_per_chunk=256, batch_size=1: skip 300 tokens drops chunk 0
+    # entirely and clamps 44 tokens (= 1 block of 8-per-chunk math floored)
+    # inside chunk 1.
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 8)]),
+        present=[True] * 3,
+        batch_size=1,
+        skip_first_n_tokens=300,
+        is_h2d=True,
+    )
+    assert [s.start_object_idx for s in plan] == [1, 2]
+    assert plan[0].launches[0].skip_blocks == 44 * 8 // 256
+    assert plan[1].launches[0].skip_blocks == 0
+
+
+def test_window_narrower_than_chunk_recalculates_skip_blocks():
+    # blocks_per_window=4 < blocks_per_chunk=8: a 6-block raw skip lands
+    # 2 blocks into the retained window (6 - (8 - 4)).
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 4)]),
+        present=[True] * 2,
+        batch_size=1,
+        skip_first_n_tokens=192,  # 6 blocks of 32 tokens
+        is_h2d=True,
+    )
+    assert plan[0].start_object_idx == 0
+    assert plan[0].launches[0].skip_blocks == 2
+    assert plan[0].launches[0].num_blocks == 4
+
+
+def test_absent_object_skips_batch_on_d2h():
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 8)]),
+        present=[True, False, True, True],
+        batch_size=2,
+        skip_first_n_tokens=0,
+        is_h2d=False,
+    )
+    assert [s.object_indices for s in plan] == [(2, 3)]
+
+
+def test_absent_object_raises_on_h2d():
+    with pytest.raises(ValueError, match="cannot perform H2D copy"):
+        build_object_group_transfer_plan(
+            _geometry([(0, 8, 8)]),
+            present=[True, None or False],
+            batch_size=2,
+            skip_first_n_tokens=0,
+            is_h2d=True,
+        )
+
+
+def test_multiple_kernel_groups_launch_per_group_geometry():
+    plan = build_object_group_transfer_plan(
+        _geometry([(0, 8, 8), (1, 16, 16)]),
+        present=[True] * 2,
+        batch_size=2,
+        skip_first_n_tokens=0,
+        is_h2d=True,
+    )
+    (step,) = plan
+    assert [(x.kernel_group_id, x.num_blocks) for x in step.launches] == [
+        (0, 16),
+        (1, 32),
+    ]
+
+
+def test_empty_plan_when_everything_skipped():
+    assert (
+        build_object_group_transfer_plan(
+            _geometry([(0, 8, 8)]),
+            present=[True] * 2,
+            batch_size=2,
+            skip_first_n_tokens=512,
+            is_h2d=True,
+        )
+        == []
+    )
+    assert (
+        build_object_group_transfer_plan(
+            _geometry([(0, 8, 8)]),
+            present=[],
+            batch_size=2,
+            skip_first_n_tokens=0,
+            is_h2d=True,
+        )
+        == []
+    )


### PR DESCRIPTION
Rebuilt along @ApostaC's three steps, on top of #4079 (first commit is that move; it drops out when #4079 merges):

1. Registration initializes `KVLayerGroupsManager` and derives every group's geometry from it (no per-group re-detection). The manager also validates chunk and window divisibility.
2. Block IDs are parsed per group from the manager's kernel groups; sliding-window groups keep only the trailing window of each chunk.
3. Gather/scatter call the shared helpers moved in #4079, extended with `blocks_per_window`.

The chunk token count is `blocks_in_chunk * lcm(group block sizes)`, folding in the mixed-geometry fix @skaulintel found on the old branch (gemma-4 registered half of every chunk). Covers both transports: SHM reserves per-group slots, pickle sends a group-major payload. k3 lanes: kimi_linear_tp and engine-driven HMA lm-eval, both transports.