### PR TITLE
fix: resolve config aliases that are not also marked deprecated

### DIFF
--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -193,17 +193,18 @@ def _resolve_config_aliases(
 
     # Process each key in the input
     for key, value in config_dict.items():
-        if key in deprecated_configs:
-            # Log deprecation warning
+        if key in config_aliases:
+            # Old name for a current key: warn if it is also flagged
+            # deprecated, then map to the current name regardless. (The alias
+            # check must not sit inside the deprecated branch, or aliases that
+            # are not in deprecated_configs get dropped as "unknown".)
+            if key in deprecated_configs:
+                logger.warning("%s (source: %s)", deprecated_configs[key], source)
+            resolved[config_aliases[key]] = value
+        elif key in deprecated_configs:
+            # Deprecated key with no alias: warn and keep for compatibility
             logger.warning("%s (source: %s)", deprecated_configs[key], source)
-
-            # Map to new key if alias exists
-            if key in config_aliases:
-                new_key = config_aliases[key]
-                resolved[new_key] = value
-            else:
-                # Keep deprecated key for backward compatibility
-                resolved[key] = value
+            resolved[key] = value
         elif key in config_definitions:
             # Valid configuration key
             resolved[key] = value

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -9,8 +9,18 @@ import pytest
 
 # First Party
 from lmcache import torch_device_type
-from lmcache.v1.config import LMCacheEngineConfig, load_ec_engine_config
-from lmcache.v1.config_base import apply_remote_configs, validate_and_set_config_value
+from lmcache.v1.config import (
+    _CONFIG_ALIASES,
+    _CONFIG_DEFINITIONS,
+    _DEPRECATED_CONFIGS,
+    LMCacheEngineConfig,
+    load_ec_engine_config,
+)
+from lmcache.v1.config_base import (
+    _resolve_config_aliases,
+    apply_remote_configs,
+    validate_and_set_config_value,
+)
 
 BASE_DIR = Path(__file__).parent
 
@@ -1114,3 +1124,31 @@ class TestStoreAndRetrieveLocationEnvConversion:
         restored = LMCacheEngineConfig.from_dict(config.to_dict())
         assert restored.retrieve_locations == ["LocalCPUBackend"]
         assert restored.store_location == "LocalDiskBackend"
+
+
+def test_config_aliases_all_resolve_to_current_names():
+    """Every legacy alias maps to its current config key.
+
+    Regression: the alias lookup used to sit inside the deprecated-key
+    branch, so any alias not also listed in ``_DEPRECATED_CONFIGS`` (10 of the
+    12, e.g. ``enable_xpyd`` and the ``nixl_*`` names) fell through to the
+    "unknown configuration key" branch and was silently dropped.
+    """
+    for old_name, new_name in _CONFIG_ALIASES.items():
+        resolved = _resolve_config_aliases(
+            {old_name: "value"},
+            "test",
+            _CONFIG_DEFINITIONS,
+            _CONFIG_ALIASES,
+            _DEPRECATED_CONFIGS,
+        )
+        assert resolved == {new_name: "value"}, (
+            f"alias {old_name!r} did not resolve to {new_name!r}"
+        )
+
+
+def test_enable_xpyd_alias_applies_from_env(monkeypatch):
+    """A legacy env var name is honored end-to-end via ``from_env``."""
+    monkeypatch.setenv("LMCACHE_ENABLE_XPYD", "true")
+    config = LMCacheEngineConfig.from_env()
+    assert config.enable_pd is True


### PR DESCRIPTION
**What this PR does / why we need it**:

`_resolve_config_aliases` (`lmcache/v1/config_base.py`) only consulted the alias map *inside* the `key in deprecated_configs` branch:

```python
for key, value in config_dict.items():
    if key in deprecated_configs:
        logger.warning(...)
        if key in config_aliases:            # only reachable when ALSO deprecated
            resolved[config_aliases[key]] = value
        else:
            resolved[key] = value
    elif key in config_definitions:
        resolved[key] = value
    else:
        logger.warning("Unknown configuration key: %s ...", key, source)  # alias dies here
```

`_CONFIG_ALIASES` has 12 entries but `_DEPRECATED_CONFIGS` has 3, and only `plugin_locations` / `external_backends` appear in both. So the other **10** alias names — `enable_xpyd`, `controller_url`, `lmcache_worker_port`, and the seven `nixl_* → pd_*` names — never match the alias map and fall through to the "Unknown configuration key" branch, silently discarding the value.

This is reachable on every config-load path (`from_env` / `from_file` / `from_dict` / `update_config_from_env`, which all route through this helper). A user who sets a documented legacy name — e.g. `LMCACHE_ENABLE_XPYD=true`, or `controller_url:` in YAML — has it silently dropped, so PD / the controller is left unconfigured with no error.

The fix checks the alias map first and maps to the current key regardless of deprecation status, still emitting the deprecation warning when the key is also in `_DEPRECATED_CONFIGS`:

```python
if key in config_aliases:
    if key in deprecated_configs:
        logger.warning("%s (source: %s)", deprecated_configs[key], source)
    resolved[config_aliases[key]] = value
elif key in deprecated_configs:
    logger.warning("%s (source: %s)", deprecated_configs[key], source)
    resolved[key] = value
elif key in config_definitions:
    resolved[key] = value
else:
    logger.warning("Unknown configuration key: %s (source: %s)", key, source)
```

**Special notes for your reviewers**:

Verified against the real `_CONFIG_ALIASES` / `_DEPRECATED_CONFIGS` / `_CONFIG_DEFINITIONS` tables: before the change 10 of the 12 aliases were dropped; after, all 12 resolve and only the two genuinely-deprecated names still emit a deprecation warning. `ruff check` and `ruff format` are clean on both files.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests