### PR TITLE
[Docs] Mark MTP (speculative decoding) validation status on model recipe pages

### DIFF
--- a/docs/source/recipes/deepseek_v4_flash.rst
+++ b/docs/source/recipes/deepseek_v4_flash.rst
@@ -93,6 +93,42 @@ Compression support
      - Not validated
      -
 
+MTP (speculative decoding) support
+----------------------------------
+
+DeepSeek-V4-Flash ships a native multi-token-prediction head
+(``num_nextn_predict_layers: 1`` in its config), which vLLM uses for
+speculative decoding. The MTP head has its own KV cache layer; LMCache
+detects it from vLLM's ``speculative_config`` and stores/retrieves the
+draft-layer KV together with the target model's -- no extra LMCache flags
+are required.
+
+**Status:** Validated with LMCache (vLLM MP connector, TP4).
+
+Add the speculative config to the ``vllm serve`` command shown above:
+
+.. code-block:: bash
+
+   --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+
+Validation evidence (gsm8k store-vs-retrieve, 100 samples): scores match
+within sampling stderr (0.95 computed vs 0.96 LMCache-retrieved), and the
+MTP acceptance rate is unchanged when the prefix KV is served by LMCache
+(0.947 store run vs 0.952 retrieve run) -- i.e. the draft-layer KV survives
+the store/retrieve round-trip intact. Cold-vs-warm TTFT improved 6.6x with
+MTP enabled throughout.
+
+MTP-specific caveats:
+
+- Generation is **not bit-exact** between a cached and a fresh run: the
+  MXFP4 MoE kernels do not support vLLM's batch-invariant mode. Expect
+  score-level equivalence, not token-level.
+- On the vLLM nightly tested, engine startup with CUDA graphs crashed for
+  this model -- also with a vanilla ``vllm serve`` (no LMCache, no MTP), so
+  this is the dev-branch breakage warned about above, not an LMCache or MTP
+  interaction. ``--enforce-eager`` was used for validation; on tagged vLLM
+  releases (per the vLLM recipe) it should not be needed.
+
 Caveats
 -------
 

--- a/docs/source/recipes/gemma4.rst
+++ b/docs/source/recipes/gemma4.rst
@@ -86,6 +86,57 @@ Compression support
      - Not validated
      -
 
