### PR TITLE
docs: daily drift check — multi-process mode (2026-08-12)

### DIFF
--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -334,10 +334,15 @@ Each config module exposes a composable triple:
     add_storage_manager_args(parser)  # from distributed/config.py
       # which internally calls add_l2_adapters_args(parser)
     add_observability_args(parser)    # from mp_observability/config.py
+    add_coordinator_args(parser)      # from multiprocess/config.py
+      # coordinator registration flags (--coordinator-url and friends)
 
 ``http_server.py`` reuses this pattern, adding
-``add_http_frontend_args()`` and ``add_coordinator_args()`` for the
-``lmcache server`` CLI. CacheBlend is no longer a separate entry point —
+``add_http_frontend_args()`` (``--http-host`` / ``--http-port``) and
+``add_p2p_args()`` (the ``--p2p-*`` flags) on top for the ``lmcache
+server`` CLI; ``add_coordinator_args()`` is shared with ``server.py``
+above, so both entry points accept ``--coordinator-*`` flags. CacheBlend
+is no longer a separate entry point —
 it is opted into at runtime by passing ``--engine-type`` to
 ``server.py`` (or ``lmcache server``). ``--engine-type blend`` appends
 ``BlendV3Module`` (the current paged-aware implementation), while


### PR DESCRIPTION
## Summary

Daily docs drift check against `upstream/dev` at
[`38cb58d`](https://github.com/LMCache/LMCache/commit/38cb58d6ea6d77c63ff85684776433b89971f604),
focused on multi-process mode. One doc-only inconsistency found today,
in `docs/source/` (the user-facing MP internals page).

**`docs/source/`**

- `docs/source/mp/index.rst`: the *Config System* section described
  `server.py:parse_args()` as composing only three `add_*_args()` calls
  (`add_mp_server_args`, `add_storage_manager_args`,
  `add_observability_args`) and then told readers that `http_server.py`
  adds `add_http_frontend_args()` and `add_coordinator_args()` on top.
  Reality is the other way around for the coordinator flags:
  `server.py` (the legacy ZMQ-only entry point) also registers
  `add_coordinator_args()`, and the extra call that `http_server.py`
  makes versus `server.py` is `add_p2p_args()`, not
  `add_coordinator_args()`.

**`docs/design/`**

- No new drift found today. (`blend_server_v2.py` still appears in a
  handful of design docs — see *Not fixed in this PR* below — but those
  are pre-existing spec/proposal snapshots, not surfaced as fresh drift.)

## Evidence

### `docs/source/mp/index.rst` — stale `parse_args()` composition

Stale doc (before this PR):
[docs/source/mp/index.rst L325–L344 @ dev@38cb58d](https://github.com/LMCache/LMCache/blob/38cb58d6ea6d77c63ff85684776433b89971f604/docs/source/mp/index.rst#L325-L344)

> `server.py:parse_args()` composes them:
>
> ```python
> parser = argparse.ArgumentParser(...)
> add_mp_server_args(parser)        # from multiprocess/config.py
>                                   # includes runtime-plugin args
>                                   # (--runtime-plugin-locations,
>                                   #  --runtime-plugin-config)
> add_storage_manager_args(parser)  # from distributed/config.py
>   # which internally calls add_l2_adapters_args(parser)
> add_observability_args(parser)    # from mp_observability/config.py
> ```
>
> `http_server.py` reuses this pattern, adding
> `add_http_frontend_args()` and `add_coordinator_args()` for the
> `lmcache server` CLI.

Actual behaviour:

- `server.py:parse_args()` — [lmcache/v1/multiprocess/server.py L483–L496 @ dev@38cb58d](https://github.com/LMCache/LMCache/blob/38cb58d6ea6d77c63ff85684776433b89971f604/lmcache/v1/multiprocess/server.py#L483-L496):
  ```python
  add_mp_server_args(parser)
  add_storage_manager_args(parser)
  add_observability_args(parser)
  add_coordinator_args(parser)
  ```
- `http_server.py:parse_args()` — [lmcache/v1/multiprocess/http_server.py L266–L276 @ dev@38cb58d](https://github.com/LMCache/LMCache/blob/38cb58d6ea6d77c63ff85684776433b89971f604/lmcache/v1/multiprocess/http_server.py#L266-L276):
  ```python
  add_http_frontend_args(parser)
  add_mp_server_args(parser)
  add_p2p_args(parser)
  add_storage_manager_args(parser)
  add_observability_args(parser)
  add_coordinator_args(parser)
  ```

So the two real differences between the entry points are:

1. `server.py` also registers `add_coordinator_args()` (the doc omitted
   this fourth call from its code block).
2. `http_server.py` adds `add_http_frontend_args()` **and**
   `add_p2p_args()` on top (the doc named `add_coordinator_args()` as
   the second addition instead of `add_p2p_args()`).

The immediate user-visible consequence of the stale wording is that
`python3 -m lmcache.v1.multiprocess.server` looks as if it does not
accept the `--coordinator-*` flags — but it does, per
[server.py L495](https://github.com/LMCache/LMCache/blob/38cb58d6ea6d77c63ff85684776433b89971f604/lmcache/v1/multiprocess/server.py#L495).
The `--p2p-*` flags being exclusive to `lmcache server` is correctly
described elsewhere (see the `Server Variants` table and
[docs/source/mp/configuration.rst L189–L223](https://github.com/LMCache/LMCache/blob/38cb58d6ea6d77c63ff85684776433b89971f604/docs/source/mp/configuration.rst#L189-L223)),
but the `Config System` paragraph attributed that difference to the
wrong `add_*_args()` call.

This drift was introduced by
[#4351](https://github.com/LMCache/LMCache/pull/4351) (2026-07-31),
which reshaped both entry points' `parse_args()` but did not update
`docs/source/mp/index.rst`'s Config System paragraph.

## Proposed fix

Applied in this PR's diff:

- `docs/source/mp/index.rst`: add the fourth `add_coordinator_args()`
  line to the `server.py:parse_args()` code block, and rewrite the
  following paragraph so the differentiator between the two entry
  points is stated correctly — `http_server.py` adds
  `add_http_frontend_args()` (`--http-host` / `--http-port`) and
  `add_p2p_args()` (the `--p2p-*` flags) on top;
  `add_coordinator_args()` is shared with `server.py`.

No code changes; docs only.

## Not fixed in this PR

A few `docs/design/` pages still reference the removed
`blend_server_v2.py` module (e.g.
`docs/design/v1/mp_observability/trace.md`,
`docs/design/v1/mp_observability/EVENTS.md`,
`docs/design/cli/commands/describe.md`,
`docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md`,
`docs/design/observability/request-event-span.md`). CacheBlend is now
opted into on `server.py` via `--engine-type blend` / `blend_legacy`
rather than living in `blend_server_v2.py`, so those references are
stale. These are design-doc / historical snapshot pages (some of them
capture the state of a specific PR proposal), so I left them alone in
today's PR to avoid rewriting spec history unilaterally — flagging
here so a reviewer can decide whether they want a follow-up sweep.

## Notes

Auto-generated by the daily docs drift-check routine. **Human review
required before merge.** Kept as **draft**; not marked "Ready for
review." No code files touched. Deduplicated against prior open
drift-check PRs (#4480, #4462, #4455, #4435, #4421, #4401, #4378,
#4361); today's finding is the `parse_args()` composition paragraph in
`docs/source/mp/index.rst`, which none of them touch. The `--enable`
flag and the RequestType / `_build_modules()` gaps in the same file
are still open in #4462, so I did not re-flag them here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEzLdYDdQzz9Ri1Pq99RTk)_