### PR TITLE
fix(cacheblend): keep local matcher when fleet coordinator is enabled

### DIFF
--- a/docs/design/v1/mp_observability/blend_v3_observability.md
+++ b/docs/design/v1/mp_observability/blend_v3_observability.md
@@ -98,7 +98,7 @@ timing is GPU-accurate):
 | new event pair | span | timing source |
 |---|---|---|
 | `CB_FINGERPRINT_MATCH_*` | `cb.fingerprint_match` | CPU |
-| `CB_COORDINATOR_MATCH_*` | `cb.coordinator_match` (fleet directory leg; mutually exclusive with the local matcher) | CPU + IO |
+| `CB_COORDINATOR_MATCH_*` | `cb.coordinator_match` (fleet directory leg; additive with the local matcher) | CPU + IO |
 | (prefix lookup) | `mp.lookup_prefetch` (reused; `prefix_chunks` attr on `cb.lookup`) | CPU |
 | `CB_SPARSE_PREFETCH_*` | `cb.sparse_prefetch` (+ existing L2 prefetch span as `cb.l2_load`) | CPU + IO |
 | `CB_SCATTER_*` | `cb.scatter` (re-RoPE folded in via `n_shifted`) | `publish_on_stream` (GPU) |

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -883,6 +883,34 @@ class BlendV3Module(InstanceLivenessTarget):
         return self._token_range_matcher.match_sub_sequence(list(key.token_ids))
 
     @staticmethod
+    def _union_match_candidates(
+        local: list[CBMatchResult],
+        fleet: list[CBMatchResult],
+    ) -> list[CBMatchResult]:
+        """Union local and fleet fingerprint matches for one lookup.
+
+        Both sources are additive: the fleet directory is not a guaranteed
+        superset of the local table (best-effort cache events), so recall is
+        the union. Local is listed first so equal ``cur_st`` ties prefer the
+        local source under the stable sort in
+        :meth:`_non_overlapping_after_prefix`.
+
+        Args:
+            local: Matches from the on-server fingerprint matcher.
+            fleet: Matches from the coordinator directory (possibly empty on
+                timeout or when no coordinator query was submitted).
+
+        Returns:
+            Concatenated candidates; caller applies prefix filter + overlap
+            dedup via :meth:`_non_overlapping_after_prefix`.
+        """
+        if not fleet:
+            return local
+        if not local:
+            return fleet
+        return local + fleet
+
+    @staticmethod
     def _non_overlapping_after_prefix(
         matches: list[CBMatchResult], prefix_tokens: int
     ) -> list[CBMatchResult]:
@@ -1262,29 +1290,24 @@ class BlendV3Module(InstanceLivenessTarget):
             prefix_handle, prefix_ws = self._submit_prefix_leg(
                 key, tp_size, prefix_policy
             )
-            # Local and coordinator matching are mutually exclusive: with a
-            # coordinator the fleet directory is the only source, so skip the
-            # local matcher (and its span). The coordinator leg is async
-            # (submitted below, resolved at poll) and is timed by cb.lookup.
-            matches: list[CBMatchResult]
-            if self._coordinator is not None:
-                matches = []
-            else:
-                # Local fingerprint match: CPU-bound, tight span.
-                self._event_bus.publish(
-                    Event(
-                        event_type=EventType.CB_FINGERPRINT_MATCH_START,
-                        session_id=rid,
-                    )
+            # Local and fleet matching are additive: always run the local
+            # matcher; a coordinator only adds candidates (see blend_lookup.md).
+            # The coordinator leg is async (submitted below, resolved at poll)
+            # and is timed by cb.lookup.
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_FINGERPRINT_MATCH_START,
+                    session_id=rid,
                 )
-                matches = self._match_fingerprints(key)
-                self._event_bus.publish(
-                    Event(
-                        event_type=EventType.CB_FINGERPRINT_MATCH_END,
-                        session_id=rid,
-                        metadata={"matches": len(matches)},
-                    )
+            )
+            matches = self._match_fingerprints(key)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_FINGERPRINT_MATCH_END,
+                    session_id=rid,
+                    metadata={"matches": len(matches)},
                 )
