### PR TITLE
ci(rocm): tag the ROCm wheel with a +rocm7.2 local version

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -15,6 +15,14 @@ name: Build ROCm Artifacts
 
 on:
     workflow_call:
+        outputs:
+            rocm_version:
+                description: >-
+                    Full wheel version including the ROCm local segment
+                    (e.g. 0.5.3+rocm7.2). Consume this rather than
+                    reconstructing the version, so the local segment has a
+                    single source of truth.
+                value: ${{ jobs.build-rocm-artifacts.outputs.rocm_version }}
 
 env:
     LC_ALL: en_US.UTF-8
@@ -29,6 +37,12 @@ env:
     TORCH_ROCM_SPEC: torch==2.11.0+rocm7.2
     TORCH_ROCM_INDEX: https://download.pytorch.org/whl/rocm7.2
     PYTORCH_ROCM_ARCH: gfx942;gfx950
+    # PEP 440 local version appended to the wheel, matching how PyTorch tags its
+    # own ROCm builds (torch-2.11.0+rocm7.2). Without it the ROCm wheel is
+    # indistinguishable from the CUDA wheel on PyPI: same name, same version,
+    # same interpreter tag, differing only in the manylinux minor. Bump together
+    # with TORCH_ROCM_SPEC/TORCH_ROCM_INDEX above.
+    ROCM_LOCAL_VERSION: rocm7.2
 
 defaults:
     run:
@@ -41,6 +55,8 @@ jobs:
     build-rocm-artifacts:
         name: Build ROCm wheel (gfx942, gfx950)
         runs-on: ubuntu-latest
+        outputs:
+            rocm_version: ${{ steps.rocm-version.outputs.rocm_version }}
         steps:
             - name: "Harden Runner"
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
@@ -74,13 +90,15 @@ jobs:
               uses: ./.github/actions/free-disk-space
 
             - name: Get base version for rocm wheel
+              id: rocm-version
               run: |
                 if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
                   BASE="${GITHUB_REF_NAME#v}"
                 else
                   BASE=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 | sed 's/^v//' || echo "0.0.0.dev")
                 fi
-                echo "ROCM_VERSION=${BASE}" >> "$GITHUB_ENV"
+                echo "ROCM_VERSION=${BASE}+${ROCM_LOCAL_VERSION}" >> "$GITHUB_ENV"
+                echo "rocm_version=${BASE}+${ROCM_LOCAL_VERSION}" >> "$GITHUB_OUTPUT"
 
             # Build inside the ROCm dev image. No GPU is needed to compile HIP
             # kernels; PYTORCH_ROCM_ARCH bakes gfx942+gfx950 code objects into

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -380,7 +380,7 @@ jobs:
                   Install into an upstream vLLM ROCm container:
                   \`\`\`
                   VERSION=${{ github.ref_name }}
-                  pip install lmcache==\${VERSION#v} --no-deps \\
+                  pip install lmcache==${{ needs.build-rocm.outputs.rocm_version }} --no-deps \\
                     --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/\${VERSION}-rocm
                   \`\`\`" \
                     dist/*.whl

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -78,7 +78,7 @@ Install LMCache
                                 --entrypoint bash vllm/vllm-openai-rocm:v0.25.0
 
                             VERSION=0.5.3  # replace with target release
-                            pip install lmcache==${VERSION} --no-deps \
+                            pip install lmcache==${VERSION}+rocm7.2 --no-deps \
                                 --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VERSION}-rocm
 
                         .. note::
@@ -86,6 +86,13 @@ Install LMCache
                             The wheel excludes torch and the ROCm runtime libraries (they bind to the
                             host image at runtime). Match the wheel's minor torch/ROCm version to your
                             container; for other bases, use the **From Source** tab.
+
+                        .. note::
+
+                            The ROCm wheel carries a ``+rocm7.2`` PEP 440 local version, so
+                            ``pip show lmcache`` reports which build is installed and the ROCm
+                            build can be requested explicitly. A bare ``lmcache==${VERSION}``
+                            also resolves it, since ``==`` ignores the local segment.
 
             .. tab-item:: Nightly
 


### PR DESCRIPTION
## Why

`build_rocm_artifacts.yml` states in its own header that the ROCm wheel "carries a `+rocm7.2` local version". The build never applied one. The published asset on `v0.5.3-rocm` is:

```
lmcache-0.5.3-cp312-cp312-manylinux_2_35_x86_64.whl
```

versus the CUDA wheel on PyPI:

```
lmcache-0.5.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
```

Same distribution name, same version, same interpreter tag, differing only in the manylinux minor. Nothing in the artifact identifies it as a ROCm build, so an installed wheel can't be told apart after the fact and the ROCm build can't be pinned explicitly. My fault — I wrote that flow in #4273.

This applies the local version the comment already promises, matching how PyTorch tags its own ROCm builds (`torch-2.11.0+rocm7.2`).

**What this does not do:** it doesn't change which wheel a resolver prefers. `0.5.3+rocm7.2` sorts *above* `0.5.3`, so where both are visible the ROCm wheel already won. The win is that `pip show lmcache` reports the build in use, and that the ROCm wheel can be pinned as `lmcache==0.5.3+rocm7.2`.

Existing instructions keep working — a bare `==0.5.3` matches a local version under PEP 440, so nothing that pins the plain version breaks.

## What

- `build_rocm_artifacts.yml`: add `ROCM_LOCAL_VERSION: rocm7.2` beside the existing ABI pins and apply it to the wheel version.
- Expose the resolved version as a `workflow_call` output, and consume it in the release notes in `publish.yml` rather than repeating the literal. A comment drifting from behaviour is what hid this in the first place; copying the string into a second workflow would set up the same failure.
- `installation.rst`: pin explicitly and note what the local version buys.

## Testing

Ran the real build script in `rocm/dev-ubuntu-22.04:7.2.3-complete` on MI300X, same command CI issues:

```
dist/lmcache-0.5.3+rocm7.2-cp312-cp312-manylinux_2_35_x86_64.whl
```

Installed into the upstream image (`vllm/vllm-openai-rocm:v0.26.0`, torch 2.11.0, ROCm 7.2.3, cp312):

| check | result |
|---|---|
| `pip install ... --no-deps` | clean |
| `pip show lmcache` | `Version: 0.5.3+rocm7.2` |
| `import lmcache` | OK |
| `llvm-objdump --offloading` on `c_ops*.so` | `gfx942`, `gfx950` |

Arch code objects are unchanged, so the version change doesn't disturb the fat binary.

Version resolution checked both ways: non-tag builds produce `0.5.3+rocm7.2`, tag builds `0.5.4+rocm7.2`.

Follow-up: a rolling `nightly-rocm` release (the actual parity gap raised in #4029) is next, and wants this landed first so nightly artifacts aren't ambiguous too.
