### PR TITLE
[MP][Coordinator] Persist the key directory, pins and quotas

### DIFF
--- a/docs/design/v1/mp_coordinator/key_directory.md
+++ b/docs/design/v1/mp_coordinator/key_directory.md
@@ -18,10 +18,11 @@ serving hot path**:
 - It is built purely from `CacheEvent` batches emitted by MP servers. It
 never mutates memory and never grants access to bytes.
 - Every answer is a **hint**. Consumers (P2P discovery, cache control, prefetch planning) must validate at the owning MP server before touching bytes (validate-on-use). Stale state costs a wasted probe or a missed reuse.
-- All state is reconstructible by replaying the event stream (with a
-durable transport such as a message queue, replay from retention also
-covers coordinator restarts and detected gaps); nothing is persisted
-at the moment.
+- Almost all state is reconstructible by replaying the event stream, and
+what is not — L2 placements no reporter will re-announce — is carried
+across restarts by a checkpoint (see *Snapshot and restore*). Operator
+intent is not reconstructible at all and is stored separately (see
+*Metadata state*).
 
 ## Event application semantics
 
@@ -172,7 +173,7 @@ reporter:
 ```
 ObjectKey → _KeyRecord {
     placements: list[Placement],   # ≤1 per placement identity (see STORE)
-    content_hash_hex, last_access
+    last_access
 }
 chunk_hash → _TokenBinding { token_ids: uint32[], token_offset, keys }
 instance_id → set[ObjectKey]       # L1 reverse index
@@ -187,6 +188,106 @@ The Python-phase directory is keyed by `ObjectKey` directly (hashable
 frozen dataclass). The RFC's 16-byte
 `key_hash` with interned `model_id`/`salt_id` is a memory/native-port
 optimization (M6), not a semantic change.
+
+## Snapshot and restore
+
+The event stream cannot rebuild the directory on its own: an L2 object
+stored hours ago is never re-announced. `KeyDirectory.snapshot()` captures
+the state and `restore()` loads it back, across three layers that know
+nothing of each other — `persistence/snapshot_codec.py` owns the format
+(msgpack via `msgspec`, as the trace subsystem does, with the token
+arrays written raw beside it so the encoder never copies them),
+[`store.py`](../../../../lmcache/v1/mp_coordinator/persistence/store.py)
+owns where the bytes live (`LocalArtifactStore` today, an object store one
+class later), and `persistence/checkpoint.py` owns when.
+
+- **`snapshot()` copies nothing large.** It returns an immutable capture
+sharing no mutable state with the directory, taken under the lock, so the
+caller can encode it off-thread. Token arrays are aliased — bindings
+replace them wholesale and never write in place.
+- **What is not captured.** The blend index is derived from the token
+bindings and rebuilt on restore, so `enable_blend_lookup` must run first.
+Content-free bindings and each binding's key set are likewise re-derived
+from the key table.
+- **The ingest gate's cursors ride along.** They are not the directory's
+to capture — the gate owns them (see [ingest.md](ingest.md)) — but they
+must be restored *with* the placements they gate, because fencing only
+fires when a prior incarnation exists to compare against. Restore the
+directory without them and an emitter that restarted during the outage
+looks brand new, so the L1 slice its previous incarnation reported is
+never dropped. `write_snapshot` therefore takes both, and
+`EventGate.stats()` doubles as the capture half of
+`EventGate.restore_cursors`.
+- **Cursors restore as captured**, so an instance that kept emitting
+while the coordinator was away trips `gap_detected` on its first batch
+back. That is a true report; producer-side spill is what would close it.
+- **The derived views are rebuilt too.** `restore` fills the directory
+alone, so the load replays restored placements through the
+`CacheEventBroadcaster` as synthesized `STORE` batches — otherwise the
+coordinator returns holding a full directory and zero accounted bytes,
+with quota enforcement blind to everything stored before the restart.
+Replay order does not matter: what it rebuilds is per-salt byte totals.
+- **Anything the replay cannot rebuild is a `DurableComponent`** whose
+`persistence_type` is `CHECKPOINT`; it lands in the checkpoint's trailing
+sections, restored after the replay so it replaces whatever that left
+behind.
+Today that is the eviction policy: an ordering-based one (the per-salt
+LRU) *is* its recency, and `last_access` cannot stand in for it — that
+is one flush-quantized timestamp per key rather than a sequence, and
+comparable across emitters only as far as their clocks agree. Durability
+is optional on `EvictionPolicy`, defaulting to capturing nothing, so a
+policy that derives everything from its keys needs no section and a
+deployment that swaps policies simply finds none under the new name. The
+sections are JSON inside the binary artifact, so a component owns its
+shape without knowing the key table.
+- **Atomicity belongs to the store**, not the caller: the local backend
+writes beside the target and renames, an object store would simply PUT.
+- **Every failure is survivable.** A missing, corrupt, or
+future-version checkpoint logs and starts cold; a failed write retries
+next tick. The coordinator never refuses to boot over one.
+
+Enabled by `--snapshot-path`; `--snapshot-interval` (default 60s) paces the
+writes, `0` writes only on shutdown, and the lifespan writes once more on a
+clean stop.
+
+## Metadata state
+
+Pins and per-`cache_salt` quotas, in
+[`metadata_persister.py`](../../../../lmcache/v1/mp_coordinator/persistence/metadata_persister.py)
+behind `--metadata-path`. A separate artifact because it agrees with the
+snapshot on nothing that matters: small, JSON, unreconstructible, and
+consequential to lose.
+
+- **Components serialize themselves.** Each implements `name` /
+`persistence_type` / `capture` / `restore` — the shape
+`CacheEventBroadcaster.register_consumer` uses. The persister knows
+storage and nothing else, and takes only `METADATA` components,
+rejecting derived state outright.
+- **Controllers are discovered, not listed.** `build_durable_owners`
+scans `controllers/` for classes implementing `DurableOwner` and builds
+each one — via its `from_config` when it has one, so configuration stays
+next to the code that reads it. `collect_durable_components` then asks
+each owner what it needs persisted (`FleetEvictionController` returns the
+pin table, the quota registry, and the eviction policy) and groups them
+by `persistence_type`. Dropping a controller into that directory is
+therefore the whole of adding it: nothing in `create_app` enumerates
+controllers or knows what any of them stores. Each metadata section validates itself with a Pydantic
+model, so nothing outside a component parses the document.
+- **Written on change, not on a tick.** Intent moves rarely, so
+`MetadataPersister.save()` runs synchronously with the request that changed something —
+a `200` from `POST /cache/pins` means the pin survives a restart. Every
+mutating handler must `await` it; that is the one contract a new pin or
+quota endpoint has to honour.
+- **Restore order matters.** Metadata loads before the checkpoint's
+replay: quotas *arm* eviction, pins are the only thing holding it off,
+and the replay is what puts keys in the LRU.
+- **Restored intent may be stale**, and staleness here is not harmless —
+a quota raised while the coordinator was down comes back at its old lower
+value and over-evicts. The load logs the document's age; the external
+controller stays the authority, as it already is for quotas.
+- **Failures degrade to no state**, which leaves eviction disarmed
+(`effective_limit_bytes` returns `None`) rather than enforcing something
+wrong.
 
 ## HTTP surface
 
@@ -245,9 +346,13 @@ gate — see [ingest.md](ingest.md).
 `/directory/blend-lookup` and retiring `blend_directory.py` plus the
 per-store fingerprint publish. The coordinator side is done — see
 [blend_index.md](blend_index.md).
-- Checkpointing and the
-`DELETE_PENDING`/pin placement states used by tier-aware cache-control
-directives (M3–M4 of the RFC).
+- **Producer-side spill**: a checkpoint restores what was captured, not
+what arrived while the coordinator was down — those events are dropped
+by the emitter and show up as a `seq` gap on the first batch back.
+Buffering them at the MP server closes that window (see
+[cache_events.md](cache_events.md)).
+- The `DELETE_PENDING`/pin placement states used by tier-aware
+cache-control directives (M3–M4 of the RFC).
 - **Token store (I3)**: the opt-in `content_hash → token_ids` store for
 `key → tokens` introspection, fed by `TOKENS` events and refcounted from
 key records via the `content_hash` back-pointer. Nothing

--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -68,6 +68,21 @@ Options
    * - ``--blend-probe-stride N``
      - Positions between CacheBlend match probes; ``1`` probes every offset
        for full recall (default: ``1``). Ignored unless blend lookup is on.
+   * - ``--snapshot-path FILE``
+     - Checkpoint the key directory to this file so a restart recovers the
+       placements the event stream never re-announces (cold L2 objects). Unset
+       (the default) disables checkpointing and the coordinator starts cold
+       every time.
+   * - ``--snapshot-interval SECS``
+     - Seconds between checkpoint writes; ``0`` writes only on shutdown
+       (default: ``60``). Ignored unless ``--snapshot-path`` is set.
+   * - ``--metadata-path FILE``
+     - Store operator-set state — L2 pins and per-``cache_salt`` quotas — in
+       this file so a restart keeps enforcing them. Written whenever pins or
+       quotas change, not on the snapshot timer. Nothing can rebuild this
+       state from the event stream; unset (the default) starts with no pins
+       and no quotas, which leaves eviction disarmed until the controller
+       re-syncs.
    * - ``--timeout-keep-alive SECS``
      - Seconds the HTTP server keeps idle connections open before closing
        them. Must be greater than the MP servers' heartbeat interval

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -88,6 +88,20 @@ keeps the default below.
      - ``1``
      - Positions between CacheBlend match probes. ``1`` probes every offset
        for full recall. Ignored unless blend lookup is on.
+   * - ``--snapshot-path``
+     - (empty)
+     - File the key directory is checkpointed to. Empty disables
+       checkpointing and the coordinator starts cold after every
+       restart. See `Surviving a coordinator restart`_.
+   * - ``--snapshot-interval``
+     - ``60``
+     - Seconds between checkpoint writes; ``0`` writes only on shutdown.
+       Ignored unless ``--snapshot-path`` is set. Does not affect the
+       metadata file, which is written whenever pins or quotas change.
+   * - ``--metadata-path``
+     - (empty)
+     - File the operator-set state (L2 pins and per-``cache_salt`` quotas)
+       is stored in. See `Surviving a coordinator restart`_.
    * - ``--timeout-keep-alive``
      - ``10``
      - Seconds the HTTP server keeps idle connections open before closing
@@ -105,6 +119,66 @@ keeps the default below.
        mode exposes ``/metrics`` on the coordinator HTTP port. When set, the
        local ``/metrics`` endpoint returns 404.
 
+Surviving a coordinator restart
+-------------------------------
+
+The key directory is built entirely from the MP servers' cache-event stream, so
+a coordinator that restarts with an empty directory loses every placement the
+stream will never re-announce — L2 objects stored some time ago, whose bytes
+outlive every reporter. Until something stores those chunks again, the fleet
+cannot discover them.
+
+Point ``--snapshot-path`` at a file to checkpoint the directory instead:
+
+.. code-block:: bash
+
+    lmcache coordinator --snapshot-path /var/lib/lmcache/directory.snapshot
+
+The coordinator then writes a checkpoint every ``--snapshot-interval`` seconds
+(default 60) and once more on clean shutdown, and loads it on boot. Restoring
+also rebuilds the per-``cache_salt`` usage view and the eviction LRU, so quota
+enforcement resumes accounting for what was already stored rather than starting
+from zero.
+
+**Operator-set state is a second, separate file.** L2 pins and per-tenant
+quotas are not observations of the cache — nothing can rebuild them by
+replaying events — so they are stored apart from the snapshot, as readable
+JSON, under ``--metadata-path``:
+
+.. code-block:: bash
+
+    lmcache coordinator \
+        --snapshot-path /var/lib/lmcache/directory.snapshot \
+        --metadata-path /var/lib/lmcache/metadata.json
+
+This file is **not** on the snapshot timer. It is rewritten whenever a pin or
+quota changes, before the request that made the change returns — so a ``200``
+from ``POST /cache/pins`` means the pin will survive a restart.
+
+Without it, a restarted coordinator holds no pins and no quotas, which leaves
+eviction disarmed until your controller re-syncs them. With it, enforcement
+resumes immediately — but the restored values are only as fresh as the last
+change, so a quota edited while the coordinator was down comes back at its
+old value. The controller remains the authority and should still re-sync;
+the file's age is logged on load.
+
+Operational notes:
+
+- **The file is disposable.** A missing, unreadable, or corrupt checkpoint is
+  logged and the coordinator starts cold — it never refuses to boot over one.
+  A failed write is logged and retried on the next interval.
+- **Writes are atomic.** The checkpoint is written beside the target and
+  renamed into place, so a crash mid-write cannot leave a torn file. Point the
+  path at persistent storage that survives the coordinator's own restarts (a
+  ``PersistentVolume`` rather than an ephemeral container filesystem).
+- **Size scales with cached tokens**, since the file carries each chunk's token
+  ids once per chunk hash. Budget on the order of a kilobyte per distinct
+  chunk.
+- **Events missed while the coordinator was down are still lost.** An MP server
+  that kept serving during the outage resumes at a higher sequence number, and
+  the coordinator flags that instance's slice with ``gap_detected`` (visible in
+  ``GET /directory/stats``). The checkpoint restores what it captured, not what
+  it missed.
 Coordinator metrics export
 --------------------------
 

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -142,6 +142,36 @@ class CoordinatorCommand(BaseCommand):
             ),
         )
         parser.add_argument(
+            "--snapshot-path",
+            type=str,
+            default=None,
+            help=(
+                "Checkpoint the key directory to this file so a restart "
+                "recovers placements the event stream never re-announces "
+                "(cold L2 objects). Unset disables checkpointing."
+            ),
+        )
+        parser.add_argument(
+            "--snapshot-interval",
+            type=float,
+            default=None,
+            help=(
+                "Seconds between key-directory checkpoints; 0 writes only "
+                "on shutdown. Ignored without --snapshot-path (default: 60)."
+            ),
+        )
+        parser.add_argument(
+            "--metadata-path",
+            type=str,
+            default=None,
+            help=(
+                "Store operator-set state (L2 pins and per-cache_salt quotas) "
+                "in this file so a restart keeps enforcing them. Nothing can "
+                "rebuild this state; unset, the coordinator starts with none "
+                "and waits for the controller to re-sync."
+            ),
+        )
+        parser.add_argument(
             "--timeout-keep-alive",
             type=int,
             default=None,
@@ -213,6 +243,9 @@ class CoordinatorCommand(BaseCommand):
                 ("hash_algorithm", args.hash_algorithm),
                 ("enable_blend_lookup", args.enable_blend_lookup),
                 ("blend_probe_stride", args.blend_probe_stride),
+                ("snapshot_path", args.snapshot_path),
+                ("snapshot_interval", args.snapshot_interval),
+                ("metadata_path", args.metadata_path),
                 ("timeout_keep_alive", args.timeout_keep_alive),
                 ("otlp_endpoint", args.otlp_endpoint),
             )

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -50,6 +50,20 @@ class L1BackendType(str, enum.Enum):
     GDS = "gds"
 
 
+class PersistenceType(str, enum.Enum):
+    """Which durable artifact a piece of coordinator state belongs in.
+
+    The two differ in cadence and in what can rebuild them.
+    ``CHECKPOINT`` state is derived from the cache-event stream, so it
+    rides with the periodic directory checkpoint and is disposable.
+    ``METADATA`` state is set by an operator and nothing can reconstruct
+    it, so it is written the moment it changes.
+    """
+
+    CHECKPOINT = "checkpoint"
+    METADATA = "metadata"
+
+
 class TrimPolicy(enum.Enum):
     """How to pick the retained subset of found keys for a prefetch.
 

--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -5,10 +5,10 @@ Eviction module to determine what to evict from L1 and L2 caches.
 
 # Standard
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 # First Party
-from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.api import ObjectKey, PersistenceType
 from lmcache.v1.distributed.internal_api import (
     EvictionAction,
     EvictionDestination,
@@ -40,6 +40,43 @@ class EvictionPolicy:
         (e.g., ``IsolatedLRUEvictionPolicy``) should override to return True.
         """
         return False
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        """Default: a policy's durable state rides with the checkpoint."""
+        return PersistenceType.CHECKPOINT
+
+    @property
+    def name(self) -> str:
+        """Name of this policy's section in a durable checkpoint.
+
+        Per implementation, not per interface: a deployment that swaps
+        policies finds no section under the new name and starts from
+        whatever rebuilds the keys, rather than misreading the old one.
+        """
+        return "eviction_policy"
+
+    def capture(self) -> Mapping[str, object]:
+        """Return the state a checkpoint must carry for this policy.
+
+        Default is empty: a policy whose ordering is implied by the keys
+        it is given needs nothing beyond them. Subclasses whose ordering
+        *is* their state (e.g. an LRU, where recency is position rather
+        than a stored timestamp) override this and :meth:`restore`.
+
+        Returns:
+            JSON-compatible values, keyed however the policy likes.
+        """
+        return {}
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        """Load a :meth:`capture` value.
+
+        Default is a no-op, matching the empty default capture.
+
+        Args:
+            state: The section a checkpoint held for this policy.
+        """
 
     @abstractmethod
     def register_eviction_destination(self, destination: EvictionDestination):

--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -18,11 +18,12 @@ from __future__ import annotations
 
 # Standard
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
+from typing import cast
 import threading
 
 # First Party
-from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.api import ObjectKey, PersistenceType
 from lmcache.v1.distributed.eviction import EvictionPolicy
 from lmcache.v1.distributed.internal_api import (
     EvictionAction,
@@ -189,3 +190,83 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         """Return the set of cache_salts with at least one tracked key."""
         with self._lock:
             return list(self._per_salt_order.keys())
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        """The ordering is derived from the event stream, so it rides with
+        the directory checkpoint."""
+        return PersistenceType.CHECKPOINT
+
+    @property
+    def name(self) -> str:
+        """Name of this policy's section in a durable checkpoint."""
+        return "lru_order"
+
+    def capture(self) -> Mapping[str, object]:
+        """Return each bucket's eviction order, least-recently-used first.
+
+        The ordering *is* the state: recency lives in position, not in a
+        timestamp, so nothing outside this policy can reconstruct it.
+
+        Returns:
+            ``{"buckets": {cache_salt: [(chunk_hash, model_name, kv_rank,
+            object_group_id), ...]}}``, each list in the order eviction
+            would pick them. One tuple per key rather than a mapping: this
+            runs on the caller's thread every checkpoint, and a fleet's
+            worth of per-key dicts is the most expensive thing in it. The
+            salt is the bucket, so it is not repeated.
+        """
+        with self._lock:
+            return {
+                "buckets": {
+                    cache_salt: [
+                        (
+                            key.chunk_hash,
+                            key.model_name,
+                            key.kv_rank,
+                            key.object_group_id,
+                        )
+                        for key in order
+                    ]
+                    for cache_salt, order in self._per_salt_order.items()
+                }
+            }
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        """Replace every bucket's ordering with a captured one.
+
+        Call once at startup, after whatever rebuilt the keys themselves —
+        this replaces their ordering rather than merging into it.
+
+        Args:
+            state: A :meth:`capture` value, as decoded from the
+                checkpoint holding it.
+        """
+        buckets = cast("Mapping[str, list[Sequence[object]]]", state["buckets"])
+        with self._lock:
+            self._per_salt_order = {
+                cache_salt: OrderedDict(
+                    (_decode_key(record, cache_salt), None) for record in ordered
+                )
+                for cache_salt, ordered in buckets.items()
+            }
+
+
+# -- Internals ----------------------------------------------------------------
+
+
+def _decode_key(record: Sequence[object], cache_salt: str) -> ObjectKey:
+    """Rebuild a key from one tuple :meth:`capture` wrote.
+
+    Args:
+        record: ``(chunk_hash, model_name, kv_rank, object_group_id)``.
+        cache_salt: The bucket the record was stored under.
+    """
+    chunk_hash, model_name, kv_rank, object_group_id = record
+    return ObjectKey(
+        chunk_hash=cast(bytes, chunk_hash),
+        model_name=str(model_name),
+        kv_rank=cast(int, kv_rank),
+        object_group_id=cast(int, object_group_id),
+        cache_salt=cache_salt,
+    )

--- a/lmcache/v1/distributed/quota_manager.py
+++ b/lmcache/v1/distributed/quota_manager.py
@@ -25,9 +25,12 @@ Salts without an explicit entry resolve through two different lenses:
 from __future__ import annotations
 
 # Standard
+from collections.abc import Mapping
+from typing import cast
 import threading
 
 # First Party
+from lmcache.v1.distributed.api import PersistenceType
 from lmcache.v1.distributed.internal_api import QuotaEntry
 
 
@@ -135,6 +138,51 @@ class QuotaManager:
         """
         with self._lock:
             return cache_salt in self._limits
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        """Operator-set limits; nothing else can reconstruct them."""
+        return PersistenceType.METADATA
+
+    @property
+    def name(self) -> str:
+        """Name of this registry's section in a durable document."""
+        return "quotas"
+
+    def capture(self) -> Mapping[str, object]:
+        """Return the limits in durable form.
+
+        Taken under one lock acquisition, so the per-salt limits and the
+        default cannot disagree about a concurrent update.
+
+        Returns:
+            ``{"limits": {cache_salt: limit_bytes}, "default_limit_bytes":
+            int | None}``.
+        """
+        with self._lock:
+            return {
+                "limits": dict(self._limits),
+                "default_limit_bytes": self._default_limit_bytes,
+            }
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        """Replace the limits with a captured set.
+
+        Applied under one lock acquisition, so no reader sees a
+        half-restored table.
+
+        The document is the coordinator's own, so values are taken as
+        written.
+
+        Args:
+            state: A :meth:`capture` value, as decoded from the
+                document holding it — see there for the shape.
+        """
+        limits = cast("dict[str, int]", state["limits"])
+        default_limit_bytes = cast("int | None", state["default_limit_bytes"])
+        with self._lock:
+            self._limits = dict(limits)
+            self._default_limit_bytes = default_limit_bytes
 
     def list_quotas(self) -> list[QuotaEntry]:
         """Return a snapshot of all registered quotas.

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -31,15 +31,26 @@ import httpx
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import PersistenceType
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers import build_controllers
 from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
-from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
 from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
 from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.checkpoint import (
+    load_checkpoint,
+    save_checkpoint,
+)
+from lmcache.v1.mp_coordinator.persistence.metadata_persister import MetadataPersister
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactStore,
+    LocalArtifactStore,
+    NullArtifactStore,
+)
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.utils.router_discovery import discover_api_routers
@@ -84,11 +95,17 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         key_directory.enable_blend_lookup(
             chunk_size=config.chunk_size, probe_stride=config.blend_probe_stride
         )
-    eviction_controller = FleetEvictionController(
-        eviction_ratio=config.eviction_ratio,
-        trigger_watermark=config.trigger_watermark,
+    snapshot_store = LocalArtifactStore(Path(config.snapshot_path))
+    metadata_store: ArtifactStore = (
+        LocalArtifactStore(Path(config.metadata_path))
+        if config.metadata_path
+        else NullArtifactStore()
     )
-    prefetch_manager = PrefetchManager()
+    # Controllers are discovered, not listed here.
+    controllers = build_controllers(config)
+    # Named locally only because the ingest fan-out and the lifespan drive
+    # this one directly; handlers reach it through the registry.
+    eviction_controller = controllers.get(FleetEvictionController)
     # Resolves pin requests' token_ids to object keys; must match the fleet's
     # chunk size and hash algorithm (see MPCoordinatorConfig).
     token_hasher = TokenHasher(
@@ -100,14 +117,30 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     event_broadcaster.register_consumer(key_directory)
     event_broadcaster.register_consumer(eviction_controller)
     event_gate = EventGate(event_broadcaster)
+    durable = controllers.durable_components()
+    metadata_persister = MetadataPersister(metadata_store)
+    for component in durable[PersistenceType.METADATA]:
+        metadata_persister.register(component)
+    checkpoint_components = durable[PersistenceType.CHECKPOINT]
+    # Before the checkpoint's replay, so restored keys enter the eviction
+    # LRU already protected by their pins.
+    metadata_persister.load()
+    if config.snapshot_path:
+        load_checkpoint(
+            snapshot_store,
+            key_directory,
+            event_gate,
+            event_broadcaster,
+            checkpoint_components,
+        )
 
     ctx = CoordinatorContext(
         registry=registry,
-        eviction_controller=eviction_controller,
-        prefetch_manager=prefetch_manager,
+        controllers=controllers,
         token_hasher=token_hasher,
         key_directory=key_directory,
         event_gate=event_gate,
+        metadata_persister=metadata_persister,
     )
 
     async def _health_loop() -> None:
@@ -115,6 +148,19 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         while True:
             await asyncio.sleep(config.health_check_interval)
             evict_stale(registry, config.instance_timeout)
+
+    async def _snapshot_loop() -> None:
+        """Checkpoint the directory and gate cursors on a timer.
+
+        Only these run on a timer: they change continuously, so a cadence
+        is the only sensible cost. Operator intent is written when it
+        changes instead (see ``MetadataPersister``).
+        """
+        while True:
+            await asyncio.sleep(config.snapshot_interval)
+            await save_checkpoint(
+                snapshot_store, key_directory, event_gate, checkpoint_components
+            )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -126,6 +172,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         app.state.outbound_client = outbound_client
         health_task = None
         eviction_task = None
+        snapshot_task = None
         if config.health_check_interval > 0:
             health_task = asyncio.create_task(_health_loop())
         if config.eviction_check_interval > 0:
@@ -134,17 +181,26 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
                     registry, outbound_client, config.eviction_check_interval
                 )
             )
+        if config.snapshot_path and config.snapshot_interval > 0:
+            snapshot_task = asyncio.create_task(_snapshot_loop())
         logger.info(
             "MP coordinator listening on http://%s:%d", config.host, config.port
         )
         try:
             yield
         finally:
-            for task in (health_task, eviction_task):
+            for task in (health_task, eviction_task, snapshot_task):
                 if task is not None:
                     task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await task
+            if config.snapshot_path:
+                # One last write, so a clean restart resumes where this
+                # process left off rather than an interval-old copy.
+                # Metadata needs no counterpart: it is already durable.
+                await save_checkpoint(
+                    snapshot_store, key_directory, event_gate, checkpoint_components
+                )
             await eviction_controller.wait_for_in_flight_dispatches()
             await outbound_client.aclose()
 

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -42,6 +42,16 @@ class MPCoordinatorConfig:
             no content.
         blend_probe_stride: Positions between match probes; ``1`` gives full
             recall. Ignored unless ``enable_blend_lookup`` is set.
+        snapshot_path: File the key directory is checkpointed to, so a
+            restart recovers placements the event stream never
+            re-announces. Empty (the default) starts cold every time.
+        snapshot_interval: Seconds between checkpoint writes; ``0`` writes
+            only on shutdown. Ignored unless ``snapshot_path`` is set.
+        metadata_path: File the operator-set state (L2 pins and quotas)
+            is stored in. Unlike the snapshot this is intent, not a view
+            of the event stream, so nothing can rebuild it. Empty (the
+            default) starts with no pins and no quotas, leaving eviction
+            disarmed until the controller re-syncs.
         timeout_keep_alive: Seconds the HTTP server keeps idle connections
             open before closing them. Must be greater than the heartbeat
             interval of MP servers to avoid race-condition disconnects.
@@ -61,6 +71,9 @@ class MPCoordinatorConfig:
     hash_algorithm: str = "blake3"
     enable_blend_lookup: bool = False
     blend_probe_stride: int = 1
+    snapshot_path: str = ""
+    snapshot_interval: float = 60.0
+    metadata_path: str = ""
     timeout_keep_alive: int = 10
     metrics_enabled: bool = True
     otlp_endpoint: str | None = None
@@ -83,6 +96,8 @@ class MPCoordinatorConfig:
             raise ValueError(
                 "trigger_watermark must be between 0.0 (exclusive) and 1.0"
             )
+        if self.snapshot_interval < 0:
+            raise ValueError("snapshot_interval must be non-negative")
         if self.chunk_size < 1:
             raise ValueError("chunk_size must be positive")
         if not self.hash_algorithm:

--- a/lmcache/v1/mp_coordinator/controllers/__init__.py
+++ b/lmcache/v1/mp_coordinator/controllers/__init__.py
@@ -1,1 +1,138 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Discovery for the coordinator's controllers.
+
+Controllers are found by scanning this package rather than listed at the
+call site, so dropping a new one in this directory is the whole of adding
+it: startup builds it, hands it out by type, and routes whatever durable
+state it advertises.
+"""
+
+# Standard
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING, TypeVar, cast
+import importlib
+import inspect
+import pkgutil
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import PersistenceType
+from lmcache.v1.mp_coordinator.controllers.base import Controller
+from lmcache.v1.mp_coordinator.persistence.store import DurableComponent
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+logger = init_logger(__name__)
+
+ControllerT = TypeVar("ControllerT", bound=Controller)
+
+
+class ControllerRegistry:
+    """The controllers a coordinator runs, addressed by type.
+
+    Handing this around instead of one field per controller keeps adding
+    a controller to a single change: writing it.
+    """
+
+    def __init__(self, controllers: Sequence[Controller]) -> None:
+        """Index ``controllers`` by their concrete type.
+
+        Args:
+            controllers: One instance per controller class.
+
+        Raises:
+            ValueError: If a type appears twice; callers address them by
+                type, so a duplicate has no unambiguous answer.
+        """
+        self._by_type: dict[type[Controller], Controller] = {}
+        for controller in controllers:
+            if type(controller) in self._by_type:
+                raise ValueError(f"duplicate controller {type(controller).__name__}")
+            self._by_type[type(controller)] = controller
+
+    def get(self, controller_type: type[ControllerT]) -> ControllerT:
+        """Return the controller of ``controller_type``.
+
+        Args:
+            controller_type: The class to look up.
+
+        Returns:
+            The single instance of that class.
+
+        Raises:
+            KeyError: If no such controller was discovered, which means
+                the class is not a ``Controller`` under ``controllers/``.
+        """
+        try:
+            # The index is keyed by concrete type, so the value is that type;
+            # the mapping's own annotation cannot say so.
+            return cast(ControllerT, self._by_type[controller_type])
+        except KeyError:
+            raise KeyError(
+                f"no {controller_type.__name__} was discovered under "
+                f"{__name__}; is it a Controller subclass in that package?"
+            ) from None
+
+    def durable_components(self) -> dict[PersistenceType, list[DurableComponent]]:
+        """Group every controller's durable state by where it persists.
+
+        Returns:
+            A list per :class:`PersistenceType`, empty where nothing
+            applies. Controllers holding nothing durable contribute
+            nothing, so a caller need not know which those are.
+        """
+        collected: dict[PersistenceType, list[DurableComponent]] = {
+            persistence_type: [] for persistence_type in PersistenceType
+        }
+        for controller in self._by_type.values():
+            for component in controller.get_durable_components():
+                collected[component.persistence_type].append(component)
+        return collected
+
+
+def build_controllers(config: "MPCoordinatorConfig") -> ControllerRegistry:
+    """Construct every controller in this package.
+
+    Each class is built by its ``from_config``, which by default ignores
+    the configuration -- so only a controller that reads it writes one.
+
+    Args:
+        config: Passed to each ``from_config``.
+
+    Returns:
+        The registry, built in class-name order so a checkpoint's
+        sections do not depend on filesystem order.
+    """
+    controllers = [
+        controller_type.from_config(config) for controller_type in _controller_types()
+    ]
+    logger.debug(
+        "Discovered %d controller(s): %s",
+        len(controllers),
+        ", ".join(type(controller).__name__ for controller in controllers),
+    )
+    return ControllerRegistry(controllers)
+
+
+# -- Internals ----------------------------------------------------------------
+
+
+def _controller_types() -> Iterator[type[Controller]]:
+    """Yield the ``Controller`` classes defined in this package.
+
+    Only classes a module defines itself are yielded, so one imported for
+    use elsewhere is not built a second time.
+    """
+    for module_info in sorted(
+        pkgutil.iter_modules(__path__), key=lambda info: info.name
+    ):
+        module = importlib.import_module(f"{__name__}.{module_info.name}")
+        for _, candidate in sorted(inspect.getmembers(module, inspect.isclass)):
+            if (
+                candidate.__module__ == module.__name__
+                and not inspect.isabstract(candidate)
+                and issubclass(candidate, Controller)
+            ):
+                yield candidate

--- a/lmcache/v1/mp_coordinator/controllers/base.py
+++ b/lmcache/v1/mp_coordinator/controllers/base.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""What makes a class in this package a controller.
+
+Discovery builds every ``Controller`` it finds here, so the marker is
+what separates a controller from the collaborators one owns -- the usage
+view, for instance, belongs to the eviction controller and must not be
+built a second time.
+"""
+
+# Standard
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+# First Party
+from lmcache.v1.mp_coordinator.persistence.store import DurableComponent
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+
+class Controller:
+    """A collaborator the coordinator builds once at startup.
+
+    Subclass to have discovery construct it (see ``build_controllers``).
+    """
+
+    @classmethod
+    def from_config(cls, config: "MPCoordinatorConfig") -> "Controller":
+        """Build this controller from the coordinator's configuration.
+
+        Defaults to ignoring it, so only a controller that reads
+        configuration writes this hook.
+
+        Args:
+            config: The coordinator configuration.
+        """
+        return cls()
+
+    def get_durable_components(self) -> Sequence[DurableComponent]:
+        """Return the state this controller needs to outlive the process.
+
+        Empty by default, so a controller holding nothing durable says
+        nothing about persistence at all. Each component it does return
+        carries the ``persistence_type`` that decides where it is stored.
+        """
+        return ()

--- a/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
+++ b/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
@@ -8,8 +8,9 @@ See ``docs/design/v1/mp_coordinator/l2_usage_and_eviction.md``.
 from __future__ import annotations
 
 # Standard
+from collections.abc import Mapping
 from dataclasses import asdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 import asyncio
 
 # Third Party
@@ -17,13 +18,16 @@ import httpx
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.api import Tier
+from lmcache.v1.distributed.api import EncodedObjectKey, PersistenceType, Tier
+from lmcache.v1.distributed.eviction import EvictionPolicy
 from lmcache.v1.distributed.eviction_policy.isolated_lru import (
     IsolatedLRUEvictionPolicy,
 )
 from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.mp_coordinator.api import CacheEventBatch, CacheEventType
+from lmcache.v1.mp_coordinator.controllers.base import Controller
 from lmcache.v1.mp_coordinator.controllers.usage_manager import L2UsageManager
+from lmcache.v1.mp_coordinator.persistence.store import DurableComponent
 from lmcache.v1.multiprocess.cache_control.object_service import (
     MAX_DELETE_BATCH,
 )
@@ -33,10 +37,14 @@ if TYPE_CHECKING:
     from lmcache.v1.distributed.api import ObjectKey
     from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
 logger = init_logger(__name__)
 
 
-class FleetEvictionController:
+class FleetEvictionController(Controller):
     """Per-``cache_salt`` L2 eviction controller for the fleet.
 
     Owns the quota registry and usage view it enforces against, both
@@ -61,14 +69,22 @@ class FleetEvictionController:
         self._trigger_watermark = trigger_watermark
         self._policy = IsolatedLRUEvictionPolicy()
         self._in_flight_dispatches: set[asyncio.Task] = set()
-        # Reference-counted L2 pins: a key is excluded from eviction plans while
-        # its count is > 0. Not persisted across coordinator restarts.
         self._pin_counts: dict[ObjectKey, int] = {}
 
     @property
     def quota(self) -> QuotaManager:
         """The budgets this controller enforces."""
         return self._quota_manager
+
+    @property
+    def policy(self) -> EvictionPolicy:
+        """The eviction policy, checkpointed as a durable component.
+
+        What it stores is the policy's business: an ordering-based policy
+        carries its order, one that derives everything from the keys
+        carries nothing.
+        """
+        return self._policy
 
     @property
     def usage(self) -> L2UsageManager:
@@ -133,6 +149,72 @@ class FleetEvictionController:
                 self._pin_counts.pop(key, None)
             else:
                 self._pin_counts[key] = count - 1
+
+    @classmethod
+    def from_config(cls, config: "MPCoordinatorConfig") -> "FleetEvictionController":
+        """Build the controller from the coordinator's configuration.
+
+        The discovery in ``controllers/__init__`` calls this, so the
+        eviction knobs stay defined next to the code that reads them.
+
+        Args:
+            config: The coordinator configuration.
+        """
+        return cls(
+            eviction_ratio=config.eviction_ratio,
+            trigger_watermark=config.trigger_watermark,
+        )
+
+    def get_durable_components(self) -> tuple[DurableComponent, ...]:
+        """Return the state this controller owns that must outlive the process.
+
+        Each component carries its own ``persistence_type``, so a caller routes
+        them without knowing what this controller is made of -- and gaining
+        durable state here does not change the wiring.
+
+        Returns:
+            The pin table (this object), the quota limits, and the policy.
+        """
+        return (self, self._quota_manager, self._policy)
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        """Pins are operator intent; nothing else can reconstruct them."""
+        return PersistenceType.METADATA
+
+    @property
+    def name(self) -> str:
+        """Name of the pin table's section in the metadata document."""
+        return "pins"
+
+    def capture(self) -> Mapping[str, object]:
+        """Return the pin table in its durable form.
+
+        Returns:
+            ``{"entries": [{"key": <EncodedObjectKey fields>, "count":
+            int}]}``.
+        """
+        return {
+            "entries": [
+                {"key": asdict(key.to_encoded_object_key()), "count": count}
+                for key, count in self._pin_counts.items()
+            ]
+        }
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        """Replace the pin table with a captured one.
+
+        The document is the coordinator's own, so values are taken as
+        written.
+
+        Args:
+            state: A :meth:`capture` value, as decoded from the
+                metadata document — see there for the shape; non-positive
+                counts are dropped.
+        """
+        entries = cast("list[Mapping[str, object]]", state["entries"])
+        restored = (_decode_pin(entry) for entry in entries)
+        self._pin_counts = {key: count for key, count in restored if count > 0}
 
     def filter_unpinned(self, keys: list[ObjectKey]) -> list[ObjectKey]:
         """Return the subset of ``keys`` with no active L2 pin, in input order.
@@ -303,3 +385,23 @@ class FleetEvictionController:
             key_count,
             salt_count,
         )
+
+
+def _decode_pin(entry: Mapping[str, object]) -> tuple[ObjectKey, int]:
+    """Rebuild one pin from the form :meth:`capture` produced.
+
+    Args:
+        entry: One ``entries`` element of the pin section.
+
+    Returns:
+        The key and its pin count.
+    """
+    fields = cast("Mapping[str, object]", entry["key"])
+    encoded = EncodedObjectKey(
+        chunk_hash_hex=str(fields["chunk_hash_hex"]),
+        model_name=str(fields["model_name"]),
+        kv_rank=cast(int, fields["kv_rank"]),
+        object_group_id=cast(int, fields["object_group_id"]),
+        cache_salt=str(fields["cache_salt"]),
+    )
+    return encoded.to_object_key(), cast(int, entry["count"])

--- a/lmcache/v1/mp_coordinator/controllers/prefetch_manager.py
+++ b/lmcache/v1/mp_coordinator/controllers/prefetch_manager.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.controllers.base import Controller
 
 if TYPE_CHECKING:
     # Third Party
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class PrefetchManager:
+class PrefetchManager(Controller):
     """Submit warm-prefetch requests to MP servers and proxy their status."""
 
     async def submit_prefetch(

--- a/lmcache/v1/mp_coordinator/http_apis/cache_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/cache_api.py
@@ -21,6 +21,10 @@ import httpx
 
 # First Party
 from lmcache.v1.distributed.api import Tier
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
 from lmcache.v1.mp_coordinator.http_apis.dependencies import (
     get_context,
     get_outbound_client,
@@ -70,7 +74,7 @@ async def request_prefetch(body: PrefetchRequest, request: Request) -> PrefetchR
         )
 
     try:
-        result = await ctx.prefetch_manager.submit_prefetch(
+        result = await ctx.controllers.get(PrefetchManager).submit_prefetch(
             target=target,
             http_client=get_outbound_client(request),
             model_name=body.model_name,
@@ -123,7 +127,7 @@ async def get_prefetch_status(
         )
 
     try:
-        code, payload = await ctx.prefetch_manager.get_status(
+        code, payload = await ctx.controllers.get(PrefetchManager).get_status(
             target=target,
             http_client=get_outbound_client(request),
             request_id=request_id,
@@ -158,6 +162,7 @@ async def request_pin(body: PinRequest, request: Request) -> PinResponse:
         HTTPException: 400 if the token cap is exceeded or a key field is invalid.
     """
     ctx = get_context(request)
+    eviction = ctx.controllers.get(FleetEvictionController)
     try:
         resolved, chunks = resolve_object_keys(
             ctx.token_hasher,
@@ -169,7 +174,8 @@ async def request_pin(body: PinRequest, request: Request) -> PinResponse:
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None
 
-    ctx.eviction_controller.pin(resolved)
+    eviction.pin(resolved)
+    await ctx.metadata_persister.save()
     return PinResponse(
         requested=chunks,
         affected=len(resolved),
@@ -194,6 +200,7 @@ async def request_unpin(body: PinRequest, request: Request) -> PinResponse:
         HTTPException: 400 if the token cap is exceeded or a key field is invalid.
     """
     ctx = get_context(request)
+    eviction = ctx.controllers.get(FleetEvictionController)
     try:
         resolved, chunks = resolve_object_keys(
             ctx.token_hasher,
@@ -205,7 +212,8 @@ async def request_unpin(body: PinRequest, request: Request) -> PinResponse:
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None
 
-    ctx.eviction_controller.unpin(resolved)
+    eviction.unpin(resolved)
+    await ctx.metadata_persister.save()
     return PinResponse(
         requested=chunks,
         affected=len(resolved),
@@ -235,6 +243,7 @@ async def request_delete(body: DeleteRequest, request: Request) -> DeleteRespons
             unreachable or rejects the delete.
     """
     ctx = get_context(request)
+    eviction = ctx.controllers.get(FleetEvictionController)
     target = ctx.registry.get(body.instance_id)
     if target is None:
         raise HTTPException(
@@ -266,7 +275,7 @@ async def request_delete(body: DeleteRequest, request: Request) -> DeleteRespons
     # tiers; ``force`` deletes them and clears the pins.
     touches_l2 = body.tier in (Tier.L2, Tier.ALL)
     if touches_l2 and not body.force:
-        delete_keys = ctx.eviction_controller.filter_unpinned(resolved)
+        delete_keys = eviction.filter_unpinned(resolved)
         pin_skipped = len(resolved) - len(delete_keys)
     else:
         delete_keys = resolved
@@ -296,7 +305,8 @@ async def request_delete(body: DeleteRequest, request: Request) -> DeleteRespons
         node_skipped = result.get("skipped", 0)
 
     if touches_l2 and body.force:
-        ctx.eviction_controller.drop_pins(resolved)
+        eviction.drop_pins(resolved)
+        await ctx.metadata_persister.save()
 
     # ``skipped`` = L1 keys the node refused (locks) + L2 keys the coordinator
     # held back for a pin.

--- a/lmcache/v1/mp_coordinator/http_apis/dependencies.py
+++ b/lmcache/v1/mp_coordinator/http_apis/dependencies.py
@@ -17,12 +17,10 @@ from fastapi import Request
 import httpx
 
 # First Party
-from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
-    FleetEvictionController,
-)
-from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
+from lmcache.v1.mp_coordinator.controllers import ControllerRegistry
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.metadata_persister import MetadataPersister
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
@@ -33,24 +31,27 @@ class CoordinatorContext:
 
     Attributes:
         registry: Fleet membership (``MPInstance`` by ``instance_id``).
-        eviction_controller: The fleet L2 eviction control loop. Owns the
-            quota registry (``.quota``), the usage view (``.usage``), and
-            the L2 pin set.
-        prefetch_manager: Warm-prefetch proxy to MP servers.
+        controllers: The coordinator's controllers, addressed by type --
+            ``controllers.get(FleetEvictionController)`` for the fleet L2
+            eviction loop (which owns the quota registry, the usage view,
+            and the L2 pin set), ``PrefetchManager`` for warm prefetch.
         token_hasher: Resolves a pin request's ``token_ids`` to object keys
             (configured to match the fleet's ``chunk_size`` / ``hash_algorithm``).
         key_directory: Fleet-wide key → placements directory built from
             MP-server cache events (eventually consistent).
         event_gate: Ingest entry point for the fleet cache-event stream
             (``POST /events``).
+        metadata_persister: Durable store for operator intent. Every
+            handler that changes a pin or a quota must ``await`` its
+            ``save`` so the change survives a restart.
     """
 
     registry: InstanceRegistry
-    eviction_controller: FleetEvictionController
-    prefetch_manager: PrefetchManager
+    controllers: ControllerRegistry
     token_hasher: TokenHasher
     key_directory: KeyDirectory
     event_gate: EventGate
+    metadata_persister: MetadataPersister
 
 
 def get_context(request: Request) -> CoordinatorContext:

--- a/lmcache/v1/mp_coordinator/http_apis/quota_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/quota_api.py
@@ -17,6 +17,9 @@ from fastapi.responses import JSONResponse
 
 # First Party
 from lmcache.v1.distributed.api import Tier
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
 from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
 from lmcache.v1.mp_coordinator.schemas import (
     QuotaConfigRequest,
@@ -73,8 +76,10 @@ async def set_quota_config(
     default_limit_bytes = (
         None if body.default_limit_gb is None else int(body.default_limit_gb * _GB)
     )
-    quota = get_context(request).eviction_controller.quota
-    quota.set_default_limit_bytes(default_limit_bytes)
+    ctx = get_context(request)
+    eviction = ctx.controllers.get(FleetEvictionController)
+    eviction.quota.set_default_limit_bytes(default_limit_bytes)
+    await ctx.metadata_persister.save()
     return QuotaConfigResponse(default_limit_gb=body.default_limit_gb)
 
 
@@ -92,7 +97,7 @@ async def get_quota_config(
         unquota'd salts are exempt from eviction (the boot default).
     """
     _require_supported_tier(tier)
-    quota = get_context(request).eviction_controller.quota
+    quota = get_context(request).controllers.get(FleetEvictionController).quota
     default_limit = quota.get_default_limit_bytes()
     return QuotaConfigResponse(
         default_limit_gb=None if default_limit is None else _gb(default_limit)
@@ -118,12 +123,13 @@ async def set_quota(
     _require_supported_tier(body.tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
     limit_bytes = int(body.limit_gb * _GB)
+    ctx = get_context(request)
+    eviction = ctx.controllers.get(FleetEvictionController)
     try:
-        get_context(request).eviction_controller.quota.set_quota(
-            cache_salt, limit_bytes
-        )
+        eviction.quota.set_quota(cache_salt, limit_bytes)
     except ValueError:
         return JSONResponse(status_code=400, content={"error": "invalid quota limit"})
+    await ctx.metadata_persister.save()
     return QuotaResponse(cache_salt=cache_salt, limit_gb=body.limit_gb, status="ok")
 
 
@@ -142,8 +148,10 @@ async def delete_quota(
     """
     _require_supported_tier(tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
-    quota = get_context(request).eviction_controller.quota
-    removed = quota.delete_quota(cache_salt)
+    ctx = get_context(request)
+    eviction = ctx.controllers.get(FleetEvictionController)
+    removed = eviction.quota.delete_quota(cache_salt)
+    await ctx.metadata_persister.save()
     return QuotaResponse(
         cache_salt=cache_salt,
         limit_gb=0.0,
@@ -170,8 +178,9 @@ async def get_status(
     _require_supported_tier(tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
     ctx = get_context(request)
-    quota = ctx.eviction_controller.quota
-    usage = ctx.eviction_controller.usage.get(cache_salt)
+    eviction = ctx.controllers.get(FleetEvictionController)
+    quota = eviction.quota
+    usage = eviction.usage.get(cache_salt)
     exists = quota.has_quota(cache_salt)
     limit = quota.get_limit_bytes(cache_salt)
     return StatusResponse(
@@ -194,8 +203,9 @@ async def list_status(request: Request, tier: Tier = Tier.L2) -> StatusListRespo
     """
     _require_supported_tier(tier)
     ctx = get_context(request)
-    usage_view = ctx.eviction_controller.usage
-    quota_registry = ctx.eviction_controller.quota
+    eviction = ctx.controllers.get(FleetEvictionController)
+    usage_view = eviction.usage
+    quota_registry = eviction.quota
     by_salt = usage_view.get_all()
     total = usage_view.get_total()
     quota_entries = {e.cache_salt: e.limit_bytes for e in quota_registry.list_quotas()}

--- a/lmcache/v1/mp_coordinator/ingest/event_gate.py
+++ b/lmcache/v1/mp_coordinator/ingest/event_gate.py
@@ -12,6 +12,7 @@ See ``docs/design/v1/mp_coordinator/ingest.md``.
 from __future__ import annotations
 
 # Standard
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 import threading
@@ -121,6 +122,37 @@ class EventGate:
         with self._lock:
             self._broadcaster.fence_instance(instance_id)
             self._cursors.pop(instance_id, None)
+
+    def restore_cursors(self, cursors: Mapping[str, InstanceStreamStats]) -> None:
+        """Load cursors captured by :meth:`stats`.
+
+        Call once at startup, before serving, whenever the consumers'
+        state was itself restored from a checkpoint. Fencing needs a
+        prior incarnation to compare against — without these, an emitter
+        that restarted while the coordinator was down looks brand new, so
+        the L1 placements its previous incarnation reported are never
+        dropped.
+
+        Args:
+            cursors: Cursors keyed by ``instance_id``.
+
+        Raises:
+            ValueError: If the gate has already admitted a batch.
+        """
+        with self._lock:
+            if self._cursors:
+                raise ValueError(
+                    f"restore_cursors() requires an unused gate (holds "
+                    f"{len(self._cursors)} cursors)"
+                )
+            self._cursors = {
+                instance_id: _StreamCursor(
+                    incarnation=cursor.incarnation,
+                    last_seq=cursor.last_seq,
+                    gap_detected=cursor.gap_detected,
+                )
+                for instance_id, cursor in cursors.items()
+            }
 
     def stats(self) -> dict[str, InstanceStreamStats]:
         """Return a cursor snapshot keyed by ``instance_id``."""

--- a/lmcache/v1/mp_coordinator/key_directory.py
+++ b/lmcache/v1/mp_coordinator/key_directory.py
@@ -83,6 +83,31 @@ class DirectoryStats:
     blend: BlendIndexStats
 
 
+@dataclass(frozen=True)
+class DirectorySnapshot:
+    """A capture of a :class:`KeyDirectory`'s state.
+
+    Produced by :meth:`KeyDirectory.snapshot`, consumed by
+    :meth:`KeyDirectory.restore`, encoded by
+    ``persistence/snapshot_codec.py``.
+
+    Attributes:
+        keys: ``key → (last_access, placements)``, for every key with at
+            least one placement. Iteration order is the key table's
+            order, which instance records index into.
+        bindings: ``chunk_hash → (token_ids, token_offset)``, for the
+            chunks that carry content; ``token_ids`` is a read-only
+            ``uint32`` array. Chunks that never carried content are
+            absent and rebuild empty.
+        l1_keys_by_instance: The reverse index fencing needs, so a
+            restored directory can still drop an emitter's L1 slice.
+    """
+
+    keys: dict[ObjectKey, tuple[float, tuple[Placement, ...]]]
+    bindings: dict[bytes, tuple[np.ndarray, int]]
+    l1_keys_by_instance: dict[str, tuple[ObjectKey, ...]]
+
+
 @dataclass
 class _KeyRecord:
     """Directory value for one key: its placements plus recency."""
@@ -107,7 +132,9 @@ class KeyDirectory:
 
     Mutations arrive through the ingest layer's two consumer hooks,
     :meth:`consume` and :meth:`fence_instance`; reads through
-    :meth:`lookup` and :meth:`stats`. Nothing is persisted.
+    :meth:`lookup` and :meth:`stats`. The directory holds no files of its
+    own: :meth:`snapshot` and :meth:`restore` hand its state to a caller
+    that owns the storage.
 
     Fragment (blend) lookup is off until :meth:`enable_blend_lookup` is
     called, so a fleet that does not run CacheBlend hashes no content.
@@ -303,6 +330,75 @@ class KeyDirectory:
                 instance_id,
                 removed,
             )
+
+    def snapshot(self) -> DirectorySnapshot:
+        """Capture the directory's state for persistence.
+
+        Taken under the lock and sharing no structure with the directory,
+        so callers may encode it off-thread while the directory keeps
+        serving. Token arrays are aliased, not copied.
+
+        Returns:
+            The captured state.
+        """
+        with self._lock:
+            keys = {
+                key: (record.last_access, tuple(record.placements))
+                for key, record in self._directory.items()
+            }
+            bindings = {
+                chunk_hash: (binding.token_ids, binding.token_offset)
+                for chunk_hash, binding in self._token_bindings.items()
+                if binding.token_ids.size
+            }
+            l1_keys_by_instance = {
+                instance_id: tuple(keys_held)
+                for instance_id, keys_held in self._l1_keys_by_instance.items()
+            }
+            return DirectorySnapshot(
+                keys=keys,
+                bindings=bindings,
+                l1_keys_by_instance=l1_keys_by_instance,
+            )
+
+    def restore(self, snapshot: DirectorySnapshot) -> None:
+        """Load ``snapshot`` into an empty directory.
+
+        Call once at startup. Token bindings and blend fingerprints are
+        re-derived, so :meth:`enable_blend_lookup` must run first for
+        restored content to be fragment-matchable. Restoring placements
+        without the gate's cursors would leave them unfenceable — see
+        :meth:`EventGate.restore_cursors`.
+
+        Args:
+            snapshot: State captured by :meth:`snapshot`.
+
+        Raises:
+            ValueError: If the directory already holds keys.
+        """
+        with self._lock:
+            if self._directory or self._l1_keys_by_instance:
+                raise ValueError(
+                    "restore() requires an empty directory (holds "
+                    f"{len(self._directory)} keys, "
+                    f"{len(self._l1_keys_by_instance)} instances)"
+                )
+            for key, (last_access, placements) in snapshot.keys.items():
+                self._directory[key] = _KeyRecord(
+                    placements=list(placements), last_access=last_access
+                )
+                self._add_token_binding(key)
+            for chunk_hash, (token_ids, token_offset) in snapshot.bindings.items():
+                binding = self._token_bindings.get(chunk_hash)
+                if binding is None:
+                    # Content no surviving key references: nothing owns it.
+                    continue
+                binding.token_ids = token_ids
+                binding.token_offset = token_offset
+                if self._blend_lookup_enabled and token_offset != UNKNOWN_TOKEN_OFFSET:
+                    self._blend_index.add(token_ids, chunk_hash, token_offset)
+            for instance_id, l1_keys in snapshot.l1_keys_by_instance.items():
+                self._l1_keys_by_instance[instance_id] = set(l1_keys)
 
     def stats(self) -> DirectoryStats:
         """Return a point-in-time summary of directory contents."""

--- a/lmcache/v1/mp_coordinator/persistence/__init__.py
+++ b/lmcache/v1/mp_coordinator/persistence/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+"""What the coordinator keeps across a restart.
+
+Two artifacts, because they agree on nothing that matters:
+
+- The **directory checkpoint** (``checkpoint.py`` over
+  ``snapshot_codec.py``) — large, binary, derived from the event stream,
+  rewritten whole on a timer, and safe to lose.
+- The **metadata document** (``metadata_persister.py``) — small, JSON, operator
+  intent that nothing can rebuild, written when it changes.
+
+Both sit on the one storage contract in ``store.py``, so a local file
+today and an object store later are a single class apart.
+
+Verbs follow the layer, so a name says which one you are at:
+
+- ``capture`` / ``restore`` — live state ↔ a transferable value
+- ``open_read`` / ``open_write`` — byte streams over stored bytes
+- ``load`` / ``save`` — a whole artifact, storage included
+
+See ``docs/design/v1/mp_coordinator/key_directory.md``.
+"""

--- a/lmcache/v1/mp_coordinator/persistence/checkpoint.py
+++ b/lmcache/v1/mp_coordinator/persistence/checkpoint.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Directory checkpointing: load on boot, rewrite on a timer.
+
+Covers only state derived from the event stream; operator intent lives in
+``metadata_persister.py``. Best-effort throughout — an unusable checkpoint
+starts the coordinator cold and a failed write retries next tick, because
+losing any of this costs hit rate, never correctness.
+
+See ``docs/design/v1/mp_coordinator/key_directory.md``.
+"""
+
+# Standard
+from collections.abc import Iterator, Mapping, Sequence
+import asyncio
+import itertools
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
+from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate, InstanceStreamStats
+from lmcache.v1.mp_coordinator.key_directory import DirectorySnapshot, KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.snapshot_codec import (
+    SnapshotFormatError,
+    read_snapshot,
+    write_snapshot,
+)
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactNotFoundError,
+    ArtifactStore,
+    DurableComponent,
+)
+
+logger = init_logger(__name__)
+
+
+def load_checkpoint(
+    store: ArtifactStore,
+    directory: KeyDirectory,
+    gate: EventGate,
+    broadcaster: CacheEventBroadcaster,
+    components: Sequence[DurableComponent] = (),
+) -> None:
+    """Load the stored checkpoint into ``directory``, the ingest gate, and
+    the other consumers — or leave them all cold.
+
+    Call once at startup, after ``enable_blend_lookup`` and after the
+    broadcaster's consumers are registered.
+
+    Args:
+        store: Where the checkpoint is stored.
+        directory: The empty directory to populate.
+        gate: The unused ingest gate, whose cursors decide whether
+            restored L1 placements can still be fenced.
+        broadcaster: Fan-out to the other consumers, which the restored
+            placements are replayed into.
+        components: State that rides with the placements because the replay
+            cannot reconstruct it — restored *after* the replay, so it
+            replaces whatever that left behind.
+
+    Raises:
+        ValueError: If ``directory`` or ``gate`` already holds state.
+    """
+    try:
+        with store.open_read() as f:
+            snapshot, cursors, sections = read_snapshot(f)
+    except ArtifactNotFoundError:
+        logger.info("No coordinator checkpoint at %s; starting cold", store.location())
+        return
+    except (OSError, SnapshotFormatError) as e:
+        logger.warning("Ignoring coordinator checkpoint %s: %s", store.location(), e)
+        return
+    directory.restore(snapshot)
+    gate.restore_cursors(cursors)
+    for batch in _replay_batches(snapshot):
+        broadcaster.broadcast(batch)
+    for component in components:
+        if component.name in sections:
+            component.restore(sections[component.name])
+    stats = directory.stats()
+    logger.info(
+        "Restored %d keys / %d placements / %d stream cursors%s from checkpoint %s",
+        stats.num_keys,
+        stats.num_placements,
+        len(cursors),
+        "".join(f" / {key}" for key in sections),
+        store.location(),
+    )
+
+
+async def save_checkpoint(
+    store: ArtifactStore,
+    directory: KeyDirectory,
+    gate: EventGate,
+    components: Sequence[DurableComponent] = (),
+) -> None:
+    """Write the coordinator's restorable state to ``store``.
+
+    Captures on the calling thread, briefly holding each source's lock,
+    then encodes and writes off-thread. Write failures are logged rather
+    than raised.
+
+    Args:
+        store: Where to put the checkpoint.
+        directory: The directory to capture.
+        gate: The ingest gate, whose cursors are captured alongside.
+        components: State captured into the trailing sections.
+    """
+    # Cursors first: a gate ahead of the directory would drop the gap as
+    # duplicates on restore.
+    cursors = gate.stats()
+    snapshot = directory.snapshot()
+    sections = {c.name: c.capture() for c in components}
+    try:
+        await asyncio.to_thread(_write_snapshot, store, snapshot, cursors, sections)
+    except OSError as e:
+        logger.warning(
+            "Failed to write coordinator checkpoint %s: %s", store.location(), e
+        )
+        return
+    logger.debug("Checkpointed %d keys to %s", len(snapshot.keys), store.location())
+
+
+# -- Internals ----------------------------------------------------------------
+
+
+def _replay_batches(snapshot: DirectorySnapshot) -> Iterator[CacheEventBatch]:
+    """Yield restored placements as ``STORE`` batches, one per run of
+    same-identity placements.
+
+    ``restore`` fills the directory alone, so without this the coordinator
+    comes back with a full directory and zero accounted bytes. Order does
+    not matter: what the replay rebuilds is per-salt byte totals, and
+    anything order-dependent (the eviction LRU) restores itself from its
+    own section afterwards.
+    """
+    placements = [
+        (key, placement)
+        for key, (_, key_placements) in snapshot.keys.items()
+        for placement in key_placements
+    ]
+    grouped = itertools.groupby(
+        placements,
+        key=lambda item: (
+            item[1].instance_id,
+            item[1].incarnation,
+            item[1].tier,
+            item[1].backend,
+            item[1].shared,
+        ),
+    )
+    for seq, (identity, run) in enumerate(grouped, start=1):
+        instance_id, incarnation, tier, backend, shared = identity
+        yield CacheEventBatch(
+            instance_id=instance_id,
+            incarnation=incarnation,
+            seq=seq,
+            event_type=CacheEventType.STORE,
+            tier=tier,
+            backend=backend,
+            shared=shared,
+            entries=[
+                CacheEventEntry(
+                    key=key.to_encoded_object_key(), size_bytes=placement.size_bytes
+                )
+                for key, placement in run
+            ],
+        )
+
+
+def _write_snapshot(
+    store: ArtifactStore,
+    snapshot: DirectorySnapshot,
+    cursors: Mapping[str, InstanceStreamStats],
+    sections: Mapping[str, Mapping[str, object]],
+) -> None:
+    """Encode every capture into a replacement of ``store``'s contents."""
+    with store.open_write() as f:
+        write_snapshot(snapshot, cursors, sections, f)

--- a/lmcache/v1/mp_coordinator/persistence/metadata_persister.py
+++ b/lmcache/v1/mp_coordinator/persistence/metadata_persister.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Durable operator intent: L2 pins and per-``cache_salt`` quotas.
+
+Unlike the directory checkpoint, nothing can rebuild this — hence a
+separate artifact, written whenever it changes, as JSON small enough to
+read with ``cat`` when a tenant asks why their cache was evicted.
+Components register with the persister and serialize themselves (the
+shape ``CacheEventBroadcaster.register_consumer`` uses), so the persister
+knows the document and nothing about pins or quotas.
+
+See ``docs/design/v1/mp_coordinator/key_directory.md``.
+"""
+
+# Standard
+from collections.abc import Mapping
+import asyncio
+import json
+import time
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import PersistenceType
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactNotFoundError,
+    ArtifactStore,
+    DurableComponent,
+)
+
+logger = init_logger(__name__)
+
+_FORMAT_VERSION = 1
+
+
+class MetadataFormatError(Exception):
+    """The stored document is malformed or of an unknown version."""
+
+
+class MetadataPersister:
+    """Saves and restores every registered :class:`DurableComponent`.
+
+    Writes are synchronous with the change that caused them, so a pin is
+    durable by the time its response returns.
+
+    Args:
+        store: Where the document lives.
+    """
+
+    def __init__(self, store: ArtifactStore) -> None:
+        self._store = store
+        self._components: list[DurableComponent] = []
+
+    def register(self, component: DurableComponent) -> None:
+        """Add ``component`` to the document; call before :meth:`load`.
+
+        Args:
+            component: The state to persist alongside the rest. Its
+                ``persistence_type`` must be ``METADATA``.
+
+        Raises:
+            ValueError: If the component belongs in the checkpoint instead.
+                Derived state here would be rewritten on every operator
+                change and reloaded ahead of the replay that owns it.
+        """
+        if component.persistence_type is not PersistenceType.METADATA:
+            raise ValueError(
+                f"{component.name!r} is {component.persistence_type.value} state; "
+                f"the metadata document takes only metadata components"
+            )
+        self._components.append(component)
+
+    def load(self) -> None:
+        """Restore every registered component, or leave them empty.
+
+        Call once at startup, before the directory checkpoint replays
+        placements: restored pins must be in place before their keys
+        enter the eviction LRU. An unusable document is logged and
+        skipped, leaving eviction disarmed until the controller re-syncs.
+        """
+        try:
+            with self._store.open_read() as stream:
+                sections, saved_at = _decode(stream.read())
+        except ArtifactNotFoundError as e:
+            # The store's own wording covers both "not configured at all"
+            # and "configured but nothing written yet".
+            logger.info("Starting with no metadata: %s", e)
+            return
+        except (OSError, MetadataFormatError) as e:
+            logger.warning("Ignoring metadata %s: %s", self._store.location(), e)
+            return
+        try:
+            for component in self._components:
+                if component.name in sections:
+                    component.restore(sections[component.name])
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning("Ignoring metadata %s: %s", self._store.location(), e)
+            return
+        logger.info(
+            "Restored %s from %s, captured %.0fs ago; the controller remains "
+            "the authority and should re-sync",
+            ", ".join(component.name for component in self._components),
+            self._store.location(),
+            max(0.0, time.time() - saved_at),
+        )
+
+    async def save(self) -> None:
+        """Write every registered component's current state.
+
+        Call from each handler that changes durable state, after the
+        change. Write failures are logged, not raised: a full disk costs
+        the change's durability, not the request.
+        """
+        sections = {
+            component.name: component.capture() for component in self._components
+        }
+        try:
+            await asyncio.to_thread(_write, self._store, _encode(sections))
+        except OSError as e:
+            logger.warning("Failed to write metadata %s: %s", self._store.location(), e)
+
+
+# -- Internals ----------------------------------------------------------------
+
+
+def _write(store: ArtifactStore, document: bytes) -> None:
+    """Replace ``store``'s artifact with ``document``."""
+    with store.open_write() as stream:
+        stream.write(document)
+
+
+def _encode(sections: Mapping[str, Mapping[str, object]]) -> bytes:
+    """Serialize the document: version, capture time, then each section."""
+    return json.dumps(
+        {
+            "version": _FORMAT_VERSION,
+            "saved_at": time.time(),
+            "components": sections,
+        },
+        indent=2,
+    ).encode("utf-8")
+
+
+def _decode(raw: bytes) -> tuple[Mapping[str, Mapping[str, object]], float]:
+    """Parse a document written by :func:`_encode`.
+
+    Args:
+        raw: The stored bytes.
+
+    Returns:
+        The sections keyed by ``name``, and the capture time.
+
+    Raises:
+        MetadataFormatError: If the bytes are not a document of a version
+            this build reads.
+    """
+    try:
+        body = json.loads(raw)
+        version = body["version"]
+        if version != _FORMAT_VERSION:
+            raise MetadataFormatError(
+                f"unsupported metadata version {version} "
+                f"(this build reads {_FORMAT_VERSION})"
+            )
+        sections = body["components"]
+        if not isinstance(sections, dict):
+            raise MetadataFormatError("components must be an object")
+        return sections, float(body["saved_at"])
+    except MetadataFormatError:
+        raise
+    except (AttributeError, KeyError, TypeError, ValueError) as e:
+        raise MetadataFormatError(f"malformed metadata: {e}") from e

--- a/lmcache/v1/mp_coordinator/persistence/snapshot_codec.py
+++ b/lmcache/v1/mp_coordinator/persistence/snapshot_codec.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Binary codec for a coordinator checkpoint.
+
+Layout (version 1)::
+
+    magic "LMCKDIR\\0" | u32 version | u32 length | msgpack structure
+    raw uint32 token arrays, one per binding, in structure order
+
+Everything but the token arrays goes through msgpack (``msgspec``, as the
+trace format does), so the field-level encoding is declared rather than
+written out. The arrays stay outside it: they are the bulk of the file, and
+writing them raw keeps the encoder from copying a gigabyte to hand back.
+
+The reverse index and component sections name their keys by position in the
+key list, so a key referenced from several places is stored once.
+
+See ``docs/design/v1/mp_coordinator/key_directory.md``.
+"""
+
+# Standard
+from collections.abc import Mapping
+from typing import BinaryIO, cast
+import struct
+
+# Third Party
+import msgspec
+import numpy as np
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.mp_coordinator.ingest.event_gate import InstanceStreamStats
+from lmcache.v1.mp_coordinator.key_directory import DirectorySnapshot, Placement
+
+logger = init_logger(__name__)
+
+_MAGIC = b"LMCKDIR\0"
+_FORMAT_VERSION = 1
+
+# Token ids go to disk as little-endian uint32 regardless of host order,
+# so a snapshot moves between machines.
+_TOKENS = np.dtype("<u4")
+
+_PREFIX = struct.Struct("<8sII")
+
+_ENCODER = msgspec.msgpack.Encoder()
+
+
+class SnapshotFormatError(Exception):
+    """A snapshot stream is malformed, truncated, or of an unknown version."""
+
+
+def write_snapshot(
+    snapshot: DirectorySnapshot,
+    cursors: Mapping[str, InstanceStreamStats],
+    sections: Mapping[str, Mapping[str, object]],
+    stream: BinaryIO,
+) -> None:
+    """Encode the directory, the gate's cursors, and component sections.
+
+    Args:
+        snapshot: The captured directory state.
+        cursors: The ingest gate's per-emitter cursors, from
+            :meth:`EventGate.stats`.
+        sections: Each registered component's ``capture()``, keyed by
+            its ``name``.
+        stream: Binary stream to write to; positioned at the end on return.
+
+    Raises:
+        OSError: If the stream rejects a write.
+    """
+    key_indices = {key: index for index, key in enumerate(snapshot.keys)}
+    arrays = [token_ids for token_ids, _ in snapshot.bindings.values()]
+    structure = _Structure(
+        keys=[
+            _KeyRecord(key=key, last_access=last_access, placements=list(placements))
+            for key, (last_access, placements) in snapshot.keys.items()
+        ],
+        bindings=[
+            _Binding(
+                chunk_hash=chunk_hash,
+                token_offset=token_offset,
+                num_tokens=int(token_ids.size),
+            )
+            for chunk_hash, (token_ids, token_offset) in snapshot.bindings.items()
+        ],
+        l1_keys_by_instance={
+            instance_id: _indices(key_indices, l1_keys, instance_id)
+            for instance_id, l1_keys in snapshot.l1_keys_by_instance.items()
+        },
+        cursors=dict(cursors),
+        sections={key: _ENCODER.encode(payload) for key, payload in sections.items()},
+    )
+    payload = _ENCODER.encode(structure)
+    stream.write(_PREFIX.pack(_MAGIC, _FORMAT_VERSION, len(payload)))
+    stream.write(payload)
+    for token_ids in arrays:
+        stream.write(token_ids.astype(_TOKENS, copy=False).tobytes())
+
+
+def read_snapshot(
+    stream: BinaryIO,
+) -> tuple[
+    DirectorySnapshot,
+    dict[str, InstanceStreamStats],
+    dict[str, Mapping[str, object]],
+]:
+    """Decode a snapshot written by :func:`write_snapshot`.
+
+    Args:
+        stream: Binary stream positioned at the start of the snapshot.
+
+    Returns:
+        The directory state for :meth:`KeyDirectory.restore`, the cursors
+        for :meth:`EventGate.restore_cursors`, and each component's section
+        keyed by its ``name``.
+
+    Raises:
+        SnapshotFormatError: If the stream is not a snapshot, carries an
+            unsupported version, is truncated, or violates an
+            :class:`ObjectKey` invariant.
+    """
+    magic, version, length = _PREFIX.unpack(_read(stream, _PREFIX.size))
+    if magic != _MAGIC:
+        raise SnapshotFormatError(f"not a directory snapshot (magic {magic!r})")
+    if version != _FORMAT_VERSION:
+        raise SnapshotFormatError(
+            f"unsupported snapshot version {version} "
+            f"(this build reads {_FORMAT_VERSION})"
+        )
+    try:
+        structure = msgspec.msgpack.Decoder(_Structure).decode(_read(stream, length))
+        key_table = [record.key for record in structure.keys]
+        keys = {
+            record.key: (record.last_access, tuple(record.placements))
+            for record in structure.keys
+        }
+        bindings = {
+            binding.chunk_hash: (
+                _read_tokens(stream, binding.num_tokens),
+                binding.token_offset,
+            )
+            for binding in structure.bindings
+        }
+        l1_keys_by_instance = {
+            instance_id: tuple(_key_at(key_table, index, instance_id) for index in idx)
+            for instance_id, idx in structure.l1_keys_by_instance.items()
+        }
+        sections = {
+            key: cast("Mapping[str, object]", msgspec.msgpack.decode(payload))
+            for key, payload in structure.sections.items()
+        }
+    except (msgspec.MsgspecError, ValueError) as e:
+        # Covers a truncated or non-conforming payload and ObjectKey's own
+        # field invariants, which msgspec enforces on decode.
+        raise SnapshotFormatError(f"malformed directory snapshot: {e}") from e
+    return (
+        DirectorySnapshot(
+            keys=keys, bindings=bindings, l1_keys_by_instance=l1_keys_by_instance
+        ),
+        structure.cursors,
+        sections,
+    )
+
+
+# -- Internals ----------------------------------------------------------------
+
+
+class _KeyRecord(msgspec.Struct):
+    """One key with its recency and live placements."""
+
+    key: ObjectKey
+    last_access: float
+    placements: list[Placement]
+
+
+class _Binding(msgspec.Struct):
+    """One chunk's token metadata; its array follows the structure."""
+
+    chunk_hash: bytes
+    token_offset: int
+    num_tokens: int
+
+
+class _Structure(msgspec.Struct):
+    """Everything in the checkpoint except the token arrays."""
+
+    keys: list[_KeyRecord]
+    bindings: list[_Binding]
+    l1_keys_by_instance: dict[str, list[int]]
+    cursors: dict[str, InstanceStreamStats]
+    sections: dict[str, bytes]
+
+
+def _indices(
+    key_indices: Mapping[ObjectKey, int], keys: tuple[ObjectKey, ...], owner: str
+) -> list[int]:
+    """Resolve ``keys`` to key-list positions, dropping any with no record."""
+    resolved = [key_indices[key] for key in keys if key in key_indices]
+    if len(resolved) != len(keys):
+        # Tracked keys holding no placement; dropping them is what a
+        # restore would converge to anyway.
+        logger.warning(
+            "Snapshot: %s tracks %d unplaced keys; dropping them",
+            owner,
+            len(keys) - len(resolved),
+        )
+    return resolved
+
+
+def _key_at(key_table: list[ObjectKey], index: int, owner: str) -> ObjectKey:
+    """Resolve one key-list position.
+
+    Raises:
+        SnapshotFormatError: If ``index`` is out of range.
+    """
+    if index >= len(key_table):
+        raise SnapshotFormatError(
+            f"{owner!r} references key index {index} of {len(key_table)}"
+        )
+    return key_table[index]
+
+
+def _read_tokens(stream: BinaryIO, num_tokens: int) -> np.ndarray:
+    """Read one chunk's token array, as written after the structure."""
+    raw = _read(stream, num_tokens * _TOKENS.itemsize)
+    token_ids = np.frombuffer(raw, dtype=_TOKENS).astype(np.uint32, copy=False)
+    token_ids.flags.writeable = False
+    return token_ids
+
+
+def _read(stream: BinaryIO, size: int) -> bytes:
+    """Read exactly ``size`` bytes.
+
+    Raises:
+        SnapshotFormatError: If the stream ends first.
+    """
+    data = stream.read(size)
+    if len(data) != size:
+        raise SnapshotFormatError(
+            f"truncated snapshot: wanted {size} bytes, got {len(data)}"
+        )
+    return data

--- a/lmcache/v1/mp_coordinator/persistence/store.py
+++ b/lmcache/v1/mp_coordinator/persistence/store.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Where a durable artifact's bytes live, and who can produce them.
+
+One storage contract serves both artifacts: each is a single whole object,
+replaced atomically, at one location. The seam is a byte stream rather
+than a value, because the directory snapshot runs to gigabytes and neither
+side should hold two copies — the metadata document layers its JSON on top
+of the same primitive.
+
+See ``docs/design/v1/mp_coordinator/key_directory.md``.
+"""
+
+# Standard
+from abc import ABC, abstractmethod
+from collections.abc import Iterator, Mapping
+from contextlib import AbstractContextManager, contextmanager
+from pathlib import Path
+from typing import BinaryIO, Protocol
+import io
+import os
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import PersistenceType
+
+logger = init_logger(__name__)
+
+_TMP_SUFFIX = ".tmp"
+
+
+class ArtifactNotFoundError(Exception):
+    """Nothing has been stored at this location yet."""
+
+
+class ArtifactStore(ABC):
+    """Storage for one whole artifact, replaced atomically."""
+
+    @abstractmethod
+    def open_read(self) -> AbstractContextManager[BinaryIO]:
+        """Open the stored artifact for reading.
+
+        Returns:
+            A context manager yielding the artifact's byte stream.
+
+        Raises:
+            ArtifactNotFoundError: If nothing has been written yet.
+            OSError: If the backend is unreachable or unreadable.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def open_write(self) -> AbstractContextManager[BinaryIO]:
+        """Open a stream that replaces the stored artifact.
+
+        The replacement happens on clean exit: a reader sees either the
+        previous artifact or the new one, never a partial write. Leaving
+        the context via an exception discards whatever was written.
+
+        Returns:
+            A context manager yielding the byte stream to write into.
+
+        Raises:
+            OSError: If the backend rejects the write.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def location(self) -> str:
+        """Return a human-readable location, for log messages."""
+        raise NotImplementedError
+
+
+class LocalArtifactStore(ArtifactStore):
+    """A file on the coordinator's own filesystem.
+
+    Writes land beside the target and are renamed into place, so a crash
+    mid-write leaves at most a stale temporary file. On Kubernetes this
+    needs a volume outliving the pod.
+
+    Args:
+        path: The artifact file; its parent is created on write.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @contextmanager
+    def open_read(self) -> Iterator[BinaryIO]:
+        """Open the file. See :meth:`ArtifactStore.open_read`."""
+        try:
+            stream = self._path.open("rb")
+        except FileNotFoundError as e:
+            raise ArtifactNotFoundError(f"nothing stored at {self._path}") from e
+        with stream:
+            yield stream
+
+    @contextmanager
+    def open_write(self) -> Iterator[BinaryIO]:
+        """Write beside the target, then rename it into place. See
+        :meth:`ArtifactStore.open_write`."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_name(self._path.name + _TMP_SUFFIX)
+        try:
+            with tmp.open("wb") as stream:
+                yield stream
+                stream.flush()
+                os.fsync(stream.fileno())
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+        os.replace(tmp, self._path)
+
+    def location(self) -> str:
+        """Return the file path."""
+        return str(self._path)
+
+
+class NullArtifactStore(ArtifactStore):
+    """Store for an artifact with no location configured.
+
+    Reads find nothing and writes go nowhere, so the persistence path
+    needs no "is it enabled" branch.
+    """
+
+    @contextmanager
+    def open_read(self) -> Iterator[BinaryIO]:
+        """Raise, as nothing is ever stored."""
+        raise ArtifactNotFoundError("persistence is not configured")
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    @contextmanager
+    def open_write(self) -> Iterator[BinaryIO]:
+        """Yield a stream whose contents are discarded."""
+        with io.BytesIO() as stream:
+            yield stream
+
+    def location(self) -> str:
+        """Return a placeholder location."""
+        return "(not configured)"
+
+
+class DurableComponent(Protocol):
+    """Coordinator state that outlives the process by serializing itself.
+
+    Owners advertise their components (see
+    ``FleetEvictionController.get_durable_components``) and the
+    ``persistence_type`` routes each one, so neither persister needs to know
+    what any section means.
+    """
+
+    @property
+    def name(self) -> str:
+        """Name of this component's section in its artifact."""
+        ...
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        """Which artifact this component's state rides in."""
+        ...
+
+    def capture(self) -> Mapping[str, object]:
+        """Return the current state in the form the document holds."""
+        ...
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        """Replace the current state with a captured one.
+
+        Args:
+            state: A :meth:`capture` value, as decoded from the
+                document; implementations know their own shape.
+        """
+        ...

--- a/tests/cli/commands/test_coordinator.py
+++ b/tests/cli/commands/test_coordinator.py
@@ -60,6 +60,12 @@ class TestCoordinatorCommandArguments:
                 "sha256",
                 "--blend-probe-stride",
                 "2",
+                "--snapshot-path",
+                "/tmp/directory.snapshot",
+                "--snapshot-interval",
+                "30",
+                "--metadata-path",
+                "/tmp/metadata.json",
                 "--timeout-keep-alive",
                 "15",
                 "--disable-metrics",
@@ -72,6 +78,9 @@ class TestCoordinatorCommandArguments:
         assert args.chunk_size == 512
         assert args.hash_algorithm == "sha256"
         assert args.blend_probe_stride == 2
+        assert args.snapshot_path == "/tmp/directory.snapshot"
+        assert args.snapshot_interval == 30.0
+        assert args.metadata_path == "/tmp/metadata.json"
         assert args.timeout_keep_alive == 15
         assert args.disable_metrics is True
         assert args.otlp_endpoint == "http://collector:4317"
@@ -88,6 +97,9 @@ class TestCoordinatorCommandArguments:
         assert args.hash_algorithm is None
         assert args.enable_blend_lookup is None
         assert args.blend_probe_stride is None
+        assert args.snapshot_path is None
+        assert args.snapshot_interval is None
+        assert args.metadata_path is None
         assert args.timeout_keep_alive is None
         assert args.disable_metrics is None
         assert args.otlp_endpoint is None
@@ -111,6 +123,9 @@ class TestCoordinatorCommandExecute:
             hash_algorithm="sha256",
             enable_blend_lookup=True,
             blend_probe_stride=2,
+            snapshot_path="/var/lib/lmcache/directory.snapshot",
+            snapshot_interval=30.0,
+            metadata_path="/var/lib/lmcache/metadata.json",
             timeout_keep_alive=None,
             disable_metrics=True,
             otlp_endpoint="http://collector:4317",
@@ -138,6 +153,9 @@ class TestCoordinatorCommandExecute:
         assert captured["config"].hash_algorithm == "sha256"
         assert captured["config"].enable_blend_lookup is True
         assert captured["config"].blend_probe_stride == 2
+        assert captured["config"].snapshot_path == "/var/lib/lmcache/directory.snapshot"
+        assert captured["config"].snapshot_interval == 30.0
+        assert captured["config"].metadata_path == "/var/lib/lmcache/metadata.json"
         assert captured["config"].metrics_enabled is False
         assert captured["config"].otlp_endpoint == "http://collector:4317"
         # Unset flags keep the config defaults.
@@ -166,6 +184,9 @@ class TestCoordinatorCommandExecute:
             hash_algorithm=None,
             enable_blend_lookup=None,
             blend_probe_stride=None,
+            snapshot_path=None,
+            snapshot_interval=None,
+            metadata_path=None,
             timeout_keep_alive=None,
             disable_metrics=None,
             otlp_endpoint=None,

--- a/tests/v1/distributed/test_isolated_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_isolated_lru_eviction_policy.py
@@ -135,3 +135,40 @@ class TestEvictionAmount:
             key_eligible_filter=lambda k: k == k2,
         )
         assert actions[0].keys == [k2]
+
+
+class TestDurableState:
+    def test_the_section_holds_positional_records_without_the_salt(self):
+        """Capture runs on the caller's thread every checkpoint, so the
+        section stores one tuple per key rather than a mapping: a fleet's
+        worth of per-key dicts dominated the cost of taking a checkpoint.
+        The bucket already names the salt, so records do not repeat it.
+        """
+        policy = IsolatedLRUEvictionPolicy()
+        policy.on_keys_created([_key(1, cache_salt="tenant-a")])
+
+        buckets = policy.capture()["buckets"]
+
+        assert buckets == {"tenant-a": [(ObjectKey.IntHash2Bytes(1), "m", 0, 0)]}
+
+    def test_order_survives_a_capture_and_restore(self):
+        """Recency is position, so a restore that reorders a bucket
+        silently changes which key is evicted first."""
+        policy = IsolatedLRUEvictionPolicy()
+        # Created in reverse, so 3 sits at the LRU head; touching it sends
+        # it to the other end and leaves an order creation alone cannot.
+        policy.on_keys_created([_key(i) for i in (1, 2, 3)])
+        policy.on_keys_touched([_key(3)])
+
+        restored = IsolatedLRUEvictionPolicy()
+        restored.restore(policy.capture())
+
+        assert [record[0] for record in restored.capture()["buckets"][""]] == [
+            ObjectKey.IntHash2Bytes(2),
+            ObjectKey.IntHash2Bytes(1),
+            ObjectKey.IntHash2Bytes(3),
+        ]
+        victims = restored.get_eviction_actions(expected_ratio=0.4, cache_salt="")
+        assert [key.chunk_hash for key in victims[0].keys] == [
+            ObjectKey.IntHash2Bytes(2)
+        ], "the restored order must decide who is evicted first"

--- a/tests/v1/distributed/test_quota_manager.py
+++ b/tests/v1/distributed/test_quota_manager.py
@@ -245,3 +245,54 @@ class TestQuotaManagerDefaultLimit:
         qm = QuotaManager()
         with pytest.raises(ValueError):
             qm.set_default_limit_bytes(-1)
+
+
+class TestQuotaManagerDurableState:
+    """The registry's own save/restore contract, used by whatever
+    persists it."""
+
+    def test_capture_and_restore_round_trip(self):
+        qm = QuotaManager()
+        qm.set_quota("alice", 4096)
+        qm.set_quota("bob", 0)
+        qm.set_default_limit_bytes(1024)
+
+        restored = QuotaManager()
+        restored.restore(qm.capture())
+
+        assert restored.list_quotas() == qm.list_quotas()
+        assert restored.get_default_limit_bytes() == 1024
+
+    def test_capture_of_an_empty_registry_round_trips(self):
+        restored = QuotaManager()
+        restored.restore(QuotaManager().capture())
+
+        assert restored.list_quotas() == []
+        assert restored.get_default_limit_bytes() is None
+
+    def test_restore_replaces_rather_than_merges(self):
+        """A restore is the whole table, so stale entries must not linger."""
+        qm = QuotaManager()
+        qm.set_quota("stale", 4096)
+        source = QuotaManager()
+        source.set_quota("alice", 128)
+
+        qm.restore(source.capture())
+
+        assert qm.list_quotas() == [QuotaEntry(cache_salt="alice", limit_bytes=128)]
+
+    def test_restore_rejects_a_malformed_section(self):
+        """Values are trusted, but a wrong-shaped section still fails
+        rather than restoring nonsense."""
+        qm = QuotaManager()
+        with pytest.raises(ValueError):
+            qm.restore({"limits": "not-an-object", "default_limit_bytes": None})
+
+    def test_restore_rejects_a_section_missing_a_field(self):
+        """Whatever persists this catches KeyError for exactly this case."""
+        qm = QuotaManager()
+        with pytest.raises(KeyError):
+            qm.restore({"limits": {}})
+
+    def test_name_labels_the_section(self):
+        assert QuotaManager().name == "quotas"

--- a/tests/v1/mp_coordinator/persistence/__init__.py
+++ b/tests/v1/mp_coordinator/persistence/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/mp_coordinator/persistence/conftest.py
+++ b/tests/v1/mp_coordinator/persistence/conftest.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for the persistence tests."""
+
+# Standard
+from collections.abc import Callable, Iterator
+import logging
+
+# Third Party
+import pytest
+
+
+class _Collector(logging.Handler):
+    """Handler keeping every message it is given."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.NOTSET)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Record ``record``'s formatted message."""
+        self.messages.append(record.getMessage())
+
+
+@pytest.fixture
+def logged() -> Iterator[Callable[[logging.Logger], list[str]]]:
+    """Collect messages from a module logger.
+
+    ``caplog`` cannot do this for an lmcache logger:
+    ``lmcache.logging.init_logger`` disables propagation, and it applies
+    ``LMCACHE_LOG_LEVEL`` to the logger itself — CI sets that to
+    ``CRITICAL``, so records are dropped before any handler runs and
+    ``caplog.at_level`` (which raises the *root* level) has no effect.
+    Attaching here, and lowering the logger's own level, works either way.
+
+    Yields:
+        A function taking a module's ``logger`` and returning the list its
+        messages will land in.
+    """
+    attached: list[tuple[logging.Logger, _Collector, int]] = []
+
+    def attach(module_logger: logging.Logger) -> list[str]:
+        collector = _Collector()
+        attached.append((module_logger, collector, module_logger.level))
+        module_logger.setLevel(logging.DEBUG)
+        module_logger.addHandler(collector)
+        return collector.messages
+
+    yield attach
+    for module_logger, collector, level in attached:
+        module_logger.removeHandler(collector)
+        module_logger.setLevel(level)

--- a/tests/v1/mp_coordinator/persistence/test_checkpoint.py
+++ b/tests/v1/mp_coordinator/persistence/test_checkpoint.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for coordinator checkpoint load/write: the file lifecycle, the
+views rebuilt from it, pins, and the failure paths (missing, corrupt,
+unwritable)."""
+
+# Standard
+from pathlib import Path
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+import numpy as np
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
+from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate, IngestResult
+from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence import checkpoint
+from lmcache.v1.mp_coordinator.persistence.checkpoint import (
+    load_checkpoint,
+    save_checkpoint,
+)
+from lmcache.v1.mp_coordinator.persistence.snapshot_codec import read_snapshot
+from lmcache.v1.mp_coordinator.persistence.store import LocalArtifactStore
+
+
+def _key(hash_byte: int) -> ObjectKey:
+    return ObjectKey(chunk_hash=bytes([hash_byte]) * 4, model_name="m", kv_rank=0)
+
+
+def _batch(
+    seq: int = 1,
+    keys: list[ObjectKey] | None = None,
+    tier: Tier = Tier.L1,
+    backend: str = "dram",
+    token_ids: list[int] | None = None,
+    token_offset: int = 0,
+    ts: float = 0.0,
+    incarnation: int = 1,
+) -> CacheEventBatch:
+    return CacheEventBatch(
+        instance_id="node-a",
+        incarnation=incarnation,
+        seq=seq,
+        event_type=CacheEventType.STORE,
+        tier=tier,
+        backend=backend,
+        ts=ts,
+        entries=[
+            CacheEventEntry(
+                key=k.to_encoded_object_key(),
+                size_bytes=1024,
+                token_ids=token_ids or [],
+                token_offset=token_offset,
+            )
+            for k in (keys or [_key(1)])
+        ],
+    )
+
+
+def _gate() -> EventGate:
+    """A gate whose cursors ride along with the directory snapshot."""
+    return EventGate(CacheEventBroadcaster())
+
+
+def _populated() -> KeyDirectory:
+    directory = KeyDirectory()
+    directory.consume(_batch(seq=1, keys=[_key(1), _key(2)], token_ids=[7, 8]))
+    directory.consume(_batch(seq=2, tier=Tier.L2, backend="fs", keys=[_key(1)]))
+    return directory
+
+
+# -- Happy path --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_then_load_round_trips(tmp_path: Path):
+    path = tmp_path / "directory.snapshot"
+    directory = _populated()
+
+    await save_checkpoint(LocalArtifactStore(path), directory, _gate())
+    restored = KeyDirectory()
+    load_checkpoint(
+        LocalArtifactStore(path), restored, _gate(), CacheEventBroadcaster()
+    )
+
+    assert restored.stats().num_keys == directory.stats().num_keys
+    assert restored.stats().num_placements == directory.stats().num_placements
+    assert restored.lookup([_key(1)]) == directory.lookup([_key(1)])
+    assert restored.get_token_ids([_key(1).chunk_hash]) == [(7, 8)]
+
+
+@pytest.mark.asyncio
+async def test_write_creates_missing_parent_directories(tmp_path: Path):
+    path = tmp_path / "state" / "nested" / "directory.snapshot"
+
+    await save_checkpoint(LocalArtifactStore(path), _populated(), _gate())
+
+    assert path.is_file()
+
+
+@pytest.mark.asyncio
+async def test_write_leaves_no_temporary_file(tmp_path: Path):
+    path = tmp_path / "directory.snapshot"
+
+    await save_checkpoint(LocalArtifactStore(path), _populated(), _gate())
+
+    assert [p.name for p in tmp_path.iterdir()] == ["directory.snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_write_replaces_an_existing_checkpoint(tmp_path: Path):
+    path = tmp_path / "directory.snapshot"
+    await save_checkpoint(LocalArtifactStore(path), _populated(), _gate())
+    grown = _populated()
+    grown.consume(_batch(seq=3, keys=[_key(3)]))
+
+    await save_checkpoint(LocalArtifactStore(path), grown, _gate())
+
+    restored = KeyDirectory()
+    load_checkpoint(
+        LocalArtifactStore(path), restored, _gate(), CacheEventBroadcaster()
+    )
+    assert restored.stats().num_keys == 3
+
+
+@pytest.mark.asyncio
+async def test_blend_lookup_survives_a_checkpoint(tmp_path: Path):
+    path = tmp_path / "directory.snapshot"
+    directory = KeyDirectory()
+    directory.enable_blend_lookup(chunk_size=2, probe_stride=1)
+    directory.consume(_batch(seq=1, token_ids=[7, 8], token_offset=512))
+    await save_checkpoint(LocalArtifactStore(path), directory, _gate())
+
+    restored = KeyDirectory()
+    restored.enable_blend_lookup(chunk_size=2, probe_stride=1)
+    load_checkpoint(
+        LocalArtifactStore(path), restored, _gate(), CacheEventBroadcaster()
+    )
+
+    (match,) = restored.blend_match(np.asarray([7, 8], dtype=np.uint64))
+    assert match.old_st == 512
+
+
+# -- Failure paths -----------------------------------------------------------
+
+
+def test_load_of_a_missing_file_starts_cold(tmp_path: Path):
+    directory = KeyDirectory()
+
+    load_checkpoint(
+        LocalArtifactStore(tmp_path / "absent.snapshot"),
+        directory,
+        _gate(),
+        CacheEventBroadcaster(),
+    )
+
+    assert directory.stats().num_keys == 0
+
+
+def test_load_of_a_corrupt_file_starts_cold(tmp_path: Path, logged):
+    path = tmp_path / "directory.snapshot"
+    path.write_bytes(b"not a snapshot at all")
+    directory = KeyDirectory()
+
+    messages = logged(checkpoint.logger)
+    load_checkpoint(
+        LocalArtifactStore(path), directory, _gate(), CacheEventBroadcaster()
+    )
+
+    assert directory.stats().num_keys == 0
+    assert any("Ignoring coordinator checkpoint" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_load_of_a_truncated_file_starts_cold(tmp_path: Path):
+    path = tmp_path / "directory.snapshot"
+    full = tmp_path / "full.snapshot"
+    # Build a valid checkpoint, then keep only a prefix of it.
+    await save_checkpoint(LocalArtifactStore(full), _populated(), _gate())
+    path.write_bytes(full.read_bytes()[:20])
+
+    restored = KeyDirectory()
+    load_checkpoint(
+        LocalArtifactStore(path), restored, _gate(), CacheEventBroadcaster()
+    )
+
+    assert restored.stats().num_keys == 0
+
+
+@pytest.mark.asyncio
+async def test_load_into_a_populated_directory_is_rejected(tmp_path: Path):
+    path = tmp_path / "directory.snapshot"
+    await save_checkpoint(LocalArtifactStore(path), _populated(), _gate())
+    occupied = KeyDirectory()
+    occupied.consume(_batch(seq=1, keys=[_key(9)]))
+
+    with pytest.raises(ValueError, match="empty directory"):
+        load_checkpoint(
+            LocalArtifactStore(path), occupied, _gate(), CacheEventBroadcaster()
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_to_an_unwritable_path_is_logged_not_raised(tmp_path: Path, logged):
+    # A file where the parent directory must go: mkdir cannot succeed.
+    blocker = tmp_path / "blocked"
+    blocker.write_bytes(b"")
+    path = blocker / "directory.snapshot"
+
+    messages = logged(checkpoint.logger)
+    await save_checkpoint(LocalArtifactStore(path), _populated(), _gate())
+
+    assert any("Failed to write coordinator checkpoint" in m for m in messages)
+
+
+# -- Derived views -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_rebuilds_the_l2_usage_ledger(tmp_path: Path):
+    """A restored directory with an empty usage view would leave quota
+    enforcement blind to everything stored before the restart."""
+    path = tmp_path / "directory.snapshot"
+    directory = KeyDirectory()
+    salted = ObjectKey(
+        chunk_hash=b"\x01" * 4, model_name="m", kv_rank=0, cache_salt="tenant-a"
+    )
+    directory.consume(_batch(seq=1, tier=Tier.L2, backend="fs", keys=[salted]))
+    await save_checkpoint(LocalArtifactStore(path), directory, _gate())
+
+    eviction = FleetEvictionController()
+    broadcaster = CacheEventBroadcaster()
+    broadcaster.register_consumer(eviction)
+    load_checkpoint(LocalArtifactStore(path), KeyDirectory(), _gate(), broadcaster)
+
+    usage = eviction.usage
+    assert usage.get("tenant-a") == 1024
+    assert usage.get_total() == 1024
+    assert usage.get_key_size(salted) == 1024
+
+
+@pytest.mark.asyncio
+async def test_restore_reproduces_the_policy_order_exactly(tmp_path: Path):
+    """The policy rides in its own section, so its order survives verbatim —
+    including an order the placements' timestamps could not imply."""
+    path = tmp_path / "directory.snapshot"
+    directory = KeyDirectory()
+    live = FleetEvictionController()
+    broadcaster = CacheEventBroadcaster()
+    broadcaster.register_consumer(directory)
+    broadcaster.register_consumer(live)
+    for index, hash_byte in enumerate((1, 2, 3)):
+        # Every batch shares one ts, as a real flush does, so nothing in the
+        # directory records which key was touched first.
+        broadcaster.broadcast(
+            _batch(
+                seq=index + 1,
+                tier=Tier.L2,
+                backend="fs",
+                keys=[_key(hash_byte)],
+                ts=7.0,
+            )
+        )
+    # Touch the first-stored key: the live LRU now orders 2, 3, 1.
+    broadcaster.broadcast(
+        CacheEventBatch(
+            instance_id="node-a",
+            incarnation=1,
+            seq=4,
+            event_type=CacheEventType.ACCESS,
+            tier=Tier.L2,
+            backend="",
+            ts=7.0,
+            entries=[CacheEventEntry(key=_key(1).to_encoded_object_key())],
+        )
+    )
+    await save_checkpoint(LocalArtifactStore(path), directory, _gate(), [live.policy])
+
+    restored = FleetEvictionController()
+    restored.quota.set_quota("", 0)  # A zero quota evicts the salt, in LRU order.
+    restored_broadcaster = CacheEventBroadcaster()
+    restored_broadcaster.register_consumer(restored)
+    load_checkpoint(
+        LocalArtifactStore(path),
+        KeyDirectory(),
+        _gate(),
+        restored_broadcaster,
+        [restored.policy],
+    )
+
+    assert restored.compute_eviction_plan() == {"": [_key(2), _key(3), _key(1)]}
+
+
+# -- Coordinator wiring ------------------------------------------------------
+
+
+def _coordinator(snapshot_path: str, metadata_path: str = "") -> TestClient:
+    """A coordinator whose only background work is persistence."""
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        snapshot_path=snapshot_path,
+        metadata_path=metadata_path,
+        snapshot_interval=0.0,
+    )
+    return TestClient(create_app(config))
+
+
+def _store_one_key(client: TestClient) -> None:
+    resp = client.post(
+        "/events",
+        json={
+            "batches": [
+                {
+                    "instance_id": "node-a",
+                    "incarnation": 1,
+                    "seq": 1,
+                    "event_type": "store",
+                    "tier": "l2",
+                    "backend": "fs",
+                    "entries": [
+                        {
+                            "key": {
+                                "chunk_hash_hex": "aa",
+                                "model_name": "m",
+                                "kv_rank": 0,
+                            },
+                            "size_bytes": 1024,
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_a_restarted_coordinator_recovers_its_directory(tmp_path: Path):
+    """The whole point: L2 placements outlive the coordinator process."""
+    path = tmp_path / "directory.snapshot"
+
+    with _coordinator(str(path)) as client:
+        _store_one_key(client)
+        assert client.get("/directory/stats").json()["num_keys"] == 1
+
+    # Shutdown checkpointed; a fresh process picks it back up.
+    assert path.is_file()
+    with _coordinator(str(path)) as restarted:
+        stats = restarted.get("/directory/stats").json()
+        assert stats["num_keys"] == 1
+        assert stats["num_placements"] == 1
+
+
+def test_an_unconfigured_coordinator_writes_nothing(tmp_path: Path):
+    with _coordinator("") as client:
+        _store_one_key(client)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_both_artifacts_survive_a_restart(tmp_path: Path):
+    """The two halves are stored separately but must come back together:
+    the directory says what is cached, the metadata state says what may
+    not be evicted."""
+    snapshot = tmp_path / "directory.snapshot"
+    metadata = tmp_path / "metadata.json"
+
+    with _coordinator(str(snapshot), str(metadata)) as client:
+        _store_one_key(client)
+        assert (
+            client.put("/quota/config", json={"default_limit_gb": 2}).status_code == 200
+        )
+
+    assert snapshot.is_file() and metadata.is_file()
+    with _coordinator(str(snapshot), str(metadata)) as restarted:
+        assert restarted.get("/directory/stats").json()["num_keys"] == 1
+        assert restarted.get("/quota/config").json()["default_limit_gb"] == 2
+
+
+def test_each_component_is_routed_to_the_artifact_its_type_names(tmp_path: Path):
+    """The app wires durability by ``persistence_type`` alone, so this pins the
+    routing rather than the flags: derived state must reach the checkpoint
+    and operator intent the document, with neither carrying the other."""
+    snapshot = tmp_path / "directory.snapshot"
+    metadata = tmp_path / "metadata.json"
+
+    with _coordinator(str(snapshot), str(metadata)) as client:
+        _store_one_key(client)
+        assert (
+            client.put("/quota/config", json={"default_limit_gb": 2}).status_code == 200
+        )
+
+    with snapshot.open("rb") as f:
+        _, _, sections = read_snapshot(f)
+    document = json.loads(metadata.read_text())["components"]
+
+    assert set(sections) == {"lru_order"}
+    assert set(document) == {"pins", "quotas"}
+
+
+@pytest.mark.asyncio
+async def test_restored_cursors_let_a_restarted_emitter_be_fenced(tmp_path: Path):
+    """The reason cursors ride in the snapshot: fencing compares against a
+    prior incarnation, so without them a restored L1 slice is unfenceable."""
+    path = tmp_path / "directory.snapshot"
+    directory = KeyDirectory()
+    broadcaster = CacheEventBroadcaster()
+    broadcaster.register_consumer(directory)
+    gate = EventGate(broadcaster)
+    gate.ingest(_batch(seq=1, keys=[_key(1)]))  # L1 under incarnation 1
+    await save_checkpoint(LocalArtifactStore(path), directory, gate)
+
+    # A fresh coordinator restores, then the emitter comes back restarted.
+    restored = KeyDirectory()
+    restored_broadcaster = CacheEventBroadcaster()
+    restored_broadcaster.register_consumer(restored)
+    restored_gate = EventGate(restored_broadcaster)
+    load_checkpoint(
+        LocalArtifactStore(path), restored, restored_gate, restored_broadcaster
+    )
+    assert restored.lookup([_key(1)])[0], "the L1 placement should be restored"
+
+    restored_gate.ingest(_batch(incarnation=2, seq=1, keys=[_key(9)]))
+
+    # Incarnation 2 fences incarnation 1's L1 facts.
+    assert restored.lookup([_key(1)]) == [[]]
+
+
+@pytest.mark.asyncio
+async def test_a_batch_admitted_mid_capture_survives_the_restart(tmp_path: Path):
+    """No admitted batch may end up both absent from the checkpoint and
+    rejected on redelivery.
+
+    Capture is not atomic across the gate and the directory, so a batch
+    can slip between the two reads. Whichever way it lands, the emitter's
+    retry has to be able to put it back -- which only holds while the
+    stored cursors are no further ahead than the stored directory.
+    """
+    store = LocalArtifactStore(tmp_path / "directory.snapshot")
+    directory = KeyDirectory()
+    broadcaster = CacheEventBroadcaster()
+    broadcaster.register_consumer(directory)
+    gate = EventGate(broadcaster)
+    gate.ingest(_batch(seq=1, keys=[_key(1)]))
+
+    # A batch lands after the directory has been read: the worst case for
+    # the cursors, since they are written from the same capture.
+    real_snapshot = directory.snapshot
+
+    def snapshot_then_admit():
+        captured = real_snapshot()
+        gate.ingest(_batch(seq=2, keys=[_key(2)]))
+        return captured
+
+    directory.snapshot = snapshot_then_admit  # type: ignore[method-assign]
+    await save_checkpoint(store, directory, gate)
+    directory.snapshot = real_snapshot  # type: ignore[method-assign]
+
+    # Restart, then let the emitter retry the batch the checkpoint missed.
+    fresh_directory = KeyDirectory()
+    fresh_broadcaster = CacheEventBroadcaster()
+    fresh_broadcaster.register_consumer(fresh_directory)
+    fresh_gate = EventGate(fresh_broadcaster)
+    load_checkpoint(store, fresh_directory, fresh_gate, fresh_broadcaster)
+    assert fresh_directory.lookup([_key(2)]) == [[]], (
+        "the checkpoint should have missed this batch"
+    )
+
+    result = fresh_gate.ingest(_batch(seq=2, keys=[_key(2)]))
+
+    assert result is IngestResult.ADMITTED, (
+        "the retry was skipped as already-processed, so this placement is "
+        "lost for good -- the stored cursors ran ahead of the stored directory"
+    )
+    assert fresh_directory.lookup([_key(2)])[0], (
+        "the retry was admitted but its placement never reached the directory"
+    )

--- a/tests/v1/mp_coordinator/persistence/test_metadata_persister.py
+++ b/tests/v1/mp_coordinator/persistence/test_metadata_persister.py
@@ -1,0 +1,429 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for durable metadata state: pins and quotas round-tripping,
+the enforcement they restore, and the failure paths."""
+
+# Standard
+from dataclasses import asdict
+from pathlib import Path
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, PersistenceType, Tier
+from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers import ControllerRegistry
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
+from lmcache.v1.mp_coordinator.persistence import metadata_persister
+from lmcache.v1.mp_coordinator.persistence.metadata_persister import MetadataPersister
+from lmcache.v1.mp_coordinator.persistence.store import (
+    LocalArtifactStore,
+    NullArtifactStore,
+)
+
+
+def _key(hash_byte: int, cache_salt: str = "") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=bytes([hash_byte]) * 4,
+        model_name="m",
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+def _l2_store(eviction: FleetEvictionController, key: ObjectKey) -> None:
+    """Feed one L2 store event through the controller, as the gate does."""
+    batch = CacheEventBatch(
+        instance_id="node-a",
+        incarnation=1,
+        seq=1,
+        event_type=CacheEventType.STORE,
+        tier=Tier.L2,
+        backend="fs",
+        entries=[CacheEventEntry(key=key.to_encoded_object_key(), size_bytes=1024)],
+    )
+    eviction.consume(batch)
+
+
+def _managers() -> tuple[QuotaManager, FleetEvictionController]:
+    """The controller and the quota registry it owns — the two durable
+    components the persister carries."""
+    controller = FleetEvictionController()
+    return controller.quota, controller
+
+
+def _captured_pins(*pins: tuple[ObjectKey, int]) -> dict[str, object]:
+    """The durable form ``FleetEvictionController.capture`` produces."""
+    return {
+        "entries": [
+            {"key": asdict(key.to_encoded_object_key()), "count": count}
+            for key, count in pins
+        ]
+    }
+
+
+def _persister(store, quota: QuotaManager, eviction: FleetEvictionController):
+    """A persister wired the way ``create_app`` wires it."""
+    persister = MetadataPersister(store)
+    persister.register(eviction)
+    persister.register(quota)
+    return persister
+
+
+# -- Round trip --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pins_and_quotas_round_trip(tmp_path: Path):
+    store = LocalArtifactStore(tmp_path / "metadata.json")
+    quota, eviction = _managers()
+    quota.set_quota("tenant-a", 4096)
+    quota.set_default_limit_bytes(1024)
+    eviction.pin([_key(1), _key(1), _key(2)])
+
+    await _persister(store, quota, eviction).save()
+    restored_quota, restored_eviction = _managers()
+    _persister(store, restored_quota, restored_eviction).load()
+
+    assert restored_eviction.capture() == _captured_pins((_key(1), 2), (_key(2), 1))
+    assert restored_quota.get_limit_bytes("tenant-a") == 4096
+    assert restored_quota.get_default_limit_bytes() == 1024
+
+
+@pytest.mark.asyncio
+async def test_salted_keys_round_trip(tmp_path: Path):
+    store = LocalArtifactStore(tmp_path / "metadata.json")
+    quota, eviction = _managers()
+    salted = _key(1, cache_salt="tenant-a")
+    eviction.pin([salted])
+
+    await _persister(store, quota, eviction).save()
+    _, restored_eviction = _managers()
+    _persister(store, QuotaManager(), restored_eviction).load()
+
+    assert restored_eviction.capture() == _captured_pins((salted, 1))
+
+
+@pytest.mark.asyncio
+async def test_an_empty_state_round_trips(tmp_path: Path):
+    store = LocalArtifactStore(tmp_path / "metadata.json")
+    quota, eviction = _managers()
+
+    await _persister(store, quota, eviction).save()
+    restored_quota, restored_eviction = _managers()
+    _persister(store, restored_quota, restored_eviction).load()
+
+    assert restored_eviction.capture() == {"entries": []}
+    assert restored_quota.list_quotas() == []
+    assert restored_quota.get_default_limit_bytes() is None
+
+
+@pytest.mark.asyncio
+async def test_the_stored_document_is_readable(tmp_path: Path):
+    """JSON is a deliberate choice here — an operator should be able to
+    read why a tenant's cache was evicted."""
+    path = tmp_path / "metadata.json"
+    quota, eviction = _managers()
+    quota.set_quota("tenant-a", 4096)
+    eviction.pin([_key(1)])
+
+    await _persister(LocalArtifactStore(path), quota, eviction).save()
+
+    body = json.loads(path.read_text())
+    assert body["version"] == 1
+    assert body["components"]["quotas"]["limits"] == {"tenant-a": 4096}
+    assert body["components"]["pins"]["entries"][0]["count"] == 1
+    assert (
+        body["components"]["pins"]["entries"][0]["key"]["chunk_hash_hex"]
+        == _key(1).chunk_hash.hex()
+    )
+
+
+# -- What the state actually buys --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restored_quotas_arm_eviction(tmp_path: Path):
+    """Without restored quotas the coordinator comes back unable to
+    enforce anything until the controller re-syncs."""
+    store = LocalArtifactStore(tmp_path / "metadata.json")
+    quota, eviction = _managers()
+    quota.set_quota("", 0)  # A zero quota evicts the whole salt.
+    await _persister(store, quota, eviction).save()
+
+    restored_quota, restored_eviction = _managers()
+    _persister(store, restored_quota, restored_eviction).load()
+    _l2_store(restored_eviction, _key(1))
+
+    assert restored_eviction.compute_eviction_plan() == {"": [_key(1)]}
+
+
+@pytest.mark.asyncio
+async def test_a_restored_pin_survives_restored_quotas(tmp_path: Path):
+    """The pair has to be restored together: quotas arm eviction, pins
+    are the only thing holding it off."""
+    store = LocalArtifactStore(tmp_path / "metadata.json")
+    quota, eviction = _managers()
+    quota.set_quota("", 0)
+    eviction.pin([_key(1)])
+    await _persister(store, quota, eviction).save()
+
+    restored_quota, restored_eviction = _managers()
+    _persister(store, restored_quota, restored_eviction).load()
+    _l2_store(restored_eviction, _key(1))
+    _l2_store(restored_eviction, _key(2))
+
+    assert restored_eviction.compute_eviction_plan() == {"": [_key(2)]}
+
+
+# -- Failure paths -----------------------------------------------------------
+
+
+def test_a_missing_file_starts_with_no_state(tmp_path: Path):
+    quota, eviction = _managers()
+
+    _persister(LocalArtifactStore(tmp_path / "absent.json"), quota, eviction).load()
+
+    assert eviction.capture() == {"entries": []}
+    assert quota.get_default_limit_bytes() is None
+
+
+def test_a_corrupt_file_starts_with_no_state(tmp_path: Path, logged):
+    path = tmp_path / "metadata.json"
+    path.write_text("{not json at all")
+    quota, eviction = _managers()
+
+    messages = logged(metadata_persister.logger)
+    _persister(LocalArtifactStore(path), quota, eviction).load()
+
+    assert eviction.capture() == {"entries": []}
+    assert any("Ignoring metadata" in m for m in messages)
+
+
+def test_an_unsupported_version_starts_with_no_state(tmp_path: Path, logged):
+    path = tmp_path / "metadata.json"
+    path.write_text(json.dumps({"version": 99, "saved_at": 0.0, "components": {}}))
+    quota, eviction = _managers()
+
+    messages = logged(metadata_persister.logger)
+    _persister(LocalArtifactStore(path), quota, eviction).load()
+
+    assert any("unsupported metadata version 99" in m for m in messages)
+
+
+def test_a_pin_with_an_invalid_key_starts_with_no_state(tmp_path: Path, logged):
+    """A key whose stored fields violate an ObjectKey invariant is a
+    corrupt document, not a startup failure."""
+    path = tmp_path / "metadata.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "saved_at": 0.0,
+                "components": {
+                    "pins": {
+                        "entries": [
+                            {
+                                "key": {
+                                    "chunk_hash_hex": "aa",
+                                    "model_name": "m@x",
+                                    "kv_rank": 0,
+                                },
+                                "count": 1,
+                            }
+                        ]
+                    }
+                },
+            }
+        )
+    )
+    quota, eviction = _managers()
+
+    messages = logged(metadata_persister.logger)
+    _persister(LocalArtifactStore(path), quota, eviction).load()
+
+    assert eviction.capture() == {"entries": []}
+    assert any("Ignoring metadata" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_an_unwritable_path_is_logged_not_raised(tmp_path: Path, logged):
+    blocker = tmp_path / "blocked"
+    blocker.write_bytes(b"")
+    quota, eviction = _managers()
+
+    messages = logged(metadata_persister.logger)
+    await _persister(
+        LocalArtifactStore(blocker / "metadata.json"), quota, eviction
+    ).save()
+
+    assert any("Failed to write metadata" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_write_leaves_no_temporary_file(tmp_path: Path):
+    path = tmp_path / "metadata.json"
+    quota, eviction = _managers()
+    await _persister(LocalArtifactStore(path), quota, eviction).save()
+
+    assert [p.name for p in tmp_path.iterdir()] == ["metadata.json"]
+
+
+# -- Change-driven persistence ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persist_writes_the_current_state(tmp_path: Path):
+    path = tmp_path / "metadata.json"
+    quota, eviction = _managers()
+    persister = _persister(LocalArtifactStore(path), quota, eviction)
+    eviction.pin([_key(1)])
+
+    await persister.save()
+
+    assert (
+        json.loads(path.read_text())["components"]["pins"]["entries"][0]["count"] == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_store_discards_writes(tmp_path: Path):
+    quota, eviction = _managers()
+    eviction.pin([_key(1)])
+
+    await _persister(NullArtifactStore(), quota, eviction).save()
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_an_unconfigured_store_loads_nothing():
+    quota, eviction = _managers()
+
+    _persister(NullArtifactStore(), quota, eviction).load()
+
+    assert eviction.capture() == {"entries": []}
+
+
+# -- Coordinator wiring -------------------------------------------------------
+
+
+def _coordinator(metadata_path: str) -> TestClient:
+    """A coordinator with no timers at all, so only change-driven writes fire."""
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        snapshot_interval=0.0,
+        metadata_path=metadata_path,
+    )
+    return TestClient(create_app(config))
+
+
+def _pin(client: TestClient, token_ids: list[int]) -> None:
+    resp = client.post(
+        "/cache/pins",
+        json={
+            "model_name": "m",
+            "world_size": 1,
+            "token_ids": token_ids,
+            "cache_salt": "",
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_a_pin_is_durable_when_its_request_returns(tmp_path: Path):
+    """No timer runs here, and the file is read straight after the
+    response: the write has to be synchronous with the request."""
+    path = tmp_path / "metadata.json"
+
+    with _coordinator(str(path)) as client:
+        _pin(client, list(range(256)))
+        assert json.loads(path.read_text())["components"]["pins"]["entries"]
+
+
+def test_a_quota_survives_a_restart(tmp_path: Path):
+    path = tmp_path / "metadata.json"
+
+    with _coordinator(str(path)) as client:
+        assert (
+            client.put("/quota/config", json={"default_limit_gb": 2}).status_code == 200
+        )
+        assert path.is_file()
+
+    with _coordinator(str(path)) as restarted:
+        assert restarted.get("/quota/config").json()["default_limit_gb"] == 2
+
+
+class TestPersistenceTypeDispatch:
+    """The persistence_type flag is what routes a component to its artifact."""
+
+    def test_a_controller_without_durable_state_is_skipped(self):
+        """Startup passes every controller it built, so one that persists
+        nothing must cost nothing rather than need excluding by hand."""
+        collected = ControllerRegistry([PrefetchManager()]).durable_components()
+
+        assert collected == {
+            PersistenceType.CHECKPOINT: [],
+            PersistenceType.METADATA: [],
+        }
+
+    def test_components_are_collected_into_the_artifact_they_name(self):
+        """The whole point of the flag: a caller routes state without
+        knowing which controller produced it or what it holds."""
+        collected = ControllerRegistry(
+            [FleetEvictionController(), PrefetchManager()]
+        ).durable_components()
+
+        assert {
+            persistence_type: [c.name for c in components]
+            for persistence_type, components in collected.items()
+        } == {
+            PersistenceType.CHECKPOINT: ["lru_order"],
+            PersistenceType.METADATA: ["pins", "quotas"],
+        }
+
+    def test_the_controller_advertises_every_component_it_owns(self):
+        """Callers wire durability through this one call, so a component
+        added inside the controller needs no change outside it."""
+        controller = FleetEvictionController()
+
+        components = controller.get_durable_components()
+
+        assert {c.name for c in components} == {"pins", "quotas", "lru_order"}
+
+    def test_operator_intent_and_derived_state_are_told_apart(self):
+        """Pins and quotas are authored and irreplaceable; the policy's
+        order is derived from the stream and rides with the checkpoint."""
+        controller = FleetEvictionController()
+
+        by_type = {
+            c.name: c.persistence_type for c in controller.get_durable_components()
+        }
+
+        assert by_type == {
+            "pins": PersistenceType.METADATA,
+            "quotas": PersistenceType.METADATA,
+            "lru_order": PersistenceType.CHECKPOINT,
+        }
+
+    def test_registering_checkpoint_state_as_metadata_is_rejected(self, tmp_path: Path):
+        """A mis-declared component would be rewritten on every operator
+        change and reloaded ahead of the replay that owns it, so this fails
+        at startup rather than producing a quietly wrong document."""
+        persister = MetadataPersister(LocalArtifactStore(tmp_path / "metadata.json"))
+        policy = FleetEvictionController().policy
+
+        with pytest.raises(ValueError, match="checkpoint state"):
+            persister.register(policy)

--- a/tests/v1/mp_coordinator/persistence/test_snapshot_codec.py
+++ b/tests/v1/mp_coordinator/persistence/test_snapshot_codec.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for key-directory snapshot capture, encoding, and restore."""
+
+# Standard
+from collections.abc import Mapping
+import io
+
+# Third Party
+import msgspec
+import numpy as np
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.ingest.event_gate import InstanceStreamStats
+from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.snapshot_codec import (
+    SnapshotFormatError,
+    read_snapshot,
+    write_snapshot,
+)
+
+
+def _chash(hash_byte: int) -> bytes:
+    return bytes([hash_byte]) * 4
+
+
+def _key(hash_byte: int, kv_rank: int = 0, cache_salt: str = "") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=_chash(hash_byte),
+        model_name="m",
+        kv_rank=kv_rank,
+        cache_salt=cache_salt,
+    )
+
+
+def _batch(
+    instance_id: str = "node-a",
+    incarnation: int = 1,
+    seq: int = 1,
+    event_type: CacheEventType = CacheEventType.STORE,
+    tier: Tier = Tier.L1,
+    backend: str = "dram",
+    keys: list[ObjectKey] | None = None,
+    size_bytes: int = 1024,
+    shared: bool = False,
+    ts: float = 0.0,
+    token_ids: list[int] | None = None,
+    token_offset: int = 0,
+) -> CacheEventBatch:
+    entries = [
+        CacheEventEntry(
+            key=k.to_encoded_object_key(),
+            size_bytes=size_bytes,
+            token_ids=token_ids or [],
+            token_offset=token_offset,
+        )
+        for k in (keys or [_key(0xAA)])
+    ]
+    return CacheEventBatch(
+        instance_id=instance_id,
+        incarnation=incarnation,
+        seq=seq,
+        event_type=event_type,
+        tier=tier,
+        backend=backend,
+        entries=entries,
+        shared=shared,
+        ts=ts,
+    )
+
+
+def _populated() -> KeyDirectory:
+    """A directory exercising every field the format carries."""
+    directory = KeyDirectory()
+    directory.consume(
+        _batch(seq=1, keys=[_key(1), _key(2)], token_ids=[7, 8], token_offset=512)
+    )
+    directory.consume(
+        _batch(seq=2, tier=Tier.L2, backend="fs", keys=[_key(1)], size_bytes=4096)
+    )
+    directory.consume(
+        _batch(
+            seq=3,
+            tier=Tier.L2,
+            backend="s3",
+            shared=True,
+            keys=[_key(3)],
+            size_bytes=64,
+            ts=99.5,
+        )
+    )
+    # A second reporter, a salted key, a non-zero rank, and a seq gap.
+    directory.consume(
+        _batch(instance_id="node-b", seq=1, keys=[_key(4, kv_rank=3, cache_salt="u1")])
+    )
+    directory.consume(_batch(instance_id="node-b", seq=7, keys=[_key(5)]))
+    return directory
+
+
+def _cursors(**streams: tuple[int, int, bool]) -> dict[str, InstanceStreamStats]:
+    """Gate cursors as ``instance_id=(incarnation, last_seq, gap_detected)``."""
+    return {
+        instance_id: InstanceStreamStats(
+            incarnation=incarnation, last_seq=last_seq, gap_detected=gap
+        )
+        for instance_id, (incarnation, last_seq, gap) in streams.items()
+    }
+
+
+def _encode(
+    directory: KeyDirectory,
+    cursors: dict[str, InstanceStreamStats] | None = None,
+    sections: dict[str, Mapping[str, object]] | None = None,
+) -> io.BytesIO:
+    """Encode a directory, and optionally cursors and component sections."""
+    stream = io.BytesIO()
+    write_snapshot(directory.snapshot(), cursors or {}, sections or {}, stream)
+    stream.seek(0)
+    return stream
+
+
+def _round_trip(directory: KeyDirectory) -> KeyDirectory:
+    """Encode ``directory``'s snapshot and restore it into a fresh one."""
+    snapshot, _, _ = read_snapshot(_encode(directory))
+    restored = KeyDirectory()
+    restored.restore(snapshot)
+    return restored
+
+
+def _all_keys(directory: KeyDirectory) -> dict[ObjectKey, list]:
+    total, page = directory.list_keys(limit=1000)
+    assert total == len(page)
+    return page
+
+
+# -- Round trip --------------------------------------------------------------
+
+
+def test_round_trip_preserves_placements():
+    directory = _populated()
+
+    restored = _round_trip(directory)
+
+    assert _all_keys(restored) == _all_keys(directory)
+    for key in (_key(1), _key(2), _key(3), _key(4, kv_rank=3, cache_salt="u1")):
+        assert restored.lookup([key]) == directory.lookup([key])
+
+
+def test_round_trip_preserves_counts_and_l1_reverse_index():
+    directory = _populated()
+
+    restored = _round_trip(directory)
+
+    before = directory.stats()
+    after = restored.stats()
+    assert after.num_keys == before.num_keys
+    assert after.num_placements == before.num_placements
+    assert after.l1_keys_by_instance == before.l1_keys_by_instance
+
+
+def test_round_trip_preserves_gate_cursors():
+    """Restored placements are only fenceable if the cursors come back
+    with them, so the codec carries both."""
+    cursors = _cursors(**{"node-a": (1, 3, False), "node-b": (7, 12, True)})
+
+    _, restored, _ = read_snapshot(_encode(_populated(), cursors))
+
+    assert restored == cursors
+    # The gap the gate saw is carried across, not laundered.
+    assert restored["node-b"].gap_detected is True
+
+
+def test_round_trip_preserves_token_bindings():
+    directory = _populated()
+
+    restored = _round_trip(directory)
+
+    assert restored.get_token_ids([_chash(1), _chash(2)]) == [(7, 8), (7, 8)]
+    # A chunk that never carried content restores as a content-free binding.
+    assert restored.get_token_ids([_chash(3)]) == [()]
+
+
+def test_round_trip_of_empty_directory():
+    restored = _round_trip(KeyDirectory())
+
+    assert restored.stats().num_keys == 0
+    assert restored.stats().l1_keys_by_instance == {}
+
+
+def test_restored_directory_accepts_further_events():
+    directory = _populated()
+    restored = _round_trip(directory)
+
+    restored.consume(_batch(seq=4, keys=[_key(6)]))
+
+    assert len(restored.lookup([_key(6)])[0]) == 1
+
+
+def test_restored_l1_key_sets_drive_fencing():
+    """Fencing needs the per-instance L1 key set, so the snapshot must
+    carry it rather than re-deriving it from placements."""
+    restored = _round_trip(_populated())
+
+    restored.fence_instance("node-a")
+
+    # L1 placements go; the L2 ones the same instance reported survive.
+    assert restored.lookup([_key(2)]) == [[]]
+    [l2_only] = restored.lookup([_key(1)])
+    assert [p.tier for p in l2_only] == [Tier.L2]
+
+
+# -- Blend index -------------------------------------------------------------
+
+
+def test_blend_matching_works_after_restore():
+    directory = KeyDirectory()
+    directory.enable_blend_lookup(chunk_size=2, probe_stride=1)
+    directory.consume(_batch(seq=1, keys=[_key(1)], token_ids=[7, 8], token_offset=512))
+
+    snapshot, _, _ = read_snapshot(_encode(directory))
+    restored = KeyDirectory()
+    restored.enable_blend_lookup(chunk_size=2, probe_stride=1)
+    restored.restore(snapshot)
+
+    (match,) = restored.blend_match(np.asarray([7, 8], dtype=np.uint64))
+    assert match.old_st == 512
+    assert restored.blend_stats().num_chunks == 1
+
+
+def test_blend_index_stays_empty_when_lookup_is_disabled():
+    directory = KeyDirectory()
+    directory.enable_blend_lookup(chunk_size=2, probe_stride=1)
+    directory.consume(_batch(seq=1, keys=[_key(1)], token_ids=[7, 8], token_offset=512))
+
+    # Restoring without enabling blend lookup keeps the content, not the index.
+    restored = _round_trip(directory)
+
+    assert restored.get_token_ids([_chash(1)]) == [(7, 8)]
+    assert restored.blend_match(np.asarray([7, 8], dtype=np.uint64)) == []
+
+
+# -- Restore guards ----------------------------------------------------------
+
+
+def test_restore_rejects_a_non_empty_directory():
+    directory = _populated()
+    snapshot = directory.snapshot()
+    occupied = KeyDirectory()
+    occupied.consume(_batch(seq=1, keys=[_key(9)]))
+
+    with pytest.raises(ValueError, match="empty directory"):
+        occupied.restore(snapshot)
+
+
+# -- Malformed streams -------------------------------------------------------
+
+
+def test_read_rejects_a_foreign_stream():
+    with pytest.raises(SnapshotFormatError, match="not a directory snapshot"):
+        read_snapshot(io.BytesIO(b"\x00" * 64))
+
+
+def test_read_rejects_an_unsupported_version():
+    body = bytearray(_encode(_populated()).getvalue())
+    body[8] = 99  # the version word follows the 8-byte magic
+    with pytest.raises(SnapshotFormatError, match="unsupported snapshot version 99"):
+        read_snapshot(io.BytesIO(bytes(body)))
+
+
+def test_read_rejects_a_truncated_stream():
+    body = _encode(_populated()).getvalue()
+
+    with pytest.raises(SnapshotFormatError, match="truncated snapshot"):
+        read_snapshot(io.BytesIO(body[: len(body) // 2]))
+
+
+def test_read_rejects_an_out_of_range_key_index():
+    """The writer cannot emit one — it derives indices from the same key
+    list — so this guards a corrupted file."""
+    directory = KeyDirectory()
+    directory.consume(_batch(seq=1, keys=[_key(1)]))
+    body = _encode(directory).getvalue()
+    # Prefix is magic(8) + version(4) + structure length(4).
+    length = int.from_bytes(body[12:16], "little")
+    structure = msgspec.msgpack.decode(body[16 : 16 + length])
+    structure["l1_keys_by_instance"]["node-a"] = [5]
+    payload = msgspec.msgpack.encode(structure)
+    corrupted = (
+        body[:12] + len(payload).to_bytes(4, "little") + payload + body[16 + length :]
+    )
+
+    with pytest.raises(SnapshotFormatError, match="references key index 5"):
+        read_snapshot(io.BytesIO(corrupted))

--- a/tests/v1/mp_coordinator/test_cache_api.py
+++ b/tests/v1/mp_coordinator/test_cache_api.py
@@ -18,6 +18,9 @@ from lmcache.v1.mp_coordinator.api import (
 )
 from lmcache.v1.mp_coordinator.app import create_app
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
 from lmcache.v1.multiprocess.cache_control.key_resolver import resolve_object_keys
 
 
@@ -155,7 +158,9 @@ def test_pin_then_unpin_tracks_l2_eviction():
                     ],
                 )
             )
-        assert ctx.eviction_controller.compute_eviction_plan()["alice"]
+        assert ctx.controllers.get(FleetEvictionController).compute_eviction_plan()[
+            "alice"
+        ]
 
         resp = client.post("/cache/pins", json=_pin_body())
         assert resp.status_code == 200, resp.text
@@ -165,7 +170,9 @@ def test_pin_then_unpin_tracks_l2_eviction():
             "status": "pinned",
         }
         # Pinned: the keys drop out of the eviction plan.
-        assert ctx.eviction_controller.compute_eviction_plan() == {}
+        assert (
+            ctx.controllers.get(FleetEvictionController).compute_eviction_plan() == {}
+        )
 
         resp = client.request("DELETE", "/cache/pins", json=_pin_body())
         assert resp.status_code == 200, resp.text
@@ -175,7 +182,9 @@ def test_pin_then_unpin_tracks_l2_eviction():
             "status": "unpinned",
         }
         # Unpinned: the keys are eligible for eviction again.
-        assert ctx.eviction_controller.compute_eviction_plan()["alice"]
+        assert ctx.controllers.get(FleetEvictionController).compute_eviction_plan()[
+            "alice"
+        ]
 
 
 def test_pin_short_sequence_is_noop():
@@ -335,7 +344,9 @@ def test_delete_non_force_holds_back_l2_pinned_key():
         ctx = client.app.state.ctx
         client.app.state.outbound_client = _mock_delete_server(deletes)
         keys = _resolve_delete(ctx)
-        ctx.eviction_controller.pin([keys[0]])  # protect one key at L2
+        ctx.controllers.get(FleetEvictionController).pin(
+            [keys[0]]
+        )  # protect one key at L2
 
         resp = client.post("/cache/delete", json=_delete_body("mp-1"))
         assert resp.status_code == 200, resp.text
@@ -344,7 +355,10 @@ def test_delete_non_force_holds_back_l2_pinned_key():
         assert len(deletes) == 1
         assert len(deletes[0]["keys"]) == len(keys) - 1
         # The pin survives (non-force does not drop it).
-        assert ctx.eviction_controller.filter_unpinned([keys[0]]) == []
+        assert (
+            ctx.controllers.get(FleetEvictionController).filter_unpinned([keys[0]])
+            == []
+        )
 
 
 def test_delete_force_removes_and_drops_l2_pin():
@@ -358,7 +372,7 @@ def test_delete_force_removes_and_drops_l2_pin():
         ctx = client.app.state.ctx
         client.app.state.outbound_client = _mock_delete_server(deletes)
         keys = _resolve_delete(ctx)
-        ctx.eviction_controller.pin([keys[0]])
+        ctx.controllers.get(FleetEvictionController).pin([keys[0]])
 
         resp = client.post("/cache/delete", json=_delete_body("mp-1", force=True))
         assert resp.status_code == 200, resp.text
@@ -368,7 +382,9 @@ def test_delete_force_removes_and_drops_l2_pin():
         assert len(deletes[0]["keys"]) == len(keys)
         assert resp.json()["skipped"] == 0
         # ...and the coordinator dropped the L2 pin.
-        assert ctx.eviction_controller.filter_unpinned([keys[0]]) == [keys[0]]
+        assert ctx.controllers.get(FleetEvictionController).filter_unpinned(
+            [keys[0]]
+        ) == [keys[0]]
 
 
 def test_delete_l1_tier_ignores_l2_pins():
@@ -382,7 +398,7 @@ def test_delete_l1_tier_ignores_l2_pins():
         ctx = client.app.state.ctx
         client.app.state.outbound_client = _mock_delete_server(deletes)
         keys = _resolve_delete(ctx)
-        ctx.eviction_controller.pin([keys[0]])
+        ctx.controllers.get(FleetEvictionController).pin([keys[0]])
 
         resp = client.post("/cache/delete", json=_delete_body("mp-1", tier="l1"))
         assert resp.status_code == 200, resp.text
@@ -391,7 +407,10 @@ def test_delete_l1_tier_ignores_l2_pins():
         assert deletes[0]["tier"] == "l1"
         assert len(deletes[0]["keys"]) == len(keys)
         assert resp.json()["affected"] == len(keys)  # L1 only
-        assert ctx.eviction_controller.filter_unpinned([keys[0]]) == []  # pin untouched
+        assert (
+            ctx.controllers.get(FleetEvictionController).filter_unpinned([keys[0]])
+            == []
+        )  # pin untouched
 
 
 def test_delete_server_unreachable_returns_502():

--- a/tests/v1/mp_coordinator/test_controller_discovery.py
+++ b/tests/v1/mp_coordinator/test_controller_discovery.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for controller discovery: what the scan finds, builds, and skips."""
+
+# Standard
+import sys
+import textwrap
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import PersistenceType
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers import build_controllers
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
+from lmcache.v1.mp_coordinator.controllers.usage_manager import L2UsageManager
+
+
+class TestControllerDiscovery:
+    def test_a_controller_owning_durable_state_is_found(self):
+        """The scan replaces a hand-written list, so the one controller
+        with durable state today must come back from it."""
+        registry = build_controllers(MPCoordinatorConfig())
+
+        assert isinstance(
+            registry.get(FleetEvictionController), FleetEvictionController
+        )
+
+    def test_a_collaborator_a_controller_owns_is_not_built_separately(self):
+        """``L2UsageManager`` sits in this package but belongs to the
+        eviction controller; a second copy would account nothing."""
+        registry = build_controllers(MPCoordinatorConfig())
+
+        with pytest.raises(KeyError, match="L2UsageManager"):
+            registry.get(L2UsageManager)  # type: ignore[type-var]
+
+    def test_a_controller_without_durable_state_is_still_built(self):
+        """Discovery builds every controller, not only the durable ones —
+        the prefetch manager is reached through the same registry."""
+        registry = build_controllers(MPCoordinatorConfig())
+
+        assert isinstance(registry.get(PrefetchManager), PrefetchManager)
+
+    def test_configuration_reaches_the_discovered_controller(self):
+        """Discovery replaces a call site that passed config explicitly,
+        so the knobs have to survive the indirection."""
+        config = MPCoordinatorConfig(eviction_ratio=0.33, trigger_watermark=0.77)
+
+        controller = build_controllers(config).get(FleetEvictionController)
+
+        actions = controller.policy.get_eviction_actions(
+            expected_ratio=0.33, cache_salt=""
+        )
+        assert actions == []  # nothing tracked yet, but the ratio was accepted
+        assert isinstance(controller, FleetEvictionController)
+
+    def test_a_controller_added_to_the_package_is_picked_up(self, tmp_path):
+        """The point of scanning: a new controller needs no edit to
+        ``create_app``. This drops one into the package and checks that
+        both discovery and the type-based routing collect it.
+        """
+        # First Party
+        from lmcache.v1.mp_coordinator import controllers
+
+        module_path = tmp_path / "late_controller.py"
+        module_path.write_text(
+            textwrap.dedent(
+                '''
+                # SPDX-License-Identifier: Apache-2.0
+                """A controller that appears only for this test."""
+
+                from collections.abc import Mapping
+
+                from lmcache.v1.distributed.api import PersistenceType
+                from lmcache.v1.mp_coordinator.controllers.base import Controller
+
+
+                class LateController(Controller):
+                    """Owns one metadata section."""
+
+                    def get_durable_components(self):
+                        return (self,)
+
+                    @property
+                    def persistence_type(self):
+                        return PersistenceType.METADATA
+
+                    @property
+                    def name(self):
+                        return "late"
+
+                    def capture(self) -> Mapping[str, object]:
+                        return {"seen": True}
+
+                    def restore(self, state: Mapping[str, object]) -> None:
+                        pass
+                '''
+            )
+        )
+        controllers.__path__.append(str(tmp_path))
+        try:
+            collected = build_controllers(MPCoordinatorConfig()).durable_components()
+        finally:
+            controllers.__path__.remove(str(tmp_path))
+            sys.modules.pop(f"{controllers.__name__}.late_controller", None)
+
+        assert "late" in [c.name for c in collected[PersistenceType.METADATA]]


### PR DESCRIPTION
**What this PR does / why we need it**:

The coordinator loses two kinds of state on restart: the **key directory**,
built from the MP-server event stream and so missing every placement the stream
will never re-announce (cold L2 objects), and **pins and quotas**, which nothing
can rebuild at all.

This persists both, under `lmcache/v1/mp_coordinator/persistence/`. Opt-in and
off by default — `--snapshot-path` (paced by `--snapshot-interval`, default 60s)
and `--metadata-path`. Unset, nothing changes.

**Special notes for your reviewers**:

Separate artifacts on purpose: the snapshot is large, binary, derived, and safe
to lose; the metadata document is small, JSON, and written synchronously with
the change, so a `200` from `POST /cache/pins` means the pin survives a restart.

Two things restore does beyond loading:

- The directory's placements are replayed through the `CacheEventBroadcaster`,
  rebuilding the usage view and eviction LRU — otherwise quota enforcement comes
  back blind to everything stored before the restart. Ordered by ascending
  recency, which is how the LRU rebuilds its ordering.
- Metadata loads first: quotas arm eviction, and pins are the only thing holding
  it off.

Any unusable artifact is logged and the coordinator starts cold rather than
failing to boot.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
