### PR TITLE
[MP] Skip NIXL poll sleep on terminal state

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -33,6 +33,7 @@ import uuid
 # Third Party
 from nixl._api import nixl_agent as NixlAgent
 from nixl._api import nixl_agent_config as NixlAgentConfig
+from nixl._api import nixl_xfer_handle as NixlXferHandle
 from nixl._api import (
     nixlBind,
 )
@@ -315,7 +316,7 @@ class DynamicNixlStorageAgent:
             return os.path.join(self.file_path, _object_key_to_relpath(key))
         return os.path.join(self.file_path, _object_key_to_filename(key))
 
-    async def _post_non_blocking(self, handle):
+    async def _post_non_blocking(self, handle: NixlXferHandle) -> None:
         """Await a nixl transfer until done."""
         state = self.nixl_agent.transfer(handle)
         while state != "DONE" and state != "ERR":
@@ -323,7 +324,8 @@ class DynamicNixlStorageAgent:
                 state = self.nixl_agent.check_xfer_state(handle)
             except nixlBind.nixlBackendError:
                 raise
-            await asyncio.sleep(0.01)
+            if state != "DONE" and state != "ERR":
+                await asyncio.sleep(0.01)
         if state == "ERR":
             raise RuntimeError("NIXL transfer failed")
 

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -367,7 +367,7 @@ class NixlStorageAgent:
         if state == "ERR":
             raise RuntimeError("NIXL transfer failed")
 
-    async def post_non_blocking(self, handle: NixlXferHandle):
+    async def post_non_blocking(self, handle: NixlXferHandle) -> None:
         """Post a Nixl transfer handle and await until the transfer is done."""
 
         state = self.nixl_agent.transfer(handle)
@@ -379,7 +379,8 @@ class NixlStorageAgent:
                 raise
 
             # TODO(Jiayi): Tune this for better perf
-            await asyncio.sleep(0.01)
+            if state != "DONE" and state != "ERR":
+                await asyncio.sleep(0.01)
 
         if state == "ERR":
             raise RuntimeError("NIXL transfer failed")


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

The async completion loop in the NIXL store L2 adapters (static NixlStorageAgent.post_non_blocking and dynamic DynamicNixlStorageAgent._post_non_blocking) called await asyncio.sleep(0.01) unconditionally on every iteration, including the iteration where check_xfer_state() had already returned DONE or ERR. As a result, any transfer that started in a pending state paid one extra fixed 10ms delay after it had actually completed, before the loop exited.

This PR guards the sleep so it only runs while the transfer is still pending. When the state check reports a terminal state, the loop now exits immediately instead of yielding for another 10ms.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
