### PR TITLE
fix(config): fall back to defaults when loading invalid or null values

### DIFF
--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -8,7 +8,7 @@ for all LMCache configuration systems to avoid code duplication.
 
 # Standard
 from dataclasses import make_dataclass
-from typing import Any, Callable, Dict, Optional, Protocol, Union
+from typing import Any, Callable, Dict, Optional, Protocol, Union, get_args
 import ast
 import json
 import os
@@ -25,8 +25,44 @@ from lmcache.logging import init_logger
 logger = init_logger(__name__)
 
 
-def _apply_env_converter_safely(config_definitions, name, value):
-    """Apply env_converter to a value safely."""
+def _allows_none(config: Dict[str, Any]) -> bool:
+    """Check whether a config field's declared type permits None.
+
+    Args:
+        config: A single field definition from ``config_definitions``.
+
+    Returns:
+        True if the declared ``type`` is Optional (or not declared),
+        False otherwise.
+    """
+    declared_type = config.get("type")
+    if declared_type is None:
+        return True
+    return type(None) in get_args(declared_type)
+
+
+def _apply_env_converter_safely(
+    config_definitions: Dict[str, Any],
+    name: str,
+    value: Any,
+    use_default_on_error: bool = False,
+) -> Any:
+    """Apply env_converter to a value safely.
+
+    Args:
+        config_definitions: Mapping of field names to their definitions.
+        name: The configuration field name.
+        value: The raw value to convert.
+        use_default_on_error: If True, fall back to the field's default
+            (instead of None) when conversion fails, or when the value is
+            None but the field's declared type does not allow None. Used by
+            the config loading paths so a bad or empty value never replaces
+            the documented default.
+
+    Returns:
+        The converted value. On failure, the field's default if
+        ``use_default_on_error`` is True, otherwise None.
+    """
     if name not in config_definitions:
         return value
 
@@ -36,9 +72,32 @@ def _apply_env_converter_safely(config_definitions, name, value):
         try:
             # Don't apply converter if value is None
             if value is None:
+                default = config.get("default")
+                if (
+                    use_default_on_error
+                    and default is not None
+                    and not _allows_none(config)
+                ):
+                    logger.warning(
+                        "Config %s has a null value but is not nullable; "
+                        "using default %r",
+                        name,
+                        default,
+                    )
+                    return default
                 return None
             return env_converter(value)
         except (ValueError, json.JSONDecodeError) as e:
+            if use_default_on_error:
+                default = config.get("default")
+                logger.warning(
+                    "Failed to convert value for %s=%r: %s; using default %r",
+                    name,
+                    value,
+                    e,
+                    default,
+                )
+                return default
             log_message = f"Failed to convert value for {name}={value!r}: {e}"
             logger.warning(log_message)
             # Return None if conversion fails
@@ -290,7 +349,7 @@ def create_config_class(
                     value = _parse_quoted_string(raw_value)
                     # Apply env_converter safely
                     config_values[name] = _apply_env_converter_safely(
-                        config_definitions, name, value
+                        config_definitions, name, value, use_default_on_error=True
                     )
                     user_set_keys.add(name)  # Mark as user-set
                 except (ValueError, json.JSONDecodeError) as e:
@@ -339,7 +398,7 @@ def create_config_class(
                 value = config["default"]
             # Apply env_converter safely regardless of whether value is None or not
             config_values[name] = _apply_env_converter_safely(
-                config_definitions, name, value
+                config_definitions, name, value, use_default_on_error=True
             )
 
         instance = cls(**config_values)

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -168,6 +168,45 @@ def test_update_config_from_env_error_handling():
     del os.environ["LMCACHE_CONTROLLER_PULL_URL"]
 
 
+def test_from_env_invalid_value_falls_back_to_default():
+    os.environ["LMCACHE_CHUNK_SIZE"] = "invalid_number"
+    try:
+        config = LMCacheEngineConfig.from_env()
+        assert config.chunk_size == 256
+    finally:
+        del os.environ["LMCACHE_CHUNK_SIZE"]
+
+
+def test_from_file_invalid_value_falls_back_to_default(tmp_path: Path):
+    config_path = tmp_path / "lmcache.yaml"
+    config_path.write_text("chunk_size: invalid_number\n")
+    config = LMCacheEngineConfig.from_file(config_path)
+    assert config.chunk_size == 256
+
+
+def test_from_file_empty_value_falls_back_to_default(tmp_path: Path):
+    # A key present without a value (e.g. the value was commented out)
+    # parses as None and must not override the non-nullable default.
+    config_path = tmp_path / "lmcache.yaml"
+    config_path.write_text(
+        "chunk_size:\nlocal_cpu:\nmax_local_cpu_size:\n",
+    )
+    config = LMCacheEngineConfig.from_file(config_path)
+    assert config.chunk_size == 256
+    assert config.local_cpu is True
+    assert config.max_local_cpu_size == 5.0
+    config.validate()
+
+
+def test_from_file_explicit_null_preserved_for_optional_field(tmp_path: Path):
+    # remote_serde is Optional[str]: an explicit null must stay None
+    # even though the field's default is "naive".
+    config_path = tmp_path / "lmcache.yaml"
+    config_path.write_text("remote_serde: null\n")
+    config = LMCacheEngineConfig.from_file(config_path)
+    assert config.remote_serde is None
+
+
 @pytest.mark.parametrize("use_mla", [True, False])
 def test_get_lookup_server_worker_ids(use_mla):
     config = LMCacheEngineConfig.from_defaults()


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #4541

`from_env()` and `from_file()` set a field to `None` instead of its default when the value fails conversion — `_apply_env_converter_safely` swallows the `ValueError`, so the default-fallback `except` handler in `_from_env` is dead code — and a YAML key present without a value (e.g. the value was commented out) nulls non-Optional fields through the `value is None` short-circuit. The `None` then either crashes far from the config (`chunk_size=None` → `TypeError` inside `token_database`) or silently disables features (`local_cpu:` with no value skips the CPU backend with no error).

The fix adds an opt-in `use_default_on_error` flag to `_apply_env_converter_safely`, used only by the loading paths:

- conversion failure → warn and use the field default (matching both the dead handler's intent and `update_config_from_env`, which already keeps the old value in this case);
- null value for a field whose declared type does not allow `None` → warn and use the default;
- explicit `null` for Optional-typed fields (e.g. `remote_serde: null`) is preserved;
- `validate_and_set_config_value` and override handling are untouched — they rely on the None-on-failure contract to *reject* bad runtime updates, which is the correct behavior there.

**The test** (fails before, passes after):

```
tests/v1/test_config.py::test_from_env_invalid_value_falls_back_to_default
tests/v1/test_config.py::test_from_file_invalid_value_falls_back_to_default
tests/v1/test_config.py::test_from_file_empty_value_falls_back_to_default
tests/v1/test_config.py::test_from_file_explicit_null_preserved_for_optional_field
```

Before (dev @ 0373a57): `3 failed, 1 passed` (the explicit-null test already passed). After: `4 passed`, and the full `tests/v1/test_config.py` suite is unchanged otherwise (`88 passed`; the 4 `@pytest.mark.cuda` Nixl tests fail identically before and after on a CPU-only machine).

**Special notes for your reviewers**:
- This is my first PR to LMCache.
- I ran `pre-commit run` on the changed files — all green (isort, ruff, ruff-format, codespell, mypy, SPDX).

**If applicable**:
- [x] this PR contains unit tests