### PR TITLE
[Perf][P2P] Slice NIXL L1 memory registration to avoid the >4 GiB destination-MR throughput cliff

### DIFF
--- a/docs/design/v1/distributed/transfer_channel/overall.md
+++ b/docs/design/v1/distributed/transfer_channel/overall.md
@@ -98,7 +98,7 @@ The normal way application code obtains a context:
 
 | Function | Purpose |
 |---|---|
-| `initialize_transfer_channel_context(transfer_channel_type, l1_memory_desc, listen_url, advertise_url, **kwargs)` | Create the process-global context via the registered factory. Raises if one already exists, or if the type is unknown. `**kwargs` are forwarded to the factory (e.g. `backends=["UCX"]` for nixl). |
+| `initialize_transfer_channel_context(transfer_channel_type, l1_memory_desc, listen_url, advertise_url, **kwargs)` | Create the process-global context via the registered factory. Raises if one already exists, or if the type is unknown. `**kwargs` are forwarded to the factory (e.g. `backends=["UCX"]` and `mr_slice_bytes` for nixl). |
 | `get_transfer_channel_context()` | Return the global context (raises if not initialized). |
 | `delete_transfer_channel_context()` | Close and clear the global context. |
 
@@ -110,8 +110,9 @@ typically obtained from `L1MemoryManager.get_l1_memory_desc()`.
 
 ## How a read flows
 
-1. **Register.** Each peer builds a context, which registers its whole L1 buffer
-   with the transport and binds its handshake server.
+1. **Register.** Each peer builds a context, which registers its L1 buffer with
+   the transport (as one region or as `mr_slice_bytes`-capped slices) and binds
+   its handshake server.
 2. **Connect / handshake.** The reader calls
    `get_transfer_channel_client(peer_url)`. If no client exists, the context
    dials the peer's server and exchanges transport metadata (agent identity and
@@ -140,8 +141,17 @@ default). It self-registers under the type name `"nixl"` at import time. Notable
 points:
 
 - **One agent per context.** The context creates a single `nixl_agent`, registers
-  the whole L1 buffer once, and builds a page-granular transfer-descriptor list
+  the L1 buffer once, and builds a page-granular transfer-descriptor list
   over `[base, base+size)` using `align_bytes` as the page size.
+- **Sliced memory registration.** `mr_slice_bytes` caps the size of each
+  memory-registration slice (0 = one region covering the whole buffer). RDMA
+  reads whose *destination* sits in a single registered region larger than
+  ~4 GiB run at ~55% of line rate (NIC translation-cache pressure on the
+  requester; measured 9.3 → 6.0 GB/s on 100 GbE RoCE), so the MP server's
+  `P2PConfig` defaults to 3.5 GiB slices. Slice boundaries are rounded down to
+  `align_bytes` multiples so no transfer page straddles two registrations, and
+  nixl/UCX transparently splits reads that span a slice boundary — the
+  page-index math and the descriptor list are unaffected by slicing.
 - **Handshake over ZMQ.** Metadata is exchanged over a ZMQ `REP`/`REQ` socket
   (not the LMCache MQ — that would be overkill and would leak transfer-channel
   functions into the global MQ). The messages are a small `msgspec` tagged union

--- a/docs/design/v1/distributed/transfer_channel/overall.md
+++ b/docs/design/v1/distributed/transfer_channel/overall.md
@@ -148,10 +148,13 @@ points:
   reads whose *destination* sits in a single registered region larger than
   ~4 GiB run at ~55% of line rate (NIC translation-cache pressure on the
   requester; measured 9.3 → 6.0 GB/s on 100 GbE RoCE), so the MP server's
-  `P2PConfig` defaults to 3.5 GiB slices. Slice boundaries are rounded down to
-  `align_bytes` multiples so no transfer page straddles two registrations, and
-  nixl/UCX transparently splits reads that span a slice boundary — the
-  page-index math and the descriptor list are unaffected by slicing.
+  `P2PConfig.nixl_mr_slice_bytes` (CLI `--p2p-nixl-mr-slice-bytes`) defaults to
+  3.5 GiB slices. Slice boundaries are rounded down to `align_bytes` multiples
+  so no transfer page straddles two registrations, and nixl/UCX transparently
+  splits reads that span a slice boundary — the page-index math and the
+  descriptor list are unaffected by slicing. The slice layout itself is
+  computed by the pure function `compute_mr_slice_regions`, unit-tested
+  without a nixl runtime.
 - **Handshake over ZMQ.** Metadata is exchanged over a ZMQ `REP`/`REQ` socket
   (not the LMCache MQ — that would be overkill and would leak transfer-channel
   functions into the global MQ). The messages are a small `msgspec` tagged union

--- a/lmcache/tools/transfer_channel_benchmark/benchmark.py
+++ b/lmcache/tools/transfer_channel_benchmark/benchmark.py
@@ -146,6 +146,7 @@ def server_main(cfg: BenchmarkConfig) -> None:
             listen_url=cfg.url,
             advertise_url=cfg.url,
             backends=[cfg.nixl_backend],
+            mr_slice_bytes=cfg.mr_slice_bytes,
         )
         try:
             _serve_catalog(cfg, catalog)
@@ -243,6 +244,7 @@ def client_main(cfg: BenchmarkConfig) -> bool:
             listen_url=cfg.listen_url,
             advertise_url=cfg.listen_url,
             backends=[cfg.nixl_backend],
