### PR TITLE
[Fix][MP] Release only still-held locks in free_lookup_locks (hybrid SW/linear-attention groups)

### DIFF
--- a/docs/source/recipes/kimi_k3.rst
+++ b/docs/source/recipes/kimi_k3.rst
@@ -17,6 +17,9 @@ Validated models
 
 - `moonshotai/Kimi-K3 <https://huggingface.co/moonshotai/Kimi-K3>`_
   (8× NVIDIA B300)
+- `moonshotai/Kimi-K3 <https://huggingface.co/moonshotai/Kimi-K3>`_ MXFP4
+  (8× AMD MI355X, via the InferenceX AgentX benchmark; fp8 KV cache,
+  DSpark speculative decoding)
 
 .. tab-set::
    :sync-group: engine
@@ -46,27 +49,41 @@ Validated models
 
       As a Mamba / linear-attention hybrid, Kimi K3 needs the same three
       settings as the other KDA / GDN hybrids: the ``align`` Mamba cache mode,
-      prefix caching, and a chunk size matched to vLLM's *unified block size*
-      ``N`` (see :ref:`mamba-block-size` for how ``N`` is determined). For
-      Kimi K3 at ``--tensor-parallel-size 8`` the unified block size is
-      ``N = 768``:
+      prefix caching, and a chunk size that is a multiple of **every** engine
+      KV group's ``tokens_per_block`` (see :ref:`mamba-block-size` for how
+      the unified block size ``N`` is determined). For Kimi K3 at
+      ``--tensor-parallel-size 8`` the validated values are:
 
       .. list-table::
          :header-rows: 1
-         :widths: 50 25 25
+         :widths: 34 22 22 22
 
-         * - Model
-           - Unified block size ``N``
-           - GPUs (TP)
-         * - ``moonshotai/Kimi-K3``
+         * - Platform (TP 8)
+           - Attention block ``N``
+           - KDA state group
+           - Minimum ``--chunk-size``
+         * - NVIDIA B300 (bf16 KV)
            - 768
-           - 8
+           - 768
+           - 768
+         * - AMD MI355X (fp8 KV, ``TRITON_MLA``)
+           - 1536
+           - 3072
+           - 3072
 
-      ``N`` depends on the tensor-parallel size (the KDA state is sharded
-      across TP ranks while the MLA cache is not), so after changing
-      ``--tensor-parallel-size`` always re-read ``N`` from vLLM's
-      ``Setting attention block size to N tokens`` startup log line and
-      re-derive ``--chunk-size`` and ``--max-num-batched-tokens`` from it.
+      ``N`` depends on the tensor-parallel size, the KV cache dtype, and the
+      attention backend (the KDA state is sharded across TP ranks while the
+      MLA cache is not, and vLLM sizes the attention block so the attention
+      page is at least as large as the mamba page). **Do not copy a number
+      from this table for a different stack.** After changing
+      ``--tensor-parallel-size``, ``--kv-cache-dtype``, or the platform,
+      re-read ``N`` from vLLM's ``Setting attention block size to N tokens``
+      startup log line and re-derive ``--chunk-size`` from it. The KDA state
+      group can register a *larger* ``tokens_per_block`` than ``N`` (the
+      MI355X row above registers 3072 against ``N = 1536``); LMCache rejects
+      a chunk size that is not a multiple of every group's block size at
+      engine startup, and the error message names the offending group and
+      value — take the final chunk size from that, not from ``N`` alone.
 
       Start the LMCache MP server (``--chunk-size`` = ``N`` = 768):
 
@@ -100,7 +117,6 @@ Validated models
              --reasoning-parser kimi_k3 \
              --enable-prefix-caching \
              --mamba-cache-mode align \
-             --max-num-batched-tokens 1500 \
              --kv-transfer-config \
              '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.port":6555}}'
 
@@ -114,17 +130,19 @@ Validated models
         the recurrent state.
       - ``--separate-object-groups`` (server) is **required** for hybrid
         Mamba / linear-attention models: it gives the KDA layers their own
