### PR TITLE
[Bug][S3] propagate connector errors off CRT threads and trip breaker on HTTP failures

### DIFF
--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -21,6 +21,13 @@ from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 
+# HTTP statuses that mark a request as permanently rejected rather than
+# transiently failed: the request is refused for what it is, so retrying it
+# for every subsequent chunk hits the same wall. They therefore count toward
+# the connection circuit breaker. 404 is deliberately excluded: it is an
+# expected cache miss, not a broken connection.
+NON_RETRYABLE_STATUS_CODES = frozenset({400, 401, 403})
+
 
 class Priorities(IntEnum):
     PEEK = auto()
@@ -298,9 +305,15 @@ class S3Connector(RemoteConnector):
         self,
         key_str: str,
         mem_obj: MemoryObj,
-    ) -> "s3.S3Request":
+    ) -> tuple["s3.S3Request", dict]:
         """
         Download a file from S3.
+
+        Returns:
+            The in-flight request and the dict its completion callback
+            records into. The dict holds the aws-crt error under "err" and
+            the HTTP status under "status", and is only meaningful once
+            `finished_future` has resolved.
         """
         headers = HttpHeaders()
         headers.add("Host", self.s3_endpoint)
@@ -315,14 +328,17 @@ class S3Connector(RemoteConnector):
             # Directly write chunk to the memory object at the correct offset
             self._write_mem_obj(mem_obj, chunk, offset)
 
+        done = {"err": None, "status": None}
+
         # NOTE(Jiayi): Run in crt threads (not this thread) with GIL
         # See https://github.com/awslabs/aws-crt-python/blob/4250709624119de1af3ca86816e1a154fcac7cc8/source/common.c#L51
+        # Only record here: aws-crt resolves `finished_future` before running
+        # this callback, so raising would not reach the awaiting coroutine.
+        # The caller inspects `done` after the await instead, the same way
+        # `_get_object_size` inspects `got`.
         def on_done(error=None, status_code=None, **kwargs):
-            ok = (status_code in (200, 206)) or (status_code is None)
-            if error or not ok:
-                raise RuntimeError(
-                    f"Failed to download {key_str} from S3: {error or status_code}"
-                )
+            done["err"] = error
+            done["status"] = status_code
 
         # TODO(Jiayi): Need to support offset to enable zero-copy
         # More concretely, we need to get the shared memory offset.
@@ -336,7 +352,27 @@ class S3Connector(RemoteConnector):
             on_done=on_done,
         )
 
-        return s3_req
+        return s3_req, done
+
+    @staticmethod
+    def _download_error(key_str: str, done: dict) -> Optional[str]:
+        """
+        Check a completed download for failure.
+
+        Args:
+            key_str: The key that was downloaded, used in the message.
+            done: The dict recorded by `_s3_download`'s completion callback,
+                holding the aws-crt error under "err" and the HTTP status
+                under "status".
+
+        Returns:
+            An error message if the download failed, None otherwise.
+        """
+        status_code = done["status"]
+        ok = (status_code in (200, 206)) or (status_code is None)
+        if done["err"] or not ok:
+            return f"Failed to download {key_str} from S3: {done['err'] or status_code}"
+        return None
 
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         # Circuit breaker: if connection is disabled, return None immediately
@@ -380,7 +416,7 @@ class S3Connector(RemoteConnector):
             memory_obj.ref_count_down()
             return None
 
