### PR TITLE
fix(mp): back cupy stream with torch on ROCm to avoid cudaErrorInsufficientDriver

### DIFF
--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -11,6 +11,7 @@ This module provides GPU-side KV cache management functionality, including:
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 import array
+import functools
 
 # Third Party
 import torch
@@ -18,6 +19,7 @@ import torch
 if TYPE_CHECKING:
     # Third Party
     import cupy
+
 
 # First Party
 from lmcache import torch_dev
@@ -39,6 +41,66 @@ from lmcache.v1.multiprocess.group_view import (
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
 
 logger = init_logger(__name__)
+
+
+@functools.cache
+def _is_rocm() -> bool:
+    """Return ``True`` when the active PyTorch build targets ROCm/HIP.
+
+    On ROCm builds ``torch.version.hip`` is a version string; on CUDA
+    builds it is ``None``.  Cached so the check runs at most once.
+    """
+    return getattr(torch.version, "hip", None) is not None
+
+
+class _RocmTorchStreamAdapter:
+    """cupy.cuda.ExternalStream drop-in backed by a torch HIP stream.
+
+    LMCache uses ``cupy.cuda.ExternalStream`` purely as a thin handle
+    around an already-existing torch stream: it exposes ``.ptr`` (the
+    raw stream handle handed to native ``_lmc_ops`` recorders) and
+    ``launch_host_func`` (best-effort telemetry callbacks on the
+    event bus).  On AMD ROCm the cupy build shipped in the runtime is a
+    CUDA build and raises ``cudaErrorInsufficientDriver`` the moment any
+    of its runtime entry points (e.g. ``streamIsCapturing`` inside
+    ``launch_host_func``) is touched, which breaks context registration.
+
+    This adapter reproduces the small surface LMCache relies on using the
+    underlying torch stream, so no cupy runtime call is made on ROCm.  It
+    mirrors the synchronous-callback semantics already used by the
+    CPU-platform ``StubStream``.
+    """
+
+    def __init__(self, torch_stream: "torch.cuda.Stream") -> None:
+        self._torch_stream = torch_stream
+        # cupy's ``ExternalStream.ptr`` and torch's ``Stream.cuda_stream``
+        # are both the same underlying HIP stream handle, so native
+        # recorders that take a raw stream pointer accept either.
+        self.ptr = torch_stream.cuda_stream
+
+    def launch_host_func(self, func, *args, **kwargs) -> None:
+        """Run ``func`` synchronously (best-effort, never propagates).
+
+        ``cupy.cuda.Stream.launch_host_func`` schedules a host callback on
+        the stream's completion queue.  These callbacks are best-effort
+        telemetry, so invoking them synchronously is semantically safe.
+        """
+        try:
+            func(*args, **kwargs)
+        except Exception:  # noqa: BLE001 - callbacks must not disrupt transfer
+            pass
+
+    def synchronize(self) -> None:
+        self._torch_stream.synchronize()
+
+    def wait_event(self, event) -> None:
+        self._torch_stream.wait_event(event)
+
+    def wait_stream(self, stream) -> None:
+        self._torch_stream.wait_stream(stream)
+
+    def record_event(self, event=None):
+        return self._torch_stream.record_event(event)
 
 
 def unwrap_kv_cache_tensors(kv_caches: KVCache) -> list[torch.Tensor]:
@@ -418,12 +480,17 @@ class GPUCacheContext(BaseCacheContext):
         with torch_dev.stream(self.cuda_stream_):
             get_gds_context().register_gpu_buffer(self._temp_buffer.buffer)
 
-        # Third Party
-        import cupy
+        if _is_rocm():
+            # ROCm: cupy is a CUDA build here and raises
+            # cudaErrorInsufficientDriver; back the stream with torch.
+            self.cupy_stream_ = _RocmTorchStreamAdapter(self.cuda_stream_)
+        else:
+            # Third Party
+            import cupy
 
-        self.cupy_stream_: "cupy.cuda.Stream" = cupy.cuda.ExternalStream(
-            self.cuda_stream_.cuda_stream, self.device_.index
-        )
+            self.cupy_stream_ = cupy.cuda.ExternalStream(
+                self.cuda_stream_.cuda_stream, self.device_.index
+            )
 
         # Extra initialization
         self.cupy_stream_.launch_host_func(
@@ -561,12 +628,17 @@ class PlainGPUCacheContext:
 
         # GPU streams
         self._cuda_stream = torch_dev.Stream(device=self._device)
-        # Third Party
-        import cupy
+        if _is_rocm():
+            # ROCm: cupy is a CUDA build here and raises
+            # cudaErrorInsufficientDriver; back the stream with torch.
+            self._cupy_stream = _RocmTorchStreamAdapter(self._cuda_stream)
+        else:
+            # Third Party
+            import cupy
 
-        self._cupy_stream: "cupy.cuda.Stream" = cupy.cuda.ExternalStream(
-            self._cuda_stream.cuda_stream, self._device.index
-        )
+            self._cupy_stream = cupy.cuda.ExternalStream(
+                self._cuda_stream.cuda_stream, self._device.index
+            )
 
         # Extra initialization
         self._cupy_stream.launch_host_func(


### PR DESCRIPTION
## Problem

`GPUCacheContext` / `PlainGPUCacheContext` wrap their torch stream in a `cupy.cuda.ExternalStream`, using it only as a thin handle that exposes:
- `.ptr` — the raw stream handle passed to native `_lmc_ops` recorders
- `launch_host_func` — best-effort event-bus telemetry callbacks

On **AMD ROCm**, the cupy build present in the runtime is a **CUDA** build. The first cupy runtime entry point touched during KV-cache registration (`streamIsCapturing`, reached from inside `launch_host_func`) raises:

```
cupy_backends.cuda.api.runtime.CUDARuntimeError:
  cudaErrorInsufficientDriver: CUDA driver version is insufficient for CUDA runtime version
```

This aborts `REGISTER_KV_CACHE`, so the **default `lmcache_driven` transfer path is unusable on every ROCm deployment**.

### Traceback

```
File ".../lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py", line 878, in register_kv_cache
    cache_context = create_cache_context(...)
File ".../lmcache/v1/platform/cuda/cache_context.py", in __init__
    self.cupy_stream_.launch_host_func(...)
File "cupy/cuda/stream.pyx", ... in is_capturing
File "cupy_backends/cuda/api/runtime.pyx", line 146, in check_status
cupy_backends.cuda.api.runtime.CUDARuntimeError:
  cudaErrorInsufficientDriver: CUDA driver version is insufficient for CUDA runtime version
```

> Note: this is a **distinct** ROCm blocker from #4419. #4419 is the *retrieve*-path `Event.from_ipc_handle` deadlock; this one happens earlier, on the *register* path. Both must be fixed for `lmcache_driven` to work on ROCm.

## Fix

- Add a cached `_is_rocm()` helper (checks `torch.version.hip`).
- Add a small `_RocmTorchStreamAdapter` that reproduces the exact surface LMCache uses — `.ptr`, `launch_host_func`, `synchronize`, `wait_event`, `wait_stream`, `record_event` — directly on the underlying torch stream, so **no cupy runtime call is made on ROCm**.
  - `.ptr` maps to `torch_stream.cuda_stream`, which is the same underlying HIP stream handle cupy's `.ptr` would return, so native recorders accept it unchanged.
  - `launch_host_func` runs the callback synchronously — these callbacks are best-effort telemetry, so this is semantically safe. This mirrors the CPU-platform `StubStream` already in-tree (`lmcache/v1/platform/cpu/stub_cpu_device.py`).
- Guard both `GPUCacheContext.__init__` and `PlainGPUCacheContext.__init__` with `_is_rocm()`. **CUDA / non-ROCm paths are byte-for-byte unchanged** — the cupy branch only runs when `_is_rocm()` is `False`.

## Why this approach

`cupy_stream` is used across `blend.py`, `blend_v3.py`, `qstore.py` and `lmcache_driven_transfer.py`, not only for the init log. A minimal stub that implements just `.ptr` + `launch_host_func` would `AttributeError` on those paths, so the adapter implements the full surface. Alternatives considered and rejected:
- **Ship a ROCm cupy build** — cupy's ROCm support is weak and gfx942 wheels are not readily available; would add a heavy build/CI dependency.
- **Remove cupy entirely (also on CUDA)** — much larger change touching the NVIDIA hot path; out of scope for a bug fix.

## Verification

Tested on AMD MI300X (gfx942), ROCm 7.14, PyTorch 2.11, vLLM 0.23, DeepSeek-V2-Lite, **default `lmcache_driven`** transfer:

| | Before | After |
|---|---|---|
| `REGISTER_KV_CACHE` | ❌ `cudaErrorInsufficientDriver` | ✅ Registered KV cache, 27 layers |
| store / retrieve | N/A (never registered) | ✅ Stored 3584 in 0.065s / Retrieved 3584 in 0.030s |
| repeated request latency | N/A | 0.21s vs cold 0.89s (~4×) |
| GPU faults | aborts | 0 |

The change is contained to one file and has zero effect on CUDA builds.
