### PR TITLE
[MP] feat:support lazy offload

### DIFF
--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -126,6 +126,8 @@ class FIFOOffloadPolicy(OffloadPolicy):
                 to_offload.append(self._pending_items[req_id])
                 del self._pending_items[req_id]
                 self._finished_requests_count -= 1
+            if len(to_offload) >= count:
+                break
         return to_offload
 
 
@@ -156,12 +158,13 @@ class LazyOffloadPendingStore:
         else:
             raise ValueError(f"Unknown offload policy: {policy}")
 
-        # TODO: support more flexible select count
+        # TODO(chunxiaozheng): support more flexible select count
         self._select_count = (
             configs.get("lmcache.mp.lazy_offload_select_count", 10) if configs else 10
         )
 
-        # TODO: use gpu block pool to judge should offload and select items
+        # TODO(chunxiaozheng): use gpu block pool to judge should offload
+        #  and select items
         # GPU block pool reference
         self._gpu_block_pool: "BlockPool | None" = None
 

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -140,9 +140,9 @@ class LazyOffloadPendingStore:
 
         # TODO: use gpu block pool to judge should offload and select items
         # GPU block pool reference
-        self._gpu_block_pool: BlockPool | None = None
+        self._gpu_block_pool: "BlockPool | None" = None
 
-    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
         """Bind the GPU block pool to the pending store."""
         self._gpu_block_pool = gpu_block_pool
 

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Standard
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+# First Party
+from lmcache.utils import init_logger as lmcache_init_logger
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPRequestMetadata
+
+
+logger = lmcache_init_logger(__name__)
+
+
+@dataclass
+class PendingStoreItem:
+    """
+    Represents a pending store operation in the lazy offload queue.
+
+    Attributes:
+        metadata: The store metadata to be submitted.
+    """
+
+    metadata: "LMCacheMPRequestMetadata"
+
+
+# TODO: support more offload policies
+class OffloadPolicy(ABC):
+    """
+    Abstract base class for lazy offload policies.
+
+    Subclasses define when to trigger offload (should_offload) and
+    which items to return (select_items).
+    """
+
+    @abstractmethod
+    def add(self, item: PendingStoreItem):
+        """Add a pending store item to the queue or other data structures."""
+        ...
+
+    @abstractmethod
+    def should_offload(self) -> bool:
+        """Determine whether the queue should be drained.
+
+        Returns:
+            True if offload should be triggered.
+        """
+        ...
+
+    @abstractmethod
+    def select_items(self, count: int) -> Iterator[PendingStoreItem]:
+        """Select which items to offload from the queue.
+
+        Args:
+            count: The number of items to select.
+
+        Returns:
+            A Iterator of PendingStoreItem.
+        """
+        ...
+
+
+class FIFOOffloadPolicy(OffloadPolicy):
+    """
+    FIFO offload policy: triggers when pending count reaches threshold,
+    and returns a fixed batch_size number of items from the front.
+    """
+
+    def __init__(self, configs: dict | None = None):
+        """
+        Args:
+            configs: The configuration for the FIFO offload policy.
+        """
+        self.pending_items: list[PendingStoreItem] = []
+        self.threshold = (
+            configs.get("lmcache.mp.lazy_offload_threshold", 100) if configs else 100
+        )
+        logger.info(
+            "lazy offload enabled with FIFO policy, offload threshold: %d",
+            self.threshold,
+        )
+
+    def add(self, item: PendingStoreItem):
+        """Add a pending store item to the queue."""
+        self.pending_items.append(item)
+
+    def should_offload(self) -> bool:
+        """Trigger offload when pending count >= threshold."""
+        return len(self.pending_items) >= self.threshold
+
+    def select_items(self, count: int) -> Iterator[PendingStoreItem]:
+        """Yield the first batch_size items (FIFO order)."""
+        to_offload = self.pending_items[:count]
+        self.pending_items = self.pending_items[count:]
+        return iter(to_offload)
+
+
+class LazyOffloadPendingStore:
+    """
+    Buffering store operations in lazy offload mode.
+
+    Store metadata is accumulated here instead of being immediately submitted.
+    When the offload policy decides it's time, a batch of items is drained
+    and returned for submission.
+    """
+
+    def __init__(
+        self,
+        configs: dict | None = None,
+    ):
+        """
+        Initialize the pending store queue.
+
+        Args:
+            configs: The configuration for the pending store.
+        """
+        policy = (
+            configs.get("lmcache.mp.lazy_offload_policy", "FIFO") if configs else "FIFO"
+        )
+        if policy == "FIFO":
+            self._policy = FIFOOffloadPolicy(configs)
+        else:
+            raise ValueError(f"Unknown offload policy: {policy}")
+
+        # TODO: support more flexible select count
+        self._select_count = (
+            configs.get("lmcache.mp.lazy_offload_select_count", 10) if configs else 10
+        )
+
+        # check if the block hashes are the same when trigger offload
+        self._request_block_hashes: dict[str, dict[int, bytes]] = {}
+
+    def add(self, item: PendingStoreItem, block_hashes: dict[int, bytes]) -> None:
+        """Add a pending store item to the pending store."""
+        self._request_block_hashes[item.metadata.request_id] = block_hashes
+        self._policy.add(item)
+
+    def should_offload(self) -> bool:
+        """Check if the queue should be drained based on the policy."""
+        return self._policy.should_offload()
+
+    def select_items(self) -> Iterator[PendingStoreItem]:
+        """
+        Drain items from the queue according to the policy.
+
+        Returns:
+            Iterator of pending store items to be submitted.
+        """
+        return self._policy.select_items(self._select_count)
+
+    def get_block_hashes(self, request_id: str) -> dict[int, bytes]:
+        return self._request_block_hashes.get(request_id, {})
+
+    def remove_block_hashes(self, request_id: str) -> None:
+        self._request_block_hashes.pop(request_id, None)

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
-from dataclasses import dataclass
+from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 # First Party
@@ -26,10 +26,16 @@ class PendingStoreItem:
     Represents a pending store operation in the lazy offload queue.
 
     Attributes:
-        metadata: The store metadata to be submitted.
+        request_id: The request id of the pending store request.
+        metadatas: The store metadata to be submitted.
+        is_finished: Whether the request is finished.
     """
 
-    metadata: "LMCacheMPRequestMetadata"
+    request_id: str
+    metadatas: list[tuple["LMCacheMPRequestMetadata", dict[int, bytes]]] = field(
+        default_factory=list
+    )
+    is_finished: bool = False
 
 
 # TODO: support more offload policies
@@ -42,8 +48,13 @@ class OffloadPolicy(ABC):
     """
 
     @abstractmethod
-    def add(self, item: PendingStoreItem):
-        """Add a pending store item to the queue or other data structures."""
+    def add(self, meta: "LMCacheMPRequestMetadata", block_hashes: dict[int, bytes]):
+        """Add a pending store item to the pending store."""
+        ...
+
+    @abstractmethod
+    def mark_req_finished(self, req_id: str):
+        """Mark the pending store item finished."""
         ...
 
     @abstractmethod
@@ -56,14 +67,14 @@ class OffloadPolicy(ABC):
         ...
 
     @abstractmethod
-    def select_items(self, count: int) -> Iterator[PendingStoreItem]:
+    def select_items(self, count: int) -> list[PendingStoreItem]:
         """Select which items to offload from the queue.
 
         Args:
             count: The number of items to select.
 
         Returns:
-            A Iterator of PendingStoreItem.
+            A list of PendingStoreItem.
         """
         ...
 
@@ -79,28 +90,43 @@ class FIFOOffloadPolicy(OffloadPolicy):
         Args:
             configs: The configuration for the FIFO offload policy.
         """
-        self.pending_items: list[PendingStoreItem] = []
-        self.threshold = (
+        self._pending_items: dict[str, PendingStoreItem] = {}
+        self._threshold = (
             configs.get("lmcache.mp.lazy_offload_threshold", 100) if configs else 100
         )
+        self._finished_requests_count = 0
         logger.info(
             "lazy offload enabled with FIFO policy, offload threshold: %d",
-            self.threshold,
+            self._threshold,
         )
 
-    def add(self, item: PendingStoreItem):
-        """Add a pending store item to the queue."""
-        self.pending_items.append(item)
+    def add(self, meta: "LMCacheMPRequestMetadata", block_hashes: dict[int, bytes]):
+        if meta.request_id not in self._pending_items:
+            self._pending_items[meta.request_id] = PendingStoreItem(
+                request_id=meta.request_id
+            )
+        self._pending_items[meta.request_id].metadatas.append((meta, block_hashes))
+
+    def mark_req_finished(self, req_id: str):
+        if req_id in self._pending_items:
+            self._pending_items[req_id].is_finished = True
+            self._finished_requests_count += 1
+        else:
+            raise ValueError(
+                f"mark req finished failed: req_id: {req_id} not in pending_items"
+            )
 
     def should_offload(self) -> bool:
-        """Trigger offload when pending count >= threshold."""
-        return len(self.pending_items) >= self.threshold
+        return self._finished_requests_count >= self._threshold
 
-    def select_items(self, count: int) -> Iterator[PendingStoreItem]:
-        """Yield the first batch_size items (FIFO order)."""
-        to_offload = self.pending_items[:count]
-        self.pending_items = self.pending_items[count:]
-        return iter(to_offload)
+    def select_items(self, count: int) -> list[PendingStoreItem]:
+        to_offload = []
+        for req_id in list(self._pending_items.keys()):
+            if self._pending_items[req_id].is_finished:
+                to_offload.append(self._pending_items[req_id])
+                del self._pending_items[req_id]
+                self._finished_requests_count -= 1
+        return to_offload
 
 
 class LazyOffloadPendingStore:
@@ -135,27 +161,33 @@ class LazyOffloadPendingStore:
             configs.get("lmcache.mp.lazy_offload_select_count", 10) if configs else 10
         )
 
-        # check if the block hashes are the same when trigger offload
-        self._request_block_hashes: dict[str, dict[int, bytes]] = {}
-
         # TODO: use gpu block pool to judge should offload and select items
         # GPU block pool reference
         self._gpu_block_pool: "BlockPool | None" = None
+
+        # save all request block ids for free
+        self._request_block_ids: dict[str, list[int]] = defaultdict(list)
 
     def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
         """Bind the GPU block pool to the pending store."""
         self._gpu_block_pool = gpu_block_pool
 
-    def add(self, item: PendingStoreItem, block_hashes: dict[int, bytes]) -> None:
-        """Add a pending store item to the pending store."""
-        self._request_block_hashes[item.metadata.request_id] = block_hashes
-        self._policy.add(item)
+    def add(self, meta: "LMCacheMPRequestMetadata") -> None:
+        """Add a pending store meta to the pending store."""
+        if self._gpu_block_pool:
+            block_hashes = {
+                bid: self._gpu_block_pool.blocks[bid].block_hash
+                for bid in meta.op.flat_block_ids
+            }
+            self._policy.add(meta, block_hashes)
+        else:
+            raise ValueError("gpu block pool not bound")
 
     def should_offload(self) -> bool:
         """Check if the queue should be drained based on the policy."""
         return self._policy.should_offload()
 
-    def select_items(self) -> Iterator[PendingStoreItem]:
+    def select_items(self) -> list[PendingStoreItem]:
         """
         Drain items from the queue according to the policy.
 
@@ -164,8 +196,15 @@ class LazyOffloadPendingStore:
         """
         return self._policy.select_items(self._select_count)
 
-    def get_block_hashes(self, request_id: str) -> dict[int, bytes]:
-        return self._request_block_hashes.get(request_id, {})
+    def mark_req_finished(self, req_id: str):
+        self._policy.mark_req_finished(req_id)
 
-    def remove_block_hashes(self, request_id: str) -> None:
-        self._request_block_hashes.pop(request_id, None)
+    def update_request_gpu_block_ids(self, req_id: str, block_ids: list[int]):
+        self._request_block_ids[req_id].extend(block_ids)
+
+    def get_request_gpu_block_ids(self, req_id: str) -> list[int]:
+        return self._request_block_ids[req_id]
+
+    def remove_request_gpu_block_ids(self, req_id: str):
+        if req_id in self._request_block_ids:
+            del self._request_block_ids[req_id]

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING
 from lmcache.utils import init_logger as lmcache_init_logger
 
 if TYPE_CHECKING:
+    # Third Party
+    from vllm.v1.core.block_pool import BlockPool
+
     # First Party
     from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPRequestMetadata
 
@@ -134,6 +137,14 @@ class LazyOffloadPendingStore:
 
         # check if the block hashes are the same when trigger offload
         self._request_block_hashes: dict[str, dict[int, bytes]] = {}
+
+        # TODO: use gpu block pool to judge should offload and select items
+        # GPU block pool reference
+        self._gpu_block_pool: BlockPool | None = None
+
+    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+        """Bind the GPU block pool to the pending store."""
+        self._gpu_block_pool = gpu_block_pool
 
     def add(self, item: PendingStoreItem, block_hashes: dict[int, bytes]) -> None:
         """Add a pending store item to the pending store."""

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -38,7 +38,7 @@ class PendingStoreItem:
     is_finished: bool = False
 
 
-# TODO: support more offload policies
+# TODO(chunxiaozheng): support more offload policies
 class OffloadPolicy(ABC):
     """
     Abstract base class for lazy offload policies.

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -45,7 +45,7 @@ class OffloadPolicy(ABC):
 
     Policies run in the scheduler role through :class:`LazyOffloadPendingStore`;
     worker processes do not create or call them. Subclasses decide whether
-    offload is due and select items in one ``select_items`` operation.
+    offload is due and pop items in one ``pop_items_for_offload`` operation.
     """
 
     @abstractmethod
@@ -68,15 +68,18 @@ class OffloadPolicy(ABC):
         ...
 
     @abstractmethod
-    def select_items(self, count: int) -> list[PendingStoreItem]:
-        """Select and remove items to offload when the policy is triggered.
+    def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
+        """Pop items to offload only when the policy's condition is satisfied.
+
+        When the condition is not satisfied, this method returns an empty list
+        and leaves pending items in the queue.
 
         Args:
-            count: Maximum number of items to select.
+            count: Maximum number of items to pop.
 
         Returns:
-            Selected pending store items, or an empty list when offload should
-            not be triggered.
+            Popped pending store items, or an empty list when offload is not
+            due.
         """
         ...
 
@@ -84,7 +87,7 @@ class OffloadPolicy(ABC):
 class FIFOOffloadPolicy(OffloadPolicy):
     """
     FIFO offload policy: when finished request count reaches the threshold,
-    returns a fixed number of items from the front.
+    pops a fixed number of items from the front.
     """
 
     def __init__(self, configs: dict | None = None):
@@ -118,7 +121,7 @@ class FIFOOffloadPolicy(OffloadPolicy):
                 f"mark req finished failed: req_id: {req_id} not in pending_items"
             )
 
-    def select_items(self, count: int) -> list[PendingStoreItem]:
+    def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
         if count <= 0 or self._finished_requests_count < self._threshold:
             return []
 
@@ -187,8 +190,8 @@ class LazyOffloadPendingStore:
         else:
             raise ValueError("gpu block pool not bound")
 
-    def select_items(self) -> list[PendingStoreItem]:
-        """Drain items from the queue when the policy's trigger is satisfied.
+    def pop_items_for_offload(self) -> list[PendingStoreItem]:
+        """Pop items from the queue when the policy's trigger is satisfied.
 
         An empty result means offload is not currently due.
 
@@ -196,7 +199,7 @@ class LazyOffloadPendingStore:
             Pending store items to submit, or an empty list when no offload is
             due.
         """
-        return self._policy.select_items(self._select_count)
+        return self._policy.pop_items_for_offload(self._select_count)
 
     def mark_req_finished(self, req_id: str):
         self._policy.mark_req_finished(req_id)

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
-from abc import ABC, abstractmethod
 from collections import defaultdict
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 # First Party
-from lmcache.utils import init_logger as lmcache_init_logger
+from lmcache.integration.vllm.lazy_offload_policy.base import (
+    OffloadPolicy,
+    PendingStoreItem,
+)
+from lmcache.integration.vllm.lazy_offload_policy.fifo import FIFOOffloadPolicy
 
 if TYPE_CHECKING:
     # Third Party
@@ -15,125 +17,6 @@ if TYPE_CHECKING:
 
     # First Party
     from lmcache.integration.vllm.lmcache_mp_metadata import LMCacheMPRequestMetadata
-
-
-logger = lmcache_init_logger(__name__)
-
-
-@dataclass
-class PendingStoreItem:
-    """
-    Represents a pending store operation in the lazy offload queue.
-
-    Attributes:
-        request_id: The request id of the pending store request.
-        metadatas: The store metadata to be submitted.
-        is_finished: Whether the request is finished.
-    """
-
-    request_id: str
-    metadatas: list[tuple["LMCacheMPRequestMetadata", dict[int, bytes]]] = field(
-        default_factory=list
-    )
-    is_finished: bool = False
-
-
-# TODO(chunxiaozheng): support more offload policies
-class OffloadPolicy(ABC):
-    """
-    Abstract base class for lazy offload policies.
-
-    Policies run in the scheduler role through :class:`LazyOffloadPendingStore`;
-    worker processes do not create or call them. Subclasses decide whether
-    offload is due and pop items in one ``pop_items_for_offload`` operation.
-    """
-
-    @abstractmethod
-    def add(self, meta: "LMCacheMPRequestMetadata", block_hashes: dict[int, bytes]):
-        """Add cache blocks from one request to the pending store.
-
-        Args:
-            meta: Store metadata for a subset of one request's cache blocks.
-                Chunked prefill or the scheduler's ``max-num-batched-tokens``
-                limit can schedule one request multiple times, so policies must
-                aggregate its metadata by ``meta.request_id``.
-            block_hashes: Mapping from the GPU block IDs in ``meta`` to their
-                corresponding block hashes captured when the metadata is queued.
-        """
-        ...
-
-    @abstractmethod
-    def mark_req_finished(self, req_id: str):
-        """Mark the pending store item finished."""
-        ...
-
-    @abstractmethod
-    def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
-        """Pop items to offload only when the policy's condition is satisfied.
-
-        When the condition is not satisfied, this method returns an empty list
-        and leaves pending items in the queue.
-
-        Args:
-            count: Maximum number of items to pop.
-
-        Returns:
-            Popped pending store items, or an empty list when offload is not
-            due.
-        """
-        ...
-
-
-class FIFOOffloadPolicy(OffloadPolicy):
-    """
-    FIFO offload policy: when finished request count reaches the threshold,
-    pops a fixed number of items from the front.
-    """
-
-    def __init__(self, configs: dict | None = None):
-        """
-        Args:
-            configs: The configuration for the FIFO offload policy.
-        """
-        self._pending_items: dict[str, PendingStoreItem] = {}
-        self._threshold = (
-            configs.get("lmcache.mp.lazy_offload_threshold", 100) if configs else 100
-        )
-        self._finished_requests_count = 0
-        logger.info(
-            "lazy offload enabled with FIFO policy, offload threshold: %d",
-            self._threshold,
-        )
-
-    def add(self, meta: "LMCacheMPRequestMetadata", block_hashes: dict[int, bytes]):
-        if meta.request_id not in self._pending_items:
-            self._pending_items[meta.request_id] = PendingStoreItem(
-                request_id=meta.request_id
-            )
-        self._pending_items[meta.request_id].metadatas.append((meta, block_hashes))
-
-    def mark_req_finished(self, req_id: str):
-        if req_id in self._pending_items:
-            self._pending_items[req_id].is_finished = True
-            self._finished_requests_count += 1
-        else:
-            raise ValueError(
-                f"mark req finished failed: req_id: {req_id} not in pending_items"
-            )
-
-    def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
-        if count <= 0 or self._finished_requests_count < self._threshold:
-            return []
-
-        to_offload = []
-        for req_id in list(self._pending_items.keys()):
-            if self._pending_items[req_id].is_finished:
-                to_offload.append(self._pending_items[req_id])
-                del self._pending_items[req_id]
-                self._finished_requests_count -= 1
-            if len(to_offload) >= count:
-                break
-        return to_offload
 
 
 class LazyOffloadPendingStore:
@@ -155,13 +38,7 @@ class LazyOffloadPendingStore:
         Args:
             configs: The configuration for the pending store.
         """
