### PR TITLE
[good-first-issue] storage: convert f-string log calls in infinistore_adapter.py to %-format (#4402)

### DIFF
--- a/lmcache/v1/storage_backend/connector/infinistore_adapter.py
+++ b/lmcache/v1/storage_backend/connector/infinistore_adapter.py
@@ -24,7 +24,7 @@ class InfinistoreConnectorAdapter(ConnectorAdapter):
         # Local
         from .infinistore_connector import InfinistoreConnector
 
-        logger.info(f"Creating Infinistore connector for URL: {context.url}")
+        logger.info("Creating Infinistore connector for URL: %s", context.url)
         hosts = context.url.split(",")
         if len(hosts) > 1:
             raise ValueError(


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #4402
Refs #3372

Convert the `logger.info(f"...")` call in
`lmcache/v1/storage_backend/connector/infinistore_adapter.py` to lazy `%-format`
so the message is interpolated only when the log record is actually emitted
(ruff G004). No behavior change; format style only.

```diff
-        logger.info(f"Creating Infinistore connector for URL: {context.url}")
+        logger.info("Creating Infinistore connector for URL: %s", context.url)
```

**Special notes for your reviewers**:

- Same lazy-logging pattern as #4319 for `redis_adapter.py`; this is the only
  `logger.*` call in the file, so it completes the conversion here.
- `ruff check --select G004` flags the original line and passes after the change.
  Note `G` is currently commented out in the `[tool.ruff.lint] select` list in
  `pyproject.toml`, so this is not yet CI-enforced — happy to fold in enabling
  `G` repo-wide as a follow-up if maintainers want it.
- `ruff format --check`, `ruff check`, `isort --check-only` and `codespell` are
  all clean on the touched file.
- The two remaining f-strings in the file are `raise ValueError(...)` messages,
  which G004 does not cover; left unchanged.
- Commit includes DCO sign-off (`-s`).

@linear3735 commented `/claim` on #4402 on 2026-08-03 but the issue was never
assigned and no PR followed, so I picked it up per the 7-day guidance in #3372.
Happy to close this if they are still working on it.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

_Disclosure: written with AI assistance; the lint commands above were run locally
against `dev` @ 9fc6e1af._
