### PR TITLE
docs: daily drift check — multi-process mode (2026-08-04)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -121,13 +121,14 @@ Source: ``lmcache/v1/multiprocess/config.py``
        truncating the prefix at the gap. No effect for other engines. See
        :doc:`/mp/l2_storage/fault_inject` for a way to exercise it.
    * - ``--separate-object-groups`` / ``--no-separate-object-groups``
-     - ``True``
+     - ``False``
      - Split a hybrid model's kernel groups into one object group per
        cross-chunk attention window (full attention, each sliding-window
-       size, mamba/GDN) at KV-cache registration. On by default; pass
-       ``--no-separate-object-groups`` to keep all layers in a single
-       full-attention object group. Transparent to correctness; a non-hybrid
-       model always resolves to one object group. See :doc:`/mp/hybrid_models`.
+       size, mamba/GDN) at KV-cache registration. Off by default (all
+       layers share a single full-attention object group); pass
+       ``--separate-object-groups`` to opt in. Transparent to correctness;
+       a non-hybrid model always resolves to one object group. See
+       :doc:`/mp/hybrid_models`.
 
 Lookup Hash Logging
 -------------------

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -840,9 +840,10 @@ pinned keys from quota-based eviction. L2 pins are fleet-wide (per
 Local resolution requires the coordinator's ``chunk_size`` and
 ``hash_algorithm`` (see `Configuration`_) to match the MP servers' ``--chunk-size``
 / ``--hash-algorithm``; otherwise the resolved keys will not match what was
-stored and the pin protects nothing. It also requires the MP servers to be
-launched with ``--no-separate-object-groups`` (the coordinator resolves keys in
-a single object group).
+stored and the pin protects nothing. It also requires the MP servers to run
+with a single object group — the default (``--separate-object-groups`` off);
+if ``--separate-object-groups`` is enabled, the coordinator's single-group
+resolution will not match the stored keys.
 
 ``POST /cache/pins``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -110,19 +110,19 @@ Object-group separation
 
 At KV-cache registration LMCache buckets a hybrid model's layers into **object
 groups** — the unit it stores and retrieves as one object. By default
-(``--separate-object-groups``, on) each distinct cross-chunk attention window
-becomes its own object group: full-attention layers form one group, and each
-sliding-window size (mamba / GDN included) forms another. Pass
-``--no-separate-object-groups`` to keep every layer in a single full-attention
-object group instead (the previous behavior).
+(``--separate-object-groups``, off) every layer stays in a single
+full-attention object group. Pass ``--separate-object-groups`` to bucket each
+distinct cross-chunk attention window into its own object group: full-attention
+layers form one group, and each sliding-window size (mamba / GDN included)
+forms another.
 
 .. code-block:: bash
 
-   # default: one object group per attention window
+   # default: a single full-attention object group for all layers
    lmcache server --chunk-size 256 --l1-size-gb 100
 
-   # opt out: a single full-attention object group for all layers
-   lmcache server --chunk-size 256 --l1-size-gb 100 --no-separate-object-groups
+   # opt in: one object group per attention window
+   lmcache server --chunk-size 256 --l1-size-gb 100 --separate-object-groups
 
 The flag is transparent to correctness — prefix caching and KV reuse behave the
 same either way, and a non-hybrid model (a single attention behavior) always


### PR DESCRIPTION
## Summary

Daily automated docs-drift check found that the default value of the MP server flag `--separate-object-groups` was flipped in code but not in docs. Three English pages under `docs/source/mp/` still describe the pre-flip default and misdirect users about the out-of-the-box behavior.

### `docs/source/mp/`

- **`configuration.rst`** (flag table): default column read `True`; wording said "On by default; pass `--no-separate-object-groups` …". Now `False`, "Off by default (all layers share a single full-attention object group); pass `--separate-object-groups` to opt in."
- **`hybrid_models.rst`** ("Object-group separation" section, incl. two `lmcache server` examples): described the on-by-default behavior with `--no-separate-object-groups` as the opt-out and "previous behavior". Flipped: off-by-default single group is the current behavior, `--separate-object-groups` is the opt-in.
- **`coordinator.rst`** (pin/unpin local-resolution note): previously instructed operators to launch MP servers with `--no-separate-object-groups`. That flag is now the default; the note now warns that enabling `--separate-object-groups` will break the coordinator's single-group key resolution for pins.

### `docs/design/`

No drift detected in `docs/design/` for this flag (no references there).

## Evidence

Current code — `lmcache/v1/multiprocess/config.py` (upstream/dev @ `3b8093c`):

- Dataclass default: [`separate_object_groups: bool = False`](https://github.com/LMCache/LMCache/blob/3b8093cf8860a39d05937af915adfb5db493a047/lmcache/v1/multiprocess/config.py#L52-L55)
- Argparse default: [`default=False`](https://github.com/LMCache/LMCache/blob/3b8093cf8860a39d05937af915adfb5db493a047/lmcache/v1/multiprocess/config.py#L357-L363) with help text `(Default is False)`

Change that introduced the flip — PR [#3869](https://github.com/LMCache/LMCache/pull/3869) ([`75e6083`](https://github.com/LMCache/LMCache/commit/75e6083f12d6f08f84463c99932024e087656b64), "Prefetch sliding window 3/3"): flipped the dataclass and argparse defaults from `True` to `False` and updated the inline docstring/help, but did not touch `docs/source/mp/*.rst`.

Stale doc locations (before this PR):

- `docs/source/mp/configuration.rst` L123-L130 — default column shows `True`.
- `docs/source/mp/hybrid_models.rst` L108-L125 — "By default (`--separate-object-groups`, on)" + two examples using `--no-separate-object-groups` as the opt-out.
- `docs/source/mp/coordinator.rst` L840-L845 — "requires the MP servers to be launched with `--no-separate-object-groups`".

## Proposed fix

Already applied in this PR's diff (docs-only, 3 files, +18 / -16).

## Notes

- **Auto-generated by the daily drift-check routine** focused on multi-process mode. Human review is required before merge.
- **Docs-only:** no code files touched. If reviewers disagree with the code default change itself, that is a separate discussion — this PR only aligns the docs with the current code.
- **Chinese localization** (`docs/source/locale/zh_CN/…`) still references the old default and the pre-rename `--coordinator-l2-event-*` flag spellings (renamed in PR #4292, back-compat aliases added in PR #4395). These `.po` files are generated from the English sources; leaving them to the normal translation refresh.
- **Related MP change not requiring doc updates:** PR [#4395](https://github.com/LMCache/LMCache/pull/4395) ("Restore compat for renamed coordinator event flags") — the English MP docs already use the new `--coordinator-event-{reporting,flush-interval}` spellings introduced in PR #4292.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACY4t5V6ARPKxVEBYZ9vJH)_