### PR TITLE
[Bugfix] disk: release accounted disk space on external removals

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -254,6 +254,20 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
         force: bool = True,
     ) -> bool:
+        """
+        Remove a cached chunk from disk and release its accounted space.
+
+        :param key: The cache key identifying the chunk to remove.
+        :param force: ``True`` for removals initiated outside the backend
+            (the caller does not hold ``disk_lock`` and has not adjusted the
+            disk space accounting). ``False`` is reserved for the internal
+            eviction path in ``submit_put_task``, which already holds
+            ``disk_lock`` and has already deducted the chunk from
+            ``current_cache_size`` before calling this method.
+
+        :return: ``True`` if the key was present and removed, ``False`` if
+            it was not cached.
+        """
         lock_context = self.disk_lock if force else nullcontext()
         with lock_context:
             if not (meta := self.dict.pop(key, None)):
@@ -263,6 +277,14 @@ class LocalDiskBackend(StorageBackendInterface):
             size = meta.size
             self.usage -= size
             self.stats_monitor.update_local_storage_usage(self.usage)
+
+            # Release the space this chunk reserved in `submit_put_task`.
+            # Deducted next to `usage` and before the fallible `os.remove` so
+            # both counters stay consistent with `dict` on every exit path.
+            # Skipped when force=False: the internal eviction path already
+            # deducted the chunk before calling us.
+            if force:
+                self.current_cache_size -= size
 
             # NOTE: The following code will cause deadlock
             # res = asyncio.run_coroutine_threadsafe(

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -610,3 +610,184 @@ class TestBatchedGetBlocking:
         results = local_disk_backend.batched_get_blocking([])
         assert results == []
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestDiskSpaceAccountingOnRemove:
+    """Tests for how the disk budget is accounted across removals.
+
+    ``submit_put_task`` charges every chunk against ``max_local_disk_size``
+    and drops the put when the budget is exhausted and nothing can be
+    evicted.  Removing a chunk therefore has to give its space back, or the
+    backend ends up refusing puts while the disk is actually empty.
+    """
+
+    _SHAPE = torch.Size([2, 2, 16, 8, 128])
+    _DTYPE = torch.bfloat16
+
+    @pytest.fixture
+    def running_loop(self):
+        """Create an asyncio event loop running in a background thread.
+
+        ``submit_put_task`` hands the disk write to the backend's event loop,
+        so the loop has to be running for a put to ever reach the disk.
+        """
+        loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def run_loop() -> None:
+            asyncio.set_event_loop(loop)
+            ready.set()
+            loop.run_forever()
+
+        thread = threading.Thread(target=run_loop, daemon=True)
+        thread.start()
+        if not ready.wait(timeout=5.0):
+            raise RuntimeError("Event loop thread failed to start within 5 seconds")
+
+        yield loop
+
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+    def test_put_accepted_after_stored_keys_are_removed(
+        self,
+        temp_disk_path: str,
+        running_loop: asyncio.AbstractEventLoop,
+        local_cpu_backend: LocalCPUBackend,
+    ) -> None:
+        """Space freed by ``batched_remove`` is available to later puts.
+
+        Fills the disk budget, drops every key through the public
+        ``batched_remove`` API, then stores a new chunk.  The new chunk has
+        to land on disk -- the disk is empty at that point, so there is room
+        for it.
+        """
+        backend = self._make_backend(
+            temp_disk_path, running_loop, local_cpu_backend, chunk_budget=2.5
+        )
+        try:
+            stored_keys = [create_test_key(i) for i in range(300, 302)]
+            for key in stored_keys:
+                assert self._put_and_wait(backend, key, local_cpu_backend), (
+                    f"initial put for {key} was dropped"
+                )
+                assert backend.contains(key)
+
+            assert backend.batched_remove(stored_keys) == len(stored_keys)
+            for key in stored_keys:
+                assert not backend.contains(key)
+
+            fresh_key = create_test_key(302)
+            assert self._put_and_wait(backend, fresh_key, local_cpu_backend), (
+                "put was dropped even though every stored key had been "
+                "removed and the disk was empty"
+            )
+            assert backend.contains(fresh_key)
+        finally:
+            backend.close()
+            local_cpu_backend.memory_allocator.close()
+
+    def test_eviction_keeps_only_the_newest_chunks(
+        self,
+        temp_disk_path: str,
+        running_loop: asyncio.AbstractEventLoop,
+        local_cpu_backend: LocalCPUBackend,
+    ) -> None:
+        """Storing past the budget evicts the oldest chunks -- and no more.
+
+        Four chunks are stored into a budget that holds two, so the two
+        oldest must be gone and the two newest must remain.  Releasing more
+        space than a chunk occupies would let the cache grow past its
+        budget instead.
+        """
+        backend = self._make_backend(
+            temp_disk_path, running_loop, local_cpu_backend, chunk_budget=2.5
+        )
+        try:
+            keys = [create_test_key(i) for i in range(310, 314)]
+            for key in keys:
+                assert self._put_and_wait(backend, key, local_cpu_backend), (
+                    f"put for {key} was dropped"
+                )
+
+            assert not backend.contains(keys[0])
+            assert not backend.contains(keys[1])
+            assert backend.contains(keys[2])
+            assert backend.contains(keys[3])
+        finally:
+            backend.close()
+            local_cpu_backend.memory_allocator.close()
+
+    def _make_backend(
+        self,
+        disk_path: str,
+        loop: asyncio.AbstractEventLoop,
+        cpu_backend: LocalCPUBackend,
+        chunk_budget: float,
+    ) -> LocalDiskBackend:
+        """Build a backend whose disk budget holds ``chunk_budget`` chunks.
+
+        The budget is derived from the physical size of a real allocation so
+        that it stays exact whatever the allocator's alignment is.
+
+        :param disk_path: Directory to use for the disk cache.
+        :param loop: Running event loop the backend submits its writes to.
+        :param cpu_backend: Backend used to allocate the staging memory.
+        :param chunk_budget: Disk capacity, expressed in ``_SHAPE`` chunks.
+        :returns: A backend configured with that capacity.
+        """
+        probe = self._allocate_chunk(cpu_backend)
+        chunk_size = probe.get_physical_size()
+        probe.ref_count_down()
+
+        config = create_test_config(
+            disk_path, max_disk_size=chunk_budget * chunk_size / 1024**3
+        )
+        return LocalDiskBackend(
+            config=config,
+            loop=loop,
+            local_cpu_backend=cpu_backend,
+            dst_device=f"{torch_device_type}:0",
+        )
+
+    def _allocate_chunk(self, cpu_backend: LocalCPUBackend) -> MemoryObj:
+        """Allocate one staging chunk of ``_SHAPE``.
+
+        :param cpu_backend: Backend used to allocate the staging memory.
+        :returns: The allocated memory object.
+        """
+        # busy_loop=False so an exhausted pool fails here instead of spinning.
+        memory_obj = cpu_backend.allocate(
+            self._SHAPE, self._DTYPE, MemoryFormat.KV_2LTD, busy_loop=False
+        )
+        assert memory_obj is not None, "CPU staging allocation failed"
+        return memory_obj
+
+    def _put_and_wait(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+        cpu_backend: LocalCPUBackend,
+        timeout: float = 10.0,
+    ) -> bool:
+        """Store one chunk under *key* and wait for the disk write to finish.
+
+        :param backend: The backend under test.
+        :param key: Key to store the chunk under.
+        :param cpu_backend: Backend used to allocate the staging chunk.
+        :param timeout: Seconds to wait for the completion callback.
+        :returns: ``True`` once the write completed, ``False`` if the backend
+            dropped the put -- the completion callback only runs for puts
+            that were accepted.
+        """
+        memory_obj = self._allocate_chunk(cpu_backend)
+        done = threading.Event()
+
+        def on_complete(_key: CacheEngineKey) -> None:
+            done.set()
+
+        backend.submit_put_task(key, memory_obj, on_complete_callback=on_complete)
+        stored = done.wait(timeout=timeout)
+        memory_obj.ref_count_down()
+        return stored


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4546

