### PR TITLE
platform/cuda: add shared-flag event IPC backend (event IPC without hostIPC)

### DIFF
--- a/docs/design/v1/platform/cuda/shared_flag_event_ipc.md
+++ b/docs/design/v1/platform/cuda/shared_flag_event_ipc.md
@@ -1,0 +1,121 @@
+# Shared-Flag Event IPC Backend
+
+## Motivation
+
+The `lmcache_driven` handle path orders cross-process KV transfers with
+device events (`event_ipc_abstraction.md`). The CUDA implementation behind
+`DefaultEventIPCBackend` uses interprocess event handles — and empirically
+(driver 580, CUDA 13) those only resolve when both processes share a
+`/dev/shm` tmpfs. CUDA IPC *memory* handles have no such dependency: they
+rendezvous in the kernel driver and work across fully isolated containers.
+On Kubernetes, the event handles are what force `hostIPC: true` (or a
+shared hostPath tmpfs) onto the vLLM pod and the LMCache DaemonSet for
+every STORE/RETRIEVE. `SharedFlagEventIPCBackend` removes that requirement
+by implementing event semantics on memory handles alone.
+
+## Mechanism
+
+Each process lazily allocates one flag buffer per GPU (4096 × 8-byte
+slots) and exports it once with `cudaIpcGetMemHandle`. An event is a
+`(slot, sequence)` event object:
+
+| protocol method | implementation |
+| --- | --- |
+| `create_event` | new event object; no slot until first record |
+| `record_event(e, stream)` | assign the stream's slot, bump its sequence, `cuStreamWriteValue64(slot, seq)` on `stream` |
+| `export_event` | pack `(version, mem handle, slot offset, seq)` — 81 bytes, self-contained, rides the existing opaque `bytes` wire field |
+| `import_event` | open the exporter's flag buffer once (cached), return a wait/query-only event |
+| `wait_event(e, stream)` | `cuStreamWaitValue64(slot, seq, GEQ)` on `stream` |
+| `query_event` / `synchronize_event` | 8-byte device read (poll) |
+
+Slots are assigned per recording stream: each slot's values are
+stream-ordered, hence monotonic, which keeps the `>= seq` wait race-free.
+Slot 0 is reserved for the `check_event_support` probe.
+
+## Empirically load-bearing details (driver 580 / CUDA 13)
+
+- **Never device-sync inside lazy buffer allocation** — it runs inside the
+  first `record_event`, and a `cudaDeviceSynchronize` there drains the
+  caller's recording stream, silently breaking record ordering. The buffer
+  is zeroed via `cudaMemsetAsync` on its own stream.
+- **Host-side slot reads go through a dedicated non-blocking stream** so
+  they cannot synchronize with caller streams blocked in a flag wait.
+- **`CU_STREAM_WAIT_VALUE_GEQ` is cyclic**: `(int64_t)(*addr - value) >= 0`,
+  not a plain unsigned compare. Harmless with monotonic sequences, but any
+  future special value written into a slot must stay below `INT64_MAX`.
+- **Do not gate on `CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS`** — it
+  reports 0 on drivers where the v2 memops (default since CUDA 12) work.
+  `check_event_support` probes with real calls.
+
+## Semantics vs `DefaultEventIPCBackend`
+
+Identical for the lifecycle LMCache uses (create → record → export →
+import → wait/query/synchronize), including "never-recorded = complete".
+Deliberate differences:
+
+- **Snapshot exports**: an exported handle captures the sequence at export
+  time; a re-record does not move it (a CUDA event handle tracks the live
+  object). LMCache exports once, after the single record.
+- **Same-process import works** (resolved via a local registry).
+- **Dead peer = unbounded wait, same as CUDA events.** No event backend
+  has a timeout on the event leg (`cudaEventSynchronize` has none either);
+  peer-death detection belongs to the message-queue timeouts, and
+  `DeviceMessagingFuture.wait()` already documents that its timeout covers
+  only the message, not the device event.
+
+## Possible extension: force-releasing a dead peer's waiters ("poison")
+
+Unlike CUDA events, this design *could* offer an escape hatch, because the
+completion state is plain memory the waiting side can write: on an mq
+timeout, write a huge value into the slot to satisfy every pending and
+future wait, retire the slot from allocation, and fail later imports of
+that `(handle, slot)` pair closed (a live peer still recording there would
+otherwise look complete before its GPU work ran). A prototype was
+implemented and tested, then removed as unused until the mq-timeout wiring
+exists. Two empirically verified requirements for reviving it:
+
+- The release write must be a `cuStreamWriteValue64` on a never-blocked
+  stream — a plain host/DMA memcpy updates the memory but never wakes a
+  pending `cuStreamWaitValue64` (semaphore wait, verified on driver 580).
+- The value must be `INT64_MAX`, not `UINT64_MAX`: the GEQ comparison is
+  cyclic, and `UINT64_MAX` is -1 signed, satisfying nothing.
+
+## Constraints
+
+- Same as KV-cache tensor IPC: exporter and importer must have different
+  PID *values* (namespace isolation is fine); a collision fails at
+  `cudaIpcOpenMemHandle` with error 201.
+- Buffers and imported mappings live for the process lifetime (32 KiB per
+  process/device); slots are not reclaimed.
+- Requires `cuda-python` (`cuda.bindings`), resolved lazily on first use
+  through the package-shared accessor in `platform/cuda/utils.py` (also
+  used by `RawCudaIPCWrapper`), so importing lmcache never requires it.
+- `synchronize_event` host-polls (100 µs) instead of blocking in the
+  driver; a perf consideration for the wiring phase.
+
+## Integration constraints (must be resolved before spec binding)
+
+`DefaultEventIPCBackend.export_event` accepts any interprocess-capable
+device event; this backend only exports its own event objects. Call sites that
+bypass the backend break the moment `CudaDeviceSpec.event_ipc_backend`
+returns it:
+
+- vLLM MP connectors create producer events with
+  `torch_dev.Event(interprocess=True)` (`lmcache_mp_connector.py:510/:586`
+  + `_0180`/`_0201` twins); SGLang and TRT-LLM adapters likewise. They
+  must use `backend.create_event` / `record_event` — the event objects satisfy the
+  `IPCEvent` duck protocol, so `event.wait(stream)` call sites keep
+  working.
+- CacheBlend/qstore server modules return raw `event.ipc_handle()` bytes
+  instead of `export_event(...)`; already outside the event-IPC
+  abstraction (see `event_ipc_abstraction.md` non-goals), must migrate
+  first.
+
+Only `lmcache_driven_transfer.py` (server) and `futures.py` route every
+event operation through the backend today.
+
+## Status
+
+Standalone implementation, not yet bound to
+`CudaDeviceSpec.event_ipc_backend`. Selection/config plumbing is a
+follow-up, alongside the raw KV-wrapper work for hostIPC-free deployment.

