### PR TITLE
[Fix][CLI] long-doc-permutator: size contexts in tokens, not words

### DIFF
--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -418,10 +418,10 @@ chunk-level cache lookup and eviction.
 | Field | CLI arg | Default | Description |
 |-------|---------|---------|-------------|
 | `num_contexts` | `--ldp-num-contexts` | 5 | Number of unique context documents (`N`) |
-| `context_length` | `--ldp-context-length` | 5000 | Tokens per context |
-| `system_prompt_length` | `--ldp-system-prompt-length` | 1000 | Shared system prompt tokens (`0` disables) |
+| `context_length` | `--ldp-context-length` | 5000 | Tokens per context (exact) |
+| `system_prompt_length` | `--ldp-system-prompt-length` | 1000 | Shared system prompt tokens, exact (`0` disables) |
 | `num_permutations` | `--ldp-num-permutations` | 10 | Distinct permutations to send (capped at `N!`) |
-| `vocab_size` | (none — hardcoded in factory) | 8000 | Vocabulary pool size for synthetic context generation |
+| `vocab_size` | (none — hardcoded in factory) | 8000 | Number of distinct single-token words contexts are sampled from |
 | `num_inflight_requests` | `--ldp-num-inflight-requests` | 1 | Max concurrent in-flight requests |
 
 **Stress axes** (each config field tunes one):
@@ -436,9 +436,27 @@ chunk-level cache lookup and eviction.
 
 **Behavior:**
 
-- **Data generation:** Builds a deterministic vocab pool of pseudo-words,
-  generates `num_contexts` distinct contexts (each seeded independently so
-  token sequences truly diverge), and enumerates permutations.
+- **Data generation:** Builds a deterministic pool of `vocab_size` words that
+  each cost exactly one token under the model's tokenizer, generates
+  `num_contexts` distinct contexts from it (each seeded independently so token
+  sequences truly diverge), and enumerates permutations. Because every word is
+  one token and begins a word, a context of `context_length` words is exactly
+  `context_length` tokens whatever order a permutation puts them in — the
+  configured lengths are exact, not estimates.
+- **Tokenizer families.** Candidates are read from the vocabulary's *keys*, so
+  byte-level BPE (`Ġthe`) and SentencePiece (`▁the`) are both covered;
+  `decode()` would drop the SentencePiece marker and find nothing. Words are
+  then joined by whichever convention that tokenizer makes exact — each word
+  carrying a leading space, or plain separators for tokenizers that charge a
+  token for an explicit leading space — and the total is checked before use.
+  WordPiece (BERT) marks continuations rather than word starts and is not
+  supported; the workload says so instead of guessing.
+- **Tokenizer is required.** Without one the workload cannot honour a length
+  expressed in tokens, so it raises instead of falling back to a text-level
+  approximation, which would silently benchmark a different operating point
+  than the flags describe. The tokenizer is loaded from `--model`, which
+  defaults to the name the engine reports from `/v1/models`; pass `--model`
+  explicitly when that name is not a HuggingFace repo ID or a local path.
 - **Permutation enumeration:** For small `N`, iterates `itertools.permutations`
   and truncates. When `N!` is much larger than `num_permutations * 10`, samples
   random permutations into a `set` to avoid exhausting an enormous search

--- a/lmcache/cli/commands/bench/engine_bench/command.py
+++ b/lmcache/cli/commands/bench/engine_bench/command.py
@@ -175,13 +175,15 @@ def add_engine_arguments(parser: argparse.ArgumentParser) -> None:
         "--ldp-context-length",
         type=int,
         default=5000,
