### PR TITLE
docs: daily drift check — multi-process mode (2026-08-07)

### DIFF
--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -974,9 +974,12 @@ pinned keys from quota-based eviction. L2 pins are fleet-wide (per
 Local resolution requires the coordinator's ``chunk_size`` and
 ``hash_algorithm`` (see `Configuration`_) to match the MP servers' ``--chunk-size``
 / ``--hash-algorithm``; otherwise the resolved keys will not match what was
-stored and the pin protects nothing. It also requires the MP servers to be
-launched with ``--no-separate-object-groups`` (the coordinator resolves keys in
-a single object group).
+stored and the pin protects nothing. It also requires the MP servers **not** to
+be launched with ``--separate-object-groups`` — the coordinator resolves keys
+in a single object group, so any server running with separated object groups
+would produce different keys. Object-group separation is off by default (see
+:doc:`/mp/configuration`), so passing no flag is fine; deployments that pin
+must simply avoid enabling ``--separate-object-groups``.
 
 ``POST /cache/pins``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current `dev`
code (`upstream/dev` HEAD [`8932ed0`](https://github.com/LMCache/LMCache/commit/8932ed07b58ae6c4039de270c90c92a022e604d0)),
focused on the multi-process mode. One drift item today, in
`docs/source/`, caused by yesterday's default-flag flip in PR [#4437](https://github.com/LMCache/LMCache/pull/4437).
Prior open drift-check PRs still track their own items and do not
overlap this one — most recently [#4435](https://github.com/LMCache/LMCache/pull/4435)
(2026-08-05) on L2-adapter method signatures in `docs/source/mp/index.rst`,
and [#4421](https://github.com/LMCache/LMCache/pull/4421) (2026-08-04)
which fixed the `--separate-object-groups` default flip in
`configuration.rst` / `hybrid_models.rst` but did not touch the
coordinator page addressed here.

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/coordinator.rst`** — the L2-pin section under
  *Pin/unpin (protecting cache from eviction)* still tells users the
  MP servers must be launched *with* ``--no-separate-object-groups``
  (see [lines 977-979](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/docs/source/mp/coordinator.rst#L977-L979)).

  PR [#4437](https://github.com/LMCache/LMCache/pull/4437)
  ([`d131cec`](https://github.com/LMCache/LMCache/commit/d131cecfbda1c73019c56bf5173c6110b6c01f35),
  2026-08-06) flipped ``--separate-object-groups``'s default from
  ``True`` to ``False`` — see
  [`lmcache/v1/multiprocess/config.py:53`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/lmcache/v1/multiprocess/config.py#L53)
  (dataclass default) and
  [`config.py:357-363`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/lmcache/v1/multiprocess/config.py#L357-L363)
  (argparse default). That PR updated the flag row in
  [`docs/source/mp/configuration.rst`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/docs/source/mp/configuration.rst#L123-L133)
  and the object-group-separation section in
  [`docs/source/mp/hybrid_models.rst`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/docs/source/mp/hybrid_models.rst#L108-L131),
  but missed the coordinator page.

  With the new default, ``--no-separate-object-groups`` is redundant:
  users get the coordinator-compatible behavior by passing no flag at
  all. Telling readers the servers "must be launched with
  ``--no-separate-object-groups``" implies a flag they need to remember
  to pass — the real constraint is the inverse: they must not enable
  ``--separate-object-groups``. That's what a deployment engineer needs
  to know when deciding whether their existing launch command is
  pin-compatible.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/mp/coordinator.rst` — Pin/unpin section ([lines 977-979](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/docs/source/mp/coordinator.rst#L977-L979)) | "requires the MP servers to be launched with ``--no-separate-object-groups`` (the coordinator resolves keys in a single object group)." | Requires the MP servers **not** to be launched with ``--separate-object-groups`` — object-group separation is off by default, so passing no flag is fine; pin-using deployments must simply avoid enabling ``--separate-object-groups``. Cross-links to `mp/configuration.rst` for the default table. |

### `docs/design/`

No drift detected in `docs/design/` today. The MP-adjacent changes
since the last drift check —

- **PR [#4425](https://github.com/LMCache/LMCache/pull/4425)** ([`3031f71`](https://github.com/LMCache/LMCache/commit/3031f71e66f8872f8c763544e6ad4a654e566629))
  moved `LMCacheMPRequestTracker`, `LMCacheMPRequestState`,
  `LMCacheMPRequestMetadata`, and `LMCacheMPConnectorMetadata` out of
  [`lmcache/integration/vllm/lmcache_mp_connector.py`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/lmcache/integration/vllm/lmcache_mp_connector.py)
  into a new
  [`lmcache/integration/vllm/lmcache_mp_metadata.py`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/lmcache/integration/vllm/lmcache_mp_metadata.py).
  Grepping `docs/source/` for these classes returns no hits, so no
  user-facing doc is stale. The only design-doc reference is
  [`docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md),
  which describes these classes as living in `lmcache_mp_connector.py`
  "in the vLLM repo" — a pre-existing wider drift (the connector has
  been in this LMCache repo, at
  `lmcache/integration/vllm/lmcache_mp_connector.py`, for some time),
  not caused by yesterday's refactor. Left alone here so the fix can be
  addressed as a single design-doc pass rather than a partial rename.
- **PR [#4431](https://github.com/LMCache/LMCache/pull/4431)** ([`6604b0d`](https://github.com/LMCache/LMCache/commit/6604b0d578df2530dc6303992a043b51832a7f6a))
  moved the static `EngineKVFormat` facts onto `KVFormatSpec` and
  refreshed
  [`docs/design/v1/gpu_connector/layout-invariant.md`](https://github.com/LMCache/LMCache/blob/8932ed07b58ae6c4039de270c90c92a022e604d0/docs/design/v1/gpu_connector/layout-invariant.md)
  in the same PR. Grep confirms no other doc still calls
  `is_cross_layer_format(fmt)` or `is_hnd(fmt)` (the helpers replaced
  by class attributes).
- **PR [#4437](https://github.com/LMCache/LMCache/pull/4437)** ([`d131cec`](https://github.com/LMCache/LMCache/commit/d131cecfbda1c73019c56bf5173c6110b6c01f35))
  refreshed `docs/source/mp/{configuration,hybrid_models}.rst` and the
  Kimi / Qwen recipes; the coordinator drift above is the only spot it
  missed.
- **PR [#4367](https://github.com/LMCache/LMCache/pull/4367)** aligned
  `LazyMemoryAllocator`'s buffer base but did not change any
  user-visible flag or API — its doc surface
  (`docs/source/api_reference/configurations.rst`, `enable_lazy_memory_allocator`)
  is unchanged.
- **PR [#4439](https://github.com/LMCache/LMCache/pull/4439)**,
  **[#4443](https://github.com/LMCache/LMCache/pull/4443)**, and
  **[#4195](https://github.com/LMCache/LMCache/pull/4195)** are
  benchmark, CI, and packaging changes with no doc implications for
  multi-process mode.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One file
touched:

- `docs/source/mp/coordinator.rst`

## Code bugs surfaced (not fixed here)

None new from today's check. (Pre-existing items from earlier drift
checks remain open — none of them are re-flagged here.)

## Chinese localization note

`docs/source/locale/zh_CN/LC_MESSAGES/mp/coordinator.po:1241` mirrors
the stale English sentence and will need a matching update on the next
translation pass. These `.po` files are regenerated from English
sources; leaving them to the normal translation refresh cycle.

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Needs human review before merge. Kept as
**draft**; not marked "Ready for review." No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNMPwi3mmg3ju2ZMSvGXxv)_