### PR TITLE
[Bugfix] SegmentTokenDatabase: add missing return in the segment splitter's early-exit guard

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -468,10 +468,15 @@ class SegmentTokenDatabase(TokenDatabase):
         self.sep_len = len(self.sep_tokens)
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
-        """Match the `sep_tokens` with sliding windows"""
+        """Match the `sep_tokens` with sliding windows.
+
+        When there is no separator to look for (`sep_len == 0`) or the input is
+        too short to contain one, the whole input is yielded as a single chunk.
+        """
 
         if self.sep_len == 0 or len(tokens) < self.sep_len:
             yield tokens
+            return
 
         # Unfold into sliding windows
         # shape: (num_tokens-sep_len+1, sep_len)

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import patch
 import hashlib
 import os
 
@@ -23,6 +24,40 @@ def hf_credentials_available() -> bool:
     return bool(
         token_env or os.path.exists(default_token_file) or os.path.exists(token_file)
     )
+
+
+class StubTokenizer:
+    """Tokenizer stand-in that encodes any text to a fixed list of token ids.
+
+    ``SegmentTokenDatabase`` only ever encodes ``blend_special_str``, so a
+    fixed encoding is enough to pin down the separator -- and therefore its
+    length -- without downloading a real tokenizer.
+    """
+
+    def __init__(self, encoded: list[int]) -> None:
+        self.encoded = encoded
+
+    def encode(self, text: str) -> list[int]:
+        return list(self.encoded)
+
+
+def make_segment_token_database(encoded_sep: list[int]) -> SegmentTokenDatabase:
+    """Build a ``SegmentTokenDatabase`` with a deterministic separator.
+
+    Args:
+        encoded_sep: What the tokenizer returns for ``blend_special_str``.
+            The database drops the leading token, so the separator ends up
+            being ``encoded_sep[1:]``.
+
+    Returns:
+        A database backed by a stub tokenizer, so neither network access nor
+        Hugging Face credentials are required.
+    """
+    cfg = LMCacheEngineConfig.from_legacy(blend_special_str=" # # ")
+    metadata = dumb_metadata()
+    with patch("lmcache.v1.token_database.AutoTokenizer") as auto_tokenizer:
+        auto_tokenizer.from_pretrained.return_value = StubTokenizer(encoded_sep)
+        return SegmentTokenDatabase(cfg, metadata)
 
 
 @pytest.mark.parametrize("chunk_length", [16, 64, 256])
@@ -130,6 +165,56 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         assert key.chunk_hash == hashes[i]
         # print(st, starts[i])
         # print(ed, ends[i])
+
+
+def test_segment_token_database_splits_on_separator() -> None:
+    """Separators split the input, and their tokens belong to no chunk."""
+    db = make_segment_token_database([0, 100, 200])
+    assert len(db.sep_tokens) == 2
+
+    left = torch.tensor([1, 2, 3], dtype=torch.long)
+    right = torch.tensor([4, 5], dtype=torch.long)
+    tokens = torch.cat([left, db.sep_tokens, right])
+
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
+
+    assert [(start, end) for start, end, _ in results] == [(0, 3), (5, 7)]
+
+
+def test_segment_token_database_input_shorter_than_separator() -> None:
+    """Input too short to hold a separator comes back as one whole chunk.
+
+    Regression test: the short-input guard used to fall through into the
+    sliding-window match, where ``torch.Tensor.unfold`` raises a RuntimeError
+    because it cannot build a window wider than the input.
+    """
+    db = make_segment_token_database([0, 100, 200, 300])
+    assert len(db.sep_tokens) == 3
+
+    tokens = torch.tensor([7, 8], dtype=torch.long)
+
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
+
+    assert [(start, end) for start, end, _ in results] == [(0, 2)]
+
+
+def test_segment_token_database_empty_separator() -> None:
+    """An empty separator leaves the input unsplit.
+
+    ``sep_tokens`` is empty whenever the tokenizer encodes
+    ``blend_special_str`` to a single token, because the database drops the
+    leading one. Regression test: the guard for that case used to fall through
+    into the sliding-window match, where a zero-width window matches at every
+    position and shreds the input into single-token and empty chunks.
+    """
+    db = make_segment_token_database([0])
+    assert len(db.sep_tokens) == 0
+
+    tokens = generate_tokens(8, "cpu")
+
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
+
+    assert [(start, end) for start, end, _ in results] == [(0, 8)]
 
 
 def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4544

`SegmentTokenDatabase._fast_split_by_subtensor` is a generator, so the `yield tokens` in its degenerate-case guard suspends but never exits — the next `next()` resumes straight into the sliding-window match that the guard exists to skip. The fix is the missing `return`:

```python
 if self.sep_len == 0 or len(tokens) < self.sep_len:
     yield tokens
+    return
```

Two unrelated-looking failures fall out of that one omission:

**1. `len(tokens) < self.sep_len` — loud.** `tokens.unfold(0, self.sep_len, 1)` refuses to build a window wider than the tensor and raises `RuntimeError: maximum size for tensor at dimension 0 is N but size is M`. Because a generator only resumes on demand, the consumer gets the correct chunk first and the exception lands one `next()` later — i.e. at the `for start, end, key in self.token_database.process_tokens(...)` loops in `cache_engine.py`, not at the call that built the generator.

