### PR TITLE
ci: pre-merge PR base branch in k3 builds

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -11,6 +11,7 @@ trap 'echo "ERROR: setup-env.sh failed at line $LINENO (exit code $?)" >&2' ERR
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
+merge_pr_base_branch
 
 # Resolve which vLLM nightly to install. Sets PINNED_VLLM_VERSION (empty
 # string means "use latest nightly", any other value means

--- a/.buildkite/k3_harness/setup-lmcache-only-env.sh
+++ b/.buildkite/k3_harness/setup-lmcache-only-env.sh
@@ -12,6 +12,7 @@ trap 'echo "ERROR: setup-lmcache-only-env.sh failed at line $LINENO (exit code $
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
+merge_pr_base_branch
 
 echo "--- :python: Installing LMCache from source (no vLLM)"
 # Skip setuptools_scm git describe; the repo carries non-PEP-440 tags

--- a/.buildkite/k3_tests/common_scripts/helpers.sh
+++ b/.buildkite/k3_tests/common_scripts/helpers.sh
@@ -5,6 +5,76 @@
 # Track background PIDs for cleanup
 TRACKED_PIDS=()
 
+github_https_remote_url() {
+    local remote_url="$1"
+    case "$remote_url" in
+        https://*|http://*)
+            printf '%s\n' "$remote_url"
+            ;;
+        git@github.com:*)
+            printf 'https://github.com/%s\n' "${remote_url#git@github.com:}"
+            ;;
+        ssh://git@github.com/*)
+            printf 'https://github.com/%s\n' "${remote_url#ssh://git@github.com/}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Merge the PR base branch into the current checkout for Buildkite PR builds.
+# Buildkite's checkout step may leave the pod on the raw PR head commit rather
+# than a synthetic merge commit, so tests can miss conflicts/regressions that
+# only appear once the latest base branch is merged in.
+merge_pr_base_branch() {
+    local pr_number="${BUILDKITE_PULL_REQUEST:-false}"
+    if [[ -z "${pr_number}" || "${pr_number}" == "false" ]]; then
+        echo "--- :git: Not a PR build; skipping base-branch pre-merge"
+        return 0
+    fi
+
+    local base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}"
+    local remote_name="${1:-origin}"
+    local merge_ref="refs/remotes/${remote_name}/${base_branch}"
+    local fetch_source="${remote_name}"
+    local remote_url
+    remote_url="$(git remote get-url "${remote_name}")"
+
+    # The checkout phase may have SSH available even when the test container
+    # does not. Convert GitHub SSH remotes to HTTPS so the pre-merge fetch is
+    # portable across the different K3 job images.
+    if fetch_source="$(github_https_remote_url "${remote_url}")"; then
+        :
+    else
+        fetch_source="${remote_name}"
+    fi
+
+    echo "--- :git: Pre-merging ${remote_name}/${base_branch} into PR head"
+
+    git fetch --no-tags "${fetch_source}" \
+        "+refs/heads/${base_branch}:${merge_ref}"
+
+    if git merge-base --is-ancestor "${merge_ref}" HEAD; then
+        echo "  Current checkout already contains ${remote_name}/${base_branch}"
+        return 0
+    fi
+
+    local git_user_name
+    git_user_name="$(git config --get user.name || true)"
+    if [[ -z "${git_user_name}" ]]; then
+        git config user.name "buildkite-ci"
+    fi
+
+    local git_user_email
+    git_user_email="$(git config --get user.email || true)"
+    if [[ -z "${git_user_email}" ]]; then
+        git config user.email "buildkite-ci@lmcache.ai"
+    fi
+
+    GIT_MERGE_AUTOEDIT=no git merge --no-ff --no-edit "${merge_ref}"
+}
+
 # Check that all visible GPUs have sufficient free memory.
 # Fails fast with a clear message if a host-level process is hogging GPU memory.
 # Usage: check_gpu_health [min_free_percent]


### PR DESCRIPTION
## Summary
- add a shared helper that fetches and pre-merges `origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}` for Buildkite PR builds
- call that helper from both k3 setup entrypoints before installing LMCache or running tests
- keep the change scoped to CI scripts only

## Why
PR #4474 exposed that the k3 unit pipeline was testing the raw PR head instead of the PR head merged with the latest `origin/dev`. That let the job validate stale code relative to the true merge target and produced misleading failures.

By pre-merging the base branch inside the k3 job setup, PR builds now exercise the same code shape reviewers care about, and true merge conflicts fail early in setup instead of surfacing later as confusing test errors.

## Validation
- `bash -n .buildkite/k3_tests/common_scripts/helpers.sh`
- `bash -n .buildkite/k3_harness/setup-lmcache-only-env.sh`
- `bash -n .buildkite/k3_harness/setup-env.sh`
- simulated PR-build merge in a temporary git repo: first run created the expected merge commit, second run was a no-op once the base branch was already contained
