### PR TITLE
[MP] Add byte-aware admission for L2 prefetch loads

### DIFF
--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -61,6 +61,11 @@ Commonly used flags include:
      - L1 fill ratio at which eviction begins.
    * - ``--eviction-ratio RATIO``
      - Fraction of L1 cleared per eviction cycle.
+   * - ``--l2-prefetch-load-admission-wait-seconds SECONDS``
+     - Maximum interval without a successful byte-aware L2-to-L1 load
+       admission before blocked prefetches fall back to L1-only results.
+       Plans larger than total L1 capacity skip waiting. The default ``0``
+       disables admission waiting.
    * - ``--max-workers N``
      - Number of server worker processes.
    * - ``--coordinator-url URL``

--- a/docs/source/mp/l2_storage/index.rst
+++ b/docs/source/mp/l2_storage/index.rst
@@ -135,6 +135,26 @@ increases L1 memory pressure from in-flight data.
    * - ``--l2-prefetch-max-in-flight``
      - ``8``
      - Maximum number of concurrent prefetch requests.
+   * - ``--l2-prefetch-load-admission-wait-seconds``
+     - ``0``
+     - Maximum interval without a successful byte-aware load admission before
+       blocked prefetches fall back to their L1-only results. A positive value
+       avoids transient L1 out-of-memory misses under concurrent,
+       variable-sized loads; ``0`` disables admission waiting.
+
+Admission waiting orders ready requests by planned L1 bytes, allowing a small
+prefetch to use capacity that is insufficient for an earlier large prefetch.
+Plans larger than total L1 capacity skip the queue because waiting cannot make
+them fit. This preserves the existing immediate fallback for such plans.
+Requests that have waited for the configured interval receive FIFO priority
+over new small requests. Each successful admission restarts the no-progress
+timer; if no waiting load can be admitted for the full interval, blocked
+requests fall back without attempting allocations that cannot fit. The value
+is therefore an idle-progress timeout, not a per-request latency bound: a
+request can wait longer while the queue continues making progress. For
+example, to tolerate 100 ms gaps between capacity releases::
+
+    --l2-prefetch-load-admission-wait-seconds 0.1
 
 Buffer-Only Mode
 ~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -8,6 +8,7 @@ Configuration for distributed storage manager
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 import argparse
+import math
 import os
 
 # First Party
@@ -253,6 +254,9 @@ class StorageManagerConfig:
     prefetch_max_in_flight: int = 8
     """ Maximum number of concurrent prefetch requests. """
 
+    prefetch_load_admission_wait_seconds: float = 0.0
+    """ Maximum interval without a successful L1 load admission. """
+
     periodic_notifier_interval_ms: int = 5
     """ Interval (ms) for the periodic event notifier heartbeat. """
 
@@ -296,6 +300,14 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
         ValueError: If mutually exclusive L1 tiers are both configured, or
             hybrid L1 is paired with incompatible L2 adapters.
     """
+    if (
+        not math.isfinite(config.prefetch_load_admission_wait_seconds)
+        or config.prefetch_load_admission_wait_seconds < 0
+    ):
+        raise ValueError(
+            "prefetch load admission wait seconds must be finite and non-negative"
+        )
+
     if (
         config.l1_manager_config.gds_l1_config is not None
         and config.l1_manager_config.memory_config.devdax_path
@@ -514,6 +526,17 @@ def add_storage_manager_args(
         help="Maximum number of concurrent prefetch requests. Default is 8.",
     )
     policy_group.add_argument(
+        "--l2-prefetch-load-admission-wait-seconds",
+        type=float,
+        default=0.0,
+        help=(
+            "Maximum seconds without a successful byte-aware L2-to-L1 load "
+            "admission before blocked prefetches fall back to L1-only results. "
+            "Plans larger than total L1 capacity skip waiting. "
+            "0 disables byte-aware admission. Default is 0."
+        ),
+    )
+    policy_group.add_argument(
         "--periodic-notifier-interval-ms",
         type=int,
         default=5,
@@ -607,6 +630,9 @@ def parse_args_to_config(
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
         prefetch_max_in_flight=args.l2_prefetch_max_in_flight,
+        prefetch_load_admission_wait_seconds=(
+            args.l2_prefetch_load_admission_wait_seconds
+        ),
         periodic_notifier_interval_ms=args.periodic_notifier_interval_ms,
     )
     return config

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -50,10 +50,11 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from itertools import groupby
 from operator import attrgetter
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable
 import enum
 import select
 import threading
+import time
 
 # First Party
 from lmcache.lmcache_native import Bitmap
@@ -69,6 +70,7 @@ from lmcache.v1.distributed.api import (
 )
 from lmcache.v1.distributed.bitmap_ops.fold import fold_unfold_ranked
 from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.internal_api import L1ManagerListener
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.storage_controller import StorageControllerInterface
@@ -97,6 +99,43 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+class _L1CapacityNotifier(L1ManagerListener):
+    def __init__(self, notify: Callable[[], None]) -> None:
+        self._notify = notify
+        self._active = True
+        self._lock = threading.Lock()
+
+    def disable(self) -> None:
+        with self._lock:
+            self._active = False
+
+    def on_l1_keys_reserved_read(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_read_finished(self, keys: list[ObjectKey]) -> None:
+        self._notify_if_active()
+
+    def on_l1_keys_reserved_write(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_write_finished(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_deleted_by_manager(self, keys: list[ObjectKey]) -> None:
+        self._notify_if_active()
+
+    def on_l1_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def _notify_if_active(self) -> None:
+        with self._lock:
+            if self._active:
+                self._notify()
+
+
 # HELPER FUNCTIONS
 def merge_bitmaps(bitmaps: Iterable[Bitmap], num_keys: int) -> Bitmap:
     """Merge bitmaps with a bitwise OR into a ``num_keys``-sized bitmap.
