### PR TITLE
[good-first-issue] health_monitor: convert f-string log calls in base.py to %-format

### DIFF
--- a/lmcache/v1/health_monitor/base.py
+++ b/lmcache/v1/health_monitor/base.py
@@ -243,15 +243,16 @@ class HealthMonitor(PeriodicThread):
             try:
                 instances = cls.create(self._manager)
             except Exception as e:
-                logger.warning(f"Failed to create health check {cls.__name__}: {e}")
+                logger.warning("Failed to create health check %s: %s", cls.__name__, e)
                 continue
             for instance in instances:
                 self._health_checks.append(instance)
                 # Initialize previous status as healthy
                 self._previous_check_status[instance.name()] = True
                 logger.info(
-                    f"Registered health check: {instance.name()} "
-                    f"with fallback_policy: {instance.fallback_policy}"
+                    "Registered health check: %s with fallback_policy: %s",
+                    instance.name(),
+                    instance.fallback_policy,
                 )
 
     def get_health_checks(self) -> List[HealthCheck]:
@@ -323,8 +324,9 @@ class HealthMonitor(PeriodicThread):
         backend_name = check.get_bypass_backend_name()
         if backend_name is None:
             logger.warning(
-                f"Health check {check.name()} has LOCAL_CPU fallback but "
-                "get_bypass_backend_name() returned None"
+                "Health check %s has LOCAL_CPU fallback but "
+                "get_bypass_backend_name() returned None",
+                check.name(),
             )
             return
 
@@ -355,16 +357,17 @@ class HealthMonitor(PeriodicThread):
             if local_cpu is not None:
                 local_cpu.use_hot = True
                 logger.info(
-                    f"Enabled hot_cache for LocalCPUBackend due to "
-                    f"{check.name()} failure"
+                    "Enabled hot_cache for LocalCPUBackend due to %s failure",
+                    check.name(),
                 )
 
             # Record this backend as bypassed
             self._bypassed_backends[backend_name] = check.name()
 
             logger.info(
-                f"Applied LOCAL_CPU fallback for {check.name()}: "
-                f"bypassing {backend_name}"
+                "Applied LOCAL_CPU fallback for %s: bypassing %s",
+                check.name(),
+                backend_name,
             )
 
     def _recover_from_local_cpu_fallback(self, check: HealthCheck) -> None:
@@ -406,8 +409,9 @@ class HealthMonitor(PeriodicThread):
             del self._bypassed_backends[backend_name]
 
             logger.info(
-                f"Recovered from LOCAL_CPU fallback for {check.name()}: "
-                f"restored {backend_name}"
+                "Recovered from LOCAL_CPU fallback for %s: restored %s",
+                check.name(),
+                backend_name,
             )
 
             # Only restore hot_cache when ALL backends have recovered
@@ -418,8 +422,9 @@ class HealthMonitor(PeriodicThread):
                     # This prevents new data from being written during clear()
                     local_cpu.use_hot = self._original_hot_cache
                     logger.info(
-                        f"Restored hot_cache setting to {self._original_hot_cache} "
-                        f"for LocalCPUBackend (all backends restored)"
+                        "Restored hot_cache setting to %s "
+                        "for LocalCPUBackend (all backends restored)",
+                        self._original_hot_cache,
                     )
 
                     # Then, clear hot_cache if it was originally disabled
@@ -457,10 +462,12 @@ class HealthMonitor(PeriodicThread):
             try:
                 is_healthy = check.check()
             except IrrecoverableException:
-                logger.error(f"Health check {check_name} raised IrrecoverableException")
+                logger.error(
+                    "Health check %s raised IrrecoverableException", check_name
+                )
                 raise
             except Exception as e:
-                logger.error(f"Health check {check_name} raised exception: {e}")
+                logger.error("Health check %s raised exception: %s", check_name, e)
                 is_healthy = False
 
             # Update previous status
@@ -469,13 +476,13 @@ class HealthMonitor(PeriodicThread):
             if is_healthy:
                 # Check recovered
                 if not was_healthy:
-                    logger.info(f"Health check {check_name} recovered")
+                    logger.info("Health check %s recovered", check_name)
                     # If this check was using LOCAL_CPU fallback, recover
                     if check.fallback_policy == FallbackPolicy.LOCAL_CPU:
                         self._recover_from_local_cpu_fallback(check)
             else:
                 # Check failed
-                logger.warning(f"Health check failed: {check_name}")
+                logger.warning("Health check failed: %s", check_name)
 
                 if check.fallback_policy == FallbackPolicy.RECOMPUTE:
                     # RECOMPUTE policy: mark as unhealthy
@@ -516,9 +523,9 @@ class HealthMonitor(PeriodicThread):
         thread = super().start()
         if thread is not None:
             logger.info(
-                f"Started health monitor thread with "
-                f"{len(active_checks)} active checks, "
-                f"interval: {self._ping_interval}s"
+                "Started health monitor thread with %d active checks, interval: %ss",
+                len(active_checks),
+                self._ping_interval,
             )
         return thread
 
@@ -562,7 +569,7 @@ class HealthMonitor(PeriodicThread):
                 },
             )
         except IrrecoverableException as e:
-            logger.error(f"Irrecoverable error in health monitor: {e}")
+            logger.error("Irrecoverable error in health monitor: %s", e)
             self._set_healthy(False)
             # Re-raise to stop the thread
             raise


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3372

All 13 `logger.*` calls in `lmcache/v1/health_monitor/base.py` used f-strings, so each
message was formatted even when the record was filtered out. Convert them to lazy
`%-format` (ruff G004). No behavior change; format style only.

Continues the same cleanup as #4319 (`redis_adapter.py`), #4331 (`audit_connector.py`)
and #4477 (`infinistore_adapter.py`).

**Special notes for your reviewers**:

- `ruff check --select G004` on this file: **13 violations before, 0 after**.
- **Message text is unchanged.** Since this hand-edits 13 message strings, I verified
  it mechanically rather than by eye: I parsed the pre- and post-change file, replaced
  every f-string `{expr}` and every `%s`/`%d` placeholder with a sentinel, and diffed
  the resulting literals. All 13 match exactly.
- Placeholder count equals argument count for all 13 calls (checked via AST).
- Two calls needed care: one mixed an f-string with an adjacent plain string, and one
  carried an `f` prefix with no placeholders at all — both are now plain strings.
- `ruff format --check`, `ruff check`, `isort --check-only`, `codespell`: all clean.
- No test in the repo asserts on `record.msg`, so this does not require the test
  adjustment that #4331 needed.
- Commit includes DCO sign-off (`-s`).

There are ~400 more G004 hits elsewhere in `lmcache/v1/` (largest: `eic_connector.py`,
`bigtable_connector.py`, `sagemaker_hyperpod_connector.py`, `hf3fs_connector.py`).
Happy to keep going file-by-file if this shape is what you want — I'd rather confirm
the approach on one reviewable PR than open a pile of them at once.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

_Disclosure: written with AI assistance; all commands above were run locally against
`dev` @ 9fc6e1af._
