### PR TITLE
[MP][Bugfix] free_lookup_locks: release only the keys the prefetch actually locked

### DIFF
--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -406,6 +406,14 @@ class LookupModule:
             job.attn_desc.num_chunks_in_sw,
         )
 
+        # Record the model-wide hit length on the session so a later
+        # free_lookup_locks can reconstruct which keys the prefetch
+        # read-locked (see ``unfold``: full-attention groups lock the whole
+        # hit prefix, sliding-window groups only its in-window suffix).
+        self._ctx.session_manager.get_or_create(
+            job.request_id
+        ).prefetch_hit_chunks = found_count
+
         self._ctx.event_bus.publish(
             Event(
                 event_type=EventType.MP_LOOKUP_PREFETCH_END,
@@ -470,6 +478,19 @@ class LookupModule:
         ``start`` and ``end`` must be aligned to ``chunk_size``; it is the
         caller's responsibility to align the boundaries as desired.
 
+        Only the keys the prefetch actually read-locked are released.
+        Mirroring ``unfold``, for a model-wide hit of ``H`` chunks a
+        full-attention group locks chunks ``[0, H)`` while a sliding-window
+        group locks only the trailing ``[max(0, H - window), H)``; each
+        group releases the intersection of its locked range with
+        ``[start, end)``.  The hit length is read from the session, where
+        ``query_prefetch_status`` recorded it when the prefetch result was
+        consumed.  If it was never recorded, full-attention groups fall
+        back to releasing the whole ``[start, end)`` range while
+        sliding-window groups release nothing: a leaked read lock expires
+        with its TTL, whereas an over-release could strip a lock held by a
+        concurrent reader of the same chunk.
+
         Computes the extra reader count from ``tp_size`` and
         ``world_size`` the same way :meth:`lookup` does, so
         the correct number of locks is released.
@@ -484,16 +505,44 @@ class LookupModule:
         )
         if not chunk_hashes:
             return
-        # Release across every object group, mirroring lookup, which locks keys
-        # in every group; releasing only group 0 would leak the rest.
-        #
-        # NOTE: correct only for full attention, where every locked chunk is a
-        # hit chunk. Sliding-window groups do not retain chunks outside their
-        # window, so once SWA prefetch lands this must skip those chunks instead
-        # of releasing every one -- otherwise chunks the engine still holds can
-        # be over-released (e.g. window=512, LMCache hit 1024, vLLM hit 768 ->
-        # chunks 512..768 may leak). Revisit when sliding-window prefetch is on.
-        obj_keys = self._chunk_major_object_keys(key, chunk_hashes)
+
+        start_chunk = key.start // self._ctx.chunk_size
+        end_chunk = start_chunk + len(chunk_hashes)
+
+        attn_desc = self._ctx.layout_desc_registry.find_attn_desc(
+            key.model_name, key.world_size
+        )
+        hit_chunks = self._ctx.session_manager.get_or_create(
+            key.request_id
+        ).prefetch_hit_chunks
+        if hit_chunks < 0:
+            logger.warning(
+                "free_lookup_locks for request %s before its prefetch result "
+                "was consumed; releasing full-attention groups only",
+                key.request_id,
+            )
+
+        # Release across every object group, mirroring lookup, which locks
+        # keys in every group; releasing only group 0 would leak the rest.
+        obj_keys: list[ObjectKey] = []
+        for group_idx, window in enumerate(attn_desc.num_chunks_in_sw):
+            if hit_chunks < 0:
+                if window >= 0:
+                    continue
+                lo, hi = start_chunk, end_chunk
+            else:
+                # Locked range per ``unfold``: the whole hit prefix for full
+                # attention, its trailing ``window`` chunks otherwise.
+                lo = 0 if window < 0 else max(0, hit_chunks - window)
+                lo = max(lo, start_chunk)
+                hi = min(hit_chunks, end_chunk)
+            if lo >= hi:
+                continue
+            group_hashes = chunk_hashes[lo - start_chunk : hi - start_chunk]
+            obj_keys.extend(ipc_key_to_object_keys(key, group_hashes, [group_idx])[0])
+
+        if not obj_keys:
+            return
 
         extra_count = compute_extra_count(tp_size, key.world_size)
 

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -479,17 +479,6 @@ class LookupModule:
         caller's responsibility to align the boundaries as desired.
 
         Only the keys the prefetch actually read-locked are released.
-        Mirroring ``unfold``, for a model-wide hit of ``H`` chunks a
-        full-attention group locks chunks ``[0, H)`` while a sliding-window
-        group locks only the trailing ``[max(0, H - window), H)``; each
-        group releases the intersection of its locked range with
-        ``[start, end)``.  The hit length is read from the session, where
-        ``query_prefetch_status`` recorded it when the prefetch result was
-        consumed.  If it was never recorded, full-attention groups fall
-        back to releasing the whole ``[start, end)`` range while
-        sliding-window groups release nothing: a leaked read lock expires
-        with its TTL, whereas an over-release could strip a lock held by a
-        concurrent reader of the same chunk.
 
         Computes the extra reader count from ``tp_size`` and
         ``world_size`` the same way :meth:`lookup` does, so

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -41,6 +41,11 @@ class Session:
     num_chunks_processed: int = 0
     created_at: float = field(default_factory=time.time)
     lookup_ipc_key: Optional[IPCCacheServerKey] = None
+    prefetch_hit_chunks: int = -1
+    """Model-wide prefix hit length in chunks, recorded by
+    ``query_prefetch_status`` when the prefetch result is consumed; ``-1``
+    until then.  ``free_lookup_locks`` uses it to reconstruct which keys the
+    prefetch read-locked (see ``unfold``)."""
     extras: dict[str, Any] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -42,10 +42,6 @@ class Session:
     created_at: float = field(default_factory=time.time)
     lookup_ipc_key: Optional[IPCCacheServerKey] = None
     prefetch_hit_chunks: int = -1
-    """Model-wide prefix hit length in chunks, recorded by
-    ``query_prefetch_status`` when the prefetch result is consumed; ``-1``
-    until then.  ``free_lookup_locks`` uses it to reconstruct which keys the
-    prefetch read-locked (see ``unfold``)."""
     extras: dict[str, Any] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import threading
 
 # First Party
+from lmcache.v1.distributed.api import AttnWindowDesc
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -87,15 +88,40 @@ def test_mq_free_locks():
 # ============================================================================
 
 
+def _make_free_locks_ctx(
+    chunk_hashes: list[bytes],
+    windows: list[int],
+    hit_chunks: int,
+) -> MagicMock:
+    """Build a mock engine context for free_lookup_locks tests.
+
+    Args:
+        chunk_hashes: Hashes returned for the freed [start, end) range.
+        windows: Per-object-group windows for the registered AttnWindowDesc.
+        hit_chunks: Prefetch hit length recorded on the session (-1 for
+            "never recorded").
+
+    Returns:
+        The configured MagicMock context.
+    """
+    ctx = MagicMock()
+    ctx.chunk_size = 256
+    ctx.token_hasher.chunk_size = 256
+    ctx.token_hasher.compute_chunk_hashes.return_value = chunk_hashes
+    ctx.layout_desc_registry.find_attn_desc.return_value = AttnWindowDesc(
+        num_chunks_in_sw=windows
+    )
+    ctx.session_manager.get_or_create.return_value.prefetch_hit_chunks = hit_chunks
+    return ctx
+
+
 def test_server_free_lookup_locks_calls_finish_read_prefetched():
     """LookupModule.free_lookup_locks should resolve hash keys and call
     finish_read_prefetched on the storage manager."""
     # First Party
     from lmcache.v1.multiprocess.modules.lookup import LookupModule
 
-    ctx = MagicMock()
-    ctx.token_hasher.chunk_size = 256
-    ctx.token_hasher.compute_chunk_hashes.return_value = [b"hash0"]
+    ctx = _make_free_locks_ctx([b"hash0"], windows=[-1], hit_chunks=1)
 
     module = LookupModule(ctx)
 
@@ -112,6 +138,107 @@ def test_server_free_lookup_locks_calls_finish_read_prefetched():
     module.context.storage_manager.finish_read_prefetched.assert_called_once_with(
         sentinel_obj_keys, extra_count=0
     )
+
+
+def _free_locks_key(num_tokens: int, start: int, end: int) -> IPCCacheServerKey:
+    """Build a lookup-style (worker_id=None) key over [start, end)."""
+    return IPCCacheServerKey(
+        model_name="testmodel",
+        world_size=1,
+        worker_id=None,
+        token_ids=tuple(range(num_tokens)),
+        start=start,
+        end=end,
+        request_id="req-sw",
+    )
+
+
+def _released_chunks(finish_read_mock: MagicMock) -> set[tuple[int, bytes]]:
+    """Collect (object_group_id, chunk_hash) pairs released by the module."""
+    (obj_keys,), kwargs = finish_read_mock.call_args
+    assert kwargs == {"extra_count": 0}
+    return {(k.object_group_id, k.chunk_hash) for k in obj_keys}
+
+
+def test_server_free_lookup_locks_sliding_window_skips_unlocked_chunks():
+    """A sliding-window group must release only its locked suffix.
+
+    Hit of 4 chunks, windows [1, -1], freed range [0, 3): the window group
+    locked only chunk 3, which is outside the range, so only the
+    full-attention group's chunks 0-2 are released.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.modules.lookup import LookupModule
+
+    hashes = [b"h0", b"h1", b"h2"]
+    ctx = _make_free_locks_ctx(hashes, windows=[1, -1], hit_chunks=4)
+    module = LookupModule(ctx)
+
+    module.free_lookup_locks(_free_locks_key(1024, start=0, end=768), 1)
+
+    released = _released_chunks(ctx.storage_manager.finish_read_prefetched)
+    assert released == {(1, b"h0"), (1, b"h1"), (1, b"h2")}
+
+
+def test_server_free_lookup_locks_sliding_window_releases_locked_suffix():
+    """Freeing the whole hit range releases the window group's suffix.
+
+    Hit of 4 chunks, windows [1, -1], freed range [0, 4): the window group
+    releases chunk 3, the full-attention group releases chunks 0-3.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.modules.lookup import LookupModule
+
+    hashes = [b"h0", b"h1", b"h2", b"h3"]
+    ctx = _make_free_locks_ctx(hashes, windows=[1, -1], hit_chunks=4)
+    module = LookupModule(ctx)
+
+    module.free_lookup_locks(_free_locks_key(1024, start=0, end=1024), 1)
+
+    released = _released_chunks(ctx.storage_manager.finish_read_prefetched)
+    assert released == {
+        (0, b"h3"),
+        (1, b"h0"),
+        (1, b"h1"),
+        (1, b"h2"),
+        (1, b"h3"),
+    }
+
+
+def test_server_free_lookup_locks_caps_release_at_hit_length():
+    """Chunks beyond the hit length were never locked and must not be freed."""
+    # First Party
+    from lmcache.v1.multiprocess.modules.lookup import LookupModule
+
+    hashes = [b"h0", b"h1", b"h2", b"h3"]
+    ctx = _make_free_locks_ctx(hashes, windows=[-1], hit_chunks=2)
+    module = LookupModule(ctx)
+
+    module.free_lookup_locks(_free_locks_key(1024, start=0, end=1024), 1)
+
+    released = _released_chunks(ctx.storage_manager.finish_read_prefetched)
+    assert released == {(0, b"h0"), (0, b"h1")}
+
+
+def test_server_free_lookup_locks_unknown_hit_skips_window_groups():
+    """Without a recorded hit length, window groups release nothing.
+
+    Full-attention groups keep the legacy full-range release; a
+    sliding-window group's locked suffix is unknown, so it is skipped
+    (leaked locks expire with the TTL, over-releasing could strip a
+    concurrent reader's lock).
+    """
+    # First Party
+    from lmcache.v1.multiprocess.modules.lookup import LookupModule
+
+    hashes = [b"h0", b"h1", b"h2"]
+    ctx = _make_free_locks_ctx(hashes, windows=[1, -1], hit_chunks=-1)
+    module = LookupModule(ctx)
+
+    module.free_lookup_locks(_free_locks_key(1024, start=0, end=768), 1)
+
+    released = _released_chunks(ctx.storage_manager.finish_read_prefetched)
+    assert released == {(1, b"h0"), (1, b"h1"), (1, b"h2")}
 
 
 def test_server_free_lookup_locks_no_matching_chunks():

--- a/tests/v1/multiprocess/test_lookup_wait_prefetch.py
+++ b/tests/v1/multiprocess/test_lookup_wait_prefetch.py
@@ -66,6 +66,11 @@ def test_wait_prefetch_status_returns_count_and_consumes_job():
     ctx.event_bus.publish.assert_called_once()
     # Exactly-once: the job is removed after a non-None result.
     assert "req" not in module._prefetch_jobs
+    # The hit length is recorded on the session so free_lookup_locks can
+    # later reconstruct which keys the prefetch read-locked.
+    ctx.session_manager.get_or_create.assert_called_once_with("req")
+    session = ctx.session_manager.get_or_create.return_value
+    assert session.prefetch_hit_chunks == 4
 
 
 def test_wait_prefetch_status_timeout_returns_none_and_keeps_job():


### PR DESCRIPTION
**What this PR does / why we need it**:

`free_lookup_locks` releases the read locks that a lookup's prefetch acquired but
the engine will never retrieve (e.g. chunks already covered by vLLM's local prefix
cache). It rebuilt the key set as the full cross product of
`chunks-in-range × all object groups` — but the prefetch (via `unfold`) locks
sliding-window object groups only on the trailing `[max(0, H - window), H)` chunks
of the model-wide hit `H`, not on the whole prefix.

On hybrid-attention models with `--separate-object-groups` this made every warm
request call `finish_read` on keys the prefetch never locked. Observed with
Kimi-K3 (windows `[1, -1]`, TP=8, chunk size 768): a single 167-chunk warm request
emitted 1328 warnings —

    L1Manager: finish read on non-existing key ... (1200×)
    L1Manager: finish read on non-read-locked key ... (128×)

Beyond the log noise, releasing a lock you don't hold is unsafe under concurrency:
if another in-flight request legitimately holds a read lock on one of those keys
(overlapping-prefix workloads), the spurious `finish_read` strips that reader's
lock and its data can be evicted mid-read.

Fix — make the release side mirror `unfold`'s locking contract:

- `Session` gains `prefetch_hit_chunks`, recorded by `query_prefetch_status` when
  the prefetch result is consumed (which all connector free paths do first).
- `free_lookup_locks` now releases, per object group, exactly
  `locked(group) ∩ [start, end)`:
  - full attention: `[0, H)`
  - sliding window: `[max(0, H - window), H)`
- Full-attention releases are additionally capped at `H` (keys past the hit were
  never locked).
- Defensive fallback when no hit was recorded (free before any status query):
  full-attention groups keep the legacy full-range release; sliding-window groups
  release nothing — a leaked read lock expires with its TTL, an over-release could
  corrupt a concurrent reader.

This also resolves the pre-existing NOTE in `free_lookup_locks` about SWA
over-release (`window=512, LMCache hit 1024, vLLM hit 768`): the window group now
releases `[512, 768)` while the retrieve releases `[768, 1024)` — no leak, no
double release.

Verified end-to-end with Kimi-K3 (TP=8) + the long-doc-qa benchmark: warm request
retrieved 122k tokens/rank with zero `L1Manager` finish-read warnings (previously
1328 per request).

**Special notes for your reviewers**:

- The locked-range formula intentionally duplicates `unfold`'s semantics
  (`lmcache/v1/distributed/bitmap_ops/fold.py`) analytically instead of storing
  the retain bitmap; the hit length is the only state carried over, on the
  already-per-request `Session`.
- `query_prefetch_status` is the single point where the hit is recorded;
  `wait_prefetch_status` delegates to it, so both polling paths are covered.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
