### PR TITLE
Refactor memory allocator package exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,11 @@ mypy --config-file=pyproject.toml   # Type checking
 codespell --toml pyproject.toml     # Spell checking
 ```
 
+Before running `pre-commit run --all-files`, verify that `cargo`, `rustfmt`, and
+the Rust toolchain are on `PATH`. The repository's pre-commit config includes
+Rust format and clippy hooks, so the run will fail even for Python-only changes
+when those commands are missing.
+
 C++/CUDA files use clang-format (Google style, 80-col). Rust code in `rust/` uses `cargo fmt` and `cargo clippy`.
 
 All Python files require an `# SPDX-License-Identifier: Apache-2.0` header as the first line.
@@ -216,4 +221,3 @@ When reviewing code (or self-checking before submitting), verify all of the foll
 - [ ] No unnecessary memory copies or allocations in hot paths.
 - [ ] Thread safety is maintained for shared data structures.
 - [ ] CUDA/GPU resources are properly managed (allocated, freed, synchronized).
-

--- a/lmcache/v1/memory_allocators/__init__.py
+++ b/lmcache/v1/memory_allocators/__init__.py
@@ -2,22 +2,41 @@
 
 # Standard
 from importlib import import_module
+from pathlib import Path
+import ast
 
-_EXPORT_TO_MODULE = {
-    "AdHocMemoryAllocator": "ad_hoc_memory_allocator",
-    "BufferAllocator": "buffer_allocator",
-    "CuFileMemoryAllocator": "cu_file_memory_allocator",
-    "DevDaxMemoryAllocator": "devdax_memory_allocator",
-    "GPUMemoryAllocator": "gpu_memory_allocator",
-    "HipFileMemoryAllocator": "hip_file_memory_allocator",
-    "HostMemoryAllocator": "host_memory_allocator",
-    "LazyMemoryAllocator": "lazy_memory_allocator",
-    "MixedMemoryAllocator": "mixed_memory_allocator",
-    "PagedCpuGpuMemoryAllocator": "paged_cpu_gpu_memory_allocator",
-    "PagedTensorMemoryAllocator": "paged_tensor_memory_allocator",
-    "PinMemoryAllocator": "pin_memory_allocator",
-    "TensorMemoryAllocator": "tensor_memory_allocator",
-}
+
+def _is_exported_allocator(class_def: ast.ClassDef) -> bool:
+    """Return whether a top-level class should be re-exported by this package."""
+    return not class_def.name.startswith("_") and class_def.name.endswith("Allocator")
+
+
+def _discover_allocator_exports() -> dict[str, str]:
+    """Build the lazy export map from allocator modules on disk."""
+    exports: dict[str, str] = {}
+    package_dir = Path(__file__).resolve().parent
+
+    for module_path in sorted(package_dir.glob("*_allocator.py")):
+        module = module_path.stem
+        syntax_tree = ast.parse(
+            module_path.read_text(encoding="utf-8"),
+            filename=str(module_path),
+        )
+        for node in syntax_tree.body:
+            if not isinstance(node, ast.ClassDef) or not _is_exported_allocator(node):
+                continue
+
+            previous = exports.setdefault(node.name, module)
+            if previous != module:
+                raise RuntimeError(
+                    "duplicate memory allocator export "
+                    f"{node.name!r} in {previous!r} and {module!r}"
+                )
+
+    return exports
+
+
+_EXPORT_TO_MODULE = _discover_allocator_exports()
 
 
 def __getattr__(name: str) -> object:
@@ -42,4 +61,9 @@ def __getattr__(name: str) -> object:
     return value
 
 
-__all__ = list(_EXPORT_TO_MODULE)
+def __dir__() -> list[str]:
+    """Return the package attributes exposed for interactive discovery."""
+    return sorted(set(globals()) | set(__all__))
+
+
+__all__ = sorted(_EXPORT_TO_MODULE)