-        s3_req = self._s3_download(
+        s3_req, done = self._s3_download(
             key_str=key_str,
             mem_obj=memory_obj,
         )
@@ -389,15 +425,22 @@ class S3Connector(RemoteConnector):
             # use blocking_timeout_sec in config to control the timeout
             await asyncio.wrap_future(s3_req.finished_future)
 
+            download_error = self._download_error(key_str, done)
+            if download_error is not None:
+                raise RuntimeError(download_error)
+
             # Reset failure counter on success
             self._reset_connection_failures()
 
             return memory_obj
         except Exception as e:
             error_msg = str(e)
+            status_code = self._failed_status_code(e, done)
 
             # Update connection failures and check if it's a connection error
-            is_connection_error = self._update_connection_failures(error_msg)
+            is_connection_error = self._update_connection_failures(
+                error_msg, status_code
+            )
 
             if not is_connection_error:
                 # Log non-connection errors
@@ -419,6 +462,7 @@ class S3Connector(RemoteConnector):
 
         memory_objs: List[Optional[MemoryObj]] = []
         futures = []
+        dones = []
         future_to_memobj_idx = []
 
         for idx, key in enumerate(keys):
@@ -460,12 +504,13 @@ class S3Connector(RemoteConnector):
 
             memory_objs.append(memory_obj)
 
-            s3_req = self._s3_download(
+            s3_req, done = self._s3_download(
                 key_str=key_str,
                 mem_obj=memory_obj,
             )
             fut = asyncio.wrap_future(s3_req.finished_future)
             futures.append(fut)
+            dones.append(done)
             future_to_memobj_idx.append(len(memory_objs) - 1)
 
         # Use return_exceptions to prevent one failure from stopping all downloads
@@ -475,11 +520,22 @@ class S3Connector(RemoteConnector):
 
         for future_idx, result in enumerate(results):
             memobj_idx = future_to_memobj_idx[future_idx]
+            done = dones[future_idx]
+            key_str = keys[memobj_idx].to_string()
 
+            # A request that aws-crt did not fail may still have completed
+            # with an error status; its completion callback only records.
             if isinstance(result, Exception):
-                error_msg = str(result)
+                error_msg: Optional[str] = str(result)
+                status_code = self._failed_status_code(result, done)
+            else:
+                error_msg = self._download_error(key_str, done)
+                status_code = done["status"]
 
-                is_connection_error = self._update_connection_failures(error_msg)
+            if error_msg is not None:
+                is_connection_error = self._update_connection_failures(
+                    error_msg, status_code
+                )
 
                 if not is_connection_error:
                     # Log non-connection errors
@@ -505,9 +561,15 @@ class S3Connector(RemoteConnector):
         self,
         key_str: str,
         memory_obj: MemoryObj,
-    ) -> "s3.S3Request":
+    ) -> tuple["s3.S3Request", dict]:
         """
         Upload a file to S3.
+
+        Returns:
+            The in-flight request and the dict its completion callback
+            records into. The dict holds the aws-crt error under "err" and
+            the HTTP status under "status", and is only meaningful once
+            `finished_future` has resolved.
         """
         # Zero-copy approach using MemoryViewStream
         stream = MemoryViewStream(memory_obj.byte_array)
@@ -525,12 +587,11 @@ class S3Connector(RemoteConnector):
 
         done = {"err": None, "status": None}
 
+        # Runs in crt threads, like `_s3_download`'s callback: only record
+        # here, the caller inspects `done` after awaiting the request.
         def on_done(error=None, status_code=None, **kwargs):
             done["err"] = error
             done["status"] = status_code
-
-            if done["err"] or done["status"] not in (200, 201):
-                raise RuntimeError(f"Upload failed in S3Connector: {done}")
 
         s3_req = s3.S3Request(
             client=self.s3_client,
@@ -540,7 +601,7 @@ class S3Connector(RemoteConnector):
             region=self.s3_region,
             on_done=on_done,
         )