+            mr_slice_bytes=cfg.mr_slice_bytes,
         )
         try:
             local_addrs = ctx.get_transfer_channel_address(

--- a/lmcache/tools/transfer_channel_benchmark/config.py
+++ b/lmcache/tools/transfer_channel_benchmark/config.py
@@ -72,6 +72,8 @@ class BenchmarkConfig:
         num_objects: Number of objects transferred per read.
         num_source_objects: Number of source objects the server allocates. The
             client reads a random ``num_objects``-sized subset of these.
+        mr_slice_bytes: Maximum bytes per transfer-channel memory-registration
+            slice; 0 registers the L1 buffer as a single region.
         use_lazy: Whether the L1 memory manager uses lazy allocation.
         iters: Number of measured read iterations.
         warmup: Number of warmup read iterations (not measured).
@@ -91,6 +93,7 @@ class BenchmarkConfig:
     object_size: int = DEFAULT_OBJECT_SIZE
     num_objects: int = 100
     num_source_objects: int = 0
+    mr_slice_bytes: int = 0
     use_lazy: bool = False
     iters: int = 5
     warmup: int = 1
@@ -198,6 +201,13 @@ def add_benchmark_arguments(parser: argparse.ArgumentParser) -> None:
         help="server source pool size; 0 means 5 * --num-objects.",
     )
     parser.add_argument(
+        "--mr-slice-bytes",
+        type=parse_size,
+        default=0,
+        help="maximum bytes per memory-registration slice (e.g. 3.5GB); "
+        "0 registers the L1 buffer as a single region.",
+    )
+    parser.add_argument(
         "--use-lazy",
         action="store_true",
         help="use the lazy L1 allocator (experimental for registration).",
@@ -243,6 +253,7 @@ def build_config(args: argparse.Namespace) -> BenchmarkConfig:
         object_size=args.object_size,
         num_objects=args.num_objects,
         num_source_objects=args.num_source_objects,
+        mr_slice_bytes=args.mr_slice_bytes,
         use_lazy=args.use_lazy,
         iters=args.iters,
         warmup=args.warmup,

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -317,6 +317,7 @@ class NixlTransferChannelContext(TransferChannelContext):
         listen_url: str,
         advertise_url: str,
         backends: Optional[list[str]] = None,
+        mr_slice_bytes: int = 0,
     ) -> None:
         """
         Creates the transfer channel context using nixl.
@@ -326,6 +327,16 @@ class NixlTransferChannelContext(TransferChannelContext):
             listen_url: The URL to listen on for incoming connections.
             advertise_url: The URL to advertise to peers for them to connect to us.
             backends: Optional list of nixl backends to use (e.g., ["UCX"])
+            mr_slice_bytes: Maximum bytes per memory-registration slice; 0
+                registers the whole buffer as a single region. RDMA-read
+                throughput on the requesting peer drops sharply once a single
+                registration exceeds ~4 GiB (NIC translation-cache pressure),
+                so large L1 buffers should be sliced. Reads spanning a slice
+                boundary are split transparently by nixl.
+
+        Raises:
+            ValueError: If ``mr_slice_bytes`` is negative, or positive but
+                smaller than the buffer's alignment.
         """
         nixl_agent, nixl_agent_config = _load_nixl()
 
@@ -335,12 +346,36 @@ class NixlTransferChannelContext(TransferChannelContext):
         self.advertise_url = advertise_url
         backends = backends if backends else ["UCX"]
 
+        if mr_slice_bytes < 0:
+            raise ValueError(f"mr_slice_bytes must be >= 0, got {mr_slice_bytes}")
+        if 0 < mr_slice_bytes < self._align:
+            raise ValueError(
+                f"mr_slice_bytes ({mr_slice_bytes}) must be at least the "
+                f"buffer alignment ({self._align})"
+            )
+
         self.agent_name = str(uuid.uuid4())
         self.agent = nixl_agent(self.agent_name, nixl_agent_config(backends=backends))
 
-        # Register the whole L1 buffer once (CPU/DRAM, fixed nixl dev_id=0).
+        # Register the L1 buffer (CPU/DRAM, fixed nixl dev_id=0), either as one
+        # region or as slices of at most mr_slice_bytes. Slice boundaries are
+        # rounded down to align-page multiples so no xfer page straddles two
+        # registrations.
         ptr, size = l1_memory_desc.ptr, l1_memory_desc.size
-        self._reg_descs = self.agent.get_reg_descs([(ptr, size, 0, "")], "cpu")
+        if mr_slice_bytes > 0:
+            slice_bytes = mr_slice_bytes - (mr_slice_bytes % self._align)
+            reg_list = [
+                (addr, min(slice_bytes, ptr + size - addr), 0, "")
+                for addr in range(ptr, ptr + size, slice_bytes)
+            ]
+            logger.info(
+                "Registering L1 as %d MR slices of <=%d bytes each",
+                len(reg_list),
+                slice_bytes,
+            )
+        else:
+            reg_list = [(ptr, size, 0, "")]
+        self._reg_descs = self.agent.get_reg_descs(reg_list, "cpu")
         self.agent.register_memory(self._reg_descs)
 
         # Build + prep a page-granular local xfer dlist over the whole buffer.
@@ -610,7 +645,9 @@ def create_nixl_transfer_channel_context(
         listen_url: ``host:port`` this peer's server binds to.
         advertise_url: ``host:port`` this peer advertises as its identity.
         **kwargs: Accepts ``backends`` (an optional list of nixl backends,
-            e.g. ``["UCX"]``).
+            e.g. ``["UCX"]``) and ``mr_slice_bytes`` (maximum bytes per
+            memory-registration slice; 0, the default, registers the whole
+            buffer as one region).
 
     Returns:
         A new ``NixlTransferChannelContext`` instance.
