### PR TITLE
ci(rocm): publish a rolling nightly-rocm wheel release

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -15,6 +15,17 @@ name: Build ROCm Artifacts
 
 on:
     workflow_call:
+        inputs:
+            dev_version:
+                description: >-
+                    Build a .devN pre-release instead of the current release
+                    version. Mirrors setuptools_scm guess-next-dev, so nightly
+                    ROCm wheels are versioned like the cu130/cu129 nightlies
+                    (e.g. 0.5.4.dev15+rocm7.2) and never collide with a
+                    published release.
+                type: boolean
+                default: false
+                required: false
         outputs:
             rocm_version:
                 description: >-
@@ -91,11 +102,22 @@ jobs:
 
             - name: Get base version for rocm wheel
               id: rocm-version
+              env:
+                DEV_VERSION: ${{ inputs.dev_version }}
               run: |
+                LATEST_TAG=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
                 if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
                   BASE="${GITHUB_REF_NAME#v}"
+                elif [[ "${DEV_VERSION}" == "true" && -n "${LATEST_TAG}" ]]; then
+                  # guess-next-dev, matching setuptools_scm and therefore the
+                  # cu130/cu129 nightlies: bump the patch of the newest release
+                  # and append the commit count since that tag.
+                  COMMITS=$(git rev-list --count "${LATEST_TAG}..HEAD")
+                  IFS=. read -r MAJOR MINOR PATCH <<< "${LATEST_TAG#v}"
+                  BASE="${MAJOR}.${MINOR}.$((PATCH + 1)).dev${COMMITS}"
                 else
