### PR TITLE
[Controller] Multi-holder lookup: report every instance holding a prefix

### DIFF
--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -382,21 +382,48 @@ class KVController:
     # suffix chunk is still in the system. LMCache should guarantee
     # this does not happen.
     # TODO(Jiayi): The current implementation does not consider
-    # the location of the kv chunks. It simply returns the
-    # `instance_id` with longest prefix.
+    # the location of the kv chunks when ranking: the location is
+    # reported per instance but not ranked on.
     # TODO(Jiayi): Need to get rid of the hash somehow
     async def lookup(self, msg: LookupMsg) -> LookupRetMsg:
+        """
+        Report, for every instance, how long a prefix of ``msg.tokens``
+        it holds.
+
+        ``layout_info`` maps ``instance_id -> (location, matched_tokens)``
+        and is populated for **every** instance still matching the prefix,
+        not only the first holder found: callers that compare instances
+        (for example a cache- and load-aware router) need the full holder
+        set. An instance's credit is contiguous from token 0 - it stops
+        counting at its first missing chunk even if it holds later
+        chunks, so a reported match is a prefix the instance can actually
+        serve, not a count of scattered chunks.
+
+        The first entry of ``layout_info`` is the same instance the
+        previous first-match-only implementation credited for the first
+        chunk, so callers that read only the first entry are unaffected.
+        """
         tokens = msg.tokens
         layout_info = {}
+        # None means "first chunk": every instance is still a candidate.
+        contiguous = None
         for start, end, key in self.token_database.process_tokens(
             tokens, make_key=False
         ):
-            result = self.registry.find_kv(key)
-            if result is None:
+            holders = self.registry.find_kv_all(key)
+            if contiguous is not None:
+                holders = {
+                    instance_id: info
+                    for instance_id, info in holders.items()
+                    if instance_id in contiguous
+                }
+            if not holders:
                 break
-            matched_instance = result.instance_id
-            matched_location = result.location
-            layout_info[matched_instance] = (matched_location, end)
+            for instance_id, info in holders.items():
+                # `end` is the running token offset, so the last write per
+                # instance is its longest matched prefix.
+                layout_info[instance_id] = (info.location, end)
+            contiguous = set(holders)
         return LookupRetMsg(layout_info=layout_info, event_id=msg.event_id)
 
     # TODO: improve the matching logic, return multi results

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -605,6 +605,46 @@ class RegistryTree:
                     return result
             return None
 
