### PR TITLE
fix(core): page-align LazyMemoryAllocator's buffer for full-rate H2D DMA reads

### DIFF
--- a/lmcache/v1/memory_allocators/lazy_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/lazy_memory_allocator.py
@@ -109,9 +109,19 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             buf = arr_type.from_address(ptr)
             self._buffer = torch.frombuffer(buf, dtype=torch.uint8)
         else:
-            self._buffer = torch.empty(
-                self._final_size, dtype=torch.uint8, device="cpu", pin_memory=False
+            # torch's CPU allocator returns 64 B-aligned pointers (page + 64 B),
+            # but the GPU copy engine needs a 128 B-aligned source for full-rate
+            # DMA reads (~35% H2D loss otherwise); keep a page-aligned view.
+            self._raw_buffer = torch.empty(
+                self._final_size + AddressManager.ALIGN_BYTES,
+                dtype=torch.uint8,
+                device="cpu",
+                pin_memory=False,
             )
+            align_offset = (-self._raw_buffer.data_ptr()) % AddressManager.ALIGN_BYTES
+            self._buffer = self._raw_buffer[
+                align_offset : align_offset + self._final_size
+            ]
 
         # Pin the first `curr_size` bytes (aligned to the internal chunk size)
         self._pin_memory_chunk(0, self._curr_size)

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -19,6 +19,7 @@ from lmcache.v1.memory_allocators.paged_tensor_memory_allocator import (
 from lmcache.v1.memory_allocators.pin_memory_allocator import PinMemoryAllocator
 from lmcache.v1.memory_allocators.tensor_memory_allocator import TensorMemoryAllocator
 from lmcache.v1.memory_management import (
+    AddressManager,
     BytesBufferMemoryObj,
     MemoryFormat,
     MemoryObjMetadata,
@@ -695,6 +696,38 @@ class TestLazyMemoryAllocator:
         assert memory_obj is not None
         assert memory_obj.is_valid()
 
+        allocator.close()
+
+    def test_allocated_tensors_are_page_aligned(self, lazy_allocator_cls):
+        """Every allocation must be page-aligned for full-rate H2D DMA reads.
+
+        The GPU copy engine needs a 128 B-aligned source pointer to DMA-read
+        at full rate (a misaligned source costs ~35% of H2D bandwidth on the
+        retrieve path), while torch.empty CPU tensors land at page + 64 B.
+        The allocator page-aligns its pool base; combined with the
+        AddressManager.ALIGN_BYTES placement of objects within the pool,
+        every handed-out tensor must therefore be page-aligned.
+        """
+        allocator = lazy_allocator_cls(
+            init_size=self.INIT_SIZE,
+            final_size=self.FINAL_SIZE,
+        )
+
+        # Odd shapes exercise non-trivial offsets within the pool.
+        shapes = [
+            torch.Size([3, 5, 7]),
+            torch.Size([1000]),
+            torch.Size([513, 129]),
+        ]
+        memory_objs = []
+        for shape in shapes:
+            memory_obj = allocator.allocate(shape, torch.bfloat16)
+            assert memory_obj is not None
+            assert memory_obj.tensor is not None
+            assert memory_obj.tensor.data_ptr() % AddressManager.ALIGN_BYTES == 0
+            memory_objs.append(memory_obj)
+
+        allocator.batched_free(memory_objs)
         allocator.close()
 
     def test_allocate_returns_none_when_out_of_memory(self, lazy_allocator_cls):


### PR DESCRIPTION
## Summary

`LazyMemoryAllocator` (the default L1 allocator in MP mode since #2463) backs its pool with `torch.empty`, whose CPU pointers land at **page + 64 B** (torch's 64-byte CPU allocator). The GPU copy engine needs a **128 B-aligned source for full-rate DMA reads**, so every H2D copy out of the pool (the retrieve / TTFT-critical path) ran at ~2/3 of PCIe bandwidth: **~34.5 GB/s vs ~56.6 GB/s** on the test platform. DMA writes are insensitive to source alignment, which is why the store path (D2H) was never affected and the regression stayed invisible.

The fix is ~10 lines: over-allocate the pool by `AddressManager.ALIGN_BYTES` (4096) and hand out a page-aligned view, keeping the raw tensor alive. Since `AddressManager` already places every `MemoryObj` at `ALIGN_BYTES` multiples *relative to the pool base*, aligning the base fixes every allocation. Lazy growth, background chunked `cudaHostRegister`, and the chunk-aware memcpy are untouched.

## Root cause evidence

Offset sweep over a single anonymous mmap + `cuMemHostRegister` region, identical 96 × 36 MiB H2D loop (pure driver API), only the start offset varies:

| offset from page-aligned base | H2D GB/s |
|---|---|
| +0 / +128 / +256 / +512 / +4096 | 56.6–56.7 |
| +32 | 37.2 |
| **+64 (= every `torch.empty` CPU tensor)** | **37.3** |
| +192 | 40.4 |

⇒ requirement is `ptr % 128 == 0`. `cudaHostRegister` itself is innocent: page-aligned registered memory reaches the same 56.7 GB/s as `cudaHostAlloc`. (`--no-l1-use-lazy` sidestepped the issue only because `cudaHostAlloc` happens to return page-aligned pointers.)

## Measured impact (RTX PRO 6000 Blackwell, PCIe ceiling ≈56.7 GB/s, AMD EPYC, IOMMU on)

**Production copy helper** (`gpu_ops.lmcache_memcpy_async_h2d` over allocator-carved 36 MiB KV chunks): 34.6 → **56.1 GB/s**.

**Full vLLM + LMCache MP-server sweep** (Qwen3-8B, chunk 256, nsys-measured; unpatched vs patched, same command line):

| prompt tokens | H2D op GB/s | warm request wall |
|---|---|---|
| 4 096 | 34.7 → **56.6** | 0.098 → 0.090 s |
| 16 384 | 34.9 → **56.6** | 0.177 → **0.151 s** (−15%) |
| 30 000 | 36.6 → **56.6** | 0.268 → **0.223 s** (−17%) |

**`lmcache bench engine` (long-doc-qa, 12 docs × 40 000 tokens, serialized queries)**:

| metric | before | after |
|---|---|---|
| p50 TTFT | 279.5 ms | **215.1 ms (−23%)** |
| p99 TTFT | 291.0 ms | **219.2 ms (−24.7%)** |

D2H (store) throughput and cold-request walls are unchanged in every experiment, as alignment-insensitive DMA writes predict.

## Reproduction (the exact setup behind the bench numbers)

Start the MP cache server (`PYTHONHASHSEED` must be identical across all processes in MP mode):

```bash
PYTHONHASHSEED=0 lmcache server --host localhost --port 5559 --http-port 8082 \
    --l1-size-gb 88 --eviction-policy LRU --chunk-size 256
```

Start vLLM bound to it:

```bash
PYTHONHASHSEED=0 vllm serve /path/to/Qwen3-8B --served-model-name Qwen3-8B \
    --port 8002 --gpu-memory-utilization 0.3 \
    --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://localhost","lmcache.mp.port":5559}}'
```

Run the benchmark:

```bash
lmcache bench engine --engine-url http://localhost:8002 --model Qwen3-8B \
    --workload long-doc-qa --no-interactive \
    --tokens-per-gb-kvcache 6781 --kv-cache-volume 70.8 \
    --ldqa-document-length 40000 --ldqa-query-per-document 3 \
    --ldqa-num-inflight-requests 1 --ldqa-max-output-length 16 \
    --seed 42
```

Two knobs are deliberate:

- `--gpu-memory-utilization 0.3` keeps vLLM's GPU KV pool at ~1–2 documents, so the benchmark queries cannot be served from vLLM's own prefix cache and must re-load KV from LMCache L1 over H2D — the path under test. (`--kv-cache-volume 70.8` ⇒ 12 documents of 40 000 tokens ≈ 66 GiB of KV, far above the GPU pool.)
- 40 000-token documents (≈5.5 GiB KV each on Qwen3-8B) make TTFT copy-dominated, so the H2D rate shows up directly in p50 TTFT.

To A/B against the pre-fix allocator, run the same benchmark on a checkout with only `lmcache/v1/memory_allocators/lazy_memory_allocator.py` reverted (restart the server between runs; each run starts with an empty L1). Independent manual reruns of both arms reproduced the table above within ~3 ms (p50 281.2 → 218.3 ms).

## Test

Adds `test_allocated_tensors_are_page_aligned` to the existing `TestLazyMemoryAllocator` suite: allocates odd-shaped objects and asserts `tensor.data_ptr() % AddressManager.ALIGN_BYTES == 0` through the public interface. Verified it fails on the previous allocator (pool base at page + 64 B) and passes with the fix.

## Notes

- This closes the perf-validation gap tracked in #2379 ("End-to-end test to verify the performance" was still unchecked); the misalignment shipped silently when #2463 flipped the default on.
- Audited the other host buffers: `HostMemoryAllocator` / `AdHocMemoryAllocator` are pageable (not DMA-read directly by the copy engine), the devdax and NUMA paths are mmap-based (page-aligned), and `PinMemoryAllocator` uses `cudaHostAlloc` (page-aligned) — the lazy pool was the only affected one.
- Numbers are from one platform (Blackwell workstation GPU / EPYC / IOMMU on). The 128 B read-alignment cliff may differ elsewhere, but page-aligning the base is free and strictly safe.