-        help="Token length of each context (default: 5000).",
+        help="Exact token length of each context (default: 5000). Requires a "
+        "loadable tokenizer; pass --model when the engine reports a name that "
+        "is not a HuggingFace repo ID or local path.",
     )
     ldp_group.add_argument(
         "--ldp-system-prompt-length",
         type=int,
         default=1000,
-        help="Token length of the shared system prompt (default: 1000). "
+        help="Exact token length of the shared system prompt (default: 1000). "
         "Use 0 for no system prompt.",
     )
     ldp_group.add_argument(

--- a/lmcache/cli/commands/bench/engine_bench/tokenizers.py
+++ b/lmcache/cli/commands/bench/engine_bench/tokenizers.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tokenizer helpers shared by the engine-benchmark workloads.
+
+Workloads that promise a prompt of *N tokens* need the model's tokenizer to
+keep that promise: any text-level proxy (word counts, character counts)
+drifts by a per-tokenizer expansion factor, so the same flags produce
+different-sized prompts on different models.
+"""
+
+# Standard
+from dataclasses import dataclass
+import random
+import re
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+# A pool entry is a vocabulary token that starts a new word and continues
+# with plain lowercase letters.  Starting a word is what makes concatenation
+# exact: such a token is segmented independently of its neighbours, so the
+# count does not depend on the order a permutation puts the words in.
+# Restricting to ASCII letters keeps entries clear of digits, punctuation
+# and byte-fallback fragments, which merge with adjacent text.
+_WORD_RE = re.compile(r"^[a-z]+$")
+
+# How each tokenizer family spells "this token begins a word": a literal
+# space, GPT-2 byte-level BPE's ``Ġ``, or SentencePiece's ``▁``.  Matching on
+# the raw vocabulary key rather than on ``decode()`` output matters —
+# SentencePiece decodes ``▁the`` to ``"the"``, dropping the very marker that
+# identifies it, so a decode-based filter finds nothing on those models.
+_WORD_START_MARKERS = (" ", "Ġ", "▁")
+
+# Stand-in for "some word already precedes this one", used to measure a
+# candidate's cost in mid-text position.  Any short word would do.
+_PROBE_WORD = "x"
+
+
+@dataclass(frozen=True)
+class TokenPool:
+    """Words that each cost one token, plus how to join them.
+
+    The joining convention is part of the pool, not a caller's choice: the
+    same words cost a different number of tokens under the wrong one, which
+    is the whole failure this module exists to prevent.
+    """
+
+    words: list[str]
+    leading_space: bool
+    """Whether the text must open with a space.
+
+    Most tokenizers fold a leading space into the following word's token, so
+    every word — the first included — carries one.  A few (Phi-3) emit a
+    standalone token for an explicit leading space; there the words are
+    merely separated by spaces and the text starts with a letter.
+    """
+
+    def join(self, words: list[str]) -> str:
+        """Join ``words`` into text that encodes to ``len(words)`` tokens."""
+        text = " ".join(words)
+        if text and self.leading_space:
+            return " " + text
+        return text
+
+
+def _verify(tokenizer, words: list[str], prefix: str, base: int) -> list[str]:
+    """Keep the words that still cost exactly one token after ``prefix``.
+
+    Vocabulary keys are a hint, not a contract — a key that looks like a
+    word need not survive the tokenizer's own pre-tokenization, so each
+    candidate is encoded as it will appear in a prompt.
+    """
+    encoded = tokenizer([prefix + w for w in words], add_special_tokens=False)
+    return [
+        w
+        for w, ids_ in zip(words, encoded["input_ids"], strict=False)
+        if len(ids_) == base + 1
+    ]
+
+
+def try_load_tokenizer(model_name: str | None):
+    """Best-effort load of a model's tokenizer.
+
+    Args:
+        model_name: HuggingFace repo ID or local path.  ``None`` short-
+            circuits to ``None``.
+
+    Returns:
+        The tokenizer, or ``None`` if ``transformers`` isn't installed or
+        the tokenizer can't be loaded.  Callers decide whether that is
+        fatal — workloads whose length contract depends on the tokenizer
+        should fail rather than silently generate mis-sized prompts.
+    """
+    if model_name is None:
+        return None
+    try:
+        # Third Party
+        from transformers import AutoTokenizer
+    except ImportError:
+        logger.warning("transformers is not installed; no tokenizer available")
+        return None
+    try:
+        return AutoTokenizer.from_pretrained(model_name)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not load tokenizer for %s (%s)", model_name, e)
+        return None
+
+
+def build_single_token_pool(
+    tokenizer,
+    size: int,
+    seed: int = 42,
+) -> TokenPool:
+    """Pick ``size`` words that each cost exactly one token.
+
+    Text built with :meth:`TokenPool.join` tokenizes to exactly one token
+    per word, so a workload can hit a requested token count exactly instead
+    of approximating it.
+
+    Args:
+        tokenizer: A HuggingFace tokenizer.
+        size: Number of words to return.
+        seed: Random seed; the same seed and tokenizer yield the same pool.
+
+    Returns:
+        A :class:`TokenPool` of ``size`` words and the convention for
+        joining them.
+
+    Raises:
+        ValueError: If the tokenizer yields fewer than ``size`` usable
+            words under either convention, or if the resulting text does
+            not encode to ``size`` tokens after all.
+    """
+    special = set(tokenizer.all_special_ids or [])
+
+    seen: set[str] = set()
+    for key, token_id in tokenizer.get_vocab().items():
+        if token_id in special or not key.startswith(_WORD_START_MARKERS):
+            continue
+        word = key[1:]
+        if _WORD_RE.match(word):
+            seen.add(word)
+    # ``get_vocab()`` is a plain dict; sort so the pool depends only on the
+    # tokenizer and the seed.
+    words = sorted(seen)
+
+    verified: list[str] = []
+    leading_space = True
+    if words:
+        verified = _verify(tokenizer, words, " ", 0)
+        if len(verified) < size:
+            # A tokenizer that charges for an explicit leading space (Phi-3)
+            # rejects every candidate above; there the words are separated
+            # rather than prefixed.
+            base = len(tokenizer.encode(_PROBE_WORD, add_special_tokens=False))
+            separated = _verify(tokenizer, words, _PROBE_WORD + " ", base)
+            if len(separated) > len(verified):
+                verified, leading_space = separated, False
+
+    if len(verified) < size:
+        raise ValueError(
+            f"Tokenizer yielded only {len(verified)} words that stay a "
+            f"single token in context, need {size}. Use a smaller "
+            f"vocab_size, or a model whose tokenizer marks word starts "
+            f"(byte-level BPE or SentencePiece do; WordPiece does not)."
+        )
+
+    pool = TokenPool(random.Random(seed).sample(verified, size), leading_space)
+
+    # What is promised is a total, and per-word costs are not obliged to
+    # compose.  Check the total rather than trusting that they do.
+    actual = len(tokenizer.encode(pool.join(pool.words), add_special_tokens=False))
+    if actual != size:
+        raise ValueError(
+            f"Built a {size}-word pool but its text encodes to {actual} "
+            f"tokens; this tokenizer does not segment words independently, "
+            f"so exact token lengths cannot be honoured for it."
+        )
+
+    logger.debug(
+        "Single-token pool: %d candidates, %d verified, sampling %d (leading_space=%s)",
+        len(words),
+        len(verified),
+        size,
+        leading_space,
+    )
+    return pool

--- a/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
@@ -133,6 +133,7 @@ def create_workload(
             stats_collector=stats_collector,
             progress_monitor=progress_monitor,
             seed=config.seed,
+            model_name=config.model,
         )
 
     if config.workload == "long-doc-qa":

--- a/lmcache/cli/commands/bench/engine_bench/workloads/long_doc_permutator.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/long_doc_permutator.py
@@ -14,6 +14,12 @@ Stress axes (controlled by config):
     3. Chunk Homogeneity           -> vocab_size
     4. Prefix Domination           -> system_prompt_length
     5. Concurrency                 -> num_inflight_requests
+
+Context and system-prompt lengths are exact token counts, not estimates:
+all synthetic text is built from words that encode to exactly one token
+under the model's own tokenizer (see
+:mod:`lmcache.cli.commands.bench.engine_bench.tokenizers`).  This workload
+therefore requires a loadable tokenizer.
 """
 
 # Standard
@@ -27,6 +33,11 @@ import random
 from lmcache.cli.commands.bench.engine_bench.progress import ProgressMonitor
 from lmcache.cli.commands.bench.engine_bench.request_sender import RequestSender
 from lmcache.cli.commands.bench.engine_bench.stats import StatsCollector
+from lmcache.cli.commands.bench.engine_bench.tokenizers import (
+    TokenPool,
+    build_single_token_pool,
+    try_load_tokenizer,
+)
 from lmcache.cli.commands.bench.engine_bench.workloads.base import BaseWorkload
 from lmcache.logging import init_logger
 
@@ -76,13 +87,14 @@ class LongDocPermutatorConfig:
 
         Args:
             num_contexts: Number of unique context documents.
-            context_length: Token length of each context.
-            system_prompt_length: Token length of the shared system prompt.
-                Use 0 for no system prompt.
+            context_length: Exact token length of each context.
+            system_prompt_length: Exact token length of the shared system
+                prompt.  Use 0 for no system prompt.
             num_permutations: Number of distinct permutations to send.
                 Capped at N! where N = num_contexts.
-            vocab_size: Vocabulary pool size for context generation.
-                Smaller values increase chunk hash collision risk.
+            vocab_size: Number of distinct single-token words to sample
+                context content from.  Smaller values increase chunk hash
+                collision risk.
             num_inflight_requests: Max concurrent in-flight requests.
 
         Returns:
@@ -103,91 +115,48 @@ class LongDocPermutatorConfig:
 # ---------------------------------------------------------------------------
 
 
-def _generate_vocab_pool(size: int, seed: int = 42) -> list[str]:
-    """Generate a vocabulary pool of ``size`` unique pseudo-words.
-
-    Deterministically generates synthetic words so every token is unique.
+def _generate_system_prompt(length: int, pool: TokenPool, seed: int = 42) -> str:
+    """Generate a deterministic shared system prompt of ``length`` tokens.
 
     Args:
-        size: Number of unique words to generate.
+        length: Exact token length of the system prompt.
+        pool: Single-token words to sample from.
         seed: Random seed for reproducibility.
 
     Returns:
-        Sorted list of unique pseudo-words.
-    """
-    rng = random.Random(seed)
-    vowels = "aeiou"
-    consonants = "bcdfghjklmnpqrstvwxyz"
-    pool: set[str] = set()
-    while len(pool) < size:
-        length = rng.randint(3, 7)
-        word = ""
-        for j in range(length):
-            if j % 2 == 0:
-                word += rng.choice(consonants)
-            else:
-                word += rng.choice(vowels)
-        word = f"{word}{len(pool)}"
-        pool.add(word)
-    return sorted(pool)
-
-
-def _generate_system_prompt(length: int, seed: int = 42) -> str:
-    """Generate a deterministic shared system prompt of ~``length`` tokens.
-
-    Args:
-        length: Approximate token length of the system prompt.
-        seed: Random seed for reproducibility.
-
-    Returns:
-        A string of ``length`` space-separated words.
+        A string that encodes to exactly ``length`` tokens.
     """
     if length == 0:
         return ""
     rng = random.Random(seed)
-    words = [
-        "the",
-        "system",
-        "will",
-        "process",
-        "your",
-        "request",
-        "and",
-        "provide",
-        "an",
-        "answer",
-        "based",
-        "on",
-        "context",
-    ]
-    return " ".join(rng.choices(words, k=length))
+    return pool.join(rng.choices(pool.words, k=length))
 
 
 def _generate_contexts(
     num_contexts: int,
     length: int,
-    vocab_pool: list[str],
+    pool: TokenPool,
     seed: int = 123,
 ) -> list[str]:
-    """Generate ``num_contexts`` unique context blocks of ~``length`` tokens.
+    """Generate ``num_contexts`` unique context blocks of ``length`` tokens.
 
-    Each context draws from ``vocab_pool`` with a per-context seed so the
-    token sequences genuinely diverge.
+    Each context draws from ``pool`` with a per-context seed so the
+    token sequences genuinely diverge — contexts sharing content would
+    collide on chunk hashes and inflate the blend hit rate.
 
     Args:
         num_contexts: Number of context documents to generate.
-        length: Approximate token length of each context.
-        vocab_pool: Pool of words to sample from.
+        length: Exact token length of each context.
+        pool: Single-token words to sample from.
         seed: Base random seed; each context uses seed + i.
 
     Returns:
-        List of context strings.
+        List of context strings, each encoding to exactly ``length`` tokens.
     """
     contexts = []
     for i in range(num_contexts):
         rng = random.Random(seed + i)
-        body = " ".join(rng.choices(vocab_pool, k=length))
-        contexts.append(body)
+        contexts.append(pool.join(rng.choices(pool.words, k=length)))
     return contexts
 
 
@@ -250,23 +219,48 @@ class LongDocPermutatorWorkload(BaseWorkload):
         stats_collector: StatsCollector,
         progress_monitor: ProgressMonitor,
         seed: int = 42,
+        model_name: str | None = None,
     ) -> None:
         super().__init__(request_sender, stats_collector, progress_monitor)
         self._config = config
         self._seed = seed
 