@@ -108,6 +147,15 @@ def merge_bitmaps(bitmaps: Iterable[Bitmap], num_keys: int) -> Bitmap:
     for bm in bitmaps:
         merged = merged | bm
     return merged
+
+
+def _layout_size_bytes(layout: MemoryLayoutDesc, align_bytes: int) -> int:
+    """Return the physical L1 allocation size for one layout."""
+    raw_size = sum(
+        shape.numel() * dtype.itemsize
+        for shape, dtype in zip(layout.shapes, layout.dtypes, strict=True)
+    )
+    return ((raw_size + align_bytes - 1) // align_bytes) * align_bytes
 
 
 def build_trim_mask(
@@ -183,6 +231,7 @@ PrefetchRequestId = int
 
 class PrefetchPhase(enum.Enum):
     LOOKUP = enum.auto()
+    WAIT_LOAD = enum.auto()
     PLAN_AND_LOAD = enum.auto()
 
 
@@ -221,6 +270,9 @@ class InFlightPrefetchRequest:
 
     # Load phase: adapter_idx -> bitmap of key indices to load
     load_plan: dict[int, Bitmap] = field(default_factory=dict)
+    planned_hit_length: int = 0
+    planned_load_bytes: int = 0
+    load_queued_at: float = 0.0
     # Load phase: adapter_idx -> task_id (removed as results arrive)
     pending_load_tasks: dict[int, L2TaskId] = field(default_factory=dict)
     # Load phase: adapter_idx -> L1 bytes reserved for that adapter's
@@ -266,6 +318,9 @@ class PrefetchController(StorageControllerInterface):
         adapter_descriptors: Descriptors for each L2 adapter (same order).
         policy: The prefetch policy for load plan decisions.
         max_in_flight: Maximum number of concurrent prefetch requests.
+        load_admission_wait_seconds: Maximum interval without a successful
+            waiting-load admission before blocked prefetches fall back to
+            their L1-only results.
     """
 
     # Singleton dispatch for the in-flight load gauges: tests may construct
@@ -282,6 +337,7 @@ class PrefetchController(StorageControllerInterface):
         adapter_descriptors: list[AdapterDescriptor],
         policy: PrefetchPolicy,
         max_in_flight: int = 8,
+        load_admission_wait_seconds: float = 0.0,
     ) -> None:
         self._l1_manager = l1_manager
         self._l2_adapters: dict[int, L2AdapterInterface] = {
@@ -293,6 +349,13 @@ class PrefetchController(StorageControllerInterface):
         }
         self._policy = policy
         self._max_in_flight = max_in_flight
+        self._load_admission_wait_seconds = load_admission_wait_seconds
+        self._enable_load_admission = load_admission_wait_seconds > 0
+        self._l1_align_bytes = 1
+        if self._enable_load_admission:
+            l1_memory_desc = self._l1_manager.get_l1_memory_desc()
+            if l1_memory_desc is not None:
+                self._l1_align_bytes = l1_memory_desc.align_bytes
 
         # Adapters that are being drained and will be removed after all
         # the in-flight operations are done.
@@ -312,13 +375,21 @@ class PrefetchController(StorageControllerInterface):
         self._status_in_flight_count: int = 0
         self._status_pending_count: int = 0
         self._status_lookup_phase_count: int = 0
+        self._status_wait_load_phase_count: int = 0
         self._status_load_phase_count: int = 0
+        self._load_admission_last_progress_at: float | None = None
 
         # Thread-safe submission queue (external -> background)
         self._submission_lock = threading.Lock()
         self._submission_queue: list[tuple[PrefetchRequestId, PrefetchRequestSpec]] = []
         self._next_request_id: PrefetchRequestId = 0
         self._submission_efd = create_event_notifier()
+        self._l1_capacity_notifier: _L1CapacityNotifier | None = None
+        if self._enable_load_admission:
+            self._l1_capacity_notifier = _L1CapacityNotifier(
+                self._submission_efd.notify
+            )
+            self._l1_manager.register_listener(self._l1_capacity_notifier)
 
         # Thread-safe lookup results (background -> external)
         self._lookup_results_lock = threading.Lock()
@@ -521,10 +592,13 @@ class PrefetchController(StorageControllerInterface):
             "is_healthy": is_healthy,
             "thread_alive": is_healthy,
             "max_in_flight": self._max_in_flight,
+            "load_admission_enabled": self._enable_load_admission,
+            "load_admission_wait_seconds": self._load_admission_wait_seconds,
             "submission_queue_size": submission_queue_size,
             "pending_queue_size": self._status_pending_count,
             "in_flight_request_count": self._status_in_flight_count,
             "lookup_phase_count": self._status_lookup_phase_count,
+            "wait_load_phase_count": self._status_wait_load_phase_count,
             "load_phase_count": self._status_load_phase_count,
             "completed_results_count": completed_results_count,
             "num_l2_adapters": len(self._l2_adapters),
@@ -603,6 +677,8 @@ class PrefetchController(StorageControllerInterface):
         Cleans up any in-flight requests (releases L1 write locks,
         L2 locks) before returning.
         """
+        if self._l1_capacity_notifier is not None:
+            self._l1_capacity_notifier.disable()
         self._stop_flag.set()
         self._submission_efd.notify()
         self._thread.join()
@@ -688,7 +764,12 @@ class PrefetchController(StorageControllerInterface):
             # First, apply runtime add/remove of the L2 adapters.
             self._apply_pending_adapter_ops(poller)
 
-            ready = poller.poll(PREFETCH_LOOP_POLL_TIMEOUT_MS)
+            poll_timeout_ms = (
+                self._next_poll_timeout_ms()
+                if self._enable_load_admission
+                else PREFETCH_LOOP_POLL_TIMEOUT_MS
+            )
+            ready = poller.poll(poll_timeout_ms)
 
             signaled_adapters: dict[PrefetchPhase, set[int]] = {
                 phase: set() for phase in PrefetchPhase
@@ -730,10 +811,12 @@ class PrefetchController(StorageControllerInterface):
                         )
 
             try:
+                if self._enable_load_admission:
+                    self._start_waiting_loads()
                 self._start_pending_requests()
             except Exception:
                 logger.exception(
-                    "Unexpected error in prefetch loop while starting pending requests"
+                    "Unexpected error while starting pending prefetch work"
                 )
 
             # Finalize any draining adapter no longer have any in-flight
@@ -818,6 +901,83 @@ class PrefetchController(StorageControllerInterface):
             request_id, spec = self._pending_queue.pop(0)
             self._status_pending_count -= 1
             self._start_lookup_phase(request_id, spec)
+
+    def _load_capacity_status(
+        self, request: InFlightPrefetchRequest
+    ) -> tuple[bool, bool]:
+        if not self._enable_load_admission:
+            return True, True
+        used, total = self._l1_manager.get_memory_usage()
+        return (
+            request.planned_load_bytes <= total,
+            request.planned_load_bytes <= total - used,
+        )
+
+    def _next_poll_timeout_ms(self) -> int:
+        now = time.monotonic()
+        deadlines: list[float] = []
+        for request in self._in_flight_requests.values():
+            if request.phase is not PrefetchPhase.WAIT_LOAD:
+                continue
+            aging_deadline = request.load_queued_at + self._load_admission_wait_seconds
+            if aging_deadline > now:
+                deadlines.append(aging_deadline)
+        if self._load_admission_last_progress_at is not None:
+            deadlines.append(
+                self._load_admission_last_progress_at
+                + self._load_admission_wait_seconds
+            )
+        if not deadlines:
+            return PREFETCH_LOOP_POLL_TIMEOUT_MS
+        remaining_ms = max(0, int((min(deadlines) - now) * 1000) + 1)
+        return min(PREFETCH_LOOP_POLL_TIMEOUT_MS, remaining_ms)
+
+    def _start_waiting_loads(self) -> None:
+        now = time.monotonic()
+        waiting = [
+            request
+            for request in self._in_flight_requests.values()
+            if request.phase is PrefetchPhase.WAIT_LOAD
+        ]
+        if not waiting:
+            self._load_admission_last_progress_at = None
+            return
+        if self._load_admission_last_progress_at is None:
+            self._load_admission_last_progress_at = min(
+                request.load_queued_at for request in waiting
+            )
+        waiting.sort(
+            key=lambda request: (
+                now - request.load_queued_at < self._load_admission_wait_seconds,
+                request.request_id
+                if now - request.load_queued_at >= self._load_admission_wait_seconds
+                else request.planned_load_bytes,
+                request.request_id,
+            )
+        )
+        for request in waiting:
+            _, fits_now = self._load_capacity_status(request)
+            if fits_now:
+                self._start_planned_load(
+                    request, request.load_plan, request.planned_hit_length
+                )
+                if (
+                    request.request_id in self._in_flight_requests
+                    and request.phase is PrefetchPhase.PLAN_AND_LOAD
+                ):
+                    self._load_admission_last_progress_at = now
+                continue
+
+            if (
+                now - self._load_admission_last_progress_at
+                < self._load_admission_wait_seconds
+            ):
+                return
+
+            self._finish_request(request)
+
+        if self._status_wait_load_phase_count == 0:
+            self._load_admission_last_progress_at = None
 
     # =========================================================================
     # Lookup phase
@@ -1011,14 +1171,58 @@ class PrefetchController(StorageControllerInterface):
         # |out of L1-hit sw|in L1-hit sw|out of L2-hit sw|in L2-hit sw| remaining  |
         #                               ^ L1 hit length               ^ L1+L2 hit length
         # |       -        |     -      |       -        |  loading   |     -      |
+        if not self._enable_load_admission:
+            self._start_planned_load(request, trimmed_plan, hit_length)
+            return
+
         keys_to_reserve = merge_bitmaps(trimmed_plan.values(), num_keys).gather(
+            request.keys
+        )
+        request.load_plan = trimmed_plan
+        request.planned_hit_length = hit_length
+        request.planned_load_bytes = sum(
+            _layout_size_bytes(
+                request.group_layout_descs[key.object_group_id],
+                self._l1_align_bytes,
+            )
+            for key in keys_to_reserve
+        )
+
+        can_ever_fit, fits_now = self._load_capacity_status(request)
+        queue_has_waiters = self._status_wait_load_phase_count > 0
+        if not can_ever_fit or (fits_now and not queue_has_waiters):
+            self._start_planned_load(request, trimmed_plan, hit_length)
+        else:
+            # A waiting request only needs L2 locks for its final load plan.
+            self._release_l2_locks(request, keep=request.load_plan)
+            request.phase = PrefetchPhase.WAIT_LOAD
+            queued_at = time.monotonic()
+            request.load_queued_at = queued_at
+            if self._status_wait_load_phase_count == 0:
+                self._load_admission_last_progress_at = queued_at
+            self._status_load_phase_count -= 1
+            self._status_wait_load_phase_count += 1
+
+    def _start_planned_load(
+        self,
+        request: InFlightPrefetchRequest,
+        load_plan: dict[int, Bitmap],
+        hit_length: int,
+    ) -> None:
+        if request.phase is PrefetchPhase.WAIT_LOAD:
+            self._status_wait_load_phase_count -= 1
+            request.phase = PrefetchPhase.PLAN_AND_LOAD
+            self._status_load_phase_count += 1
+
+        num_keys = len(request.keys)
+        keys_to_reserve = merge_bitmaps(load_plan.values(), num_keys).gather(
             request.keys
         )
         reserved = self._reserve_load_buffers(request, keys_to_reserve)
         if len(reserved) < len(keys_to_reserve):
             self._finish_request(request)
             return
-        request.load_plan = trimmed_plan
+        request.load_plan = load_plan
 
         # Step 4 — free L2 lookup locks for keys outside the plan.
         # L2 lookup locks:
@@ -1028,7 +1232,7 @@ class PrefetchController(StorageControllerInterface):
         self._release_l2_locks(request, keep=request.load_plan)
 
         # Step 5 — submit loads; report the hit.
-        self._submit_load_tasks(request, trimmed_plan)
+        self._submit_load_tasks(request, load_plan)
         self._report_lookup_hit(request, hit_length)
 
     def _reserve_load_buffers(
@@ -1464,6 +1668,8 @@ class PrefetchController(StorageControllerInterface):
             self._status_in_flight_count -= 1
             if removed.phase == PrefetchPhase.LOOKUP:
                 self._status_lookup_phase_count -= 1
+            elif removed.phase == PrefetchPhase.WAIT_LOAD:
+                self._status_wait_load_phase_count -= 1
             elif removed.phase == PrefetchPhase.PLAN_AND_LOAD:
                 self._status_load_phase_count -= 1
         logger.debug(

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -352,10 +352,12 @@ class PrefetchController(StorageControllerInterface):
         self._load_admission_wait_seconds = load_admission_wait_seconds
         self._enable_load_admission = load_admission_wait_seconds > 0
         self._l1_align_bytes = 1
+        self._l1_max_capacity_bytes = 0
         if self._enable_load_admission:
             l1_memory_desc = self._l1_manager.get_l1_memory_desc()
             if l1_memory_desc is not None:
                 self._l1_align_bytes = l1_memory_desc.align_bytes
+                self._l1_max_capacity_bytes = l1_memory_desc.size
 
         # Adapters that are being drained and will be removed after all
         # the in-flight operations are done.
@@ -908,8 +910,11 @@ class PrefetchController(StorageControllerInterface):
         if not self._enable_load_admission:
             return True, True
         used, total = self._l1_manager.get_memory_usage()
+        # Lazy L1 reports committed capacity in ``total`` while its descriptor
+        # covers the final backing buffer.
+        max_capacity = max(total, self._l1_max_capacity_bytes)
         return (
-            request.planned_load_bytes <= total,
+            request.planned_load_bytes <= max_capacity,
             request.planned_load_bytes <= total - used,
         )
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -152,6 +152,7 @@ class StorageManager:
             adapter_descriptors=list(self._adapter_descriptors.values()),
             policy=create_prefetch_policy(config.prefetch_policy),
             max_in_flight=config.prefetch_max_in_flight,
+            load_admission_wait_seconds=config.prefetch_load_admission_wait_seconds,
         )
         self._prefetch_controller.start()
 

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -34,6 +34,7 @@ from lmcache.v1.distributed.config import (
     parse_args,
 )
 from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
     FaultInjectL2Adapter,
@@ -775,6 +776,59 @@ class TestLoadAdmission:
         assert result.get_indices_list() == []
         assert elapsed < 0.08
         assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
+
+    def test_load_waits_for_lazy_l1_final_capacity(self):
+        """A load that fits final lazy capacity is not treated as oversized."""
+        layout = make_large_layout()
+        l1_manager = make_l1_manager(4 * 1024 * 1024)
+
+        class ExpandingCapacityL1:
+            def __init__(self, inner: L1Manager) -> None:
+                self.inner = inner
+                self.current_total = 2 * 1024 * 1024
+
+            def get_memory_usage(self) -> tuple[int, int]:
+                used, _ = self.inner.get_memory_usage()
+                return used, self.current_total
+
+            def get_l1_memory_desc(self) -> L1MemoryDesc | None:
+                return self.inner.get_l1_memory_desc()
+
+            def expand(self) -> None:
+                self.current_total = 4 * 1024 * 1024
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.inner, name)
+
+        expanding_l1 = ExpandingCapacityL1(l1_manager)
+        adapter = make_adapter()
+        key = make_object_key(26_000)
+        store_keys_in_l2(adapter, [key], layout)
+        ctrl = PrefetchController(
+            l1_manager=expanding_l1,  # type: ignore[arg-type]
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=2.0,
+        )
+        ctrl.start()
+
+        request_id = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([key], {0: layout})
+        )
+        assert wait_for_condition(
+            lambda: ctrl.report_status()["wait_load_phase_count"] == 1
+        )
+
+        expanding_l1.expand()
+        result = wait_for_prefetch_result_bitmap(ctrl, request_id, timeout=2.0)
+        assert result is not None
+        assert result.get_indices_list() == [0]
+        l1_manager.finish_read([key])
 
         ctrl.stop()
         adapter.close()

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -28,7 +28,11 @@ from lmcache.v1.distributed.api import (
     PrefetchRequestSpec,
     TrimPolicy,
 )
-from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.config import (
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    parse_args,
+)
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
@@ -77,6 +81,30 @@ def make_layout() -> MemoryLayoutDesc:
     return MemoryLayoutDesc(
         shapes=[torch.Size([100, 2, 512])],
         dtypes=[torch.bfloat16],
+    )
+
+
+def make_large_layout() -> MemoryLayoutDesc:
+    """Create a 4 MiB layout for capacity-admission tests."""
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([2 * 1024 * 1024])],
+        dtypes=[torch.bfloat16],
+    )
+
+
+def make_l1_manager(size_bytes: int) -> L1Manager:
+    """Create a fixed-size L1 manager for capacity-admission tests."""
+    return L1Manager(
+        L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=size_bytes,
+                use_lazy=False,
+                init_size_in_bytes=size_bytes,
+                align_bytes=0x1000,
+            ),
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        )
     )
 
 