@@ -620,6 +657,7 @@ def create_nixl_transfer_channel_context(
         listen_url=listen_url,
         advertise_url=advertise_url,
         backends=kwargs.get("backends"),
+        mr_slice_bytes=kwargs.get("mr_slice_bytes", 0),
     )
 
 

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -67,6 +67,54 @@ def _parse_url(url: str) -> tuple[str, int]:
     return host, int(port)
 
 
+def compute_mr_slice_regions(
+    ptr: int, size: int, mr_slice_bytes: int, align_bytes: int
+) -> list[tuple[int, int, int, str]]:
+    """Compute the memory-registration regions covering an L1 buffer.
+
+    With ``mr_slice_bytes == 0`` the whole buffer is a single region. Otherwise
+    the buffer is partitioned into consecutive slices of at most
+    ``mr_slice_bytes`` each, with the slice length rounded down to an
+    ``align_bytes`` multiple so no transfer page straddles two registrations.
+    The returned regions exactly partition ``[ptr, ptr + size)``: no gaps, no
+    overlaps, and every boundary between two regions is ``ptr`` plus an
+    ``align_bytes`` multiple.
+
+    This is a pure function so the slicing invariants can be unit-tested
+    without a nixl runtime.
+
+    Args:
+        ptr: Base address of the buffer.
+        size: Size of the buffer in bytes.
+        mr_slice_bytes: Maximum bytes per registration slice; 0 disables
+            slicing.
+        align_bytes: The transfer page size (buffer alignment); slice lengths
+            are rounded down to multiples of it.
+
+    Returns:
+        Nixl registration region tuples ``(addr, length, dev_id, meta)`` with
+        ``dev_id=0`` and empty ``meta``.
+
+    Raises:
+        ValueError: If ``mr_slice_bytes`` is negative, or positive but smaller
+            than ``align_bytes``.
+    """
+    if mr_slice_bytes < 0:
+        raise ValueError(f"mr_slice_bytes must be >= 0, got {mr_slice_bytes}")
+    if 0 < mr_slice_bytes < align_bytes:
+        raise ValueError(
+            f"mr_slice_bytes ({mr_slice_bytes}) must be at least the "
+            f"buffer alignment ({align_bytes})"
+        )
+    if mr_slice_bytes == 0:
+        return [(ptr, size, 0, "")]
+    slice_bytes = mr_slice_bytes - (mr_slice_bytes % align_bytes)
+    return [
+        (addr, min(slice_bytes, ptr + size - addr), 0, "")
+        for addr in range(ptr, ptr + size, slice_bytes)
+    ]
+
+
 ############################################################
 # Handshake messages (msgspec, tagged union)
 ############################################################
@@ -346,35 +394,22 @@ class NixlTransferChannelContext(TransferChannelContext):
         self.advertise_url = advertise_url
         backends = backends if backends else ["UCX"]
 
-        if mr_slice_bytes < 0:
-            raise ValueError(f"mr_slice_bytes must be >= 0, got {mr_slice_bytes}")
-        if 0 < mr_slice_bytes < self._align:
-            raise ValueError(
-                f"mr_slice_bytes ({mr_slice_bytes}) must be at least the "
-                f"buffer alignment ({self._align})"
+        # Compute (and validate) the registration layout before creating the
+        # nixl agent so a bad mr_slice_bytes fails without leaking an agent.
+        ptr, size = l1_memory_desc.ptr, l1_memory_desc.size
+        reg_list = compute_mr_slice_regions(ptr, size, mr_slice_bytes, self._align)
+        self._num_mr_slices = len(reg_list)
+        if self._num_mr_slices > 1:
+            logger.info(
+                "Registering L1 as %d MR slices of <=%d bytes each",
+                self._num_mr_slices,
+                reg_list[0][1],
             )
 
         self.agent_name = str(uuid.uuid4())
         self.agent = nixl_agent(self.agent_name, nixl_agent_config(backends=backends))
 
-        # Register the L1 buffer (CPU/DRAM, fixed nixl dev_id=0), either as one
-        # region or as slices of at most mr_slice_bytes. Slice boundaries are
-        # rounded down to align-page multiples so no xfer page straddles two
-        # registrations.
-        ptr, size = l1_memory_desc.ptr, l1_memory_desc.size
-        if mr_slice_bytes > 0:
-            slice_bytes = mr_slice_bytes - (mr_slice_bytes % self._align)
-            reg_list = [
-                (addr, min(slice_bytes, ptr + size - addr), 0, "")
-                for addr in range(ptr, ptr + size, slice_bytes)
-            ]
-            logger.info(
-                "Registering L1 as %d MR slices of <=%d bytes each",
-                len(reg_list),
-                slice_bytes,
-            )
-        else:
-            reg_list = [(ptr, size, 0, "")]
+        # Register the L1 buffer (CPU/DRAM, fixed nixl dev_id=0).
         self._reg_descs = self.agent.get_reg_descs(reg_list, "cpu")
         self.agent.register_memory(self._reg_descs)
 
@@ -400,6 +435,15 @@ class NixlTransferChannelContext(TransferChannelContext):
             l1_memory_desc=l1_memory_desc,
             context=self,
         )
+
+    @property
+    def num_mr_slices(self) -> int:
+        """Number of memory-registration regions covering the L1 buffer.
+
+        1 when ``mr_slice_bytes`` was 0 (single region); otherwise the number
+        of slices actually registered with nixl.
+        """
+        return self._num_mr_slices
 
     ############################################################
     # Address translation

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -166,11 +166,12 @@ class P2PConfig:
     transfer_engine: str = "nixl"
     """Transfer-channel implementation to use."""
 