-        vocab_pool = _generate_vocab_pool(config.vocab_size, seed=seed)
+        # The configured lengths are exact token counts, which is only
+        # meaningful against the tokenizer the engine actually uses.  Without
+        # one this workload would silently emit prompts several times larger
+        # than requested, so refuse to run rather than produce numbers that
+        # describe a different operating point than the flags claim.
+        tokenizer = try_load_tokenizer(model_name)
+        if tokenizer is None:
+            raise ValueError(
+                "long-doc-permutator needs a tokenizer to size its contexts "
+                f"in tokens, but none could be loaded for model {model_name!r} "
+                "(auto-detected from the engine when --model is omitted). "
+                "Pass --model with a HuggingFace repo ID or a local path, "
+                "e.g. --model openai/gpt-oss-20b, and make sure transformers "
+                "is installed."
+            )
+
+        pool = build_single_token_pool(tokenizer, config.vocab_size, seed=seed)
         self._system_prompt = _generate_system_prompt(
-            config.system_prompt_length, seed=seed
+            config.system_prompt_length, pool, seed=seed
         )
         self._contexts = _generate_contexts(
-            config.num_contexts, config.context_length, vocab_pool, seed=seed + 1
+            config.num_contexts, config.context_length, pool, seed=seed + 1
         )
         self._permutations = _enumerate_permutations(
             config.num_contexts, config.num_permutations, seed=seed
         )
         self._request_list = self._build_request_list()
         self._request_index = 0
