### PR TITLE
refactor(kv_format): move EngineKVFormat facts onto KVFormatSpec

### DIFF
--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -153,15 +153,16 @@ enum class EngineKVFormat : int {
 // the two sides can never drift; the predicates below are one-line lookups.
 // Exactly one structural shape (cross_layer / kv_list / layer_list) is true per
 // format. The remaining flags are modifiers layered on top of it.
+// Every field defaults to false; the table below only sets the true ones.
 struct FormatFacts {
-  bool is_cross_layer;   // all layers in one fused tensor
-  bool is_kv_list;       // keys and values in two top-level lists
-  bool is_layer_list;    // one list entry per layer
-  bool is_mla;           // MLA: single latent KV head (no separate K/V)
-  bool is_hnd;           // heads before block tokens (HND layout)
-  bool is_fused_packed;  // K/V packed in trailing dim (kv_size == 1)
-  bool is_two_major;     // size-2 K/V axis precedes the block axis
-  bool is_pbs_fused;     // paged buffer size fused into one axis
+  bool is_cross_layer = false;   // all layers in one fused tensor
+  bool is_kv_list = false;       // keys and values in two top-level lists
+  bool is_layer_list = false;    // one list entry per layer
+  bool is_mla = false;           // MLA: single latent KV head (no separate K/V)
+  bool is_hnd = false;           // heads before block tokens (HND layout)
+  bool is_fused_packed = false;  // K/V packed in trailing dim (kv_size == 1)
+  bool is_two_major = false;     // size-2 K/V axis precedes the block axis
+  bool is_pbs_fused = false;     // paged buffer size fused into one axis
 };
 
 // clang-format off

--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -148,49 +148,85 @@ enum class EngineKVFormat : int {
   #define LMC_KV_FORMAT_HD
 #endif
 
-// Structural shape of the normalized kv_caches: exactly one is true per format.
+// Static layout facts for each format, declared once per format (indexed by the
+// enum value). This mirrors the facts declared on each Python KVFormatSpec so
+// the two sides can never drift; the predicates below are one-line lookups.
+// Exactly one structural shape (cross_layer / kv_list / layer_list) is true per
+// format. The remaining flags are modifiers layered on top of it.
+struct FormatFacts {
+  bool is_cross_layer;  // all layers in one fused tensor
+  bool is_kv_list;      // keys and values in two top-level lists
+  bool is_layer_list;   // one list entry per layer
+  bool is_mla;          // MLA: single latent KV head (no separate K/V)
+  bool is_hnd;          // heads before block tokens (HND layout)
+  bool is_fused_packed; // K/V packed in trailing dim (kv_size == 1)
+  bool is_two_major;    // size-2 K/V axis precedes the block axis
+  bool is_pbs_fused;    // paged buffer size fused into one axis
+};
+
+// clang-format off
+LMC_KV_FORMAT_HD constexpr FormatFacts FORMAT_FACTS[] = {
+    /*  0 NB_NL_TWO_BS_NH_HS      */ {true,  false, false, false,
+                                      false, false, false, false},
+    /*  1 NL_X_TWO_NB_BS_NH_HS    */ {false, false, true,  false,
+                                      false, false, true,  false},
+    /*  2 NL_X_NB_TWO_BS_NH_HS    */ {false, false, true,  false,
+                                      false, false, false, false},
+    /*  3 NL_X_NB_BS_HS           */ {false, false, true,  true,
+                                      false, false, false, false},
+    /*  4 TWO_X_NL_X_NBBS_NH_HS   */ {false, true,  false, false,
+                                      false, false, false, false},
+    /*  5 NL_X_NBBS_ONE_HS        */ {false, false, true,  true,
+                                      false, false, false, true},
+    /*  6 NL_X_TWO_NB_NH_BS_HS    */ {false, false, true,  false,
+                                      true,  false, true,  false},
+    /*  7 NL_X_NB_TWO_NH_BS_HS    */ {false, false, true,  false,
+                                      true,  false, false, false},
+    /*  8 NB_NL_TWO_NH_BS_HS      */ {true,  false, false, false,
+                                      true,  false, false, false},
+    /*  9 TWO_X_NL_X_NB_BS_NH_HS  */ {false, true,  false, false,
+                                      false, false, false, false},
+    /* 10 NL_X_NB_NH_BS_TWO_HS    */ {false, false, true,  false,
+                                      true,  true,  false, false},
+    /* 11 NL_X_NB_BS_NH_TWO_HS    */ {false, false, true,  false,
+                                      false, true,  false, false},
+    /* 12 NL_X_NB_NH_BS_CS        */ {false, false, true,  false,
+                                      true,  true,  false, false},
+    /* 13 NL_X_NB_BS_NH_CS        */ {false, false, true,  false,
+                                      false, true,  false, false},
+    /* 14 NL_X_NB_BSV_BSS         */ {false, false, true,  true,
+                                      false, false, false, false},
+};
+// clang-format on
+
+LMC_KV_FORMAT_HD constexpr const FormatFacts& format_facts(EngineKVFormat f) {
+  return FORMAT_FACTS[static_cast<int>(f)];
+}
 
 // All layers in one fused tensor.
 LMC_KV_FORMAT_HD constexpr bool is_cross_layer(EngineKVFormat f) {
-  return f == EngineKVFormat::NB_NL_TWO_BS_NH_HS ||
-         f == EngineKVFormat::NB_NL_TWO_NH_BS_HS;
+  return format_facts(f).is_cross_layer;
 }
 
 // Keys and values in two separate top-level lists: [key_layers, value_layers].
 LMC_KV_FORMAT_HD constexpr bool is_kv_list(EngineKVFormat f) {
-  return f == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS ||
-         f == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS;
+  return format_facts(f).is_kv_list;
 }
 
 // One list entry per layer: kv_caches[layer_idx] is that layer's tensor.
 LMC_KV_FORMAT_HD constexpr bool is_layer_list(EngineKVFormat f) {
-  return f == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS ||
-         f == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS ||
-         f == EngineKVFormat::NL_X_NB_BS_HS ||
-         f == EngineKVFormat::NL_X_NBBS_ONE_HS ||
-         f == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
-         f == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS ||
-         f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||
-         f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS ||
-         f == EngineKVFormat::NL_X_NB_NH_BS_CS ||
-         f == EngineKVFormat::NL_X_NB_BS_NH_CS ||
-         f == EngineKVFormat::NL_X_NB_BSV_BSS;
+  return format_facts(f).is_layer_list;
 }
 
 // Multi-head Latent Attention: a single latent KV head (no separate K/V split).
 // The blocked-scale indexer cache transfers like MLA (single plane,
 // kv_size == 1); only its paged addressing differs.
 LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
-  return f == EngineKVFormat::NL_X_NB_BS_HS ||     // vLLM MLA
-         f == EngineKVFormat::NL_X_NBBS_ONE_HS ||  // SGLang MLA
-         f == EngineKVFormat::NL_X_NB_BSV_BSS;     // DSA indexer (blocked)
+  return format_facts(f).is_mla;
 }
 
 // vLLM fused K/V: K and V packed in the trailing dim (2 * head_size), no
 // separate K/V axis — transferred as one k_or_v == 0 pass (like MLA).
 LMC_KV_FORMAT_HD constexpr bool is_fused_packed(EngineKVFormat f) {
-  return f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||  // fused HND (deprecated)
-         f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS ||  // fused NHD (deprecated)
-         f == EngineKVFormat::NL_X_NB_NH_BS_CS ||      // content-size HND
-         f == EngineKVFormat::NL_X_NB_BS_NH_CS;        // content-size NHD
+  return format_facts(f).is_fused_packed;
 }

--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -154,48 +154,37 @@ enum class EngineKVFormat : int {
 // Exactly one structural shape (cross_layer / kv_list / layer_list) is true per
 // format. The remaining flags are modifiers layered on top of it.
 struct FormatFacts {
-  bool is_cross_layer;  // all layers in one fused tensor
-  bool is_kv_list;      // keys and values in two top-level lists
-  bool is_layer_list;   // one list entry per layer
-  bool is_mla;          // MLA: single latent KV head (no separate K/V)
-  bool is_hnd;          // heads before block tokens (HND layout)
-  bool is_fused_packed; // K/V packed in trailing dim (kv_size == 1)
-  bool is_two_major;    // size-2 K/V axis precedes the block axis
-  bool is_pbs_fused;    // paged buffer size fused into one axis
+  bool is_cross_layer;   // all layers in one fused tensor
+  bool is_kv_list;       // keys and values in two top-level lists
+  bool is_layer_list;    // one list entry per layer
+  bool is_mla;           // MLA: single latent KV head (no separate K/V)
+  bool is_hnd;           // heads before block tokens (HND layout)
+  bool is_fused_packed;  // K/V packed in trailing dim (kv_size == 1)
+  bool is_two_major;     // size-2 K/V axis precedes the block axis
+  bool is_pbs_fused;     // paged buffer size fused into one axis
 };
 
 // clang-format off
 LMC_KV_FORMAT_HD constexpr FormatFacts FORMAT_FACTS[] = {
-    /*  0 NB_NL_TWO_BS_NH_HS      */ {true,  false, false, false,
-                                      false, false, false, false},
-    /*  1 NL_X_TWO_NB_BS_NH_HS    */ {false, false, true,  false,
-                                      false, false, true,  false},
-    /*  2 NL_X_NB_TWO_BS_NH_HS    */ {false, false, true,  false,
-                                      false, false, false, false},
-    /*  3 NL_X_NB_BS_HS           */ {false, false, true,  true,
-                                      false, false, false, false},
-    /*  4 TWO_X_NL_X_NBBS_NH_HS   */ {false, true,  false, false,
-                                      false, false, false, false},
-    /*  5 NL_X_NBBS_ONE_HS        */ {false, false, true,  true,
-                                      false, false, false, true},
-    /*  6 NL_X_TWO_NB_NH_BS_HS    */ {false, false, true,  false,
-                                      true,  false, true,  false},
-    /*  7 NL_X_NB_TWO_NH_BS_HS    */ {false, false, true,  false,
-                                      true,  false, false, false},
-    /*  8 NB_NL_TWO_NH_BS_HS      */ {true,  false, false, false,
-                                      true,  false, false, false},
-    /*  9 TWO_X_NL_X_NB_BS_NH_HS  */ {false, true,  false, false,
-                                      false, false, false, false},
-    /* 10 NL_X_NB_NH_BS_TWO_HS    */ {false, false, true,  false,
-                                      true,  true,  false, false},
-    /* 11 NL_X_NB_BS_NH_TWO_HS    */ {false, false, true,  false,
-                                      false, true,  false, false},
-    /* 12 NL_X_NB_NH_BS_CS        */ {false, false, true,  false,
-                                      true,  true,  false, false},
-    /* 13 NL_X_NB_BS_NH_CS        */ {false, false, true,  false,
-                                      false, true,  false, false},
-    /* 14 NL_X_NB_BSV_BSS         */ {false, false, true,  true,
-                                      false, false, false, false},
+    /*  0 NB_NL_TWO_BS_NH_HS      */ {.is_cross_layer = true},
+    /*  1 NL_X_TWO_NB_BS_NH_HS    */ {.is_layer_list = true,  .is_two_major = true},
+    /*  2 NL_X_NB_TWO_BS_NH_HS    */ {.is_layer_list = true},
+    /*  3 NL_X_NB_BS_HS           */ {.is_layer_list = true,  .is_mla = true},
+    /*  4 TWO_X_NL_X_NBBS_NH_HS   */ {.is_kv_list = true},
+    /*  5 NL_X_NBBS_ONE_HS        */ {.is_layer_list = true,  .is_mla = true,
+                                      .is_pbs_fused = true},
+    /*  6 NL_X_TWO_NB_NH_BS_HS    */ {.is_layer_list = true,  .is_hnd = true,
+                                      .is_two_major = true},
+    /*  7 NL_X_NB_TWO_NH_BS_HS    */ {.is_layer_list = true,  .is_hnd = true},
+    /*  8 NB_NL_TWO_NH_BS_HS      */ {.is_cross_layer = true, .is_hnd = true},
+    /*  9 TWO_X_NL_X_NB_BS_NH_HS  */ {.is_kv_list = true},
+    /* 10 NL_X_NB_NH_BS_TWO_HS    */ {.is_layer_list = true,  .is_hnd = true,
+                                      .is_fused_packed = true},
+    /* 11 NL_X_NB_BS_NH_TWO_HS    */ {.is_layer_list = true,  .is_fused_packed = true},
+    /* 12 NL_X_NB_NH_BS_CS        */ {.is_layer_list = true,  .is_hnd = true,
+                                      .is_fused_packed = true},
+    /* 13 NL_X_NB_BS_NH_CS        */ {.is_layer_list = true,  .is_fused_packed = true},
+    /* 14 NL_X_NB_BSV_BSS         */ {.is_layer_list = true,  .is_mla = true},
 };
 // clang-format on
 

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -50,14 +50,24 @@ kv_format/
     └── <engine>.py            #   one file per engine (a single discover())
 ```
 
-- **One spec class per format — pure geometry.** Each `EngineKVFormat`
-  maps to exactly one `KVFormatSpec` subclass that knows how to index a
-  value of that format. A spec describes *only* layout geometry; both the
+- **One spec class per format — geometry plus static facts.** Each
+  `EngineKVFormat` maps to exactly one `KVFormatSpec` subclass that knows how to
+  index a value of that format. A spec describes *only* layout; both the
   class and its file are named after the format member (e.g.
   `NB_NL_TWO_BS_NH_HS_Spec` in `nb_nl_two_bs_nh_hs.py`) — a geometry
   encoding, never an engine. `get_spec(kv, fmt)` returns an instance for
   geometry; `get_spec_class(fmt)` returns the class for static facts
   (`is_mla`, `is_hnd`, `is_cross_layer`, `attention_backends`).
+- **Static facts are class attributes, declared once.** The structural shape
+  (`is_cross_layer` / `is_kv_list` / `is_layer_list`, exactly one true) and the
+  `is_mla` / `is_hnd` / `is_fused_packed` / `is_two_major` / `is_pbs_fused`
+  modifiers are booleans on the spec, defaulting to `False` so a spec only
+  declares what applies. Consumers read them via `get_spec_class(fmt)` — a
+  call site must never re-list formats (`fmt in (A, B, ...)`), which is how
+  the same predicate used to drift across `torch_ops.py`, the transfer
+  helpers and the connectors. The device kernels keep their own copy in
+  `csrc/engine_kv_format.h`; `tests/v1/gpu_connector/test_kv_format_classification.py`
+  pins the two sides together and enforces the structural partition.
 - **Backend labels are diagnostic, colocated on the spec.** A single
   `EngineKVFormat` can be produced by several (engine, attention-backend)
   combinations, so each spec lists them in `attention_backends` (a tuple),
@@ -105,13 +115,15 @@ kv_format/
    returning `(format, kv)`; any reshape-via-hints (e.g. TRT-LLM's 4-D `view`'d
    to 6-D) happens in the same method before the shape checks.
 3. Add a `KVFormatSpec` subclass as a new `specs/<engine_kv_format>.py` file
-   (named after the format, declaring its `engine_kv_format`). `registry.py`
+   (named after the format, declaring its `engine_kv_format` and its static
+   facts — the structural flag plus any modifier that applies). `registry.py`
    discovers it automatically — no other file changes. The ABC makes the
    required accessors explicit (a spec missing one raises `TypeError` on first
    `get_spec`, which the golden test triggers).
-4. Add a row to the golden table in
-   `tests/v1/gpu_connector/test_kv_format_specs.py` and a detection
-   case in `test_kv_format_detection.py`.
+4. Add a row to the golden tables in
+   `tests/v1/gpu_connector/test_kv_format_specs.py` and
+   `test_kv_format_classification.py`, plus a detection case in
+   `test_kv_format_detection.py`.
 
 No other Python module should need edits. If you're editing
 `kv_layer_groups.py`, `gpu_context.py`, or any `KVLayerGroupInfo`
@@ -149,8 +161,8 @@ an `EngineKVFormat`. Nothing else may index raw shapes.
 
 The two cross-layer formats (`NB_NL_TWO_*`) share a single base
 pointer, the kernel walks layers internally via `shape_desc.nl`. Use
-`is_cross_layer_format(fmt)` for that dispatch and `is_hnd(fmt)` to
-detect head-major within-block layouts.
+`get_spec_class(fmt).is_cross_layer` for that dispatch and
+`.is_hnd` to detect head-major within-block layouts.
 
 ### Reshape-via-hints (TRT-LLM)
 
@@ -182,7 +194,7 @@ helper.
 | `get_head_size(kv, fmt, layer_idx=0)` | yes | |
 | `get_hidden_dim_size(kv, fmt, layer_idx=0)` | yes | |
 | `get_dtype(kv, fmt, layer_idx=0)` | yes | |
-| `is_mla(fmt)`, `is_hnd(fmt)` | — | Format predicates. |
+| `is_mla(fmt)` | — | Format predicate; the other static facts are read off `get_spec_class(fmt)`. |
 | `get_device(kv)` | — | Format-agnostic (descends to any leaf). |
 
 ### Pointer and descriptor builders
@@ -205,6 +217,9 @@ consumer code must never do any of the following — it queries via the
 `utils.py` facade instead:
 
 - `isinstance(kv_cache, (tuple, list))` to distinguish layouts.
+- Re-listing formats to recover a static fact (`fmt in (A, B)`,
+  `fmt == NL_X_NB_NH_BS_CS`) — read it off `get_spec_class(fmt)` instead, or
+  add the missing fact to the specs.
 - Indexing raw shapes (`tensor.shape[3]`, `len(shape) == 5`) to derive
   dimensions.
 - Hand-rolled list-depth probing (`while isinstance(x, list): depth +=

--- a/lmcache/v1/gpu_connector/kv_format/specs/base.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/base.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Per-format geometry interface for GPU KV caches.
 
-Each :class:`KVFormatSpec` holds the geometry accessors for one
-``EngineKVFormat`` -- methods that read shape off a normalized ``kv_caches``.
-The format's static facts (MLA and the structural shape) live on the
-``EngineKVFormat`` enum itself (``csrc/engine_kv_format.h``, read via
-``lmc_ops``), shared with the device kernels. The enum is the single source of
-truth for which formats exist; engine identity lives only in detection. The
-format -> spec table is in ``registry.py``.
+Each :class:`KVFormatSpec` owns everything that is true of one
+``EngineKVFormat``: the geometry accessors (methods that read shape off a
+normalized ``kv_caches``) plus the static layout facts (``is_mla``, ``is_hnd``,
+the structural shape, ...) as class attributes. The facts are mirrored for the
+device kernels in ``csrc/engine_kv_format.h``; Python call sites read them from
+the spec via ``get_spec_class`` instead of re-listing formats inline, and
+``tests/v1/gpu_connector/test_kv_format_classification.py`` pins the two sides
+together. The enum is the single source of truth for which formats exist;
+engine identity lives only in detection. The format -> spec table is in
+``registry.py``.
 """
 
 # Standard
@@ -90,11 +93,14 @@ class KVFormatSpec(ABC):
     since one format may come from many (engine, backend) pairs.
 
     Class attributes: ``engine_kv_format`` (the format this describes, its
-    identity) and ``attention_backends`` (diagnostic labels; first is the
-    representative). The format's static facts -- ``is_mla`` and the structural
-    shape ``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list`` -- live on the
-    ``EngineKVFormat`` itself (``csrc/engine_kv_format.h``, read via ``lmc_ops``),
-    shared with the device kernels.
+    identity), ``attention_backends`` (diagnostic labels; first is the
+    representative) and the format's **static layout facts** -- the structural
+    shape (``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list``, exactly one
+    true) plus the ``is_mla`` / ``is_hnd`` / ``is_fused_packed`` /
+    ``is_two_major`` / ``is_pbs_fused`` modifiers. They default to ``False``, so
+    a spec only declares what applies to it, and every consumer reads them
+    through ``get_spec_class(fmt)`` -- no format lists at call sites. The device
+    kernels keep their own copy in ``csrc/engine_kv_format.h``.
 
     Method usage by mode -- every spec is consumed through the ``get_*``
     facade in ``gpu_connector.utils``:
@@ -117,6 +123,29 @@ class KVFormatSpec(ABC):
 
     engine_kv_format: ClassVar["lmc_ops.EngineKVFormat"]
     attention_backends: ClassVar[tuple[str, ...]] = ()
+
+    # ── Static layout facts (see the class docstring) ──────────────────
+    # Structural shape of the normalized ``kv_caches``: exactly one is true.
+    # All layers in one fused tensor.
+    is_cross_layer: ClassVar[bool] = False
+    # Keys and values in two top-level lists: ``[key_layers, value_layers]``.
+    is_kv_list: ClassVar[bool] = False
+    # One list entry per layer: ``kv_caches[layer_idx]`` is that layer.
+    is_layer_list: ClassVar[bool] = False
+
+    # Modifiers, orthogonal to the structural shape.
+    # Multi-head Latent Attention: one latent plane, no K/V split.
+    is_mla: ClassVar[bool] = False
+    # Heads stored before block tokens within a layer (HND, not NHD).
+    is_hnd: ClassVar[bool] = False
+    # K and V packed into the trailing content dim, so ``kv_size == 1``.
+    is_fused_packed: ClassVar[bool] = False
+    # The size-2 K/V axis comes before the block axis (``TWO_NB``, not
+    # ``NB_TWO``), so K and V are two contiguous planes per layer.
+    is_two_major: ClassVar[bool] = False
+    # ``num_blocks`` and ``block_size`` are folded into one PBS axis, which
+    # leaves both of them undefined for this format.
+    is_pbs_fused: ClassVar[bool] = False
 
     def __init__(self, kv_caches: DiscoverableKVCache) -> None:
         # Borrowed, not owned: see the class docstring's "Lifetime" note. The

--- a/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_bs_nh_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_bs_nh_hs.py
@@ -21,6 +21,7 @@ import lmcache.c_ops as lmc_ops
 class NB_NL_TWO_BS_NH_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
     attention_backends = ("vLLM CROSS_LAYER",)
+    is_cross_layer = True
 
     def num_layers(self) -> int:
         return self.kv_caches.shape[1]

--- a/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_nh_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_nh_bs_hs.py
@@ -22,6 +22,8 @@ import lmcache.c_ops as lmc_ops
 class NB_NL_TWO_NH_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
     attention_backends = ("TRT-LLM cross-layer (HND layout)",)
+    is_cross_layer = True
+    is_hnd = True
 
     def num_layers(self) -> int:
         return self.kv_caches.shape[1]

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_hs.py
@@ -21,6 +21,8 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     attention_backends = ("vLLM MLA",)
+    is_layer_list = True
+    is_mla = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_nh_cs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_nh_cs.py
@@ -25,6 +25,8 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_BS_NH_CS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_CS
     attention_backends = ("vLLM non-MLA blocks-first, fused K/V (NHD)",)
+    is_layer_list = True
+    is_fused_packed = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_nh_two_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_nh_two_hs.py
@@ -28,6 +28,8 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_BS_NH_TWO_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS
     attention_backends = ("vLLM non-MLA blocks-first, fused K/V (NHD)",)
+    is_layer_list = True
+    is_fused_packed = True
 
     @lmcache_deprecate(
         "NL_X_NB_BS_NH_TWO_HS is superseded by NL_X_NB_BS_NH_CS "

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py
@@ -21,3 +21,5 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_BSV_BSS_Spec(NL_X_NB_BS_HS_Spec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_BSV_BSS
     attention_backends = ("vLLM MLA",)
+    is_layer_list = True
+    is_mla = True

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_nh_bs_cs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_nh_bs_cs.py
@@ -24,6 +24,9 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_NH_BS_CS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_CS
     attention_backends = ("vLLM non-MLA blocks-first, fused K/V (HND)",)
+    is_layer_list = True
+    is_hnd = True
+    is_fused_packed = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_nh_bs_two_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_nh_bs_two_hs.py
@@ -28,6 +28,9 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_NH_BS_TWO_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS
     attention_backends = ("vLLM non-MLA blocks-first, fused K/V",)
+    is_layer_list = True
+    is_hnd = True
+    is_fused_packed = True
 
     @lmcache_deprecate(
         "NL_X_NB_NH_BS_TWO_HS is superseded by NL_X_NB_NH_BS_CS "

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_two_bs_nh_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_two_bs_nh_hs.py
@@ -22,6 +22,7 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_TWO_BS_NH_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS
     attention_backends = ("vLLM non-MLA flash infer",)
+    is_layer_list = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_two_nh_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_two_nh_bs_hs.py
@@ -23,6 +23,8 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NB_TWO_NH_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS
     attention_backends = ("vLLM non-MLA flash infer (HND layout)",)
+    is_layer_list = True
+    is_hnd = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nbbs_one_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nbbs_one_hs.py
@@ -22,6 +22,9 @@ import lmcache.c_ops as lmc_ops
 class NL_X_NBBS_ONE_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS
     attention_backends = ("SGLang MLA",)
+    is_layer_list = True
+    is_mla = True
+    is_pbs_fused = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_nb_bs_nh_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_nb_bs_nh_hs.py
@@ -22,6 +22,8 @@ import lmcache.c_ops as lmc_ops
 class NL_X_TWO_NB_BS_NH_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     attention_backends = ("vLLM non-MLA flash attention",)
+    is_layer_list = True
+    is_two_major = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_nb_nh_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_nb_nh_bs_hs.py
@@ -22,6 +22,9 @@ import lmcache.c_ops as lmc_ops
 class NL_X_TWO_NB_NH_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
     attention_backends = ("vLLM non-MLA flash attention (HND layout)",)
+    is_layer_list = True
+    is_hnd = True
+    is_two_major = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches)

--- a/lmcache/v1/gpu_connector/kv_format/specs/registry.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/registry.py
@@ -37,16 +37,30 @@ def _discover_specs() -> dict["lmc_ops.EngineKVFormat", type[KVFormatSpec]]:
 
 SPECS = _discover_specs()
 
+# Indexed by enum *value*: the native pybind ``EngineKVFormat`` and the
+# pure-Python fallback one are distinct types with the same members, and both
+# reach this table (e.g. from ``lmcache.v1.platform.torch_ops``).
+_SPECS_BY_VALUE = {int(fmt): spec for fmt, spec in SPECS.items()}
+
 
 def get_spec_class(fmt: "lmc_ops.EngineKVFormat") -> type[KVFormatSpec]:
-    """Return the spec class for *fmt*, for static facts (``is_mla``, ...).
+    """Return the spec class for *fmt* -- the owner of its static facts.
+
+    Args:
+        fmt: The Engine KV format to look up.
+
+    Returns:
+        The :class:`KVFormatSpec` subclass declaring *fmt*, which carries the
+        format's static layout facts (``is_mla``, ``is_hnd``, the structural
+        shape, ``attention_backends``, ...) as class attributes.
 
     Raises:
         ValueError: If *fmt* has no spec.
     """
-    if fmt not in SPECS:
+    spec = _SPECS_BY_VALUE.get(int(fmt))
+    if spec is None:
         raise ValueError(f"Unknown Engine KV Format: {fmt}")
-    return SPECS[fmt]
+    return spec
 
 
 def get_spec(

--- a/lmcache/v1/gpu_connector/kv_format/specs/two_x_nl_x_nb_bs_nh_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/two_x_nl_x_nb_bs_nh_hs.py
@@ -22,6 +22,7 @@ import lmcache.c_ops as lmc_ops
 class TWO_X_NL_X_NB_BS_NH_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS
     attention_backends = ("SGLang MHA via MP daemon (4-D inner)",)
+    is_kv_list = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches[0])

--- a/lmcache/v1/gpu_connector/kv_format/specs/two_x_nl_x_nbbs_nh_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/two_x_nl_x_nbbs_nh_hs.py
@@ -22,6 +22,8 @@ import lmcache.c_ops as lmc_ops
 class TWO_X_NL_X_NBBS_NH_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
     attention_backends = ("SGLang MHA (flash attention and flash infer)",)
+    is_kv_list = True
+    is_pbs_fused = True
 
     def num_layers(self) -> int:
         return len(self.kv_caches[0])

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -11,7 +11,7 @@ shim, never this module directly.
 # Standard
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import shared_memory
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 import ctypes
 import ctypes.util
 import os
@@ -36,6 +36,10 @@ from lmcache.v1.platform.ops_types import (  # noqa: F401
     TransferDirection,
     set_shape_desc_dtype,
 )
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.gpu_connector.kv_format.specs.base import KVFormatSpec
 
 # Store the tensor objects in memory so that they can be accessed
 # outside the scope of this file
@@ -578,10 +582,7 @@ def multi_layer_kv_transfer(
     valid_slots = slots_kv[valid_mask_kv].to(paged_memory_device)
 
     # 2. Determine architecture variant and tensor dimensions.
-    is_mla = int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_BS_HS),
-        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
-    )
+    is_mla = _format_spec(engine_kv_format).is_mla
     is_flash_infer = int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_TWO_BS_NH_HS)
 
     num_layers = key_value.size(1)
