### PR TITLE
[MP] NUMA-aware placement for the lazy L1 pool  in MP mode

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -246,6 +246,20 @@ Source: ``lmcache/v1/distributed/config.py``
    * - ``--l1-init-size-gb``
      - ``20``
      - Initial allocation size (GB) when using lazy allocation.
+   * - ``--l1-numa-mode``
+     - *(not set)*
+     - NUMA placement for the lazy L1 pool.  ``auto`` binds the pool to the
+       current GPU's NUMA node (detected from sysfs); ``manual`` binds it per
+       ``--l1-numa-mapping``; unset keeps first-touch placement.  Only applies
+       with lazy allocation.  Binding requires ``CAP_SYS_NICE`` (absent in
+       default containers); without it the server logs a warning and falls
+       back to default placement.
+   * - ``--l1-numa-mapping``
+     - *(not set)*
+     - GPU-to-NUMA-node mapping for ``--l1-numa-mode manual``, as
+       comma-separated ``gpu:node`` pairs, e.g. ``0:0,1:0,2:1,3:1``.  Use
+       when sysfs detection is unavailable or wrong (some VMs), or to bind
+       the pool to a non-local node deliberately.
    * - ``--l1-align-bytes``
      - ``4096``
      - Alignment size in bytes (default 4 KB).

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -44,6 +44,42 @@ def _requires_single_l1_memory_region(
     return None
 
 
+def _parse_numa_mapping(spec: str) -> dict[int, int]:
+    """Parse a ``GPU:NODE[,GPU:NODE...]`` spec into a GPU-to-NUMA dict.
+
+    Args:
+        spec: Comma-separated ``gpu_id:numa_node`` pairs of non-negative
+            integers, e.g. ``"0:0,1:0,2:1,3:1"``.
+
+    Returns:
+        Mapping from GPU index to NUMA node.
+
+    Raises:
+        ValueError: If the spec is empty, a pair is malformed or negative,
+            or a GPU id repeats.
+    """
+    mapping: dict[int, int] = {}
+    for pair in spec.split(","):
+        gpu_str, sep, node_str = pair.partition(":")
+        try:
+            if not sep:
+                raise ValueError
+            gpu, node = int(gpu_str), int(node_str)
+        except ValueError:
+            raise ValueError(
+                f"Malformed NUMA mapping pair {pair!r}; expected 'gpu:node' "
+                "with integer ids."
+            ) from None
+        if gpu < 0 or node < 0:
+            raise ValueError(f"Negative id in NUMA mapping pair {pair!r}.")
+        if gpu in mapping:
+            raise ValueError(f"Duplicate GPU id {gpu} in NUMA mapping {spec!r}.")
+        mapping[gpu] = node
+    if not mapping:
+        raise ValueError("Empty NUMA mapping spec.")
+    return mapping
+
+
 def _infer_l1_devdax_overflow_from_dax_adapter(
     memory_config: "L1MemoryManagerConfig",
     l2_adapter_config: L2AdaptersConfig,
@@ -121,6 +157,14 @@ class L1MemoryManagerConfig:
 
     shm_name: str = field(default_factory=lambda: f"lmcache_l1_pool_{os.getpid()}")
     """ POSIX shared-memory segment name for L1 pool. Empty disables SHM. """
+
+    numa_mode: str | None = None
+    """ NUMA placement for the lazy L1 pool: ``"auto"`` binds it to the
+    current GPU's node, ``"manual"`` uses ``numa_mapping``; ``None`` keeps
+    first-touch placement. Lazy only. """
+
+    numa_mapping: dict[int, int] | None = None
+    """ GPU index to NUMA node mapping for ``numa_mode="manual"``. """
 
     devdax_path: str | None = None
     """ Optional Device-DAX path to use as the L1 backing arena. """
@@ -386,6 +430,23 @@ def add_storage_manager_args(
         help="The initial size (GB) when using lazy allocation. Default is 20.",
     )
     memory_group.add_argument(
+        "--l1-numa-mode",
+        type=str,
+        choices=["auto", "manual"],
+        default=None,
+        help="NUMA placement for the lazy L1 pool: 'auto' binds the pool to "
+        "the current GPU's NUMA node, 'manual' uses --l1-numa-mapping. "
+        "Default keeps first-touch placement.",
+    )
+    memory_group.add_argument(
+        "--l1-numa-mapping",
+        type=str,
+        default=None,
+        metavar="GPU:NODE[,GPU:NODE...]",
+        help="GPU-to-NUMA-node mapping for --l1-numa-mode manual, "
+        "e.g. '0:0,1:0,2:1,3:1'.",
+    )
+    memory_group.add_argument(
         "--l1-align-bytes",
         type=int,
         default=4096,
@@ -554,7 +615,20 @@ def parse_args_to_config(
 
     Returns:
         StorageManagerConfig: The configuration object.
+
+    Raises:
+        ValueError: If the NUMA arguments are inconsistent (``manual`` mode
+            without a mapping, a mapping without ``manual`` mode) or the
+            mapping spec is malformed.
     """
+    numa_mapping = (
+        _parse_numa_mapping(args.l1_numa_mapping) if args.l1_numa_mapping else None
+    )
+    if args.l1_numa_mode == "manual" and numa_mapping is None:
+        raise ValueError("--l1-numa-mode manual requires --l1-numa-mapping.")
+    if numa_mapping is not None and args.l1_numa_mode != "manual":
+        raise ValueError("--l1-numa-mapping requires --l1-numa-mode manual.")
+
     shm_name = getattr(args, "shm_name", None)
     if shm_name is None:
         memory_config = L1MemoryManagerConfig(
@@ -562,6 +636,8 @@ def parse_args_to_config(
             use_lazy=args.l1_use_lazy,
             init_size_in_bytes=int(args.l1_init_size_gb * (1 << 30)),
             align_bytes=args.l1_align_bytes,
+            numa_mode=args.l1_numa_mode,
+            numa_mapping=numa_mapping,
             devdax_path=args.l1_devdax_path,
         )
     else:
@@ -570,6 +646,8 @@ def parse_args_to_config(
             use_lazy=args.l1_use_lazy,
             init_size_in_bytes=int(args.l1_init_size_gb * (1 << 30)),
             align_bytes=args.l1_align_bytes,
+            numa_mode=args.l1_numa_mode,
+            numa_mapping=numa_mapping,
             shm_name=shm_name,
             devdax_path=args.l1_devdax_path,
         )

--- a/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
@@ -16,6 +16,7 @@ from lmcache.v1.memory_management import (
     MemoryAllocatorInterface,
     MemoryObj,
 )
+from lmcache.v1.system_detection import NUMADetector
 
 logger = init_logger(__name__)
 
@@ -59,8 +60,16 @@ def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInt
             config.size_in_bytes,
             config.align_bytes,
         )
+        numa_mapping = NUMADetector.detect(config.numa_mode, config.numa_mapping)
+        if numa_mapping is not None:
+            logger.info(
+                "L1 pool NUMA placement enabled: %s", numa_mapping.gpu_to_numa_mapping
+            )
         return LazyMemoryAllocator(
-            config.init_size_in_bytes, config.size_in_bytes, config.align_bytes
+            config.init_size_in_bytes,
+            config.size_in_bytes,
+            config.align_bytes,
+            numa_mapping=numa_mapping,
         )
     else:
         logger.debug(

--- a/lmcache/v1/memory_allocators/lazy_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/lazy_memory_allocator.py
@@ -85,6 +85,10 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             align_bytes (int, optional): Alignment for the underlying allocations.
                 Must be a positive power of two. The buffer's base address is
                 aligned to this value, not merely the offsets within it.
+            numa_mapping (NUMAMapping, optional): GPU-to-NUMA mapping; when
+                given, the buffer is bound to the current GPU's node. A failed
+                binding (e.g. missing CAP_SYS_NICE) logs a warning and falls
+                back to default placement instead of raising.
 
         Raises:
             ValueError: If ``align_bytes`` is not a positive power of two.
@@ -94,8 +98,8 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         if align_bytes <= 0 or align_bytes & (align_bytes - 1) != 0:
             raise ValueError("align_bytes must be a positive power of two")
 
-        # Whether using NUMA allocation
-        self._use_numa = numa_mapping is not None
+        # True only when alloc_numa_ptr succeeds; selects the free path.
+        self._use_numa = False
         # Currently pinned size, only accessed by the expansion thread
         self._curr_size = align_to(init_size, self.PIN_CHUNK_SIZE)
         # Final size of the allocation, only accessed by the expansion thread
@@ -111,14 +115,25 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         # List of (ptr, size) for pinned memory chunks
         self._pin_record: list[tuple[int, int]] = []
 
-        # Detect numa mapping
+        # mbind needs CAP_SYS_NICE (absent in default containers); on
+        # failure degrade to default placement instead of failing startup.
         if numa_mapping is not None:
             numa_id = get_numa_id(numa_mapping)
-            ptr = lmc_ops.alloc_numa_ptr(self._final_size, numa_id)
-            arr_type = ctypes.c_uint8 * self._final_size
-            buf = arr_type.from_address(ptr)
-            self._buffer = torch.frombuffer(buf, dtype=torch.uint8)
-        else:
+            try:
+                ptr = lmc_ops.alloc_numa_ptr(self._final_size, numa_id)
+            except RuntimeError as exc:
+                logger.warning(
+                    "NUMA-bound allocation on node %d unavailable (%s); "
+                    "falling back to default placement.",
+                    numa_id,
+                    exc,
+                )
+            else:
+                arr_type = ctypes.c_uint8 * self._final_size
+                buf = arr_type.from_address(ptr)
+                self._buffer = torch.frombuffer(buf, dtype=torch.uint8)
+                self._use_numa = True
+        if not self._use_numa:
             # torch.empty() only guarantees 64-byte alignment, but consumers of
             # get_l1_memory_desc() (O_DIRECT, RDMA/GDS) need the buffer base
             # itself aligned to align_bytes.

--- a/lmcache/v1/system_detection.py
+++ b/lmcache/v1/system_detection.py
@@ -53,42 +53,60 @@ class SystemMemoryDetector:
 
 class NUMADetector:
     @staticmethod
-    def get_numa_mapping(config: LMCacheEngineConfig) -> Optional[NUMAMapping]:
+    def detect(
+        numa_mode: str | None,
+        gpu_to_numa_mapping: dict[int, int] | None = None,
+    ) -> Optional[NUMAMapping]:
+        """Resolve the GPU-to-NUMA mapping for a bare mode string.
+
+        Entry point for callers without an ``LMCacheEngineConfig``.
+
+        Args:
+            numa_mode: ``"auto"`` to detect from sysfs, ``"manual"`` to use
+                *gpu_to_numa_mapping*, ``None`` to disable.
+            gpu_to_numa_mapping: GPU index to NUMA node mapping; required
+                when *numa_mode* is ``"manual"``, ignored otherwise.
+
+        Returns:
+            The resolved mapping, or ``None`` when *numa_mode* is ``None``.
+
+        Raises:
+            ValueError: If *numa_mode* is not ``"auto"``, ``"manual"``, or
+                ``None``, or is ``"manual"`` without a mapping.
         """
-        Get NUMA mapping.
-        """
-        assert config.numa_mode in ["manual", "auto", None], (
-            "NUMA mode must be either 'auto',  'manual', or None."
-            f" Current mode: {config.numa_mode}"
+        if numa_mode is None:
+            return None
+        if numa_mode == "auto":
+            return NUMADetector._read_from_sys()
+        if numa_mode == "manual":
+            if not gpu_to_numa_mapping:
+                raise ValueError("numa_mode 'manual' requires a GPU-to-NUMA mapping.")
+            return NUMAMapping(gpu_to_numa_mapping=gpu_to_numa_mapping)
+        raise ValueError(
+            f"Unsupported numa_mode {numa_mode!r}; expected 'auto', 'manual', or None."
         )
-
-        numa_mapping: Optional[NUMAMapping] = None
-        if config.numa_mode == "manual":
-            numa_mapping = NUMADetector._read_from_config(config)
-        elif config.numa_mode == "auto":
-            numa_mapping = NUMADetector._read_from_sys()
-
-        return numa_mapping
 
     @staticmethod
-    def _read_from_config(config) -> NUMAMapping:
+    def get_numa_mapping(config: LMCacheEngineConfig) -> Optional[NUMAMapping]:
+        """Resolve the NUMA mapping from an engine config.
+
+        Adapter over :meth:`detect` for callers holding an
+        ``LMCacheEngineConfig``; ``"manual"`` mode reads the mapping from
+        ``config.extra_config["gpu_to_numa_mapping"]``.
+
+        Args:
+            config: Engine config carrying ``numa_mode`` and, for manual
+                mode, the mapping in ``extra_config``.
+
+        Returns:
+            The resolved mapping, or ``None`` when NUMA is disabled.
+
+        Raises:
+            ValueError: If ``numa_mode`` is invalid or ``"manual"`` without
+                a mapping in ``extra_config``.
         """
-        Read NUMA mapping from the LMCache configuration.
-        """
-
-        assert config.extra_config is not None, (
-            "NUMA mode is set but extra_config is None. "
-            "Please ensure the configuration is properly set."
-        )
-
-        assert "gpu_to_numa_mapping" in config.extra_config, (
-            "NUMA mode is set to `manual` but gpu_to_numa_mapping is None. "
-            "Please ensure the configuration is properly set."
-        )
-
-        gpu_to_numa_mapping = config.extra_config.get("gpu_to_numa_mapping")
-
-        return NUMAMapping(gpu_to_numa_mapping)
+        mapping = (config.extra_config or {}).get("gpu_to_numa_mapping")
+        return NUMADetector.detect(config.numa_mode, mapping)
 
     @staticmethod
     def _read_from_sys() -> Optional[NUMAMapping]:


### PR DESCRIPTION
**What this PR does / why we need it**:

Wire the allocator's existing numa_mapping support into the MP server's pool creation: --l1-numa-mode auto binds the pool to the current GPU's node detected from sysfs, manual binds it per an explicit --l1-numa-mapping. mbind needs CAP_SYS_NICE, absent in default containers, so a denied binding degrades to default placement with a warning, and the free path follows actual binding success. Default keeps first-touch placement.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
