### PR TITLE
docs: daily drift check — multi-process mode (2026-08-08)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -130,6 +130,18 @@ Source: ``lmcache/v1/multiprocess/config.py``
        independently, and is what allows ``--max-num-batched-tokens`` to exceed
        twice the block size). For a non-hybrid model it makes no difference —
        every layer resolves to one object group. See :doc:`/mp/hybrid_models`.
+   * - ``--enable``
+     - ``[]``
+     - Zero or more experimental intermediate-tensor transfer modules
+       to load alongside the standard KV transfer path. Currently the
+       only supported value is ``transfer_query``, which loads the
+       ``QStoreModule`` (paged Q ring buffer for query-tensor caching)
+       and its ``REGISTER_Q_CACHE`` / ``UNREGISTER_Q_CACHE`` / ``STORE_Q``
+       RPCs. Requires ``--supported-transfer-mode`` to be
+       ``lmcache_driven`` or ``auto``; the enabled names are also
+       reported back over the ``GET_EXPERIMENTAL`` RPC. See
+       ``lmcache/v1/multiprocess/modules/experimental/__init__.py`` for
+       the current set of supported values.
 
 Lookup Hash Logging
 -------------------

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -95,18 +95,22 @@ All server entry points share the same ``MPCacheServer`` and
 ``StorageManager`` core. ``MPCacheServer`` is now a thin compositor:
 it holds an ``MPCacheServerContext`` and a list of ``EngineModule``
 instances assembled by ``_build_modules()`` (in ``server.py``)
-based on ``--engine-type`` and ``--supported-transfer-mode``.
+based on ``--engine-type``, ``--supported-transfer-mode``, and
+``--enable``.
 
 **``server.py``** -- The default ZMQ-only server.  Creates an
 ``MPCacheServer``, assembles the engine modules
-(``LookupModule`` + ``ManagementModule`` + ``LMCacheDrivenTransferModule``
+(``LookupModule`` + ``P2PController`` (always loaded) +
+``ManagementModule`` + ``LMCacheDrivenTransferModule``
 and/or ``EngineDrivenTransferModule`` depending on
 ``--supported-transfer-mode`` — ``lmcache_driven`` or ``engine_driven`` loads
 just one,
 ``auto`` (default) loads both — plus a CacheBlend module when
 ``--engine-type`` is set: ``blend`` appends ``BlendV3Module`` (the
 current paged-aware implementation), and ``blend_legacy`` appends
-``BlendModule`` (the original)). Starts a ``MessageQueueServer``,
+``BlendModule`` (the original), plus any experimental transfer
+modules opted into via ``--enable`` (currently ``transfer_query`` →
+``QStoreModule``)). Starts a ``MessageQueueServer``,
 registers handlers for every ``RequestType`` exposed by the loaded
 modules, and blocks in a keep-alive loop.
 
@@ -171,6 +175,21 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
    * - ``UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT``
      - SYNC
      - Unregister an engine-driven KV cache context.
+   * - ``REGISTER_Q_CACHE``
+     - SYNC
+     - (Experimental) Register a paged Q ring buffer (query-tensor cache)
+       for a vLLM instance. Served by ``QStoreModule``; loaded only when
+       ``--enable transfer_query`` is passed (requires
+       ``--supported-transfer-mode`` ``lmcache_driven`` or ``auto``).
+   * - ``UNREGISTER_Q_CACHE``
+     - SYNC
+     - (Experimental) Unregister a paged Q ring buffer. Loaded only when
+       ``--enable transfer_query`` is passed.
+   * - ``STORE_Q``
+     - BLOCKING
+     - (Experimental) Store paged Q ring blocks. Same shape as ``STORE``
+       but for the query-tensor cache. Loaded only when
+       ``--enable transfer_query`` is passed.
    * - ``STORE``
      - BLOCKING
      - Store KV cache chunks from GPU to L1 (CPU). LMCache-driven
@@ -233,6 +252,11 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
    * - ``GET_CHUNK_SIZE``
      - SYNC
      - Return the server's chunk size.
+   * - ``GET_EXPERIMENTAL``
+     - SYNC
+     - Return the list of experimental intermediate-tensor transfer
+       types the server was launched with (the values passed via
+       ``--enable``; empty when none are enabled).
    * - ``PING``
      - BLOCKING
      - Liveness ping; the handler always returns ``True``.
@@ -601,11 +625,15 @@ Key Source Files
      - Engine module implementations: ``lookup.py`` (``LookupModule``),
        ``management.py`` (``ManagementModule``), ``lmcache_driven_transfer.py``
        (``LMCacheDrivenTransferModule``), ``engine_driven_transfer.py``
-       (``EngineDrivenTransferModule``), ``blend.py``
+       (``EngineDrivenTransferModule``), ``p2p_controller.py``
+       (``P2PController``, always loaded), ``blend.py``
        (``BlendModule`` / ``BlendEngineV2``, selected by
-       ``--engine-type blend_legacy``), and ``blend_v3.py``
+       ``--engine-type blend_legacy``), ``blend_v3.py``
        (``BlendV3Module``, the paged-aware CacheBlend V3 pipeline
-       selected by ``--engine-type blend``).
+       selected by ``--engine-type blend``), and
+       ``experimental/qstore.py`` (``QStoreModule``, paged Q ring buffer
+       for query-tensor caching; opted into via
+       ``--enable transfer_query``).
    * - ``lmcache/v1/multiprocess/http_server.py``
      - FastAPI wrapper with health check and many other useful APIs
    * - ``lmcache/v1/multiprocess/http_api_registry.py``


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current `dev`
code (`upstream/dev` HEAD [`4521c3f`](https://github.com/LMCache/LMCache/commit/4521c3f9f1b821654e5a52d53e5a34da9afe28fb)),
focused on the multi-process mode. Two drift items today, both in
`docs/source/`, both accumulated from the query-tensor / experimental
transfer work that landed earlier (the QStoreModule / GET_EXPERIMENTAL
plumbing plus the P2PController always-loaded change).

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/index.rst`** — the `RequestType` table under
  *ZMQ Protocol* is missing four request types that already exist in
  [`lmcache/v1/multiprocess/protocols/base.py`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/protocols/base.py#L26-L98):

  | Request type | Handler | Served by | Loaded when |
  |---|---|---|---|
  | `REGISTER_Q_CACHE` | SYNC | `QStoreModule` ([qstore.py:203](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/modules/experimental/qstore.py#L203)) | `--enable transfer_query` |
  | `UNREGISTER_Q_CACHE` | SYNC | `QStoreModule` ([qstore.py:208](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/modules/experimental/qstore.py#L208)) | `--enable transfer_query` |
  | `STORE_Q` | BLOCKING | `QStoreModule` ([qstore.py:213](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/modules/experimental/qstore.py#L213)) | `--enable transfer_query` |
  | `GET_EXPERIMENTAL` | SYNC | `ManagementModule` ([management.py:99-104](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/modules/management.py#L99-L104)) | always |

  Their protocol definitions live in
  [`protocols/engine.py`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/protocols/engine.py#L61-L79)
  (Q RPCs) and
  [`protocols/controller.py`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/protocols/controller.py#L63-L67)
  (`GET_EXPERIMENTAL`), and the `RequestType` enum in
  [`protocols/base.py`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/protocols/base.py)
  is validated against every `REQUEST_NAMES` list at startup — so the
  code side is definitive and the docs are the ones out of date.

- **`docs/source/mp/index.rst`** — the `_build_modules()` description
  in the *Engine and Modules* section under `**server.py**` lists
  `LookupModule + ManagementModule + LMCacheDrivenTransferModule /
  EngineDrivenTransferModule + (blend module)`, but the actual return
  value in
  [`server.py:_build_modules()`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/server.py#L320-L333)
  also includes `P2PController` unconditionally and any
  `*experimental_modules` opted into via `--enable`
  ([server.py:293-317](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/server.py#L293-L317)).
  The `P2PController` mention appears further down in the
  `P2P_LOOKUP_AND_LOCK` row of the table ("loaded unconditionally by
  `_build_modules()`"), but the composition paragraph above it and
  the *Key Source Files* table below leave both out. Same section:
  the *Key Source Files* row for `lmcache/v1/multiprocess/modules/`
  did not list `p2p_controller.py` or `experimental/qstore.py`, both
  of which exist in the tree.

- **`docs/source/mp/configuration.rst`** — the *MP Server* CLI table
  did not include `--enable`, which is defined at
  [`config.py:387`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/config.py#L387-L395)
  and is the flag that opts a server into the experimental transfer
  modules above (currently just `transfer_query`, defined in
  [`modules/experimental/__init__.py`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/lmcache/v1/multiprocess/modules/experimental/__init__.py)).
  Without the row users have no way to discover the flag from the
  reference page; the section header even says the page documents
  "every CLI argument accepted by the LMCache multiprocess server."

### `docs/design/`

No drift detected in `docs/design/` today. The MP-adjacent design docs
under `docs/design/v1/multiprocess/`, `docs/design/v1/mp_coordinator/`,
and `docs/design/v1/mp_observability/` all describe the current code.
The SDK design docs
([`docs/design/sdk/qringbuffer.md`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/docs/design/sdk/qringbuffer.md)
and
[`docs/design/sdk/context.md`](https://github.com/LMCache/LMCache/blob/4521c3f9f1b821654e5a52d53e5a34da9afe28fb/docs/design/sdk/context.md))
already document `REGISTER_Q_CACHE` / `STORE_Q` / `UNREGISTER_Q_CACHE`,
so the user-facing MP index was the only place the RPCs were missing.

Yesterday's PR [#4455](https://github.com/LMCache/LMCache/pull/4455)
(coordinator pin/unpin section on `--separate-object-groups`) and
2026-08-05 PR [#4435](https://github.com/LMCache/LMCache/pull/4435)
(L2 adapter method signatures) are still open and touch neither the
`RequestType` table nor `--enable`, so no overlap. The recent MP
commits since the last run were reviewed for other drift and found
clean:

- **PR [#4425](https://github.com/LMCache/LMCache/pull/4425)** — dataclass
  move under `multiprocess/`. Class names not referenced from any doc.
- **PR [#4404](https://github.com/LMCache/LMCache/pull/4404)** — token
  directory API changes. Already reflected in
  `docs/source/mp/coordinator.rst` and `docs/design/v1/mp_coordinator/`.
- **PR [#4438](https://github.com/LMCache/LMCache/pull/4438)** — fleet
  blend lookup from key directory. Already covered in
  `docs/design/v1/mp_coordinator/blend_lookup.md` and the
  `POST /directory/blend-lookup` section of `coordinator.rst`.
- **PR [#4310](https://github.com/LMCache/LMCache/pull/4310)** — quota
  accounting on the cache-event stream. Matches the current wording in
  `docs/source/mp/coordinator.rst` (Quota, usage, and eviction section).
- **PR [#4395](https://github.com/LMCache/LMCache/pull/4395)** — MP
  operator compat for renamed coordinator event flags. Docs already
  document the new names (`--coordinator-event-reporting`) and mark
  the pre-v0.5.3 spellings as deprecated in `config.py` (SUPPRESS'd from
  `--help`).

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. Two files
touched:

- `docs/source/mp/index.rst`
- `docs/source/mp/configuration.rst`

## Code bugs surfaced (not fixed here)

None new from today's check. (Pre-existing items from earlier drift
checks remain open — none of them are re-flagged here.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Needs human review before merge. Kept as
**draft**; not marked "Ready for review." No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPZcFAe6ARkcZwLM7kNAmF)_