### PR TITLE
docs: daily drift check — multi-process mode (2026-08-05)

### DIFF
--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -410,9 +410,11 @@ L2 Adapters
 
 The ``L2AdapterInterface`` (in ``base.py``) defines three async task methods:
 
-- ``submit_store_task(key, data)`` -- Push data to L2.
-- ``submit_lookup_and_lock_task(keys)`` -- Check if keys exist in L2.
-- ``submit_load_task(keys, layout_desc)`` -- Load data from L2 into L1.
+- ``submit_store_task(keys, objects)`` -- Push memory objects to L2.
+- ``submit_lookup_and_lock_task(keys, group_layout_descs)`` -- Check if
+  keys exist in L2 and lock them for a subsequent load.
+- ``submit_load_task(keys, objects)`` -- Load data from L2 into the
+  caller-provided memory objects in L1.
 
 The factory function ``create_l2_adapter()`` (in ``__init__.py``) uses
 ``isinstance()`` on the config type to instantiate the correct adapter.


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current `dev`
code (`upstream/dev` HEAD [`24159d6`](https://github.com/LMCache/LMCache/commit/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1)),
focused on the multi-process mode. One drift item today, in
`docs/source/`. Prior open drift-check PRs still track their own items
and do not overlap this one — most recently
[#4421](https://github.com/LMCache/LMCache/pull/4421) (2026-08-04) on
the `--separate-object-groups` default flip, and
[#4285](https://github.com/LMCache/LMCache/pull/4285) (2026-07-28)
which fixed the immediately adjacent `create_l2_adapter()` factory
description in the same file but did not touch the method-signature
bullets addressed here.

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/index.rst`** — the L2 Adapters section listed
  three `L2AdapterInterface` method signatures that no longer match
  the abstract methods in
  [`lmcache/v1/distributed/l2_adapters/base.py:205-333`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/lmcache/v1/distributed/l2_adapters/base.py#L205-L333).
  A reader taking the doc at face value gets two of the three method
  signatures wrong (misnamed second parameter on `submit_load_task`;
  wrong parameter names entirely on `submit_store_task`) and a stale
  view of the third (`submit_lookup_and_lock_task` had its second
  argument renamed on 2026-08-05, unrelated to the doc omission).

  Concretely:

  - `submit_store_task(key, data)` — the interface takes
    `keys: list[ObjectKey], objects: list[MemoryObj]` (plural, and
    `objects`, not `data`). See
    [`base.py:205-224`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/lmcache/v1/distributed/l2_adapters/base.py#L205-L224).
  - `submit_lookup_and_lock_task(keys)` — the interface takes a
    second argument, and PR [#4407](https://github.com/LMCache/LMCache/pull/4407)
    ([`29de05f`](https://github.com/LMCache/LMCache/commit/29de05fd671da976f875defabc2304e0fc9bbd87),
    2026-08-05) renamed it from `layout_desc: MemoryLayoutDesc` to
    `group_layout_descs: dict[int, MemoryLayoutDesc]`. See
    [`base.py:243-263`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/lmcache/v1/distributed/l2_adapters/base.py#L243-L263).
    The design-doc side of the same rename was updated in the same
    PR — see
    [`docs/design/v1/distributed/l2_adapters/overall.md:89`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/docs/design/v1/distributed/l2_adapters/overall.md#L89)
    and
    [`docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md:30`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md#L30) —
    but this user-facing bullet was missed.
  - `submit_load_task(keys, layout_desc)` — the interface takes
    `keys: list[ObjectKey], objects: list[MemoryObj]`. `submit_load_task`
    never took `layout_desc`; the second parameter is the caller-provided
    memory-object buffer. See
    [`base.py:309-333`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/lmcache/v1/distributed/l2_adapters/base.py#L309-L333).

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/mp/index.rst` — L2 Adapters section ([lines 413-415](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/docs/source/mp/index.rst#L413-L415)) | `submit_store_task(key, data)` / `submit_lookup_and_lock_task(keys)` / `submit_load_task(keys, layout_desc)` | `submit_store_task(keys, objects)` / `submit_lookup_and_lock_task(keys, group_layout_descs)` / `submit_load_task(keys, objects)`, with the "Push data / Load data" phrasing tightened to match. |

### `docs/design/`

No drift detected in `docs/design/` today — the L2-adapter design
docs ([`overall.md`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/docs/design/v1/distributed/l2_adapters/overall.md),
[`p2p_l2_adapter.md`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md))
were updated in-tree by PR [#4407](https://github.com/LMCache/LMCache/pull/4407)
alongside the code change. The MP coordinator design docs
([`docs/design/v1/mp_coordinator/*`](https://github.com/LMCache/LMCache/blob/24159d6b3bb4c94fcc3e74b76cc8630f90764cc1/docs/design/v1/mp_coordinator/README.md))
and `docs/source/mp/coordinator.rst` were likewise refreshed by PRs
[#4310](https://github.com/LMCache/LMCache/pull/4310) and
[#4404](https://github.com/LMCache/LMCache/pull/4404). New per-file
design docs added by
[5f44a9e](https://github.com/LMCache/LMCache/commit/5f44a9e9d7e87e797dedf84c3f0475d4a52a5677) /
[38c3584](https://github.com/LMCache/LMCache/commit/38c358429d28eec194cb42367765e6dfe28b1c76)
(MUSA MP block transfer) are self-contained and consistent with the
new modules they describe.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One
file touched:

- `docs/source/mp/index.rst`

## Code bugs surfaced (not fixed here)

None new from today's check. (Pre-existing items from earlier drift
checks remain open — none of them are re-flagged here.)

## Chinese localization note

`docs/source/locale/zh_CN/LC_MESSAGES/mp/index.po` mirrors the stale
English bullets and also carries the pre-rename
`--coordinator-l2-event-*` and `/quota/events` spellings. These `.po`
files are regenerated from English sources; leaving them to the
normal translation refresh cycle.

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Needs human review before merge. Kept as
**draft**; not marked "Ready for review." No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpHK74zF4iMNV6znJV44ay)_