-        cache objects and is what lets ``--max-num-batched-tokens`` exceed
-        ``2N``.
-      - ``--chunk-size`` (server) must be a multiple of the unified block size
-        ``N = 768`` — ``--chunk-size N`` is the simplest choice. LMCache
-        raises at engine startup if it is not.
-      - ``--max-num-batched-tokens`` must be **at least** ``N`` (= ``768``); the
-        validated value is ``1500``. ``align`` snapshots the KDA state only on a
-        block boundary at the end of a scheduler step. Within ``[N, 2N)`` every
-        step advances exactly one block, snapshotting every boundary (finest
-        reuse); with ``--separate-object-groups`` values ``≥ 2N`` are allowed
-        too, trading coarser reuse for higher prefill throughput. See
+        cache objects.
+      - ``--chunk-size`` (server) must be a multiple of **every** engine KV
+        group's ``tokens_per_block`` (see the table above) — on stacks where
+        all groups share the unified block size, ``--chunk-size N`` is the
+        simplest choice. LMCache raises at engine startup if it is not.
+      - ``--max-num-batched-tokens`` no longer needs to be set explicitly.
+        The constraint is only that it be **at least** ``N`` (``align``
+        snapshots the KDA state on block boundaries at the end of a
+        scheduler step), which vLLM's default already satisfies. Earlier
+        revisions of this recipe pinned ``1500`` as a workaround from before
+        ``--separate-object-groups`` allowed values ``≥ 2N``; that pin is
+        obsolete. Smaller values within ``[N, 2N)`` snapshot every block
+        boundary (finest reuse) at the cost of prefill throughput. See
         :doc:`../mp/hybrid_models` for the full rationale.
       - The server's ``--port 6555`` must match ``lmcache.mp.port`` in the
         connector config.
@@ -183,12 +201,46 @@ Compression support
      - Not supported
      - Hybrid groups' cached pages are byte-opaque.
 
+Operational notes from sustained-load validation
+------------------------------------------------
+
+Learned from running this recipe under the InferenceX AgentX trace-replay
+benchmark on 8× MI355X (100k–330k-token contexts, ~1 hour of sustained load,
+DRAM offload as the external tier):
+
+- **Size the L1 against** ``/dev/shm``, **not free DRAM.** The MP server's L1
+  pool is backed by POSIX shared memory in every transfer mode, so the usable
+  ceiling is the ``/dev/shm`` tmpfs mount (Linux default: 50% of RAM), not
+  total host memory. Pre-flight the budget: on the engine-driven path an
+  oversized L1 silently falls back to the (much slower) pickle transport; on
+  the ``lmcache_driven`` path the server-side capacity check does not run, so
+  writes can hit ``SIGBUS`` when the tmpfs fills.
+- **Pin** ``--supported-transfer-mode lmcache_driven`` **for benchmarks.**
+  The default ``auto`` advertises both transfer paths; pinning one makes the
+  measured data path deterministic across runs.
+- ``--enable-extra-logging`` (server) logs cumulative per-device store and
+  retrieve token counters, which pair with vLLM's
+  ``vllm:external_prefix_cache_queries`` / ``hits`` metrics to attribute hit
+  rates: external hits are counted only on tokens the local GPU prefix cache
+  missed, so the two hit populations are disjoint and the external hit rate
+  reads as "share of locally-missed tokens served by LMCache".
+
 Caveats
 -------
 
 - **Pre-release engine support.** Until vLLM ships K3 in a stable release, pin
   both sides: the ``vllm/vllm-openai:kimi-k3`` Docker image on the vLLM side
   and an LMCache nightly from 2026-07-27 or newer (stable from 0.5.3).
+- **Concurrent load on hybrid models requires the sliding-window
+  lock-release fix.** Versions up to and including 0.5.4rc1 over-release
+  read locks when freeing the vLLM-hit prefix: for linear-attention (KDA)
+  object groups, the lookup only retains locks on the trailing window, and
+  the extra releases decrement locks held by concurrent requests on the same
+  content-addressed chunks. Under L1 eviction pressure this lets evicted
+  state pages be reclaimed mid-retrieve — observed as ``finish read on
+  non-read-locked key`` warnings followed by corrupted generations or GPU
+  ``hipErrorIllegalAddress`` / ``HSA_STATUS_ERROR_EXCEPTION`` faults. Use a
+  release containing the fix for any multi-request workload.
 - Generation is **not guaranteed bit-exact** between a cached and a fresh run
   under concurrent load: KDA / GDN linear-attention backends do not support
   vLLM's batch-invariant mode, so kernel results can vary with batch

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -406,6 +406,13 @@ class LookupModule:
             job.attn_desc.num_chunks_in_sw,
         )
 