@@ -565,6 +593,424 @@ class TestNoHits:
         assert result == 0, f"Expected 0 prefix hits, got {result}"
 
         ctrl.stop()
+
+
+class TestLoadAdmission:
+    """Byte-aware admission should serialize loads under transient pressure."""
+
+    def test_disabled_admission_does_not_observe_l1_capacity(self):
+        """The default path does not add L1 calls or change lock timing."""
+        l1_manager = make_l1_manager(4 * 1024 * 1024)
+        layout = make_large_layout()
+        adapter = make_adapter()
+        key = make_object_key(9_000)
+        store_keys_in_l2(adapter, [key], layout)
+
+        class CapacityRejectingL1:
+            def __init__(self, inner: L1Manager) -> None:
+                self.inner = inner
+
+            def get_l1_memory_desc(self) -> None:
+                raise AssertionError("disabled admission inspected L1 layout")
+
+            def get_memory_usage(self) -> tuple[int, int]:
+                raise AssertionError("disabled admission inspected L1 capacity")
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self.inner, name)
+
+        ctrl = PrefetchController(
+            l1_manager=CapacityRejectingL1(l1_manager),  # type: ignore[arg-type]
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+        request_id = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([key], {0: layout})
+        )
+
+        result = wait_for_prefetch_result_bitmap(ctrl, request_id)
+        assert result is not None
+        assert result.get_indices_list() == [0]
+        l1_manager.finish_read([key])
+
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
+
+    def test_config_parsing_and_validation(self):
+        config = parse_args(
+            [
+                "--l1-size-gb",
+                "1",
+                "--eviction-policy",
+                "noop",
+                "--l2-prefetch-load-admission-wait-seconds",
+                "0.25",
+            ]
+        )
+        assert config.prefetch_load_admission_wait_seconds == 0.25
+
+        for invalid in ("-1", "nan", "inf"):
+            with pytest.raises(ValueError, match="finite and non-negative"):
+                parse_args(
+                    [
+                        "--l1-size-gb",
+                        "1",
+                        "--eviction-policy",
+                        "noop",
+                        "--l2-prefetch-load-admission-wait-seconds",
+                        invalid,
+                    ]
+                )
+
+    def test_waiting_load_starts_after_capacity_is_released(self):
+        """A second hit waits for the first reader instead of failing L1 OOM."""
+        layout = make_large_layout()
+        l1_manager = make_l1_manager(4 * 1024 * 1024)
+        adapter = make_adapter()
+        keys = [make_object_key(10_000), make_object_key(10_001)]
+        store_keys_in_l2(adapter, keys, layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=2.0,
+        )
+        ctrl.start()
+
+        first = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([keys[0]], {0: layout})
+        )
+        second = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([keys[1]], {0: layout})
+        )
+
+        first_result = wait_for_prefetch_result_bitmap(ctrl, first)
+        assert first_result is not None
+        assert first_result.get_indices_list() == [0]
+        assert wait_for_condition(
+            lambda: ctrl.report_status()["wait_load_phase_count"] == 1
+        )
+
+        l1_manager.finish_read([keys[0]])
+        second_result = wait_for_prefetch_result_bitmap(ctrl, second)
+        assert second_result is not None
+        assert second_result.get_indices_list() == [0]
+        l1_manager.finish_read([keys[1]])
+
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
+
+    def test_wait_timeout_falls_back_without_leaking_locks(self):
+        """Permanent pressure cannot leave a prefetch waiting indefinitely."""
+        layout = make_large_layout()
+        l1_manager = make_l1_manager(4 * 1024 * 1024)
+        blocker = make_object_key(20_000)
+        reserve = l1_manager.reserve_write(
+            [blocker], is_temporary=[False], layout_desc=layout, mode="new"
+        )
+        assert reserve[blocker][0] == L1Error.SUCCESS
+        l1_manager.finish_write([blocker])
+
+        adapter = make_adapter()
+        key = make_object_key(20_001)
+        store_keys_in_l2(adapter, [key], layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=0.1,
+        )
+        ctrl.start()
+
+        request_id = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([key], {0: layout})
+        )
+        started = time.monotonic()
+        result = wait_for_prefetch_result_bitmap(ctrl, request_id, timeout=2.0)
+        elapsed = time.monotonic() - started
+
+        assert result is not None
+        assert result.get_indices_list() == []
+        assert elapsed >= 0.08
+        assert elapsed < 1.0
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+        assert ctrl.report_status()["wait_load_phase_count"] == 0
+
+        ctrl.stop()
+        adapter.close()
+        l1_manager.delete([blocker])
+        l1_manager.close()
+
+    def test_oversized_load_skips_admission_wait(self):
+        """A load larger than total L1 capacity cannot benefit from waiting."""
+        layout = make_large_layout()
+        l1_manager = make_l1_manager(2 * 1024 * 1024)
+        adapter = make_adapter()
+        key = make_object_key(25_000)
+        store_keys_in_l2(adapter, [key], layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=0.1,
+        )
+        ctrl.start()
+
+        request_id = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([key], {0: layout})
+        )
+        started = time.monotonic()
+        result = wait_for_prefetch_result_bitmap(ctrl, request_id, timeout=2.0)
+        elapsed = time.monotonic() - started
+
+        assert result is not None
+        assert result.get_indices_list() == []
+        assert elapsed < 0.08
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
+
+    def test_no_progress_timeout_finishes_blocked_requests_together(self):
+        """Permanent pressure costs one timeout, not one timeout per request."""
+        layout = make_large_layout()
+        l1_manager = make_l1_manager(4 * 1024 * 1024)
+        blocker = make_object_key(27_000)
+        reserve = l1_manager.reserve_write(
+            [blocker], is_temporary=[False], layout_desc=layout, mode="new"
+        )
+        assert reserve[blocker][0] == L1Error.SUCCESS
+        l1_manager.finish_write([blocker])
+
+        adapter = make_adapter()
+        keys = [make_object_key(27_001), make_object_key(27_002)]
+        store_keys_in_l2(adapter, keys, layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=0.1,
+        )
+        ctrl.start()
+
+        first = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([keys[0]], {0: layout})
+        )
+        second = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([keys[1]], {0: layout})
+        )
+        started = time.monotonic()
+        first_result = wait_for_prefetch_result_bitmap(ctrl, first, timeout=2.0)
+        first_elapsed = time.monotonic() - started
+        second_result = wait_for_prefetch_result_bitmap(ctrl, second, timeout=2.0)
+        second_elapsed = time.monotonic() - started
+
+        assert first_result is not None
+        assert first_result.get_indices_list() == []
+        assert second_result is not None
+        assert second_result.get_indices_list() == []
+        assert first_elapsed >= 0.08
+        assert second_elapsed - first_elapsed < 0.08
+        assert second_elapsed < 0.3
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+
+        ctrl.stop()
+        adapter.close()
+        l1_manager.delete([blocker])
+        l1_manager.close()
+
+    def test_successful_admission_restarts_no_progress_timeout(self):
+        """A successful admission gives the remaining queue a fresh window."""
+        layout = make_large_layout()
+        l1_manager = make_l1_manager(4 * 1024 * 1024)
+        blocker = make_object_key(28_000)
+        reserve = l1_manager.reserve_write(
+            [blocker], is_temporary=[False], layout_desc=layout, mode="new"
+        )
+        assert reserve[blocker][0] == L1Error.SUCCESS
+        l1_manager.finish_write([blocker])
+
+        adapter = make_adapter()
+        keys = [make_object_key(28_001), make_object_key(28_002)]
+        store_keys_in_l2(adapter, keys, layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=0.2,
+        )
+        ctrl.start()
+
+        first = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([keys[0]], {0: layout})
+        )
+        second = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([keys[1]], {0: layout})
+        )
+        started = time.monotonic()
+        time.sleep(0.1)
+        l1_manager.delete([blocker])
+
+        first_result = wait_for_prefetch_result_bitmap(ctrl, first, timeout=2.0)
+        first_elapsed = time.monotonic() - started
+        second_result = wait_for_prefetch_result_bitmap(ctrl, second, timeout=2.0)
+        second_elapsed = time.monotonic() - started
+
+        assert first_result is not None
+        assert first_result.get_indices_list() == [0]
+        assert first_elapsed < 0.25
+        assert second_result is not None
+        assert second_result.get_indices_list() == []
+        assert second_elapsed >= 0.24
+        assert second_elapsed < 0.6
+        l1_manager.finish_read([keys[0]])
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
+
+    def test_smaller_waiting_load_is_admitted_first(self):
+        """A small load proceeds when a prior large load still cannot fit."""
+        small_layout = make_large_layout()
+        large_layout = MemoryLayoutDesc(
+            shapes=[torch.Size([4 * 1024 * 1024])],
+            dtypes=[torch.bfloat16],
+        )
+        l1_manager = make_l1_manager(8 * 1024 * 1024)
+        blocker = make_object_key(30_000)
+        reserve = l1_manager.reserve_write(
+            [blocker], is_temporary=[False], layout_desc=large_layout, mode="new"
+        )
+        assert reserve[blocker][0] == L1Error.SUCCESS
+        l1_manager.finish_write([blocker])
+
+        adapter_config = MockL2AdapterConfig(max_size_gb=0.02, mock_bandwidth_gb=10.0)
+        adapter = MockL2Adapter(adapter_config)
+        large_key = make_object_key(30_001)
+        small_key = make_object_key(30_002)
+        store_keys_in_l2(adapter, [large_key], large_layout)
+        store_keys_in_l2(adapter, [small_key], small_layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[AdapterDescriptor(index=0, config=adapter_config)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=2.0,
+        )
+        ctrl.start()
+
+        large = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([large_key], {0: large_layout})
+        )
+        small = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([small_key], {0: small_layout})
+        )
+        assert wait_for_condition(
+            lambda: ctrl.report_status()["wait_load_phase_count"] == 2
+        )
+
+        l1_manager.delete([blocker])
+        small_result = wait_for_prefetch_result_bitmap(ctrl, small)
+        assert small_result is not None
+        assert small_result.get_indices_list() == [0]
+        assert ctrl.query_prefetch_result(large) is None
+
+        l1_manager.finish_read([small_key])
+        large_result = wait_for_prefetch_result_bitmap(ctrl, large)
+        assert large_result is not None
+        assert large_result.get_indices_list() == [0]
+        l1_manager.finish_read([large_key])
+
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
+
+    def test_aged_large_load_precedes_a_new_small_load(self):
+        """An aged request gets priority instead of starving behind new work."""
+        small_layout = make_large_layout()
+        large_layout = MemoryLayoutDesc(
+            shapes=[torch.Size([4 * 1024 * 1024])],
+            dtypes=[torch.bfloat16],
+        )
+        l1_manager = make_l1_manager(8 * 1024 * 1024)
+        blocker = make_object_key(31_000)
+        reserve = l1_manager.reserve_write(
+            [blocker], is_temporary=[False], layout_desc=large_layout, mode="new"
+        )
+        assert reserve[blocker][0] == L1Error.SUCCESS
+        l1_manager.finish_write([blocker])
+
+        adapter_config = MockL2AdapterConfig(max_size_gb=0.03, mock_bandwidth_gb=10.0)
+        adapter = MockL2Adapter(adapter_config)
+        large_key = make_object_key(31_001)
+        first_small_key = make_object_key(31_002)
+        late_small_key = make_object_key(31_003)
+        store_keys_in_l2(adapter, [large_key], large_layout)
+        store_keys_in_l2(adapter, [first_small_key, late_small_key], small_layout)
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[AdapterDescriptor(index=0, config=adapter_config)],
+            policy=DefaultPrefetchPolicy(),
+            load_admission_wait_seconds=0.6,
+        )
+        ctrl.start()
+
+        large = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([large_key], {0: large_layout})
+        )
+        first_small = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([first_small_key], {0: small_layout})
+        )
+        assert wait_for_condition(
+            lambda: ctrl.report_status()["wait_load_phase_count"] == 2
+        )
+        both_queued_at = time.monotonic()
+
+        time.sleep(max(0.0, both_queued_at + 0.3 - time.monotonic()))
+        l1_manager.delete([blocker])
+        first_small_result = wait_for_prefetch_result_bitmap(ctrl, first_small)
+        assert first_small_result is not None
+        assert first_small_result.get_indices_list() == [0]
+
+        time.sleep(max(0.0, both_queued_at + 0.65 - time.monotonic()))
+        late_small = ctrl.submit_prefetch_request(
+            PrefetchRequestSpec([late_small_key], {0: small_layout})
+        )
+        assert wait_for_condition(
+            lambda: ctrl.report_status()["wait_load_phase_count"] == 2
+        )
+        assert ctrl.query_prefetch_result(late_small) is None
+
+        l1_manager.finish_read([first_small_key])
+        large_result = wait_for_prefetch_result_bitmap(ctrl, large)
+        assert large_result is not None
+        assert large_result.get_indices_list() == [0]
+        assert ctrl.query_prefetch_result(late_small) is None
+
+        l1_manager.finish_read([large_key])
+        late_small_result = wait_for_prefetch_result_bitmap(ctrl, late_small)
+        assert late_small_result is not None
+        assert late_small_result.get_indices_list() == [0]
+        l1_manager.finish_read([late_small_key])
+
+        assert wait_for_condition(lambda: adapter.debug_get_locked_key_count() == 0)
+        ctrl.stop()
+        adapter.close()
+        l1_manager.close()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The MP prefetch controller limits in-flight work by request count, but L2 hits
can have very different L1 footprints. Today each hit tries to reserve its
entire load plan immediately. When several loads race for a nearly full L1,
requests that lose the race drop valid L2 hits even if memory is released
shortly afterward.

