### PR TITLE
[Bugfix] Fix logging calls that drop their message at runtime, and guard against regressions

### DIFF
--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -264,8 +264,7 @@ class MockConnector(RemoteConnector):
         for i, mock_obj in enumerate(mock_objs):
             if mock_obj is None:
                 logger.warning(
-                    f"Mock object is None on {i}",
-                    f" out of {len(mock_objs)} objects",
+                    "Mock object is None on %d out of %d objects", i, len(mock_objs)
                 )
                 break
             metadata = mock_obj.metadata
@@ -276,8 +275,10 @@ class MockConnector(RemoteConnector):
             )
             if memory_obj is None:
                 logger.warning(
-                    "Failed to allocate memory even with",
-                    f" busy loop on {i} out of {len(mock_objs)} objects",
+                    "Failed to allocate memory even with busy loop on %d out of "
+                    "%d objects",
+                    i,
+                    len(mock_objs),
                 )
                 break
             memory_objs.append(memory_obj)

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -152,7 +152,9 @@ class PeerInfo:
         try:
             self.lookup_socket.close(linger=0)
         except Exception as e:
-            logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
+            logger.error(
+                "Failed to close peer %s lookup socket: %s", self.peer_init_url, e
+            )
         self.lookup_socket = new_lookup_socket
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ select = [
     # "I",
     # flake8-logging-format
     #"G",
+    # pylint: logging call passes too many / too few args for its format string.
+    # Such a call raises TypeError inside logging and the message is dropped.
+    "PLE1205",
+    "PLE1206",
     # flake8-self (private member access)
     "SLF",
 ]

