### PR TITLE
[Bug][Executor] drain the queue before cancelling workers on AsyncPQExecutor shutdown

### DIFF
--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -710,4 +710,6 @@ class S3Connector(RemoteConnector):
             self.connection_failures = 0
 
     async def close(self):
-        await self.pq_executor.shutdown(wait=True)
+        # `shutdown` is synchronous and blocks on a coroutine scheduled on this
+        # same loop, so awaiting it here would deadlock. Await the async form.
+        await self.pq_executor.shutdown_async(wait=True)

--- a/lmcache/v1/storage_backend/job_executor/pq_executor.py
+++ b/lmcache/v1/storage_backend/job_executor/pq_executor.py
@@ -107,20 +107,26 @@ class AsyncPQExecutor(BaseJobExecutor):
                 (sentinel_priority, next(self._counter), _SENTINEL, None, {}, None)
             )
 
-        # Cancel all worker futures to ensure they stop
-        # Even when wait=False, we should cancel workers to prevent hanging coroutines
-        for fut in self._workers:
-            if not fut.done():
-                fut.cancel()
-
         if wait:
-            # Let workers drain tasks and exit gracefully
+            # Let workers drain tasks and exit gracefully. Cancelling before
+            # draining would stop a worker before it consumes its sentinel, so
+            # `task_done` would never be called for that item and this join
+            # would wait forever.
             await self._queue.join()
+            # Cancel all worker futures after queue is drained
+            for fut in self._workers:
+                if not fut.done():
+                    fut.cancel()
             # Wait for all workers to complete (with cancellation handling)
             await asyncio.gather(
                 *[asyncio.wrap_future(fut, loop=self.loop) for fut in self._workers],
                 return_exceptions=True,
             )
+        else:
+            # When wait=False, just cancel workers immediately
+            for fut in self._workers:
+                if not fut.done():
+                    fut.cancel()
 
     def shutdown(self, wait: bool = True) -> None:
         """Sync shutdown — blocks the calling thread until shutdown is complete."""

--- a/tests/v1/storage_backend/test_pq_executor.py
+++ b/tests/v1/storage_backend/test_pq_executor.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for `AsyncPQExecutor` shutdown."""
+
+# Standard
+import asyncio
+import threading
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
+
+
+@pytest.fixture
+def loop_in_thread():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, name="test-pq-loop")
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5.0)
+
+
+def run(loop, coro, timeout=10.0):
+    """Run a coroutine on ``loop`` and wait for it, failing on a hang."""
+    return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=timeout)
+
+
+def test_shutdown_drains_queued_jobs(loop_in_thread):
+    """``wait=True`` runs queued jobs and returns instead of blocking.
+
+    Cancelling the workers before draining would stop one before it consumes
+    its sentinel, leaving `task_done` uncalled and `queue.join()` waiting
+    forever.
+    """
+    executor = AsyncPQExecutor(loop_in_thread)
+    completed = []
+
+    async def job(value: int) -> int:
+        completed.append(value)
+        return value
+
+    async def scenario():
+        submitted = [
+            asyncio.ensure_future(executor.submit_job(job, i)) for i in range(8)
+        ]
+        # Let every submission reach the queue before shutting down.
+        await asyncio.sleep(0.05)
+        await executor.shutdown_async(wait=True)
+        return await asyncio.gather(*submitted)
+
+    results = run(loop_in_thread, scenario())
+
+    assert sorted(results) == list(range(8))
+    assert sorted(completed) == list(range(8))
+
+
+def test_shutdown_without_wait_returns(loop_in_thread):
+    """``wait=False`` returns promptly instead of draining the queue."""
+    executor = AsyncPQExecutor(loop_in_thread)
+
+    run(loop_in_thread, executor.shutdown_async(wait=False), timeout=5.0)
+
+
+def test_shutdown_is_idempotent(loop_in_thread):
+    """A second shutdown is a no-op rather than a second drain."""
+    executor = AsyncPQExecutor(loop_in_thread)
+
+    run(loop_in_thread, executor.shutdown_async(wait=True))
+    run(loop_in_thread, executor.shutdown_async(wait=True), timeout=5.0)


### PR DESCRIPTION
Fixes #4489

**What this PR does / why we need it**:

`AsyncPQExecutor.shutdown_async` cancelled the worker futures and *then* awaited
`queue.join()`. A sentinel is pushed per worker just above that, and `_worker`
calls `task_done()` when it consumes one — so a worker cancelled before it
reaches its sentinel leaves the queue's unfinished count above zero and the
join waits forever.

`AsyncPQThreadPoolExecutor.shutdown_async`, in the same file, already does this
in the correct order: drain first, cancel after, with a separate `else` branch
that cancels immediately when `wait=False`. This PR makes the base class match
its own subclass.

`S3Connector.close()` separately awaited the **synchronous** `shutdown`, which
calls `run_coroutine_threadsafe(...).result()` — blocking the very loop the
coroutine needs in order to make progress. It now awaits `shutdown_async`.

**Special notes for your reviewers**:

@zhengfeihe — kept small as asked: +16/−8 across two source files, plus a test
file. No behaviour change beyond the ordering.

The hang is timing dependent, which is worth knowing when reading the test.
Against the unfixed executor the two `wait=True` tests pass on Python 3.10,
3.11 and 3.12 and **fail on 3.13** (10s timeout, 5/5 runs), where cancellation
lands before the workers drain. The CI matrix covers 3.13, so this is reachable
from CI — it is how the bug was found, via a fixture teardown in #4484.

Note this touches `s3_connector.py`, which #4484 also modifies, in a different
region. They should merge cleanly; whichever lands second I will rebase if
needed.

#4484's test fixture currently works around this by shutting down with
`wait=False`. I left that as is rather than have that PR depend on this one.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