-        return s3_req
+        return s3_req, done
 
     async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):
         """
@@ -569,10 +630,16 @@ class S3Connector(RemoteConnector):
             )
             return
 
+        # Recorded by the upload's completion callback, see `_s3_upload`.
+        done: dict = {"err": None, "status": None}
+
         try:
             logger.debug("Uploading %s to S3", key_str)
-            s3_req = self._s3_upload(key_str, memory_obj)
+            s3_req, done = self._s3_upload(key_str, memory_obj)
             await asyncio.wrap_future(s3_req.finished_future)
+
+            if done["err"] or done["status"] not in (200, 201):
+                raise RuntimeError(f"Upload failed in S3Connector: {done}")
 
             self.object_size_cache[key_str] = memory_obj.get_physical_size()
             logger.debug("Uploaded %s to S3 successfully", key_str)
@@ -581,9 +648,12 @@ class S3Connector(RemoteConnector):
             self._reset_connection_failures()
         except Exception as e:
             error_msg = str(e)
+            status_code = self._failed_status_code(e, done)
 
             # Update connection failures and check if it's a connection error
-            is_connection_error = self._update_connection_failures(error_msg)
+            is_connection_error = self._update_connection_failures(
+                error_msg, status_code
+            )
 
             if not is_connection_error:
                 # Log non-connection errors
@@ -674,7 +744,42 @@ class S3Connector(RemoteConnector):
     def support_batched_get(self) -> bool:
         return True
 
-    def _update_connection_failures(self, error_msg: str) -> bool:
+    @staticmethod
+    def _failed_status_code(error: Exception, done: dict) -> Optional[int]:
+        """
+        Recover the HTTP status a failed operation completed with.
+
+        Args:
+            error: The exception the operation failed with.
+            done: The dict recorded by the operation's completion callback,
+                holding the HTTP status under "status".
+
+        Returns:
+            The HTTP status if one is known, None otherwise.
+        """
+        # aws-crt carries the status on the `S3ResponseError` it raises; what
+        # the callback recorded is the fallback for locally raised failures.
+        status_code = getattr(error, "status_code", None)
+        if status_code is None:
+            status_code = done["status"]
+        return status_code
+
+    def _update_connection_failures(
+        self, error_msg: str, status_code: Optional[int] = None
+    ) -> bool:
+        """
+        Count a failed operation against the circuit breaker.
+
+        Args:
+            error_msg: The error message the operation failed with.
+            status_code: The HTTP status the operation completed with, if
+                one is known.
+
+        Returns:
+            True if the failure was a connection-level error, False
+            otherwise. A False return does not mean the failure was ignored:
+            a non-retryable HTTP status counts toward the breaker too.
+        """
         # Check if it's a connection error
         is_connection_error = (
             "CONNECTION_REFUSED" in error_msg
@@ -682,15 +787,25 @@ class S3Connector(RemoteConnector):
             or "DNS" in error_msg
             or "TIMEOUT" in error_msg
         )
+        is_non_retryable_status = status_code in NON_RETRYABLE_STATUS_CODES
 
-        if is_connection_error:
+        if is_connection_error or is_non_retryable_status:
             self.connection_failures += 1
-            logger.error(
-                "S3 connection error (%s/%s): %s",
-                self.connection_failures,
-                self.max_connection_failures,
-                error_msg,
-            )
+            if is_connection_error:
+                logger.error(
+                    "S3 connection error (%s/%s): %s",
+                    self.connection_failures,
+                    self.max_connection_failures,
+                    error_msg,
+                )
+            else:
+                logger.error(
+                    "S3 request rejected with non-retryable status %s (%s/%s): %s",
+                    status_code,
+                    self.connection_failures,
+                    self.max_connection_failures,
+                    error_msg,
+                )
 
             if self.connection_failures >= self.max_connection_failures:
                 self.connection_disabled = True

--- a/tests/v1/storage_backend/test_s3_connector.py
+++ b/tests/v1/storage_backend/test_s3_connector.py
@@ -1,0 +1,438 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the native S3 connector's error handling.
+
+``awscrt`` is a real LMCache dependency, so only the ``s3.S3Request``
+boundary is stubbed here.  The stub reproduces the two properties of the
+real completion path that these tests are about (see
+``awscrt.s3._S3RequestCore._on_finish``):
+
+1. ``finished_future`` is resolved *before* ``on_done`` is invoked, so an
+   exception raised by ``on_done`` can never reach the awaiting coroutine.
+2. ``on_done`` runs on an aws-crt thread, not on the event loop, so such an
+   exception is handed to the unraisable hook and printed as
+   ``Exception ignored in: <awscrt.s3._S3RequestCore object at 0x...>``.
+
+Driving that boundary needs no S3 endpoint, no credentials, no GPU and no
+network.
+"""
+
+# Standard
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+import asyncio
+import threading
+
+# Third Party
+from awscrt import s3
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import CacheEngineKey, start_loop_in_thread_with_exceptions
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.connector.s3_connector import S3Connector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+
+@dataclass
+class Completion:
+    """One scripted aws-crt completion for a stubbed ``s3.S3Request``.
+
+    Attributes:
+        status_code: HTTP status handed to ``on_done`` (and to ``on_headers``
+            for HEAD requests). ``None`` models the "unknown status" that
+            aws-crt reports when the C layer gives status 0.
+        error: Exception aws-crt would set on ``finished_future``. ``None``
+            models a request that aws-crt considers successful, whatever the
+            HTTP status is.
+        content_length: Value of the ``Content-Length`` response header,
+            reported through ``on_headers``. Only used by HEAD requests.
+        body: Response body delivered through ``on_body``. Only used by GET
+            requests.
+    """
+
+    status_code: Optional[int] = 200
+    error: Optional[Exception] = None
+    content_length: Optional[int] = None
+    body: bytes = b""
+
+
+class StubS3Request:
+    """Stand-in for a single in-flight ``s3.S3Request``.
+
+    The request completes immediately, on a separate thread, the way aws-crt
+    completes one on its own IO threads.
+    """
+
+    def __init__(self, kwargs: dict[str, Any], completion: Completion) -> None:
+        """Record the request and complete it with the scripted outcome.
+
+        Args:
+            kwargs: Keyword arguments the connector passed to ``s3.S3Request``.
+            completion: The outcome to deliver to the connector's callbacks.
+        """
+        self.kwargs = kwargs
+        self.completion = completion
+        self.finished_future: Future = Future()
+        # Exception raised by ``on_done``, which aws-crt swallows.
+        self.callback_error: Optional[Exception] = None
+
+        thread = threading.Thread(target=self._complete, name="stub-aws-crt")
+        thread.start()
+        thread.join()
+
+    def _complete(self) -> None:
+        """Deliver headers, body and completion, in aws-crt's order."""
+        completion = self.completion
+
+        on_headers = self.kwargs.get("on_headers")
+        if on_headers is not None:
+            headers = []
+            if completion.content_length is not None:
+                headers.append(("Content-Length", str(completion.content_length)))
+            on_headers(completion.status_code, headers)
+
+        on_body = self.kwargs.get("on_body")
+        if on_body is not None and completion.body:
+            on_body(completion.body, 0)
+
+        # The future is resolved before ``on_done`` runs, exactly as
+        # ``_S3RequestCore._on_finish`` does it.
+        if completion.error is not None:
+            self.finished_future.set_exception(completion.error)
+        else:
+            self.finished_future.set_result(None)
+
+        on_done = self.kwargs.get("on_done")
+        if on_done is not None:
+            try:
+                on_done(error=completion.error, status_code=completion.status_code)
+            except Exception as exc:
+                # aws-crt cannot propagate this: the future is already
+                # resolved and this is not the event loop thread. Record it
+                # so tests can assert the connector does not rely on it.
+                self.callback_error = exc
+
+
+@dataclass
+class StubS3RequestFactory:
+    """Replacement for ``s3.S3Request`` that completes every request at once.
+
+    Completions are scripted per ``s3.S3RequestType``. When several are
+    scripted for a type they are consumed in order and the last one stays in
+    effect for any further request of that type. Unscripted types get a
+    successful completion.
+
+    Attributes:
+        completions: Scripted completions, keyed by request type.
+        requests: Every request the connector has constructed, in order.
+    """
+
+    completions: dict[Any, List[Completion]] = field(default_factory=dict)
+    requests: List[StubS3Request] = field(default_factory=list)
+
+    def script(self, request_type: Any, *completions: Completion) -> None:
+        """Queue completions for a request type.
+
+        Args:
+            request_type: The ``s3.S3RequestType`` to script.
+            completions: Completions to deliver, in order.
+        """
+        self.completions.setdefault(request_type, []).extend(completions)
+
+    def of_type(self, request_type: Any) -> List[StubS3Request]:
+        """Return the recorded requests of one type.
+
+        Args:
+            request_type: The ``s3.S3RequestType`` to filter on.
+
+        Returns:
+            The matching requests, in construction order.
+        """
+        return [r for r in self.requests if r.kwargs.get("type") is request_type]
+
+    @property
+    def callback_errors(self) -> List[Exception]:
+        """Return the exceptions raised by ``on_done`` callbacks."""
+        return [r.callback_error for r in self.requests if r.callback_error is not None]
+
+    def __call__(self, **kwargs: Any) -> StubS3Request:
+        """Construct and immediately complete a stubbed request.
+
+        Args:
+            kwargs: The keyword arguments the connector passes through.
+
+        Returns:
+            The completed stub request.
+        """
+        queued = self.completions.get(kwargs.get("type"), [])
+        if len(queued) > 1:
+            completion = queued.pop(0)
+        elif queued:
+            completion = queued[0]
+        else:
+            completion = Completion()
+
+        request = StubS3Request(kwargs, completion)
+        self.requests.append(request)
+        return request
+
+
+def create_test_metadata(kv_shape=(1, 2, 16, 8, 128), chunk_size=16) -> LMCacheMetadata:
+    """Build metadata for a small CPU-only chunk layout."""
+    return LMCacheMetadata(
+        model_name="test_model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.bfloat16,
+        kv_shape=kv_shape,
+        chunk_size=chunk_size,
+    )
+
+
+def create_test_key(key_id: int = 0) -> CacheEngineKey:
+    """Build a cache key that is unique per ``key_id``."""
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+    )
+
+
+@pytest.fixture
+def async_loop():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(
+        target=start_loop_in_thread_with_exceptions,
+        args=(loop,),
+        name="test-s3-loop",
+    )
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def local_cpu_backend(memory_allocator):
+    config = LMCacheEngineConfig.from_legacy(chunk_size=16)
+    metadata = create_test_metadata()
+    return LocalCPUBackend(config, metadata, memory_allocator=memory_allocator)
+
+
+@pytest.fixture
+def stub_s3_request(monkeypatch):
+    """Replace ``s3.S3Request`` for the duration of one test."""
+    factory = StubS3RequestFactory()
+    monkeypatch.setattr(s3, "S3Request", factory)
+    return factory
+
+
+@pytest.fixture
+def connector(async_loop, local_cpu_backend, stub_s3_request):
+    conn = S3Connector(
+        s3_endpoint="s3://test-bucket.s3.example.com",
+        loop=async_loop,
+        local_cpu_backend=local_cpu_backend,
+        s3_num_io_threads=1,
+        s3_prefer_http2=False,
+        s3_region="us-east-1",
+        s3_enable_s3express=False,
+        disable_tls=True,
+        aws_access_key_id="test-access-key-id",
+        aws_secret_access_key="test-secret-access-key",
+    )
+    yield conn
+    # Drain the job executor on the loop before the loop is stopped, so its
+    # workers are not left pending.
+    run(async_loop, conn.pq_executor.shutdown_async(wait=True))
+
+
+def run(loop, coro):
+    """Run a coroutine on the connector's loop and wait for it."""
+    return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=10.0)
+
+
+def allocate_chunk(connector, local_cpu_backend) -> MemoryObj:
+    """Allocate one full chunk, the same way ``get`` does."""
+    memory_obj = local_cpu_backend.allocate(
+        connector.meta_shapes,
+        connector.meta_dtypes,
+        connector.meta_fmt,
+    )
+    assert memory_obj is not None
+    return memory_obj
+
+
+def script_head_hit(stub_s3_request, connector) -> None:
+    """Script a HEAD response advertising one full chunk."""
+    stub_s3_request.script(
+        s3.S3RequestType.DEFAULT,
+        Completion(status_code=200, content_length=connector.full_chunk_size_bytes),
+    )
+
+
+class TestErrorPropagation:
+    """Failures reported by aws-crt must reach the awaiting coroutine."""
+
+    def test_put_http_error_is_not_swallowed(
+        self, connector, async_loop, local_cpu_backend, stub_s3_request
+    ):
+        stub_s3_request.script(s3.S3RequestType.PUT_OBJECT, Completion(status_code=400))
+        key = create_test_key(1)
+        memory_obj = allocate_chunk(connector, local_cpu_backend)
+
+        run(async_loop, connector.put(key, memory_obj))
+
+        # Raising from the completion callback is a no-op, so the connector
+        # must not depend on it.
+        assert stub_s3_request.callback_errors == []
+        # A failed upload must not be recorded as a stored object, otherwise
+        # later lookups treat the key as a hit that S3 cannot serve.
+        assert key.to_string() not in connector.object_size_cache
+        memory_obj.ref_count_down()
+
+    def test_get_http_error_is_not_swallowed(
+        self, connector, async_loop, stub_s3_request
+    ):
+        script_head_hit(stub_s3_request, connector)
+        stub_s3_request.script(s3.S3RequestType.GET_OBJECT, Completion(status_code=403))
+
+        result = run(async_loop, connector.get(create_test_key(2)))
+
+        assert stub_s3_request.callback_errors == []
+        # A rejected download must not be handed back as cache content.
+        assert result is None
+
+    def test_batched_get_http_error_is_not_swallowed(
+        self, connector, async_loop, stub_s3_request
+    ):
+        script_head_hit(stub_s3_request, connector)
+        stub_s3_request.script(s3.S3RequestType.GET_OBJECT, Completion(status_code=403))
+        keys = [create_test_key(3), create_test_key(4)]
+
+        results = run(async_loop, connector.batched_get(keys))
+
+        assert stub_s3_request.callback_errors == []
+        assert results == [None, None]
+
+
+class TestCircuitBreaker:
+    """Persistent HTTP failures must trip the breaker, 404s must not."""
+
+    def test_http_error_counts_toward_breaker(
+        self, connector, async_loop, local_cpu_backend, stub_s3_request
+    ):
+        stub_s3_request.script(s3.S3RequestType.PUT_OBJECT, Completion(status_code=400))
+        memory_obj = allocate_chunk(connector, local_cpu_backend)
+
+        run(async_loop, connector.put(create_test_key(5), memory_obj))
+
+        assert connector.connection_failures == 1
+        memory_obj.ref_count_down()
+
+    def test_repeated_http_errors_disable_the_connection(
+        self, connector, async_loop, local_cpu_backend, stub_s3_request
+    ):
+        stub_s3_request.script(s3.S3RequestType.PUT_OBJECT, Completion(status_code=400))
+
+        for key_id in range(connector.max_connection_failures):
+            memory_obj = allocate_chunk(connector, local_cpu_backend)
+            run(async_loop, connector.put(create_test_key(key_id), memory_obj))
+            memory_obj.ref_count_down()
+
+        assert connector.connection_disabled is True
+
+        # Once disabled, no further request may be issued.
+        issued = len(stub_s3_request.of_type(s3.S3RequestType.PUT_OBJECT))
+        memory_obj = allocate_chunk(connector, local_cpu_backend)
+        run(async_loop, connector.put(create_test_key(99), memory_obj))
+        assert len(stub_s3_request.of_type(s3.S3RequestType.PUT_OBJECT)) == issued
+        memory_obj.ref_count_down()
+
+    def test_crt_error_with_http_status_counts_toward_breaker(
+        self, connector, async_loop, local_cpu_backend, stub_s3_request
+    ):
+        # What a real backend produces: aws-crt fails the request with an
+        # error whose message carries no connection-level keyword, so only
+        # the HTTP status identifies it as non-retryable.
+        stub_s3_request.script(
+            s3.S3RequestType.PUT_OBJECT,
+            Completion(
+                status_code=400,
+                error=RuntimeError("AWS_ERROR_S3_INVALID_RESPONSE_STATUS"),
+            ),
+        )
+        memory_obj = allocate_chunk(connector, local_cpu_backend)
+
+        run(async_loop, connector.put(create_test_key(6), memory_obj))
+
+        assert connector.connection_failures == 1
+        memory_obj.ref_count_down()
+
+    def test_head_miss_does_not_count_toward_breaker(
+        self, connector, async_loop, stub_s3_request
+    ):
+        # A 404 is an expected cache miss, not a broken connection.
+        stub_s3_request.script(
+            s3.S3RequestType.DEFAULT,
+            Completion(status_code=404, error=RuntimeError("404 Not Found")),
+        )
+        key = create_test_key(7)
+
+        assert run(async_loop, connector.exists(key)) is False
+        assert run(async_loop, connector.get(key)) is None
+
+        assert connector.connection_failures == 0
+        assert connector.connection_disabled is False
+        # The miss must short-circuit before any download is issued.
+        assert stub_s3_request.of_type(s3.S3RequestType.GET_OBJECT) == []
+
+
+class TestSuccessPaths:
+    """Successful transfers must keep working unchanged."""
+
+    @pytest.mark.parametrize("status_code", [200, 201])
+    def test_put_success(
+        self, connector, async_loop, local_cpu_backend, stub_s3_request, status_code
+    ):
+        stub_s3_request.script(
+            s3.S3RequestType.PUT_OBJECT, Completion(status_code=status_code)
+        )
+        key = create_test_key(8)
+        memory_obj = allocate_chunk(connector, local_cpu_backend)
+
+        run(async_loop, connector.put(key, memory_obj))
+
+        assert connector.object_size_cache[key.to_string()] == (
+            memory_obj.get_physical_size()
+        )
+        assert connector.connection_failures == 0
+        assert stub_s3_request.callback_errors == []
+        memory_obj.ref_count_down()
+
+    @pytest.mark.parametrize("status_code", [200, 206, None])
+    def test_get_success(self, connector, async_loop, stub_s3_request, status_code):
+        # ``status_code is None`` is aws-crt's "unknown status", which the
+        # connector treats as success.
+        payload = b"lmcache" * 16
+        script_head_hit(stub_s3_request, connector)
+        stub_s3_request.script(
+            s3.S3RequestType.GET_OBJECT,
+            Completion(status_code=status_code, body=payload),
+        )
+
+        result = run(async_loop, connector.get(create_test_key(9)))
+
+        assert isinstance(result, MemoryObj)
+        assert bytes(result.byte_array)[: len(payload)] == payload
+        assert connector.connection_failures == 0
+        assert stub_s3_request.callback_errors == []
+        result.ref_count_down()