**2. `self.sep_len == 0` — silent, and worse.** `unfold(0, 0, 1)` produces `len(tokens) + 1` zero-width windows, and `.all(dim=1)` over a zero-width dimension is vacuously True, so *every* index registers as a separator match. An 8-token input comes out as 11 chunks — the whole input, then two empties bracketing eight single-token slices — and `process_tokens` mints a separate cache key for each one, including zero-length `(start, end)` ranges that `cache_engine.store` then sizes memory objects from.

`sep_len == 0` is reachable through configuration rather than hypothetical: `self.sep_tokens = self.tokenizer.encode(config.blend_special_str)[1:]` unconditionally drops the first token id (the `TODO (Jiayi)` right above it flags that leading-special-token assumption as a guess), so any tokenizer / `blend_special_str` pair that encodes to exactly one token leaves the separator empty.

**Demonstrating it without torch.** torch is not installable in my environment (see the reviewer notes), so I transcribed the method to plain lists, reproducing the only two torch behaviours that matter here: `unfold`'s bounds check, and a `.all()` reduction over a zero-width dimension being vacuously True. Output of that standalone script (not committed):

```
1. Generator semantics: `yield` alone does not exit the function
      ... still executing after the early yield!
   consumed: ['early guard', 'fell through']

2. Normal case (separator present)
  tokens=[1, 2, 3, 100, 200, 4, 5]  sep=[100, 200]
  buggy (as shipped): 2 chunk(s) -> [[1, 2, 3], [4, 5]]
  fixed  (with return): 2 chunk(s) -> [[1, 2, 3], [4, 5]]

3. Input shorter than the separator
  tokens=[7, 8]  sep=[100, 200, 300]
  buggy (as shipped): RuntimeError: maximum size for tensor at dimension 0 is 2 but size is 3
  fixed  (with return): 1 chunk(s) -> [[7, 8]]

4. Empty separator (sep_len == 0)
  tokens=[1, 2, 3, 4, 5, 6, 7, 8]  sep=[]
  buggy (as shipped): 11 chunk(s) -> [[1, 2, 3, 4, 5, 6, 7, 8], [], [1], [2], [3], [4], [5], [6], [7], [8], []]
  fixed  (with return): 1 chunk(s) -> [[1, 2, 3, 4, 5, 6, 7, 8]]
```

Case 2 is the reason one of the new tests covers the ordinary split path: the fix must be inert there, and it is.

**Tests.** Three tests in `tests/v1/test_token_database.py`, all driven through the public `process_tokens` — no private members touched. The existing `test_segment_token_database` is `skipif`-gated on Hugging Face credentials because the constructor calls `AutoTokenizer.from_pretrained`; stubbing that one third-party seam lets the new tests run unconditionally, and it is also the only way to pin `sep_len` deterministically — including to `0`, which no real tokenizer would reliably give us.

**Special notes for your reviewers**:

- **I could not execute the test suite locally, and want to be upfront about that.** The only interpreter available to me is Python 3.14, which is outside this project's `requires-python = ">=3.10,<3.14"`, so `pip install -e .` refuses; `tests/conftest.py` imports `torch` and `tests/v1/utils.py` imports the compiled `lmcache.lmcache_native` extension, neither of which I can provide here. **The new tests are statically checked but unexecuted.** Everything I did run, against the two changed files, on `dev` @ `0373a573`:

  | check | result |
  |---|---|
  | `ruff check` (0.11.7, CI's pin) | `All checks passed!` |
  | `ruff format --check` | `2 files already formatted` |
  | `isort --check-only --diff` | clean, no diff |
  | `codespell --toml pyproject.toml` | clean |
  | `python tools/check_spdx_header.py` | clean |
  | `mypy --ignore-missing-imports --follow-imports=silent --explicit-package-bases` | `Success: no issues found in 2 source files` |

  The expected `(start, end)` values in the tests were derived by hand from the splitter's index arithmetic and cross-checked against the transcription above — its case-2 chunks `[[1, 2, 3], [4, 5]]` are exactly the `[(0, 3), (5, 7)]` the separator test asserts, once `process_tokens` adds the separator offset. CI is the real check here; if anything goes red I will turn it around promptly.

- **Trailing empty chunk: noticed, deliberately left alone.** While in the method I checked the other suspicious edge the reviewer might ask about: when a separator sits at the very *end* of the input, the trailing `yield tokens[start:]` does emit an empty tensor, and `process_tokens` turns it into a zero-length `(start, end)` range with `start == end`, which `cache_engine.store` sizes a memory object from via `num_tokens = end - start`. It looks latent rather than actively firing (blend inputs end with content, and the existing test builds its input that way), and suppressing it would change chunk-emission semantics — which I am in no position to validate without being able to run the suite. Recorded as a note on #4544 instead of widening this PR.

- **Docstring.** I added two lines to the private method's docstring stating what the guard promises, because that promise is precisely what the new tests assert. Happy to drop it if you would rather the diff be the single `return`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