`LocalDiskBackend` reserves disk budget in `submit_put_task` and charges it to
`self.current_cache_size`, but only its own eviction loop ever gave that space
back. On `dev` the counter has exactly four references, all in
`local_disk_backend.py`: it is zeroed at init (175), read by the capacity gate
(346), decremented by the internal eviction loop (358), and incremented by every
accepted put (364). `remove()` is not among them — it shrank `usage` and popped
the entry from `self.dict`, but left `current_cache_size` inflated forever.

The internal eviction loop gets away with that because it deducts the chunk
itself before delegating:

```python
for evict_key in evict_keys:
    self.current_cache_size -= self.dict[evict_key].size

self.batched_remove(evict_keys, force=False)
```

Every removal that originates *outside* the backend takes the default
`force=True` and was never accounted for. `StorageManager.remove` and
`StorageManager.batched_remove` both call the backend with that default, so
`LMCacheEngine.clear()`, `move()`, `compress()`, `decompress()` and the
remove-after-retrieve path all leak budget on each call.

Because the drift is monotonic, `current_cache_size` eventually exceeds
`max_local_disk_size`. From then on the `while` loop in `submit_put_task` asks
the cache policy for a victim, gets nothing back (the dict genuinely is empty,
or holds far less than the counter claims), logs

```
No eviction candidates found. Disk space under pressure.
```

and returns without storing. **The disk tier silently degrades to a no-op for
the rest of the process** — puts stop landing, hit rate collapses, and the only
signal is a warning blaming disk pressure while the disk is nearly empty. The
`usage` metric stays accurate the whole time, so monitoring shows an empty disk
cache that refuses to accept data.

**The fix** — deduct the chunk in `remove()` when `force=True`:

