### PR TITLE
fix: bound multiprocess retrieve completion

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -565,6 +565,13 @@ All connector-level options are passed through
      - ``10.0``
      - Interval (seconds) between periodic heartbeat pings sent from the
        connector to the server.
+   * - ``lmcache.mp.retrieve_timeout``
+     - ``0.0``
+     - Maximum time (seconds) from retrieve submission to device-event
+       completion. ``0`` disables the deadline. When enabled, expiry raises
+       a timeout and aborts the worker rather than releasing target KV blocks:
+       the underlying transfer currently has no cancellation acknowledgement,
+       so reusing those blocks could allow a late DMA write to corrupt KV.
    * - ``lmcache.mp.mp_transfer_mode``
      - ``auto``
      - Routing mode for the worker -> server transfer context. One of

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -5,8 +5,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Protocol
 import enum
+import math
 import os
 import threading
+import time
 import uuid
 
 # Third Party
@@ -27,6 +29,7 @@ from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
     expand_engine_block_ids,
 )
+from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context import (
@@ -57,6 +60,11 @@ class ExtraConfigDefault(enum.Enum):
     # Interval (seconds) between periodic heartbeat pings
     # to the server.
     heartbeat_interval = 10.0
+    # Maximum time (seconds) from retrieve submission to device-event
+    # completion. Zero disables the deadline. A deadline raises instead of
+    # releasing target blocks because the underlying transfer cannot yet be
+    # cancelled or quarantined safely.
+    retrieve_timeout = 0.0
     # Routing mode for ``create_transfer_context``: ``auto`` keeps the
     # historical CUDA -> lmcache_driven / others -> engine_driven dispatch;
     # ``lmcache_driven`` forces the IPC / SHM zero-copy path where the
@@ -1053,6 +1061,7 @@ class LMCacheMPWorkerAdapter:
             cfg = _resolve_extra_config(extra_config)
             mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
             heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+            retrieve_timeout = cfg[ExtraConfigDefault.retrieve_timeout.name]
             # Only treat ``mp_transfer_mode`` as an explicit override when
             # the user actually set it in extra_config; otherwise leave it
             # as ``None`` so ``create_transfer_context`` can still consult
@@ -1066,8 +1075,15 @@ class LMCacheMPWorkerAdapter:
                 self._mp_transfer_mode = None
         else:
             self._mp_transfer_mode = None
+            retrieve_timeout = ExtraConfigDefault.retrieve_timeout.value
+        if not math.isfinite(retrieve_timeout) or retrieve_timeout < 0:
+            raise ValueError(
+                "lmcache.mp.retrieve_timeout must be a finite, non-negative "
+                f"number, got {retrieve_timeout}"
+            )
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
+        self._retrieve_timeout = retrieve_timeout
 
         # Instance id for GPU worker. uuid4-derived (OS entropy) rather
         # than os.getpid() to avoid collision in containerized deployments.
@@ -1091,6 +1107,7 @@ class LMCacheMPWorkerAdapter:
         self.retrieve_futures: dict[
             str, tuple[MessagingFuture[RetrieveResult], list[int]]
         ] = {}
+        self._retrieve_started_at: dict[str, float] = {}
         # The IPC handle is not enough by itself; CUDA needs the exporting
         # event object to stay alive until the consumer is done with it.
         self.store_events: dict[str, _IpcEvent] = {}
@@ -1466,6 +1483,7 @@ class LMCacheMPWorkerAdapter:
             skip_first_n_tokens=op.skip_first_n_tokens,
         )
         self.retrieve_futures[request_id] = (future, op.flat_block_ids)
+        self._retrieve_started_at[request_id] = time.monotonic()
         self.retrieve_events[request_id] = event
 
     @_lmcache_nvtx_annotate
@@ -1559,6 +1577,11 @@ class LMCacheMPWorkerAdapter:
                 including retrieves dropped at submit time while unhealthy
                 (reported exactly once; blocks already in error_block_ids).
 
+        Raises:
+            LMCacheTimeoutError: If an enabled retrieve deadline expires.
+                The worker fails closed without releasing target blocks because
+                the in-flight transfer has no cancellation acknowledgement.
+
         Notes:
             When enabling async scheduling in vLLM, the same request ID may appear
             multiple times in `finished_req_ids_from_engine`. The adapter should
@@ -1580,6 +1603,7 @@ class LMCacheMPWorkerAdapter:
                 self.error_block_ids.update(r_block_ids)
             self.store_futures.clear()
             self.retrieve_futures.clear()
+            self._retrieve_started_at.clear()
             self.store_events.clear()
             self.retrieve_events.clear()
 
@@ -1621,6 +1645,20 @@ class LMCacheMPWorkerAdapter:
 
         for request_id, (r_future, _) in self.retrieve_futures.items():
             if not r_future.query():
+                started_at = self._retrieve_started_at.get(request_id)
+                if (
+                    self._retrieve_timeout > 0
+                    and started_at is not None
+                    and time.monotonic() - started_at >= self._retrieve_timeout
+                ):
+                    raise LMCacheTimeoutError(
+                        "LMCache retrieve for request_id=%s did not complete "
+                        "within %.3fs; aborting the worker because the "
+                        "in-flight transfer cannot be cancelled or its target "
+                        "KV blocks safely reused"
+                        % (request_id, self._retrieve_timeout),
+                        session_id=request_id,
+                    )
                 continue
 
             r_result = r_future.result(timeout=60)
@@ -1640,6 +1678,7 @@ class LMCacheMPWorkerAdapter:
             self.store_events.pop(request_id, None)
         for request_id in finished_retrieves:
             self.retrieve_futures.pop(request_id, None)
