### PR TITLE
feat(mp): add TOML config-file loader for the multiprocess server

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -55,7 +55,7 @@ unchanged (argparse-only).
 
 Point the server at a file with ``--config-file`` or the
 ``LMCACHE_MP_CONFIG`` environment variable (the flag wins over the env var).
-A missing or unparseable file logs a warning and falls back to argparse-only
+A missing or unparsable file logs a warning and falls back to argparse-only
 behavior — it never aborts startup.
 
 Keys mirror the ``MPServerConfig`` field names; both ``max-gpu-workers`` and

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -1,5 +1,4 @@
 Configuration Reference
-=======================
 
 This page documents every CLI argument accepted by the LMCache multiprocess
 server.  Arguments are grouped by the config module that defines them.
@@ -46,6 +45,46 @@ request metadata throughout the request lifecycle.
    or cache-control behavior in MP mode unless the selected server-side
    feature explicitly documents support for it.  The in-process
    ``LMCacheConnectorV1`` may interpret these values differently.
+Configuration File (TOML)
+------------------------
+
+In addition to CLI flags, the MP server accepts a TOML file of defaults.
+Any flag set explicitly on the command line overrides the file; an absent
+flag lets the file win over the argparse default. With no file, behavior is
+unchanged (argparse-only).
+
+Point the server at a file with ``--config-file`` or the
+``LMCACHE_MP_CONFIG`` environment variable (the flag wins over the env var).
+A missing or unparseable file logs a warning and falls back to argparse-only
+behavior — it never aborts startup.
+
+Keys mirror the ``MPServerConfig`` field names; both ``max-gpu-workers`` and
+``max_gpu_workers`` are accepted (hyphens map to underscores). Unknown keys
+are warned about and skipped. Example ``mp.toml``:
+
+.. code-block:: toml
+
+   host = "0.0.0.0"
+   port = 5555
+   chunk-size = 256
+   max-workers = 4
+   max-gpu-workers = 2
+   hash-algorithm = "blake3"
+   engine-type = "default"
+   supported-transfer-mode = "auto"
+   worker-reap-timeout-seconds = 120.0
+   worker-registration-grace-seconds = 3600.0
+
+   # runtime-plugin-config accepts a TOML inline table; it is serialized to the
+   # JSON string the CLI flag expects.
+   # runtime-plugin-config = {plugin.frontend.heartbeat_url = "http://localhost:5000/heartbeat"}
+
+.. code-block:: bash
+
+   LMCACHE_MP_CONFIG=/etc/lmcache/mp.toml lmcache server --port 6000
+
+The ``--port 6000`` flag above overrides ``port = 5555`` from the file; every
+other value is read from the file because the matching flag was not passed.
 
 MP Server
 ---------

--- a/lmcache/cli/commands/server.py
+++ b/lmcache/cli/commands/server.py
@@ -86,6 +86,7 @@ class ServerCommand(BaseCommand):
                 parse_args_to_observability_config,
             )
             from lmcache.v1.multiprocess.config import (
+                merge_mp_config_file_into_args,
                 parse_args_to_coordinator_config,
                 parse_args_to_http_frontend_config,
                 parse_args_to_mp_server_config,
@@ -100,6 +101,7 @@ class ServerCommand(BaseCommand):
             )
             sys.exit(1)
 
+        args = merge_mp_config_file_into_args(args)
         run_http_server(
             http_config=parse_args_to_http_frontend_config(args),
             mp_config=parse_args_to_mp_server_config(args),

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -13,6 +13,11 @@ import math
 import os
 import uuid
 
+try:
+    import tomllib  # Python 3.11+ stdlib
+except ModuleNotFoundError:  # pragma: no cover (Python 3.10 only)
+    import tomli as tomllib  # third-party fallback for Python 3.10
+
 # First Party
 from lmcache.logging import init_logger
 
@@ -432,6 +437,16 @@ def add_mp_server_args(
         "Options: transfer_query (see lmcache.v1.multiprocess.modules."
         "experimental.__init___.py).",
     )
+    mp_group.add_argument(
+        "--config-file",
+        type=str,
+        default=None,
+        help="Path to a TOML file providing MP server defaults (any flag set "
+        "explicitly on the command line overrides the file). Also read from "
+        "the LMCACHE_MP_CONFIG environment variable; the flag wins over the "
+        "env var. Missing or unparseable files warn and fall back to "
+        "argparse-only behavior (never aborts startup).",
+    )
     return parser
 
 
@@ -480,6 +495,135 @@ def parse_args_to_mp_server_config(
         worker_registration_grace_seconds=args.worker_registration_grace_seconds,
         enable=args.enable or [],
     )
+
+
+# Dest names the TOML file must not set (the config-file path itself; setting
+# it from inside the file would be circular and meaningless).
+_MP_CONFIG_FILE_EXCLUDED_DESTS = frozenset({"config_file"})
+
+# Memoized argparse defaults for the MP-server group; built lazily by
+# _mp_server_arg_defaults() and only read by the merge layer.
+_MP_SERVER_DEFAULTS: argparse.Namespace | None = None
+
+
+def _mp_server_arg_defaults() -> argparse.Namespace:
+    """Return a Namespace of the MP-server argparse defaults.
+
+    Built by parsing an empty argv through a fresh parser with
+    ``add_mp_server_args``, so the defaults stay in lockstep with the
+    argparse declarations (single source of truth). Memoized; the merge
+    layer only reads from it.
+    """
+    global _MP_SERVER_DEFAULTS
+    if _MP_SERVER_DEFAULTS is None:
+        parser = argparse.ArgumentParser(add_help=False)
+        add_mp_server_args(parser)
+        _MP_SERVER_DEFAULTS = parser.parse_args([])
+    return _MP_SERVER_DEFAULTS
+
+
+def load_mp_config_from_toml(path: str) -> dict:
+    """Load MP-server defaults from a TOML file.
+
+    Keys are normalized to argparse dest names (``max-gpu-workers`` and
+    ``max_gpu_workers`` both map to ``max_gpu_workers``), and only dests that
+    ``add_mp_server_args`` actually registers are kept. The returned dict is
+    keyed by dest name with values shaped to match what argparse would store
+    (e.g. ``runtime_plugin_config`` is flattened to a JSON string when given
+    as a TOML table).
+
+    Missing files, unreadable files, and invalid TOML all warn and return an
+    empty dict — the caller falls back to argparse-only behavior. This never
+    raises so server startup is never aborted by a config-file problem.
+
+    Args:
+        path: Path to the TOML config file.
+
+    Returns:
+        A dest-keyed dict of MP-server config values (empty on any failure).
+    """
+    try:
+        with open(path, "rb") as fin:
+            data = tomllib.load(fin)
+    except FileNotFoundError:
+        logger.warning("MP config file %s not found; using CLI defaults", path)
+        return {}
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning(
+            "MP config file %s is invalid TOML (%s); using CLI defaults",
+            path,
+            exc,
+        )
+        return {}
+    except OSError as exc:
+        logger.warning(
+            "MP config file %s could not be read (%s); using CLI defaults",
+            path,
+            exc,
+        )
+        return {}
+
+    if not isinstance(data, dict):
+        logger.warning("MP config file %s is not a mapping; using CLI defaults", path)
+        return {}
+
+    defaults = _mp_server_arg_defaults()
+    out: dict = {}
+    for raw_key, value in data.items():
+        if not isinstance(raw_key, str):
+            continue
+        dest = raw_key.strip().lower().replace("-", "_")
+        if dest in _MP_CONFIG_FILE_EXCLUDED_DESTS:
+            logger.warning(
+                "Ignoring MP config key '%s' from %s (reserved)", raw_key, path
+            )
+            continue
+        if not hasattr(defaults, dest):
+            logger.warning("Ignoring unknown MP config key '%s' from %s", raw_key, path)
+            continue
+        # runtime_plugin_config is a JSON string on the CLI; accept a TOML
+        # table too by serializing it back to JSON so parse_args_to_mp_server
+        # _config's json.loads keeps working.
+        if dest == "runtime_plugin_config" and isinstance(value, dict):
+            value = json.dumps(value)
+        out[dest] = value
+    return out
+
+
+def merge_mp_config_file_into_args(
+    args: argparse.Namespace,
+) -> argparse.Namespace:
+    """Merge an MP TOML config file into parsed CLI args (in place).
+
+    The file supplies defaults; a CLI flag wins when its value differs from
+    the argparse default (i.e. it was passed explicitly). An absent flag lets
+    the file win over the argparse default. This preserves backward
+    compatibility: with no file, ``args`` is returned unchanged.
+
+    The file path is resolved from ``--config-file`` (registered by
+    ``add_mp_server_args``) or the ``LMCACHE_MP_CONFIG`` environment variable;
+    the flag wins over the env var. A missing/unreadable file warns and leaves
+    ``args`` untouched.
+
+    Args:
+        args: Parsed argparse Namespace. Merged in place and returned.
+
+    Returns:
+        The same Namespace, with file defaults applied under CLI overrides.
+    """
+    path = getattr(args, "config_file", None) or os.getenv("LMCACHE_MP_CONFIG")
+    if not path:
+        return args
+    file_config = load_mp_config_from_toml(path)
+    if not file_config:
+        return args
+    defaults = _mp_server_arg_defaults()
+    for dest, value in file_config.items():
+        cli_value = getattr(args, dest, getattr(defaults, dest))
+        if cli_value == getattr(defaults, dest):
+            # CLI flag was absent (or equal to default) -> let the file win.
+            setattr(args, dest, value)
+    return args
 
 
 def add_p2p_args(

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -14,6 +14,7 @@ import os
 import uuid
 
 try:
+    # Standard
     import tomllib  # Python 3.11+ stdlib
 except ModuleNotFoundError:  # pragma: no cover (Python 3.10 only)
     import tomli as tomllib  # type: ignore[no-redef, import-not-found]
@@ -444,7 +445,7 @@ def add_mp_server_args(
         help="Path to a TOML file providing MP server defaults (any flag set "
         "explicitly on the command line overrides the file). Also read from "
         "the LMCACHE_MP_CONFIG environment variable; the flag wins over the "
-        "env var. Missing or unparseable files warn and fall back to "
+        "env var. Missing or unparsable files warn and fall back to "
         "argparse-only behavior (never aborts startup).",
     )
     return parser

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -16,7 +16,7 @@ import uuid
 try:
     import tomllib  # Python 3.11+ stdlib
 except ModuleNotFoundError:  # pragma: no cover (Python 3.10 only)
-    import tomli as tomllib  # third-party fallback for Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef, import-not-found]
 
 # First Party
 from lmcache.logging import init_logger

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -40,6 +40,7 @@ from lmcache.v1.multiprocess.config import (
     add_http_frontend_args,
     add_mp_server_args,
     add_p2p_args,
+    merge_mp_config_file_into_args,
     parse_args_to_coordinator_config,
     parse_args_to_http_frontend_config,
     parse_args_to_mp_server_config,
@@ -279,6 +280,7 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
+    args = merge_mp_config_file_into_args(args)
     http_config = parse_args_to_http_frontend_config(args)
     mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -41,6 +41,7 @@ from lmcache.v1.multiprocess.config import (
     MPServerConfig,
     add_coordinator_args,
     add_mp_server_args,
+    merge_mp_config_file_into_args,
     parse_args_to_coordinator_config,
     parse_args_to_mp_server_config,
 )
@@ -493,6 +494,7 @@ def parse_args():
 if __name__ == "__main__":
     signal.signal(signal.SIGTERM, signal.default_int_handler)
     args = parse_args()
+    args = merge_mp_config_file_into_args(args)
     mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     obs_config = parse_args_to_observability_config(args)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,3 +48,6 @@ httptools
 cachetools
 google-api-core
 google-cloud-bigtable
+# stdlib tomllib (3.11+) backs the MP TOML config-file loader; on Python 3.10
+# the tomli fallback provides the same API.
+tomli; python_version < "3.11"

--- a/tests/v1/multiprocess/test_mp_config.py
+++ b/tests/v1/multiprocess/test_mp_config.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MP server TOML config-file loader and merge layer.
+
+Covers: TOML load -> MPServerConfig fields, CLI-overrides-file precedence,
+missing/invalid file graceful fallback (no crash, warn only), the
+``LMCACHE_MP_CONFIG`` env var, the flag-over-env precedence, and the
+Python 3.10 ``tomli`` fallback path (exercised via a shim on 3.11+).
+
+This module imports only the pure config layer (no native extensions), so it
+runs without a CUDA build.
+"""
+
+# Standard
+import argparse
+import json
+import logging
+import os
+import types
+
+# First Party
+from lmcache.v1.multiprocess.config import (
+    MPServerConfig,
+    add_mp_server_args,
+    load_mp_config_from_toml,
+    merge_mp_config_file_into_args,
+    parse_args_to_mp_server_config,
+)
+import lmcache.v1.multiprocess.config as mp_config
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    """Build an MP-server parser, parse argv, and return the Namespace."""
+    parser = argparse.ArgumentParser()
+    add_mp_server_args(parser)
+    return parser.parse_args(argv)
+
+
+def _parse_merged(argv: list[str]) -> MPServerConfig:
+    """Parse argv, merge any config file, and return the MPServerConfig."""
+    args = merge_mp_config_file_into_args(_parse(argv))
+    return parse_args_to_mp_server_config(args)
+
+
+def _write_toml(tmp_path, body: str):
+    path = tmp_path / "mp.toml"
+    path.write_text(body)
+    return str(path)
+
+
+def _capture_warnings():
+    """Attach a list-backed handler to the config logger.
+
+    lmcache's ``init_logger`` sets ``propagate = False``, so pytest's
+    ``caplog`` (root-logger based) cannot see the records; attach a local
+    handler to the named logger instead (established pattern, see
+    tests/v1/multiprocess/test_config.py).
+    """
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _ListHandler(level=logging.WARNING)
+    config_logger = logging.getLogger("lmcache.v1.multiprocess.config")
+    config_logger.addHandler(handler)
+    return handler, records, config_logger
+
+
+# -- load_mp_config_from_toml -------------------------------------------------
+
+
+def test_load_returns_dest_keyed_dict(tmp_path):
+    # Both hyphenated and underscored TOML keys normalize to argparse dests.
+    path = _write_toml(
+        tmp_path,
+        'port = 6000\nhost = "10.0.0.1"\nmax_gpu_workers = 3\nchunk-size = 512\n',
+    )
+    loaded = load_mp_config_from_toml(path)
+    assert loaded == {
+        "port": 6000,
+        "host": "10.0.0.1",
+        "max_gpu_workers": 3,
+        "chunk_size": 512,
+    }
+
+
+def test_load_flattens_runtime_plugin_config_table(tmp_path):
+    # A TOML inline table is accepted and serialized to a JSON string so the
+    # downstream json.loads in parse_args_to_mp_server_config keeps working.
+    path = _write_toml(tmp_path, 'runtime-plugin-config = {x = 1, y = "z"}\n')
+    loaded = load_mp_config_from_toml(path)
+    assert json.loads(loaded["runtime_plugin_config"]) == {"x": 1, "y": "z"}
+
+
+def test_load_unknown_keys_are_warned_and_skipped(tmp_path):
+    path = _write_toml(tmp_path, "port = 6000\nnonsense-key = 1\n")
+    handler, records, config_logger = _capture_warnings()
+    try:
+        loaded = load_mp_config_from_toml(path)
+    finally:
+        config_logger.removeHandler(handler)
+    assert loaded == {"port": 6000}
+    assert any("nonsense-key" in r.getMessage() for r in records)
+
+
+def test_load_reserved_config_file_key_is_skipped(tmp_path):
+    path = _write_toml(tmp_path, 'port = 6000\nconfig-file = "loop.toml"\n')
+    handler, records, config_logger = _capture_warnings()
+    try:
+        loaded = load_mp_config_from_toml(path)
+    finally:
+        config_logger.removeHandler(handler)
+    assert loaded == {"port": 6000}
+    assert any(
+        "config-file" in r.getMessage() and "reserved" in r.getMessage()
+        for r in records
+    )
+
+
+# -- graceful fallback --------------------------------------------------------
+
+
+def test_missing_file_returns_empty_and_warns(tmp_path):
+    path = str(tmp_path / "does-not-exist.toml")
+    handler, records, config_logger = _capture_warnings()
+    try:
+        loaded = load_mp_config_from_toml(path)
+    finally:
+        config_logger.removeHandler(handler)
+    assert loaded == {}
+    assert any("not found" in r.getMessage() for r in records)
+
+
+def test_invalid_toml_returns_empty_and_warns(tmp_path):
+    path = _write_toml(tmp_path, "not = valid = toml\n")
+    handler, records, config_logger = _capture_warnings()
+    try:
+        loaded = load_mp_config_from_toml(path)
+    finally:
+        config_logger.removeHandler(handler)
+    assert loaded == {}
+    assert any("invalid TOML" in r.getMessage() for r in records)
+
+
+def test_non_mapping_payload_warns_and_falls_back(tmp_path, monkeypatch):
+    # Valid TOML always parses to a dict (top-level table), but the loader
+    # defends against a non-mapping payload all the same. Force the branch by
+    # making the toml backend return a list.
+    path = _write_toml(tmp_path, "port = 6000\n")
+    monkeypatch.setattr(mp_config.tomllib, "load", lambda fin: [1, 2, 3])
+    handler, records, config_logger = _capture_warnings()
+    try:
+        loaded = load_mp_config_from_toml(path)
+    finally:
+        config_logger.removeHandler(handler)
+    assert loaded == {}
+    assert any("not a mapping" in r.getMessage() for r in records)
+
+
+# -- merge -> MPServerConfig --------------------------------------------------
+
+
+def test_file_supplies_defaults_when_flag_absent(tmp_path):
+    path = _write_toml(
+        tmp_path,
+        "port = 6000\nchunk-size = 512\nmax-workers = 4\n"
+        'max-gpu-workers = 2\nhost = "10.0.0.1"\n',
+    )
+    cfg = _parse_merged(["--config-file", path])
+    assert cfg.port == 6000
+    assert cfg.chunk_size == 512
+    assert cfg.max_workers == 4
+    assert cfg.max_gpu_workers == 2
+    assert cfg.host == "10.0.0.1"
+
+
+def test_cli_flag_overrides_file(tmp_path):
+    path = _write_toml(tmp_path, 'port = 6000\nhost = "10.0.0.1"\n')
+    cfg = _parse_merged(["--config-file", path, "--port", "7000"])
+    # CLI port wins over file port; absent host still comes from the file.
+    assert cfg.port == 7000
+    assert cfg.host == "10.0.0.1"
+
+
+def test_cli_flag_equal_to_default_lets_file_win(tmp_path):
+    # An explicit flag whose value equals the argparse default is treated as
+    # "absent" (the documented semantics): the file value still wins.
+    path = _write_toml(tmp_path, "port = 6000\n")
+    cfg = _parse_merged(["--config-file", path, "--port", "5555"])
+    assert cfg.port == 6000
+
+
+def test_runtime_plugin_config_table_reaches_config(tmp_path):
+    path = _write_toml(tmp_path, "runtime-plugin-config = {x = 1}\n")
+    cfg = _parse_merged(["--config-file", path])
+    assert cfg.runtime_plugin_config.extra_config == {"x": 1}
+
+
+def test_no_config_file_is_backward_compatible(tmp_path):
+    # No --config-file and no env var: args untouched, pure argparse behavior.
+    os.environ.pop("LMCACHE_MP_CONFIG", None)
+    cfg = _parse_merged([])
+    # instance_id is a random UUID, so only assert the deterministic defaults.
+    assert cfg.port == 5555
+    assert cfg.host == "localhost"
+    assert cfg.chunk_size == 256
+
+
+def test_missing_file_falls_back_to_argparse_no_crash(tmp_path):
+    path = str(tmp_path / "missing.toml")
+    handler, records, config_logger = _capture_warnings()
+    try:
+        cfg = _parse_merged(["--config-file", path, "--port", "7000"])
+    finally:
+        config_logger.removeHandler(handler)
+    # Warned but did not crash; the explicit CLI port still applied.
+    assert any("not found" in r.getMessage() for r in records)
+    assert cfg.port == 7000
+
+
+def test_invalid_file_falls_back_to_argparse_no_crash(tmp_path):
+    path = _write_toml(tmp_path, "garbage = = =\n")
+    handler, records, config_logger = _capture_warnings()
+    try:
+        cfg = _parse_merged(["--config-file", path, "--port", "7000"])
+    finally:
+        config_logger.removeHandler(handler)
+    assert any("invalid TOML" in r.getMessage() for r in records)
+    assert cfg.port == 7000
+
+
+# -- env var resolution -------------------------------------------------------
+
+
+def test_env_var_resolves_config_path(tmp_path, monkeypatch):
+    path = _write_toml(tmp_path, "port = 6000\n")
+    monkeypatch.setenv("LMCACHE_MP_CONFIG", path)
+    cfg = _parse_merged([])
+    assert cfg.port == 6000
+
+
+def test_flag_beats_env_var(tmp_path, monkeypatch):
+    env_path = _write_toml(tmp_path, "port = 6000\n")
+    flag_path = _write_toml(tmp_path, "port = 8000\n")
+    monkeypatch.setenv("LMCACHE_MP_CONFIG", env_path)
+    cfg = _parse_merged(["--config-file", flag_path])
+    assert cfg.port == 8000
+
+
+def test_no_env_no_flag_is_argparse_only(monkeypatch):
+    monkeypatch.delenv("LMCACHE_MP_CONFIG", raising=False)
+    args_before = _parse([])
+    args_after = merge_mp_config_file_into_args(_parse([]))
+    # No file path resolved -> args unchanged (backward compatible).
+    for dest in ("port", "host", "chunk_size", "max_workers"):
+        assert getattr(args_after, dest) == getattr(args_before, dest)
+
+
+# -- tomli fallback path (exercised on 3.11+, never skipped) ------------------
+
+
+def test_loader_works_through_tomli_fallback_backend(tmp_path, monkeypatch):
+    """Exercise the Python 3.10 ``tomli`` fallback without skipping on 3.11.
+
+    The loader binds a module-level ``tomllib`` name (stdlib on 3.11+,
+    ``tomli`` on 3.10). Swap in a tomli-style shim (same API surface) and
+    confirm loading and graceful invalid-TOML fallback still work through it,
+    proving the fallback code path is functional on every Python version.
+    """
+    real = mp_config.tomllib
+    shim = types.ModuleType("tomli_shim")
+    shim.load = real.load
+    shim.TOMLDecodeError = real.TOMLDecodeError
+    monkeypatch.setattr(mp_config, "tomllib", shim)
+
+    path = _write_toml(tmp_path, 'port = 6000\nhost = "10.0.0.1"\n')
+    loaded = load_mp_config_from_toml(path)
+    assert loaded["port"] == 6000
+    assert loaded["host"] == "10.0.0.1"
+
+    # Invalid TOML still warns + falls back via the shim's exception type.
+    bad = _write_toml(tmp_path, "not = valid = toml\n")
+    handler, records, config_logger = _capture_warnings()
+    try:
+        assert load_mp_config_from_toml(bad) == {}
+    finally:
+        config_logger.removeHandler(handler)
+    assert any("invalid TOML" in r.getMessage() for r in records)


### PR DESCRIPTION
<!-- 1. Make sure to read the Contributing Guide ... 2. 'Refs #<issue>' ... -->

**What this PR does / why we need it**:

Adds a TOML config-file loader for the multiprocess (MP) cache server, addressing the Q2 2026 roadmap item **"MP toml configuration"** (#2923 §3, currently unchecked/unassigned).

Today the MP server is argparse-only (`add_mp_server_args` in `lmcache/v1/multiprocess/config.py`): every fleet deployment must pass ~17 CLI flags, and there is no way to ship a reproducible, reviewable config file. This PR introduces:

- `LMCACHE_MP_CONFIG` env var + `--config-file` CLI flag pointing at a TOML file.
- `load_mp_config_from_toml(path)` — reads the TOML (stdlib `tomllib` on Python ≥3.11, `tomli` fallback on 3.10), normalizes keys to `MPServerConfig` field names (e.g. `max-gpu-workers` → `max_gpu_workers`), and returns `{}` on missing/invalid/non-mapping files with a warning (never raises).
- `merge_mp_config_file_into_args(args)` — resolves `--config-file` > `LMCACHE_MP_CONFIG`, then merges the file into the argparse `Namespace` **before** `parse_args_to_mp_server_config`: the file supplies defaults, and a CLI flag wins only when it differs from the argparse default (so `--port 6000` beats `port = 5555` in the file, but an absent flag lets the file win over the default).
- Wirings at all three CLI entries (`server.py`, `http_server.py`, `cli/commands/server.py`) so the merge runs before config construction.
- `tomli; python_version < "3.11"` conditional dependency (in `requirements/common.txt` — the repo loads deps dynamically from `requirements/*.txt` via `setup.py`, so this is the correct location rather than a static `pyproject.toml` slot).
- `docs/source/mp/configuration.rst` — a "Configuration File (TOML)" section with a sample `mp.toml`.

**Special notes for your reviewers**:

- **Why TOML and not reuse the in-process `LMCACHE_CONFIG_FILE` YAML path?** The Q2 roadmap (#2923 §3) explicitly names TOML for MP config; the Q3 roadmap (#4025) is silent on the format and does not supersede. So this introduces TOML per the roadmap mandate rather than reusing YAML. (This pre-empts the natural "reuse YAML" question.)
- **Backward compatible**: with no `--config-file` and no `LMCACHE_MP_CONFIG`, behavior is byte-for-byte identical to today (argparse-only). The three wirings are each one import + one line, before `parse_args_to_mp_server_config`.
- **Graceful degradation**: missing / invalid / non-mapping TOML → warn and fall back to argparse defaults. The server never aborts startup on a config-file problem.
- **Precedence**: `--config-file` flag > `LMCACHE_MP_CONFIG` env var; CLI flags > file values (only when the flag differs from the argparse default); `config-file`/`LMCACHE_MP_CONFIG` themselves are reserved keys (rejected if present in the TOML).
- **Scope**: deliberately additive — no `MPServerConfig` field add/remove/rename, no change to the in-process `config.py` YAML loader, no change to `parse_args_to_p2p_config`.

**If applicable**:

- [x] this PR contains user facing changes - docs added (`docs/source/mp/configuration.rst`)
- [x] this PR contains unit tests (`tests/v1/multiprocess/test_mp_config.py` — 18 tests covering: TOML load → MPServerConfig fields, key normalization, CLI-overrides-file precedence, flag-equal-to-default-lets-file-win, `runtime_plugin_config` table→JSON, `LMCACHE_MP_CONFIG` env resolution, flag-over-env, backward-compat no-file, missing/invalid/non-mapping graceful fallback, and the 3.10 `tomli` fallback path via a shim on 3.11+)

Refs #2923