+            )
             job = _CBUnifiedJob(
                 matches=matches,
                 num_tokens=len(key.token_ids),
@@ -1325,9 +1348,12 @@ class BlendV3Module(InstanceLivenessTarget):
         if not job.sparse_started:
             prefix_tokens = prefix_chunks * chunk_size
             if self._coordinator is not None:
-                candidates = self._poll_coordinator_match(job, rid)
-                if candidates is None:
+                fleet = self._poll_coordinator_match(job, rid)
+                if fleet is None:
                     return None  # coordinator still in flight (bounded by deadline)
+                # Union local + fleet; timeout / empty fleet degrades to
+                # local-only via an empty fleet list.
+                candidates = self._union_match_candidates(job.matches, fleet)
             else:
                 candidates = job.matches
             # Under SEGMENTED_PREFIX, a same-position match the prefix leg already

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -425,7 +425,8 @@ def test_poll_coordinator_match_deferred_then_resolved():
 
 
 def test_poll_coordinator_match_gives_up_past_deadline():
-    """PENDING past the deadline degrades to local-only ([]) and drops state."""
+    """PENDING past the deadline returns [] (empty fleet); callers union with
+    local matches so the lookup degrades to local-only."""
     # First Party
     from lmcache.v1.mp_coordinator.blend_client import PENDING
 
@@ -437,6 +438,52 @@ def test_poll_coordinator_match_gives_up_past_deadline():
 
     assert eng._poll_coordinator_match(job, "rid") == []
     coordinator.take_match.assert_called_once_with("rid")
+
+
+def test_union_match_candidates_prefers_local_on_cur_st_tie():
+    """Local is listed first so equal cur_st ties keep the local old_st under
+    the stable sort in _non_overlapping_after_prefix."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CBMatchResult
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    local = CBMatchResult(old_st=0, old_ed=4, cur_st=8, cur_ed=12, hash=b"\x01")
+    fleet = CBMatchResult(old_st=100, old_ed=104, cur_st=8, cur_ed=12, hash=b"\x01")
+    union = v3_mod.BlendV3Module._union_match_candidates([local], [fleet])
+    kept = v3_mod.BlendV3Module._non_overlapping_after_prefix(union, 0)
+
+    assert len(kept) == 1
+    assert kept[0].old_st == 0
+
+
+def test_union_match_candidates_empty_sides():
+    """Either empty side returns the other list unchanged (no copy)."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CBMatchResult
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    local = [CBMatchResult(old_st=0, old_ed=4, cur_st=4, cur_ed=8, hash=b"\x01")]
+    fleet = [CBMatchResult(old_st=0, old_ed=4, cur_st=12, cur_ed=16, hash=b"\x02")]
+    union = v3_mod.BlendV3Module._union_match_candidates
+
+    assert union(local, []) is local
+    assert union([], fleet) is fleet
+    assert union([], []) == []
+
+
+def test_fleet_timeout_union_keeps_local_matches():
+    """Coordinator timeout yields an empty fleet list; union still keeps
+    whatever the local matcher already found."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CBMatchResult
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    local = [CBMatchResult(old_st=0, old_ed=4, cur_st=4, cur_ed=8, hash=b"\x01")]
+    fleet_timed_out: list[CBMatchResult] = []
+    kept = v3_mod.BlendV3Module._non_overlapping_after_prefix(
+        v3_mod.BlendV3Module._union_match_candidates(local, fleet_timed_out), 0
+    )
+    assert [r.hash for r in kept] == [b"\x01"]
 
 
 def test_non_overlapping_after_prefix():
@@ -1034,13 +1081,13 @@ def test_union_of_local_and_fleet_matches_collapses_duplicates():
     from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
 
     dedup = v3_mod.BlendV3Module._non_overlapping_after_prefix
+    union_fn = v3_mod.BlendV3Module._union_match_candidates
     shared = CBMatchResult(old_st=0, old_ed=4, cur_st=8, cur_ed=12, hash=b"\x01")
     local_only = CBMatchResult(old_st=4, old_ed=8, cur_st=12, cur_ed=16, hash=b"\x02")
     fleet_only = CBMatchResult(old_st=8, old_ed=12, cur_st=16, cur_ed=20, hash=b"\x03")
 
     # Same chunk reported by both sources, plus one unique to each.
-    union = [shared, local_only] + [shared, fleet_only]
-    kept = dedup(union, 0)
+    kept = dedup(union_fn([shared, local_only], [shared, fleet_only]), 0)
 
     assert [r.hash for r in kept] == [b"\x01", b"\x02", b"\x03"]
 
@@ -1053,9 +1100,10 @@ def test_union_recall_is_at_least_either_source_alone():
     from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
 
     dedup = v3_mod.BlendV3Module._non_overlapping_after_prefix
+    union_fn = v3_mod.BlendV3Module._union_match_candidates
     local = [CBMatchResult(old_st=0, old_ed=4, cur_st=4, cur_ed=8, hash=b"\x01")]
     fleet = [CBMatchResult(old_st=0, old_ed=4, cur_st=12, cur_ed=16, hash=b"\x02")]
 
     assert len(dedup(local, 0)) == 1
     assert len(dedup(fleet, 0)) == 1
-    assert len(dedup(local + fleet, 0)) == 2
+    assert len(dedup(union_fn(local, fleet), 0)) == 2


### PR DESCRIPTION
**What this PR does / why we need it**:

### Problem
When a CacheBlend MP server is configured with a coordinator, `cb_unified_lookup` treated local fingerprint matching and fleet (coordinator) matching as **mutually exclusive**: the local matcher was skipped entirely and only fleet results were used.

That diverges from the documented contract in `docs/design/v1/mp_coordinator/blend_lookup.md` (**additive**: local always runs; coordinator only adds candidates). In practice it causes **false misses** when:

- cache-event flush to the coordinator is lagging,
- an event batch is dropped / token binding was evicted,
- the coordinator match deadline is exceeded (the code already logged “local-only”, but `job.matches` had been left empty).

### Motivation
Fleet index is best-effort, not a guaranteed superset of the local table. Running only fleet with a coordinator present makes recall strictly worse than local-only for the failure modes above. Additive union restores the intended robustness with only the cost of a local vectorized probe (already cheap on the path that pays for a coordinator RTT).

### Solution
1. Always run `_match_fingerprints` (emit `CB_FINGERPRINT_MATCH_*` as before).
2. After the prefix leg, poll the coordinator (unchanged defer/deadline behavior).
3. Build candidates with new `_union_match_candidates(local, fleet)` (local listed first so equal `cur_st` ties prefer local under the existing stable leftmost-greedy dedup).
4. Continue through `_non_overlapping_after_prefix` + sparse prefetch unchanged.
5. Docs: fix observability note that claimed the legs were mutually exclusive.

### Verification
Unit tests (pass):

```bash
pytest -q tests/v1/multiprocess/test_blend_v3_load_store_opts.py \
  -k 'union or fleet_timeout or coordinator_match'
# 7 passed
```

Also ran a local before/after recall check with the real `BlendTokenRangeMatcherV3` on `store=A+B+C`, `query=B+D+C` (fragment leg, `chunk_size=4`):

```text
### fleet_empty_event_lag
    local hits: 2  fleet hits: 0
    OLD (fleet-only w/ coord): 0 matches, 0 tokens
    NEW (local∪fleet):         2 matches, 8 tokens
    Δ tokens: +8  (IMPROVED)

### fleet_timeout
    OLD: 0 tokens → NEW: 8 tokens  (+8)

### fleet_partial_only_B
    OLD: 4 tokens → NEW: 8 tokens  (+4)

### fleet_complete_superset
    OLD: 8 tokens → NEW: 8 tokens  (+0, same)

### fleet_only_remote_chunk
    OLD: 4 tokens → NEW: 4 tokens  (+0, same)

SUMMARY: improved 3/5, unchanged 2/5, regressed 0/5
```

Steady-state (fleet already complete) and remote-only hits are unchanged; gains show up exactly when fleet is empty/partial/timed out while local still has content.

Note: full GPU vLLM + `lmcache_cacheblend` e2e was not run on this Mac (no CUDA / private plugin). The above validates the candidate-selection change this PR makes.

**Special notes for your reviewers**:

- Behavior change only when `_coordinator is not None`. No coordinator → same as before.
- Prefer local on `cur_st` ties intentionally (local L1 is more reliable for retrieve).
- Signed-off-by included (DCO).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
- [x] design-doc note updated (`blend_v3_observability.md`)


Made with [Cursor](https://cursor.com)