-    mr_slice_bytes: int = 3_758_096_384
-    """Maximum bytes per transfer-channel memory-registration slice; 0
-    registers the L1 buffer as a single region. RDMA-read throughput on the
-    requesting peer drops sharply (~9.3 to ~6 GB/s on 100 GbE) once a single
-    registration exceeds ~4 GiB, so the default keeps slices at 3.5 GiB."""
+    nixl_mr_slice_bytes: int = 3_758_096_384
+    """Maximum bytes per nixl memory-registration slice; 0 registers the L1
+    buffer as a single region. RDMA-read throughput on the requesting peer
+    drops sharply (~9.3 to ~6 GB/s on 100 GbE) once a single registration
+    exceeds ~4 GiB, so the default keeps slices at 3.5 GiB. Only consumed by
+    the nixl transfer engine."""
 
     @property
     def enabled(self) -> bool:
@@ -494,12 +495,13 @@ def add_p2p_args(
         help="Transfer-channel implementation to use. Default is nixl.",
     )
     group.add_argument(
-        "--p2p-mr-slice-bytes",
+        "--p2p-nixl-mr-slice-bytes",
         type=int,
-        default=DEFAULT_P2P_CONFIG.mr_slice_bytes,
-        help="Maximum bytes per transfer-channel memory-registration slice; "
+        default=DEFAULT_P2P_CONFIG.nixl_mr_slice_bytes,
+        help="Maximum bytes per nixl memory-registration slice; "
         "0 registers the L1 buffer as a single region. Default is 3.5 GiB "
-        "(single registrations beyond ~4 GiB degrade RDMA-read throughput).",
+        "(single registrations beyond ~4 GiB degrade RDMA-read throughput). "
+        "Only consumed by the nixl transfer engine.",
     )
     return parser
 
@@ -521,8 +523,8 @@ def parse_args_to_p2p_config(
         lookup_timeout=getattr(args, "p2p_lookup_timeout", 30.0),
         load_timeout=getattr(args, "p2p_load_timeout", 30.0),
         transfer_engine=getattr(args, "p2p_transfer_engine", "nixl"),
-        mr_slice_bytes=getattr(
-            args, "p2p_mr_slice_bytes", DEFAULT_P2P_CONFIG.mr_slice_bytes
+        nixl_mr_slice_bytes=getattr(
+            args, "p2p_nixl_mr_slice_bytes", DEFAULT_P2P_CONFIG.nixl_mr_slice_bytes
         ),
     )
 

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -166,6 +166,12 @@ class P2PConfig:
     transfer_engine: str = "nixl"
     """Transfer-channel implementation to use."""
 
+    mr_slice_bytes: int = 3_758_096_384
+    """Maximum bytes per transfer-channel memory-registration slice; 0
+    registers the L1 buffer as a single region. RDMA-read throughput on the
+    requesting peer drops sharply (~9.3 to ~6 GB/s on 100 GbE) once a single
+    registration exceeds ~4 GiB, so the default keeps slices at 3.5 GiB."""
+
     @property
     def enabled(self) -> bool:
         """Whether P2P is enabled (an advertise URL is configured)."""
@@ -487,6 +493,14 @@ def add_p2p_args(
         default="nixl",
         help="Transfer-channel implementation to use. Default is nixl.",
     )
+    group.add_argument(
+        "--p2p-mr-slice-bytes",
+        type=int,
+        default=DEFAULT_P2P_CONFIG.mr_slice_bytes,
+        help="Maximum bytes per transfer-channel memory-registration slice; "
+        "0 registers the L1 buffer as a single region. Default is 3.5 GiB "
+        "(single registrations beyond ~4 GiB degrade RDMA-read throughput).",
+    )
     return parser
 
 
@@ -507,6 +521,9 @@ def parse_args_to_p2p_config(
         lookup_timeout=getattr(args, "p2p_lookup_timeout", 30.0),
         load_timeout=getattr(args, "p2p_load_timeout", 30.0),
         transfer_engine=getattr(args, "p2p_transfer_engine", "nixl"),
+        mr_slice_bytes=getattr(
+            args, "p2p_mr_slice_bytes", DEFAULT_P2P_CONFIG.mr_slice_bytes
+        ),
     )
 
 

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -144,6 +144,7 @@ class P2PController:
             self._ctx.storage_manager.l1_memory_desc,
             listen_url=self._p2p_config.effective_listen_url,
             advertise_url=self._p2p_config.advertise_url,
+            mr_slice_bytes=self._p2p_config.mr_slice_bytes,
         )
         self._instances_url = coordinator_config.url.rstrip("/") + "/instances"
         timeout = max(1.0, coordinator_config.heartbeat_interval)

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -144,7 +144,7 @@ class P2PController:
             self._ctx.storage_manager.l1_memory_desc,
             listen_url=self._p2p_config.effective_listen_url,
             advertise_url=self._p2p_config.advertise_url,
-            mr_slice_bytes=self._p2p_config.mr_slice_bytes,
+            mr_slice_bytes=self._p2p_config.nixl_mr_slice_bytes,
         )
         self._instances_url = coordinator_config.url.rstrip("/") + "/instances"
         timeout = max(1.0, coordinator_config.heartbeat_interval)