--- a/lmcache/v1/platform/cuda/ipc_wrapper.py
+++ b/lmcache/v1/platform/cuda/ipc_wrapper.py
@@ -25,6 +25,7 @@ import torch
 # First Party
 from lmcache import torch_device_type
 from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
+from lmcache.v1.platform.cuda.utils import _cuda
 
 
 class CudaIPCWrapper(DeviceIPCWrapper):
@@ -121,16 +122,9 @@ class RawCudaIPCWrapper(DeviceIPCWrapper):
 
         assert_contiguous(tensor)
 
-        try:
-            # Third Party
-            from cuda.bindings import runtime as cudart
-        except ImportError:
-            # Third Party
-            from cuda import cudart
-
         data_ptr = tensor.data_ptr()
-        err, ipc_handle = cudart.cudaIpcGetMemHandle(data_ptr)
-        if err != cudart.cudaError_t.cudaSuccess:
+        err, ipc_handle = _cuda.runtime.cudaIpcGetMemHandle(data_ptr)
+        if err != _cuda.runtime.cudaError_t.cudaSuccess:
             raise RuntimeError(
                 f"cudaIpcGetMemHandle failed: {err} (ptr=0x{data_ptr:x})"
             )
@@ -156,21 +150,14 @@ class RawCudaIPCWrapper(DeviceIPCWrapper):
         # Third Party
         import cupy
 
-        try:
-            # Third Party
-            from cuda.bindings import runtime as cudart
-        except ImportError:
-            # Third Party
-            from cuda import cudart
-
         device_index = self._get_device_index_from_uuid(self.device_uuid)
 
-        handle = cudart.cudaIpcMemHandle_t()
+        handle = _cuda.runtime.cudaIpcMemHandle_t()
         handle.reserved = self._ipc_handle_reserved