--- a/tests/v1/test_memory_allocator_import_surface.py
+++ b/tests/v1/test_memory_allocator_import_surface.py
@@ -2,11 +2,53 @@
 
 # Standard
 from pathlib import Path
+import ast
 import subprocess
 import sys
 import textwrap
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_ALLOCATOR_PACKAGE = _REPO_ROOT / "lmcache" / "v1" / "memory_allocators"
+
+
+def _expected_allocator_exports() -> set[str]:
+    """Return allocator class names that should be package re-exports."""
+    exports: set[str] = set()
+
+    for module_path in _ALLOCATOR_PACKAGE.glob("*_allocator.py"):
+        syntax_tree = ast.parse(
+            module_path.read_text(encoding="utf-8"),
+            filename=str(module_path),
+        )
+        for node in syntax_tree.body:
+            if (
+                isinstance(node, ast.ClassDef)
+                and not node.name.startswith("_")
+                and node.name.endswith("Allocator")
+            ):
+                exports.add(node.name)
+
+    return exports
+
+
+def _expected_allocator_modules() -> set[str]:
+    """Return allocator module names used by the lazy import surface test."""
+    modules: set[str] = set()
+
+    for module_path in _ALLOCATOR_PACKAGE.glob("*_allocator.py"):
+        syntax_tree = ast.parse(
+            module_path.read_text(encoding="utf-8"),
+            filename=str(module_path),
+        )
+        if any(
+            isinstance(node, ast.ClassDef)
+            and not node.name.startswith("_")
+            and node.name.endswith("Allocator")
+            for node in syntax_tree.body
+        ):
+            modules.add(module_path.stem)
+
+    return modules
 
 
 def _run_import_script(script: str) -> None:
@@ -34,27 +76,17 @@ def _run_import_script(script: str) -> None:
 
 def test_memory_allocators_package_import_is_lazy() -> None:
     """Importing the allocator package does not eagerly import submodules."""
+    allocator_modules = sorted(_expected_allocator_modules())
+    expected_exports = sorted(_expected_allocator_exports())
+
     _run_import_script(
-        """
+        f"""
         import sys
 
         import lmcache.v1.memory_allocators as allocators
 
-        allocator_modules = {
-            "ad_hoc_memory_allocator",
-            "buffer_allocator",
-            "cu_file_memory_allocator",
-            "devdax_memory_allocator",
-            "gpu_memory_allocator",
-            "hip_file_memory_allocator",
-            "host_memory_allocator",
-            "lazy_memory_allocator",
-            "mixed_memory_allocator",
-            "paged_cpu_gpu_memory_allocator",
-            "paged_tensor_memory_allocator",
-            "pin_memory_allocator",
-            "tensor_memory_allocator",
-        }
+        allocator_modules = {allocator_modules!r}
+        expected_exports = {expected_exports!r}
         loaded = sorted(
             name
             for name in sys.modules
@@ -62,6 +94,7 @@ def test_memory_allocators_package_import_is_lazy() -> None:
             and name.rsplit(".", 1)[-1] in allocator_modules
         )
         assert loaded == [], loaded
+        assert allocators.__all__ == expected_exports
         assert "LazyMemoryAllocator" in allocators.__all__
         assert "TensorMemoryAllocator" in allocators.__all__
         """


### PR DESCRIPTION
## Summary
- replace the handwritten allocator export map with AST-based discovery over `*_allocator.py`
- keep lazy package exports and add a regression test that new allocator modules are exported automatically
- document that full `pre-commit` runs require the Rust toolchain on PATH

## Testing
- `/Users/mbl/projects/LMCache/.venv/bin/pytest -xvs tests/v1/test_memory_allocator_import_surface.py`
- `/Users/mbl/projects/LMCache/.venv/bin/pre-commit run --all-files` *(fails in this environment only because `cargo`/`rustfmt` are not installed; Python hooks passed and commit-time hooks passed for changed files)*