@@ -689,10 +690,7 @@ def multi_layer_kv_transfer_unilateral(
         H2D = LMCache  -> PagedBuffer
         D2H = PagedBuffer -> LMCache
     """
-    is_mla = int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_BS_HS),
-        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
-    )
+    is_mla = _format_spec(engine_kv_format).is_mla
 
     # MLA case collapses back to multi_layer_kv_transfer
     # (vLLM and SGLang indexing are compatible)
@@ -741,82 +739,70 @@ def multi_layer_kv_transfer_unilateral(
                 key_value[kv_idx, layer_id, valid_mask_kv, :] = gathered.to(kv_device)
 
 
-# Pure-Python mirrors of the c_ops predicates (csrc/engine_kv_format.h); the
-# parity test pins these to the same names and signatures.
+# Every static fact about a format lives on its ``KVFormatSpec``; the helpers
+# below only look it up. The four public ones mirror the c_ops predicates
+# (csrc/engine_kv_format.h) -- the parity test pins them to the same names and
+# signatures.
+def _format_spec(engine_kv_format: EngineKVFormat) -> "type[KVFormatSpec]":
+    """Return the spec class owning *engine_kv_format*'s static layout facts.
+
+    Args:
+        engine_kv_format: The format to look up.
+
+    Returns:
+        The ``KVFormatSpec`` subclass declared for the format.
+
+    Raises:
+        ValueError: If the format has no spec.
+    """
+    # Imported lazily, not at module scope: the specs package reads
+    # ``lmcache.c_ops``, whose shim is installed only once this module (the
+    # torch baseline behind it) has been imported.
+    # First Party
+    from lmcache.v1.gpu_connector.kv_format.specs.registry import get_spec_class
+
+    return get_spec_class(engine_kv_format)
+
+
 def is_cross_layer(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when all layers live in one fused tensor."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.NB_NL_TWO_BS_NH_HS),
-        int(EngineKVFormat.NB_NL_TWO_NH_BS_HS),
-    )
+    return _format_spec(engine_kv_format).is_cross_layer
 
 
 def is_kv_list(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when keys and values are two separate top-level lists."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS),
-        int(EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS),
-    )
+    return _format_spec(engine_kv_format).is_kv_list
 
 
 def is_layer_list(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when the structure is one list entry per layer."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS),
-        int(EngineKVFormat.NL_X_NB_TWO_BS_NH_HS),
-        int(EngineKVFormat.NL_X_NB_BS_HS),
-        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
-        int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS),
-        int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS),
-        int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
-        int(EngineKVFormat.NL_X_NB_BS_NH_TWO_HS),
-        int(EngineKVFormat.NL_X_NB_NH_BS_CS),
-        int(EngineKVFormat.NL_X_NB_BS_NH_CS),
-        int(EngineKVFormat.NL_X_NB_BSV_BSS),
-    )
+    return _format_spec(engine_kv_format).is_layer_list
 
 
 def is_mla(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when a KV format uses MLA paged layout."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_BS_HS),
-        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
-        int(EngineKVFormat.NL_X_NB_BSV_BSS),
-    )
-
-
-def _is_cross_layer_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True when a KV format uses a single cross-layer tensor."""
-    return is_cross_layer(engine_kv_format)
-
-
-def _is_sglang_mha_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True when a KV format uses SGLang MHA layout (2*NL tensors)."""
-    return is_kv_list(engine_kv_format)
+    return _format_spec(engine_kv_format).is_mla
 
 
 def _is_hnd_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True when a per-layer KV format stores heads before block tokens (HND)."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS),
-        int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS),
-    )
+    """Return True when a KV format stores heads before block tokens (HND)."""
+    return _format_spec(engine_kv_format).is_hnd
 
 
 def _is_fused_kv_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True for per-layer formats whose K/V pair is packed in the
-    trailing dim (kv_size == 1, shape_desc.hs == 2 * head_size)."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
-        int(EngineKVFormat.NL_X_NB_BS_NH_TWO_HS),
-        int(EngineKVFormat.NL_X_NB_NH_BS_CS),
-        int(EngineKVFormat.NL_X_NB_BS_NH_CS),
-    )
+    """Return True for formats whose K/V pair is packed in the trailing dim
+    (kv_size == 1, shape_desc.hs == 2 * head_size)."""
+    return _format_spec(engine_kv_format).is_fused_packed
 
 
-def _is_mla_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True when a KV format uses MLA paged layout."""
-    return is_mla(engine_kv_format)
+def _is_two_major_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when the size-2 K/V axis precedes the block axis."""
+    return _format_spec(engine_kv_format).is_two_major
+
+
+def _is_pbs_fused_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when num_blocks and block_size are one folded PBS axis."""
+    return _format_spec(engine_kv_format).is_pbs_fused
 
 
 _ELEMENT_SIZE_TO_DTYPE: dict[int, torch.dtype] = {
@@ -957,7 +943,7 @@ def _normalize_paged_layers(
         - ``list[list[torch.Tensor]]`` (2 x NL) for SGLang MHA formats.
         - ``list[torch.Tensor]`` (per-layer) for all other formats.
     """
-    if _is_cross_layer_format(engine_kv_format):
+    if is_cross_layer(engine_kv_format):
         if isinstance(paged_buffer_ptrs_tensor, torch.Tensor):
             if _is_ptr_tensor(paged_buffer_ptrs_tensor):
                 # 1-D pointer tensor with a single entry → reconstruct full tensor.
@@ -971,7 +957,7 @@ def _normalize_paged_layers(
                 bs = int(shape_desc.bs)
                 nh = int(shape_desc.nh)
                 hs = int(shape_desc.hs)
-                if int(engine_kv_format) == int(EngineKVFormat.NB_NL_TWO_NH_BS_HS):
+                if _is_hnd_format(engine_kv_format):
                     shape: tuple[int, ...] = (nb, nl, 2, nh, bs, hs)
                 else:
                     shape = (nb, nl, 2, bs, nh, hs)
@@ -982,7 +968,7 @@ def _normalize_paged_layers(
             "Cross-layer formats require a single torch.Tensor input; "
             "got: " + type(paged_buffer_ptrs_tensor).__name__
         )
-    if _is_sglang_mha_format(engine_kv_format):
+    if is_kv_list(engine_kv_format):
         if _is_ptr_tensor(paged_buffer_ptrs_tensor):
             # 1-D pointer tensor [K_L0,...,K_LN-1, V_L0,...,V_LN-1] → nested list.
             if shape_desc is None or device is None or dtype is None:
@@ -995,7 +981,7 @@ def _normalize_paged_layers(
             bs = int(shape_desc.bs)
             nh = int(shape_desc.nh)
             hs = int(shape_desc.hs)
-            is_flat = int(engine_kv_format) == int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS)
+            is_flat = _is_pbs_fused_format(engine_kv_format)
             per_layer_shape: tuple[int, ...] = (
                 (nb * bs, nh, hs) if is_flat else (nb, bs, nh, hs)
             )
@@ -1106,7 +1092,7 @@ def _normalize_lmcache_objects(
         nh = int(shape_desc.nh)
         hs = int(shape_desc.hs)
         chunk_tokens = lmcache_chunk_size
-        if _is_mla_format(engine_kv_format):
+        if is_mla(engine_kv_format):
             chunk_shape: tuple[int, ...] = (nl, chunk_tokens, hs)
         elif _is_fused_kv_format(engine_kv_format):
             # Single plane: hs is the packed 2 * head_size.
@@ -1206,7 +1192,7 @@ def multi_layer_block_kv_transfer(
     blocks_per_object = lmcache_chunk_size // int(shape_desc.bs)
     block_size = int(shape_desc.bs)
 
-    if _is_cross_layer_format(engine_kv_format):
+    if is_cross_layer(engine_kv_format):
         _transfer_cross_layer(
             normalized,
             object_tensors,
@@ -1218,7 +1204,7 @@ def multi_layer_block_kv_transfer(
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif _is_sglang_mha_format(engine_kv_format):
+    elif is_kv_list(engine_kv_format):
         _transfer_sglang_mha(
             normalized,
             object_tensors,
@@ -1230,7 +1216,7 @@ def multi_layer_block_kv_transfer(
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif _is_mla_format(engine_kv_format):
+    elif is_mla(engine_kv_format):
         _transfer_per_layer_mla(
             normalized,
             object_tensors,
@@ -1243,6 +1229,8 @@ def multi_layer_block_kv_transfer(
             skip_prefix_n_blocks,
         )
     elif _is_fused_kv_format(engine_kv_format):
+        # Before the HND branch: the fused formats are HND/NHD too, but their
+        # packed K/V axis needs the single-plane path.
         _transfer_per_layer_fused(
             normalized,
             object_tensors,
@@ -1340,7 +1328,7 @@ def _transfer_cross_layer(
 ) -> None:
     """Handle cross-layer formats: single tensor [NB, NL, 2, ...]."""
     # NHD: [NB, NL, 2, BS, NH, HS]  HND: [NB, NL, 2, NH, BS, HS]
-    is_hnd = int(engine_kv_format) == int(EngineKVFormat.NB_NL_TWO_NH_BS_HS)
+    is_hnd = _is_hnd_format(engine_kv_format)
     num_layers = paged_tensor.shape[1]
 
     if is_hnd:
@@ -1423,7 +1411,7 @@ def _transfer_sglang_mha(
     """Handle SGLang MHA formats: 2*NL tensors (list[list[Tensor]])."""
     # TWO_X_NL_X_NBBS_NH_HS: each tensor [NB*BS, NH, HS]
     # TWO_X_NL_X_NB_BS_NH_HS: each tensor [NB, BS, NH, HS]
-    is_flat = int(engine_kv_format) == int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS)
+    is_flat = _is_pbs_fused_format(engine_kv_format)
     num_layers = len(paged_tensors[0])
 
     # Determine target device from first tensor
@@ -1504,7 +1492,7 @@ def _transfer_per_layer_mla(
     if not layer_tensors or not object_tensors:
         return
 
-    is_flat = int(engine_kv_format) == int(EngineKVFormat.NL_X_NBBS_ONE_HS)
+    is_flat = _is_pbs_fused_format(engine_kv_format)
     target_device = layer_tensors[0].device
     if is_flat:
         token_offsets = torch.arange(block_size, dtype=torch.long, device=target_device)
@@ -1581,8 +1569,11 @@ def _transfer_per_layer_hnd(
     target_device = layer_tensors[0].device
     block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
+    # Two-major keeps K and V as separate leading planes ([2, NB, NH, BS, HS]);
+    # otherwise the size-2 axis sits after the blocks ([NB, 2, NH, BS, HS]).
+    is_two_major = _is_two_major_format(engine_kv_format)
     first_layer = layer_tensors[0]
-    if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
+    if is_two_major:
         first_k = first_layer[0]
     else:
         first_k = first_layer[:, 0]
@@ -1621,7 +1612,7 @@ def _transfer_per_layer_hnd(
                 device=target_device,
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                if is_two_major:
                     k_t, v_t = layer[0], layer[1]
                     torch.index_select(k_t, 0, eff_idx, out=scratch)
                     chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
@@ -1649,7 +1640,7 @@ def _transfer_per_layer_hnd(
                 target_device, non_blocking=True
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                if is_two_major:
                     k_t, v_t = layer[0], layer[1]
                 else:
                     k_t, v_t = layer[:, 0], layer[:, 1]
@@ -1664,7 +1655,7 @@ def _transfer_per_layer_hnd(
                     .reshape(n_valid, block_size, nh, hs)
                     .permute(0, 2, 1, 3)
                 )
-                if int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS):
+                if not is_two_major:
                     layer.index_copy_(
                         0, eff_idx, torch.stack([k_blocks, v_blocks], dim=1)
                     )
@@ -1703,10 +1694,7 @@ def _transfer_per_layer_fused(
         layer.reshape(*layer.shape[:3], -1) if layer.dim() == 5 else layer
         for layer in layer_tensors
     ]
-    is_hnd = int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
-        int(EngineKVFormat.NL_X_NB_NH_BS_CS),
-    )
+    is_hnd = _is_hnd_format(engine_kv_format)
     first = layers[0]
     if is_hnd:
         _nb0, nh0, _bs0, hs0 = first.shape
@@ -1777,8 +1765,11 @@ def _transfer_per_layer_nhd(
     target_device = layer_tensors[0].device
     block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
+    # Two-major keeps K and V as separate leading planes ([2, NB, BS, NH, HS]);
+    # otherwise the size-2 axis sits after the blocks ([NB, 2, BS, NH, HS]).
+    is_two_major = _is_two_major_format(engine_kv_format)
     first_layer = layer_tensors[0]
-    if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
+    if is_two_major:
         first_k = first_layer[0]
     else:
         first_k = first_layer[:, 0]
@@ -1809,7 +1800,7 @@ def _transfer_per_layer_nhd(
                 device=target_device,
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                if is_two_major:
                     k_t, v_t = layer[0], layer[1]
                     torch.index_select(
                         k_t,
@@ -1841,7 +1832,7 @@ def _transfer_per_layer_nhd(
                 target_device, non_blocking=True
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                if is_two_major:
                     k_t, v_t = layer[0], layer[1]
                     k_t.index_copy_(
                         0,
@@ -1908,10 +1899,7 @@ def single_layer_kv_transfer(
     valid_token_indices = torch.nonzero(valid_mask_kv, as_tuple=True)[0]
     valid_slots = slots_kv[valid_mask_kv].to(paged_memory_device)
 
-    is_mla = int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_BS_HS),
-        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
-    )
+    is_mla = _format_spec(engine_kv_format).is_mla
 
     if is_mla:
         # ── MLA format ──
@@ -1935,7 +1923,7 @@ def single_layer_kv_transfer(
     else:
         # ── Non-MLA format ──
         # Determine vLLM layout and block_size
-        is_two_major = int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS)
+        is_two_major = _is_two_major_format(engine_kv_format)
         # flash attn:
         #   [2, num_blocks, block_size, num_heads, head_size]
         #   -> dim2 = block_size

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -372,6 +372,31 @@ def _alloc_page_aligned_pinned_view(size: int) -> Tuple[torch.Tensor, int]:
     return aligned_view, aligned_view.data_ptr()
 
 
+# Every static fact about a format lives on its ``KVFormatSpec``; the public
+# ``is_*`` helpers below only look it up. They mirror the c_ops predicates
+# (csrc/engine_kv_format.h) -- the parity test pins them to the same names and
+# signatures.
+def _format_spec(engine_kv_format: EngineKVFormat) -> "type[KVFormatSpec]":
+    """Return the spec class owning *engine_kv_format*'s static layout facts.
+
+    Args:
+        engine_kv_format: The format to look up.
+
+    Returns:
+        The ``KVFormatSpec`` subclass declared for the format.
+
+    Raises:
+        ValueError: If the format has no spec.
+    """
+    # Imported lazily, not at module scope: the specs package reads
+    # ``lmcache.c_ops``, whose shim is installed only once this module (the
+    # torch baseline behind it) has been imported.
+    # First Party
+    from lmcache.v1.gpu_connector.kv_format.specs.registry import get_spec_class
+
+    return get_spec_class(engine_kv_format)
+
+
 def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
     """Non-CUDA equivalent of allocating pinned memory with NUMA awareness.
     On XPU, uses pin_memory=True (SYCL USM host allocation) for fast transfers.
@@ -737,31 +762,6 @@ def multi_layer_kv_transfer_unilateral(
             else:
                 gathered = paged_tensor.index_select(0, valid_slots)
                 key_value[kv_idx, layer_id, valid_mask_kv, :] = gathered.to(kv_device)
-
-
-# Every static fact about a format lives on its ``KVFormatSpec``; the helpers
-# below only look it up. The four public ones mirror the c_ops predicates
-# (csrc/engine_kv_format.h) -- the parity test pins them to the same names and
-# signatures.
-def _format_spec(engine_kv_format: EngineKVFormat) -> "type[KVFormatSpec]":
-    """Return the spec class owning *engine_kv_format*'s static layout facts.
-
-    Args:
-        engine_kv_format: The format to look up.
-
-    Returns:
-        The ``KVFormatSpec`` subclass declared for the format.
-
-    Raises:
-        ValueError: If the format has no spec.
-    """
-    # Imported lazily, not at module scope: the specs package reads
-    # ``lmcache.c_ops``, whose shim is installed only once this module (the
-    # torch baseline behind it) has been imported.
-    # First Party
-    from lmcache.v1.gpu_connector.kv_format.specs.registry import get_spec_class
-
-    return get_spec_class(engine_kv_format)
 
 
 def is_cross_layer(engine_kv_format: EngineKVFormat) -> bool:

--- a/tests/v1/gpu_connector/test_kv_format_classification.py
+++ b/tests/v1/gpu_connector/test_kv_format_classification.py
@@ -2,14 +2,17 @@
 """Golden tests for the ``EngineKVFormat`` classification predicates.
 
 The structural shape (``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list``)
-and the ``is_mla`` modifier are defined once in ``csrc/engine_kv_format.h`` and
-read via ``lmc_ops``, shared with the device kernels. This file pins each
-format's classification and enforces that the three structural flags partition
-every format (exactly one is true), so a new format or an edit cannot silently
-break the contract the per-layer detection relies on.
+and the ``is_mla`` modifier are declared once per format on its
+:class:`KVFormatSpec` and mirrored for the device kernels in
+``csrc/engine_kv_format.h`` (reached via ``lmc_ops``). This file pins each
+format's classification, checks the two sides agree, and enforces that the
+three structural flags partition every format (exactly one is true), so a new
+format or an edit cannot silently break the contract the per-layer detection
+relies on.
 """
 
 # First Party
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 import lmcache.c_ops as lmc_ops
 
 F = lmc_ops.EngineKVFormat
@@ -33,6 +36,26 @@ EXPECTED = {
     F.NL_X_NB_BSV_BSS: (False, False, True, True),
 }
 
+# Facts that only the spec carries (no c_ops predicate mirrors them):
+# (is_hnd, is_fused_packed, is_two_major, is_pbs_fused) per format.
+EXPECTED_SPEC_FACTS = {
+    F.NB_NL_TWO_BS_NH_HS: (False, False, False, False),
+    F.NB_NL_TWO_NH_BS_HS: (True, False, False, False),
+    F.TWO_X_NL_X_NBBS_NH_HS: (False, False, False, True),
+    F.TWO_X_NL_X_NB_BS_NH_HS: (False, False, False, False),
+    F.NL_X_TWO_NB_BS_NH_HS: (False, False, True, False),
+    F.NL_X_NB_TWO_BS_NH_HS: (False, False, False, False),
+    F.NL_X_TWO_NB_NH_BS_HS: (True, False, True, False),
+    F.NL_X_NB_TWO_NH_BS_HS: (True, False, False, False),
+    F.NL_X_NB_NH_BS_TWO_HS: (True, True, False, False),
+    F.NL_X_NB_BS_NH_TWO_HS: (False, True, False, False),
+    F.NL_X_NB_NH_BS_CS: (True, True, False, False),
+    F.NL_X_NB_BS_NH_CS: (False, True, False, False),
+    F.NL_X_NB_BS_HS: (False, False, False, False),
+    F.NL_X_NBBS_ONE_HS: (False, False, False, True),
+    F.NL_X_NB_BSV_BSS: (False, False, False, False),
+}
+
 
 def _all_formats():
     return [v for v in vars(F).values() if isinstance(v, F)]
@@ -49,9 +72,32 @@ def test_classification_matches_golden():
         assert got == expected, f"{fmt}: got {got}, expected {expected}"
 
 
+def test_spec_facts_match_predicates():
+    # The spec is the Python-side owner of the facts; on a native build the
+    # predicates come from csrc, so this pins the two copies together.
+    for fmt in _all_formats():
+        spec = get_spec_class(fmt)
+        got = (spec.is_cross_layer, spec.is_kv_list, spec.is_layer_list, spec.is_mla)
+        expected = (
+            lmc_ops.is_cross_layer(fmt),
+            lmc_ops.is_kv_list(fmt),
+            lmc_ops.is_layer_list(fmt),
+            lmc_ops.is_mla(fmt),
+        )
+        assert got == expected, f"{fmt}: spec {got}, c_ops {expected}"
+
+
+def test_spec_only_facts_match_golden():
+    for fmt, expected in EXPECTED_SPEC_FACTS.items():
+        spec = get_spec_class(fmt)
+        got = (spec.is_hnd, spec.is_fused_packed, spec.is_two_major, spec.is_pbs_fused)
+        assert got == expected, f"{fmt}: got {got}, expected {expected}"
+
+
 def test_every_format_is_pinned():
     # A new EngineKVFormat must be added to EXPECTED (and classified) deliberately.
     assert set(_all_formats()) == set(EXPECTED)
+    assert set(_all_formats()) == set(EXPECTED_SPEC_FACTS)
 
 
 def test_structural_flags_partition_every_format():


### PR DESCRIPTION
## What

Move the `EngineKVFormat` classification out of the call sites and onto the
per-format `KVFormatSpec`.

`torch_ops.py` had the same format lists written down over and over: `is_mla`
in three places, HND in three places (`_is_hnd_format`, the cross-layer
helper, the fused helper), plus a scatter of inline `fmt == SOME_FORMAT`
checks in the transfer helpers. They were already slightly out of sync with
each other, and adding a format meant grepping for all of them.

## How

Each spec now declares its own static facts as class attributes (default
`False`, so a spec only states what applies to it):

- structural shape: `is_cross_layer` / `is_kv_list` / `is_layer_list`
- modifiers: `is_mla`, `is_hnd`, `is_fused_packed`, `is_two_major`,
  `is_pbs_fused`

```python
class NL_X_NB_NH_BS_CS_Spec(KVFormatSpec):
    engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_CS
    attention_backends = ("vLLM non-MLA blocks-first, fused K/V (HND)",)
    is_layer_list = True
    is_hnd = True
    is_fused_packed = True
```

Everything else reads them through `get_spec_class(fmt)`; the four public
`torch_ops` predicates (`is_cross_layer` / `is_kv_list` / `is_layer_list` /
`is_mla`) keep their names and signatures and are now one-line lookups, so the
`c_ops` parity contract is unchanged. `csrc/engine_kv_format.h` keeps its copy —
the device kernels need it — and the classification test now pins the two sides
against each other.

`get_spec_class` indexes by enum *value*, because the native pybind
`EngineKVFormat` and the pure-Python fallback one are different types with the
same members and both reach the table.

## Notes

- `_is_cross_layer_format` / `_is_sglang_mha_format` / `_is_mla_format` were
  pure aliases of the public predicates; dropped in favour of the public ones.
- Python-side `is_hnd` is now the honest fact ("heads before block tokens"), so
  it also covers the cross-layer and fused HND formats. The dispatch in
  `multi_layer_block_kv_transfer` is unaffected (cross-layer and fused are
  matched by earlier branches); the local HND flags in the cross-layer and fused
  helpers now come from the same fact instead of their own lists.
- `_per_layer_paged_shape` still switches on the format: that one renders a
  *paged buffer* shape rather than answering a yes/no fact, so it is left alone.

## Test

- `pytest tests/v1/gpu_connector tests/v1/test_torch_ops.py tests/v1/test_c_ops_parity.py tests/v1/test_mp_mem_kernels.py tests/v1/platform tests/cli` — pass
- new: `test_spec_facts_match_predicates` (spec vs `c_ops`) and
  `test_spec_only_facts_match_golden` (golden table for the spec-only facts)
- `pre-commit run --all-files` — all Python hooks pass (the Rust clippy hook
  fails on macOS because `io-uring` is Linux-only, unrelated to this change)