+            self._retrieve_started_at.pop(request_id, None)
             self.retrieve_events.pop(request_id, None)
 
         # Retrieves dropped while unhealthy still must be reported,

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -385,6 +385,81 @@ def test_retrieve_keeps_event_until_future_finishes(fake_adapter):
     assert event_ref() is None
 
 
+def test_retrieve_timeout_is_disabled_by_default(fake_adapter, monkeypatch) -> None:
+    """A pending retrieve remains pending when the opt-in deadline is zero."""
+    adapter, _send_mock, _future = fake_adapter
+    pending = MagicMock(name="pending_retrieve")
+    pending.query.return_value = False
+    transfer_ctx = MagicMock()
+    transfer_ctx.submit_retrieve.return_value = pending
+    adapter.transfer_ctx = transfer_ctx
+    clock = [10.0]
+    monkeypatch.setattr(adapter_mod.time, "monotonic", lambda: clock[0])
+    adapter.submit_retrieve_request("req-1", _op([[7]]), MagicMock())
+    clock[0] = 10_000.0
+
+    finished_stores, finished_retrieves = adapter.get_finished(set())
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+    pending.query.assert_called_once_with()
+
+
+def test_retrieve_timeout_fails_closed_without_releasing_blocks(
+    fake_adapter, monkeypatch
+) -> None:
+    """Expiry aborts polling but keeps the future/blocks quarantined."""
+    _adapter, _send_mock, _future = fake_adapter
+    adapter = _make_worker_adapter(extra_config={"lmcache.mp.retrieve_timeout": 30.0})
+    pending = MagicMock(name="pending_retrieve")
+    pending.query.return_value = False
+    transfer_ctx = MagicMock()
+    transfer_ctx.submit_retrieve.return_value = pending
+    adapter.transfer_ctx = transfer_ctx
+    clock = [100.0]
+    monkeypatch.setattr(adapter_mod.time, "monotonic", lambda: clock[0])
+    adapter.submit_retrieve_request("req-1", _op([[7, 8]]), MagicMock())
+    clock[0] = 130.0
+
+    with pytest.raises(TimeoutError, match="in-flight transfer cannot be cancelled"):
+        adapter.get_finished(set())
+
+    assert adapter.get_block_ids_with_load_errors() == set()
+    # It remains pending and fails closed again: target blocks were not
+    # reported reusable after the first timeout.
+    with pytest.raises(TimeoutError):
+        adapter.get_finished(set())
+
+
+def test_ready_retrieve_wins_at_deadline(fake_adapter, monkeypatch) -> None:
+    """A ready event completes normally even when its deadline has arrived."""
+    _adapter, _send_mock, _future = fake_adapter
+    adapter = _make_worker_adapter(extra_config={"lmcache.mp.retrieve_timeout": 30.0})
+    complete = MagicMock(name="complete_retrieve")
+    complete.query.return_value = True
+    complete.result.return_value = True
+    transfer_ctx = MagicMock()
+    transfer_ctx.submit_retrieve.return_value = complete
+    adapter.transfer_ctx = transfer_ctx
+    clock = [100.0]
+    monkeypatch.setattr(adapter_mod.time, "monotonic", lambda: clock[0])
+    adapter.submit_retrieve_request("req-1", _op([[7]]), MagicMock())
+    clock[0] = 130.0
+
+    _finished_stores, finished_retrieves = adapter.get_finished(set())
+
+    assert finished_retrieves == {"req-1"}
+    assert adapter.get_finished(set())[1] == set()
+
+
+@pytest.mark.parametrize("value", [-1, float("inf"), float("nan")])
+def test_retrieve_timeout_rejects_invalid_values(fake_adapter, value) -> None:
+    _adapter, _send_mock, _future = fake_adapter
+
+    with pytest.raises(ValueError, match="finite, non-negative"):
+        _make_worker_adapter(extra_config={"lmcache.mp.retrieve_timeout": value})
+
+
 def test_instance_id_is_uuid_derived_63_bit_int(fake_adapter) -> None:
     """instance_id is a 63-bit int, not the PID, and unique per adapter."""
     adapter, _send_mock, _ = fake_adapter


### PR DESCRIPTION
## Summary

- add opt-in `lmcache.mp.retrieve_timeout` for MP retrieve completion
- track each retrieve from submission through device-event readiness
- raise `LMCacheTimeoutError` when the deadline expires
- fail closed without reporting target blocks reusable
- keep the default at `0` (disabled) for compatibility
- document the deadline and its late-DMA safety constraint

Fixes #4516.

## Safety

This intentionally does **not** call `finished_recving()`, invalidate blocks, or transparently recompute on expiry. LMCache currently has no transfer-cancellation acknowledgement or block-quarantine contract. Reusing paged-KV block IDs while an old H2D may still target them could allow late DMA to corrupt valid KV.

The initial deadline is therefore fail-stop: the error propagates out of the connector and aborts the affected worker. Transparent recovery remains follow-up work requiring cancellation + terminal acknowledgement, or allocation quarantine.

## Tests

- 6 focused CPU/static regression cases passed:
  - disabled-by-default behavior
  - expiry raises
  - expired transfers do not expose block IDs as load errors/reusable
  - a ready event wins at the deadline boundary
  - negative, infinite, and NaN values are rejected
- `ruff check` passed for changed Python files
- `ruff format --check` passed
- `py_compile` and `git diff --check` passed

A broader 32-test file run under a temporary no-native-extension test harness produced 31 passes; the one unrelated CPU-layout test requires the native `EngineKVFormat` extension and fails under that stub.