### PR TITLE
test: mock _make_event_handle in TestProcessRequestMultiWorker to fix XPU CI failure

### DIFF
--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -999,7 +999,18 @@ class TestProcessRequestMultiWorker:
                 )
             )
 
-        with patch.object(sv_helpers, "_call", side_effect=fake_call):
+        # ``_make_event_handle`` creates a real CUDA-IPC event via
+        # ``check_interprocess_event_support()``, which requires a
+        # backend that supports ``Event(interprocess=True)`` (e.g.
+        # CUDA). This test only exercises the STORE/RETRIEVE
+        # fan-out/dispatch logic, so stub it out to keep the test
+        # backend-agnostic -- it would otherwise fail on XPU/CPU-only
+        # runners with "Backend '<device>' does not support
+        # interprocess=True parameter for Events".
+        with (
+            patch.object(sv_helpers, "_call", side_effect=fake_call),
+            patch.object(sv_helpers, "_make_event_handle", return_value=b""),
+        ):
             _process_request(
                 client=None,  # type: ignore[arg-type]  # unused: _call mocked
                 seq_no=0,


### PR DESCRIPTION
## What this PR does

Fixes an XPU CI failure in `tests/cli/commands/bench/test_server_bench.py`
that is caused by a test bug, not a product bug.

`TestProcessRequestMultiWorker._run()` (covering
`test_mla_tp2_store_only_from_rank0` and
`test_non_mla_tp2_store_on_every_rank`) calls
`_process_request(use_gpu=True, use_handle=True)`, which exercises the
handle-based STORE/RETRIEVE path: `_send_store`/`_send_retrieve` →
`_make_event_handle()` → `check_interprocess_event_support()`. That
function inspects the **real** torch device backend's `Event` class
for an `interprocess=True` parameter.

The test only mocked `_call`, not `_make_event_handle`, so it
accidentally depends on real hardware/backend capability even though
it's meant to be a pure dispatch/fan-out logic test (it only asserts
call order, `key.world_size`, `key.worker_id`). `torch.cuda.Event`
supports `interprocess=True`, so this passed on CUDA CI, but
`torch.xpu.Event` does not expose that parameter, so it fails
unconditionally on XPU runners:

```
RuntimeError: Backend 'xpu' does not support interprocess=True
parameter for Events. Multiprocess IPC requires CUDA.
```

## Fix

Additionally mock `sv_helpers._make_event_handle` (returning a dummy
handle) alongside `_call` in the shared `with` block, decoupling the
dispatch-logic test from real hardware/backend capability.

## Test plan

```
pytest -q tests/cli/commands/bench/test_server_bench.py::TestProcessRequestMultiWorker
```

All 3 tests pass locally (on a CUDA-less/CPU environment, confirming
the fix removes the hardware dependency).