```python
             self.usage -= size
             self.stats_monitor.update_local_storage_usage(self.usage)

+            # Release the space this chunk reserved in `submit_put_task`.
+            # Deducted next to `usage` and before the fallible `os.remove` so
+            # both counters stay consistent with `dict` on every exit path.
+            # Skipped when force=False: the internal eviction path already
+            # deducted the chunk before calling us.
+            if force:
+                self.current_cache_size -= size
```

I considered the alternative of dropping the pre-deduction in `submit_put_task`
and letting `remove()` own the decrement unconditionally. I went with the
`if force:` guard instead because it is strictly additive — the eviction loop is
untouched, so its interleaving of "deduct, remove, re-check the gate" inside the
held `disk_lock` cannot change. It also reuses the guard the function already
has for `update_on_force_evict`, which encodes exactly the same distinction
(external removal vs. internal eviction), so there is one consistent meaning of
`force` in the method rather than two.

On the error path: `os.remove(path)` can raise after the entry has already been
popped and `usage` already decremented. Putting the new deduction next to the
`usage` update, ahead of that call, means a failing unlink leaves `dict`,
`usage` and `current_cache_size` mutually consistent rather than re-introducing
the same drift on a rarer path. It also needs no `try`/`except`, so the change
stays a single guarded statement. (The orphaned file such a failure would leave
behind is a pre-existing, separate concern and is not touched here.)

I also added a docstring to `remove()` documenting the `force` contract, since
"the caller has already adjusted the accounting" is the invariant the fix hangs
on and nothing stated it before.

**Special notes for your reviewers**:

**I could not execute the test suite locally, and I want to be upfront about
that.** My machine is Windows, and `LocalDiskBackend.__init__` calls
`os.statvfs`, which is POSIX-only — so every test in
`tests/v1/storage_backend/test_local_disk_backend.py`, existing ones included,
is unrunnable here regardless of anything else. (`torch` is also absent: the
interpreter is Python 3.14 and the project supports `>=3.10,<3.14`, so
collection stops at `import torch` before it even gets that far.) Everything
below is what I *did* run, and I have not claimed a passing test run.

Static checks, all on the two changed files, run with the CI-pinned ruff 0.11.7:

| Command | Result |
|---|---|
| `python -m ruff check` | `All checks passed!` |
| `python -m ruff format --check` | `2 files already formatted` |
| `python -m isort --check-only` | clean, no output |
| `python -m mypy --ignore-missing-imports --follow-imports=silent --explicit-package-bases` | `Success: no issues found in 2 source files` |
| `python -m codespell_lib --toml pyproject.toml` | clean, no output |
| `python tools/check_spdx_header.py` | clean |

Since I could not run the new tests, I validated the underlying arithmetic with
a standalone pure-Python model of the four `current_cache_size` sites (written
outside the repo, not committed). Chunk = 128 KiB, budget = 2.5 chunks:

```
A) store 2, remove both externally, store 1 more
   pre-fix: disk holds 0 chunk(s), usage=0 B, current_cache_size=262144 B, next put DROPPED
   fixed  : disk holds 1 chunk(s), usage=131072 B, current_cache_size=131072 B, next put ACCEPTED

B) repeated store/remove cycles on an empty disk
   pre-fix: first dropped put at cycle 2, current_cache_size=262144 B while usage=0 B
   fixed  : first dropped put at never, current_cache_size=0 B while usage=0 B

C) internal eviction only (4 puts into a budget of 2)
   pre-fix: resident=['k2', 'k3'], current_cache_size=262144 B
   fixed  : resident=['k2', 'k3'], current_cache_size=262144 B
```

B is the failure users would hit: the disk is empty every cycle (`usage=0`),
yet after two store/remove rounds the backend refuses all further puts. C is
the control — the internal eviction path behaves identically before and after,
confirming the `force=False` case is not double-counted.

**The two new tests** go in the existing
`tests/v1/storage_backend/test_local_disk_backend.py` and assert behaviour
through the public API only — no reads of `current_cache_size`:

- `test_put_accepted_after_stored_keys_are_removed` fills the budget, removes
  everything via `batched_remove`, then stores a fresh chunk and asserts
  `contains()` reports it. Pre-fix that put is dropped, so the assertion fails.
- `test_eviction_keeps_only_the_newest_chunks` stores four chunks into a budget
  of two and asserts the two oldest are gone and the two newest are resident.
  This is the guard against the opposite error — releasing space twice would let
  the cache grow past its budget.

Both size the backend from the real `get_physical_size()` of an allocation, so
the budget stays exact whatever the allocator's alignment is, and both drive
`submit_put_task`'s `on_complete_callback` through a `threading.Event` rather
than sleeping: the callback only fires for puts the backend accepted, which is
precisely the signal this bug destroys.

**Follow-up, deliberately not in this PR**: unlike `LocalCPUBackend`, whose
`submit_put_task` returns early when the key is already in `hot_cache`,
`LocalDiskBackend.submit_put_task` does not skip keys already present in
`self.dict`. Re-putting an existing key charges the budget a second time while
`insert_key` only refreshes recency, which is an independent source of the same
upward drift. I kept this PR to the remove-path accounting; happy to file that
separately.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