--- a/tests/v1/storage_backend/test_s3_connector.py
+++ b/tests/v1/storage_backend/test_s3_connector.py
@@ -250,9 +250,11 @@ def connector(async_loop, local_cpu_backend, stub_s3_request):
         aws_secret_access_key="test-secret-access-key",
     )
     yield conn
-    # Drain the job executor on the loop before the loop is stopped, so its
-    # workers are not left pending.
-    run(async_loop, conn.pq_executor.shutdown_async(wait=True))
+    # Stop the job executor's workers before the loop is stopped, so they are
+    # not left pending. `wait=False` discards anything still queued, which is
+    # what a finished test wants, and avoids waiting on a drain that a
+    # cancelled worker can no longer complete.
+    run(async_loop, conn.pq_executor.shutdown_async(wait=False))
 
 
 def run(loop, coro):


### PR DESCRIPTION
Fixes #4483

**What this PR does / why we need it**:

Two independent error-handling defects in `S3Connector`. Both reproduce against
any failing remote backend; they are independent of the bucket-addressing
question in #3376 / #2624.

*Errors raised on aws-crt threads never reached the coroutine.*
`_s3_upload.on_done` and `_s3_download.on_done` raised a `RuntimeError` on
failure, but `awscrt.s3._S3RequestCore._on_finish` resolves `finished_future`
before it invokes `on_done`, and does so on an aws-crt thread. The raise was
swallowed by the unraisable hook (`Exception ignored in: <awscrt.s3._S3RequestCore object at 0x...>`).
Where aws-crt set an error code the await still failed, but with the crt error
rather than the status that explained it; where aws-crt set no error code and
only the HTTP status was bad — the case these callbacks explicitly tested for —
the failure was lost entirely: `_put` recorded the chunk in `object_size_cache`
as if the upload had landed, and `get` returned a `MemoryObj` that was never
written.