-        err, ptr = cudart.cudaIpcOpenMemHandle(
-            handle, cudart.cudaIpcMemLazyEnablePeerAccess
+        err, ptr = _cuda.runtime.cudaIpcOpenMemHandle(
+            handle, _cuda.runtime.cudaIpcMemLazyEnablePeerAccess
         )
-        if err != cudart.cudaError_t.cudaSuccess:
+        if err != _cuda.runtime.cudaError_t.cudaSuccess:
             raise RuntimeError(f"cudaIpcOpenMemHandle failed: {err}")
 
         # Wrap as a flat ``uint8`` CuPy array, DLPack to torch, then view

--- a/lmcache/v1/platform/cuda/shared_flag_event_ipc.py
+++ b/lmcache/v1/platform/cuda/shared_flag_event_ipc.py
@@ -1,0 +1,589 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU shared-flag event IPC backend (zero host-side sharing).
+
+CUDA interprocess *event* handles (used by ``DefaultEventIPCBackend``)
+only resolve when both processes share a ``/dev/shm`` tmpfs -- on
+Kubernetes that means ``hostIPC: true``. Legacy CUDA IPC *memory* handles
+have no such dependency: they rendezvous inside the kernel driver and work
+across fully isolated containers (only the PID *values* of the two
+processes must differ, same constraint as KV-cache tensor IPC).
+
+This backend implements event semantics on memory handles alone. Each
+process lazily allocates a small shared flag buffer and
+exports it once with ``cudaIpcGetMemHandle``; an event is a
+``(slot, sequence)`` event object against it:
+
+- ``record_event`` -> ``cuStreamWriteValue64(slot, seq)`` on the stream
+- ``wait_event``   -> ``cuStreamWaitValue64(slot, seq, GEQ)`` on the stream
+- ``query_event``  -> 8-byte device read, compared against ``seq``
+- ``export_event`` -> self-contained ``(mem handle, slot offset, seq)``
+  bytes, so the importer needs no registration side channel
+
+Semantics vs ``DefaultEventIPCBackend``: a never-recorded event is
+complete; an exported handle is a snapshot of the sequence at export time
+(LMCache exports once, after the single record); same-process import is
+supported.
+
+Slots are assigned per recording stream, so each slot's values are
+stream-ordered and monotonic, keeping the GEQ wait race-free.
+
+Only events from this backend's ``create_event`` can be exported; call
+sites constructing ``torch_dev.Event(interprocess=True)`` directly must be
+migrated before binding this backend to the device spec. See
+``docs/design/v1/platform/cuda/shared_flag_event_ipc.md``.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass, field
+import ctypes
+import enum
+import struct
+import threading
+import time
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.platform.cuda.utils import (
+    _CHECK_CUDA,
+    _cuda,
+    _raw_stream_handle,
+    _resolve_device_index,
+    cudaStream_t,
+)
+
+logger = init_logger(__name__)
+
+#: 8-byte flag slots per buffer; slot 0 is reserved for the
+#: ``check_event_support`` probe.
+_SLOT_COUNT = 4096
+_SLOT_BYTES = 8
+_PROBE_SLOT_OFFSET = 0
+_FIRST_ALLOCATABLE_SLOT = 1
+
+#: Wire format: version, 64-byte cudaIpcMemHandle, slot offset, sequence.
+_HANDLE_VERSION = 1
+_EXPORT_STRUCT = struct.Struct("!B64sQQ")
+
+#: Sentinels for a local event that has not been recorded yet.
+_UNASSIGNED_SLOT_OFFSET = -1
+_UNRECORDED_SEQ = 0
+
+
+class SharedFlagEventOrigin(enum.Enum):
+    """Which side of the wire a :class:`SharedFlagEvent` was created on."""
+
+    LOCAL = "local"
+    IMPORTED = "imported"
+
+
+@dataclass
+class SharedFlagEvent:
+    """A ``(slot, sequence)`` event object against a shared flag buffer.
+
+    Created by :class:`SharedFlagEventIPCBackend`; callers treat it as
+    opaque.
+
+    Attributes:
+        origin: LOCAL events are recordable; IMPORTED are wait/query only. Just
+            a safeguard so that we don't make stupid mistakes and fail silently.
+        device_index: CUDA device ordinal the event operates on.
+        base_ptr: Flag buffer pointer in this process (0 until the
+            first record assigns a slot).
+        slot_offset: Byte offset of the slot (-1 until the first record).
+        seq: Target sequence number; 0 means never recorded. Flag's value
+            >= than a event's seq number means such event is complete.
+        handle_bytes: The buffer's ``cudaIpcMemHandle`` bytes (empty until
+            the first record).
+    """
+
+    origin: SharedFlagEventOrigin
+    device_index: int
+    base_ptr: int = 0
+    slot_offset: int = _UNASSIGNED_SLOT_OFFSET
+    seq: int = _UNRECORDED_SEQ
+    handle_bytes: bytes = b""
+
+    def wait(self, stream: object | None = None) -> None:
+        """Make ``stream`` wait for this event (``IPCEvent`` duck method).
+
+        Args:
+            stream: Stream that should wait; ``None`` for the current one.
+        """
+        _enqueue_wait(self, stream)
+
+
+@dataclass
+class _SharedFlagBuffer:
+    """Per-device flag buffer owned by one backend instance.
+
+    Attributes:
+        device_index: CUDA device ordinal the buffer lives on.
+        base_ptr: Device pointer of the buffer.
+        handle_bytes: ``cudaIpcMemHandle`` bytes exported at allocation.
+        host_ops_stream: Dedicated non-blocking stream for host-initiated
+            slot reads/writes, so they never synchronize with (possibly
+            blocked) caller streams.
+        lock: Guards the mutable fields below; ``record_event`` holds it
+            through the write enqueue (see there).
+        slot_by_stream: Raw ``cudaStream_t`` -> slot index.
+        next_seq_by_slot: Slot index -> last assigned sequence.
+        next_free_slot: Next never-used slot. Slots are not reclaimed.
+    """
+
+    device_index: int
+    base_ptr: int
+    handle_bytes: bytes
+    host_ops_stream: object
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    slot_by_stream: dict[cudaStream_t, int] = field(default_factory=dict)
+    next_seq_by_slot: dict[int, int] = field(default_factory=dict)
+    next_free_slot: int = _FIRST_ALLOCATABLE_SLOT
+
+    def assign_locked(self, raw_stream: cudaStream_t) -> tuple[int, int]:
+        """Assign the next sequence for ``raw_stream``'s slot.
+
+        Caller must hold :attr:`lock` through the flag write enqueue.
+
+        Args:
+            raw_stream: Raw ``cudaStream_t`` of the recording stream.
+
+        Returns:
+            A ``(slot_offset, seq)`` pair for this record.
+
+        Raises:
+            RuntimeError: If all slots are in use.
+        """
+        slot: int | None = self.slot_by_stream.get(raw_stream)
+        if slot is None:
+            if self.next_free_slot >= _SLOT_COUNT:
+                raise RuntimeError(
+                    f"Flag buffer on cuda:{self.device_index} is "
+                    f"out of slots ({_SLOT_COUNT}); too many distinct "
+                    "recording streams."
+                )
+            slot = self.next_free_slot
+            self.next_free_slot += 1
+            self.slot_by_stream[raw_stream] = slot
+        seq: int = self.next_seq_by_slot.get(slot, _UNRECORDED_SEQ) + 1
+        self.next_seq_by_slot[slot] = seq
+        return slot * _SLOT_BYTES, seq
+
+
+# Flag-buffer base pointers created by this process, by handle bytes:
+# import_event resolves same-process handles locally, since
+# cudaIpcOpenMemHandle cannot open a handle in the exporting process.
+_LOCAL_BUFFERS_BY_HANDLE: dict[bytes, int] = {}
+# Imported buffers by (handle bytes, importer device index); mappings live
+# for the process lifetime (32 KiB each).
+_IMPORTED_BUFFERS_BY_HANDLE: dict[tuple[bytes, int], int] = {}
+_HANDLE_REGISTRY_LOCK = threading.Lock()
+
+
+def _enqueue_wait(event: SharedFlagEvent, stream: object | None) -> None:
+    """Enqueue a ``cuStreamWaitValue64`` for ``event`` on ``stream``.
+
+    Never-recorded events are complete; nothing is enqueued.
+
+    Args:
+        event: The event to wait for.
+        stream: Stream that should wait; ``None`` for the current stream.
+    """
+    if event.seq == _UNRECORDED_SEQ:
+        return
+    raw: cudaStream_t = _raw_stream_handle(stream, event.device_index)
+    with torch.cuda.device(event.device_index):
+        result: tuple[object, ...] = _cuda.driver.cuStreamWaitValue64(
+            _cuda.driver.CUstream(raw),
+            _cuda.driver.CUdeviceptr(event.base_ptr + event.slot_offset),
+            event.seq,
+            _cuda.driver.CUstreamWaitValue_flags.CU_STREAM_WAIT_VALUE_GEQ,
+        )
+    _CHECK_CUDA(result, "cuStreamWaitValue64")
+
+
+class SharedFlagEventIPCBackend:
+    """CUDA event-IPC backend over shared flag slots in IPC-shared memory.
+
+    Implements the
+    :class:`~lmcache.v1.platform.base.event_ipc.EventIPCBackend` protocol
+    with the same observable semantics as ``DefaultEventIPCBackend`` but
+    without CUDA interprocess event handles (which need a shared
+    ``/dev/shm``); see the module docstring.
+
+    Thread safety: all methods may be called from multiple threads.
+    """
+
+    def __init__(self) -> None:
+        self.device_type: str = "cuda"
+        self._lock = threading.Lock()
+        self._buffers: dict[int, _SharedFlagBuffer] = {}
+        self._probed_devices: set[int] = set()
+
+    def check_event_support(self, device: object) -> None:
+        """Validate shared-flag event IPC on ``device`` with a live probe."""
+        device_index: int = _resolve_device_index(device)
+        with self._lock:
+            if device_index in self._probed_devices:
+                return
+
+        # Allocates the buffer and round-trips a write/wait pair through the
+        # reserved probe slot. Probes with real calls on purpose: the
+        # ``CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS`` attribute reports 0
+        # on drivers where the v2 memops (default since CUDA 12) work.
+        try:
+            buffer: _SharedFlagBuffer = self._get_buffer(device_index)
+            probe_ptr: int = buffer.base_ptr + _PROBE_SLOT_OFFSET
+            stream_hdl: cudaStream_t = _raw_stream_handle(
+                buffer.host_ops_stream, device_index
+            )
+            with torch.cuda.device(device_index):
+                _CHECK_CUDA(
+                    _cuda.driver.cuStreamWriteValue64(
+                        _cuda.driver.CUstream(stream_hdl),
+                        _cuda.driver.CUdeviceptr(probe_ptr),
+                        1,
+                        _cuda.driver.CUstreamWriteValue_flags.CU_STREAM_WRITE_VALUE_DEFAULT,
+                    ),
+                    "cuStreamWriteValue64 (probe)",
+                )
+                _CHECK_CUDA(
+                    _cuda.driver.cuStreamWaitValue64(
+                        _cuda.driver.CUstream(stream_hdl),
+                        _cuda.driver.CUdeviceptr(probe_ptr),
+                        1,
+                        _cuda.driver.CUstreamWaitValue_flags.CU_STREAM_WAIT_VALUE_GEQ,
+                    ),
+                    "cuStreamWaitValue64 (probe)",
+                )
+                _CHECK_CUDA(
+                    _cuda.runtime.cudaStreamSynchronize(buffer.host_ops_stream),
+                    "cudaStreamSynchronize (probe)",
+                )
+        except Exception as e:
+            raise RuntimeError(
+                f"Device backend '{self.device_type}' does not support "
+                f"shared-flag event IPC on device {device_index}: {e}"
+            ) from e
+        with self._lock:
+            self._probed_devices.add(device_index)
+
+    def create_event(self, device: object) -> object:
+        """Create a new shared-flag event on ``device``."""
+        # Slot/flag binding is deferred to the recording time when stream is known.
+        return SharedFlagEvent(
+            origin=SharedFlagEventOrigin.LOCAL,
+            device_index=_resolve_device_index(device),
+        )
+
+    def record_event(self, event: object, stream: object) -> None:
+        """Record ``event`` on ``stream``.
+
+        Assigns the stream's slot, bumps its sequence, and enqueues the
+        flag write so the slot reaches that value exactly when all
+        prior work on ``stream`` has completed.
+
+        Args:
+            event: A local :class:`SharedFlagEvent`.
+            stream: Recording stream; ``None`` for the current stream.
+
+        Raises:
+            RuntimeError: If ``event`` was imported (imported events are
+                wait/query only) or the enqueue fails.
+        """
+        if not isinstance(event, SharedFlagEvent):
+            raise RuntimeError(
+                f"record_event expected a SharedFlagEvent, got {type(event)!r}"
+            )
+        if event.origin is not SharedFlagEventOrigin.LOCAL:
+            raise RuntimeError(
+                "Imported shared-flag events cannot be recorded; only the "
+                "exporting process records."
+            )
+        buffer: _SharedFlagBuffer = self._get_buffer(event.device_index)
+        stream_hdl: cudaStream_t = _raw_stream_handle(stream, event.device_index)
+        # Lock held through the enqueue: a second thread landing seq N+1's
+        # write before this thread's seq N would leave the slot at N and
+        # strand the N+1 event's waiters.
+        with buffer.lock:
+            slot_offset: int
+            seq: int
+            slot_offset, seq = buffer.assign_locked(stream_hdl)
+            event.base_ptr = buffer.base_ptr
+            event.handle_bytes = buffer.handle_bytes
+            event.slot_offset = slot_offset
+            event.seq = seq
+            with torch.cuda.device(event.device_index):
+                _CHECK_CUDA(
+                    _cuda.driver.cuStreamWriteValue64(
+                        _cuda.driver.CUstream(stream_hdl),
+                        _cuda.driver.CUdeviceptr(event.base_ptr + event.slot_offset),
+                        event.seq,
+                        _cuda.driver.CUstreamWriteValue_flags.CU_STREAM_WRITE_VALUE_DEFAULT,
+                    ),
+                    "cuStreamWriteValue64 (record)",
+                )
+
+    def export_event(self, event: object, device: object) -> bytes:
+        """Serialize ``event`` for import by another process.
+
+        Args:
+            event: A :class:`SharedFlagEvent` to export.
+            device: Device that owns the event (unused; part of the
+                protocol signature).
+
+        Returns:
+            The packed handle bytes (snapshot of the current sequence).
+
+        Raises:
+            RuntimeError: If ``event`` is not a :class:`SharedFlagEvent`.
+        """
+        if not isinstance(event, SharedFlagEvent):
+            raise RuntimeError(
+                f"export_event expected a SharedFlagEvent, got {type(event)!r}"
+            )
+        handle_bytes: bytes = event.handle_bytes
+        slot_offset: int = event.slot_offset
+        if event.seq == _UNRECORDED_SEQ:
+            # Exports as "already complete"; the wire format still needs a
+            # valid handle and offset.
+            handle_bytes = self._get_buffer(event.device_index).handle_bytes
+            slot_offset = _PROBE_SLOT_OFFSET
+        return _EXPORT_STRUCT.pack(
+            _HANDLE_VERSION, handle_bytes, slot_offset, event.seq
+        )
+
+    def import_event(self, handle: bytes, device: object) -> object:
+        """Import a serialized shared-flag event handle on ``device``.
+
+        Opens the exporter's flag buffer on first use and caches the
+        mapping for the process lifetime; same-process handles resolve to
+        the local buffer.
+
+        Args:
+            handle: Bytes produced by :meth:`export_event`.
+            device: Device on which to import the event.
+
+        Returns:
+            An imported :class:`SharedFlagEvent` (wait/query only).
+
+        Raises:
+            RuntimeError: If the payload is malformed, carries an
+                out-of-range slot offset, or the flag buffer cannot be
+                opened.
+        """
+        version: int
+        handle_bytes: bytes
+        slot_offset: int
+        seq: int
+        try:
+            version, handle_bytes, slot_offset, seq = _EXPORT_STRUCT.unpack(handle)
+        except struct.error as e:
+            raise RuntimeError(
+                f"Malformed shared-flag event handle ({len(handle)} bytes): {e}"
+            ) from e
+        if version != _HANDLE_VERSION:
+            raise RuntimeError(
+                f"Unsupported shared-flag event handle version {version}; "
+                f"this process supports version {_HANDLE_VERSION}."
+            )
+        if (
+            slot_offset < 0
+            or slot_offset >= _SLOT_COUNT * _SLOT_BYTES
+            or slot_offset % _SLOT_BYTES != 0
+        ):
+            raise RuntimeError(
+                f"Shared-flag event handle carries an invalid slot offset "
+                f"{slot_offset}; expected an {_SLOT_BYTES}-byte-aligned "
+                f"offset below {_SLOT_COUNT * _SLOT_BYTES}."
+            )
+        device_index = _resolve_device_index(device)
+
+        # Lock held across the open so two threads importing the same new
+        # handle cannot race it (opening is rare; imports hit the cache).
+        base_ptr: int
+        with _HANDLE_REGISTRY_LOCK:
+            local_base: int | None = _LOCAL_BUFFERS_BY_HANDLE.get(handle_bytes)
+            if local_base is not None:
+                base_ptr = local_base
+            else:
+                cached: int | None = _IMPORTED_BUFFERS_BY_HANDLE.get(
+                    (handle_bytes, device_index)
+                )
+                if cached is not None:
+                    base_ptr = cached
+                else:
+                    ipc_handle = _cuda.runtime.cudaIpcMemHandle_t()
+                    ipc_handle.reserved = handle_bytes
+                    with torch.cuda.device(device_index):
+                        open_result = _cuda.runtime.cudaIpcOpenMemHandle(
+                            ipc_handle,
+                            _cuda.runtime.cudaIpcMemLazyEnablePeerAccess,
+                        )
+                        _CHECK_CUDA(open_result, "cudaIpcOpenMemHandle (flag buffer)")
+                        _err, opened_ptr = open_result
+                        base_ptr = int(opened_ptr)
+                    _IMPORTED_BUFFERS_BY_HANDLE[(handle_bytes, device_index)] = base_ptr
+
+        return SharedFlagEvent(
+            origin=SharedFlagEventOrigin.IMPORTED,
+            device_index=device_index,
+            base_ptr=base_ptr,
+            slot_offset=slot_offset,
+            seq=seq,
+            handle_bytes=handle_bytes,
+        )
+
+    def wait_event(self, event: object, stream: object) -> None:
+        """Make ``stream`` wait for ``event``.
+
+        Args:
+            event: A local or imported :class:`SharedFlagEvent`.
+            stream: Stream that should wait; ``None`` for the current one.
+
+        Raises:
+            RuntimeError: If ``event`` is not a :class:`SharedFlagEvent` or
+                the enqueue fails.
+        """
+        if not isinstance(event, SharedFlagEvent):
+            raise RuntimeError(
+                f"wait_event expected a SharedFlagEvent, got {type(event)!r}"
+            )
+        _enqueue_wait(event, stream)
+
+    def query_event(self, event: object) -> bool:
+        """Return whether ``event`` has completed.
+
+        Args:
+            event: A local or imported :class:`SharedFlagEvent`.
+
+        Returns:
+            ``True`` when the slot has reached the event's sequence (or
+            the event was never recorded); otherwise ``False``.
+
+        Raises:
+            RuntimeError: If ``event`` is not a :class:`SharedFlagEvent` or
+                the device read fails.
+        """
+        if not isinstance(event, SharedFlagEvent):
+            raise RuntimeError(
+                f"query_event expected a SharedFlagEvent, got {type(event)!r}"
+            )
+        if event.seq == _UNRECORDED_SEQ:
+            return True
+        return self._read_slot(event) >= event.seq
+
+    def synchronize_event(self, event: object, device: object) -> None:
+        """Block the host until ``event`` completes (poll-based).
+
+        Blocks indefinitely while the record point is unreached, like a
+        CUDA event synchronize.
+
+        Args:
+            event: A local or imported :class:`SharedFlagEvent`.
+            device: Device that owns the event (unused; part of the
+                protocol signature).
+
+        Raises:
+            RuntimeError: If ``event`` is not a :class:`SharedFlagEvent` or
+                a device read fails.
+        """
+        while not self.query_event(event):
+            time.sleep(0.0001)
+
+    def _get_buffer(self, device_index: int) -> _SharedFlagBuffer:
+        """Return the flag buffer for ``device_index``, allocating it
+        on first use.
+
+        Args:
+            device_index: CUDA device ordinal.
+
+        Returns:
+            The per-device :class:`_SharedFlagBuffer` of this backend.
+
+        Raises:
+            RuntimeError: If allocation or IPC export fails.
+        """
+        # Lock-free fast path: query/synchronize poll this on every
+        # iteration, and buffers are never removed.
+        if (buffer := self._buffers.get(device_index)) is not None:
+            return buffer
+        with self._lock:
+            if (buffer := self._buffers.get(device_index)) is not None:
+                return buffer
+            nbytes: int = _SLOT_COUNT * _SLOT_BYTES
+            with torch.cuda.device(device_index):
+                malloc_result = _cuda.runtime.cudaMalloc(nbytes)
+                _CHECK_CUDA(malloc_result, "cudaMalloc")
+                _err, base = malloc_result
+                stream_result = _cuda.runtime.cudaStreamCreateWithFlags(
+                    _cuda.runtime.cudaStreamNonBlocking
+                )
+                _CHECK_CUDA(stream_result, "cudaStreamCreateWithFlags")
+                _err, host_stream = stream_result
+                # Zero the slots on the buffer's own stream, never via a
+                # device-wide sync: this runs lazily inside the first
+                # record_event, and draining the caller's recording stream
+                # here would break the record's ordering guarantee.
+                _CHECK_CUDA(
+                    _cuda.runtime.cudaMemsetAsync(base, 0, nbytes, host_stream),
+                    "cudaMemsetAsync",
+                )
+                _CHECK_CUDA(
+                    _cuda.runtime.cudaStreamSynchronize(host_stream),
+                    "cudaStreamSynchronize (flag buffer init)",
+                )
+                handle_result = _cuda.runtime.cudaIpcGetMemHandle(base)
+                _CHECK_CUDA(handle_result, "cudaIpcGetMemHandle")
+                _err, handle = handle_result
+            buffer = _SharedFlagBuffer(
+                device_index=device_index,
+                base_ptr=int(base),
+                handle_bytes=bytes(handle.reserved),
+                host_ops_stream=host_stream,
+            )
+            with _HANDLE_REGISTRY_LOCK:
+                _LOCAL_BUFFERS_BY_HANDLE[buffer.handle_bytes] = buffer.base_ptr
+            self._buffers[device_index] = buffer
+            logger.info(
+                "Allocated shared-flag event buffer on cuda:%d (%d slots)",
+                device_index,
+                _SLOT_COUNT,
+            )
+            return buffer
+
+    def _read_slot(self, event: SharedFlagEvent) -> int:
+        """Read the current 64-bit value of ``event``'s slot.
+
+        Args:
+            event: A recorded or imported event.
+
+        Returns:
+            The slot's current value.
+
+        Raises:
+            RuntimeError: If the device read fails.
+        """
+        host_stream: object = self._get_buffer(event.device_index).host_ops_stream
+        value: ctypes.c_uint64 = ctypes.c_uint64(0)
+        with torch.cuda.device(event.device_index):
+            _CHECK_CUDA(
+                _cuda.runtime.cudaMemcpyAsync(
+                    ctypes.addressof(value),
+                    event.base_ptr + event.slot_offset,
+                    _SLOT_BYTES,
+                    _cuda.runtime.cudaMemcpyKind.cudaMemcpyDeviceToHost,
+                    host_stream,
+                ),
+                "cudaMemcpyAsync (flag read)",
+            )
+            _CHECK_CUDA(
+                _cuda.runtime.cudaStreamSynchronize(host_stream),
+                "cudaStreamSynchronize (flag read)",
+            )
+        return value.value

--- a/lmcache/v1/platform/cuda/utils.py
+++ b/lmcache/v1/platform/cuda/utils.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared CUDA helpers for the cuda platform package.
+
+Holds the lazy cuda-python bindings accessor and small conversion/
+validation helpers used by the IPC modules. ``cuda-python`` is not a
+declared lmcache dependency and the platform package is imported eagerly
+by device discovery, so the bindings must not be imported at module load;
+the first attribute access imports them.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from functools import lru_cache
+from types import ModuleType
+from typing import TypeAlias
+
+# Third Party
+import torch
+
+#: Raw ``cudaStream_t`` value (the driver-level stream id), as carried in
+#: Python ints -- e.g. ``torch.cuda.Stream.cuda_stream``.
+cudaStream_t: TypeAlias = int
+
+
+@lru_cache(maxsize=1)
+def _import_cuda_bindings() -> tuple[ModuleType, ModuleType]:
+    """Import and cache the ``(driver, runtime)`` CUDA bindings."""
+    try:
+        # Third Party
+        from cuda.bindings import driver, runtime
+    except ImportError:
+        # Third Party
+        from cuda import cuda as driver
+        from cuda import cudart as runtime
+    return driver, runtime
+
+
+class _CudaBindings:
+    """Lazy accessor; see the module docstring."""
+
+    @property
+    def driver(self) -> ModuleType:
+        """The CUDA driver-API bindings module."""
+        return _import_cuda_bindings()[0]
+
+    @property
+    def runtime(self) -> ModuleType:
+        """The CUDA runtime-API bindings module."""
+        return _import_cuda_bindings()[1]
+
+
+#: Shared lazy accessor for modules of the cuda platform package.
+_cuda = _CudaBindings()
+
+
+def _CHECK_CUDA(result: tuple[object, ...], what: str) -> None:
+    """Validate the ``(err, *payload)`` tuple of a cuda-python call.
+
+    Args:
+        result: The tuple returned by the call.
+        what: Operation name for the error message.
+
+    Raises:
+        RuntimeError: If the call did not return success (0).
+    """
+    if result[0] != 0:
+        raise RuntimeError(f"{what} failed: {result[0]}")
+
+
+def _resolve_device_index(device: object) -> int:
+    """Resolve a CUDA device ordinal from a device-like object.
+
+    Args:
+        device: An integer ordinal, a device string (``"cuda:0"``), or a
+            ``torch.device``-like object with an ``index`` attribute.
+
+    Returns:
+        The CUDA device ordinal; the current device when the object
+        carries no explicit index (e.g. ``torch.device("cuda")``).
+    """
+    if isinstance(device, int):
+        return device
+    index: int | None
+    if isinstance(device, str):
+        index = torch.device(device).index
+    else:
+        attr: object = getattr(device, "index", None)
+        index = attr if isinstance(attr, int) else None
+    if index is None:
+        return torch.cuda.current_device()
+    return int(index)
+
+
+def _raw_stream_handle(stream: object, device_index: int) -> cudaStream_t:
+    """Resolve the raw ``cudaStream_t`` value from a stream-like object.
+
+    Args:
+        stream: A ``torch.cuda.Stream``-like object (has ``cuda_stream``),
+            a raw integer handle, a cuda-bindings ``cudaStream_t``, or
+            ``None`` for the current stream of ``device_index``.
+        device_index: Device whose current stream is used for ``None``.
+
+    Returns:
+        The raw stream handle as an integer.
+
+    Raises:
+        RuntimeError: If the object cannot be resolved to a stream handle.
+    """
+    if stream is None:
+        return torch.cuda.current_stream(device_index).cuda_stream
+    raw: object = getattr(stream, "cuda_stream", None)
+    if isinstance(raw, int):
+        return raw
+    try:
+        return int(stream)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        raise RuntimeError(
+            f"Cannot resolve a CUDA stream handle from {type(stream)!r}; "
+            "expected a torch.cuda.Stream-like object, an integer handle, "
+            "or None."
+        ) from None

--- a/tests/v1/platform/test_shared_flag_event_ipc.py
+++ b/tests/v1/platform/test_shared_flag_event_ipc.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the GPU shared-flag event IPC backend.
+
+Parity cases are parametrized over both backends; shared-flag-only cases
+cover what CUDA events cannot do (same-process import).
+"""
+
+# Standard
+from multiprocessing import get_context
+from multiprocessing.connection import Connection
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.platform.base.event_ipc import (
+    DefaultEventIPCBackend,
+    EventIPCBackend,
+)
+from lmcache.v1.platform.cuda.shared_flag_event_ipc import (
+    SharedFlagEventIPCBackend,
+)
+
+pytestmark = [
+    pytest.mark.cuda,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device"),
+]
+
+DEVICE = "cuda:0"
+
+#: Matmul iterations that keep an H100/H200-class GPU busy for hundreds of
+#: milliseconds; slower GPUs only get slower, which these tests tolerate.
+_BUSY_ITERS_SHORT = 200
+_BUSY_ITERS_LONG = 600
+
+
+def _make_backend(kind: str) -> EventIPCBackend:
+    """Construct a backend by parametrization key."""
+    if kind == "shared_flag":
+        return SharedFlagEventIPCBackend()
+    return DefaultEventIPCBackend()
+
+
+def _enqueue_busy_work(stream: torch.cuda.Stream, iters: int) -> torch.Tensor:
+    """Enqueue ``iters`` chained matmuls on ``stream``.
+
+    Tensors are allocated inside the stream context (no cross-stream
+    allocator hazards). Keep the returned tensor alive until sync.
+    """
+    with torch.cuda.stream(stream):
+        a = torch.randn(4096, 4096, device=DEVICE)
+        b = torch.randn(4096, 4096, device=DEVICE)
+        for _ in range(iters):
+            a = a @ b
+            a = a / a.norm()
+    return a
+
+
+def test_shared_flag_backend_satisfies_protocol() -> None:
+    assert isinstance(SharedFlagEventIPCBackend(), EventIPCBackend)
+
+
+def test_check_event_support_passes_on_cuda() -> None:
+    backend = SharedFlagEventIPCBackend()
+    backend.check_event_support(torch.device(DEVICE))  # must not raise
+    # Second call exercises the probed-device cache.
+    backend.check_event_support(torch.device(DEVICE))
+
+
+@pytest.mark.parametrize("kind", ["default", "shared_flag"])
+def test_unrecorded_event_is_complete(kind: str) -> None:
+    """A never-recorded event queries True and never blocks (both backends)."""
+    backend = _make_backend(kind)
+    device = torch.device(DEVICE)
+    event = backend.create_event(device)
+    assert backend.query_event(event) is True
+    backend.synchronize_event(event, device)  # must return immediately
+    stream = torch.cuda.Stream()
+    backend.wait_event(event, stream)  # must be a no-op enqueue
+    stream.synchronize()
+
+
+def test_query_transitions_with_recording_stream() -> None:
+    """query_event flips False -> True when the recording stream drains."""
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    stream = torch.cuda.Stream()
+    keepalive = _enqueue_busy_work(stream, _BUSY_ITERS_SHORT)
+
+    event = backend.create_event(device)
+    backend.record_event(event, stream)
+    assert backend.query_event(event) is False
+
+    stream.synchronize()
+    assert backend.query_event(event) is True
+    del keepalive
+
+
+def test_same_process_export_import_orders_consumer_stream() -> None:
+    """Imported event gates a consumer stream behind the producer's work
+    (shared-flag-only: CUDA event handles cannot be self-imported).
+    """
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    producer = torch.cuda.Stream()
+    consumer = torch.cuda.Stream()
+
+    payload = torch.zeros(1, device=DEVICE, dtype=torch.int64)
+    keepalive = _enqueue_busy_work(producer, _BUSY_ITERS_SHORT)
+    with torch.cuda.stream(producer):
+        payload.fill_(42)
+    event = backend.create_event(device)
+    backend.record_event(event, producer)
+
+    imported = backend.import_event(backend.export_event(event, device), device)
+    assert backend.query_event(imported) is False
+
+    with torch.cuda.stream(consumer):
+        backend.wait_event(imported, consumer)
+        observed = payload.clone()
+    consumer.synchronize()
+
+    assert observed.item() == 42
+    assert backend.query_event(imported) is True
+    assert producer.query() is True  # consumer only finished after producer
+    del keepalive
+
+
+def test_reexport_after_rerecord_uses_higher_sequence() -> None:
+    """Re-recording produces a later completion point; both imports drain."""
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    stream = torch.cuda.Stream()
+
+    event = backend.create_event(device)
+    backend.record_event(event, stream)
+    first = backend.export_event(event, device)
+    backend.record_event(event, stream)
+    second = backend.export_event(event, device)
+    assert first != second
+
+    stream.synchronize()
+    assert backend.query_event(backend.import_event(first, device)) is True
+    assert backend.query_event(backend.import_event(second, device)) is True
+
+
+def test_events_on_different_streams_are_independent() -> None:
+    """A busy stream's pending event must not delay another stream's event."""
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    busy = torch.cuda.Stream()
+    idle = torch.cuda.Stream()
+
+    keepalive = _enqueue_busy_work(busy, _BUSY_ITERS_SHORT)
+    busy_event = backend.create_event(device)
+    backend.record_event(busy_event, busy)
+
+    idle_event = backend.create_event(device)
+    backend.record_event(idle_event, idle)
+    backend.synchronize_event(idle_event, device)  # must not block on `busy`
+
+    assert backend.query_event(busy_event) is False
+    busy.synchronize()
+    assert backend.query_event(busy_event) is True
+    del keepalive
+
+
+def test_event_object_satisfies_ipc_event_duck_protocol() -> None:
+    """Events expose wait(stream) so they fit IPCEvent call sites."""
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    stream = torch.cuda.Stream()
+
+    event = backend.create_event(device)
+    backend.record_event(event, stream)
+    waiter = torch.cuda.Stream()
+    event.wait(waiter)  # type: ignore[attr-defined]
+    waiter.synchronize()
+
+
+def test_import_rejects_malformed_handles() -> None:
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    with pytest.raises(RuntimeError, match="Malformed shared-flag event handle"):
+        backend.import_event(b"junk", device)
+
+
+def test_import_rejects_unsupported_version_and_bad_offset() -> None:
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    stream = torch.cuda.Stream()
+    event = backend.create_event(device)
+    backend.record_event(event, stream)
+    exported = backend.export_event(event, device)
+
+    wrong_version = bytes([99]) + exported[1:]
+    with pytest.raises(RuntimeError, match="version 99"):
+        backend.import_event(wrong_version, device)
+
+    # Slot offset lives in bytes 65..72 (big-endian) of the payload.
+    huge_offset = exported[:65] + (1 << 20).to_bytes(8, "big") + exported[73:]
+    with pytest.raises(RuntimeError, match="invalid slot offset"):
+        backend.import_event(huge_offset, device)
+
+
+def test_stale_slot_value_does_not_satisfy_next_sequence() -> None:
+    """A drained earlier event's residue in the shared slot must not
+    complete a later event (guards against a GEQ off-by-one).
+    """
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    stream = torch.cuda.Stream()
+
+    first = backend.create_event(device)
+    backend.record_event(first, stream)
+    stream.synchronize()  # slot now holds first's sequence
+
+    keepalive = _enqueue_busy_work(stream, _BUSY_ITERS_SHORT)
+    second = backend.create_event(device)
+    backend.record_event(second, stream)
+    imported = backend.import_event(backend.export_event(second, device), device)
+    assert backend.query_event(imported) is False
+
+    stream.synchronize()
+    assert backend.query_event(imported) is True
+    del keepalive
+
+
+def test_record_rejects_imported_event() -> None:
+    backend = SharedFlagEventIPCBackend()
+    device = torch.device(DEVICE)
+    stream = torch.cuda.Stream()
+    event = backend.create_event(device)
+    backend.record_event(event, stream)
+    imported = backend.import_event(backend.export_event(event, device), device)
+    with pytest.raises(RuntimeError, match="cannot be recorded"):
+        backend.record_event(imported, stream)
+
+
+def _cross_process_consumer(kind: str, conn: Connection) -> None:
+    """Child: import the received handle, synchronize on it, and report
+    (query at import, blocked duration, query after).
+    """
+    torch.cuda.init()
+    torch.cuda.set_device(0)
+    backend = _make_backend(kind)
+    device = torch.device(DEVICE)
+    conn.send("ready")
+
+    handle = conn.recv()
+    event = backend.import_event(handle, device)
+    query_at_import = backend.query_event(event)
+    start = time.monotonic()
+    backend.synchronize_event(event, device)
+    blocked_for = time.monotonic() - start
+    query_after = backend.query_event(event)
+    conn.send((query_at_import, blocked_for, query_after))
+
+
+@pytest.mark.parametrize("kind", ["default", "shared_flag"])
+def test_cross_process_synchronize_blocks_until_record_point(
+    kind: str,
+) -> None:
+    """A separate process blocks on the imported event until the producer's
+    stream reaches the record point (same host, so the default backend
+    works and serves as the parity reference).
+    """
+    ctx = get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe()
+    child = ctx.Process(target=_cross_process_consumer, args=(kind, child_conn))
+    child.start()
+    try:
+        assert parent_conn.recv() == "ready"
+
+        backend = _make_backend(kind)
+        device = torch.device(DEVICE)
+        stream = torch.cuda.Stream()
+        keepalive = _enqueue_busy_work(stream, _BUSY_ITERS_LONG)
+        event = backend.create_event(device)
+        backend.record_event(event, stream)
+        busy_started = time.monotonic()
+        parent_conn.send(backend.export_event(event, device))
+
+        query_at_import, blocked_for, query_after = parent_conn.recv()
+        stream.synchronize()
+        busy_duration = time.monotonic() - busy_started
+
+        assert query_at_import is False
+        assert query_after is True
+        # The child must have been genuinely blocked on the GPU work, and
+        # released no later than the producer stream drained.
+        assert blocked_for >= 0.05
+        assert blocked_for <= busy_duration + 1.0
+        del keepalive
+    finally:
+        child.join(timeout=60)
+        if child.is_alive():
+            child.kill()
+            child.join()
+    assert child.exitcode == 0


### PR DESCRIPTION
## Motivation

Deploying MP mode on Kubernetes currently requires `hostIPC: true` on both the vLLM pod and the LMCache DaemonSet. We traced the actual dependency: CUDA interprocess **event** handles (`cudaIpcGetEventHandle`/`cudaIpcOpenEventHandle`, used by `DefaultEventIPCBackend`) only resolve when both processes share a `/dev/shm` tmpfs — that is the hostIPC side effect the `lmcache_driven` path depends on for every STORE/RETRIEVE. CUDA IPC **memory** handles have no such dependency: they rendezvous inside the kernel driver and work across fully isolated containers.

## What this adds

`SharedFlagEventIPCBackend` — an `EventIPCBackend` implementation built on memory handles alone:

- Each process lazily allocates a 32 KiB flag buffer per GPU (4096 × 8-byte slots) and exports it once with `cudaIpcGetMemHandle`.
- An event is a `(slot, sequence)` pair: `record_event` = `cuStreamWriteValue64(slot, seq)` on the recording stream; `wait_event` = `cuStreamWaitValue64(slot, seq, GEQ)`; query/synchronize = 8-byte device read.
- Exported handles are self-contained (mem handle + slot offset + sequence, 81 bytes), so they ride the existing opaque-bytes wire field with no registration side channel.
- Slots are per recording stream, keeping slot values monotonic and the GEQ wait race-free.

Also consolidates shared CUDA plumbing into `platform/cuda/utils.py` (lazy cuda-python bindings accessor + small helpers) and switches `ipc_wrapper.py` to it, removing duplicated try/except import blocks (first commit).

## Verification

- 15 tests in `tests/v1/platform/test_shared_flag_event_ipc.py`, parity-parametrized against `DefaultEventIPCBackend` where CUDA events also work (never-recorded semantics, cross-process blocking-until-record-point), plus shared-flag-only coverage (same-process import ordering, stream independence, stale-slot/sequence discipline, malformed/version/offset handle rejection).
- Verified end-to-end across two fully isolated docker containers (separate IPC + PID namespaces, no shared /dev/shm): imported event queried incomplete while the producer stream was busy, a gated read blocked until the record point and observed only the post-record data.
- `pre-commit` (ruff, mypy, isort, codespell) clean; full `tests/v1/platform/` suite passes (134 passed, 6 skipped).

## Scope / status

Standalone: **not yet bound** to `CudaDeviceSpec.event_ipc_backend`. The design doc (`docs/design/v1/platform/cuda/shared_flag_event_ipc.md`) records the empirically load-bearing details (driver 580 / CUDA 13), the deliberate semantic differences vs CUDA events, and the integration constraints that must be resolved before spec binding (connector call sites constructing `torch_dev.Event(interprocess=True)` directly must route through the backend). Selection/config plumbing is a follow-up alongside the raw KV-wrapper work for hostIPC-free deployment.