--- a/tests/v1/distributed/transfer_channel/test_mr_slice_regions.py
+++ b/tests/v1/distributed/transfer_channel/test_mr_slice_regions.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for ``compute_mr_slice_regions``, the pure slicing math behind
+sliced NIXL memory registration.
+
+Unlike ``test_nixl_impl.py`` these tests need no nixl runtime (the function is
+deliberately pure), so they always run in CI and pin down the invariants that
+the hardware-dependent integration tests cannot: the regions exactly partition
+the buffer, respect the slice cap, and land on alignment boundaries.
+"""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.transfer_channel.impl.nixl_impl import (
+    compute_mr_slice_regions,
+)
+
+
+def _check_partition_invariants(
+    regions: list[tuple[int, int, int, str]],
+    ptr: int,
+    size: int,
+    mr_slice_bytes: int,
+    align_bytes: int,
+) -> None:
+    """Assert regions exactly partition [ptr, ptr + size) per the contract."""
+    assert len(regions) >= 1
+    # Consecutive coverage: no gaps, no overlaps, exact start and end.
+    assert regions[0][0] == ptr
+    for (addr, length, dev_id, meta), nxt in zip(regions, regions[1:], strict=False):
+        assert addr + length == nxt[0]
+    last_addr, last_len, _, _ = regions[-1]
+    assert last_addr + last_len == ptr + size
+    for addr, length, dev_id, meta in regions:
+        assert length > 0
+        assert length <= mr_slice_bytes or mr_slice_bytes == 0
+        assert dev_id == 0
+        assert meta == ""
+        # Every boundary between two regions is ptr + a multiple of align.
+        if addr != ptr:
+            assert (addr - ptr) % align_bytes == 0
+
+
+def test_zero_mr_slice_bytes_registers_single_region():
+    regions = compute_mr_slice_regions(0x1000, 4096, 0, 256)
+    assert regions == [(0x1000, 4096, 0, "")]
+
+
+def test_even_split_into_exact_slices():
+    regions = compute_mr_slice_regions(0x1000, 4096, 1024, 256)
+    assert regions == [
+        (0x1000, 1024, 0, ""),
+        (0x1000 + 1024, 1024, 0, ""),
+        (0x1000 + 2048, 1024, 0, ""),
+        (0x1000 + 3072, 1024, 0, ""),
+    ]
+
+
+def test_last_slice_is_shorter_when_size_is_not_a_multiple():
+    regions = compute_mr_slice_regions(0, 2560, 1024, 256)
+    assert regions == [(0, 1024, 0, ""), (1024, 1024, 0, ""), (2048, 512, 0, "")]
+
+
+def test_slice_cap_is_rounded_down_to_alignment():
+    # 1100 rounds down to 1024 (4 x 256), so the layout matches slice=1024.
+    regions = compute_mr_slice_regions(0, 4096, 1100, 256)
+    assert [length for _, length, _, _ in regions] == [1024, 1024, 1024, 1024]
+
+
+def test_slice_larger_than_buffer_yields_single_region():
+    regions = compute_mr_slice_regions(0x2000, 1024, 4096, 256)
+    assert regions == [(0x2000, 1024, 0, "")]
+
+
+def test_negative_mr_slice_bytes_raises_value_error():
+    with pytest.raises(ValueError):
+        compute_mr_slice_regions(0, 4096, -1, 256)
+
+
+def test_mr_slice_bytes_below_alignment_raises_value_error():
+    with pytest.raises(ValueError):
+        compute_mr_slice_regions(0, 4096, 255, 256)
+
+
+@pytest.mark.parametrize("ptr", [0, 0x1000, 0xDEAD0000])
+@pytest.mark.parametrize("size_pages", [1, 3, 7, 64, 1023])
+@pytest.mark.parametrize("align_bytes", [256, 4096, 65536])
+@pytest.mark.parametrize("slice_pages", [1, 2, 5, 16, 10_000])
+def test_partition_invariants_hold_across_parameter_sweep(
+    ptr: int, size_pages: int, align_bytes: int, slice_pages: int
+):
+    """Sweep buffer/slice geometries; every combination must exactly partition
+    the buffer (production-scale ratios are covered by page counts, so the
+    sweep stays fast)."""
+    size = size_pages * align_bytes
+    # Perturb the cap so rounding-down is exercised, not just exact multiples.
+    mr_slice_bytes = slice_pages * align_bytes + align_bytes - 1
+    regions = compute_mr_slice_regions(ptr, size, mr_slice_bytes, align_bytes)
+    _check_partition_invariants(regions, ptr, size, mr_slice_bytes, align_bytes)
+
+
+def test_production_geometry_24_gib_l1_with_3_5_gib_slices():
+    """The shipped default: a 24 GiB L1 sliced at 3.5 GiB -> 7 regions."""
+    align = 65536
+    size = 24 * 1024**3
+    regions = compute_mr_slice_regions(0, size, 3_758_096_384, align)
+    assert len(regions) == 7
+    _check_partition_invariants(regions, 0, size, 3_758_096_384, align)

--- a/tests/v1/distributed/transfer_channel/test_nixl_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_nixl_impl.py
@@ -234,3 +234,65 @@ def test_connecting_registers_clients_on_both_sides(fresh_contexts):
 def test_server_is_available_from_context(shared_contexts):
     ctx_a, _, _, _ = shared_contexts
     assert ctx_a.get_transfer_channel_server() is not None
+
+
+# =========================================================
+# MR slicing (mr_slice_bytes)
+# =========================================================
+def test_sliced_registration_serves_read_across_slice_boundary():
+    """With mr_slice_bytes=1024 the 4096-byte buffer registers as 4 slices;
+    a read spanning the destination's first slice boundary must still land
+    intact (nixl splits transfers across registration slices transparently).
+    """
+    ctx_a = ctx_b = None
+    buf_a = torch.zeros(_BUF_SIZE, dtype=torch.uint8)
+    buf_b = torch.arange(0, 256, dtype=torch.uint8).repeat(_BUF_SIZE // 256)
+    desc_a = L1MemoryDesc(ptr=buf_a.data_ptr(), size=buf_a.numel(), align_bytes=_ALIGN)
+    desc_b = L1MemoryDesc(ptr=buf_b.data_ptr(), size=buf_b.numel(), align_bytes=_ALIGN)
+    url_a, url_b = _next_url(), _next_url()
+    try:
+        ctx_a = NixlTransferChannelContext(
+            desc_a, listen_url=url_a, advertise_url=url_a, mr_slice_bytes=1024
+        )
+        ctx_b = NixlTransferChannelContext(
+            desc_b, listen_url=url_b, advertise_url=url_b, mr_slice_bytes=1024
+        )
+        client = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+
+        # [768, 1792) crosses the slice boundary at 1024 on both sides.
+        local = ctx_a.get_transfer_channel_address([(768, 1024)])
+        remote = ctx_b.get_transfer_channel_address([(768, 1024)])
+        task_id = client.submit_read(local, remote)
+
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert result.succeeded_mask == [True]
+        assert torch.equal(buf_a[768:1792], buf_b[768:1792])
+        # Regions outside the read stay untouched.
+        assert torch.count_nonzero(buf_a[:768]) == 0
+        assert torch.count_nonzero(buf_a[1792:]) == 0
+    finally:
+        if ctx_a is not None:
+            ctx_a.close()
+        if ctx_b is not None:
+            ctx_b.close()
+
+
+def test_mr_slice_bytes_negative_raises_value_error():
+    buf = torch.zeros(_BUF_SIZE, dtype=torch.uint8)
+    desc = L1MemoryDesc(ptr=buf.data_ptr(), size=buf.numel(), align_bytes=_ALIGN)
+    url = _next_url()
+    with pytest.raises(ValueError):
+        NixlTransferChannelContext(
+            desc, listen_url=url, advertise_url=url, mr_slice_bytes=-1
+        )
+
+
+def test_mr_slice_bytes_below_alignment_raises_value_error():
+    buf = torch.zeros(_BUF_SIZE, dtype=torch.uint8)
+    desc = L1MemoryDesc(ptr=buf.data_ptr(), size=buf.numel(), align_bytes=_ALIGN)
+    url = _next_url()
+    with pytest.raises(ValueError):
+        NixlTransferChannelContext(
+            desc, listen_url=url, advertise_url=url, mr_slice_bytes=_ALIGN - 1
+        )

--- a/tests/v1/distributed/transfer_channel/test_nixl_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_nixl_impl.py
@@ -257,6 +257,12 @@ def test_sliced_registration_serves_read_across_slice_boundary():
         ctx_b = NixlTransferChannelContext(
             desc_b, listen_url=url_b, advertise_url=url_b, mr_slice_bytes=1024
         )
+        # Slicing must actually have happened -- guard against a regression
+        # that ignores mr_slice_bytes and registers one region (a single-MR
+        # read across [768, 1792) would pass the data checks below too).
+        assert ctx_a.num_mr_slices == _BUF_SIZE // 1024
+        assert ctx_b.num_mr_slices == _BUF_SIZE // 1024
+
         client = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
 
         # [768, 1792) crosses the slice boundary at 1024 on both sides.

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -234,17 +234,17 @@ def _parse_p2p(argv: list[str]) -> P2PConfig:
     return parse_args_to_p2p_config(parser.parse_args(argv))
 
 
-def test_p2p_mr_slice_defaults_to_3_5_gib():
+def test_p2p_nixl_mr_slice_defaults_to_3_5_gib():
     config = _parse_p2p([])
-    assert config.mr_slice_bytes == 3_758_096_384
-    assert config.mr_slice_bytes == P2PConfig().mr_slice_bytes
+    assert config.nixl_mr_slice_bytes == 3_758_096_384
+    assert config.nixl_mr_slice_bytes == P2PConfig().nixl_mr_slice_bytes
 
 
-def test_p2p_mr_slice_flag_is_parsed():
-    config = _parse_p2p(["--p2p-mr-slice-bytes", "1073741824"])
-    assert config.mr_slice_bytes == 1073741824
+def test_p2p_nixl_mr_slice_flag_is_parsed():
+    config = _parse_p2p(["--p2p-nixl-mr-slice-bytes", "1073741824"])
+    assert config.nixl_mr_slice_bytes == 1073741824
 
 
-def test_p2p_mr_slice_zero_disables_slicing():
-    config = _parse_p2p(["--p2p-mr-slice-bytes", "0"])
-    assert config.mr_slice_bytes == 0
+def test_p2p_nixl_mr_slice_zero_disables_slicing():
+    config = _parse_p2p(["--p2p-nixl-mr-slice-bytes", "0"])
+    assert config.nixl_mr_slice_bytes == 0

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -18,10 +18,13 @@ import pytest
 from lmcache.v1.multiprocess.config import (
     CoordinatorConfig,
     MPServerConfig,
+    P2PConfig,
     add_coordinator_args,
     add_mp_server_args,
+    add_p2p_args,
     parse_args_to_coordinator_config,
     parse_args_to_mp_server_config,
+    parse_args_to_p2p_config,
 )
 
 _COORD_ENV = (
@@ -220,3 +223,28 @@ def test_deprecated_flags_log_warning():
 def test_deprecated_flush_interval_flag_rejects_nonpositive():
     with pytest.raises(ValueError):
         _parse(["--coordinator-l2-event-flush-interval", "0"])
+
+
+# ---------------------------------------------------------------------------
+# P2P args (MR-slice size)
+# ---------------------------------------------------------------------------
+def _parse_p2p(argv: list[str]) -> P2PConfig:
+    parser = argparse.ArgumentParser()
+    add_p2p_args(parser)
+    return parse_args_to_p2p_config(parser.parse_args(argv))
+
+
+def test_p2p_mr_slice_defaults_to_3_5_gib():
+    config = _parse_p2p([])
+    assert config.mr_slice_bytes == 3_758_096_384
+    assert config.mr_slice_bytes == P2PConfig().mr_slice_bytes
+
+
+def test_p2p_mr_slice_flag_is_parsed():
+    config = _parse_p2p(["--p2p-mr-slice-bytes", "1073741824"])
+    assert config.mr_slice_bytes == 1073741824
+
+
+def test_p2p_mr_slice_zero_disables_slicing():
+    config = _parse_p2p(["--p2p-mr-slice-bytes", "0"])
+    assert config.mr_slice_bytes == 0


### PR DESCRIPTION
**What this PR does / why we need it**:

RDMA reads whose **destination** lies in a single NIXL memory registration
larger than ~4 GiB run at ~55% of line rate on our 100 GbE RoCE testbed
(mlx5, 4 KB-page registration, IOMMU on): ~6.0 GB/s instead of ~9.3 GB/s.
A production L1 buffer is tens of GB and is registered as one region, so the
MP-server P2P path always sits in the slow regime.

Controlled experiments isolating the variable (transfer channel benchmark,
zero GPU, two nodes):

| read | destination MR layout | GB/s |
|---|---|---|
| 3.62 GB | 6.5 GiB × 1 | 6.00 |
| 3.62 GB | **3.5 GiB × 2 (same total bytes)** | **9.24** |
| 5.89 GB | 5.9 GiB × 1 | 6.02 |
| 5.89 GB | **3.5 + 2.4 GiB slices** | **9.32** |
| 5.89 GB | 24 GiB × 1 | 6.04 |
| 5.89 GB | 24 GiB in 3.5 GiB slices | 9.24 |

Three properties pin down the mechanism as **per-MR translation depth** on
the requesting NIC (not total pinned memory, not read size):

- Same read size and same *total* registered bytes; only the slicing differs
  (rows 1–2).
- The penalty is a step, not a slope: a 24 GiB single MR is no slower than a
  5.9 GiB one (rows 3 vs 5).
- It is asymmetric: inflating the *source* MR is free; only the destination
  (where the NIC writes) matters.

**The fix**: register the L1 buffer as multiple page-aligned slices of at
most `mr_slice_bytes` instead of one region. Slice boundaries are rounded
down to `align_bytes` multiples so no transfer page straddles two
registrations, and NIXL/UCX transparently splits reads that span a slice
boundary (verified with the benchmark's `--verify` data check) — the
page-index math and the descriptor list are completely untouched, so the
whole change is confined to the registration call in
`NixlTransferChannelContext.__init__`.

Configuration is layered:

- Mechanism (`NixlTransferChannelContext(mr_slice_bytes=...)`): default `0`
  = single region, behavior unchanged.
- Policy (`P2PConfig.mr_slice_bytes`, CLI `--p2p-mr-slice-bytes`): default
  **3.5 GiB = slicing ON** for the MP server's P2P path.
- The transfer channel benchmark gains `--mr-slice-bytes` (accepts `3.5GB`)
  so the effect can be measured directly.

Measured impact, three levels of the same stack (all A/B with the flag as
the only delta):

| level | before | after |
|---|---|---|
| raw channel, 5.89 GB read | 6.0 GB/s | **9.3 GB/s (+55%)** |
| MP-server P2P, per request (40K-token doc: lookup incl. wire + retrieve) | ~1236 ms | **~900 ms (−27%)** |
| full stack: 2-node vLLM + `lmcache bench engine` long-doc-qa, p50 TTFT | 1545.8 ms | **1197.8 ms (−22.5%)** |

**Special notes for your reviewers**:

- The ~4 GiB threshold is presumably NIC/IOMMU-dependent (we measured mlx5 /
  100 GbE / IOMMU on / 4 KB pages). 3.5 GiB was the fastest measured safe
  size on this hardware; since slicing a small buffer is harmless (a <3.5 GiB
  buffer still gets one region), a conservative default seemed better than
  auto-detection. `--p2p-mr-slice-bytes 0` restores the old behavior.
- Only the requester/destination side benefits, but the default applies to
  both peers (each side registers its own L1 once and both may act as
  readers).
- Scope: this touches only the MP-server transfer channel
  (`lmcache/v1/distributed/transfer_channel/`). The legacy
  `lmcache/v1/transfer_channel/nixl_channel.py` (P/D-disagg path) has the
  same single-large-MR pattern and would need the same treatment; left out
  deliberately to keep this PR focused.
- `nixl_storage_backend.py` already registers per-page and is unaffected.

**Reproduction A — isolated channel (two nodes, no GPU needed;
`CUDA_VISIBLE_DEVICES=` works)**:

```bash
# node A (source)
python -m lmcache.tools.transfer_channel_benchmark --role server \
  --transfer-channel-type nixl --url 0.0.0.0:7600 --control-url 0.0.0.0:7610 \
  --buffer-size $((6144*1048576)) --page-size 65536 \
  --object-size $((36*1048576)) --num-objects 156 --num-source-objects 156

# node B (destination/requester) — run once per arm:
#   arm 1: --mr-slice-bytes 0      (single MR,   ~6 GB/s here)
#   arm 2: --mr-slice-bytes 3.5GB  (sliced,      ~9.3 GB/s here)
python -m lmcache.tools.transfer_channel_benchmark --role client \
  --transfer-channel-type nixl --url <nodeA>:7600 --control-url <nodeA>:7610 \
  --listen-url <nodeB>:7601 --page-size 65536 --object-size $((36*1048576)) \
  --num-objects 156 --iters 10 --warmup 2 --seed 0 --verify \
  --mr-slice-bytes 3.5GB
```

**Reproduction B — full-stack TTFT A/B (two nodes, one GPU each;
this is the −22.5% p50 TTFT experiment)**:

Design: warm node A's L1 with 8 × 40K-token documents through vLLM-A, then
run the *same* documents (same `--seed`) against vLLM-B — every lookup on B
misses locally and P2P-loads the full document (~5.9 GB) from A. P2P-loaded
keys are retained as temporary (deleted after the read), so **every query
re-pays the full wire cost**, which makes TTFT a direct read of wire
throughput. The two arms differ ONLY in server-B's `--p2p-mr-slice-bytes`;
restart server-B *and* vLLM-B between arms (fresh L1 + fresh connector),
leave A untouched.

All LMCache/vLLM processes need `PYTHONHASHSEED=0` (MP mode).

```bash
# 0) coordinator (runs anywhere; here: node B)
lmcache coordinator --host 0.0.0.0 --port 9300

# 1) node A — MP server + vLLM (will hold the warm KV cache).
#    L1 must fit all docs below the eviction trigger watermark (default 0.8):
#    8 docs x 40K tok x 147456 B/tok (Qwen3-8B) = 47.2 GB -> 64 GB L1 (69% full).
lmcache server --host 0.0.0.0 --port 5560 --http-port 8080 \
  --l1-size-gb 64 --eviction-policy LRU --chunk-size 256 \
  --p2p-advertise-url <nodeA-ip>:9400 --p2p-transfer-engine nixl \
  --coordinator-url http://<nodeB-ip>:9300 --coordinator-advertise-ip <nodeA-ip>

vllm serve Qwen/Qwen3-8B --port 8000 --max-model-len 40960 \
  --gpu-memory-utilization 0.3 \
  --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both",
    "kv_connector_extra_config":{"lmcache.mp.host":"tcp://localhost","lmcache.mp.port":5560}}'

# 2) warm A (1 query/doc stores the docs into A's L1), then verify no eviction:
lmcache bench engine --engine-url http://<nodeA-ip>:8000 --model Qwen3-8B \
  --workload long-doc-qa --no-interactive --seed 42 \
  --tokens-per-gb-kvcache 6781 --kv-cache-volume 47.2 \
  --ldqa-document-length 40000 --ldqa-query-per-document 1 \
  --ldqa-num-inflight-requests 1 --ldqa-max-output-length 16
curl -s http://<nodeA-ip>:8080/metrics | grep -E "chunks_total|usage_ratio"
#   -> lmcache_mp_l1_write_chunks_total = 1248 (8 docs x 156 chunks),
#      lmcache_mp_l1_usage_ratio ~= 0.69, and NO lmcache_mp_l1_evicted_chunks_total
#      line (the counter is only exported after the first eviction)

# 3) node B — MP server + vLLM. Start B only AFTER the warm pass finished
#    (kv_role is kv_both, so a live B would also save the docs it prefills
#    and cross-seed the fleet). ONE arm per run; between arms stop BOTH,
#    then relaunch. Arm "off" adds `--p2p-mr-slice-bytes 0`; arm "on" uses
#    the default (3.5 GiB slices).
lmcache server --host 0.0.0.0 --port 5561 --http-port 8081 \
  --l1-size-gb 24 --eviction-policy LRU --chunk-size 256 \
  --p2p-advertise-url <nodeB-ip>:9401 --p2p-transfer-engine nixl \
  --coordinator-url http://<nodeB-ip>:9300 --coordinator-advertise-ip <nodeB-ip> \
  # --p2p-mr-slice-bytes 0        # <- arm "off" only

# --gpu-memory-utilization on B is LOAD-BEARING: vLLM-B's own KV pool must be
# SMALLER than the doc set (here ~29 GB < 47.2 GB), otherwise vLLM's built-in
# prefix cache retains the docs after the first query and later queries never
# reach LMCache/P2P at all. 0.3 on a 96 GB card ~= 29 GB; scale to your VRAM.
vllm serve Qwen/Qwen3-8B --port 8001 --max-model-len 40960 \
  --gpu-memory-utilization 0.3 \
  --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both",
    "kv_connector_extra_config":{"lmcache.mp.host":"tcp://localhost","lmcache.mp.port":5561}}'

# 4) the measured pass: same seed => same docs => every query P2P-loads from A
lmcache bench engine --engine-url http://<nodeB-ip>:8001 --model Qwen3-8B \
  --workload long-doc-qa --no-interactive --seed 42 \
  --tokens-per-gb-kvcache 6781 --kv-cache-volume 47.2 \
  --ldqa-document-length 40000 --ldqa-query-per-document 3 \
  --ldqa-num-inflight-requests 1 --ldqa-max-output-length 16 \
  --output-dir out-<arm> --json
# TTFT (the headline metric): out-<arm>/**/bench_summary.json -> results.p50_ttft_ms
```

TTFT is the primary metric and needs nothing extra. The per-transfer wire
GB/s we quote additionally came from a small logging hook around NIXL's
`get_xfer_telemetry` in the channel client (not part of this PR); the TTFT
delta reproduces without it.

Our numbers (Qwen3-8B, 2× dual-socket nodes, 100 GbE RoCE, 24 queries/arm):
p50 TTFT 1545.8 → 1197.8 ms, wire median 4.97 → 6.79 GB/s. A second,
independent run of this recipe exactly as written reproduced it within
noise: p50 TTFT 1542.6 → 1207.1 ms (−21.8%), wire 5.02 → 6.39 GB/s.

**If applicable**:

- [x] this PR contains user facing changes - docs added
      (`docs/design/v1/distributed/transfer_channel/overall.md`: registration
      contract + slicing rationale)
- [x] this PR contains unit tests
      (`test_nixl_impl.py`: cross-slice-boundary read with data verification,
      validation errors; `test_config.py`: flag parsing/default/disable)