### PR TITLE
[Feature] Per-request KV retention windows (TTL) for L2 eviction

### DIFF
--- a/docs/design/v1/distributed/retention.md
+++ b/docs/design/v1/distributed/retention.md
@@ -74,8 +74,7 @@ and the deadlines are pushed out.
 ## Eviction integration (`storage_controllers/eviction_controller.py`)
 
 Both L2 eviction branches pass ``RetentionManager.is_evictable`` as the
-``key_eligible_filter``, including the unregistered-salt wipe — the
-retention promise outranks allowlist cleanup. ``is_evictable`` compares the
+``key_eligible_filter``. ``is_evictable`` compares the
 deadline against the clock at ask time, so an expired key is eligible even
 before the next sweep. The loop calls ``sweep()`` once per cycle to release
 expired budget; keys deleted outside the loop are dropped via ``forget``.
@@ -87,9 +86,11 @@ expired budget; keys deleted outside the loop are dropped via ``forget``.
   the eviction-enabled adapter's capacity retention may shield. Capacity
   is taken at boot; adapters added at runtime do not grow the budget.
 - While retention is enabled, config validation requires at most one
-  eviction-enabled adapter -- the default store policy replicates chunks
+  eviction-enabled adapter (the default store policy replicates chunks
   to every adapter, so one budget cannot keep several adapters below
-  their watermarks -- and rejects a fraction at or above that adapter's
+  their watermarks), rejects the per-tenant ``IsolatedLRU`` policy (the
+  budget has no per-salt dimension, so one tenant could capture it
+  all), and rejects a fraction at or above that adapter's
   ``trigger_watermark``.
 - ``report_status()`` on the eviction controller gains a ``retention``
   section: live keys/bytes, budget, and the lifetime ``stamps`` /

--- a/docs/design/v1/distributed/retention.md
+++ b/docs/design/v1/distributed/retention.md
@@ -1,0 +1,109 @@
+# Explicit retention: TTL-shielded chunks in the L2 eviction loop
+
+A per-request capability that lets a store carry a retention ttl: the chunks
+it covers are **shielded from L2 eviction** until the ttl expires, then
+**rejoin the normal LRU pool** — expiry never deletes data. It is **opt-in**
+(``retention_max_fraction`` defaults to ``0``, which rejects every
+registration) and **additive** (with no ttl-carrying requests the eviction
+loop behaves exactly as before).
+
+Code: `lmcache/v1/distributed/retention_manager.py` (the ledger),
+`lmcache/v1/distributed/storage_manager.py` (budget wiring),
+`lmcache/v1/distributed/storage_controllers/eviction_controller.py`
+(enforcement), `lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py`
+(store-time stamping), `lmcache/v1/multiprocess/custom_types.py` (wire
+field), `lmcache/integration/vllm/` (per-request plumbing).
+
+## Why
+
+Serving platforms want to promise "this prompt's KV survives the next hour"
+(paid or pinned prompt caching). A plain LRU tier cannot make that promise —
+one traffic burst evicts the prefix — and a separate pinned storage path
+would duplicate the tier, the transfer path, and the accounting. Retention
+adds the promise to the existing tier as a per-key eviction veto with a
+bounded footprint.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant V as vLLM MP connector
+    participant T as store() (lmcache_driven_transfer)
+    participant R as RetentionManager
+    participant E as L2EvictionController
+
+    V->>T: store op (token range, block ids, retention_ttl_sec=3600)
+    T->>T: reserve_write(..., "new") — declines cached chunks
+    T->>T: D2H copy for missing chunks only
+    T->>R: note_stored(retainable keys, sizes, ttl) after commit
+    loop each eviction cycle
+        E->>R: sweep() — drop expired, release budget
+        E->>R: is_evictable(key) per LRU candidate
+        R-->>E: False while window open → skip key
+    end
+```
+
+The connector reads ``lmcache_retention_ttl_sec`` from the request's
+``kv_transfer_params`` and attaches it to every store op of the request.
+Expired keys leave the ledger and age out of L2 like any other key.
+
+## RetentionManager (`retention_manager.py`)
+
+Thread-safe map of ``ObjectKey -> (deadline, size)``. Deadlines are
+**extend-only** (``max(existing, now + ttl)``), so a shorter later ttl never
+shrinks a granted window. Deadlines are mirrored in a ``SortedKeyList``
+ordered by deadline and kept in lockstep with the map: stamps and
+deadline-moving extends update it in O(log n), ``sweep()`` pops expired keys
+off the front, and the no-expiry case is a single comparison.
+
+## Store-time stamping (`modules/lmcache_driven_transfer.py`)
+
+The stamp collects the chunks that are **freshly reserved or already
+present in L1** (``StorageManager.has_l1_object``): a ttl store must also
+extend chunks that earlier requests stored, which is what makes re-warming
+a window work, while a chunk whose reservation failed holds no data and is
+never stamped. Present chunks have no memory object to measure, so sizes
+come from the group layout. The ledger call happens only after every
+object group's transfer succeeded — a failed store registers nothing.
+
+A fully-cached ttl re-store therefore costs no I/O: the connector skips its
+stored-tokens marker for retention requests so the store op covers the
+whole prefix, reserve mode ``"new"`` declines every chunk, no bytes move,
+and the deadlines are pushed out.
+
+## Eviction integration (`storage_controllers/eviction_controller.py`)
+
+Both L2 eviction branches pass ``RetentionManager.is_evictable`` as the
+``key_eligible_filter``, including the unregistered-salt wipe — the
+retention promise outranks allowlist cleanup. ``is_evictable`` compares the
+deadline against the clock at ask time, so an expired key is eligible even
+before the next sweep. The loop calls ``sweep()`` once per cycle to release
+expired budget; keys deleted outside the loop are dropped via ``forget``.
+
+## Configuration
+
+- ``retention_max_fraction`` (``StorageManagerConfig``; server CLI
+  ``--retention-max-fraction``, default ``0`` = disabled): fraction of
+  total L2 capacity retention may shield. Capacity is summed over
+  eviction-enabled adapters at boot; adapters added at runtime do not grow
+  the budget.
+- Config validation rejects a fraction at or above any adapter's
+  ``trigger_watermark``.
+- ``report_status()`` on the eviction controller gains a ``retention``
+  section: live keys/bytes, budget, and the lifetime ``stamps`` /
+  ``extends`` / ``expirations`` / ``budget_rejections`` counters.
+
+## Invariants
+
+> **Eviction can always make progress.** Retained bytes stay within
+> ``retention_max_fraction × capacity`` and the fraction is validated below
+> the trigger watermark, so an eviction pass always finds unshielded mass.
+> Keys past the budget are simply not registered — the store itself
+> proceeds, and the data stays subject to normal LRU eviction.
+
+> **Expiry never deletes.** ``sweep()`` drops ledger entries, not data.
+
+> A store that raises registers nothing; a chunk is stamped only when
+> freshly written or present in L1 at store time. The rare stamp that
+> outlives its data (a stream failure after submit, a concurrent writer
+> that fails) is inert and lapses at its ttl.

--- a/docs/design/v1/distributed/retention.md
+++ b/docs/design/v1/distributed/retention.md
@@ -84,10 +84,12 @@ expired budget; keys deleted outside the loop are dropped via ``forget``.
 
 - ``retention_max_fraction`` (``StorageManagerConfig``; server CLI
   ``--retention-max-fraction``, default ``0`` = disabled): fraction of
-  total L2 capacity retention may shield. Capacity is summed over
-  eviction-enabled adapters at boot; adapters added at runtime do not grow
-  the budget.
-- Config validation rejects a fraction at or above any adapter's
+  the eviction-enabled adapter's capacity retention may shield. Capacity
+  is taken at boot; adapters added at runtime do not grow the budget.
+- While retention is enabled, config validation requires at most one
+  eviction-enabled adapter -- the default store policy replicates chunks
+  to every adapter, so one budget cannot keep several adapters below
+  their watermarks -- and rejects a fraction at or above that adapter's
   ``trigger_watermark``.
 - ``report_status()`` on the eviction controller gains a ``retention``
   section: live keys/bytes, budget, and the lifetime ``stamps`` /

--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -66,7 +66,8 @@ Commonly used flags include:
        ttl-retained chunks may shield from eviction (``0`` disables
        retention, default). Requires at most one eviction-enabled adapter
        and must stay below its eviction trigger watermark so eviction
-       always has unshielded keys to take.
+       always has unshielded keys to take. Incompatible with the
+       per-tenant ``IsolatedLRU`` eviction policy.
    * - ``--max-workers N``
      - Number of server worker processes.
    * - ``--coordinator-url URL``

--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -61,6 +61,11 @@ Commonly used flags include:
      - L1 fill ratio at which eviction begins.
    * - ``--eviction-ratio RATIO``
      - Fraction of L1 cleared per eviction cycle.
+   * - ``--retention-max-fraction RATIO``
+     - Fraction of total L2 capacity that ttl-retained chunks may shield
+       from eviction (``0`` disables retention, default). Must stay below
+       the eviction trigger watermark so eviction always has unshielded
+       keys to take.
    * - ``--max-workers N``
      - Number of server worker processes.
    * - ``--coordinator-url URL``

--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -62,10 +62,11 @@ Commonly used flags include:
    * - ``--eviction-ratio RATIO``
      - Fraction of L1 cleared per eviction cycle.
    * - ``--retention-max-fraction RATIO``
-     - Fraction of total L2 capacity that ttl-retained chunks may shield
-       from eviction (``0`` disables retention, default). Must stay below
-       the eviction trigger watermark so eviction always has unshielded
-       keys to take.
+     - Fraction of the eviction-enabled L2 adapter's capacity that
+       ttl-retained chunks may shield from eviction (``0`` disables
+       retention, default). Requires at most one eviction-enabled adapter
+       and must stay below its eviction trigger watermark so eviction
+       always has unshielded keys to take.
    * - ``--max-workers N``
      - Number of server worker processes.
    * - ``--coordinator-url URL``

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -736,8 +736,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         assert ret % self.scheduler_adapter.lmcache_tokens_per_chunk == 0
 
-        # Update num stored tokens for the tracker
-        tracker.increase_num_stored_tokens(ret)
+        # Update num stored tokens for the tracker. A retention request
+        # deliberately skips this: its store op must also cover the
+        # already-cached prefix so the server can extend those chunks'
+        # retention windows. Reserve mode "new" skips the re-copy, so
+        # the wider op stores nothing twice.
+        if tracker.retention_ttl_sec <= 0:
+            tracker.increase_num_stored_tokens(ret)
 
         # Save the vllm and lmcache hit tokens. The vLLM hit count is
         # rounded down to a boundary aligned for every engine group (e.g.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -572,12 +572,14 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         request_ids = []
         ops = []
         cache_salts = []
+        retention_ttl_secs = []
         for meta in metadata.requests:
             if meta.direction != "STORE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
             cache_salts.append(meta.cache_salt)
+            retention_ttl_secs.append(meta.retention_ttl_sec)
 
         if len(request_ids) == 0:
             if self.dispatcher is not None:
@@ -588,7 +590,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         event.record()
 
         self.worker_adapter.batched_submit_store_requests(
-            request_ids, ops, event, cache_salts=cache_salts
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            retention_ttl_secs=retention_ttl_secs,
         )
         if self.dispatcher is not None:
             dispatch(self.dispatcher, "wait_for_save", event=event)

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -69,11 +69,22 @@ class LMCacheMPRequestTracker:
 
     cache_salt: str = ""
 
+    # Retention ttl parsed from kv_transfer_params; attached to every
+    # store of this request. 0 means no retention.
+    retention_ttl_sec: int = 0
+
     mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
         self.cache_salt: str = request.cache_salt or ""
+        params = getattr(request, "kv_transfer_params", None) or {}
+        try:
+            self.retention_ttl_sec = max(
+                0, int(params.get("lmcache_retention_ttl_sec", 0))
+            )
+        except (TypeError, ValueError):
+            self.retention_ttl_sec = 0
         self.all_token_ids = request.all_token_ids
         self.allocated_block_ids = {}
         self.num_stored_tokens = 0
@@ -171,6 +182,7 @@ class LMCacheMPRequestMetadata:
     direction: Literal["STORE", "RETRIEVE"]
     op: LoadStoreOp
     cache_salt: str = ""
+    retention_ttl_sec: int = 0
 
     @staticmethod
     def GetStoreMetadata(
@@ -258,6 +270,7 @@ class LMCacheMPRequestMetadata:
                 direction="STORE",
                 op=op,
                 cache_salt=tracker.cache_salt,
+                retention_ttl_sec=tracker.retention_ttl_sec,
             )
 
             # Update the request tracker

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -83,7 +83,7 @@ class LMCacheMPRequestTracker:
             self.retention_ttl_sec = max(
                 0, int(params.get("lmcache_retention_ttl_sec", 0))
             )
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             self.retention_ttl_sec = 0
         self.all_token_ids = request.all_token_ids
         self.allocated_block_ids = {}

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1369,6 +1369,7 @@ class LMCacheMPWorkerAdapter:
         op: LoadStoreOp,
         event: _IpcEvent,
         cache_salt: str = "",
+        retention_ttl_sec: int = 0,
     ):
         """
         Submit a KV cache store request to LMCache
@@ -1379,6 +1380,8 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
             cache_salt: Per-user isolation salt.
+            retention_ttl_sec: Shield the stored chunks from eviction for
+                this many seconds; 0 requests no retention.
         """
         self._ensure_heartbeat_started()
 
@@ -1395,6 +1398,7 @@ class LMCacheMPWorkerAdapter:
             op.end,
             request_id=request_id,
             cache_salt=cache_salt,
+            retention_ttl_sec=retention_ttl_sec,
         )
         if self.transfer_ctx is None:
             raise RuntimeError(
@@ -1475,6 +1479,7 @@ class LMCacheMPWorkerAdapter:
         ops: list[LoadStoreOp],
         event: _IpcEvent,
         cache_salts: list[str] | None = None,
+        retention_ttl_secs: list[int] | None = None,
     ):
         """
         Submit a batched store request to LMCache
@@ -1488,11 +1493,19 @@ class LMCacheMPWorkerAdapter:
             cache_salts: Per-user isolation salts, one per request. If None,
                 all requests use cache_salt="". The list length should be the same as
                 request_ids.
+            retention_ttl_secs: Retention windows in seconds, one per request.
+                If None, no request asks for retention.
         """
         if cache_salts is None:
             cache_salts = [""] * len(request_ids)
-        for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
-            self.submit_store_request(request_id, op, event, cache_salt=salt)
+        if retention_ttl_secs is None:
+            retention_ttl_secs = [0] * len(request_ids)
+        for request_id, op, salt, ttl in zip(
+            request_ids, ops, cache_salts, retention_ttl_secs, strict=False
+        ):
+            self.submit_store_request(
+                request_id, op, event, cache_salt=salt, retention_ttl_sec=ttl
+            )
 
     @_lmcache_nvtx_annotate
     def batched_submit_retrieve_requests(
@@ -1766,6 +1779,7 @@ class LMCacheMPWorkerAdapter:
         end: int,
         request_id: str,
         cache_salt: str = "",
+        retention_ttl_sec: int = 0,
     ) -> IPCCacheServerKey:
         """Convert token IDs to an IPC cache engine key.
 
@@ -1775,6 +1789,7 @@ class LMCacheMPWorkerAdapter:
             end: End token index.
             request_id: The request ID.
             cache_salt: Per-user isolation salt.
+            retention_ttl_sec: Retention window in seconds (0 = none).
 
         Returns:
             IPCCacheServerKey: The constructed key.
@@ -1788,4 +1803,5 @@ class LMCacheMPWorkerAdapter:
             end=end,
             request_id=request_id,
             cache_salt=cache_salt,
+            retention_ttl_sec=retention_ttl_sec,
         )

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -245,10 +245,10 @@ class StorageManagerConfig:
     """ The configuration for L2 adapters. """
 
     retention_max_fraction: float = 0.0
-    """ Fraction of total L2 capacity that retention may shield from
-    eviction. 0 disables retention. When set, it must stay below every
-    adapter's trigger_watermark so the eviction loop always has
-    evictable keys. """
+    """ Fraction of the eviction-enabled L2 adapter's capacity that
+    retention may shield from eviction. 0 disables retention. Requires
+    at most one eviction-enabled adapter and must stay below its
+    trigger_watermark. """
 
     store_policy: str = "default"
     """ The L2 store policy name. """
@@ -309,14 +309,24 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
         raise ValueError("gds-l1-path cannot be used with l1-devdax-path")
 
     if config.retention_max_fraction > 0:
-        for ac in config.l2_adapter_config.adapters:
-            if ac.eviction_config is None:
-                continue
-            if config.retention_max_fraction >= ac.eviction_config.trigger_watermark:
+        eviction_configs = [
+            ec
+            for ac in config.l2_adapter_config.adapters
+            if (ec := ac.eviction_config) is not None
+        ]
+        if len(eviction_configs) > 1:
+            raise ValueError(
+                "retention_max_fraction supports at most one eviction-enabled "
+                f"L2 adapter (got {len(eviction_configs)}): the default store "
+                "policy replicates chunks to every adapter, so one budget "
+                "cannot keep each adapter below its eviction watermark"
+            )
+        for ec in eviction_configs:
+            if config.retention_max_fraction >= ec.trigger_watermark:
                 raise ValueError(
                     f"retention_max_fraction ({config.retention_max_fraction}) "
                     "must be below the L2 trigger_watermark "
-                    f"({ac.eviction_config.trigger_watermark})"
+                    f"({ec.trigger_watermark})"
                 )
 
     memory_config = config.l1_manager_config.memory_config

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -244,6 +244,12 @@ class StorageManagerConfig:
     )
     """ The configuration for L2 adapters. """
 
+    retention_max_fraction: float = 0.0
+    """ Fraction of total L2 capacity that retention may shield from
+    eviction. 0 disables retention. When set, it must stay below every
+    adapter's trigger_watermark so the eviction loop always has
+    evictable keys. """
+
     store_policy: str = "default"
     """ The L2 store policy name. """
 
@@ -301,6 +307,17 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
         and config.l1_manager_config.memory_config.devdax_path
     ):
         raise ValueError("gds-l1-path cannot be used with l1-devdax-path")
+
+    if config.retention_max_fraction > 0:
+        for ac in config.l2_adapter_config.adapters:
+            if ac.eviction_config is None:
+                continue
+            if config.retention_max_fraction >= ac.eviction_config.trigger_watermark:
+                raise ValueError(
+                    f"retention_max_fraction ({config.retention_max_fraction}) "
+                    "must be below the L2 trigger_watermark "
+                    f"({ac.eviction_config.trigger_watermark})"
+                )
 
     memory_config = config.l1_manager_config.memory_config
     if not (memory_config.devdax_path and memory_config.devdax_size_in_bytes):

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -488,6 +488,14 @@ def add_storage_manager_args(
         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
         "Default is 0.2.",
     )
+    eviction_group.add_argument(
+        "--retention-max-fraction",
+        type=float,
+        default=0.0,
+        help="Fraction of total L2 capacity that explicit retention may "
+        "shield from eviction. 0 disables retention. Must be below the "
+        "eviction trigger watermark. Default is 0.0.",
+    )
 
     # L2 Policies
     # Import here to break circular dependency:
@@ -621,6 +629,7 @@ def parse_args_to_config(
         l1_manager_config=l1_manager_config,
         eviction_config=eviction_config,
         l2_adapter_config=l2_adapter_config,
+        retention_max_fraction=args.retention_max_fraction,
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
         prefetch_max_in_flight=args.l2_prefetch_max_in_flight,

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -322,6 +322,13 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
                 "cannot keep each adapter below its eviction watermark"
             )
         for ec in eviction_configs:
+            if ec.eviction_policy == "IsolatedLRU":
+                raise ValueError(
+                    "retention_max_fraction does not support the IsolatedLRU "
+                    "eviction policy: the retention budget has no per-salt "
+                    "dimension, so one tenant could shield the whole budget "
+                    "and starve the rest"
+                )
             if config.retention_max_fraction >= ec.trigger_watermark:
                 raise ValueError(
                     f"retention_max_fraction ({config.retention_max_fraction}) "

--- a/lmcache/v1/distributed/retention_manager.py
+++ b/lmcache/v1/distributed/retention_manager.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Per-key retention registry for explicitly retained KV chunks.
+
+A store request may carry a retention ttl (see
+``IPCCacheServerKey.retention_ttl_sec``). The chunks written by such a
+store are registered here with a deadline; eviction paths consult
+``is_evictable`` and skip keys whose deadline has not passed. Expired
+keys are dropped by ``sweep`` and thereby rejoin the normal LRU pool --
+expiry never deletes data.
+
+Deadlines are extend-only: re-storing a key with a shorter ttl never
+shortens its existing window.
+
+A byte budget caps how much of the cache retention can shield, so the
+eviction loop always has evictable keys left. Keys that would push the
+retained total over the budget are simply not registered -- the store
+itself proceeds and the data stays subject to normal LRU eviction.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Callable
+import threading
+import time
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import ObjectKey
+
+logger = init_logger(__name__)
+
+
+class RetentionManager:
+    """Thread-safe map of ObjectKey -> retention deadline.
+
+    Args:
+        max_retained_bytes: Byte budget for retained data. 0 rejects
+            every registration (retention effectively disabled).
+        clock: Monotonic time source, injectable for tests.
+    """
+
+    def __init__(
+        self,
+        max_retained_bytes: int,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._clock = clock
+        self._max_retained_bytes = max_retained_bytes
+        # ObjectKey -> (deadline, size_bytes)
+        self._entries: dict[ObjectKey, tuple[float, int]] = {}
+        self._retained_bytes = 0
+        self._num_stamps = 0
+        self._num_extends = 0
+        self._num_expirations = 0
+        self._num_budget_rejections = 0
+
+    def note_stored(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+        ttl_sec: int,
+    ) -> int:
+        """Register (or extend) retention for freshly stored keys.
+
+        Extending an already-retained key is always allowed and costs no
+        budget. New keys are admitted while the retained total stays
+        within the budget; the rest are skipped and counted as
+        rejections.
+
+        Returns the number of keys registered or extended.
+        """
+        if ttl_sec <= 0 or not keys:
+            return 0
+        deadline = self._clock() + ttl_sec
+        accepted = 0
+        with self._lock:
+            for key, size in zip(keys, sizes, strict=True):
+                entry = self._entries.get(key)
+                if entry is not None:
+                    if deadline > entry[0]:
+                        self._entries[key] = (deadline, entry[1])
+                    self._num_extends += 1
+                    accepted += 1
+                    continue
+                if self._retained_bytes + size > self._max_retained_bytes:
+                    self._num_budget_rejections += 1
+                    continue
+                self._entries[key] = (deadline, size)
+                self._retained_bytes += size
+                self._num_stamps += 1
+                accepted += 1
+            retained_bytes = self._retained_bytes
+        if accepted < len(keys):
+            logger.warning(
+                "Retention budget exhausted: admitted %d of %d keys "
+                "(retained_bytes=%d, budget=%d)",
+                accepted,
+                len(keys),
+                retained_bytes,
+                self._max_retained_bytes,
+            )
+        return accepted
+
+    @property
+    def max_retained_bytes(self) -> int:
+        """The configured retention byte budget (0 = retention disabled)."""
+        return self._max_retained_bytes
+
+    def is_evictable(self, key: ObjectKey) -> bool:
+        """False while the key's retention window is still open."""
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return True
+            return entry[0] <= self._clock()
+
+    def forget(self, keys: list[ObjectKey]) -> None:
+        """Drop entries for keys deleted outside the eviction loop."""
+        with self._lock:
+            for key in keys:
+                entry = self._entries.pop(key, None)
+                if entry is not None:
+                    self._retained_bytes -= entry[1]
+
+    def sweep(self) -> int:
+        """Drop expired entries so their keys rejoin the LRU pool."""
+        now = self._clock()
+        with self._lock:
+            expired = [
+                key for key, (deadline, _) in self._entries.items() if deadline <= now
+            ]
+            for key in expired:
+                self._retained_bytes -= self._entries.pop(key)[1]
+            self._num_expirations += len(expired)
+        return len(expired)
+
+    def report_status(self) -> dict:
+        with self._lock:
+            return {
+                "retained_keys": len(self._entries),
+                "retained_bytes": self._retained_bytes,
+                "max_retained_bytes": self._max_retained_bytes,
+                "stamps": self._num_stamps,
+                "extends": self._num_extends,
+                "expirations": self._num_expirations,
+                "budget_rejections": self._num_budget_rejections,
+            }

--- a/lmcache/v1/distributed/retention_manager.py
+++ b/lmcache/v1/distributed/retention_manager.py
@@ -72,12 +72,21 @@ class RetentionManager:
     ) -> int:
         """Register (or extend) retention for freshly stored keys.
 
-        Extending an already-retained key is always allowed and costs no
-        budget. New keys are admitted while the retained total stays
-        within the budget; the rest are skipped and counted as
-        rejections.
+        Thread-safe. Extending an already-retained key is always allowed,
+        never shortens its deadline, and costs no budget. New keys are
+        admitted while the retained total stays within the budget; the
+        rest are skipped and counted as rejections.
 
-        Returns the number of keys registered or extended.
+        Args:
+            keys: Chunk keys covered by the store, including chunks that
+                were already cached. Same length as sizes.
+            sizes: Byte size of each key's chunk, charged against the
+                budget when the key is newly registered.
+            ttl_sec: Seconds from now to shield the keys. Values <= 0
+                make the call a no-op.
+
+        Returns:
+            The number of keys registered or extended.
         """
         if ttl_sec <= 0 or not keys:
             return 0
@@ -120,7 +129,15 @@ class RetentionManager:
         return self._max_retained_bytes
 
     def is_evictable(self, key: ObjectKey) -> bool:
-        """False while the key's retention window is still open."""
+        """Whether eviction may take the key.
+
+        Args:
+            key: The chunk key an eviction pass is considering.
+
+        Returns:
+            False while the key's retention window is still open; True
+            otherwise, including for keys that were never registered.
+        """
         with self._lock:
             entry = self._entries.get(key)
             if entry is None:
@@ -128,7 +145,13 @@ class RetentionManager:
             return entry[0] <= self._clock()
 
     def forget(self, keys: list[ObjectKey]) -> None:
-        """Drop entries for keys deleted outside the eviction loop."""
+        """Drop entries for keys deleted outside the eviction loop.
+
+        Args:
+            keys: Keys whose data was removed (e.g. an adapter clear);
+                their budget bytes are released immediately. Unknown
+                keys are ignored.
+        """
         with self._lock:
             for key in keys:
                 entry = self._entries.pop(key, None)
@@ -137,7 +160,11 @@ class RetentionManager:
                     self._retained_bytes -= entry[1]
 
     def sweep(self) -> int:
-        """Drop expired entries so their keys rejoin the LRU pool."""
+        """Drop expired entries so their keys rejoin the LRU pool.
+
+        Returns:
+            The number of entries that expired.
+        """
         now = self._clock()
         expired = 0
         with self._lock:
@@ -148,7 +175,15 @@ class RetentionManager:
             self._num_expirations += expired
         return expired
 
-    def report_status(self) -> dict:
+    def report_status(self) -> dict[str, int]:
+        """Snapshot of ledger state and lifetime counters.
+
+        Returns:
+            A dict with "retained_keys" (live entries), "retained_bytes"
+            (bytes currently shielded), "max_retained_bytes" (configured
+            budget, 0 = disabled), and the lifetime counters "stamps",
+            "extends", "expirations", and "budget_rejections".
+        """
         with self._lock:
             return {
                 "retained_keys": len(self._entries),

--- a/lmcache/v1/distributed/retention_manager.py
+++ b/lmcache/v1/distributed/retention_manager.py
@@ -23,8 +23,12 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Callable
+import operator
 import threading
 import time
+
+# Third Party
+from sortedcontainers import SortedKeyList
 
 # First Party
 from lmcache.logging import init_logger
@@ -52,6 +56,8 @@ class RetentionManager:
         self._max_retained_bytes = max_retained_bytes
         # ObjectKey -> (deadline, size_bytes)
         self._entries: dict[ObjectKey, tuple[float, int]] = {}
+        # (deadline, key) ordered by deadline; in lockstep with _entries.
+        self._deadlines = SortedKeyList(key=operator.itemgetter(0))
         self._retained_bytes = 0
         self._num_stamps = 0
         self._num_extends = 0
@@ -82,7 +88,9 @@ class RetentionManager:
                 entry = self._entries.get(key)
                 if entry is not None:
                     if deadline > entry[0]:
+                        self._deadlines.remove((entry[0], key))
                         self._entries[key] = (deadline, entry[1])
+                        self._deadlines.add((deadline, key))
                     self._num_extends += 1
                     accepted += 1
                     continue
@@ -90,6 +98,7 @@ class RetentionManager:
                     self._num_budget_rejections += 1
                     continue
                 self._entries[key] = (deadline, size)
+                self._deadlines.add((deadline, key))
                 self._retained_bytes += size
                 self._num_stamps += 1
                 accepted += 1
@@ -124,19 +133,20 @@ class RetentionManager:
             for key in keys:
                 entry = self._entries.pop(key, None)
                 if entry is not None:
+                    self._deadlines.remove((entry[0], key))
                     self._retained_bytes -= entry[1]
 
     def sweep(self) -> int:
         """Drop expired entries so their keys rejoin the LRU pool."""
         now = self._clock()
+        expired = 0
         with self._lock:
-            expired = [
-                key for key, (deadline, _) in self._entries.items() if deadline <= now
-            ]
-            for key in expired:
+            while self._deadlines and self._deadlines[0][0] <= now:
+                _, key = self._deadlines.pop(0)
                 self._retained_bytes -= self._entries.pop(key)[1]
-            self._num_expirations += len(expired)
-        return len(expired)
+                expired += 1
+            self._num_expirations += expired
+        return expired
 
     def report_status(self) -> dict:
         with self._lock:

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 # Standard
 from abc import abstractmethod
 from collections import Counter
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 import threading
 import time
@@ -29,6 +30,7 @@ from lmcache.v1.mp_observability.event_bus import get_event_bus
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.distributed.quota_manager import QuotaManager
+    from lmcache.v1.distributed.retention_manager import RetentionManager
 
 logger = init_logger(__name__)
 
@@ -235,9 +237,11 @@ class L2EvictionController(StorageControllerInterface):
         self,
         l2_adapter_states: list[L2AdapterEvictionState],
         quota_manager: QuotaManager | None = None,
+        retention_manager: "RetentionManager | None" = None,
     ):
         self._adapter_states = l2_adapter_states
         self._quota_manager = quota_manager
+        self._retention_manager = retention_manager
         # Guards _adapter_states against concurrent runtime add/remove.
         self._states_lock = threading.Lock()
         self._stop_flag = threading.Event()
@@ -294,15 +298,22 @@ class L2EvictionController(StorageControllerInterface):
                     "num_cache_salt_buckets": len(usage.bytes_by_cache_salt),
                 }
             )
-        return {
+        status = {
             "is_healthy": self._thread.is_alive(),
             "thread_alive": self._thread.is_alive(),
             "adapters": adapter_statuses,
         }
+        if self._retention_manager is not None:
+            status["retention"] = self._retention_manager.report_status()
+        return status
 
     def _eviction_loop(self):
         while not self._stop_flag.is_set():
             time.sleep(1)
+            # Expired retention entries rejoin the LRU pool; sweeping
+            # here also releases their budget bytes.
+            if self._retention_manager is not None:
+                self._retention_manager.sweep()
             # Hold the lock across the whole pass so remove_adapter_state
             # cannot detach (and the caller close) an adapter while we are
             # calling into it.
@@ -315,6 +326,12 @@ class L2EvictionController(StorageControllerInterface):
             self._check_and_evict_by_cache_salt(state)
         else:
             self._check_and_evict_global(state)
+
+    def _key_eligible_filter(self) -> Callable[[ObjectKey], bool] | None:
+        """Retention veto for eviction candidates; None when disabled."""
+        if self._retention_manager is None:
+            return None
+        return self._retention_manager.is_evictable
 
     def _check_and_evict_global(self, state: L2AdapterEvictionState):
         """Aggregate-usage eviction (``LRU`` / ``noop``)."""
@@ -340,7 +357,10 @@ class L2EvictionController(StorageControllerInterface):
             current_usage,
             watermark,
         )
-        actions = state.eviction_policy.get_eviction_actions(eviction_ratio)
+        actions = state.eviction_policy.get_eviction_actions(
+            eviction_ratio,
+            key_eligible_filter=self._key_eligible_filter(),
+        )
         for action in actions:
             self._execute_eviction_action(state.adapter, action)
 
@@ -392,7 +412,9 @@ class L2EvictionController(StorageControllerInterface):
                 effective_ratio,
             )
             actions = state.eviction_policy.get_eviction_actions(
-                effective_ratio, cache_salt=cache_salt
+                effective_ratio,
+                key_eligible_filter=self._key_eligible_filter(),
+                cache_salt=cache_salt,
             )
             for action in actions:
                 pending.setdefault(action.destination, []).extend(action.keys)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -35,6 +35,7 @@ from lmcache.v1.distributed.l2_adapters.reconfiguration import (
 )
 from lmcache.v1.distributed.l2_adapters.serde_wrapper import SerdeL2AdapterWrapper
 from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.distributed.retention_manager import RetentionManager
 from lmcache.v1.distributed.serde import create_serde_processor
 from lmcache.v1.distributed.storage_controllers import (
     L1EvictionController,
@@ -107,6 +108,22 @@ class StorageManager:
         # reference. No explicit cleanup on close — the registry is
         # just a dict protected by a lock and has no OS resources.
         self._quota_manager = QuotaManager()
+
+        # Retention budget: a fraction of total L2 capacity. The fraction
+        # is validated against adapter watermarks at config time; capacity
+        # is taken at boot, so adapters added at runtime do not grow the
+        # budget.
+        l2_capacity_bytes = 0
+        for adapter_id, ac in zip(
+            self._l2_adapters, config.l2_adapter_config.adapters, strict=True
+        ):
+            if ac.eviction_config is None:
+                continue
+            usage = self._l2_adapters[adapter_id].get_usage()
+            l2_capacity_bytes += max(0, usage.total_capacity_bytes)
+        self._retention_manager = RetentionManager(
+            max_retained_bytes=int(config.retention_max_fraction * l2_capacity_bytes)
+        )
 
         # Unified L2 eviction controller for all adapters with eviction
         # config. Aggregate-usage policies (``LRU``, ``noop``) need
@@ -781,6 +798,11 @@ class StorageManager:
         storage manager creates the registry at construction time.
         """
         return self._quota_manager
+
+    @property
+    def retention_manager(self) -> RetentionManager:
+        """The per-key retention registry shared by store and eviction."""
+        return self._retention_manager
 
     @property
     def l1_memory_desc(self) -> L1MemoryDesc:

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -147,7 +147,9 @@ class StorageManager:
                     )
                 )
         self._l2_eviction_controller = L2EvictionController(
-            l2_eviction_states, quota_manager=self._quota_manager
+            l2_eviction_states,
+            quota_manager=self._quota_manager,
+            retention_manager=self._retention_manager,
         )
         self._l2_eviction_controller.start()
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -244,6 +244,18 @@ class StorageManager:
 
         return result
 
+    def has_l1_object(self, key: ObjectKey) -> bool:
+        """Whether L1 currently holds an entry for the key.
+
+        Args:
+            key: The object key to look up.
+
+        Returns:
+            True if an L1 entry exists (written or being written),
+            False otherwise.
+        """
+        return self._l1_manager.get_object_state(key) is not None
+
     @enable_tracing()
     def finish_write(
         self,

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -109,9 +109,10 @@ class StorageManager:
         # just a dict protected by a lock and has no OS resources.
         self._quota_manager = QuotaManager()
 
-        # Retention budget: a fraction of total L2 capacity. The fraction
-        # is validated against adapter watermarks at config time; capacity
-        # is taken at boot, so adapters added at runtime do not grow the
+        # Retention budget: a fraction of the eviction-enabled adapter's
+        # capacity (validation caps retention configs at one such adapter,
+        # so this sum is that adapter's capacity, or zero). Capacity is
+        # taken at boot, so adapters added at runtime do not grow the
         # budget.
         l2_capacity_bytes = 0
         for adapter_id, ac in zip(

--- a/lmcache/v1/multiprocess/cache_control/object_service.py
+++ b/lmcache/v1/multiprocess/cache_control/object_service.py
@@ -149,7 +149,9 @@ class ObjectService:
         Key-addressed. L1 deletion respects read/write locks unless ``force``;
         L2 deletion is idempotent at the adapter level (absent / locked keys are
         skipped). The L2 adapter is only resolved when the tier includes L2, so a
-        pure ``l1`` delete works on an L1-only server.
+        pure ``l1`` delete works on an L1-only server. An L2 delete also drops
+        the keys' retention ledger entries -- an explicit delete outranks a
+        retention window.
 
         Returns:
             ``{"deleted", "skipped", "ok"[, "error"]}``: ``deleted`` is the total
@@ -193,6 +195,9 @@ class ObjectService:
             try:
                 await asyncio.to_thread(adapter.delete, parsed)
                 deleted += len(parsed)
+                # The data is gone; release any retention windows now
+                # rather than at ttl expiry.
+                self._engine.storage_manager.retention_manager.forget(parsed)
             except Exception as exc:  # noqa: BLE001 - structured result, not a crash
                 ok = False
                 error = str(exc)

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -60,6 +60,13 @@ class IPCCacheServerKey:
     # ObjectKey.cache_salt). Validated in __post_init__.
     cache_salt: str = ""
 
+    # === Explicit retention request (not part of cache identity) ===
+    # A store carrying a nonzero ttl asks the server to shield the written
+    # chunks from eviction until the window expires. msgspec encodes
+    # dataclasses as maps, so payloads that predate this field decode with
+    # the default (no retention).
+    retention_ttl_sec: int = field(compare=False, default=0)
+
     # Duplicated from ObjectKey — cannot import ObjectKey here due to
     # circular dependency (api.py imports IPCCacheServerKey).
     _SALT_FORBIDDEN_CHARS = frozenset("@/\\\x00")
@@ -75,6 +82,10 @@ class IPCCacheServerKey:
             raise ValueError(
                 f"cache_salt exceeds max length {self._SALT_MAX_LEN} "
                 f"(got {len(self.cache_salt)})"
+            )
+        if self.retention_ttl_sec < 0:
+            raise ValueError(
+                f"retention_ttl_sec must be non-negative (got {self.retention_ttl_sec})"
             )
 
     # Helper function for unit tests only
@@ -113,6 +124,7 @@ class IPCCacheServerKey:
             end=self.end,
             request_id=self.request_id,
             cache_salt=self.cache_salt,
+            retention_ttl_sec=self.retention_ttl_sec,
         )
 
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -1085,6 +1085,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
 
             reserved_dict: dict[ObjectKey, MemoryObj] = {}
             all_dict: dict[ObjectKey, MemoryObj] = {}
+            retain_keys: list[ObjectKey] = []
+            retain_sizes: list[int] = []
             total_bytes: int = 0
             store_succeeded = False
             try:
@@ -1104,6 +1106,20 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                             iter(reserved_dict.values())
                         ).get_size() * len(reserved_dict)
 
+                    if key.retention_ttl_sec > 0:
+                        # Retain every chunk of this store, whether written
+                        # now or already cached: a ttl store must also extend
+                        # chunks that earlier requests stored. Sizes come from
+                        # the group layout (uniform per group).
+                        chunk_bytes = sum(
+                            shape.numel() * dtype.itemsize
+                            for shape, dtype in zip(
+                                layout_desc.shapes, layout_desc.dtypes, strict=True
+                            )
+                        )
+                        retain_keys.extend(obj_keys)
+                        retain_sizes.extend([chunk_bytes] * len(obj_keys))
+
                     # Keys not in reserved_dict (skipped by the storage manager)
                     # become None entries; the helper skips them for D2H.
                     memory_objs: list[MemoryObj | None] = [
@@ -1122,6 +1138,10 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     )
 
                 store_succeeded = True
+                if retain_keys:
+                    self._ctx.storage_manager.retention_manager.note_stored(
+                        retain_keys, retain_sizes, key.retention_ttl_sec
+                    )
             except Exception:
                 logger.exception("Cannot store keys due to exception")
             finally:

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -1107,18 +1107,23 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                         ).get_size() * len(reserved_dict)
 
                     if key.retention_ttl_sec > 0:
-                        # Retain every chunk of this store, whether written
-                        # now or already cached: a ttl store must also extend
-                        # chunks that earlier requests stored. Sizes come from
-                        # the group layout (uniform per group).
+                        # A ttl store also extends already-present chunks;
+                        # keys that failed reservation hold no data and are
+                        # not shielded.
+                        group_retain = [
+                            k
+                            for k in obj_keys
+                            if k in reserved_dict
+                            or self._ctx.storage_manager.has_l1_object(k)
+                        ]
                         chunk_bytes = sum(
                             shape.numel() * dtype.itemsize
                             for shape, dtype in zip(
                                 layout_desc.shapes, layout_desc.dtypes, strict=True
                             )
                         )
-                        retain_keys.extend(obj_keys)
-                        retain_sizes.extend([chunk_bytes] * len(obj_keys))
+                        retain_keys.extend(group_retain)
+                        retain_sizes.extend([chunk_bytes] * len(group_retain))
 
                     # Keys not in reserved_dict (skipped by the storage manager)
                     # become None entries; the helper skips them for D2H.

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -208,6 +208,23 @@ def wait_for_sparse_found(
 class TestStorageManagerBasic:
     """Tests for basic functionality of StorageManager."""
 
+    def test_has_l1_object(self, basic_storage_manager_config, basic_layout):
+        """Present after reserve, gone after delete, False for unknown keys."""
+        storage_manager = StorageManager(basic_storage_manager_config)
+        object_key = make_object_key(chunk_hash=424242)
+
+        assert not storage_manager.has_l1_object(object_key)
+
+        storage_manager.reserve_write([object_key], basic_layout, mode="new")
+        assert storage_manager.has_l1_object(object_key)
+        storage_manager.finish_write([object_key])
+        assert storage_manager.has_l1_object(object_key)
+
+        storage_manager.delete_l1_keys([object_key], force=True)
+        assert not storage_manager.has_l1_object(object_key)
+
+        storage_manager.close()
+
     def test_basic_reserve_write(self, basic_storage_manager_config, basic_layout):
         """Test basic reserve and write functionality."""
         storage_manager = StorageManager(basic_storage_manager_config)

--- a/tests/v1/distributed/test_l2_retention_eviction.py
+++ b/tests/v1/distributed/test_l2_retention_eviction.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""L2 eviction must skip retained keys until their window expires.
+
+Drives :class:`L2EvictionController` against a :class:`MockL2Adapter`
+with a :class:`RetentionManager` injected, covering both the global-LRU
+branch and the per-``cache_salt`` wipe branch.
+"""
+
+# Standard
+import os
+import select
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.config import EvictionConfig
+from lmcache.v1.distributed.eviction import L2EvictionPolicy
+from lmcache.v1.distributed.eviction_policy.isolated_lru import (
+    IsolatedLRUEvictionPolicy,
+)
+from lmcache.v1.distributed.eviction_policy.lru import LRUEvictionPolicy
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.distributed.retention_manager import RetentionManager
+from lmcache.v1.distributed.storage_controllers.eviction_controller import (
+    L2AdapterEvictionState,
+    L2EvictionController,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+
+OBJ_FLOATS = 128
+OBJ_BYTES = OBJ_FLOATS * 4
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _key(chunk_id: int, cache_salt: str = "") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+def _memory_obj() -> TensorMemoryObj:
+    raw = torch.empty(OBJ_FLOATS, dtype=torch.float32)
+    raw.fill_(1.0)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([OBJ_FLOATS]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=OBJ_BYTES,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw, metadata, parent_allocator=None)
+
+
+def _wait_fd(fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if not events:
+        return False
+    try:
+        os.eventfd_read(fd)
+    except BlockingIOError:
+        pass
+    return True
+
+
+def _store_sync(adapter: MockL2Adapter, key: ObjectKey, obj: TensorMemoryObj):
+    adapter.submit_store_task([key], [obj])
+    assert _wait_fd(adapter.get_store_event_fd()), "store event timed out"
+    adapter.pop_completed_store_tasks()
+
+
+@pytest.fixture
+def global_lru_setup():
+    """Tiny-capacity adapter + global LRU policy + retention. Eviction
+    ratio 1.0 so an over-watermark pass evicts every eligible key --
+    whatever survives did so because retention vetoed it."""
+    adapter = MockL2Adapter(
+        MockL2AdapterConfig(
+            max_size_gb=(8 * OBJ_BYTES) / (1024**3),
+            mock_bandwidth_gb=10.0,
+        )
+    )
+    policy = LRUEvictionPolicy()
+    adapter.register_listener(L2EvictionPolicy(policy))
+
+    state = L2AdapterEvictionState(
+        adapter_id=0,
+        adapter=adapter,
+        eviction_config=EvictionConfig(
+            eviction_policy="LRU",
+            trigger_watermark=0.8,
+            eviction_ratio=1.0,
+        ),
+    )
+    state.eviction_policy = policy
+
+    clock = FakeClock()
+    retention = RetentionManager(max_retained_bytes=100 * OBJ_BYTES, clock=clock)
+    controller = L2EvictionController([state], retention_manager=retention)
+    yield adapter, controller, state, retention, clock
+    adapter.close()
+
+
+def test_retained_key_survives_over_watermark_cycle(global_lru_setup):
+    adapter, controller, state, retention, _ = global_lru_setup
+
+    for i in range(8):
+        _store_sync(adapter, _key(i), _memory_obj())
+    retention.note_stored([_key(0)], [OBJ_BYTES], ttl_sec=300)
+    assert adapter.get_usage().usage_fraction >= 0.8
+
+    controller._check_and_evict(state)
+
+    assert _key(0) in adapter._memory_objects, "retained key was evicted"
+    assert _key(1) not in adapter._memory_objects, "unretained keys must go"
+    assert adapter.get_usage().total_bytes_used == OBJ_BYTES
+
+
+def test_expired_key_rejoins_lru_pool(global_lru_setup):
+    adapter, controller, state, retention, clock = global_lru_setup
+
+    for i in range(8):
+        _store_sync(adapter, _key(i), _memory_obj())
+    retention.note_stored([_key(0)], [OBJ_BYTES], ttl_sec=300)
+
+    clock.advance(301)
+    # Expiry alone makes the key eligible; sweep only reconciles budget.
+    controller._check_and_evict(state)
+    assert _key(0) not in adapter._memory_objects
+
+    assert retention.sweep() == 1
+    assert retention.report_status()["retained_bytes"] == 0
+
+
+def test_salt_wipe_respects_retention():
+    """The unregistered-salt wipe (allowlist rule) must not delete keys
+    inside an open retention window."""
+    adapter = MockL2Adapter(
+        MockL2AdapterConfig(max_size_gb=0.001, mock_bandwidth_gb=10.0)
+    )
+    policy = IsolatedLRUEvictionPolicy()
+    adapter.register_listener(L2EvictionPolicy(policy))
+    state = L2AdapterEvictionState(
+        adapter_id=0,
+        adapter=adapter,
+        eviction_config=EvictionConfig(
+            eviction_policy="IsolatedLRU",
+            trigger_watermark=0.8,
+            eviction_ratio=1.0,
+        ),
+    )
+    state.eviction_policy = policy
+
+    clock = FakeClock()
+    retention = RetentionManager(max_retained_bytes=100 * OBJ_BYTES, clock=clock)
+    controller = L2EvictionController(
+        [state], quota_manager=QuotaManager(), retention_manager=retention
+    )
+    try:
+        for i in range(4):
+            _store_sync(adapter, _key(i, "alice"), _memory_obj())
+        retention.note_stored([_key(0, "alice")], [OBJ_BYTES], ttl_sec=300)
+
+        # alice has no quota entry -> effective limit 0 -> full wipe.
+        controller._check_and_evict(state)
+
+        assert _key(0, "alice") in adapter._memory_objects
+        assert _key(1, "alice") not in adapter._memory_objects
+
+        clock.advance(301)
+        controller._check_and_evict(state)
+        assert _key(0, "alice") not in adapter._memory_objects
+    finally:
+        adapter.close()
+
+
+def test_report_status_retention_section(global_lru_setup):
+    adapter, controller, state, retention, _ = global_lru_setup
+
+    retention.note_stored([_key(0)], [OBJ_BYTES], ttl_sec=300)
+    status = controller.report_status()
+    assert status["retention"]["retained_keys"] == 1
+    assert status["retention"]["retained_bytes"] == OBJ_BYTES
+
+    bare = L2EvictionController([state])
+    assert "retention" not in bare.report_status()

--- a/tests/v1/distributed/test_l2_retention_eviction.py
+++ b/tests/v1/distributed/test_l2_retention_eviction.py
@@ -18,15 +18,11 @@ import torch
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.config import EvictionConfig
 from lmcache.v1.distributed.eviction import L2EvictionPolicy
-from lmcache.v1.distributed.eviction_policy.isolated_lru import (
-    IsolatedLRUEvictionPolicy,
-)
 from lmcache.v1.distributed.eviction_policy.lru import LRUEvictionPolicy
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
     MockL2Adapter,
     MockL2AdapterConfig,
 )
-from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.distributed.retention_manager import RetentionManager
 from lmcache.v1.distributed.storage_controllers.eviction_controller import (
     L2AdapterEvictionState,
@@ -156,48 +152,6 @@ def test_expired_key_rejoins_lru_pool(global_lru_setup):
 
     assert retention.sweep() == 1
     assert retention.report_status()["retained_bytes"] == 0
-
-
-def test_salt_wipe_respects_retention():
-    """The unregistered-salt wipe (allowlist rule) must not delete keys
-    inside an open retention window."""
-    adapter = MockL2Adapter(
-        MockL2AdapterConfig(max_size_gb=0.001, mock_bandwidth_gb=10.0)
-    )
-    policy = IsolatedLRUEvictionPolicy()
-    adapter.register_listener(L2EvictionPolicy(policy))
-    state = L2AdapterEvictionState(
-        adapter_id=0,
-        adapter=adapter,
-        eviction_config=EvictionConfig(
-            eviction_policy="IsolatedLRU",
-            trigger_watermark=0.8,
-            eviction_ratio=1.0,
-        ),
-    )
-    state.eviction_policy = policy
-
-    clock = FakeClock()
-    retention = RetentionManager(max_retained_bytes=100 * OBJ_BYTES, clock=clock)
-    controller = L2EvictionController(
-        [state], quota_manager=QuotaManager(), retention_manager=retention
-    )
-    try:
-        for i in range(4):
-            _store_sync(adapter, _key(i, "alice"), _memory_obj())
-        retention.note_stored([_key(0, "alice")], [OBJ_BYTES], ttl_sec=300)
-
-        # alice has no quota entry -> effective limit 0 -> full wipe.
-        controller._check_and_evict(state)
-
-        assert _key(0, "alice") in adapter._memory_objects
-        assert _key(1, "alice") not in adapter._memory_objects
-
-        clock.advance(301)
-        controller._check_and_evict(state)
-        assert _key(0, "alice") not in adapter._memory_objects
-    finally:
-        adapter.close()
 
 
 def test_report_status_retention_section(global_lru_setup):

--- a/tests/v1/distributed/test_retention_config.py
+++ b/tests/v1/distributed/test_retention_config.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Config validation for retention: watermark bound and adapter count."""
 
+# Standard
+from typing import Literal
+
 # Third Party
 import pytest
 
@@ -19,11 +22,13 @@ from lmcache.v1.distributed.l2_adapters.config import (
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 
 
-def _adapter(evicting: bool = True) -> MockL2AdapterConfig:
+def _adapter(
+    evicting: bool = True, policy: Literal["LRU", "IsolatedLRU", "noop"] = "LRU"
+) -> MockL2AdapterConfig:
     config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
     if evicting:
         config.eviction_config = EvictionConfig(
-            eviction_policy="LRU", trigger_watermark=0.8, eviction_ratio=0.2
+            eviction_policy=policy, trigger_watermark=0.8, eviction_ratio=0.2
         )
     return config
 
@@ -70,3 +75,8 @@ def test_non_evicting_adapters_do_not_count():
     validate_storage_manager_config(
         _config(0.7, [_adapter(), _adapter(evicting=False)])
     )
+
+
+def test_isolated_lru_is_rejected():
+    with pytest.raises(ValueError, match="IsolatedLRU"):
+        validate_storage_manager_config(_config(0.7, [_adapter(policy="IsolatedLRU")]))

--- a/tests/v1/distributed/test_retention_config.py
+++ b/tests/v1/distributed/test_retention_config.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Config validation for retention: watermark bound and adapter count."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+    validate_storage_manager_config,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    L2AdaptersConfig,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
+
+
+def _adapter(evicting: bool = True) -> MockL2AdapterConfig:
+    config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+    if evicting:
+        config.eviction_config = EvictionConfig(
+            eviction_policy="LRU", trigger_watermark=0.8, eviction_ratio=0.2
+        )
+    return config
+
+
+def _config(
+    fraction: float, adapters: list[L2AdapterConfigBase]
+) -> StorageManagerConfig:
+    return StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=64 * 1024 * 1024,
+                use_lazy=False,
+                init_size_in_bytes=64 * 1024 * 1024,
+                align_bytes=0x1000,
+            ),
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+        l2_adapter_config=L2AdaptersConfig(adapters=adapters),
+        retention_max_fraction=fraction,
+    )
+
+
+def test_fraction_must_stay_below_watermark():
+    with pytest.raises(ValueError, match="trigger_watermark"):
+        validate_storage_manager_config(_config(0.8, [_adapter()]))
+
+
+def test_single_eviction_enabled_adapter_is_accepted():
+    validate_storage_manager_config(_config(0.7, [_adapter()]))
+
+
+def test_multiple_eviction_enabled_adapters_are_rejected():
+    with pytest.raises(ValueError, match="one eviction-enabled"):
+        validate_storage_manager_config(_config(0.5, [_adapter(), _adapter()]))
+
+
+def test_disabled_retention_ignores_adapter_count():
+    validate_storage_manager_config(_config(0.0, [_adapter(), _adapter()]))
+
+
+def test_non_evicting_adapters_do_not_count():
+    validate_storage_manager_config(
+        _config(0.7, [_adapter(), _adapter(evicting=False)])
+    )

--- a/tests/v1/distributed/test_retention_manager.py
+++ b/tests/v1/distributed/test_retention_manager.py
@@ -119,3 +119,38 @@ def test_nonpositive_ttl_is_a_noop():
     assert manager.note_stored([_key(1)], [100], ttl_sec=0) == 0
     assert manager.note_stored([_key(1)], [100], ttl_sec=-5) == 0
     assert manager.report_status()["retained_keys"] == 0
+
+
+def test_sweep_at_original_deadline_spares_extended_key():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=1000, clock=clock)
+
+    manager.note_stored([_key(1)], [100], ttl_sec=10)
+    clock.advance(5)
+    manager.note_stored([_key(1)], [100], ttl_sec=100)
+
+    clock.advance(10)
+    assert manager.sweep() == 0
+    assert not manager.is_evictable(_key(1))
+
+    clock.advance(100)
+    assert manager.sweep() == 1
+    assert manager.is_evictable(_key(1))
+
+
+def test_deadline_index_stays_in_lockstep_with_entries():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=10_000, clock=clock)
+
+    manager.note_stored([_key(i) for i in range(5)], [100] * 5, ttl_sec=10)
+    manager.note_stored([_key(i) for i in range(3)], [100] * 3, ttl_sec=50)
+    manager.forget([_key(3)])
+    assert len(manager._deadlines) == len(manager._entries) == 4
+
+    clock.advance(11)
+    assert manager.sweep() == 1
+    assert len(manager._deadlines) == len(manager._entries) == 3
+
+    clock.advance(50)
+    assert manager.sweep() == 3
+    assert len(manager._deadlines) == len(manager._entries) == 0

--- a/tests/v1/distributed/test_retention_manager.py
+++ b/tests/v1/distributed/test_retention_manager.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""RetentionManager: deadlines, budget, expiry, and eviction eligibility."""
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.retention_manager import RetentionManager
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _key(i: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=i.to_bytes(8, "little"),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def test_stamped_key_is_shielded_until_deadline():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=1000, clock=clock)
+
+    assert manager.is_evictable(_key(1))
+    manager.note_stored([_key(1)], [100], ttl_sec=300)
+    assert not manager.is_evictable(_key(1))
+
+    clock.advance(299)
+    assert not manager.is_evictable(_key(1))
+    clock.advance(2)
+    # Expired keys are evictable immediately, before any sweep runs.
+    assert manager.is_evictable(_key(1))
+
+
+def test_extend_only_never_shortens():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=1000, clock=clock)
+
+    manager.note_stored([_key(1)], [100], ttl_sec=3600)
+    manager.note_stored([_key(1)], [100], ttl_sec=300)
+    clock.advance(600)
+    # The later, shorter ttl must not have shortened the 1h window.
+    assert not manager.is_evictable(_key(1))
+
+    manager.note_stored([_key(1)], [100], ttl_sec=7200)
+    clock.advance(3600)
+    # And a longer ttl extends it.
+    assert not manager.is_evictable(_key(1))
+
+
+def test_extend_is_budget_free():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=100, clock=clock)
+
+    assert manager.note_stored([_key(1)], [100], ttl_sec=300) == 1
+    # Budget is full; extending the same key must still succeed.
+    assert manager.note_stored([_key(1)], [100], ttl_sec=600) == 1
+    status = manager.report_status()
+    assert status["retained_bytes"] == 100
+    assert status["extends"] == 1
+    assert status["budget_rejections"] == 0
+
+
+def test_budget_rejects_new_keys_but_store_semantics_unchanged():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=150, clock=clock)
+
+    accepted = manager.note_stored([_key(1), _key(2)], [100, 100], ttl_sec=300)
+    assert accepted == 1
+    assert not manager.is_evictable(_key(1))
+    # The rejected key is simply not shielded.
+    assert manager.is_evictable(_key(2))
+    assert manager.report_status()["budget_rejections"] == 1
+
+
+def test_zero_budget_disables_retention():
+    manager = RetentionManager(max_retained_bytes=0, clock=FakeClock())
+    assert manager.note_stored([_key(1)], [100], ttl_sec=300) == 0
+    assert manager.is_evictable(_key(1))
+
+
+def test_sweep_frees_budget_for_new_keys():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=100, clock=clock)
+
+    manager.note_stored([_key(1)], [100], ttl_sec=300)
+    assert manager.note_stored([_key(2)], [100], ttl_sec=300) == 0
+
+    clock.advance(301)
+    assert manager.sweep() == 1
+    assert manager.note_stored([_key(2)], [100], ttl_sec=300) == 1
+    status = manager.report_status()
+    assert status["retained_keys"] == 1
+    assert status["retained_bytes"] == 100
+    assert status["expirations"] == 1
+
+
+def test_forget_releases_budget():
+    clock = FakeClock()
+    manager = RetentionManager(max_retained_bytes=100, clock=clock)
+
+    manager.note_stored([_key(1)], [100], ttl_sec=300)
+    manager.forget([_key(1), _key(2)])
+    assert manager.is_evictable(_key(1))
+    assert manager.report_status()["retained_bytes"] == 0
+    assert manager.note_stored([_key(2)], [100], ttl_sec=300) == 1
+
+
+def test_nonpositive_ttl_is_a_noop():
+    manager = RetentionManager(max_retained_bytes=1000, clock=FakeClock())
+    assert manager.note_stored([_key(1)], [100], ttl_sec=0) == 0
+    assert manager.note_stored([_key(1)], [100], ttl_sec=-5) == 0
+    assert manager.report_status()["retained_keys"] == 0

--- a/tests/v1/distributed/test_retention_manager.py
+++ b/tests/v1/distributed/test_retention_manager.py
@@ -138,19 +138,20 @@ def test_sweep_at_original_deadline_spares_extended_key():
     assert manager.is_evictable(_key(1))
 
 
-def test_deadline_index_stays_in_lockstep_with_entries():
+def test_forget_and_expiry_interleave_cleanly():
     clock = FakeClock()
     manager = RetentionManager(max_retained_bytes=10_000, clock=clock)
 
     manager.note_stored([_key(i) for i in range(5)], [100] * 5, ttl_sec=10)
     manager.note_stored([_key(i) for i in range(3)], [100] * 3, ttl_sec=50)
     manager.forget([_key(3)])
-    assert len(manager._deadlines) == len(manager._entries) == 4
+    assert manager.report_status()["retained_keys"] == 4
 
     clock.advance(11)
     assert manager.sweep() == 1
-    assert len(manager._deadlines) == len(manager._entries) == 3
+    assert manager.report_status()["retained_keys"] == 3
 
     clock.advance(50)
     assert manager.sweep() == 3
-    assert len(manager._deadlines) == len(manager._entries) == 0
+    assert manager.report_status()["retained_keys"] == 0
+    assert manager.report_status()["retained_bytes"] == 0

--- a/tests/v1/multiprocess/http_apis/test_cache_api.py
+++ b/tests/v1/multiprocess/http_apis/test_cache_api.py
@@ -19,6 +19,7 @@ import pytest
 
 # First Party
 from lmcache.v1.distributed.api import KeyEntry, KeyListPage, ObjectKey
+from lmcache.v1.distributed.retention_manager import RetentionManager
 from lmcache.v1.multiprocess.cache_control.object_service import MAX_DELETE_BATCH
 from lmcache.v1.multiprocess.http_apis.cache_api import router as cache_router
 from lmcache.v1.multiprocess.http_apis.dependencies import build_context
@@ -82,6 +83,9 @@ class _FakeStorageManager:
     l1_skip: int = 0
     # Records (keys, force) for each delete_l1_keys call.
     l1_delete_calls: list[tuple[list, bool]] = field(default_factory=list)
+    retention_manager: RetentionManager = field(
+        default_factory=lambda: RetentionManager(max_retained_bytes=1_000_000)
+    )
 
     def l2_adapters(self) -> list[tuple[_FakeDescriptor, _FakeAdapter]]:
         return [(_FakeDescriptor(type_name=n), a) for n, a in self.adapters]
@@ -122,6 +126,57 @@ def _sm_with(*entries: tuple[str, _FakeAdapter]) -> _FakeStorageManager:
 
 
 class TestDeleteObjectsEndpoint:
+    def test_l2_delete_releases_retention(self):
+        primary = _FakeAdapter()
+        sm = _sm_with(("s3", primary))
+        key = ObjectKey(
+            chunk_hash=b"\x00\x00\x00\x01",
+            model_name="llama",
+            kv_rank=0,
+            cache_salt="alice",
+        )
+        sm.retention_manager.note_stored([key], [100], ttl_sec=300)
+        assert not sm.retention_manager.is_evictable(key)
+        client = TestClient(_make_app(sm))
+
+        resp = client.request(
+            "DELETE",
+            "/cache/objects",
+            json={
+                "keys": [
+                    {
+                        "chunk_hash_hex": _hex(1),
+                        "model_name": "llama",
+                        "kv_rank": 0,
+                        "cache_salt": "alice",
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert sm.retention_manager.is_evictable(key)
+        assert sm.retention_manager.report_status()["retained_keys"] == 0
+
+    def test_l1_delete_keeps_retention(self):
+        primary = _FakeAdapter()
+        sm = _sm_with(("s3", primary))
+        key = ObjectKey(chunk_hash=b"\x00\x00\x00\x01", model_name="llama", kv_rank=0)
+        sm.retention_manager.note_stored([key], [100], ttl_sec=300)
+        client = TestClient(_make_app(sm))
+
+        resp = client.request(
+            "DELETE",
+            "/cache/objects",
+            json={
+                "tier": "l1",
+                "keys": [
+                    {"chunk_hash_hex": _hex(1), "model_name": "llama", "kv_rank": 0}
+                ],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert not sm.retention_manager.is_evictable(key)
+
     def test_happy_path_defaults_to_primary(self):
         primary = _FakeAdapter()
         secondary = _FakeAdapter()

--- a/tests/v1/multiprocess/test_custom_types.py
+++ b/tests/v1/multiprocess/test_custom_types.py
@@ -385,3 +385,71 @@ def test_block_allocation_record_list_serialization():
     assert decoded[1].req_id == "req-2"
     assert decoded[1].new_block_ids == []
     assert decoded[1].new_token_ids == [40, 50]
+
+
+def test_ipc_cache_engine_key_retention_roundtrip():
+    """The retention ttl survives encode/decode and stays out of cache identity."""
+    plain = IPCCacheServerKey.from_token_ids(
+        model_name="test_model",
+        world_size=4,
+        worker_id=1,
+        token_ids=list(range(256)),
+        start=0,
+        end=256,
+        request_id="r1",
+    )
+    retained = IPCCacheServerKey(
+        model_name="test_model",
+        world_size=4,
+        worker_id=1,
+        token_ids=tuple(range(256)),
+        start=0,
+        end=256,
+        request_id="r2",
+        retention_ttl_sec=3600,
+    )
+
+    decoded = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(retained), type=IPCCacheServerKey
+    )
+    assert decoded.retention_ttl_sec == 3600
+
+    # Same content -> same cache entry, with or without retention.
+    assert decoded == plain
+    assert hash(decoded) == hash(plain)
+
+    copy = decoded.no_worker_id_version()
+    assert copy.retention_ttl_sec == 3600
+
+
+def test_ipc_cache_engine_key_retention_wire_default():
+    """A payload encoded without the retention field decodes to 0."""
+    payload = {
+        "model_name": "test_model",
+        "world_size": 4,
+        "worker_id": 1,
+        "token_ids": list(range(8)),
+        "start": 0,
+        "end": 8,
+        "request_id": "r1",
+        "cache_salt": "",
+    }
+
+    decoded = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(payload), type=IPCCacheServerKey
+    )
+    assert decoded.retention_ttl_sec == 0
+
+
+def test_ipc_cache_engine_key_negative_retention_rejected():
+    with pytest.raises(ValueError):
+        IPCCacheServerKey(
+            model_name="m",
+            world_size=1,
+            worker_id=0,
+            token_ids=(1,),
+            start=0,
+            end=1,
+            request_id="r",
+            retention_ttl_sec=-1,
+        )

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -270,7 +270,9 @@ def test_server_store_and_retrieve_delegate_event_ordering(
         "get_and_touch_context_entry",
         lambda instance_id: entry,
     )
-    key = SimpleNamespace(request_id="request", cache_salt="", worker_id=0)
+    key = SimpleNamespace(
+        request_id="request", cache_salt="", worker_id=0, retention_ttl_sec=0
+    )
 
     assert module.store(key, 1, [[]], b"store-producer") == (
         b"completion-handle",

--- a/tests/v1/multiprocess/test_retention_store_submit.py
+++ b/tests/v1/multiprocess/test_retention_store_submit.py
@@ -3,10 +3,12 @@
 
 # Standard
 from types import SimpleNamespace
+from typing import cast
 
 # First Party
 from lmcache.integration.vllm.vllm_multi_process_adapter import (
     LMCacheMPWorkerAdapter,
+    ParallelStrategy,
 )
 
 
@@ -14,7 +16,9 @@ def _bare_worker_adapter() -> LMCacheMPWorkerAdapter:
     """Adapter with only the attrs _create_key needs; no ZMQ or heartbeat."""
     adapter = object.__new__(LMCacheMPWorkerAdapter)
     adapter.model_name = "test_model"
-    adapter.parallel_strategy = SimpleNamespace(kv_world_size=1, kv_worker_id=0)
+    adapter.parallel_strategy = cast(
+        ParallelStrategy, SimpleNamespace(kv_world_size=1, kv_worker_id=0)
+    )
     return adapter
 
 

--- a/tests/v1/multiprocess/test_retention_store_submit.py
+++ b/tests/v1/multiprocess/test_retention_store_submit.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Retention params must flow through the worker adapter's store submits."""
+
+# Standard
+from types import SimpleNamespace
+
+# First Party
+from lmcache.integration.vllm.vllm_multi_process_adapter import (
+    LMCacheMPWorkerAdapter,
+)
+
+
+def _bare_worker_adapter() -> LMCacheMPWorkerAdapter:
+    """Adapter with only the attrs _create_key needs; no ZMQ or heartbeat."""
+    adapter = object.__new__(LMCacheMPWorkerAdapter)
+    adapter.model_name = "test_model"
+    adapter.parallel_strategy = SimpleNamespace(kv_world_size=1, kv_worker_id=0)
+    return adapter
+
+
+def test_worker_create_key_carries_retention():
+    key = _bare_worker_adapter()._create_key(
+        [1, 2, 3],
+        0,
+        3,
+        request_id="r",
+        cache_salt="s",
+        retention_ttl_sec=300,
+    )
+    assert key.retention_ttl_sec == 300
+    assert key.cache_salt == "s"
+
+
+def test_worker_create_key_defaults_to_no_retention():
+    key = _bare_worker_adapter()._create_key([1, 2, 3], 0, 3, request_id="r")
+    assert key.retention_ttl_sec == 0
+
+
+def test_batched_store_fans_out_per_request_retention():
+    adapter = _bare_worker_adapter()
+    calls = []
+
+    def fake_submit(request_id, op, event, cache_salt="", retention_ttl_sec=0):
+        calls.append((request_id, cache_salt, retention_ttl_sec))
+
+    adapter.submit_store_request = fake_submit
+
+    adapter.batched_submit_store_requests(
+        ["a", "b"],
+        [object(), object()],
+        object(),
+        cache_salts=["", "s"],
+        retention_ttl_secs=[0, 3600],
+    )
+    assert calls == [("a", "", 0), ("b", "s", 3600)]
+
+
+def test_batched_store_defaults_mean_no_retention():
+    """Callers that predate retention must behave exactly as before."""
+    adapter = _bare_worker_adapter()
+    calls = []
+
+    def fake_submit(request_id, op, event, cache_salt="", retention_ttl_sec=0):
+        calls.append((request_id, cache_salt, retention_ttl_sec))
+
+    adapter.submit_store_request = fake_submit
+
+    adapter.batched_submit_store_requests(
+        ["a", "b"],
+        [object(), object()],
+        object(),
+        cache_salts=["", "s"],
+    )
+    assert calls == [("a", "", 0), ("b", "s", 0)]


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds opt-in per-request retention: a request may carry `lmcache_retention_ttl_sec` in vLLM's `kv_transfer_params`, and the chunks its store covers are shielded from L2 eviction until the ttl expires. On expiry the chunks simply rejoin the LRU pool — expiry never deletes data. This lets a serving platform offer pinned/paid prompt caching ("this prompt's KV survives the next hour") on the existing tier, without a separate storage path.

- `RetentionManager` (new, `lmcache/v1/distributed/`) keeps per-key deadlines under a byte budget, `retention_max_fraction` × the eviction-enabled adapter's capacity. Default `0.0`, so behavior is unchanged unless the operator enables it (`--retention-max-fraction`; validation requires at most one eviction-enabled adapter — the default store policy replicates chunks to every adapter — and a fraction below its eviction trigger watermark, so eviction always finds unshielded keys). Deadlines are extend-only; sweep uses a deadline-ordered index (`sortedcontainers`, already a dependency), so the idle case is a single comparison.
- The MP connector threads the ttl from `kv_transfer_params` to the store key (`compare=False` — not cache identity). The server registers deadlines only after the store commits, and only for chunks that were freshly written or already present (`StorageManager.has_l1_object`) — a chunk whose reservation failed never enters the ledger.
- Both L2 eviction branches consult `RetentionManager.is_evictable` as the key-eligibility filter; expired entries are swept each cycle. `report_status` gains a retention section. An explicit `DELETE /cache/objects` drops the affected ledger entries (`forget`) — an explicit delete outranks a retention window; automatic eviction does not.
- A fully-cached ttl re-store still reaches the server (the connector skips its stored-tokens marker for retention requests), reserve mode `"new"` declines every present chunk, and the deadlines are pushed out — extends move no data.

Design doc: `docs/design/v1/distributed/retention.md`. Server flag documented in `docs/source/cli/server.rst`.

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