--- a/tests/test_logging_format.py
+++ b/tests/test_logging_format.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guards logging calls in ``lmcache/`` against format-string/argument mismatches.
+
+``logging`` renders a record lazily as ``msg % args``. When the two disagree the
+formatting raises ``TypeError`` *inside* the logging machinery, so the intended
+message is replaced by a ``--- Logging error ---`` traceback on stderr. These
+calls sit on failure paths, which is exactly where losing the message hurts most.
+
+Ruff's ``PLE1205``/``PLE1206`` cover the static-string case. They cannot see
+through an f-string, so ``logger.warning(f"a {x}", " and b")`` -- a stray comma
+where implicit string concatenation was intended -- stays invisible to the
+linter. This test closes that gap while the codebase migrates from f-string
+logging to %-format.
+"""
+
+# Standard
+from pathlib import Path
+from typing import List, Optional, Tuple
+import ast
+import re
+
+LMCACHE_ROOT = Path(__file__).resolve().parents[1] / "lmcache"
+
+LOG_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "exception", "critical", "fatal"}
+)
+
+# Excluded from linting in pyproject.toml; generated vLLM connector shims.
+EXCLUDED = ("lmcache_mp_connector_",)
+
+# %[(key)][flags][width][.precision][length]conversion
+PERCENT_SPEC = re.compile(
+    r"%(?:\((?P<key>[^)]*)\))?"
+    r"[#0\- +]*"
+    r"(?P<width>\*|\d+)?"
+    r"(?:\.(?P<precision>\*|\d+))?"
+    r"[hlL]?"
+    r"(?P<conversion>[diouxXeEfFgGcrsa%])"
+)
+
+
+def iter_source_files() -> List[Path]:
+    """Return every Python file in the ``lmcache`` package that CI lints."""
+    return [
+        path
+        for path in sorted(LMCACHE_ROOT.rglob("*.py"))
+        if not any(marker in path.name for marker in EXCLUDED)
+    ]
+
+
+def resolve_logger_method(call: ast.Call) -> Optional[str]:
+    """Return the log level for ``call`` if it looks like a logging call.
+
+    Matches ``<receiver>.<level>(...)`` where the receiver's name contains
+    "log" (``logger``, ``logging``, ``self.logger``, ``_LOG``, ...). Narrow on
+    purpose: a false positive here would fail CI on unrelated code.
+    """
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr not in LOG_METHODS:
+        return None
+
+    receiver = func.value
+    if isinstance(receiver, ast.Name):
+        name = receiver.id
+    elif isinstance(receiver, ast.Attribute):
+        name = receiver.attr
+    else:
+        return None
+
+    return func.attr if "log" in name.lower() else None
+
+
+def literal_format_string(node: ast.expr) -> Optional[str]:
+    """Return the statically known part of a format string, or ``None``.
+
+    For an f-string only the literal segments are returned; interpolations
+    cannot contribute ``%`` placeholders.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return None
+
+
+def count_placeholders(fmt: str) -> Tuple[int, int, int]:
+    """Return ``(positional, mapping, star)`` placeholder counts for ``fmt``."""
+    positional = mapping = star = 0
+    for match in PERCENT_SPEC.finditer(fmt):
+        if match.group("conversion") == "%":
+            continue
+        if match.group("key") is not None:
+            mapping += 1
+        else:
+            positional += 1
+        star += (match.group("width") == "*") + (match.group("precision") == "*")
+    return positional, mapping, star
+
+
+def find_violations(source_file: Path) -> List[str]:
+    """Return a human-readable description of each mismatched call in a file."""
+    tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or resolve_logger_method(node) is None:
+            continue
+        if not node.args or any(isinstance(arg, ast.Starred) for arg in node.args):
+            continue
+
+        fmt = literal_format_string(node.args[0])
+        if fmt is None:
+            continue
+
+        expected, mapping, star = count_placeholders(fmt)
+        # Mapping style takes a single dict; star width/precision consumes extra
+        # positional args. Neither is statically checkable here.
+        if mapping or star:
+            continue
+
+        supplied = len(node.args) - 1
+        if expected != supplied:
+            location = f"{source_file.relative_to(LMCACHE_ROOT.parent)}:{node.lineno}"
+            violations.append(
+                f"{location} expects {expected} arg(s) but {supplied} "
+                f"were supplied: {fmt!r}"
+            )
+    return violations
+
+
+def test_logging_calls_match_their_format_string() -> None:
+    """Every logging call supplies exactly as many args as its format consumes."""
+    violations = [
+        violation
+        for source_file in iter_source_files()
+        for violation in find_violations(source_file)
+    ]
+
+    assert not violations, (
+        "Logging calls would raise TypeError at runtime:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4539

Three `logger.*` calls passed more positional arguments than their format string consumes. `logging` renders a record lazily as `msg % args`, so each of these raises `TypeError: not all arguments converted during string formatting` *inside* the logging machinery. Python's logging swallows that and prints a `--- Logging error ---` traceback to stderr instead — **the intended message is never emitted**. All three sit on failure paths, which is exactly where losing the message hurts most.

**1. `p2p_backend.py`** — two arguments, one placeholder. The caught exception had no placeholder to receive it, so the reason a peer socket failed to close was discarded entirely:

```python
 except Exception as e:
-    logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
+    logger.error(
+        "Failed to close peer %s lookup socket: %s", self.peer_init_url, e
+    )
```

**2 & 3. `mock_connector.py`** — a stray comma where implicit string concatenation was intended. This both truncated the message ("Failed to allocate memory even with") and turned its tail into an argument. Rewritten as `%`-format, matching the convention in #3372:

```python
 logger.warning(
-    "Failed to allocate memory even with",
-    f" busy loop on {i} out of {len(mock_objs)} objects",
+    "Failed to allocate memory even with busy loop on %d out of "
+    "%d objects",
+    i,
+    len(mock_objs),
 )
```

**Preventing regressions.** `PLE1205`/`PLE1206` were not in the ruff `select` list, so nothing in CI catches this. Enabling just those two rules reports **exactly the two static cases fixed here and nothing else repo-wide**, so they turn on with no extra cleanup:

```
$ ruff check --select PLE1205,PLE1206 .
All checks passed!     # after this PR; 2 errors before it
```

I deliberately left `G` (flake8-logging-format) commented out — it currently reports 511 findings, mostly the f-string logging already being migrated file-by-file.

Ruff cannot see through an f-string, so case 2 above stays invisible to `PLE1205`. `tests/test_logging_format.py` closes that gap with a small AST walk over `lmcache/`. It is stdlib-only, runs in <1s, and reports every offending call in one assertion:

```
AssertionError: Logging calls would raise TypeError at runtime:
  lmcache/v1/storage_backend/connector/mock_connector.py:266 expects 0 arg(s) but 1 were supplied: 'Mock object is None on '
  lmcache/v1/storage_backend/connector/mock_connector.py:278 expects 0 arg(s) but 1 were supplied: 'Failed to allocate memory even with'
  lmcache/v1/storage_backend/p2p_backend.py:155 expects 1 arg(s) but 2 were supplied: 'Failed to close peer %s lookup socket'
```

**Special notes for your reviewers**:

- Verified the test actually catches the bugs: it fails with all three findings above when the two source fixes are reverted, and passes with them applied.
- The checker is intentionally conservative to avoid false positives on unrelated code — it skips `*args` splats, `%(name)s` mapping style, and `*` width/precision, and only treats a receiver whose name contains "log" as a logger.
- Ran locally on `dev` @ `0373a573`: `ruff check` (clean repo-wide with the new rules), `ruff format --check` (1177 files already formatted), `isort`, `codespell`, the SPDX header hook, and `mypy` on the new file — all clean.
- Happy to split the `pyproject.toml` rule change into its own PR if you would rather keep the fix and the lint change separate.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
