### PR TITLE
docs: daily drift check — multi-process mode (2026-08-10)

### DIFF
--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -94,9 +94,9 @@ A second set of env-only knobs controls the startup L2 resync —
 eviction loop.
 
 The coordinator drives fleet-wide L2 eviction by calling each MP
-server's ``DELETE /l2`` endpoint, and resync paginates ``GET /l2/keys``
-on a registered MP server. Both endpoints are documented at
-:ref:`mp-http-l2-keys-api`.
+server's ``DELETE /cache/objects`` endpoint, and resync paginates
+``GET /cache/objects`` on a registered MP server. Both endpoints are
+documented at :ref:`mp-http-l2-keys-api`.
 
 See :doc:`/mp/coordinator` for the coordinator's architecture, registration
 protocol, and HTTP API.

--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -62,7 +62,10 @@ Commonly used flags include:
    * - ``--eviction-ratio RATIO``
      - Fraction of L1 cleared per eviction cycle.
    * - ``--max-workers N``
-     - Number of server worker processes.
+     - Base number of worker **threads**; sets the default for both the GPU
+       affinity pool (STORE/RETRIEVE) and the CPU normal pool (LOOKUP, etc.).
+       Default ``1``. Override per-pool with ``--max-gpu-workers`` /
+       ``--max-cpu-workers``.
    * - ``--coordinator-url URL``
      - Register with an MP coordinator at this base URL (e.g.
        ``http://coordinator:9300``). Opt-in; enables fleet registration. See


### PR DESCRIPTION
## Summary

Daily docs drift check against `upstream/dev` at `9fc6e1a`, focused on
multi-process (MP) mode. Two doc-only inconsistencies found, both in
`docs/source/` (user-facing CLI reference pages). Nothing in
`docs/design/` was affected today.

**`docs/source/`**

- `docs/source/cli/coordinator.rst`: the "Configuration" section
  described the coordinator's fleet-wide L2 driver as calling
  `DELETE /l2` and paginating `GET /l2/keys`. Those endpoint paths do
  not exist in the MP server. The current endpoints are
  `DELETE /cache/objects` and `GET /cache/objects`.

- `docs/source/cli/server.rst`: the "Commonly used flags" table
  described `--max-workers N` as "Number of server worker processes."
  The MP server does not spawn worker processes for this flag — it
  sets the base worker **thread** count for the GPU affinity pool
  (STORE/RETRIEVE) and the CPU normal pool (LOOKUP, etc.), with
  per-pool overrides via `--max-gpu-workers` / `--max-cpu-workers`.

**`docs/design/`**

- No drift found today.

## Evidence

### `docs/source/cli/coordinator.rst` — stale endpoint paths

Stale doc (before this PR): [docs/source/cli/coordinator.rst L96-99 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/cli/coordinator.rst#L96-L99)

> The coordinator drives fleet-wide L2 eviction by calling each MP
> server's ``DELETE /l2`` endpoint, and resync paginates ``GET /l2/keys``
> on a registered MP server.

Actual endpoints (only `/cache/objects` is registered):
- [`lmcache/v1/multiprocess/http_apis/cache_api.py` L58 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/lmcache/v1/multiprocess/http_apis/cache_api.py#L58) — `@router.get("/cache/objects", ...)`
- [`lmcache/v1/multiprocess/http_apis/cache_api.py` L81 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/lmcache/v1/multiprocess/http_apis/cache_api.py#L81) — `@router.delete("/cache/objects", ...)`

The rest of the docs already refer to the current names (e.g.
[docs/source/mp/coordinator.rst L107-108](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/mp/coordinator.rst#L107-L108) and [L430](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/mp/coordinator.rst#L430),
[docs/source/mp/http_api.rst L660-693](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/mp/http_api.rst#L660-L693)) — the CLI page is the outlier.

The `:ref:` target `mp-http-l2-keys-api` still exists at
[docs/source/mp/http_api.rst L660](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/mp/http_api.rst#L660) and documents both endpoints under
their current `/cache/objects` names, so the anchor keeps working.

### `docs/source/cli/server.rst` — `--max-workers` mislabeled as processes

Stale doc (before this PR): [docs/source/cli/server.rst L64-65 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/cli/server.rst#L64-L65)

> ``--max-workers N`` — Number of server worker processes.

Actual behaviour (worker threads, base for both pools):

- [`lmcache/v1/multiprocess/config.py` L34-42 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/lmcache/v1/multiprocess/config.py#L34-L42):
  `max_workers: int = 1  # Base number of worker threads. Sets default for both GPU and CPU pools.`
  and `max_gpu_workers` / `max_cpu_workers` overrides.
- [`lmcache/v1/multiprocess/config.py` L276-296 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/lmcache/v1/multiprocess/config.py#L276-L296):
  argparse `--max-workers` help — "Base number of worker threads for
  both GPU and CPU pools. Default is 1. Can be overridden per-pool
  with --max-gpu-workers and --max-cpu-workers."
- [`lmcache/v1/multiprocess/affinity_pool.py` L6, L34](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/lmcache/v1/multiprocess/affinity_pool.py#L6-L35):
  "worker thread. Within each worker, tasks execute sequentially in FIFO order."
- [`docs/source/mp/configuration.rst` L40-52 @ dev@9fc6e1a](https://github.com/LMCache/LMCache/blob/9fc6e1afe83335a1c41b31662470fa115b2b6ac8/docs/source/mp/configuration.rst#L40-L52):
  the authoritative MP configuration reference already describes
  `--max-workers` / `--max-gpu-workers` / `--max-cpu-workers` as
  thread pool sizes.

## Proposed fix

Both fixes are applied in this PR's diff — the affected `docs/source/`
rows now match the code and the rest of the MP docs:

- `docs/source/cli/coordinator.rst`: update the Configuration paragraph
  to `DELETE /cache/objects` / `GET /cache/objects`; the
  `mp-http-l2-keys-api` reference is unchanged.
- `docs/source/cli/server.rst`: replace the `--max-workers` row with
  the thread-pool description, note the default (`1`), and point at
  the per-pool overrides.

No code changes; docs only.

## Notes

Auto-generated by the daily docs drift-check routine. **Human review
required before merge.** Deduplicated against prior open drift-check
PRs (#4462, #4455, #4435, #4421, #4401, #4378, #4361, #4304, …); the
two findings here are new and not overlapping with any of them.

---
_Generated by [Claude Code](https://claude.ai/code/session_018oBgM67Noi9pmqUN1PXxuW)_