+MTP (speculative decoding) support
+----------------------------------
+
+Gemma 4 supports MTP speculative decoding through separate **assistant
+checkpoints** (``google/gemma-4-<size>-it-assistant``), which vLLM loads as
+the draft model. The draft layers carry their own KV cache; LMCache detects
+them from vLLM's ``speculative_config`` and stores/retrieves the draft-layer
+KV together with the target model's -- no extra LMCache flags are required.
+
+**Status:** Validated with LMCache (vLLM MP connector):
+
+- ``google/gemma-4-31B-it`` + ``google/gemma-4-31B-it-assistant`` (2 GPUs)
+- ``google/gemma-4-12B-it`` + ``google/gemma-4-12B-it-assistant`` (1 GPU,
+  needs ``--enforce-eager``; see below)
+- ``google/gemma-4-E4B-it`` + ``google/gemma-4-E4B-it-assistant`` (1 GPU)
+
+Add to the ``vllm serve`` command shown above:
+
+.. code-block:: bash
+
+   --speculative-config \
+       '{"method":"mtp","model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":1}' \
+   --attention-backend TRITON_ATTN
+
+.. warning::
+
+   ``--attention-backend TRITON_ATTN`` is **required when MTP is enabled**.
+   The target model alone auto-selects the Triton backend (FlashAttention
+   does not support Gemma 4's 512-dim global-attention heads), but the
+   assistant draft model's backend selection picks FlashAttention and the
+   engine crashes at startup with *"FlashAttention forward only supports
+   head dimension at most 256"*. Pinning the backend explicitly covers both
+   models.
+
+Validation evidence (gsm8k store-vs-retrieve, 100 samples, exact score match
+required under ``VLLM_BATCH_INVARIANT=1``): 31B scored 0.78 in both the
+computed and the LMCache-retrieved run with the MTP acceptance rate unchanged
+(0.911 vs 0.910); 12B scored 0.28 in both runs (acceptance 0.854 vs 0.853);
+E4B scored 0.69 in both runs with acceptance rate identical (0.807).
+Cold-vs-warm TTFT improved 3.7x (31B) / 1.7x (12B) / 1.4x (E4B) with MTP
+enabled throughout.
+
+.. note::
+
+   The 12B Unified assistant requires ``--enforce-eager`` on the vLLM
+   nightly tested: its draft head applies a token-suppression list held in
+   an unpinned CPU tensor (``gemma4_mtp.py``, ``compute_logits``), which
+   aborts CUDA graph capture with *"Cannot copy between CPU and CUDA
+   tensors during CUDA graph capture"*. This is an upstream vLLM issue,
+   unrelated to LMCache; 31B and E4B assistants are unaffected.
+
 Caveats
 -------
 

--- a/docs/source/recipes/glm5_2.rst
+++ b/docs/source/recipes/glm5_2.rst
@@ -96,6 +96,17 @@ Compression support
      - Not validated
      -
 
+MTP (speculative decoding) support
+----------------------------------
+
+GLM-5.2 ships a native multi-token-prediction head
+(``num_nextn_predict_layers: 1``), usable for speculative decoding via
+vLLM's ``--speculative-config '{"method":"mtp","num_speculative_tokens":1}'``.
+LMCache accounts for the MTP draft layer's KV cache automatically.
+
+**Status:** Not yet validated with LMCache (validation requires an
+8-GPU node).
+
 Caveats
 -------
 

--- a/docs/source/recipes/minimax_m3.rst
+++ b/docs/source/recipes/minimax_m3.rst
@@ -77,6 +77,29 @@ Compression support
      - Not validated
      -
 
+MTP (speculative decoding) support
+----------------------------------
+
+**Status:** Not possible with the public checkpoints -- the MTP weights
+were not released.
+
+The ``config.json`` of
+`MiniMaxAI/MiniMax-M3 <https://huggingface.co/MiniMaxAI/MiniMax-M3>`_ (BF16)
+declares a native multi-token-prediction head
+(``num_nextn_predict_layers: 1``), but the checkpoint does not contain the
+MTP layer's weights, and neither does ``MiniMaxAI/MiniMax-M3-MXFP8`` (whose
+config omits the field entirely): both checkpoints hold decoder layers 0-59
+only, with no ``mtp``/``nextn`` tensors and no extra layer index. Enabling
+``--speculative-config '{"method":"mtp","num_speculative_tokens":1}'``
+fails at engine startup with vLLM's checkpoint-completeness check::
+
+   ValueError: Failed to load MTP layer 0 weights from checkpoint.
+
+This is a limitation of the released checkpoints, not of LMCache or vLLM.
+If MiniMax publishes the MTP head weights, the standard MTP spec-config
+above is expected to apply; LMCache accounts for MTP draft-layer KV caches
+automatically (validated on DeepSeek-V4-Flash and Gemma 4).
+
 Caveats
 -------
 


### PR DESCRIPTION
## Summary

Validated LMCache compatibility with vLLM MTP speculative decoding for the model
families documented under `docs/source/recipes/` that ship MTP weights, and added an
"MTP (speculative decoding) support" section to each of those pages:

| Recipe page | MTP form | Status |
|---|---|---|
| `deepseek_v4_flash.rst` | native head (`num_nextn_predict_layers: 1`) | **Validated** (TP4) |
| `gemma4.rst` | `google/*-assistant` draft checkpoints | **Validated** (31B TP2, 12B and E4B 1 GPU each) |
| `glm5_2.rst` | native head | Not yet validated (needs 8 GPUs; deferred) |
| `minimax_m3.rst` | declared in BF16 config (MXFP8 omits the field), weights NOT released | **Not possible** — documented on the page |

The remaining recipe families (qwen3, qwen3.5, kimi_k3, kimi_linear, llama, mixtral,
phi3, gpt_oss, devstral, gemma3, minimax_m2, qwen2.5-vl) have no MTP weights
(no `num_nextn_predict_layers` in their configs), so their pages are untouched.

