### PR TITLE
[Bugfix][MP] Make lookup accounting retry-safe

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -707,7 +707,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             tokens for which KV cache is actually available at the time of the
             call. If the cache cannot be loaded for some tokens (e.g., due to
             connectivity issues or eviction), those tokens must not be taken
-            into account.
+            into account. This method may be called repeatedly before block
+            allocation, so stored-token accounting must be idempotent.
         """
         tracker = self._get_or_create_request_tracker(request)
         # TODO: support loading KV for preempted requests in the future
@@ -729,8 +730,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         assert ret % self.scheduler_adapter.lmcache_tokens_per_chunk == 0
 
-        # Update num stored tokens for the tracker
-        tracker.increase_num_stored_tokens(ret)
+        # The scheduler may retry this method while allocation is blocked and
+        # the adapter will return the same cached lookup result. Account for
+        # that result only once during the lifetime of this tracker.
+        tracker.account_lookup_result(ret)
 
         # Save the vllm and lmcache hit tokens. The vLLM hit count is
         # rounded down to a boundary aligned for every engine group (e.g.

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -60,6 +60,9 @@ class LMCacheMPRequestTracker:
     # requests.
     num_stored_tokens: int = 0
 
+    # Whether the cached lookup result has been included in num_stored_tokens.
+    _lookup_result_accounted: bool = False
+
     # Staging load operation -- save vllm and lmcache hit tokens during lookup
     num_vllm_hit_tokens: int = 0
     num_lmcache_hit_tokens: int = 0
@@ -77,6 +80,7 @@ class LMCacheMPRequestTracker:
         self.all_token_ids = request.all_token_ids
         self.allocated_block_ids = {}
         self.num_stored_tokens = 0
+        self._lookup_result_accounted = False
         self.num_vllm_hit_tokens = 0
         self.num_lmcache_hit_tokens = 0
         self.state = LMCacheMPRequestState.PREFETCHING
@@ -111,6 +115,24 @@ class LMCacheMPRequestTracker:
     ####
     def increase_num_scheduled_tokens(self, num_new_tokens: int):
         self.num_scheduled_tokens += num_new_tokens
+
+    def account_lookup_result(self, num_stored_tokens: int) -> None:
+        """Include an external lookup result in the stored-token watermark.
+
+        Args:
+            num_stored_tokens: Number of prefix tokens found by the lookup.
+
+        Returns:
+            None.
+
+        Notes:
+            Only the first call affects the watermark. Later calls are ignored
+            because the scheduler may poll the same cached result repeatedly
+            before it can allocate request blocks.
+        """
+        if not self._lookup_result_accounted:
+            self.increase_num_stored_tokens(num_stored_tokens)
+            self._lookup_result_accounted = True
 
     def increase_num_stored_tokens(self, num_new_tokens: int):
         """Increase the number of stored tokens for the current request

