### PR TITLE
fix(vllm): keep multimodal identifiers out of a 16-bit collision space (#4086)

### DIFF
--- a/lmcache/integration/vllm/tests/test_mm_hash_utils.py
+++ b/lmcache/integration/vllm/tests/test_mm_hash_utils.py
@@ -8,6 +8,7 @@ import torch
 # First Party
 from lmcache.integration.vllm.utils import (
     apply_mm_hashes_to_token_ids,
+    hex_hash_to_int,
     hex_hash_to_int16,
 )
 
@@ -78,7 +79,7 @@ def test_apply_mm_hashes_to_token_ids_handles_non_hex_mm_hash() -> None:
     mm_positions = [DummyPlaceholderRange(offset=2, length=4)]
 
     out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
-    expected_val = hex_hash_to_int16(mm_hashes[0])
+    expected_val = hex_hash_to_int(mm_hashes[0])
     assert out[2:6].tolist() == [expected_val] * 4
 
 
@@ -102,11 +103,44 @@ def test_apply_mm_hashes_to_token_ids_multiple_placeholders_and_length_mismatch(
     ]
 
     out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
-    v0 = hex_hash_to_int16(mm_hashes[0])
-    v1 = hex_hash_to_int16(mm_hashes[1])
+    v0 = hex_hash_to_int(mm_hashes[0])
+    v1 = hex_hash_to_int(mm_hashes[1])
 
     assert out[0:3].tolist() == [v0] * 3
     assert out[5:9].tolist() == [v1] * 4
     # Other regions remain unchanged.
     assert out[3:5].tolist() == [0, 0]
     assert out[9:12].tolist() == [0, 0, 0]
+
+
+def test_apply_mm_hashes_keeps_identifiers_that_share_their_low_16_bits_apart() -> None:
+    # Two distinct multimodal identifiers whose hex digests agree on the last
+    # four hex digits. Truncating to 16 bits maps them onto the same filler
+    # token, so two images sharing a prompt would hash to the same chunk key
+    # and one request would be served the other's KV cache.
+    hash_a = "d34dd8790f1c4b0a9e6b2c5f8a1d3e7b4c9f0a2d6e8b1c3f5a7d9e0b2c4f6a8d"
+    hash_b = "7a65eaf5c2b8d4e60193f7a2c5b8e1d40a6f3c9b2e5d8a1f4c7b0e3d6a9f6a8d"
+    assert hash_a != hash_b
+    assert hex_hash_to_int16(hash_a) == hex_hash_to_int16(hash_b)
+
+    mm_positions = [DummyPlaceholderRange(offset=1, length=3)]
+    out_a = apply_mm_hashes_to_token_ids(
+        torch.zeros(6, dtype=torch.long), [hash_a], mm_positions
+    )
+    out_b = apply_mm_hashes_to_token_ids(
+        torch.zeros(6, dtype=torch.long), [hash_b], mm_positions
+    )
+    assert out_a.tolist() != out_b.tolist()
+
+
+def test_hex_hash_to_int_stays_within_the_signed_64_bit_range() -> None:
+    identifiers = [
+        "d34dd8790f1c4b0a9e6b2c5f8a1d3e7b4c9f0a2d6e8b1c3f5a7d9e0b2c4f6a8d",
+        "chatcmpl-a2a48871c4aad192-image-0",
+        "0x" + "f" * 64,
+        "",
+    ]
+    for identifier in identifiers:
+        value = hex_hash_to_int(identifier)
+        assert 0 <= value < 2**63
+        assert value == hex_hash_to_int(identifier)

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -140,9 +140,17 @@ def create_lmcache_ec_config() -> LMCacheEngineConfig:
     return load_ec_engine_config(base_config=lmcache_get_or_create_config())
 
 
-def hex_hash_to_int16(s: str) -> int:
+# Number of bits kept from a multimodal identifier when it is injected into
+# the token-id stream. The injected value only ever feeds the chunk hash, so
+# the sole requirement is that two distinct identifiers stay distinct; 62 bits
+# keeps the value comfortably inside the signed 64-bit range used by the token
+# tensors while making a collision astronomically unlikely.
+MM_HASH_NUM_BITS = 62
+
+
+def hex_hash_to_int(s: str, num_bits: int = MM_HASH_NUM_BITS) -> int:
     """
-    Convert a hash identifier into a 16-bit integer.
+    Convert a hash identifier into an integer of at most ``num_bits`` bits.
 
     Historically, LMCache expected multimodal identifiers to be hex strings.
     In practice (e.g., OpenAI-style multimodal requests), identifiers may be
@@ -153,19 +161,31 @@ def hex_hash_to_int16(s: str) -> int:
     # Be defensive: vLLM may pass non-string identifiers.
     s = "" if s is None else str(s)
     s_stripped = s.strip()
+    mask = (1 << num_bits) - 1
 
     # Fast-path: pure hex (optionally 0x-prefixed).
     hex_part = s_stripped[2:] if s_stripped.lower().startswith("0x") else s_stripped
     if hex_part and all(c in string.hexdigits for c in hex_part):
         try:
-            return int(hex_part, 16) & 0xFFFF
+            return int(hex_part, 16) & mask
         except ValueError:
             # Extremely unlikely (e.g., oversized/odd formatting); fall back to hashing.
             pass
 
-    # Fallback: stable 16-bit value derived from the full identifier string.
+    # Fallback: stable value derived from the full identifier string.
     digest = hashlib.sha256(s_stripped.encode("utf-8")).digest()
-    return int.from_bytes(digest[:2], byteorder="big", signed=False)
+    num_bytes = (num_bits + 7) // 8
+    return int.from_bytes(digest[:num_bytes], byteorder="big", signed=False) & mask
+
+
+def hex_hash_to_int16(s: str) -> int:
+    """
+    Convert a hash identifier into a 16-bit integer.
+
+    Kept for backwards compatibility; 16 bits are too few to identify
+    multimodal content, so use :func:`hex_hash_to_int` for that.
+    """
+    return hex_hash_to_int(s, num_bits=16)
 
 
 def apply_mm_hashes_to_token_ids(
@@ -183,7 +203,7 @@ def apply_mm_hashes_to_token_ids(
         if start >= n:
             continue
         end = min(start + length, n)
-        token_ids[start:end] = hex_hash_to_int16(hash_str)
+        token_ids[start:end] = hex_hash_to_int(hash_str)
     return token_ids
 
 


### PR DESCRIPTION
## Description

Fixes #4086.

`apply_mm_hashes_to_token_ids()` overwrites each multimodal placeholder span with one integer derived from that item's identifier, so the chunk hash — and therefore the cache key — can tell apart two requests that differ only by their image. `hex_hash_to_int16()` reduced that identifier to **16 bits**, so an entire image contributed only 65536 possible values.

Two identifiers whose digests agree on their last four hex digits become indistinguishable. A request that shares its prompt with an earlier one but carries a different image then hits the earlier request's KV cache, and the model describes an image it never saw — which is exactly the "hybrid of image A and image B" symptom in the issue. The per-pair odds are 1/65536, but they compound over the lifetime of a server, and nothing reports the collision: the read looks like an ordinary prefix hit.

## Change

* `hex_hash_to_int(s, num_bits=MM_HASH_NUM_BITS)` — same hex/SHA-256 parsing as before, parameterised on width. `MM_HASH_NUM_BITS = 62` keeps the value inside the signed 64-bit range the token tensors already use.
* `apply_mm_hashes_to_token_ids()` injects the wide value.
* `hex_hash_to_int16()` stays as a thin wrapper, so existing callers and its own tests are unchanged.

Both the vLLM v1 adapter (`get_num_new_matched_tokens`, `ReqMeta.from_request_tracker`) and the MP connector go through `apply_mm_hashes_to_token_ids()`, so the single change covers both paths. The injected value only ever feeds `TokenDatabase._hash_tokens()`, which hashes Python ints — nothing indexes a vocabulary with it.

**Compatibility:** cache keys for multimodal requests change, so multimodal entries stored by an older version miss once and are repopulated. Text-only requests are unaffected, and identifiers that already fit in 16 bits (e.g. the `"0xabcd"` fixtures in `tests/v1/test_mp_connector_mm_keys.py`) keep their current value.

## Verification

The two identifiers below are distinct but agree on their last four hex digits:

```
old (16-bit): A=27277 B=27277  collide=True
new (62-bit): A=1908855587900189325 B=899328207535172237  collide=False
```

`lmcache/integration/vllm/tests/test_mm_hash_utils.py` gains a regression test for that collision plus a range check on `hex_hash_to_int`. The two existing tests that pinned the injected fill to the 16-bit value now reference `hex_hash_to_int` instead — their assertions are unchanged in shape, only the helper they compare against moved. The four tests that cover `hex_hash_to_int16` itself are untouched and still pass.

Run against an extracted copy of both functions (old and new) with the module's own test file:

```
new code + updated tests: 9 passed
new code + original tests: 5 passed, 2 failed (the two fill-value assertions this PR updates)
```

`uvx ruff@0.11.7 format --diff` and `uvx ruff@0.11.7 check` are clean against the repo's `pyproject.toml`.

## Note on scope

@ApostaC noted on the issue that this code path is non-MP mode and slated for deprecation, but that a fix would be welcome and merged. This is that fix, kept to the collision itself — it does not touch `extra_keys` plumbing or MP-mode multimodal support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