+    def find_kv_all(
+        self,
+        key: int,
+        exclude_instance_id: Optional[str] = None,
+    ) -> dict[str, KVChunkInfo]:
+        """
+        Find a KV chunk across all instances, returning every holder.
+
+        Unlike ``find_kv``, which returns the first instance found, this
+        reports one ``KVChunkInfo`` per instance that holds the chunk (the
+        first worker found within each instance, matching ``find_kv``'s
+        choice). Callers that compare or rank instances - for example a
+        cache- and load-aware router - need the full holder set: with only
+        the first holder reported, a chunk replicated on two instances is
+        indistinguishable from one held by a single instance.
+
+        The dict preserves instance iteration order, so its first entry is
+        the same instance ``find_kv`` would return.
+
+        Args:
+            key: The KV chunk key to find.
+            exclude_instance_id: Instance ID to exclude
+            (all workers in this instance will be excluded).
+
+        Returns: A dict mapping instance_id to KVChunkInfo; empty if no
+        instance holds the chunk.
+        """
+        with self._rwlock.read_lock(timeout=1):
+            holders: dict[str, KVChunkInfo] = {}
+            for instance_id, instance_node in self.instances.items():
+                if (
+                    exclude_instance_id is not None
+                    and instance_id == exclude_instance_id
+                ):
+                    continue
+                result = instance_node.find_key_simple(key)
+                if result is not None:
+                    holders[instance_id] = result
+            return holders
+
     def find_kv_with_worker_info(
         self,
         key: int,

--- a/tests/v1/cache_controller/conftest.py
+++ b/tests/v1/cache_controller/conftest.py
@@ -272,6 +272,25 @@ def mock_reg_controller():
                     return KVChunkInfo(instance_id, worker_id, location)
         return None
 
+    def mock_find_kv_all(key, exclude_instance_id=None):
+        """Mirror RegistryTree.find_kv_all: one KVChunkInfo per holding
+        instance, in iteration order (first worker per instance wins)."""
+        # First Party
+        from lmcache.v1.cache_controller.utils import KVChunkInfo
+
+        holders = {}
+        for report_id, locations in mock_registry.kv_pool.items():
+            instance_id, worker_id = report_id
+            if exclude_instance_id and instance_id == exclude_instance_id:
+                continue
+            if instance_id in holders:
+                continue
+            for location, keys in locations.items():
+                if key in keys:
+                    holders[instance_id] = KVChunkInfo(instance_id, worker_id, location)
+                    break
+        return holders
+
     def mock_get_worker_kv_keys(instance_id, worker_id, location):
         report_id = (instance_id, worker_id)
         if report_id in mock_registry.kv_pool:
@@ -362,6 +381,7 @@ def mock_reg_controller():
     mock_registry.admit_kv = Mock(side_effect=mock_admit_kv)
     mock_registry.evict_kv = Mock(side_effect=mock_evict_kv)
     mock_registry.find_kv = Mock(side_effect=mock_find_kv)
+    mock_registry.find_kv_all = Mock(side_effect=mock_find_kv_all)
     mock_registry.get_worker_kv_keys = Mock(side_effect=mock_get_worker_kv_keys)
     mock_registry.get_total_kv_count = Mock(side_effect=mock_get_total_kv_count)
     mock_registry.get_seq_discontinuity_count = Mock(

--- a/tests/v1/cache_controller/test_multi_holder_lookup.py
+++ b/tests/v1/cache_controller/test_multi_holder_lookup.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for multi-holder lookup.
+
+``RegistryTree.find_kv_all`` reports every instance holding a chunk, and
+``KVController.lookup`` uses it to credit every instance still matching
+the request's prefix - not only the first holder found. A router that
+compares instances (for example a cache- and load-aware router) needs the
+full holder set: with only the first holder reported, a prefix replicated
+on two instances is indistinguishable from one held by a single instance.
+
+The controller-level tests use the real ``RegistryTree`` so the tests
+exercise the same code the production lookup path runs.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.cache_controller.controllers.kv_controller import KVController
+from lmcache.v1.cache_controller.message import (
+    BatchedKVOperationMsg,
+    KVOpEvent,
+    LookupMsg,
+    OpType,
+)
+from lmcache.v1.cache_controller.utils import RegistryTree
+
+LOCATION = "LocalCPUBackend"
+INST_A = "instance-a"
+INST_B = "instance-b"
+
+
+def make_controller():
+    """KVController over a real RegistryTree, with two registered
+    instances of one worker each."""
+    reg = RegistryTree()
+    for instance_id in (INST_A, INST_B):
+        reg.register_worker(
+            instance_id, 0, "127.0.0.1", 8000, None, MagicMock(), time.time()
+        )
+    ctrl = KVController(registry=reg)
+    ctrl.cluster_executor = MagicMock()
+    return ctrl, reg
+
+
+def admit(reg, instance_id, keys, location=LOCATION):
+    """Admit `keys` for `instance_id`'s worker 0 through the real batched
+    operations path."""
+    msg = BatchedKVOperationMsg(
+        instance_id=instance_id,
+        worker_id=0,
+        location=location,
+        operations=[
+            KVOpEvent(op_type=OpType.ADMIT, key=key, seq_num=i + 1)
+            for i, key in enumerate(keys)
+        ],
+    )
+    reg.handle_batched_kv_operations(msg)
+
+
+def chunks(n, size=256, first_key=1000):
+    """`n` chunk descriptors in process_tokens' (start, end, key) shape."""
+    return [(i * size, (i + 1) * size, first_key + i) for i in range(n)]
+
+
+async def lookup(ctrl, n_chunks):
+    with patch.object(ctrl.token_database, "process_tokens") as mock_process:
+        mock_process.return_value = chunks(n_chunks)
+        return await ctrl.lookup(
+            LookupMsg(event_id="event_123", tokens=list(range(n_chunks * 256)))
+        )
+
+
+class TestFindKvAll:
+    """RegistryTree.find_kv_all."""
+
+    def test_every_holder_is_reported(self):
+        _, reg = make_controller()
+        admit(reg, INST_A, [1000])
+        admit(reg, INST_B, [1000])
+        holders = reg.find_kv_all(1000)
+        assert set(holders) == {INST_A, INST_B}
+        assert holders[INST_A].location == LOCATION
+
+    def test_no_holder_is_an_empty_dict(self):
+        _, reg = make_controller()
+        assert reg.find_kv_all(9999) == {}
+
+    def test_exclude_instance_id_is_honoured(self):
+        _, reg = make_controller()
+        admit(reg, INST_A, [1000])
+        admit(reg, INST_B, [1000])
+        assert set(reg.find_kv_all(1000, exclude_instance_id=INST_A)) == {INST_B}
+
+    def test_first_entry_matches_find_kv(self):
+        """Wire compatibility: the dict's first entry is the instance
+        find_kv returns."""
+        _, reg = make_controller()
+        admit(reg, INST_A, [1000])
+        admit(reg, INST_B, [1000])
+        first_all = next(iter(reg.find_kv_all(1000).values()))
+        assert first_all == reg.find_kv(1000)
+
+
+class TestMultiHolderLookup:
+    """KVController.lookup over a real RegistryTree."""
+
+    @pytest.mark.asyncio
+    async def test_every_holder_is_credited_with_its_own_prefix(self):
+        """A holds chunks 0-2, B holds chunks 0-1: both are reported,
+        each with its own matched length."""
+        ctrl, reg = make_controller()
+        admit(reg, INST_A, [1000, 1001, 1002])
+        admit(reg, INST_B, [1000, 1001])
+        result = await lookup(ctrl, 3)
+        assert result.layout_info[INST_A] == (LOCATION, 768)
+        assert result.layout_info[INST_B] == (LOCATION, 512)
+
+    @pytest.mark.asyncio
+    async def test_credit_is_contiguous_from_token_zero(self):
+        """B holds chunks 0 and 2 but not 1: its credit stops at the gap
+        even though it holds a later chunk."""
+        ctrl, reg = make_controller()
+        admit(reg, INST_A, [1000, 1001, 1002])
+        admit(reg, INST_B, [1000, 1002])
+        result = await lookup(ctrl, 3)
+        assert result.layout_info[INST_A] == (LOCATION, 768)
+        assert result.layout_info[INST_B] == (LOCATION, 256)
+
+    @pytest.mark.asyncio
+    async def test_a_suffix_only_holder_is_never_credited(self):
+        """B holds only chunk 1. It cannot serve any prefix of the
+        request, so it earns nothing. (The previous first-match-only
+        implementation could credit exactly this case: find_kv at chunk 1
+        returned B once A was the only chunk-0 holder.)"""
+        ctrl, reg = make_controller()
+        admit(reg, INST_A, [1000, 1001])
+        admit(reg, INST_B, [1001])
+        result = await lookup(ctrl, 2)
+        assert INST_B not in result.layout_info
+        assert result.layout_info[INST_A] == (LOCATION, 512)
+
+    @pytest.mark.asyncio
+    async def test_single_holder_behaves_as_before(self):
+        ctrl, reg = make_controller()
+        admit(reg, INST_A, [1000, 1001, 1002])
+        result = await lookup(ctrl, 3)
+        assert result.layout_info == {INST_A: (LOCATION, 768)}
+
+    @pytest.mark.asyncio
+    async def test_walk_stops_when_no_instance_holds_the_next_chunk(self):
+        ctrl, reg = make_controller()
+        admit(reg, INST_A, [1000])
+        admit(reg, INST_B, [1000])
+        result = await lookup(ctrl, 3)
+        assert result.layout_info[INST_A] == (LOCATION, 256)
+        assert result.layout_info[INST_B] == (LOCATION, 256)
+
+    @pytest.mark.asyncio
+    async def test_miss_everywhere_is_an_empty_layout(self):
+        ctrl, _ = make_controller()
+        result = await lookup(ctrl, 2)
+        assert result.layout_info == {}
+
+    @pytest.mark.asyncio
+    async def test_first_entry_is_the_chunk_zero_holder_find_kv_chose(self):
+        """Wire compatibility for callers that read only the first entry
+        (e.g. production-stack's kvaware router)."""
+        ctrl, reg = make_controller()
+        admit(reg, INST_A, [1000, 1001])
+        admit(reg, INST_B, [1000, 1001, 1002])
+        result = await lookup(ctrl, 3)
+        first_instance = next(iter(result.layout_info))
+        assert first_instance == reg.find_kv(1000).instance_id


### PR DESCRIPTION
## Motivation

`KVController.lookup()` credits only the first instance found for each chunk and discards the rest, so a prefix replicated on two instances is reported as held by one. The limitation is acknowledged in the source (*"TODO: improve the matching logic, return multi results"*). It matters above the controller: a router that wants to weigh cache locality against load cannot compare or rank instances if it is told about only one — with first-match-only reporting, cache replication is invisible to routing.

## What this PR does

- **`RegistryTree.find_kv_all()`** — additive: returns one `KVChunkInfo` per instance holding the chunk, under the same read lock and with the same first-worker-per-instance choice as `find_kv`. `find_kv` itself is untouched.
- **`KVController.lookup()`** now populates `layout_info` for **every** instance still matching the request's prefix. Credit is contiguous from token 0: an instance stops earning at its first missing chunk even if it holds later chunks, so a reported match is a prefix the instance can actually serve, not a count of scattered chunks. This also fixes a subtle mis-credit in the old walk: once the first-found holder changed mid-walk, an instance could be credited for a suffix match it cannot serve as a prefix.
- **No wire change.** `layout_info` was already `{instance_id: (location, matched_tokens)}`; this fills it instead of truncating it. Its first entry is the same instance the old implementation credited for chunk 0, so callers that read only the first entry (e.g. production-stack's `kvaware` router) see unchanged behavior.

## Why now

This is the controller half of a cache- **and** load-aware routing policy; the router half is [vllm-project/production-stack#1035](https://github.com/vllm-project/production-stack/pull/1035). Measured on a 2×A10 cluster under a Zipfian shared-prefix workload (20 paired seeds per arm, exact Wilcoxon), that policy cuts load imbalance 48% vs `kvaware` (p < 0.0001) — and the fleet-wide benefit term it scores with is exactly what this lookup provides. Full methodology and per-seed data: <https://github.com/BenEpstein/caching-in-llms>.

## Tests

11 new tests in `tests/v1/cache_controller/test_multi_holder_lookup.py`, run against a **real** `RegistryTree` (registry- and controller-level): every holder reported with its own matched length, contiguity at a gap, the suffix-only-holder case, `exclude_instance_id`, first-entry compatibility with `find_kv`, and the miss/stop cases. The test conftest's mock registry gains a matching `find_kv_all` so the existing lookup tests keep passing unchanged.

`tests/v1/cache_controller/`: **223 passed** (212 before, +11). `ruff check`, `ruff format`, `isort`, `codespell`, and `mypy` (project config) are clean on the changed files.