--- a/tests/v1/test_mp_connector_lookup_retry.py
+++ b/tests/v1/test_mp_connector_lookup_retry.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for retry-safe MP connector lookup accounting."""
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module scope")
+
+# Third Party
+from vllm.v1.request import RequestStatus  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+)
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
+    LMCacheMPRequestMetadata,
+)
+
+CHUNK_SIZE = 256
+TOKENS_PER_BLOCK = 16
+
+
+class _LookupAdapter:
+    """Test adapter exposing the scheduler lookup contract."""
+
+    lmcache_tokens_per_chunk = CHUNK_SIZE
+
+    def __init__(self, hit_tokens: int) -> None:
+        self.hit_tokens = hit_tokens
+        self.cleanup_calls = 0
+
+    def maybe_submit_lookup_request(
+        self, request_id: str, token_ids: list[int], cache_salt: str = ""
+    ) -> None:
+        """Accept a lookup submission without contacting a cache server."""
+
+    def check_lookup_result(self, request_id: str) -> int:
+        """Return the cached lookup result for every scheduler retry."""
+        return self.hit_tokens
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        """Record that allocation committed and cleared the lookup result."""
+        self.cleanup_calls += 1
+
+    def free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str = "",
+    ) -> None:
+        """Accept lock releases without contacting a cache server."""
+
+
+def _make_connector(hit_tokens: int) -> tuple[LMCacheMPConnector, _LookupAdapter]:
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector.request_trackers = {}
+    adapter = _LookupAdapter(hit_tokens)
+    connector.scheduler_adapter = adapter  # type: ignore[assignment]
+    connector._hit_alignment_tokens = TOKENS_PER_BLOCK
+    return connector, adapter
+
+
+def _make_request(num_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        request_id="req-0",
+        cache_salt=None,
+        all_token_ids=list(range(num_tokens)),
+        status=RequestStatus.WAITING,
+    )
+
+
+def _make_blocks(num_blocks: int) -> SimpleNamespace:
+    return SimpleNamespace(get_block_ids=lambda: ([*range(num_blocks)],))
+
+
+def test_lookup_retry_accounts_for_stored_watermark_once() -> None:
+    """Repeated lookup polling must not compound the stored watermark."""
+    hit_tokens = 2 * CHUNK_SIZE
+    connector, adapter = _make_connector(hit_tokens)
+    request = _make_request(num_tokens=1600)
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (hit_tokens, True)
+    tracker = connector.request_trackers[request.request_id]
+    assert tracker.num_stored_tokens == hit_tokens
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (hit_tokens, True)
+    assert tracker.num_stored_tokens == hit_tokens
+
+    connector.update_state_after_alloc(
+        request, _make_blocks(num_blocks=100), hit_tokens
+    )
+    assert tracker.num_stored_tokens == hit_tokens
+
+    connector.update_state_after_alloc(
+        request, _make_blocks(num_blocks=100), hit_tokens
+    )
+    assert tracker.num_stored_tokens == hit_tokens
+    assert adapter.cleanup_calls == 1
+
+
+def test_store_after_lookup_retry_starts_at_true_watermark() -> None:
+    """Store metadata after a retry must not leave a hole after the hit."""
+    hit_tokens = 2 * CHUNK_SIZE
+    connector, _ = _make_connector(hit_tokens)
+    request = _make_request(num_tokens=1600)
+
+    connector.get_num_new_matched_tokens(request, 0)
+    connector.get_num_new_matched_tokens(request, 0)
+    connector.update_state_after_alloc(
+        request, _make_blocks(num_blocks=100), hit_tokens
+    )
+
+    tracker = connector.request_trackers[request.request_id]
+    tracker.increase_num_scheduled_tokens(1600 - hit_tokens)
+    metadata = LMCacheMPRequestMetadata.GetStoreMetadata(
+        tracker, CHUNK_SIZE, [TOKENS_PER_BLOCK]
+    )
+
+    assert metadata is not None
+    assert metadata.op.start == hit_tokens


### PR DESCRIPTION
## Purpose

Fixes #4508.

When vLLM cannot allocate slots for a waiting request, the scheduler may call `get_num_new_matched_tokens` again before `update_state_after_alloc` clears the cached lookup result. The MP connector previously added that same result to `num_stored_tokens` on every call. This inflated the stored-token watermark and could make later store metadata skip an unstored token range, leaving subsequent chunks unreachable through prefix lookup.

This PR makes lookup accounting idempotent for the lifetime of a request tracker:

- adds `account_lookup_result` to apply the cached lookup result only once;
- uses that method when the MP connector processes lookup results; and
- adds regression coverage for repeated scheduler polling, repeated `update_state_after_alloc` calls, one-time cleanup of the cached lookup result, and the resulting token range in store metadata.

## Notes

The `_lookup_result_accounted` flag belongs to each request tracker and is initialized to `False` whenever a new tracker is created. It applies only to the initial cached lookup result; updates for newly stored chunks continue to use `increase_num_stored_tokens` normally.

The regression test uses a typed scheduler-adapter double with the production method signatures, so it exercises the connector retry and allocation flow without contacting a cache server.

Validated in a Linux Codespace with vLLM 0.23.0 against the issue's reported commit, `00f763c`. The file `tests/v1/test_issue_num_stored_tokens_double_count.py` below is the repro script from #4508 and is not committed in this PR.

Before the fix:

```bash
python -m pytest --confcutdir=tests/v1 -q \
  tests/v1/test_issue_num_stored_tokens_double_count.py
```

```text
FAILED test_repeated_matched_tokens_calls_keep_stored_belief_consistent
E   AssertionError: belief corrupted: num_stored_tokens 1024 != server truth 512

FAILED test_store_after_retry_starts_at_true_watermark
E   AssertionError: store starts at 1024, leaving [512, 1024) never stored:
E   all later chunks are unreachable

2 failed, 58 warnings in 17.34s
```

After cherry-picking this fix onto `00f763c`, both the issue reproduction and the regression tests added by this PR pass:

```bash
python -m pytest --confcutdir=tests/v1 -q \
  tests/v1/test_issue_num_stored_tokens_double_count.py \
  tests/v1/test_mp_connector_lookup_retry.py
```

```text
tests/v1/test_issue_num_stored_tokens_double_count.py::test_repeated_matched_tokens_calls_keep_stored_belief_consistent PASSED
tests/v1/test_issue_num_stored_tokens_double_count.py::test_store_after_retry_starts_at_true_watermark PASSED
tests/v1/test_mp_connector_lookup_retry.py::test_lookup_retry_accounts_for_stored_watermark_once PASSED
tests/v1/test_mp_connector_lookup_retry.py::test_store_after_lookup_retry_starts_at_true_watermark PASSED

4 passed, 58 warnings in 9.26s
```

## Checklist

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