+        # Record the served hit length on the session: free_lookup_locks
+        # needs it to release only the still-held locks of sliding-window
+        # groups (their retained window is anchored at the hit end).
+        self._ctx.session_manager.get_or_create(
+            job.request_id
+        ).lookup_hit_chunks = found_count
+
         self._ctx.event_bus.publish(
             Event(
                 event_type=EventType.MP_LOOKUP_PREFETCH_END,
@@ -474,6 +481,15 @@ class LookupModule:
         ``world_size`` the same way :meth:`lookup` does, so
         the correct number of locks is released.
 
+        Only locks the lookup still holds are released. Full-attention
+        groups hold every hit chunk, so the whole ``[start, end)`` range is
+        released. Sliding-window / linear-attention groups hold only the
+        retained window ``[hit - w, hit)`` — the prefetch controller already
+        unlocked everything earlier when it trimmed the load plan. Releasing
+        those trimmed chunks again would decrement read locks held by
+        *other* requests on the same content-addressed keys, letting
+        eviction reclaim objects mid-retrieve.
+
         Args:
             key: Cache key whose read locks should be released.
             tp_size: Tensor-parallel size for MLA
@@ -484,16 +500,43 @@ class LookupModule:
         )
         if not chunk_hashes:
             return
-        # Release across every object group, mirroring lookup, which locks keys
-        # in every group; releasing only group 0 would leak the rest.
-        #
-        # NOTE: correct only for full attention, where every locked chunk is a
-        # hit chunk. Sliding-window groups do not retain chunks outside their
-        # window, so once SWA prefetch lands this must skip those chunks instead
-        # of releasing every one -- otherwise chunks the engine still holds can
-        # be over-released (e.g. window=512, LMCache hit 1024, vLLM hit 768 ->
-        # chunks 512..768 may leak). Revisit when sliding-window prefetch is on.
-        obj_keys = self._chunk_major_object_keys(key, chunk_hashes)
+
+        attn_desc = self._ctx.layout_desc_registry.find_attn_desc(
+            key.model_name, key.world_size
+        )
+        num_groups = attn_desc.num_object_groups
+        per_group = ipc_key_to_object_keys(key, chunk_hashes, list(range(num_groups)))
+
+        start_chunk = key.start // self._ctx.chunk_size
+        end_chunk = start_chunk + len(chunk_hashes)
+        hit_chunks = self._ctx.session_manager.get_or_create(
+            key.request_id
+        ).lookup_hit_chunks
+
+        # Each per-group list is chunk-major / rank-minor of length
+        # len(chunk_hashes) * num_ranks.
+        num_ranks = len(per_group[0]) // len(chunk_hashes)
+        obj_keys: list[ObjectKey] = []
+        for group_idx, group_keys in enumerate(per_group):
+            if attn_desc.is_full_attention(group_idx):
+                obj_keys.extend(group_keys)
+                continue
+            # Still held for this group: the retained window intersected
+            # with the freed range. When the caller frees the vLLM-hit
+            # prefix ahead of a retrieve, this intersection is empty and
+            # the retrieve releases the window instead; when it frees the
+            # whole hit (no retrieve), this releases exactly the window.
+            window = attn_desc.num_chunks_in_sw[group_idx]
+            held_lo = max(start_chunk, hit_chunks - window)
+            held_hi = min(end_chunk, hit_chunks)
+            if held_hi <= held_lo:
+                continue
+            lo = (held_lo - start_chunk) * num_ranks
+            hi = (held_hi - start_chunk) * num_ranks
+            obj_keys.extend(group_keys[lo:hi])
+
+        if not obj_keys:
+            return
 
         extra_count = compute_extra_count(tp_size, key.world_size)
 

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -41,6 +41,11 @@ class Session:
     num_chunks_processed: int = 0
     created_at: float = field(default_factory=time.time)
     lookup_ipc_key: Optional[IPCCacheServerKey] = None
+    lookup_hit_chunks: int = 0
+    """Chunk-length of the most recent completed lookup's servable hit,
+    recorded when the prefetch result is queried. free_lookup_locks uses it
+    to locate sliding-window groups' retained windows ``[hit - w, hit)`` —
+    the only chunks of those groups still read-locked after lookup."""
     extras: dict[str, Any] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -87,15 +87,34 @@ def test_mq_free_locks():
 # ============================================================================
 
 
+def _make_free_locks_ctx(attn_desc, hit_chunks, num_range_chunks):
+    """Build a mocked server context for free_lookup_locks tests.
+
+    Args:
+        attn_desc: The AttnWindowDesc the layout registry should return.
+        hit_chunks: The recorded lookup hit length, in chunks.
+        num_range_chunks: How many chunk hashes the ``[start, end)`` range
+            resolves to.
+    """
+    ctx = MagicMock()
+    ctx.chunk_size = 256
+    ctx.token_hasher.chunk_size = 256
+    ctx.token_hasher.compute_chunk_hashes.return_value = [
+        f"hash{i}".encode() for i in range(num_range_chunks)
+    ]
+    ctx.layout_desc_registry.find_attn_desc.return_value = attn_desc
+    ctx.session_manager.get_or_create.return_value.lookup_hit_chunks = hit_chunks
+    return ctx
+
+
 def test_server_free_lookup_locks_calls_finish_read_prefetched():
     """LookupModule.free_lookup_locks should resolve hash keys and call
     finish_read_prefetched on the storage manager."""
     # First Party
+    from lmcache.v1.distributed.api import AttnWindowDesc
     from lmcache.v1.multiprocess.modules.lookup import LookupModule
 
-    ctx = MagicMock()
-    ctx.token_hasher.chunk_size = 256
-    ctx.token_hasher.compute_chunk_hashes.return_value = [b"hash0"]
+    ctx = _make_free_locks_ctx(AttnWindowDesc([-1]), hit_chunks=1, num_range_chunks=1)
 
     module = LookupModule(ctx)
 
@@ -111,6 +130,87 @@ def test_server_free_lookup_locks_calls_finish_read_prefetched():
 
     module.context.storage_manager.finish_read_prefetched.assert_called_once_with(
         sentinel_obj_keys, extra_count=0
+    )
+
+
+def test_server_free_lookup_locks_skips_sw_group_before_retrieve():
+    """Freeing the vLLM-hit prefix ahead of a retrieve must not release
+    sliding-window group locks: the lookup only holds the retained window
+    ``[hit - w, hit)``, which lies beyond the freed prefix and is released
+    by the retrieve itself. Releasing trimmed chunks here would steal read
+    locks from concurrent requests sharing the same content-addressed keys."""
+    # First Party
+    from lmcache.v1.distributed.api import AttnWindowDesc
+    from lmcache.v1.multiprocess.modules.lookup import LookupModule
+
+    # Groups: 0 = full attention, 1 = sliding window of 1 chunk.
+    # Request hit = 4 chunks; the connector frees the vLLM-hit prefix
+    # [0, 512) = chunks 0..1 before retrieving chunks 2..3.
+    ctx = _make_free_locks_ctx(
+        AttnWindowDesc([-1, 1]), hit_chunks=4, num_range_chunks=2
+    )
+    module = LookupModule(ctx)
+
+    key = IPCCacheServerKey(
+        model_name="testmodel",
+        world_size=1,
+        worker_id=None,
+        token_ids=tuple(range(1024)),
+        start=0,
+        end=512,
+        request_id="req-sw-retrieve",
+    )
+
+    full_keys = [MagicMock(name="f0"), MagicMock(name="f1")]
+    sw_keys = [MagicMock(name="s0"), MagicMock(name="s1")]
+    with patch(
+        "lmcache.v1.multiprocess.modules.lookup.ipc_key_to_object_keys",
+        return_value=[full_keys, sw_keys],
+    ):
+        module.free_lookup_locks(key, 1)
+
+    # Only the full-attention group's prefix locks are released; the
+    # sliding-window group's retained window [3, 4) is outside [0, 2).
+    module.context.storage_manager.finish_read_prefetched.assert_called_once_with(
+        full_keys, extra_count=0
+    )
+
+
+def test_server_free_lookup_locks_releases_sw_window_without_retrieve():
+    """Freeing the whole hit (no retrieve pending) must release the
+    sliding-window group's retained window ``[hit - w, hit)`` — and only
+    that — alongside the full-attention group's full range."""
+    # First Party
+    from lmcache.v1.distributed.api import AttnWindowDesc
+    from lmcache.v1.multiprocess.modules.lookup import LookupModule
+
+    # Groups: 0 = full attention, 1 = sliding window of 1 chunk.
+    # Request hit = 4 chunks; the connector frees the whole hit [0, 1024).
+    ctx = _make_free_locks_ctx(
+        AttnWindowDesc([-1, 1]), hit_chunks=4, num_range_chunks=4
+    )
+    module = LookupModule(ctx)
+
+    key = IPCCacheServerKey(
+        model_name="testmodel",
+        world_size=1,
+        worker_id=None,
+        token_ids=tuple(range(1024)),
+        start=0,
+        end=1024,
+        request_id="req-sw-full-free",
+    )
+
+    full_keys = [MagicMock(name=f"f{i}") for i in range(4)]
+    sw_keys = [MagicMock(name=f"s{i}") for i in range(4)]
+    with patch(
+        "lmcache.v1.multiprocess.modules.lookup.ipc_key_to_object_keys",
+        return_value=[full_keys, sw_keys],
+    ):
+        module.free_lookup_locks(key, 1)
+
+    module.context.storage_manager.finish_read_prefetched.assert_called_once_with(
+        full_keys + sw_keys[3:], extra_count=0
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`free_lookup_locks` (the handler behind the connector's `FREE_LOOKUP_LOCKS` message, sent when vLLM's local prefix cache already covers part of a lookup hit) released read locks **across every object group** for the whole freed range. For sliding-window / linear-attention object groups that is an over-release: the lookup only retains locks on the trailing window `[hit - w, hit)` — the prefetch controller already unlocked everything else when it trimmed the load plan. Because object keys are content-addressed and shared across requests, each extra release decrements a read lock held by a *concurrent* request on the same chunk, and eviction can then reclaim a state page while that request's retrieve is still copying it.

Observed on Kimi-K3 (KDA/MLA hybrid, `--separate-object-groups`) under sustained agentic load with DRAM offload on 8× MI355X: tens of thousands of `L1Manager: finish read on non-read-locked key` warnings (the victim's own release finding its lock already stolen), followed — once L1 eviction became active — by corrupted generations (empty responses), `HSA_STATUS_ERROR_EXCEPTION`, and a fatal `hipErrorIllegalAddress` engine crash mid-run. Full-attention-only models are unaffected (every locked chunk there is a hit chunk, so release and acquisition balance).

The fix records the served hit length on the request's `Session` at prefetch-query time, and `free_lookup_locks` then releases, per object group, only the intersection of the still-held set with the freed range:

- full-attention groups: the whole `[start, end)` range (existing behavior);
- sliding-window / state groups: `[hit - w, hit)` clipped to the range.

This is exactly complementary to the retrieve path, which already reads and releases only each group's retained window (`group_skips` in `lmcache_driven_transfer`): when the free precedes a retrieve the window intersection is empty and the retrieve releases the window; when there is no retrieve the free releases exactly the window. No protocol change; the stale `NOTE` in `free_lookup_locks` anticipating this fix is replaced by the implementation.

Docs (Kimi K3 recipe), from validating this recipe on a second platform via the InferenceX AgentX benchmark:

- Drop the obsolete `--max-num-batched-tokens 1500` pin (a pre-`--separate-object-groups` workaround; the real constraint — at least `N` — is satisfied by vLLM's default).
- Generalize the chunk-size guidance: the chunk must be a multiple of **every** engine KV group's `tokens_per_block`, with validated values per platform (B300: 768; MI355X fp8-KV/TRITON_MLA: attention 1536, KDA state group 3072 → chunk 3072) and instructions to derive the value from vLLM's startup log rather than copying the table.
- Add operational notes from sustained-load validation: the L1 pool is `/dev/shm`-backed in every transfer mode (size against the tmpfs mount, not free DRAM), pin `--supported-transfer-mode lmcache_driven` for deterministic benchmarking, and how `--enable-extra-logging` counters pair with vLLM's `external_prefix_cache_*` metrics to attribute hit rates.
- Add a caveat that hybrid models under concurrent load require this fix (≤ 0.5.4rc1 affected).

**Special notes for your reviewers**:

- The retained-window anchor is the hit length computed in `query_prefetch_status` (the same `fold_unfold_ranked` result that drives the prefetch controller's trim), stored as `Session.lookup_hit_chunks`. A session with no recorded hit conservatively releases nothing for window groups (a bounded leak until the read-lock TTL, never an over-release).
- Multi-server mode records the global hit length while per-server tails can differ (`free_locks_after_lookup` path); that path keeps today's behavior for full-attention groups and errs toward not releasing window groups' locks, which is the safe direction.
- Repro context: InferenceX run 31648224111 (Kimi-K3 MI355X, conc 4/8/16) — conc 8 crashed with `hipErrorIllegalAddress` ~9 min into profiling immediately after the first L1 eviction wave; conc 16 degraded to empty generations; conc 4 survived (fewest concurrent retrieves overlapping eviction). 57k–120k over-release warnings per run.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