This change adds an optional admission queue for L2-to-L1 loads. It:

- calculates the aligned L1 bytes needed by the final, trimmed load plan;
- waits for capacity without reserving L1 buffers, keeping only the L2 locks
  needed by that plan;
- schedules smaller loads first, then switches to FIFO for requests that have
  waited long enough;
- routes new loads through an existing queue so they cannot bypass an aged
  request;
- wakes the queue when L1 reads finish or objects are deleted;
- falls back to the existing L1-only result after a full interval with no
  successful admission. Plans larger than the total L1 capacity do not wait.

For a lazy L1 pool, the oversized-plan check uses the final backing-buffer
capacity, while immediate admission still uses the currently committed free
bytes. A plan that fits after lazy expansion therefore waits instead of being
rejected as permanently oversized.

The feature is disabled by default. With
`--l2-prefetch-load-admission-wait-seconds=0`, the controller follows the
existing path and does not query L1 capacity or layout metadata.

Related to the dynamic prefetch admission controller item in #2923.

## Tests

- Current head, isolated NVIDIA L40S container:
  - lazy-capacity regression: 1 passed;
  - `test_prefetch_controller.py`: 59 passed;
  - `test_distributed_storage_manager.py`: 26 passed.
- Buildkite K3 passed on the current head.
- [AMD build #11175](https://buildkite.com/lmcache/unit-tests-amd/builds/11175) fails in
  `test_kv_format_classification.py::test_classification_matches_golden`.
  The [parent build #11153](https://buildkite.com/lmcache/unit-tests-amd/builds/11153) and [latest `dev` build #11166](https://buildkite.com/lmcache/unit-tests-amd/builds/11166) fail with the same
  native format-classification assertion; this PR does not touch that area.
- Changed files pass `check-spdx-header`, `isort`, `ruff`, `ruff-format`,
  `codespell`, and `mypy`.
- Sphinx parsed the two changed pages without new warnings. The full docs tree
  still has unrelated existing warnings.

## Benchmark

Test setup: one NVIDIA L40S, Qwen3.5-9B, vLLM
`v0.23.1rc1.dev753+g4875b4456`, filesystem L2, eight concurrent independent
1056-token prompts, 0.10 GiB L1, and a 1.0-second admission wait.

| Mode | Batch latency (ms), 3 runs | Median | L2-prefetched requests |
| --- | --- | --- | --- |
| Immediate allocation | 963.0 / 979.9 / 851.8 | 963.0 ms | 4/24 |
| Byte-aware admission | 574.8 / 569.4 / 575.0 | 574.8 ms | 24/24 |

Median batch latency was 40.3% lower in this deliberately constrained-L1
workload. The model and decode kernels were warmed before measurement, and the
local vLLM prefix cache was reset between rounds. In a separate ample-capacity
control, both modes completed 10/10 prefetches; admission added about 0.24%
overhead.

I also searched open PRs for `prefetch admission`, `L1 prefetch OOM`, and
`byte-aware prefetch` and found no overlapping implementation. #4523 and #4222
touch adjacent prefetch code but address different problems.

## Checklist

- [x] this PR contains user-facing changes - docs added
- [x] this PR contains unit tests