## Test setup

- vLLM `0.26.1rc1.dev306+gcb8104839` (the CI-pinned nightly from
  `buildkite_latest_tested_vllm`), LMCache from source (this branch), MP connector,
  8x H200 node.
- Protocol per `.buildkite/k3_tests/multiprocess/scripts/run-hma-lm-eval.sh`:
  lm_eval gsm8k (100 samples, temperature 0) against vLLM+LMCache → let async stores
  drain → `POST /reset_prefix_cache` (clears vLLM's APC, preserves LMCache) → re-run
  lm_eval so the prefix KV is served by LMCache → compare scores, assert retrieves
  actually happened, and compare the MTP acceptance rate between the two runs
  (draft-layer KV corruption would show up as an acceptance-rate collapse).
- MTP enabled via `--speculative-config '{"method":"mtp","num_speculative_tokens":1}'`
  (plus `"model": "google/gemma-4-*-it-assistant"` for Gemma 4).

## Results

| Model | gsm8k store / retrieve | MTP accept rate store / retrieve | LMCache retrieves | TTFT cold → warm |
|---|---|---|---|---|
| DeepSeek-V4-Flash (TP4, eager) | 0.95 / 0.96 (within stderr¹) | 0.947 / 0.952 | 400 | 2.91s → 0.44s (6.6x) |
| gemma-4-31B-it (TP2, batch-invariant) | 0.78 / 0.78 (exact) | 0.911 / 0.910 | 160 | 0.689s → 0.187s (3.7x) |
| gemma-4-12B-it (1 GPU, batch-invariant, eager) | 0.28 / 0.28 (exact) | 0.854 / 0.853 | 100 | 0.355s → 0.213s (1.7x) |
| gemma-4-E4B-it (1 GPU, batch-invariant) | 0.69 / 0.69 (exact) | 0.807 / 0.807 | 100 | 0.183s → 0.127s (1.4x) |

¹ DSV4-Flash cannot run `VLLM_BATCH_INVARIANT=1` (MXFP4 MoE backend rejects it), so
runs are not bit-exact: 78/100 responses byte-identical, 3 benign reasoning-path
divergences in both directions. Same situation as the Qwen3.5/GDN precedent — the
gate is score-level equivalence.

## Findings worth knowing (documented in the pages)

- **Gemma 4 + MTP requires `--attention-backend TRITON_ATTN`.** The target model
  auto-selects Triton, but the assistant draft model's backend selection picks
  FlashAttention, which aborts on Gemma 4's 512-dim global heads at engine startup.
- **DSV4-Flash on the tested nightly fails engine startup with CUDA graphs** —
  reproduced with a vanilla `vllm serve` (no LMCache, no MTP), i.e. it is the
  dev-branch breakage the recipe page already warns about, not an LMCache/MTP
  interaction. `--enforce-eager` was used for validation.
- LMCache needed no code changes: `calculate_draft_layers()` picks up the MTP draft
  layer via the `use_eagle()` path on this vLLM (the method string is normalized to
  `"mtp"`, so the dedicated `"deepseek_mtp"` branch no longer triggers — worth a
  follow-up cleanup).

- **Upstream vLLM bug (gemma-4-12B Unified assistant)**: its draft head's
  token-suppression list is an unpinned CPU tensor (`gemma4_mtp.py`,
  `compute_logits`), which aborts CUDA graph capture; `--enforce-eager` works
  around it. Worth reporting to vLLM.
- **MiniMax-M3 MTP is not testable**: `config.json` declares
  `num_nextn_predict_layers: 1`, but both public checkpoints (BF16 and MXFP8)
  contain decoder layers 0–59 only — no MTP/nextn tensors. vLLM fails at startup
  with "Failed to load MTP layer 0 weights from checkpoint". The recipe page now
  documents this so nobody else burns time on it; retest if MiniMax releases the
  head weights.

## Follow-ups

- GLM-5.2-FP8: not yet validated -- needs an 8-GPU node; deferred for now.