-                  BASE=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 | sed 's/^v//' || echo "0.0.0.dev")
+                  BASE="${LATEST_TAG#v}"
+                  BASE="${BASE:-0.0.0.dev}"
                 fi
                 echo "ROCM_VERSION=${BASE}+${ROCM_LOCAL_VERSION}" >> "$GITHUB_ENV"
                 echo "rocm_version=${BASE}+${ROCM_LOCAL_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -113,6 +113,59 @@ jobs:
             --prerelease \
             dist/cu129/*.whl
 
+  # ROCm nightly. Unlike the CUDA wheels above (cibuildwheel on the runner), the
+  # ROCm wheel compiles HIP kernels inside the ROCm dev image, so it reuses the
+  # same reusable workflow the release pipeline calls. dev_version keeps it
+  # versioned like the CUDA nightlies (0.5.4.devN+rocm7.2) so a nightly can
+  # never be mistaken for a release.
+  nightly-rocm-wheel:
+    name: Build ROCm nightly wheel
+    uses: ./.github/workflows/build_rocm_artifacts.yml
+    with:
+      dev_version: true
+    secrets: inherit
+
+  publish-nightly-rocm:
+    name: Publish ROCm nightly wheel
+    runs-on: ubuntu-latest
+    needs: nightly-rocm-wheel
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          disable-sudo-and-containers: false
+          egress-policy: audit
+
+      - name: Fetch ROCm nightly artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: release-rocm-artifacts
+          path: dist/rocm
+
+      - name: Publish ROCm wheels to rolling nightly-rocm release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ROCM_VERSION: ${{ needs.nightly-rocm-wheel.outputs.rocm_version }}
+        run: |
+          gh release delete nightly-rocm --yes --cleanup-tag --repo ${{ github.repository }} 2>/dev/null || true
+          gh release create nightly-rocm \
+            --repo ${{ github.repository }} \
+            --title "Nightly $(date +'%Y-%m-%d') · ROCm 7.2 (gfx942, gfx950)" \
+            --notes "Nightly ROCm 7.2 wheels built from \`dev\` on $(date +'%Y-%m-%d'),
+          for AMD Instinct gfx942 (MI300X/MI325X) and gfx950 (MI350X/MI355X),
+          ABI-matched to the upstream \`vllm/vllm-openai-rocm\` image
+          (torch 2.11, cp312).
+
+          Install into an upstream vLLM ROCm container:
+          \`\`\`
+          pip install lmcache==${ROCM_VERSION} --no-deps \\
+            --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/nightly-rocm
+          \`\`\`" \
+            --prerelease \
+            dist/rocm/*.whl
+
   nightly-build:
     name: Build image
     runs-on: ubuntu-latest

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -124,6 +124,23 @@ Install LMCache
                                 --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-cu129 \
                                 --index-strategy unsafe-best-match
 
+                    .. tab-item:: ROCm 7.2
+
+                        Run inside an upstream vLLM ROCm container so torch and the ROCm
+                        runtime are already present, then install with ``--no-deps``:
+
+                        .. code-block:: bash
+
+                            docker run -it --device /dev/kfd --device /dev/dri \
+                                --group-add video --security-opt seccomp=unconfined \
+                                --entrypoint bash vllm/vllm-openai-rocm:v0.26.0
+
+                            pip install lmcache --pre --no-deps \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-rocm
+
+                        Nightly ROCm wheels are versioned like the CUDA nightlies with the
+                        ROCm local segment appended, e.g. ``0.5.4.dev15+rocm7.2``.
+
             .. tab-item:: From Source
 
                 ``--no-build-isolation`` ensures the kernels are compiled against the same torch

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -135,11 +135,22 @@ Install LMCache
                                 --group-add video --security-opt seccomp=unconfined \
                                 --entrypoint bash vllm/vllm-openai-rocm:v0.26.0
 
-                            pip install lmcache --pre --no-deps \
+                            pip install lmcache --pre --no-deps --no-index \
                                 --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-rocm
 
                         Nightly ROCm wheels are versioned like the CUDA nightlies with the
                         ROCm local segment appended, e.g. ``0.5.4.dev15+rocm7.2``.
+
+                        .. note::
+
+                            ``--no-index`` is required here. ``--find-links`` only *adds* a
+                            source, so without it pip also considers PyPI — and under PEP 440 a
+                            pre-release such as ``0.5.4rc4`` outranks ``0.5.4.dev15+rocm7.2``, so
+                            ``--pre`` would install the CUDA wheel instead. The stable tab does
+                            not need it because ``lmcache==${VERSION}+rocm7.2`` is an exact pin
+                            that only the ROCm release can satisfy. ``--no-deps`` is what makes
+                            ``--no-index`` safe here: torch and the ROCm runtime come from the
+                            container, so nothing else needs resolving.
 
             .. tab-item:: From Source
 


### PR DESCRIPTION
## Why

`nightly_build.yml` publishes rolling `nightly` (cu13.0) and `nightly-cu129` releases. There is no ROCm equivalent, so ROCm users can't test against `dev` without building from source. That's the parity gap raised in #4029 — and unlike PyPI publication, this one is actually fixable.

Rebased onto `dev` now that #4481 has landed, so ROCm nightlies inherit the `+rocm7.2` local version and are distinguishable from the CUDA nightlies on sight.

## What

- `nightly-rocm-wheel` job calling the existing `build_rocm_artifacts.yml` reusable workflow, so nightly and release wheels are built by exactly the same path.
- `publish-nightly-rocm` job creating a rolling `nightly-rocm` release, mirroring the `nightly-cu129` pattern.
- Docs: a ROCm tab under Nightly.

### The versioning wrinkle

On non-tag refs the reusable workflow pretends to be the newest release tag. A nightly built from `dev` would therefore have been versioned `0.5.3` — colliding with the published release, and sorting as though it *were* that release.

So this adds an opt-in `dev_version` input that reproduces setuptools_scm's guess-next-dev: bump the patch of the newest tag, append the commit count. That's what the CUDA nightlies already get from cibuildwheel, so ROCm nightlies end up versioned consistently with them.

The input defaults to `false`, so the release pipeline is untouched.

## Testing

Version resolution, extracted programmatically from the workflow rather than retyped:

| ref | `dev_version` | result |
|---|---|---|
| tag `v0.5.4` | false | `0.5.4+rocm7.2` |
| `dev` | **true** | `0.5.4.dev43+rocm7.2` |
| `dev` | false | `0.5.3+rocm7.2` (unchanged) |

Cross-checked against the CUDA nightly published today, `lmcache-0.5.4.dev40-cp310-...whl` — same guess-next-dev computation, the difference being commits landed on `dev` since that build ran.

PEP 440 semantics confirmed: `0.5.4.dev43+rocm7.2` is a pre-release (so `--pre` is required, matching the CUDA nightly instructions), sorts above `0.5.3`, and below the eventual `0.5.4`.

The wheel build itself is unchanged from #4481, where I verified on MI300X that the produced wheel installs into `vllm/vllm-openai-rocm:v0.26.0` and retains gfx942 + gfx950 code objects.

## Note for reviewers

The cu13.0 and cu12.9 nightly wheels currently have *identical* filenames (`lmcache-0.5.4.dev40-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl` in both releases), so they're indistinguishable once downloaded — the same class of problem #4481 fixed for ROCm. Out of scope here; happy to follow up separately, as discussed on #4446.