Both callbacks now only record into a `done` dict, the way
`_get_object_size.on_done` already does, and `_s3_upload` / `_s3_download`
return that dict alongside the request. `_put`, `get` and `batched_get`
inspect it after awaiting the future, inside the `try` / `except` blocks that
already log and feed the circuit breaker. The GET success condition
`(status_code in (200, 206)) or (status_code is None)` is unchanged, and so is
the PUT condition `status_code in (200, 201)`.

*The circuit breaker could not trip on HTTP errors.*
`_update_connection_failures` only matched `CONNECTION_REFUSED`, `SOCKET`,
`DNS` and `TIMEOUT` in the error message, so a persistent 400/401/403 never
incremented `connection_failures`, `connection_disabled` never flipped, and
LMCache reissued a doomed request for every chunk indefinitely — the hundreds
of identical errors within seconds seen in #3376. It now takes an optional
`status_code` and counts the non-retryable ones, with a distinct log message so
a breaker trip caused by an HTTP status reads differently from one caused by a
connection error.

**Special notes for your reviewers**:

Two things I would like a decision on, both deliberately left as implemented
rather than open in the code:

1. **Which statuses count as non-retryable.** The initial set is
   `NON_RETRYABLE_STATUS_CODES = frozenset({400, 401, 403})` — the statuses
   that mean "this request is refused for what it is", so every subsequent
   chunk hits the same wall. **404 is deliberately excluded**, because
   `_get_object_size` treats it as an expected cache miss; there is a
   regression test for that. Whether 405, 409 or 5xx belong here is a
   judgement call I am happy to change.