+
+        # Measured rather than derived: the per-message totals are exact by
+        # construction, but joining contexts adds separator tokens whose
+        # count is tokenizer-specific.
+        self._tokens_per_request = sum(
+            len(tokenizer.encode(m["content"], add_special_tokens=False))
+            for m in self._request_list[0][0]
+        )
 
         self._semaphore = asyncio.Semaphore(config.num_inflight_requests)
         self._pending_tasks: set[asyncio.Task] = set()
@@ -297,6 +291,7 @@ class LongDocPermutatorWorkload(BaseWorkload):
             f"  Permutations:        {Y}{actual_perms}{R} "
             f"(of {math.factorial(c.num_contexts)} possible)\n"
             f"  Total requests:      {Y}{total}{R}\n"
+            f"  Tokens per request:  {Y}{self._tokens_per_request}{R} (measured)\n"
             f"  Vocab size:          {Y}{c.vocab_size}{R}\n"
             f"  Max inflight:        {Y}{c.num_inflight_requests}{R}\n"
             f"{B}{'═' * 50}{R}"

--- a/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/prefix_suffix_tuner.py
@@ -133,6 +133,7 @@ import random
 from lmcache.cli.commands.bench.engine_bench.progress import ProgressMonitor
 from lmcache.cli.commands.bench.engine_bench.request_sender import RequestSender
 from lmcache.cli.commands.bench.engine_bench.stats import StatsCollector
+from lmcache.cli.commands.bench.engine_bench.tokenizers import try_load_tokenizer
 from lmcache.cli.commands.bench.engine_bench.workloads.base import BaseWorkload
 from lmcache.logging import init_logger
 
@@ -309,38 +310,6 @@ class PrefixSuffixTunerConfig:
 # ---------------------------------------------------------------------------
 
 
-def _try_load_tokenizer(model_name: str | None):
-    """Best-effort load of the model's tokenizer.
-
-    Used to generate body content as random valid token-IDs, then decoded
-    back to text — guaranteeing both (a) configured token counts ≈ actual
-    tokens at the model and (b) different content per call site, so chunk
-    content-hashes don't collide across prefixes (which would inflate the
-    LMCache hit rate even in non-blend mode).
-
-    Returns ``None`` if ``transformers`` isn't installed or the tokenizer
-    can't be loaded; callers fall back to the deterministic ``"hi"``
-    filler in that case.
-    """
-    if model_name is None:
-        return None
-    try:
-        # Third Party
-        from transformers import AutoTokenizer
-    except ImportError:
-        logger.warning("transformers not available; falling back to 'hi' body filler")
-        return None
-    try:
-        return AutoTokenizer.from_pretrained(model_name)
-    except Exception as e:  # noqa: BLE001
-        logger.warning(
-            "Could not load tokenizer for %s (%s); falling back to 'hi' filler",
-            model_name,
-            e,
-        )
-        return None
-
-
 def _generate_random_body(num_tokens: int, tokenizer, rng: random.Random) -> str:
     """Build a body of ``num_tokens`` BPE tokens of unique random content.
 
@@ -463,7 +432,7 @@ class PrefixSuffixTunerWorkload(BaseWorkload):
         # prefix so non-blend cache hit-rate metrics are not inflated by
         # chunk content-hash collisions across prefixes.  Falls back to
         # ``"hi"`` filler if transformers / the tokenizer isn't loadable.
-        self._tokenizer = _try_load_tokenizer(model_name)
+        self._tokenizer = try_load_tokenizer(model_name)
 
         # Each prefix gets its own RNG state so per-prefix bodies differ.
         # Constant offsets keep reproducibility while leaving room for the

--- a/tests/cli/commands/bench/engine_bench/conftest.py
+++ b/tests/cli/commands/bench/engine_bench/conftest.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for engine-benchmark tests."""
+
+# Third Party
+import pytest
+
+# Local
+from .fake_tokenizer import FakeTokenizer, make_fake_tokenizer
+
+
+@pytest.fixture
+def fake_tokenizer() -> FakeTokenizer:
+    """A tokenizer stand-in with plenty of single-token words."""
+    return make_fake_tokenizer()