-        policy = (
-            configs.get("lmcache.mp.lazy_offload_policy", "FIFO") if configs else "FIFO"
-        )
-        if policy == "FIFO":
-            self._policy = FIFOOffloadPolicy(configs)
-        else:
-            raise ValueError(f"Unknown offload policy: {policy}")
+        self._policy = self._create_offload_policy(configs)
 
         # TODO(chunxiaozheng): support more flexible select count
         self._select_count = (
@@ -213,3 +90,12 @@ class LazyOffloadPendingStore:
     def remove_request_gpu_block_ids(self, req_id: str):
         if req_id in self._request_block_ids:
             del self._request_block_ids[req_id]
+
+    def _create_offload_policy(self, configs: dict | None) -> OffloadPolicy:
+        """Create the configured lazy-offload policy."""
+        policy = (
+            configs.get("lmcache.mp.lazy_offload_policy", "FIFO") if configs else "FIFO"
+        )
+        if policy == "FIFO":
+            return FIFOOffloadPolicy(configs)
+        raise ValueError(f"Unknown offload policy: {policy}")

--- a/lmcache/integration/vllm/lazy_offload_pending_store.py
+++ b/lmcache/integration/vllm/lazy_offload_pending_store.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from vllm.v1.core.block_pool import BlockPool
 
     # First Party
-    from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPRequestMetadata
+    from lmcache.integration.vllm.lmcache_mp_metadata import LMCacheMPRequestMetadata
 
 
 logger = lmcache_init_logger(__name__)
@@ -43,13 +43,23 @@ class OffloadPolicy(ABC):
     """
     Abstract base class for lazy offload policies.
 
-    Subclasses define when to trigger offload (should_offload) and
-    which items to return (select_items).
+    Policies run in the scheduler role through :class:`LazyOffloadPendingStore`;
+    worker processes do not create or call them. Subclasses decide whether
+    offload is due and select items in one ``select_items`` operation.
     """
 
     @abstractmethod
     def add(self, meta: "LMCacheMPRequestMetadata", block_hashes: dict[int, bytes]):
-        """Add a pending store item to the pending store."""
+        """Add cache blocks from one request to the pending store.
+
+        Args:
+            meta: Store metadata for a subset of one request's cache blocks.
+                Chunked prefill or the scheduler's ``max-num-batched-tokens``
+                limit can schedule one request multiple times, so policies must
+                aggregate its metadata by ``meta.request_id``.
+            block_hashes: Mapping from the GPU block IDs in ``meta`` to their
+                corresponding block hashes captured when the metadata is queued.
+        """
         ...
 
     @abstractmethod
@@ -58,31 +68,23 @@ class OffloadPolicy(ABC):
         ...
 
     @abstractmethod
-    def should_offload(self) -> bool:
-        """Determine whether the queue should be drained.
-
-        Returns:
-            True if offload should be triggered.
-        """
-        ...
-
-    @abstractmethod
     def select_items(self, count: int) -> list[PendingStoreItem]:
-        """Select which items to offload from the queue.
+        """Select and remove items to offload when the policy is triggered.
 
         Args:
-            count: The number of items to select.
+            count: Maximum number of items to select.
 
         Returns:
-            A list of PendingStoreItem.
+            Selected pending store items, or an empty list when offload should
+            not be triggered.
         """
         ...
 
 
 class FIFOOffloadPolicy(OffloadPolicy):
     """
-    FIFO offload policy: triggers when pending count reaches threshold,
-    and returns a fixed batch_size number of items from the front.
+    FIFO offload policy: when finished request count reaches the threshold,
+    returns a fixed number of items from the front.
     """
 
     def __init__(self, configs: dict | None = None):
@@ -116,10 +118,10 @@ class FIFOOffloadPolicy(OffloadPolicy):
                 f"mark req finished failed: req_id: {req_id} not in pending_items"
             )
 
-    def should_offload(self) -> bool:
-        return self._finished_requests_count >= self._threshold
-
     def select_items(self, count: int) -> list[PendingStoreItem]:
+        if count <= 0 or self._finished_requests_count < self._threshold:
+            return []
+
         to_offload = []
         for req_id in list(self._pending_items.keys()):
             if self._pending_items[req_id].is_finished:
@@ -163,8 +165,7 @@ class LazyOffloadPendingStore:
             configs.get("lmcache.mp.lazy_offload_select_count", 10) if configs else 10
         )
 
-        # TODO(chunxiaozheng): use gpu block pool to judge should offload
-        #  and select items
+        # TODO(chunxiaozheng): use gpu block pool to guide item selection.
         # GPU block pool reference
         self._gpu_block_pool: "BlockPool | None" = None
 
@@ -186,16 +187,14 @@ class LazyOffloadPendingStore:
         else:
             raise ValueError("gpu block pool not bound")
 
-    def should_offload(self) -> bool:
-        """Check if the queue should be drained based on the policy."""
-        return self._policy.should_offload()
-
     def select_items(self) -> list[PendingStoreItem]:
-        """
-        Drain items from the queue according to the policy.
+        """Drain items from the queue when the policy's trigger is satisfied.
+
+        An empty result means offload is not currently due.
 
         Returns:
-            Iterator of pending store items to be submitted.
+            Pending store items to submit, or an empty list when no offload is
+            due.
         """
         return self._policy.select_items(self._select_count)
 

--- a/lmcache/integration/vllm/lazy_offload_policy/__init__.py
+++ b/lmcache/integration/vllm/lazy_offload_policy/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy-offload policies used by the vLLM pending store."""

--- a/lmcache/integration/vllm/lazy_offload_policy/base.py
+++ b/lmcache/integration/vllm/lazy_offload_policy/base.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Base types for lazy-offload policies."""
+
+# Standard
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_metadata import LMCacheMPRequestMetadata
+
+
+@dataclass
+class PendingStoreItem:
+    """A pending cache-store operation for a single request.
+
+    Attributes:
+        request_id: The request identifier for the pending operation.
+        metadatas: Store metadata and the captured block hashes to submit.
+        is_finished: Whether all cache blocks for the request have been queued.
+    """
+
+    request_id: str
+    metadatas: list[tuple["LMCacheMPRequestMetadata", dict[int, bytes]]] = field(
+        default_factory=list
+    )
+    is_finished: bool = False
+
+
+class OffloadPolicy(ABC):
+    """Abstract interface for scheduler-side lazy-offload policies.
+
+    Worker processes do not create or invoke policies. Implementations aggregate
+    cache blocks by request and decide when pending items should be offloaded.
+    """
+
+    @abstractmethod
+    def add(
+        self,
+        meta: "LMCacheMPRequestMetadata",
+        block_hashes: dict[int, bytes],
+    ) -> None:
+        """Add cache blocks from one request to the pending store.
+
+        Args:
+            meta: Store metadata for a subset of a request's cache blocks.
+            block_hashes: Mapping from queued GPU block IDs to block hashes.
+        """
+
+    @abstractmethod
+    def mark_req_finished(self, req_id: str) -> None:
+        """Mark the pending store item for ``req_id`` as finished.
+
+        Args:
+            req_id: Identifier of the request that has completed.
+        """
+
+    @abstractmethod
+    def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
+        """Pop items only when the policy's offload condition is satisfied.
+
+        Args:
+            count: Maximum number of pending items to return.
+
+        Returns:
+            Pending items to offload, or an empty list when offload is not due.
+        """

--- a/lmcache/integration/vllm/lazy_offload_policy/fifo.py
+++ b/lmcache/integration/vllm/lazy_offload_policy/fifo.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FIFO lazy-offload policy."""
+
+# Standard
+from typing import TYPE_CHECKING
+
+# First Party
+from lmcache.integration.vllm.lazy_offload_policy.base import (
+    OffloadPolicy,
+    PendingStoreItem,
+)
+from lmcache.utils import init_logger as lmcache_init_logger
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_metadata import LMCacheMPRequestMetadata
+
+
+logger = lmcache_init_logger(__name__)
+
+
+class FIFOOffloadPolicy(OffloadPolicy):
+    """Offload finished pending requests in first-in, first-out order."""
+
+    def __init__(self, configs: dict | None = None) -> None:
+        """Initialize the policy.
+
+        Args:
+            configs: Optional lazy-offload configuration. The
+                ``lmcache.mp.lazy_offload_threshold`` value controls how many
+                finished requests trigger an offload.
+        """
+        self._pending_items: dict[str, PendingStoreItem] = {}
+        self._threshold = (
+            configs.get("lmcache.mp.lazy_offload_threshold", 100) if configs else 100
+        )
+        self._finished_requests_count = 0
+        logger.info(
+            "lazy offload enabled with FIFO policy, offload threshold: %d",
+            self._threshold,
+        )
+
+    def add(
+        self,
+        meta: "LMCacheMPRequestMetadata",
+        block_hashes: dict[int, bytes],
+    ) -> None:
+        """Queue cache blocks, aggregating multiple entries per request.
+
+        Args:
+            meta: Store metadata for a subset of a request's cache blocks.
+            block_hashes: Mapping from queued GPU block IDs to block hashes.
+        """
+        if meta.request_id not in self._pending_items:
+            self._pending_items[meta.request_id] = PendingStoreItem(
+                request_id=meta.request_id
+            )
+        self._pending_items[meta.request_id].metadatas.append((meta, block_hashes))
+
+    def mark_req_finished(self, req_id: str) -> None:
+        """Mark a queued request as ready for FIFO offload.
+
+        Args:
+            req_id: Identifier of the request that has completed.
+
+        Raises:
+            ValueError: If ``req_id`` has no queued cache blocks.
+        """
+        if req_id in self._pending_items:
+            self._pending_items[req_id].is_finished = True
+            self._finished_requests_count += 1
+        else:
+            raise ValueError(
+                f"mark req finished failed: req_id: {req_id} not in pending_items"
+            )
+
+    def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
+        """Return up to ``count`` finished requests in insertion order.
+
+        Args:
+            count: Maximum number of pending items to pop.
+
+        Returns:
+            Finished pending items when the threshold is reached; otherwise an
+            empty list.
+        """
+        if count <= 0 or self._finished_requests_count < self._threshold:
+            return []
+
+        to_offload = []
+        for req_id in list(self._pending_items.keys()):
+            if self._pending_items[req_id].is_finished:
+                to_offload.append(self._pending_items[req_id])
+                del self._pending_items[req_id]
+                self._finished_requests_count -= 1
+            if len(to_offload) >= count:
+                break
+        return to_offload

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -917,6 +917,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 self._gpu_block_pool.free_blocks(
                     [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
                 )
+                self._pending_store.remove_request_gpu_block_ids(req_id)
                 self.scheduler_adapter.end_session(req_id)
 
     def request_finished(

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -713,9 +713,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """Bind GPU block pool so that we can touch blocks during stores.
         Called by Scheduler after kv_cache_manager is ready."""
         if self.role == KVConnectorRole.SCHEDULER:
-            logger.info("Bind GPU block pool in LMCacheMPConnector")
+            logger.info("Bind GPU block pool in LMCacheMPConnector scheduler")
             self._gpu_block_pool = gpu_block_pool
-            if self._pending_store:
+            if self.lazy_offload:
                 self._pending_store.bind_gpu_block_pool(gpu_block_pool)
 
     def get_num_new_matched_tokens(

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -715,6 +715,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if self.role == KVConnectorRole.SCHEDULER:
             logger.info("Bind GPU block pool in LMCacheMPConnector")
             self._gpu_block_pool = gpu_block_pool
+            if self._pending_store:
+                self._pending_store.bind_gpu_block_pool(gpu_block_pool)
 
     def get_num_new_matched_tokens(
         self,

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -347,7 +347,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
 
             # GPU block pool reference
-            self._gpu_block_pool: BlockPool | None = None
+            self._gpu_block_pool: "BlockPool | None" = None
 
             # Initialize pending store for lazy offload mode
             if self.lazy_offload:
@@ -709,7 +709,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     # Scheduler-side methods
     # ==============================
 
-    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
         """Bind GPU block pool so that we can touch blocks during stores.
         Called by Scheduler after kv_cache_manager is ready."""
         if self.role == KVConnectorRole.SCHEDULER:

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -44,11 +44,16 @@ from lmcache.integration.vllm.kv_cache_group_edits import (
 from lmcache.integration.vllm.kv_cache_groups import (
     create_engine_group_infos_from_vllm,
 )
+from lmcache.integration.vllm.lazy_offload_pending_store import (
+    LazyOffloadPendingStore,
+    PendingStoreItem,
+)
 from lmcache.integration.vllm.lmcache_mp_metadata import (
     LMCacheMPConnectorMetadata,
     LMCacheMPRequestMetadata,
     LMCacheMPRequestState,
     LMCacheMPRequestTracker,
+    LMCacheMPWorkerMetadata,
 )
 from lmcache.integration.vllm.utils import (
     mla_only,
@@ -98,6 +103,7 @@ if TYPE_CHECKING:
         PromMetricT,
     )
     from vllm.forward_context import ForwardContext
+    from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -320,6 +326,12 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         self.dispatcher = None
 
+        # Lazy offload configuration: when enabled, store operations are
+        # deferred until some threshold is reached, rather than submitted at every step
+        self.lazy_offload = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.lazy_offload", False
+        )
+
         if self.role == KVConnectorRole.SCHEDULER:
             # Banner from the scheduler role only, so tensor-parallel
             # deployments print it once rather than once per worker.
@@ -333,6 +345,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+
+            # GPU block pool reference
+            self._gpu_block_pool: BlockPool | None = None
+
+            # Initialize pending store for lazy offload mode
+            if self.lazy_offload:
+                self._pending_store = LazyOffloadPendingStore(
+                    vllm_config.kv_transfer_config.kv_connector_extra_config
+                )
         elif self.role == KVConnectorRole.WORKER:
             # Node routing: a worker connects only to its local LMCache server.
             # Global ranks are assigned to nodes in contiguous blocks:
@@ -635,6 +656,17 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # logger.error("Finished req ids: %s, %s", val[0], val[1])
         return val
 
+    def build_connector_worker_meta(self):
+        if not self.lazy_offload:
+            return None
+        completed_store_requests = self.worker_adapter.get_completed_store_requests()
+        if completed_store_requests:
+            return LMCacheMPWorkerMetadata(
+                completed_store_requests=completed_store_requests
+            )
+        else:
+            return None
+
     def get_block_ids_with_load_errors(self) -> set[int]:
         """
         Get the set of block IDs that failed to load.
@@ -676,6 +708,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     # ==============================
     # Scheduler-side methods
     # ==============================
+
+    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+        """Bind GPU block pool so that we can touch blocks during stores.
+        Called by Scheduler after kv_cache_manager is ready."""
+        if self.role == KVConnectorRole.SCHEDULER:
+            logger.info("Bind GPU block pool in LMCacheMPConnector")
+            self._gpu_block_pool = gpu_block_pool
 
     def get_num_new_matched_tokens(
         self,
@@ -864,7 +903,21 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             connector_output (KVConnectorOutput): the worker-side
                 connectors output.
         """
-        return
+        if not self.lazy_offload:
+            return
+        if not self._gpu_block_pool:
+            raise ValueError("Lazy offload is enabled but gpu block pool is not binded")
+        meta = connector_output.kv_connector_worker_meta
+        if not isinstance(meta, LMCacheMPWorkerMetadata):
+            return
+        for req_id, count in meta.completed_store_requests.items():
+            if self.scheduler_adapter.update_pending_store_count(req_id, count):
+                block_hashes = self._pending_store.get_block_hashes(req_id)
+                self._gpu_block_pool.free_blocks(
+                    [self._gpu_block_pool.blocks[bid] for bid in block_hashes.keys()]
+                )
+                self._pending_store.remove_block_hashes(req_id)
+                # TODO: touch all keys in lmcache mp server
 
     def request_finished(
         self,
@@ -905,10 +958,12 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         # Clean up request tracker to prevent memory leak
         self._cleanup_request_tracker(request.request_id)
+
+        # have not been offloaded, the touch operation in end_session is incorrect
         # Notify LMCache to end the session for this request
         self.scheduler_adapter.end_session(request.request_id)
 
-        return True, (return_params or None)
+        return not self.lazy_offload, (return_params or None)
 
     def request_finished_all_groups(
         self,
@@ -1023,7 +1078,23 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 self._group_tokens_per_block,
             )
             if r_meta is not None:
-                metadata.add_request_metadata(r_meta)
+                # In lazy_offload mode, add to pending queue instead of immediate store
+                if self.lazy_offload:
+                    if self._gpu_block_pool:
+                        block_hashes = {
+                            bid: self._gpu_block_pool.blocks[bid].block_hash
+                            for bid in r_meta.op.flat_block_ids
+                        }
+                        self._pending_store.add(
+                            PendingStoreItem(metadata=r_meta), block_hashes
+                        )
+                    else:
+                        raise ValueError(
+                            "Lazy offload is enabled but no GPU block pool is binded"
+                        )
+                else:
+                    metadata.add_request_metadata(r_meta)
+        self._process_lazy_offload_store_requests(metadata)
 
     def _process_cached_requests(
         self,
@@ -1053,7 +1124,55 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             )
 
             if r_meta is not None:
-                metadata.add_request_metadata(r_meta)
+                # In lazy_offload mode, add to pending queue instead of immediate store
+                if self.lazy_offload:
+                    if self._gpu_block_pool:
+                        block_hashes = {
+                            bid: self._gpu_block_pool.blocks[bid].block_hash
+                            for bid in r_meta.op.flat_block_ids
+                        }
+                        self._pending_store.add(
+                            PendingStoreItem(metadata=r_meta), block_hashes
+                        )
+                    else:
+                        raise ValueError(
+                            "Lazy offload is enabled but no GPU block pool is binded"
+                        )
+                else:
+                    metadata.add_request_metadata(r_meta)
+        self._process_lazy_offload_store_requests(metadata)
+
+    def _process_lazy_offload_store_requests(
+        self, metadata: LMCacheMPConnectorMetadata
+    ):
+        if not self.lazy_offload or not self._pending_store.should_offload():
+            return
+
+        if not self._gpu_block_pool:
+            raise ValueError("Lazy offload is enabled but no GPU block pool is binded")
+
+        for item in self._pending_store.select_items():
+            request_id = item.metadata.request_id
+            old_block_hashes = self._pending_store.get_block_hashes(request_id)
+            gpu_block_ids = old_block_hashes.keys()
+            self._gpu_block_pool.touch(
+                [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+            )
+            new_block_hashes = {
+                bid: self._gpu_block_pool.blocks[bid].block_hash
+                for bid in gpu_block_ids
+            }
+            if old_block_hashes == new_block_hashes:
+                metadata.add_request_metadata(item.metadata)
+            else:
+                logger.warning(
+                    "Block hashes mismatch for request %s, trigger lazy offload failed",
+                    item.metadata.request_id,
+                )
+                self._gpu_block_pool.free_blocks(
+                    [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+                )
+                self._pending_store.remove_block_hashes(request_id)
 
     def _report_block_allocation_deltas(
         self,

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1163,6 +1163,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 for bid in gpu_block_ids
             }
             if old_block_hashes == new_block_hashes:
+                # remove block hashes and free blocks until store is done
                 metadata.add_request_metadata(item.metadata)
             else:
                 logger.warning(

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -651,7 +651,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             The finished saves/sends req ids must belong to a set provided in a
             call to this method (this call or a prior one).
         """
-        val = self.worker_adapter.get_finished(finished_req_ids)
+        if self.lazy_offload:
+            val = self.worker_adapter.get_finished_with_lazy_offload()
+        else:
+            val = self.worker_adapter.get_finished(finished_req_ids)
         # logger.error("Finished req ids: %s, %s", val[0], val[1])
         return val
 

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -46,7 +46,6 @@ from lmcache.integration.vllm.kv_cache_groups import (
 )
 from lmcache.integration.vllm.lazy_offload_pending_store import (
     LazyOffloadPendingStore,
-    PendingStoreItem,
 )
 from lmcache.integration.vllm.lmcache_mp_metadata import (
     LMCacheMPConnectorMetadata,
@@ -914,11 +913,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             return
         for req_id, count in meta.completed_store_requests.items():
             if self.scheduler_adapter.update_pending_store_count(req_id, count):
-                block_hashes = self._pending_store.get_block_hashes(req_id)
+                gpu_block_ids = self._pending_store.get_request_gpu_block_ids(req_id)
                 self._gpu_block_pool.free_blocks(
-                    [self._gpu_block_pool.blocks[bid] for bid in block_hashes.keys()]
+                    [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
                 )
-                self._pending_store.remove_block_hashes(req_id)
                 self.scheduler_adapter.end_session(req_id)
 
     def request_finished(
@@ -965,7 +963,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # Notify LMCache to end the session for this request
         self.scheduler_adapter.end_session(request.request_id)
 
-        return not self.lazy_offload, (return_params or None)
+        if self.lazy_offload:
+            self._pending_store.mark_req_finished(request.request_id)
+            return False, (return_params or None)
+        return True, (return_params or None)
 
     def request_finished_all_groups(
         self,
@@ -1082,18 +1083,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             if r_meta is not None:
                 # In lazy_offload mode, add to pending queue instead of immediate store
                 if self.lazy_offload:
-                    if self._gpu_block_pool:
-                        block_hashes = {
-                            bid: self._gpu_block_pool.blocks[bid].block_hash
-                            for bid in r_meta.op.flat_block_ids
-                        }
-                        self._pending_store.add(
-                            PendingStoreItem(metadata=r_meta), block_hashes
-                        )
-                    else:
-                        raise ValueError(
-                            "Lazy offload is enabled but no GPU block pool is binded"
-                        )
+                    self._pending_store.add(r_meta)
                 else:
                     metadata.add_request_metadata(r_meta)
         self._process_lazy_offload_store_requests(metadata)
@@ -1128,18 +1118,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             if r_meta is not None:
                 # In lazy_offload mode, add to pending queue instead of immediate store
                 if self.lazy_offload:
-                    if self._gpu_block_pool:
-                        block_hashes = {
-                            bid: self._gpu_block_pool.blocks[bid].block_hash
-                            for bid in r_meta.op.flat_block_ids
-                        }
-                        self._pending_store.add(
-                            PendingStoreItem(metadata=r_meta), block_hashes
-                        )
-                    else:
-                        raise ValueError(
-                            "Lazy offload is enabled but no GPU block pool is binded"
-                        )
+                    self._pending_store.add(r_meta)
                 else:
                     metadata.add_request_metadata(r_meta)
         self._process_lazy_offload_store_requests(metadata)
@@ -1151,31 +1130,34 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             return
 
         if not self._gpu_block_pool:
-            raise ValueError("Lazy offload is enabled but no GPU block pool is binded")
+            raise ValueError("Lazy offload is enabled but no GPU block pool is bound")
 
         for item in self._pending_store.select_items():
-            request_id = item.metadata.request_id
-            old_block_hashes = self._pending_store.get_block_hashes(request_id)
-            gpu_block_ids = old_block_hashes.keys()
-            self._gpu_block_pool.touch(
-                [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
-            )
-            new_block_hashes = {
-                bid: self._gpu_block_pool.blocks[bid].block_hash
-                for bid in gpu_block_ids
-            }
-            if old_block_hashes == new_block_hashes:
-                # remove block hashes and free blocks until store is done
-                metadata.add_request_metadata(item.metadata)
-            else:
-                logger.warning(
-                    "Block hashes mismatch for request %s, trigger lazy offload failed",
-                    item.metadata.request_id,
-                )
-                self._gpu_block_pool.free_blocks(
+            request_id = item.request_id
+            for meta, old_block_hashes in item.metadatas:
+                gpu_block_ids = list(old_block_hashes.keys())
+                self._gpu_block_pool.touch(
                     [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
                 )
-                self._pending_store.remove_block_hashes(request_id)
+                new_block_hashes = {
+                    bid: self._gpu_block_pool.blocks[bid].block_hash
+                    for bid in gpu_block_ids
+                }
+                if old_block_hashes == new_block_hashes:
+                    # remove block hashes and free blocks until store is done
+                    metadata.add_request_metadata(meta)
+                    self._pending_store.update_request_gpu_block_ids(
+                        request_id, gpu_block_ids
+                    )
+                else:
+                    logger.warning(
+                        "Part block hashes mismatch for request %s, skip it",
+                        request_id,
+                    )
+                    self._gpu_block_pool.free_blocks(
+                        [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+                    )
+                    break
 
     def _report_block_allocation_deltas(
         self,

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1090,7 +1090,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                     self._pending_store.add(r_meta)
                 else:
                     metadata.add_request_metadata(r_meta)
-        self._process_lazy_offload_store_requests(metadata)
+        # if scheduler_output.total_num_scheduled_tokens is 0,
+        # vllm `gpu_model_runner` will call `kv_connector_no_forward`
+        # in `execute_model`, which will result in lose some store ops.
+        # So we only trigger lazy offload when
+        # scheduler_output.total_num_scheduled_tokens > 0
+        if scheduler_output.total_num_scheduled_tokens:
+            self._process_lazy_offload_store_requests(metadata)
 
     def _process_cached_requests(
         self,
@@ -1125,7 +1131,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                     self._pending_store.add(r_meta)
                 else:
                     metadata.add_request_metadata(r_meta)
-        self._process_lazy_offload_store_requests(metadata)
+        # if scheduler_output.total_num_scheduled_tokens is 0,
+        # vllm `gpu_model_runner` will call `kv_connector_no_forward`
+        # in `execute_model`, which will result in lose some store ops.
+        # So we only trigger lazy offload when
+        # scheduler_output.total_num_scheduled_tokens > 0
+        if scheduler_output.total_num_scheduled_tokens:
+            self._process_lazy_offload_store_requests(metadata)
 
     def _process_lazy_offload_store_requests(
         self, metadata: LMCacheMPConnectorMetadata

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -919,7 +919,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                     [self._gpu_block_pool.blocks[bid] for bid in block_hashes.keys()]
                 )
                 self._pending_store.remove_block_hashes(req_id)
-                # TODO: touch all keys in lmcache mp server
+                self.scheduler_adapter.end_session(req_id)
 
     def request_finished(
         self,

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1148,7 +1148,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if not self._gpu_block_pool:
             raise ValueError("Lazy offload is enabled but no GPU block pool is bound")
 
-        for item in self._pending_store.select_items():
+        # Each item aggregates store metadata for one request. Chunked prefill
+        # or the scheduler's ``max-num-batched-tokens`` limit can schedule one
+        # request multiple times, with each metadata entry containing only that
+        # scheduling pass's blocks.
+        for item in self._pending_store.pop_items_for_offload():
             request_id = item.request_id
             for meta, old_block_hashes in item.metadatas:
                 gpu_block_ids = list(old_block_hashes.keys())

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1142,7 +1142,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     def _process_lazy_offload_store_requests(
         self, metadata: LMCacheMPConnectorMetadata
     ):
-        if not self.lazy_offload or not self._pending_store.should_offload():
+        if not self.lazy_offload:
             return
 
         if not self._gpu_block_pool:

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -8,6 +8,7 @@ import enum
 # Third Party
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
 )
 from vllm.v1.utils import ConstantList
 import torch
@@ -370,3 +371,25 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
 
     def __repr__(self):
         return self.__str__()
+
+
+@dataclass
+class LMCacheMPWorkerMetadata(KVConnectorWorkerMetadata):
+    """Worker -> Scheduler metadata for completed store events.
+
+    Each worker reports {req_id: 1} for newly completed stores.
+    ``aggregate()`` sums counts across workers within a step.
+    The scheduler-side manager accumulates across steps and processes
+    a store completion only when count reaches ``world_size``.
+    """
+
+    completed_store_requests: dict[str, int]
+
+    def aggregate(
+        self, other: "KVConnectorWorkerMetadata"
+    ) -> "KVConnectorWorkerMetadata":
+        assert isinstance(other, LMCacheMPWorkerMetadata)
+        merged = dict(self.completed_store_requests)
+        for k, v in other.completed_store_requests.items():
+            merged[k] = merged.get(k, 0) + v
+        return LMCacheMPWorkerMetadata(completed_store_requests=merged)

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -634,6 +634,11 @@ class LMCacheMPSchedulerAdapter:
         self._heartbeats: dict[str, HeartbeatThread] = {}
         self._heartbeat_lock = threading.Lock()
 
+        # For TP/PP: track partial store completions across steps.
+        # Events must be reported by all world_size workers before considered complete.
+        self._expected_worker_count = parallel_strategy.vllm_world_size
+        self._store_request_pending_counts: dict[str, int] = {}
+
     @property
     def world_size(self) -> int:
         """Get the kv world size."""
@@ -1005,6 +1010,25 @@ class LMCacheMPSchedulerAdapter:
             cache_salt=cache_salt,
         )
 
+    def update_pending_store_count(self, req_id: str, count: int) -> bool:
+        """
+        Update the pending store count for a request.
+
+        Args:
+            req_id: The request ID.
+            count: The number of workers that have finished the request.
+
+        Returns:
+            True if the store request is finished, False otherwise.
+        """
+        total = self._store_request_pending_counts.get(req_id, 0) + count
+        if total >= self._expected_worker_count:
+            self._store_request_pending_counts.pop(req_id, None)
+            return True
+        else:
+            self._store_request_pending_counts[req_id] = total
+            return False
+
 
 class LMCacheMPWorkerAdapter:
     def __init__(
@@ -1172,6 +1196,15 @@ class LMCacheMPWorkerAdapter:
                 ),
             },
         )
+
+        self.lazy_offload = (
+            extra_config.get("lmcache.mp.lazy_offload", False)
+            if extra_config
+            else False
+        )
+
+        # Completed store requests to report via build_connector_worker_meta
+        self._completed_store_requests: dict[str, int] = {}
 
     @property
     def is_healthy(self) -> bool:
@@ -1601,6 +1634,10 @@ class LMCacheMPWorkerAdapter:
             # first and deletes the request, so we must not also report it
             # in finished_sending.
             ret_stores -= finished_retrieves
+            if self.lazy_offload:
+                for req_id in ret_stores:
+                    self._completed_store_requests[req_id] = 1
+                return None, finished_retrieves
             return ret_stores, finished_retrieves
 
         finished_stores = set()
@@ -1668,7 +1705,19 @@ class LMCacheMPWorkerAdapter:
                 kv_rank=self.worker_id,
             )
 
+        if self.lazy_offload:
+            for req_id in ret_stores:
+                self._completed_store_requests[req_id] = 1
+            return None, finished_retrieves
         return ret_stores, finished_retrieves
+
+    def get_completed_store_requests(self) -> dict[str, int] | None:
+        """Return completed store requests since the last call."""
+        if not self._completed_store_requests:
+            return None
+        completed_store_requests = self._completed_store_requests
+        self._completed_store_requests = {}
+        return completed_store_requests
 
     def num_blocks_per_chunk(self) -> int:
         """

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1634,10 +1634,6 @@ class LMCacheMPWorkerAdapter:
             # first and deletes the request, so we must not also report it
             # in finished_sending.
             ret_stores -= finished_retrieves
-            if self.lazy_offload:
-                for req_id in ret_stores:
-                    self._completed_store_requests[req_id] = 1
-                return None, finished_retrieves
             return ret_stores, finished_retrieves
 
         finished_stores = set()
@@ -1705,11 +1701,122 @@ class LMCacheMPWorkerAdapter:
                 kv_rank=self.worker_id,
             )
 
-        if self.lazy_offload:
-            for req_id in ret_stores:
+        return ret_stores, finished_retrieves
+
+    @_lmcache_nvtx_annotate
+    def get_finished_with_lazy_offload(
+        self,
+    ) -> tuple[set[str] | None, set[str] | None]:
+        """
+        Check and get the finished store and retrieve requests in lazy offload mode.
+
+        Returns:
+            A tuple of two sets:
+            - The first set contains the finished store request ids.
+                In lazy offload mode, return None directly.
+            - The second set contains the finished retrieve request ids,
+                including retrieves dropped at submit time while unhealthy
+                (reported exactly once; blocks already in error_block_ids).
+        """
+        if not self.lazy_offload:
+            raise ValueError(
+                "get_finished_with_lazy_offload is only available in lazy offload mode"
+            )
+
+        if self.dispatcher is not None:
+            dispatch(self.dispatcher, "reclaim")
+
+        # If unhealthy, drain all pending futures immediately
+        if not self.is_healthy:
+            finished_stores = set(self.store_futures.keys())
+            finished_retrieves = set()
+            for request_id, (
+                _r_future,
+                r_block_ids,
+            ) in self.retrieve_futures.items():
+                finished_retrieves.add(request_id)
+                self.error_block_ids.update(r_block_ids)
+            self.store_futures.clear()
+            self.retrieve_futures.clear()
+            self.store_events.clear()
+            self.retrieve_events.clear()
+
+            # Retrieves dropped at submit time still must be reported,
+            # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
+            # Swap-drain (not update-then-clear): a concurrent
+            # submit_retrieve_request add lands in the old set (reported now)
+            # or the fresh set (reported next call), never lost.
+            dropped = self._dropped_retrieves
+            self._dropped_retrieves = set()
+            finished_retrieves.update(dropped)
+
+            for req_id in finished_stores:
                 self._completed_store_requests[req_id] = 1
             return None, finished_retrieves
-        return ret_stores, finished_retrieves
+
+        finished_stores = set()
+        finished_retrieves = set()
+        for request_id, s_future in self.store_futures.items():
+            if not s_future.query():
+                continue
+
+            s_result = s_future.result(timeout=60)
+            finished_stores.add(request_id)
+
+            if not s_result:
+                logger.error(
+                    "Something went wrong when processing the "
+                    "store request for request_id=%s",
+                    request_id,
+                )
+
+        for request_id, (r_future, _) in self.retrieve_futures.items():
+            if not r_future.query():
+                continue
+
+            r_result = r_future.result(timeout=60)
+            finished_retrieves.add(request_id)
+
+            if not r_result:
+                logger.error(
+                    "Something went wrong when processing the "
+                    "retrieve request for request_id=%s, result=%s",
+                    request_id,
+                    r_result,
+                )
+
+        # Remove the finished requests from the tracking dicts
+        for request_id in finished_stores:
+            self.store_futures.pop(request_id, None)
+            self.store_events.pop(request_id, None)
+        for request_id in finished_retrieves:
+            self.retrieve_futures.pop(request_id, None)
+            self.retrieve_events.pop(request_id, None)
+
+        # Retrieves dropped while unhealthy still must be reported,
+        # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS. No
+        # finished_sending dedup is needed (unlike the unhealthy branch): a
+        # dropped retrieve's request is parked in WAITING_FOR_REMOTE_KVS until
+        # this report, so it cannot also be engine-finished in the same call.
+        # Swap-drain so a concurrent submit_retrieve_request add is never lost.
+        dropped = self._dropped_retrieves
+        self._dropped_retrieves = set()
+        finished_retrieves.update(dropped)
+
+        # the invocation of `get_finished` means that
+        # these requests' KV caches are already fully stored.
+        # or the requests normally ends without any store.
+        if finished_stores:
+            self.request_telemetry.on_request_store_finished(
+                request_ids_set=finished_stores,
+                model_name=self.model_name,
+                world_size=self.world_size,
+                kv_rank=self.worker_id,
+            )
+
+        for req_id in finished_stores:
+            self._completed_store_requests[req_id] = 1
+        return None, finished_retrieves
 
     def get_completed_store_requests(self) -> dict[str, int] | None:
         """Return completed store requests since the last call."""

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1703,6 +1703,8 @@ class LMCacheMPWorkerAdapter:
 
         return ret_stores, finished_retrieves
 
+    # TODO(chunxiaozheng): There are some duplicated codes
+    #  with `get_finished`, optimize it later.
     @_lmcache_nvtx_annotate
     def get_finished_with_lazy_offload(
         self,

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -297,7 +297,8 @@ class MPCacheServerContext:
         """
         session = self.session_manager.get_or_create(key.request_id)
         session.set_tokens(list(key.token_ids))
-        session.lookup_ipc_key = key.no_worker_id_version()
+        if session.lookup_ipc_key is None:
+            session.lookup_ipc_key = key.no_worker_id_version()
         chunk_hashes = [
             TokenHasher.hash_to_bytes(h) for h in session.get_hashes(key.start, key.end)
         ]

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -297,6 +297,7 @@ class MPCacheServerContext:
         """
         session = self.session_manager.get_or_create(key.request_id)
         session.set_tokens(list(key.token_ids))
+        session.lookup_ipc_key = key.no_worker_id_version()
         chunk_hashes = [
             TokenHasher.hash_to_bytes(h) for h in session.get_hashes(key.start, key.end)
         ]

--- a/tests/v1/test_lazy_offload_pending_store.py
+++ b/tests/v1/test_lazy_offload_pending_store.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.integration.vllm.lazy_offload_pending_store import (
+    FIFOOffloadPolicy,
+    LazyOffloadPendingStore,
+    OffloadPolicy,
+    PendingStoreItem,
+)
+
+
+def _make_item(request_id: str = "req-0") -> PendingStoreItem:
+    """Helper to create a mock PendingStoreItem."""
+    metadata = MagicMock()
+    metadata.request_id = request_id
+    return PendingStoreItem(metadata=metadata)
+
+
+def _make_block_hashes(block_ids: list[int]) -> dict[int, bytes]:
+    """Helper to create mock block hashes."""
+    return {bid: f"hash-{bid}".encode() for bid in block_ids}
+
+
+# ===========================================================================
+# Tests for FIFOOffloadPolicy
+# ===========================================================================
+
+
+class TestFIFOOffloadPolicy:
+    def test_init_default_threshold(self):
+        policy = FIFOOffloadPolicy()
+        assert policy.threshold == 100
+
+    def test_init_custom_threshold(self):
+        configs = {"lmcache.mp.lazy_offload_threshold": 50}
+        policy = FIFOOffloadPolicy(configs)
+        assert policy.threshold == 50
+
+    def test_add_item(self):
+        policy = FIFOOffloadPolicy()
+        item = _make_item()
+        policy.add(item)
+        assert len(policy.pending_items) == 1
+        assert policy.pending_items[0] is item
+
+    def test_should_offload_below_threshold(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
+        policy.add(_make_item("req-0"))
+        policy.add(_make_item("req-1"))
+        assert policy.should_offload() is False
+
+    def test_should_offload_at_threshold(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
+        for i in range(3):
+            policy.add(_make_item(f"req-{i}"))
+        assert policy.should_offload() is True
+
+    def test_should_offload_above_threshold(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        for i in range(5):
+            policy.add(_make_item(f"req-{i}"))
+        assert policy.should_offload() is True
+
+    def test_select_items_returns_iterator(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        for i in range(5):
+            policy.add(_make_item(f"req-{i}"))
+        result = policy.select_items(3)
+        assert isinstance(result, Iterator)
+
+    def test_select_items_fifo_order(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        items = [_make_item(f"req-{i}") for i in range(5)]
+        for item in items:
+            policy.add(item)
+
+        selected = list(policy.select_items(3))
+        assert len(selected) == 3
+        assert selected[0].metadata.request_id == "req-0"
+        assert selected[1].metadata.request_id == "req-1"
+        assert selected[2].metadata.request_id == "req-2"
+
+    def test_select_items_removes_from_pending(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        for i in range(5):
+            policy.add(_make_item(f"req-{i}"))
+
+        list(policy.select_items(3))
+        assert len(policy.pending_items) == 2
+        assert policy.pending_items[0].metadata.request_id == "req-3"
+        assert policy.pending_items[1].metadata.request_id == "req-4"
+
+    def test_select_items_count_exceeds_pending(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        for i in range(3):
+            policy.add(_make_item(f"req-{i}"))
+
+        selected = list(policy.select_items(10))
+        assert len(selected) == 3
+        assert len(policy.pending_items) == 0
+
+    def test_select_items_empty_queue(self):
+        policy = FIFOOffloadPolicy()
+        selected = list(policy.select_items(5))
+        assert selected == []
+
+
+# ===========================================================================
+# Tests for LazyOffloadPendingStore
+# ===========================================================================
+
+
+class TestLazyOffloadPendingStore:
+    def test_init_default_policy(self):
+        store = LazyOffloadPendingStore()
+        assert isinstance(store._policy, FIFOOffloadPolicy)
+
+    def test_init_fifo_policy_explicit(self):
+        configs = {"lmcache.mp.lazy_offload_policy": "FIFO"}
+        store = LazyOffloadPendingStore(configs)
+        assert isinstance(store._policy, FIFOOffloadPolicy)
+
+    def test_init_unknown_policy_raises(self):
+        configs = {"lmcache.mp.lazy_offload_policy": "UNKNOWN"}
+        with pytest.raises(ValueError, match="Unknown offload policy"):
+            LazyOffloadPendingStore(configs)
+
+    def test_init_custom_select_count(self):
+        configs = {"lmcache.mp.lazy_offload_select_count": 5}
+        store = LazyOffloadPendingStore(configs)
+        assert store._select_count == 5
+
+    def test_add_stores_item_and_block_hashes(self):
+        store = LazyOffloadPendingStore()
+        item = _make_item("req-1")
+        hashes = _make_block_hashes([10, 20, 30])
+        store.add(item, hashes)
+
+        assert store.get_block_hashes("req-1") == hashes
+
+    def test_should_offload_delegates_to_policy(self):
+        configs = {"lmcache.mp.lazy_offload_threshold": 2}
+        store = LazyOffloadPendingStore(configs)
+
+        store.add(_make_item("req-0"), _make_block_hashes([0]))
+        assert store.should_offload() is False
+
+        store.add(_make_item("req-1"), _make_block_hashes([1]))
+        assert store.should_offload() is True
+
+    def test_select_items_returns_correct_count(self):
+        configs = {
+            "lmcache.mp.lazy_offload_threshold": 2,
+            "lmcache.mp.lazy_offload_select_count": 2,
+        }
+        store = LazyOffloadPendingStore(configs)
+
+        for i in range(5):
+            store.add(_make_item(f"req-{i}"), _make_block_hashes([i]))
+
+        selected = list(store.select_items())
+        assert len(selected) == 2
+
+    def test_select_items_uses_select_count(self):
+        configs = {
+            "lmcache.mp.lazy_offload_threshold": 3,
+            "lmcache.mp.lazy_offload_select_count": 3,
+        }
+        store = LazyOffloadPendingStore(configs)
+
+        for i in range(5):
+            store.add(_make_item(f"req-{i}"), _make_block_hashes([i]))
+
+        selected = list(store.select_items())
+        assert len(selected) == 3
+        assert selected[0].metadata.request_id == "req-0"
+        assert selected[2].metadata.request_id == "req-2"
+
+    def test_get_block_hashes_existing(self):
+        store = LazyOffloadPendingStore()
+        hashes = _make_block_hashes([1, 2, 3])
+        store.add(_make_item("req-x"), hashes)
+        assert store.get_block_hashes("req-x") == hashes
+
+    def test_get_block_hashes_nonexistent(self):
+        store = LazyOffloadPendingStore()
+        assert store.get_block_hashes("no-such-req") == {}
+
+    def test_remove_block_hashes(self):
+        store = LazyOffloadPendingStore()
+        store.add(_make_item("req-1"), _make_block_hashes([1]))
+        store.remove_block_hashes("req-1")
+        assert store.get_block_hashes("req-1") == {}
+
+    def test_remove_block_hashes_nonexistent_no_error(self):
+        store = LazyOffloadPendingStore()
+        # Should not raise
+        store.remove_block_hashes("nonexistent")
+
+    def test_multiple_adds_same_request_id_overwrites_hashes(self):
+        store = LazyOffloadPendingStore()
+        hashes_1 = _make_block_hashes([1, 2])
+        hashes_2 = _make_block_hashes([3, 4])
+        store.add(_make_item("req-1"), hashes_1)
+        store.add(_make_item("req-1"), hashes_2)
+        # Latest hashes should overwrite
+        assert store.get_block_hashes("req-1") == hashes_2
+
+    def test_end_to_end_flow(self):
+        """Test the full add -> should_offload -> select_items flow."""
+        configs = {
+            "lmcache.mp.lazy_offload_threshold": 3,
+            "lmcache.mp.lazy_offload_select_count": 2,
+        }
+        store = LazyOffloadPendingStore(configs)
+
+        # Add items below threshold
+        for i in range(2):
+            store.add(_make_item(f"req-{i}"), _make_block_hashes([i * 10]))
+        assert store.should_offload() is False
+
+        # Add one more to hit threshold
+        store.add(_make_item("req-2"), _make_block_hashes([20]))
+        assert store.should_offload() is True
+
+        # Select items (select_count=2)
+        selected = list(store.select_items())
+        assert len(selected) == 2
+        assert selected[0].metadata.request_id == "req-0"
+        assert selected[1].metadata.request_id == "req-1"
+
+        # After selection, below threshold again
+        assert store.should_offload() is False
+
+    def test_select_items_repeated_drains(self):
+        """Verify multiple select_items calls drain the queue incrementally."""
+        configs = {
+            "lmcache.mp.lazy_offload_threshold": 2,
+            "lmcache.mp.lazy_offload_select_count": 2,
+        }
+        store = LazyOffloadPendingStore(configs)
+
+        for i in range(6):
+            store.add(_make_item(f"req-{i}"), _make_block_hashes([i]))
+
+        batch1 = list(store.select_items())
+        assert len(batch1) == 2
+        assert batch1[0].metadata.request_id == "req-0"
+
+        batch2 = list(store.select_items())
+        assert len(batch2) == 2
+        assert batch2[0].metadata.request_id == "req-2"
+
+        batch3 = list(store.select_items())
+        assert len(batch3) == 2
+        assert batch3[0].metadata.request_id == "req-4"
+
+
+# ===========================================================================
+# Tests for OffloadPolicy (abstract interface contract)
+# ===========================================================================
+
+
+class TestOffloadPolicyInterface:
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError):
+            OffloadPolicy()  # type: ignore[abstract]
+
+    def test_custom_policy_integration(self):
+        """Verify a custom policy can be plugged in via subclassing."""
+
+        class LIFOOffloadPolicy(OffloadPolicy):
+            """LIFO policy for testing extensibility."""
+
+            def __init__(self, threshold: int = 3):
+                self.pending_items: list[PendingStoreItem] = []
+                self.threshold = threshold
+
+            def add(self, item: PendingStoreItem):
+                self.pending_items.append(item)
+
+            def should_offload(self) -> bool:
+                return len(self.pending_items) >= self.threshold
+
+            def select_items(self, count: int) -> Iterator[PendingStoreItem]:
+                # Return from the back (LIFO)
+                to_offload = self.pending_items[-count:]
+                self.pending_items = self.pending_items[:-count]
+                return iter(reversed(to_offload))
+
+        policy = LIFOOffloadPolicy(threshold=2)
+        for i in range(4):
+            policy.add(_make_item(f"req-{i}"))
+
+        assert policy.should_offload() is True
+        selected = list(policy.select_items(2))
+        assert len(selected) == 2
+        # LIFO: last added items first
+        assert selected[0].metadata.request_id == "req-3"
+        assert selected[1].metadata.request_id == "req-2"

--- a/tests/v1/test_lazy_offload_pending_store.py
+++ b/tests/v1/test_lazy_offload_pending_store.py
@@ -1,27 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from unittest.mock import MagicMock
-import sys
-
-# Mock vllm related imports
-sys.modules.setdefault("vllm", MagicMock())
-sys.modules.setdefault("vllm.distributed", MagicMock())
-sys.modules.setdefault("vllm.distributed.kv_transfer", MagicMock())
-sys.modules.setdefault("vllm.distributed.kv_transfer.kv_connector", MagicMock())
-sys.modules.setdefault("vllm.distributed.kv_transfer.kv_connector.v1", MagicMock())
-sys.modules.setdefault("vllm.distributed.kv_transfer.kv_connector.v1.base", MagicMock())
-sys.modules.setdefault("vllm.v1", MagicMock())
-sys.modules.setdefault("vllm.v1.utils", MagicMock())
 
 # Third Party
-import pytest  # noqa: E402
+import pytest
 
 # First Party
-from lmcache.integration.vllm.lazy_offload_pending_store import (  # noqa: E402
+from lmcache.integration.vllm.lazy_offload_pending_store import (
     FIFOOffloadPolicy,
     LazyOffloadPendingStore,
-    OffloadPolicy,
-    PendingStoreItem,
 )
 
 
@@ -298,66 +285,3 @@ class TestLazyOffloadPendingStore:
 
         batch4 = store.select_items()
         assert len(batch4) == 0
-
-
-# ===========================================================================
-# Tests for OffloadPolicy (abstract interface contract)
-# ===========================================================================
-
-
-class TestOffloadPolicyInterface:
-    def test_cannot_instantiate_abstract(self):
-        with pytest.raises(TypeError):
-            OffloadPolicy()  # type: ignore[abstract]
-
-    def test_custom_policy_integration(self):
-        """Verify a custom policy can be plugged in via subclassing."""
-
-        class CustomOffloadPolicy(OffloadPolicy):
-            def __init__(self):
-                self.pending_items: dict[str, PendingStoreItem] = {}
-                self.finished_count = 0
-                self.threshold = 2
-
-            def add(self, meta, block_hashes):
-                if meta.request_id not in self.pending_items:
-                    self.pending_items[meta.request_id] = PendingStoreItem(
-                        request_id=meta.request_id
-                    )
-                self.pending_items[meta.request_id].metadatas.append(
-                    (meta, block_hashes)
-                )
-
-            def mark_req_finished(self, req_id: str):
-                self.pending_items[req_id].is_finished = True
-                self.finished_count += 1
-
-            def should_offload(self) -> bool:
-                return self.finished_count >= self.threshold
-
-            def select_items(self, count: int) -> list[PendingStoreItem]:
-                result = []
-                for req_id in self.pending_items:
-                    if self.pending_items[req_id].is_finished:
-                        result.append(self.pending_items[req_id])
-                        del self.pending_items[req_id]
-                return result
-
-        policy = CustomOffloadPolicy()
-        store = LazyOffloadPendingStore()
-        store._policy = policy  # inject custom policy
-
-        gpu_pool = MagicMock()
-        gpu_pool.blocks = {
-            bid: MagicMock(block_hash=f"hash-{bid}".encode()) for bid in range(5)
-        }
-        store.bind_gpu_block_pool(gpu_pool)
-
-        store.add(_make_meta("req-0"))
-        store.add(_make_meta("req-1"))
-        store.mark_req_finished("req-0")
-        store.mark_req_finished("req-1")
-
-        assert store.should_offload() is True
-        selected = store.select_items()
-        assert len(selected) == 2

--- a/tests/v1/test_lazy_offload_pending_store.py
+++ b/tests/v1/test_lazy_offload_pending_store.py
@@ -1,13 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from collections.abc import Iterator
 from unittest.mock import MagicMock
+import sys
+
+# Mock vllm related imports
+sys.modules.setdefault("vllm", MagicMock())
+sys.modules.setdefault("vllm.distributed", MagicMock())
+sys.modules.setdefault("vllm.distributed.kv_transfer", MagicMock())
+sys.modules.setdefault("vllm.distributed.kv_transfer.kv_connector", MagicMock())
+sys.modules.setdefault("vllm.distributed.kv_transfer.kv_connector.v1", MagicMock())
+sys.modules.setdefault("vllm.distributed.kv_transfer.kv_connector.v1.base", MagicMock())
+sys.modules.setdefault("vllm.v1", MagicMock())
+sys.modules.setdefault("vllm.v1.utils", MagicMock())
 
 # Third Party
-import pytest
+import pytest  # noqa: E402
 
 # First Party
-from lmcache.integration.vllm.lazy_offload_pending_store import (
+from lmcache.integration.vllm.lazy_offload_pending_store import (  # noqa: E402
     FIFOOffloadPolicy,
     LazyOffloadPendingStore,
     OffloadPolicy,
@@ -15,11 +25,12 @@ from lmcache.integration.vllm.lazy_offload_pending_store import (
 )
 
 
-def _make_item(request_id: str = "req-0") -> PendingStoreItem:
-    """Helper to create a mock PendingStoreItem."""
-    metadata = MagicMock()
-    metadata.request_id = request_id
-    return PendingStoreItem(metadata=metadata)
+def _make_meta(request_id: str = "req-0", num_blocks: int = 1) -> MagicMock:
+    """Helper to create a mock LMCacheMPRequestMetadata."""
+    meta = MagicMock()
+    meta.request_id = request_id
+    meta.op.flat_block_ids = list(range(num_blocks))
+    return meta
 
 
 def _make_block_hashes(block_ids: list[int]) -> dict[int, bytes]:
@@ -35,80 +46,103 @@ def _make_block_hashes(block_ids: list[int]) -> dict[int, bytes]:
 class TestFIFOOffloadPolicy:
     def test_init_default_threshold(self):
         policy = FIFOOffloadPolicy()
-        assert policy.threshold == 100
+        assert policy._threshold == 100
 
     def test_init_custom_threshold(self):
         configs = {"lmcache.mp.lazy_offload_threshold": 50}
         policy = FIFOOffloadPolicy(configs)
-        assert policy.threshold == 50
+        assert policy._threshold == 50
 
-    def test_add_item(self):
+    def test_add_creates_new_item(self):
         policy = FIFOOffloadPolicy()
-        item = _make_item()
-        policy.add(item)
-        assert len(policy.pending_items) == 1
-        assert policy.pending_items[0] is item
+        meta = _make_meta("req-0")
+        hashes = _make_block_hashes([0, 1])
+        policy.add(meta, hashes)
+        assert "req-0" in policy._pending_items
+        assert len(policy._pending_items["req-0"].metadatas) == 1
+
+    def test_add_same_request_appends_metadatas(self):
+        policy = FIFOOffloadPolicy()
+        meta1 = _make_meta("req-0", num_blocks=1)
+        meta2 = _make_meta("req-0", num_blocks=2)
+        policy.add(meta1, _make_block_hashes([0]))
+        policy.add(meta2, _make_block_hashes([0, 1]))
+        assert len(policy._pending_items["req-0"].metadatas) == 2
 
     def test_should_offload_below_threshold(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
-        policy.add(_make_item("req-0"))
-        policy.add(_make_item("req-1"))
+        policy.add(_make_meta("req-0"), _make_block_hashes([0]))
+        policy.mark_req_finished("req-0")
+        assert policy._finished_requests_count == 1
         assert policy.should_offload() is False
 
     def test_should_offload_at_threshold(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
         for i in range(3):
-            policy.add(_make_item(f"req-{i}"))
+            policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
+            policy.mark_req_finished(f"req-{i}")
         assert policy.should_offload() is True
 
     def test_should_offload_above_threshold(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
         for i in range(5):
-            policy.add(_make_item(f"req-{i}"))
+            policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
+            policy.mark_req_finished(f"req-{i}")
         assert policy.should_offload() is True
 
-    def test_select_items_returns_iterator(self):
-        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
-        for i in range(5):
-            policy.add(_make_item(f"req-{i}"))
-        result = policy.select_items(3)
-        assert isinstance(result, Iterator)
+    def test_mark_req_finished_not_in_pending_raises(self):
+        policy = FIFOOffloadPolicy()
+        with pytest.raises(ValueError, match="not in pending_items"):
+            policy.mark_req_finished("nonexistent")
 
-    def test_select_items_fifo_order(self):
+    def test_select_items_returns_only_finished(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
-        items = [_make_item(f"req-{i}") for i in range(5)]
-        for item in items:
-            policy.add(item)
+        policy.add(_make_meta("req-0"), _make_block_hashes([0]))
+        policy.mark_req_finished("req-0")
+        policy.add(_make_meta("req-1"), _make_block_hashes([1]))
+        # req-1 is not finished
 
-        selected = list(policy.select_items(3))
-        assert len(selected) == 3
-        assert selected[0].metadata.request_id == "req-0"
-        assert selected[1].metadata.request_id == "req-1"
-        assert selected[2].metadata.request_id == "req-2"
+        selected = policy.select_items(10)
+        assert len(selected) == 1
+        assert selected[0].request_id == "req-0"
 
     def test_select_items_removes_from_pending(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        policy.add(_make_meta("req-0"), _make_block_hashes([0]))
+        policy.mark_req_finished("req-0")
+        policy.add(_make_meta("req-1"), _make_block_hashes([1]))
+        policy.mark_req_finished("req-1")
+
+        selected = policy.select_items(10)
+        assert len(selected) == 2
+        assert len(policy._pending_items) == 0
+        assert policy._finished_requests_count == 0
+
+    def test_select_items_skips_unfinished(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 1})
+        policy.add(_make_meta("req-0"), _make_block_hashes([0]))
+        policy.add(_make_meta("req-1"), _make_block_hashes([1]))
+        policy.mark_req_finished("req-1")
+
+        selected = policy.select_items(10)
+        assert len(selected) == 1
+        assert selected[0].request_id == "req-1"
+        # req-0 still pending
+        assert "req-0" in policy._pending_items
+
+    def test_select_items_count_limits_output(self):
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 1})
         for i in range(5):
-            policy.add(_make_item(f"req-{i}"))
+            policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
+            policy.mark_req_finished(f"req-{i}")
 
-        list(policy.select_items(3))
-        assert len(policy.pending_items) == 2
-        assert policy.pending_items[0].metadata.request_id == "req-3"
-        assert policy.pending_items[1].metadata.request_id == "req-4"
+        selected = policy.select_items(2)
+        assert len(selected) == 2
+        assert len(policy._pending_items) == 3
 
-    def test_select_items_count_exceeds_pending(self):
-        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
-        for i in range(3):
-            policy.add(_make_item(f"req-{i}"))
-
-        selected = list(policy.select_items(10))
-        assert len(selected) == 3
-        assert len(policy.pending_items) == 0
-
-    def test_select_items_empty_queue(self):
+    def test_select_items_empty(self):
         policy = FIFOOffloadPolicy()
-        selected = list(policy.select_items(5))
-        assert selected == []
+        assert policy.select_items(5) == []
 
 
 # ===========================================================================
@@ -117,6 +151,15 @@ class TestFIFOOffloadPolicy:
 
 
 class TestLazyOffloadPendingStore:
+    def _setup_store_with_gpu_pool(self, configs=None):
+        store = LazyOffloadPendingStore(configs)
+        gpu_pool = MagicMock()
+        gpu_pool.blocks = {
+            bid: MagicMock(block_hash=f"hash-{bid}".encode()) for bid in range(10)
+        }
+        store.bind_gpu_block_pool(gpu_pool)
+        return store
+
     def test_init_default_policy(self):
         store = LazyOffloadPendingStore()
         assert isinstance(store._policy, FIFOOffloadPolicy)
@@ -131,135 +174,130 @@ class TestLazyOffloadPendingStore:
         with pytest.raises(ValueError, match="Unknown offload policy"):
             LazyOffloadPendingStore(configs)
 
+    def test_init_default_select_count(self):
+        store = LazyOffloadPendingStore()
+        assert store._select_count == 10
+
     def test_init_custom_select_count(self):
         configs = {"lmcache.mp.lazy_offload_select_count": 5}
         store = LazyOffloadPendingStore(configs)
         assert store._select_count == 5
 
-    def test_add_stores_item_and_block_hashes(self):
+    def test_bind_gpu_block_pool(self):
         store = LazyOffloadPendingStore()
-        item = _make_item("req-1")
-        hashes = _make_block_hashes([10, 20, 30])
-        store.add(item, hashes)
+        gpu_pool = MagicMock()
+        store.bind_gpu_block_pool(gpu_pool)
+        assert store._gpu_block_pool is gpu_pool
 
-        assert store.get_block_hashes("req-1") == hashes
+    def test_add_without_gpu_pool_raises(self):
+        store = LazyOffloadPendingStore()
+        meta = _make_meta("req-0")
+        with pytest.raises(ValueError, match="gpu block pool not bound"):
+            store.add(meta)
+
+    def test_add_with_gpu_pool(self):
+        store = self._setup_store_with_gpu_pool()
+        meta = _make_meta("req-0", num_blocks=2)
+        store.add(meta)
+        # Verify block hashes were computed from gpu pool
+        pending = store._policy._pending_items["req-0"]
+        assert len(pending.metadatas) == 1
+        assert pending.metadatas[0][1] == {0: b"hash-0", 1: b"hash-1"}
 
     def test_should_offload_delegates_to_policy(self):
         configs = {"lmcache.mp.lazy_offload_threshold": 2}
-        store = LazyOffloadPendingStore(configs)
+        store = self._setup_store_with_gpu_pool(configs)
 
-        store.add(_make_item("req-0"), _make_block_hashes([0]))
+        store.add(_make_meta("req-0"))
+        store.mark_req_finished("req-0")
         assert store.should_offload() is False
 
-        store.add(_make_item("req-1"), _make_block_hashes([1]))
+        store.add(_make_meta("req-1"))
+        store.mark_req_finished("req-1")
         assert store.should_offload() is True
 
     def test_select_items_returns_correct_count(self):
         configs = {
-            "lmcache.mp.lazy_offload_threshold": 2,
-            "lmcache.mp.lazy_offload_select_count": 2,
-        }
-        store = LazyOffloadPendingStore(configs)
-
-        for i in range(5):
-            store.add(_make_item(f"req-{i}"), _make_block_hashes([i]))
-
-        selected = list(store.select_items())
-        assert len(selected) == 2
-
-    def test_select_items_uses_select_count(self):
-        configs = {
-            "lmcache.mp.lazy_offload_threshold": 3,
+            "lmcache.mp.lazy_offload_threshold": 1,
             "lmcache.mp.lazy_offload_select_count": 3,
         }
-        store = LazyOffloadPendingStore(configs)
+        store = self._setup_store_with_gpu_pool(configs)
 
         for i in range(5):
-            store.add(_make_item(f"req-{i}"), _make_block_hashes([i]))
+            store.add(_make_meta(f"req-{i}"))
+            store.mark_req_finished(f"req-{i}")
 
-        selected = list(store.select_items())
+        selected = store.select_items()
         assert len(selected) == 3
-        assert selected[0].metadata.request_id == "req-0"
-        assert selected[2].metadata.request_id == "req-2"
 
-    def test_get_block_hashes_existing(self):
-        store = LazyOffloadPendingStore()
-        hashes = _make_block_hashes([1, 2, 3])
-        store.add(_make_item("req-x"), hashes)
-        assert store.get_block_hashes("req-x") == hashes
+    def test_mark_req_finished(self):
+        configs = {"lmcache.mp.lazy_offload_threshold": 1}
+        store = self._setup_store_with_gpu_pool(configs)
+        store.add(_make_meta("req-0"))
+        store.mark_req_finished("req-0")
+        assert store.should_offload() is True
 
-    def test_get_block_hashes_nonexistent(self):
+    def test_update_get_remove_gpu_block_ids(self):
         store = LazyOffloadPendingStore()
-        assert store.get_block_hashes("no-such-req") == {}
+        store.update_request_gpu_block_ids("req-0", [1, 2])
+        store.update_request_gpu_block_ids("req-0", [3])
+        assert store.get_request_gpu_block_ids("req-0") == [1, 2, 3]
 
-    def test_remove_block_hashes(self):
-        store = LazyOffloadPendingStore()
-        store.add(_make_item("req-1"), _make_block_hashes([1]))
-        store.remove_block_hashes("req-1")
-        assert store.get_block_hashes("req-1") == {}
+        store.remove_request_gpu_block_ids("req-0")
+        assert store.get_request_gpu_block_ids("req-0") == []
 
-    def test_remove_block_hashes_nonexistent_no_error(self):
+    def test_get_gpu_block_ids_nonexistent_returns_empty(self):
         store = LazyOffloadPendingStore()
-        # Should not raise
-        store.remove_block_hashes("nonexistent")
-
-    def test_multiple_adds_same_request_id_overwrites_hashes(self):
-        store = LazyOffloadPendingStore()
-        hashes_1 = _make_block_hashes([1, 2])
-        hashes_2 = _make_block_hashes([3, 4])
-        store.add(_make_item("req-1"), hashes_1)
-        store.add(_make_item("req-1"), hashes_2)
-        # Latest hashes should overwrite
-        assert store.get_block_hashes("req-1") == hashes_2
+        assert store.get_request_gpu_block_ids("nonexistent") == []
 
     def test_end_to_end_flow(self):
-        """Test the full add -> should_offload -> select_items flow."""
+        """Test full add -> mark_finished -> should_offload -> select_items."""
         configs = {
             "lmcache.mp.lazy_offload_threshold": 3,
             "lmcache.mp.lazy_offload_select_count": 2,
         }
-        store = LazyOffloadPendingStore(configs)
+        store = self._setup_store_with_gpu_pool(configs)
 
-        # Add items below threshold
-        for i in range(2):
-            store.add(_make_item(f"req-{i}"), _make_block_hashes([i * 10]))
-        assert store.should_offload() is False
+        # Add items and mark them finished
+        for i in range(5):
+            store.add(_make_meta(f"req-{i}", num_blocks=1))
+        for i in range(5):
+            store.mark_req_finished(f"req-{i}")
 
-        # Add one more to hit threshold
-        store.add(_make_item("req-2"), _make_block_hashes([20]))
+        # Should be over threshold
         assert store.should_offload() is True
 
-        # Select items (select_count=2)
-        selected = list(store.select_items())
+        # Select first 2 (select_count=2)
+        selected = store.select_items()
         assert len(selected) == 2
-        assert selected[0].metadata.request_id == "req-0"
-        assert selected[1].metadata.request_id == "req-1"
+        assert selected[0].request_id == "req-0"
+        assert selected[1].request_id == "req-1"
 
-        # After selection, below threshold again
-        assert store.should_offload() is False
-
-    def test_select_items_repeated_drains(self):
-        """Verify multiple select_items calls drain the queue incrementally."""
+    def test_select_items_multiple_batches(self):
         configs = {
-            "lmcache.mp.lazy_offload_threshold": 2,
+            "lmcache.mp.lazy_offload_threshold": 1,
             "lmcache.mp.lazy_offload_select_count": 2,
         }
-        store = LazyOffloadPendingStore(configs)
+        store = self._setup_store_with_gpu_pool(configs)
 
         for i in range(6):
-            store.add(_make_item(f"req-{i}"), _make_block_hashes([i]))
+            store.add(_make_meta(f"req-{i}"))
+            store.mark_req_finished(f"req-{i}")
 
-        batch1 = list(store.select_items())
+        batch1 = store.select_items()
         assert len(batch1) == 2
-        assert batch1[0].metadata.request_id == "req-0"
+        assert batch1[0].request_id == "req-0"
 
-        batch2 = list(store.select_items())
+        batch2 = store.select_items()
         assert len(batch2) == 2
-        assert batch2[0].metadata.request_id == "req-2"
+        assert batch2[0].request_id == "req-2"
 
-        batch3 = list(store.select_items())
+        batch3 = store.select_items()
         assert len(batch3) == 2
-        assert batch3[0].metadata.request_id == "req-4"
+        assert batch3[0].request_id == "req-4"
+
+        batch4 = store.select_items()
+        assert len(batch4) == 0
 
 
 # ===========================================================================
@@ -275,32 +313,51 @@ class TestOffloadPolicyInterface:
     def test_custom_policy_integration(self):
         """Verify a custom policy can be plugged in via subclassing."""
 
-        class LIFOOffloadPolicy(OffloadPolicy):
-            """LIFO policy for testing extensibility."""
+        class CustomOffloadPolicy(OffloadPolicy):
+            def __init__(self):
+                self.pending_items: dict[str, PendingStoreItem] = {}
+                self.finished_count = 0
+                self.threshold = 2
 
-            def __init__(self, threshold: int = 3):
-                self.pending_items: list[PendingStoreItem] = []
-                self.threshold = threshold
+            def add(self, meta, block_hashes):
+                if meta.request_id not in self.pending_items:
+                    self.pending_items[meta.request_id] = PendingStoreItem(
+                        request_id=meta.request_id
+                    )
+                self.pending_items[meta.request_id].metadatas.append(
+                    (meta, block_hashes)
+                )
 
-            def add(self, item: PendingStoreItem):
-                self.pending_items.append(item)
+            def mark_req_finished(self, req_id: str):
+                self.pending_items[req_id].is_finished = True
+                self.finished_count += 1
 
             def should_offload(self) -> bool:
-                return len(self.pending_items) >= self.threshold
+                return self.finished_count >= self.threshold
 
-            def select_items(self, count: int) -> Iterator[PendingStoreItem]:
-                # Return from the back (LIFO)
-                to_offload = self.pending_items[-count:]
-                self.pending_items = self.pending_items[:-count]
-                return iter(reversed(to_offload))
+            def select_items(self, count: int) -> list[PendingStoreItem]:
+                result = []
+                for req_id in self.pending_items:
+                    if self.pending_items[req_id].is_finished:
+                        result.append(self.pending_items[req_id])
+                        del self.pending_items[req_id]
+                return result
 
-        policy = LIFOOffloadPolicy(threshold=2)
-        for i in range(4):
-            policy.add(_make_item(f"req-{i}"))
+        policy = CustomOffloadPolicy()
+        store = LazyOffloadPendingStore()
+        store._policy = policy  # inject custom policy
 
-        assert policy.should_offload() is True
-        selected = list(policy.select_items(2))
+        gpu_pool = MagicMock()
+        gpu_pool.blocks = {
+            bid: MagicMock(block_hash=f"hash-{bid}".encode()) for bid in range(5)
+        }
+        store.bind_gpu_block_pool(gpu_pool)
+
+        store.add(_make_meta("req-0"))
+        store.add(_make_meta("req-1"))
+        store.mark_req_finished("req-0")
+        store.mark_req_finished("req-1")
+
+        assert store.should_offload() is True
+        selected = store.select_items()
         assert len(selected) == 2
-        # LIFO: last added items first
-        assert selected[0].metadata.request_id == "req-3"
-        assert selected[1].metadata.request_id == "req-2"

--- a/tests/v1/test_lazy_offload_pending_store.py
+++ b/tests/v1/test_lazy_offload_pending_store.py
@@ -56,26 +56,19 @@ class TestFIFOOffloadPolicy:
         policy.add(meta2, _make_block_hashes([0, 1]))
         assert len(policy._pending_items["req-0"].metadatas) == 2
 
-    def test_should_offload_below_threshold(self):
+    def test_select_items_below_threshold_returns_empty(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
         policy.add(_make_meta("req-0"), _make_block_hashes([0]))
         policy.mark_req_finished("req-0")
-        assert policy._finished_requests_count == 1
-        assert policy.should_offload() is False
+        assert policy.select_items(10) == []
+        assert "req-0" in policy._pending_items
 
-    def test_should_offload_at_threshold(self):
+    def test_select_items_at_threshold_returns_finished_items(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
         for i in range(3):
             policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
             policy.mark_req_finished(f"req-{i}")
-        assert policy.should_offload() is True
-
-    def test_should_offload_above_threshold(self):
-        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
-        for i in range(5):
-            policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
-            policy.mark_req_finished(f"req-{i}")
-        assert policy.should_offload() is True
+        assert len(policy.select_items(10)) == 3
 
     def test_mark_req_finished_not_in_pending_raises(self):
         policy = FIFOOffloadPolicy()
@@ -83,7 +76,7 @@ class TestFIFOOffloadPolicy:
             policy.mark_req_finished("nonexistent")
 
     def test_select_items_returns_only_finished(self):
-        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
+        policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 1})
         policy.add(_make_meta("req-0"), _make_block_hashes([0]))
         policy.mark_req_finished("req-0")
         policy.add(_make_meta("req-1"), _make_block_hashes([1]))
@@ -191,17 +184,17 @@ class TestLazyOffloadPendingStore:
         assert len(pending.metadatas) == 1
         assert pending.metadatas[0][1] == {0: b"hash-0", 1: b"hash-1"}
 
-    def test_should_offload_delegates_to_policy(self):
+    def test_select_items_returns_empty_until_threshold(self):
         configs = {"lmcache.mp.lazy_offload_threshold": 2}
         store = self._setup_store_with_gpu_pool(configs)
 
         store.add(_make_meta("req-0"))
         store.mark_req_finished("req-0")
-        assert store.should_offload() is False
+        assert store.select_items() == []
 
         store.add(_make_meta("req-1"))
         store.mark_req_finished("req-1")
-        assert store.should_offload() is True
+        assert len(store.select_items()) == 2
 
     def test_select_items_returns_correct_count(self):
         configs = {
@@ -222,7 +215,7 @@ class TestLazyOffloadPendingStore:
         store = self._setup_store_with_gpu_pool(configs)
         store.add(_make_meta("req-0"))
         store.mark_req_finished("req-0")
-        assert store.should_offload() is True
+        assert [item.request_id for item in store.select_items()] == ["req-0"]
 
     def test_update_get_remove_gpu_block_ids(self):
         store = LazyOffloadPendingStore()
@@ -238,7 +231,7 @@ class TestLazyOffloadPendingStore:
         assert store.get_request_gpu_block_ids("nonexistent") == []
 
     def test_end_to_end_flow(self):
-        """Test full add -> mark_finished -> should_offload -> select_items."""
+        """Test full add -> mark_finished -> select_items flow."""
         configs = {
             "lmcache.mp.lazy_offload_threshold": 3,
             "lmcache.mp.lazy_offload_select_count": 2,
@@ -250,9 +243,6 @@ class TestLazyOffloadPendingStore:
             store.add(_make_meta(f"req-{i}", num_blocks=1))
         for i in range(5):
             store.mark_req_finished(f"req-{i}")
-
-        # Should be over threshold
-        assert store.should_offload() is True
 
         # Select first 2 (select_count=2)
         selected = store.select_items()

--- a/tests/v1/test_lazy_offload_pending_store.py
+++ b/tests/v1/test_lazy_offload_pending_store.py
@@ -56,73 +56,73 @@ class TestFIFOOffloadPolicy:
         policy.add(meta2, _make_block_hashes([0, 1]))
         assert len(policy._pending_items["req-0"].metadatas) == 2
 
-    def test_select_items_below_threshold_returns_empty(self):
+    def test_pop_items_for_offload_below_threshold_returns_empty(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
         policy.add(_make_meta("req-0"), _make_block_hashes([0]))
         policy.mark_req_finished("req-0")
-        assert policy.select_items(10) == []
+        assert policy.pop_items_for_offload(10) == []
         assert "req-0" in policy._pending_items
 
-    def test_select_items_at_threshold_returns_finished_items(self):
+    def test_pop_items_for_offload_at_threshold_returns_finished_items(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 3})
         for i in range(3):
             policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
             policy.mark_req_finished(f"req-{i}")
-        assert len(policy.select_items(10)) == 3
+        assert len(policy.pop_items_for_offload(10)) == 3
 
     def test_mark_req_finished_not_in_pending_raises(self):
         policy = FIFOOffloadPolicy()
         with pytest.raises(ValueError, match="not in pending_items"):
             policy.mark_req_finished("nonexistent")
 
-    def test_select_items_returns_only_finished(self):
+    def test_pop_items_for_offload_returns_only_finished(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 1})
         policy.add(_make_meta("req-0"), _make_block_hashes([0]))
         policy.mark_req_finished("req-0")
         policy.add(_make_meta("req-1"), _make_block_hashes([1]))
         # req-1 is not finished
 
-        selected = policy.select_items(10)
+        selected = policy.pop_items_for_offload(10)
         assert len(selected) == 1
         assert selected[0].request_id == "req-0"
 
-    def test_select_items_removes_from_pending(self):
+    def test_pop_items_for_offload_removes_from_pending(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 2})
         policy.add(_make_meta("req-0"), _make_block_hashes([0]))
         policy.mark_req_finished("req-0")
         policy.add(_make_meta("req-1"), _make_block_hashes([1]))
         policy.mark_req_finished("req-1")
 
-        selected = policy.select_items(10)
+        selected = policy.pop_items_for_offload(10)
         assert len(selected) == 2
         assert len(policy._pending_items) == 0
         assert policy._finished_requests_count == 0
 
-    def test_select_items_skips_unfinished(self):
+    def test_pop_items_for_offload_skips_unfinished(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 1})
         policy.add(_make_meta("req-0"), _make_block_hashes([0]))
         policy.add(_make_meta("req-1"), _make_block_hashes([1]))
         policy.mark_req_finished("req-1")
 
-        selected = policy.select_items(10)
+        selected = policy.pop_items_for_offload(10)
         assert len(selected) == 1
         assert selected[0].request_id == "req-1"
         # req-0 still pending
         assert "req-0" in policy._pending_items
 
-    def test_select_items_count_limits_output(self):
+    def test_pop_items_for_offload_count_limits_output(self):
         policy = FIFOOffloadPolicy({"lmcache.mp.lazy_offload_threshold": 1})
         for i in range(5):
             policy.add(_make_meta(f"req-{i}"), _make_block_hashes([i]))
             policy.mark_req_finished(f"req-{i}")
 
-        selected = policy.select_items(2)
+        selected = policy.pop_items_for_offload(2)
         assert len(selected) == 2
         assert len(policy._pending_items) == 3
 
-    def test_select_items_empty(self):
+    def test_pop_items_for_offload_empty(self):
         policy = FIFOOffloadPolicy()
-        assert policy.select_items(5) == []
+        assert policy.pop_items_for_offload(5) == []
 
 
 # ===========================================================================
@@ -184,19 +184,19 @@ class TestLazyOffloadPendingStore:
         assert len(pending.metadatas) == 1
         assert pending.metadatas[0][1] == {0: b"hash-0", 1: b"hash-1"}
 
-    def test_select_items_returns_empty_until_threshold(self):
+    def test_pop_items_for_offload_returns_empty_until_threshold(self):
         configs = {"lmcache.mp.lazy_offload_threshold": 2}
         store = self._setup_store_with_gpu_pool(configs)
 
         store.add(_make_meta("req-0"))
         store.mark_req_finished("req-0")
-        assert store.select_items() == []
+        assert store.pop_items_for_offload() == []
 
         store.add(_make_meta("req-1"))
         store.mark_req_finished("req-1")
-        assert len(store.select_items()) == 2
+        assert len(store.pop_items_for_offload()) == 2
 
-    def test_select_items_returns_correct_count(self):
+    def test_pop_items_for_offload_returns_correct_count(self):
         configs = {
             "lmcache.mp.lazy_offload_threshold": 1,
             "lmcache.mp.lazy_offload_select_count": 3,
@@ -207,7 +207,7 @@ class TestLazyOffloadPendingStore:
             store.add(_make_meta(f"req-{i}"))
             store.mark_req_finished(f"req-{i}")
 
-        selected = store.select_items()
+        selected = store.pop_items_for_offload()
         assert len(selected) == 3
 
     def test_mark_req_finished(self):
@@ -215,7 +215,7 @@ class TestLazyOffloadPendingStore:
         store = self._setup_store_with_gpu_pool(configs)
         store.add(_make_meta("req-0"))
         store.mark_req_finished("req-0")
-        assert [item.request_id for item in store.select_items()] == ["req-0"]
+        assert [item.request_id for item in store.pop_items_for_offload()] == ["req-0"]
 
     def test_update_get_remove_gpu_block_ids(self):
         store = LazyOffloadPendingStore()
@@ -231,7 +231,7 @@ class TestLazyOffloadPendingStore:
         assert store.get_request_gpu_block_ids("nonexistent") == []
 
     def test_end_to_end_flow(self):
-        """Test full add -> mark_finished -> select_items flow."""
+        """Test full add -> mark_finished -> pop_items_for_offload flow."""
         configs = {
             "lmcache.mp.lazy_offload_threshold": 3,
             "lmcache.mp.lazy_offload_select_count": 2,
@@ -245,12 +245,12 @@ class TestLazyOffloadPendingStore:
             store.mark_req_finished(f"req-{i}")
 
         # Select first 2 (select_count=2)
-        selected = store.select_items()
+        selected = store.pop_items_for_offload()
         assert len(selected) == 2
         assert selected[0].request_id == "req-0"
         assert selected[1].request_id == "req-1"
 
-    def test_select_items_multiple_batches(self):
+    def test_pop_items_for_offload_multiple_batches(self):
         configs = {
             "lmcache.mp.lazy_offload_threshold": 1,
             "lmcache.mp.lazy_offload_select_count": 2,
@@ -261,17 +261,17 @@ class TestLazyOffloadPendingStore:
             store.add(_make_meta(f"req-{i}"))
             store.mark_req_finished(f"req-{i}")
 
-        batch1 = store.select_items()
+        batch1 = store.pop_items_for_offload()
         assert len(batch1) == 2
         assert batch1[0].request_id == "req-0"
 
-        batch2 = store.select_items()
+        batch2 = store.pop_items_for_offload()
         assert len(batch2) == 2
         assert batch2[0].request_id == "req-2"
 
-        batch3 = store.select_items()
+        batch3 = store.pop_items_for_offload()
         assert len(batch3) == 2
         assert batch3[0].request_id == "req-4"
 
-        batch4 = store.select_items()
+        batch4 = store.pop_items_for_offload()
         assert len(batch4) == 0

--- a/tests/v1/test_lazy_offload_pending_store.py
+++ b/tests/v1/test_lazy_offload_pending_store.py
@@ -6,10 +6,8 @@ from unittest.mock import MagicMock
 import pytest
 
 # First Party
-from lmcache.integration.vllm.lazy_offload_pending_store import (
-    FIFOOffloadPolicy,
-    LazyOffloadPendingStore,
-)
+from lmcache.integration.vllm.lazy_offload_pending_store import LazyOffloadPendingStore
+from lmcache.integration.vllm.lazy_offload_policy.fifo import FIFOOffloadPolicy
 
 
 def _make_meta(request_id: str = "req-0", num_blocks: int = 1) -> MagicMock:


### PR DESCRIPTION
Support lazy offload.

the log as follows, the offload threshold is 2, and offload 1 request every time:
<img width="1702" height="150" alt="image" src="https://github.com/user-attachments/assets/af7dc2fb-4bf9-46fc-9daf-a917ee1c3a8e" />
<img width="1706" height="144" alt="image" src="https://github.com/user-attachments/assets/41c4decd-33ed-463c-a084-ae389a39be34" />
<img width="1690" height="146" alt="image" src="https://github.com/user-attachments/assets/96e79c98-29ac-4aa9-acc2-56839a78f639" />
<img width="1704" height="172" alt="image" src="https://github.com/user-attachments/assets/72a13b86-20bb-482e-a419-f3eae3578d46" />
<img width="1712" height="172" alt="image" src="https://github.com/user-attachments/assets/c4ef925e-81e6-40c9-bfec-aa700b71bd33" />