2. **The attribute names.** `connection_failures` and `connection_disabled`
   now also count HTTP rejections, so their names are slightly narrower than
   their meaning. I kept them as they are to keep the diff small and reviewable
   — renaming them is a separate, mechanical change if you want it.

Smaller notes:

* `_update_connection_failures` still returns `is_connection_error`, so the
  existing callers keep logging non-connection failures exactly as before. The
  docstring spells out that a `False` return no longer means "ignored".
* `_failed_status_code` prefers the `status_code` attribute that aws-crt puts
  on `S3ResponseError` and falls back to what the callback recorded. The
  callback runs after the future resolves, so on a crt-reported failure the
  recorded status can race the awaiting coroutine; reading it off the exception
  removes that race for the path that matters. (The same race is latent in the
  existing HEAD path; I have not touched it here.)
* `batched_get` was updated too — its `asyncio.gather(..., return_exceptions=True)`
  loop now sees a bad status on a future that resolved successfully.
* The new tests stub the `s3.S3Request` boundary only; the stub reproduces
  aws-crt's ordering (future first, then `on_done`, on another thread). No
  object store, credentials, GPU or network involved. All 12 fail-to-pass and
  regression cases run in a few seconds on CPU.
* Unrelated to this PR, and left alone on purpose: the tests drain the job
  executor directly instead of calling `S3Connector.close()`, because `close()`
  awaits `AsyncPQExecutor.shutdown`, which is synchronous and blocks on a
  coroutine scheduled on the very loop it is awaited on. Happy to file that
  separately.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