--- a/tests/cli/commands/bench/engine_bench/fake_tokenizer.py
+++ b/tests/cli/commands/bench/engine_bench/fake_tokenizer.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A tokenizer stand-in for engine-benchmark tests.
+
+Workloads that size their prompts in tokens need a tokenizer.  Loading a
+real one would pull in ``transformers`` and hit the network, so these
+tests use a stand-in that reproduces the one property the workloads rely
+on: GPT-style pre-tokenization, where a leading space binds to the
+following word and each ``" word"`` piece is segmented independently of
+its neighbours.
+"""
+
+# Standard
+import re
+
+# Newlines are their own piece; everything else is a run of non-space
+# characters plus the single space in front of it.
+_PIECE_RE = re.compile(r"\n+| ?[^\s]+")
+
+
+class FakeTokenizer:
+    """Minimal HuggingFace-tokenizer stand-in for offline tests."""
+
+    def __init__(
+        self,
+        words: list[str],
+        extra_tokens: tuple[str, ...] = ("\n\n", " Capitalized", " digit9"),
+        split_words: tuple[str, ...] = (),
+        marker: str = " ",
+        space_is_token: bool = False,
+    ) -> None:
+        """Build a vocabulary from ``words`` plus some unusable entries.
+
+        Args:
+            words: Words that become single ``" word"`` tokens.
+            extra_tokens: Literal token texts a pool builder must reject
+                (newlines, capitals, digits).
+            split_words: Words present in the vocabulary that nonetheless
+                re-encode to two tokens, exercising round-trip checks.
+            marker: How a vocabulary key spells "this token begins a word".
+                ``" "`` models byte-level BPE, whose keys survive
+                ``decode()``; ``"▁"`` models SentencePiece, whose keys do
+                not — ``decode()`` drops the marker instead of turning it
+                back into a space.
+            space_is_token: Model a tokenizer (Phi-3) that emits a standalone
+                token for an explicit leading space, so prefixing a word with
+                one costs two tokens rather than one.
+        """
+        self._marker = marker
+        self._space_is_token = space_is_token
+        self._id_to_text: dict[int, str] = {}
+        for i, word in enumerate(words):
+            self._id_to_text[i] = f" {word}"
+        for j, text in enumerate(extra_tokens, start=len(words)):
+            self._id_to_text[j] = text
+        if space_is_token:
+            self._id_to_text[len(self._id_to_text)] = " "
+        self._text_to_id = {t: i for i, t in self._id_to_text.items()}
+        self._split = {f" {w}" for w in split_words}
+        self.all_special_ids: list[int] = []
+
+    def get_vocab(self) -> dict[str, int]:
+        return {
+            (self._marker + t[1:] if t.startswith(" ") else t): i
+            for t, i in self._text_to_id.items()
+        }
+
+    def batch_decode(self, ids_list: list[list[int]]) -> list[str]:
+        return [self.decode(ids) for ids in ids_list]
+
+    def decode(self, ids: list[int], **_kwargs) -> str:
+        text = "".join(self._id_to_text[i] for i in ids)
+        if self._marker != " ":
+            # SentencePiece decoding drops the word-start marker rather than
+            # rendering it as a space.
+            text = text[1:] if text.startswith(" ") else text
+        return text
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        ids: list[int] = []
+        if self._space_is_token and text.startswith(" "):
+            ids.append(self._text_to_id[" "])
+            text = text[1:]
+        for piece in _PIECE_RE.findall(text):
+            if piece in self._split:
+                # Two tokens: the vocabulary entry exists but does not
+                # survive a decode/encode round trip.
+                ids.extend([self._text_to_id[piece]] * 2)
+            elif piece in self._text_to_id:
+                ids.append(self._text_to_id[piece])
+            elif self._space_is_token and f" {piece}" in self._text_to_id:
+                # Opening the text with a bare word still makes it
+                # word-initial, so it costs the same single token.
+                ids.append(self._text_to_id[f" {piece}"])
+            else:
+                # Unknown text falls back to one token per character.
+                ids.extend(range(len(piece)))
+        return ids
+
+    def __call__(self, texts: list[str], add_special_tokens: bool = False) -> dict:
+        if not texts:
+            # Real HuggingFace tokenizers raise here rather than returning an
+            # empty batch; callers must not reach this with no candidates.
+            raise IndexError("list index out of range")
+        return {"input_ids": [self.encode(t) for t in texts]}
+
+
+def make_fake_tokenizer(num_words: int = 300, **kwargs) -> FakeTokenizer:
+    """Build a :class:`FakeTokenizer` with ``num_words`` usable words."""
+    words = [f"w{i:04d}word" for i in range(num_words)]
+    # Strip digits so the words pass a letters-only pool filter.
+    words = [w.translate(str.maketrans("0123456789", "abcdefghij")) for w in words]
+    return FakeTokenizer(words, **kwargs)

--- a/tests/cli/commands/bench/engine_bench/test_tokenizers.py
+++ b/tests/cli/commands/bench/engine_bench/test_tokenizers.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the shared tokenizer helpers."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.bench.engine_bench.tokenizers import (
+    build_single_token_pool,
+    try_load_tokenizer,
+)
+
+# Local
+from .fake_tokenizer import FakeTokenizer, make_fake_tokenizer
+
+
+class TestBuildSingleTokenPool:
+    def test_returns_requested_size(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 50)
+        assert len(pool.words) == 50
+
+    def test_all_entries_are_single_tokens(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 50)
+        for word in pool.words:
+            assert len(fake_tokenizer.encode(f" {word}")) == 1
+
+    def test_all_unique(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 100)
+        assert len(set(pool.words)) == 100
+
+    def test_rejects_non_letter_entries(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 100)
+        for word in pool.words:
+            assert word.isalpha() and word.islower()
+
+    def test_rejects_words_failing_round_trip(self) -> None:
+        """A vocabulary entry that re-encodes to two tokens is unusable."""
+        tokenizer = make_fake_tokenizer(20, split_words=("waaaaword",))
+        pool = build_single_token_pool(tokenizer, 19)
+        assert "waaaaword" not in pool.words
+
+    def test_deterministic(self, fake_tokenizer: FakeTokenizer) -> None:
+        assert build_single_token_pool(fake_tokenizer, 30, seed=7) == (
+            build_single_token_pool(fake_tokenizer, 30, seed=7)
+        )
+        assert build_single_token_pool(fake_tokenizer, 30, seed=7).words == (
+            build_single_token_pool(fake_tokenizer, 30, seed=7).words
+        )
+
+    def test_different_seeds_differ(self, fake_tokenizer: FakeTokenizer) -> None:
+        assert build_single_token_pool(fake_tokenizer, 30, seed=1) != (
+            build_single_token_pool(fake_tokenizer, 30, seed=2)
+        )
+
+    def test_raises_when_pool_too_small(self, fake_tokenizer: FakeTokenizer) -> None:
+        with pytest.raises(ValueError, match="stay a\\s+single token"):
+            build_single_token_pool(fake_tokenizer, 10_000)
+
+    def test_supports_sentencepiece_vocabularies(self) -> None:
+        """SentencePiece keys must be read as keys, not via ``decode()``.
+
+        ``decode()`` drops the ``▁`` word-start marker, so a decode-based
+        filter finds no candidates at all on these models.
+        """
+        tokenizer = make_fake_tokenizer(100, marker="▁")
+        pool = build_single_token_pool(tokenizer, 50)
+        assert len(pool.words) == 50
+        assert len(tokenizer.encode(pool.join(pool.words))) == 50
+
+    def test_falls_back_to_separator_convention(self) -> None:
+        """A tokenizer may charge for an explicit leading space (Phi-3).
+
+        Prefixing every word then costs two tokens each, so the pool must
+        separate the words instead and open the text with a letter.
+        """
+        tokenizer = make_fake_tokenizer(100, marker="▁", space_is_token=True)
+        pool = build_single_token_pool(tokenizer, 50)
+        assert pool.leading_space is False
+        assert len(tokenizer.encode(pool.join(pool.words))) == 50
+
+    def test_raises_cleanly_when_no_candidates(self) -> None:
+        """No usable entries must give our error, not one from the tokenizer."""
+        tokenizer = FakeTokenizer([], extra_tokens=("\n\n", " Capitalized"))
+        with pytest.raises(ValueError, match="only 0 words"):
+            build_single_token_pool(tokenizer, 10)
+
+
+class TestTokenPoolJoin:
+    def test_token_count_equals_word_count(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 40)
+        assert len(fake_tokenizer.encode(pool.join(pool.words))) == 40
+
+    def test_every_word_carries_its_leading_space(
+        self, fake_tokenizer: FakeTokenizer
+    ) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 2)
+        assert pool.leading_space is True
+        assert pool.join(["alpha", "beta"]) == " alpha beta"
+
+    def test_separator_convention_omits_the_leading_space(self) -> None:
+        tokenizer = make_fake_tokenizer(100, marker="▁", space_is_token=True)
+        pool = build_single_token_pool(tokenizer, 50)
+        assert pool.join(["alpha", "beta"]) == "alpha beta"
+
+    def test_empty_input(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 2)
+        assert pool.join([]) == ""
+
+
+class TestTryLoadTokenizer:
+    def test_none_model_returns_none(self) -> None:
+        assert try_load_tokenizer(None) is None
+
+    def test_unloadable_model_returns_none(self) -> None:
+        assert try_load_tokenizer("/nonexistent/path/to/no/such/tokenizer") is None

--- a/tests/cli/commands/bench/engine_bench/workloads/test_long_doc_permutator.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_long_doc_permutator.py
@@ -2,7 +2,7 @@
 """Tests for long-doc-permutator workload config and workload."""
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import asyncio
 import math
 import time
@@ -12,14 +12,18 @@ import pytest
 
 # First Party
 from lmcache.cli.commands.bench.engine_bench.stats import RequestResult
+from lmcache.cli.commands.bench.engine_bench.tokenizers import build_single_token_pool
+from lmcache.cli.commands.bench.engine_bench.workloads import long_doc_permutator as ldp
 from lmcache.cli.commands.bench.engine_bench.workloads.long_doc_permutator import (
     LongDocPermutatorConfig,
     LongDocPermutatorWorkload,
     _enumerate_permutations,
     _generate_contexts,
     _generate_system_prompt,
-    _generate_vocab_pool,
 )
+
+# Local
+from ..fake_tokenizer import FakeTokenizer, make_fake_tokenizer
 
 # ---------------------------------------------------------------------------
 # LongDocPermutatorConfig — direct construction
@@ -118,72 +122,50 @@ class TestLongDocPermutatorConfigResolve:
 # ---------------------------------------------------------------------------
 
 
-class TestGenerateVocabPool:
-    def test_returns_correct_size(self) -> None:
-        pool = _generate_vocab_pool(100)
-        assert len(pool) == 100
-
-    def test_all_unique(self) -> None:
-        pool = _generate_vocab_pool(200)
-        assert len(pool) == len(set(pool))
-
-    def test_deterministic(self) -> None:
-        pool1 = _generate_vocab_pool(50, seed=42)
-        pool2 = _generate_vocab_pool(50, seed=42)
-        assert pool1 == pool2
-
-    def test_different_seeds_differ(self) -> None:
-        pool1 = _generate_vocab_pool(50, seed=1)
-        pool2 = _generate_vocab_pool(50, seed=2)
-        assert pool1 != pool2
-
-    def test_returns_sorted(self) -> None:
-        pool = _generate_vocab_pool(100)
-        assert pool == sorted(pool)
-
-
 class TestGenerateSystemPrompt:
-    def test_empty_for_zero_length(self) -> None:
-        assert _generate_system_prompt(0) == ""
+    def test_empty_for_zero_length(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 100)
+        assert _generate_system_prompt(0, pool) == ""
 
-    def test_approximate_length(self) -> None:
-        prompt = _generate_system_prompt(50)
-        # Space-separated words → len(words) == length
-        assert len(prompt.split()) == 50
+    def test_exact_token_length(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 100)
+        prompt = _generate_system_prompt(50, pool)
+        assert len(fake_tokenizer.encode(prompt)) == 50
 
-    def test_deterministic(self) -> None:
-        p1 = _generate_system_prompt(30, seed=42)
-        p2 = _generate_system_prompt(30, seed=42)
-        assert p1 == p2
+    def test_deterministic(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 100)
+        assert _generate_system_prompt(30, pool, seed=42) == (
+            _generate_system_prompt(30, pool, seed=42)
+        )
 
-    def test_different_seeds_differ(self) -> None:
-        p1 = _generate_system_prompt(30, seed=1)
-        p2 = _generate_system_prompt(30, seed=2)
-        assert p1 != p2
+    def test_different_seeds_differ(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 100)
+        assert _generate_system_prompt(30, pool, seed=1) != (
+            _generate_system_prompt(30, pool, seed=2)
+        )
 
 
 class TestGenerateContexts:
-    def test_correct_count(self) -> None:
-        pool = _generate_vocab_pool(200)
+    def test_correct_count(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 200)
         contexts = _generate_contexts(4, 50, pool)
         assert len(contexts) == 4
 
-    def test_approximate_length(self) -> None:
-        pool = _generate_vocab_pool(200)
-        contexts = _generate_contexts(3, 100, pool)
-        for ctx in contexts:
-            assert len(ctx.split()) == 100
+    def test_exact_token_length(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 200)
+        for ctx in _generate_contexts(3, 100, pool):
+            assert len(fake_tokenizer.encode(ctx)) == 100
 
-    def test_contexts_are_unique(self) -> None:
-        pool = _generate_vocab_pool(500)
+    def test_contexts_are_unique(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 250)
         contexts = _generate_contexts(5, 200, pool)
         assert len(set(contexts)) == 5
 
-    def test_deterministic(self) -> None:
-        pool = _generate_vocab_pool(200, seed=42)
-        c1 = _generate_contexts(3, 50, pool, seed=10)
-        c2 = _generate_contexts(3, 50, pool, seed=10)
-        assert c1 == c2
+    def test_deterministic(self, fake_tokenizer: FakeTokenizer) -> None:
+        pool = build_single_token_pool(fake_tokenizer, 200)
+        assert _generate_contexts(3, 50, pool, seed=10) == (
+            _generate_contexts(3, 50, pool, seed=10)
+        )
 
 
 class TestEnumeratePermutations:
@@ -261,19 +243,24 @@ def _make_mock_sender() -> MagicMock:
 def _make_workload(
     config: LongDocPermutatorConfig | None = None,
     seed: int = 42,
+    tokenizer: FakeTokenizer | None = None,
 ) -> tuple[LongDocPermutatorWorkload, MagicMock, MagicMock, MagicMock]:
     if config is None:
         config = _make_config()
+    if tokenizer is None:
+        tokenizer = make_fake_tokenizer()
     sender = _make_mock_sender()
     collector = MagicMock()
     monitor = MagicMock()
-    workload = LongDocPermutatorWorkload(
-        config,
-        sender,
-        collector,
-        monitor,
-        seed=seed,
-    )
+    with patch.object(ldp, "try_load_tokenizer", return_value=tokenizer):
+        workload = LongDocPermutatorWorkload(
+            config,
+            sender,
+            collector,
+            monitor,
+            seed=seed,
+            model_name="fake-model",
+        )
     return workload, sender, collector, monitor
 
 
@@ -285,8 +272,28 @@ def _make_workload(
 class TestLongDocPermutatorWorkloadInit:
     def test_system_prompt_built(self) -> None:
         cfg = _make_config(system_prompt_length=20)
-        w, *_ = _make_workload(cfg)
-        assert len(w._system_prompt.split()) == 20
+        tokenizer = make_fake_tokenizer()
+        w, *_ = _make_workload(cfg, tokenizer=tokenizer)
+        assert len(tokenizer.encode(w._system_prompt)) == 20
+
+    def test_contexts_have_exact_token_length(self) -> None:
+        cfg = _make_config(num_contexts=3, context_length=25)
+        tokenizer = make_fake_tokenizer()
+        w, *_ = _make_workload(cfg, tokenizer=tokenizer)
+        for ctx in w._contexts:
+            assert len(tokenizer.encode(ctx)) == 25
+
+    def test_raises_without_tokenizer(self) -> None:
+        """A tokenizer is required: the length flags are token counts."""
+        with patch.object(ldp, "try_load_tokenizer", return_value=None):
+            with pytest.raises(ValueError, match="needs a tokenizer"):
+                LongDocPermutatorWorkload(
+                    _make_config(),
+                    _make_mock_sender(),
+                    MagicMock(),
+                    MagicMock(),
+                    model_name=None,
+                )
 
     def test_system_prompt_empty_when_zero(self) -> None:
         cfg = _make_config(system_prompt_length=0)

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -329,8 +329,8 @@ class TestPrefixSuffixTunerData:
 
         fake_tok = MagicMock()
         fake_tok.decode = lambda ids, **kw: " ".join(f"id{i}" for i in ids)
-        original = psf._try_load_tokenizer
-        psf._try_load_tokenizer = lambda model_name: fake_tok
+        original = psf.try_load_tokenizer
+        psf.try_load_tokenizer = lambda model_name: fake_tok
         try:
             cfg = _make_workload_config(num_prefixes=8)
             sender = _make_mock_sender()
@@ -340,7 +340,7 @@ class TestPrefixSuffixTunerData:
                 cfg, sender, collector, monitor, seed=42, model_name="mock"
             )
         finally:
-            psf._try_load_tokenizer = original
+            psf.try_load_tokenizer = original
 
         bodies = [p.split(" ", 1)[1] for p in w._prefixes]
         # All 8 prefix bodies should be distinct token-id sequences.


### PR DESCRIPTION
**What this PR does / why we need it**:

`--ldp-context-length` and `--ldp-system-prompt-length` are documented as token
counts, but `long-doc-permutator` spent them as **word** counts: it sampled
`length` pseudo-words from a synthetic vocabulary. Each pseudo-word carries an
incrementing numeric suffix (`babazuz7151`), so it costs several BPE tokens —
and the factor is tokenizer-specific, so identical flags produce differently
sized prompts on different models.

Measured against `openai/gpt-oss-20b`:

```
lmcache bench engine --workload long-doc-permutator \
  --ldp-num-contexts 4 --ldp-context-length 4500 \
  --ldp-system-prompt-length 1000 --ldp-num-permutations 24
```

| | requested | actually sent |
|---|---|---|
| per request | 19,000 | **74,470** (3.92x) |
| whole run | 456,000 | **1,787,280** |

The expansion factor is not a constant: gpt-oss-20b sees 3.92x, Qwen3.6 sees
6.2x. So blend-vs-baseline runs are comparing at a ~4x larger operating point
than their flags describe, the comparison is not portable across models, and a
context length that looks safely inside `--max-model-len` can overflow it.

**The fix.** Build context text from words that each cost exactly one token
under the model's tokenizer, and that each begin a word. Such a token is
segmented independently of its neighbours, so N words is exactly N tokens
whichever order a permutation puts them in. The same flags now produce 4,500
tokens per context.

Candidates come from the vocabulary's *keys*, not from `decode()` output.
SentencePiece decodes `▁the` to `"the"`, dropping the very marker that
identifies a word start, so a decode-based filter finds nothing at all on
Llama-family tokenizers. Each candidate is then verified by encoding it as it
will appear in a prompt, under whichever joining convention that tokenizer
makes exact — a leading space per word, or plain separators for tokenizers that
charge a token for an explicit leading space (Phi-3). The pool carries its
convention, so the two cannot be separated, and the joined total is checked
before use.

Exercised on 18 tokenizers; 4,500 pool words encode to exactly 4,500 tokens,
and stay exact after a shuffle, on all but WordPiece:

| family | tokenizers | join | result |
|---|---|---|---|
| byte-level BPE | gpt-oss-20b, gpt2, Qwen2.5, Qwen3, Llama-3.1, falcon, gpt-neox, opt, phi-2, starcoder2, deepseek-coder | leading space | exact |
| SentencePiece | Llama-2, TinyLlama, Yi, flan-t5, xlm-roberta | leading space | exact |
| SentencePiece, space is a token | Phi-3-mini | separator | exact |
| WordPiece | bert-base-uncased | — | rejected: marks continuations (`##ing`), not word starts |

Verified end-to-end against vLLM 0.26.0 + `openai/gpt-oss-20b`, reading
`num_input_tokens` out of `bench_results.csv`:

| `-n 3 --ldp-context-length 2000 --ldp-system-prompt-length 500` | requested | `num_input_tokens` | TTFT |
|---|---|---|---|
| before | 6,500 | 24,916 (3.83x) | 1.29 s |
| after | 6,500 | **6,576** | 0.21 s |

The residual +76 is the harmony chat template (+74) plus the two `\n\n`
separators joining the three contexts into one user message — i.e. everything
the workload itself controls is now exact.

**Special notes for your reviewers**:

**This makes a tokenizer mandatory for `long-doc-permutator`** — the one
behaviour change a user can notice. A length expressed in tokens cannot be
honoured without a tokenizer, and neither text-level fallback works for *this*
workload: pseudo-words miss the count (that is the bug), and uniform filler
emits identical contexts, which collapses the blend hit rate the workload
exists to measure. So the workload now fails with the flag to set:

```
long-doc-permutator needs a tokenizer to size its contexts in tokens, but none
could be loaded for model 'not-a-real-model' (auto-detected from the engine
when --model is omitted). Pass --model with a HuggingFace repo ID or a local
path, e.g. --model openai/gpt-oss-20b, and make sure transformers is installed.
```

In the common case nothing changes: `--model` is auto-detected from the engine,
and the tokenizer loads.

Also in this PR:

- `try_load_tokenizer` is extracted into `engine_bench/tokenizers.py`, shared
  with `prefix-suffix-tuner`, next to the new single-token pool builder. That
  is the only change to `prefix-suffix-tuner`: its behaviour is untouched, it
  keeps its `"hi"`-filler fallback.
- Tests use an offline tokenizer stand-in rather than downloading a real one.
  The assertions that pinned the old behaviour (`len(ctx.split()) == length`)
  now count tokens, and fail against the old generator — under the stand-in a
  context of 100 requested words costs roughly ten times that many tokens.

Not addressed here, noted for a follow-up: `--tokens-per-gb-kvcache` /
`--lmcache-url` are required for every workload even though only KV-sizing
needs them.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests