### PR TITLE
[Bugfix] Fix EC reads from lower storage tiers

### DIFF
--- a/lmcache/v1/ec_engine.py
+++ b/lmcache/v1/ec_engine.py
@@ -183,8 +183,7 @@ class ECCacheEngine:
         """
         key = self._make_cache_key(mm_hash)
 
-        mem_objs = self._storage_manager.batched_get([key])
-        mem_obj = mem_objs[0]
+        mem_obj = self._storage_manager.get(key)
         if mem_obj is None:
             return None
         if mem_obj.tensor is None:

--- a/tests/v1/test_ec_engine.py
+++ b/tests/v1/test_ec_engine.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+import time
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.ec_engine import ECCacheEngine
+from lmcache.v1.metadata import LMCacheMetadata
+
+
+def _make_metadata() -> LMCacheMetadata:
+    return LMCacheMetadata(
+        model_name="test-ec-model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.float16,
+        kv_shape=(1, 2, 256, 1, 1),
+        role="worker",
+    )
+
+
+def _put_eventually(
+    engine: ECCacheEngine,
+    mm_hash: str,
+    tensor: torch.Tensor,
+    timeout: float = 5.0,
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while not engine.put(mm_hash, tensor):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)
+    return True
+
+
+def test_get_falls_back_to_disk_after_cpu_eviction(tmp_path: Path) -> None:
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        local_cpu=True,
+        max_local_cpu_size=0.002,
+        local_disk=str(tmp_path),
+        max_local_disk_size=1,
+        lmcache_instance_id="test-ec-tier-fallback",
+    )
+    engine = ECCacheEngine(config, _make_metadata(), torch.float16)
+
+    try:
+        first = torch.full((750, 800), 1.5, dtype=torch.float16)
+        second = torch.full((750, 800), -2.25, dtype=torch.float16)
+
+        assert engine.put("first", first)
+
+        # The pool can hold either tensor but not both. A successful second
+        # put therefore means the first entry was evicted from local CPU.
+        assert _put_eventually(engine, "second", second)
+
+        deadline = time.monotonic() + 5.0
+        while not engine.contains("first") and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert engine.contains("first")
+
+        restored = engine.get("first", "cpu")
+
+        assert restored is not None
+        assert torch.equal(restored, first)
+    finally:
+        engine.close()


### PR DESCRIPTION
  **What this PR does / why we need it**:

  `ECCacheEngine.get()` used `StorageManager.batched_get()` even though EC retrieves one key at a time. When the key was missing from LocalCPU, the batched lookup returned `[None]`.
  Since the list itself was non-empty, the lookup stopped before checking LocalDisk or another lower storage tier.

  This could make `contains()` report an EC hit while `get()` returned `None` after the entry was evicted from LocalCPU.

  This PR uses the existing single-key `StorageManager.get()` path for EC reads. This path checks the configured storage tiers in order and preserves LocalCPU write-back behavior.

  **Special notes for your reviewers**:

  The change is limited to the EC single-key read path. `StorageManager.batched_get()` and its KV cache callers are unchanged.

  A regression test fills the LocalCPU pool, evicts an EC entry, and verifies that the tensor can be restored from LocalDisk.

  Tests run:

  - `pytest -xvs tests/v1/test_ec_engine.py`
  - `pytest -xvs tests/v1/test_ec_connector.py`
  - `pytest -xvs tests/v1/storage_backend/test_storage_manager.py`
  - `pre-commit run --files lmcache/v1/ec_engine.py tests/v1/test_ec_engine.py`

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests