### PR TITLE
[CLI] make max output length tunable for the long-doc-permutator workload

### DIFF
--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -423,6 +423,7 @@ chunk-level cache lookup and eviction.
 | `num_permutations` | `--ldp-num-permutations` | 10 | Distinct permutations to send (capped at `N!`) |
 | `vocab_size` | (none — hardcoded in factory) | 8000 | Number of distinct single-token words contexts are sampled from |
 | `num_inflight_requests` | `--ldp-num-inflight-requests` | 1 | Max concurrent in-flight requests |
+| `max_output_length` | `--ldp-max-output-length` | 128 | Max tokens generated per request; `1` measures prefill alone |
 
 **Stress axes** (each config field tunes one):
 

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -325,6 +325,11 @@ dispatched with semaphore-controlled concurrency.
    * - ``--ldp-num-inflight-requests``
      - 1
      - Maximum concurrent in-flight requests.
+   * - ``--ldp-max-output-length``
+     - 128
+     - Maximum tokens to generate per permutation request. Use ``1`` to
+       measure prefill alone; combine larger values with ``--ignore-eos``
+       for a reproducible decode phase.
 
 **Example:**
 

--- a/lmcache/cli/commands/bench/engine_bench/command.py
+++ b/lmcache/cli/commands/bench/engine_bench/command.py
@@ -199,6 +199,14 @@ def add_engine_arguments(parser: argparse.ArgumentParser) -> None:
         default=1,
         help="Max concurrent in-flight requests (default: 1).",
     )
+    ldp_group.add_argument(
+        "--ldp-max-output-length",
+        type=int,
+        default=128,
+        help="Max tokens to generate per permutation request (default: 128). "
+        "Use 1 to measure prefill alone; combine larger values with "
+        "--ignore-eos for a reproducible decode phase.",
+    )
 
     # --- Long-doc-qa workload args ---
     group = parser.add_argument_group("long-doc-qa workload options")

--- a/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
+++ b/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
@@ -241,6 +241,15 @@ ALL_ITEMS: list[ConfigItem] = [
         condition=_workload_is("long-doc-permutator"),
         phase=PHASE_WORKLOAD,
     ),
+    ConfigItem(
+        key="ldp_max_output_length",
+        display_name="Max output length (tokens)",
+        description="Max tokens per request. Use 1 to measure prefill alone.",
+        input_type="int",
+        default=128,
+        condition=_workload_is("long-doc-permutator"),
+        phase=PHASE_WORKLOAD,
+    ),
     # ── Phase 3: long-doc-qa ──────────────────────────────────────────
     ConfigItem(
         key="ldqa_document_length",

--- a/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/__init__.py
@@ -63,19 +63,21 @@ _WORKLOAD_NAMES = (
     "random-prefill",
 )
 
-# Workloads that expose a user-configurable max output length, via a
-# ``max_output_length`` arg (``--ldqa-max-output-length`` / ``--mrc-output-length``).
+# Workloads that expose a user-configurable max output length, each via its own
+# flag (``--ldqa-max-output-length`` / ``--mrc-output-length`` /
+# ``--ldp-max-output-length``).
 _WORKLOADS_WITH_MAX_OUTPUT_LENGTH: frozenset[str] = frozenset(
-    {"long-doc-qa", "multi-round-chat"}
+    {"long-doc-permutator", "long-doc-qa", "multi-round-chat"}
 )
 
 
 def validate_max_output_length_supported(workload: str) -> None:
     """Validate that a max output length can be specified for ``workload``.
 
-    Only workloads with a max-output-length parameter (``long-doc-qa``,
-    ``multi-round-chat``) support setting it; every other workload fixes its
-    generation length internally, so requesting one is rejected.
+    Only workloads with a max-output-length parameter (``long-doc-permutator``,
+    ``long-doc-qa``, ``multi-round-chat``) support setting it; every other
+    workload fixes its generation length internally, so requesting one is
+    rejected.
 
     Args:
         workload: The selected workload name (``EngineBenchConfig.workload``).
@@ -126,6 +128,7 @@ def create_workload(
             num_permutations=args.ldp_num_permutations,
             vocab_size=8000,
             num_inflight_requests=args.ldp_num_inflight_requests,
+            max_output_length=args.ldp_max_output_length,
         )
         return LongDocPermutatorWorkload(
             config=ldp_workload_config,

--- a/lmcache/cli/commands/bench/engine_bench/workloads/long_doc_permutator.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/long_doc_permutator.py
@@ -15,6 +15,10 @@ Stress axes (controlled by config):
     4. Prefix Domination           -> system_prompt_length
     5. Concurrency                 -> num_inflight_requests
 
+``max_output_length`` sets how much decode follows each prefill: 1 makes the
+run a pure prefill/TTFT measurement, while larger values also exercise the
+decode phase (combine with ``--ignore-eos`` to make its length reproducible).
+
 Context and system-prompt lengths are exact token counts, not estimates:
 all synthetic text is built from words that encode to exactly one token
 under the model's own tokenizer (see
@@ -54,6 +58,7 @@ class LongDocPermutatorConfig:
     num_permutations: int = 10
     vocab_size: int = 8000
     num_inflight_requests: int = 1
+    max_output_length: int = 128
 
     def __post_init__(self) -> None:
         if self.num_contexts < 1:
@@ -72,6 +77,10 @@ class LongDocPermutatorConfig:
             raise ValueError(
                 f"num_inflight_requests must be >= 1, got {self.num_inflight_requests}"
             )
+        if self.max_output_length < 1:
+            raise ValueError(
+                f"max_output_length must be >= 1, got {self.max_output_length}"
+            )
 
     @classmethod
     def resolve(
@@ -82,6 +91,7 @@ class LongDocPermutatorConfig:
         num_permutations: int = 10,
         vocab_size: int = 8000,
         num_inflight_requests: int = 1,
+        max_output_length: int = 128,
     ) -> "LongDocPermutatorConfig":
         """Create a config directly from the provided parameters.
 
@@ -96,6 +106,9 @@ class LongDocPermutatorConfig:
                 context content from.  Smaller values increase chunk hash
                 collision risk.
             num_inflight_requests: Max concurrent in-flight requests.
+            max_output_length: Max tokens to generate per benchmark request.
+                Use 1 to measure prefill alone; combine larger values with
+                ``--ignore-eos`` for a reproducible decode phase.
 
         Returns:
             A fully-resolved LongDocPermutatorConfig.
@@ -107,6 +120,7 @@ class LongDocPermutatorConfig:
             num_permutations=num_permutations,
             vocab_size=vocab_size,
             num_inflight_requests=num_inflight_requests,
+            max_output_length=max_output_length,
         )
 
 
@@ -294,6 +308,7 @@ class LongDocPermutatorWorkload(BaseWorkload):
             f"  Tokens per request:  {Y}{self._tokens_per_request}{R} (measured)\n"
             f"  Vocab size:          {Y}{c.vocab_size}{R}\n"
             f"  Max inflight:        {Y}{c.num_inflight_requests}{R}\n"
+            f"  Max output length:   {Y}{c.max_output_length}{R} tokens\n"
             f"{B}{'═' * 50}{R}"
         )
 
@@ -390,7 +405,11 @@ class LongDocPermutatorWorkload(BaseWorkload):
         self._progress_monitor.on_request_sent(request_id)
         self._progress_monitor.log_message(f"Dispatched permutation {perm_idx}")
         try:
-            await self._request_sender.send_request(request_id, messages)
+            await self._request_sender.send_request(
+                request_id,
+                messages,
+                max_tokens=self._config.max_output_length,
+            )
         finally:
             self._semaphore.release()
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_create_workload.py
@@ -81,13 +81,16 @@ def _make_deps() -> tuple[MagicMock, MagicMock, MagicMock]:
 
 
 class TestValidateMaxOutputLengthSupported:
-    @pytest.mark.parametrize("workload", ["long-doc-qa", "multi-round-chat"])
+    @pytest.mark.parametrize(
+        "workload",
+        ["long-doc-permutator", "long-doc-qa", "multi-round-chat"],
+    )
     def test_allowed_for_workloads_with_the_parameter(self, workload: str) -> None:
         validate_max_output_length_supported(workload)
 
     @pytest.mark.parametrize(
         "workload",
-        ["long-doc-permutator", "random-prefill", "prefix-suffix-tuner"],
+        ["random-prefill", "prefix-suffix-tuner"],
     )
     def test_rejected_for_workloads_without_the_parameter(self, workload: str) -> None:
         with pytest.raises(ValueError, match="max output length cannot be specified"):

--- a/tests/cli/commands/bench/engine_bench/workloads/test_long_doc_permutator.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_long_doc_permutator.py
@@ -39,6 +39,7 @@ class TestLongDocPermutatorConfig:
         assert cfg.num_permutations == 10
         assert cfg.vocab_size == 8000
         assert cfg.num_inflight_requests == 1
+        assert cfg.max_output_length == 128
 
     def test_custom_values(self) -> None:
         cfg = LongDocPermutatorConfig(
@@ -48,6 +49,7 @@ class TestLongDocPermutatorConfig:
             num_permutations=4,
             vocab_size=500,
             num_inflight_requests=2,
+            max_output_length=1,
         )
         assert cfg.num_contexts == 3
         assert cfg.context_length == 200
@@ -55,6 +57,7 @@ class TestLongDocPermutatorConfig:
         assert cfg.num_permutations == 4
         assert cfg.vocab_size == 500
         assert cfg.num_inflight_requests == 2
+        assert cfg.max_output_length == 1
 
     def test_invalid_num_contexts_zero(self) -> None:
         with pytest.raises(ValueError, match="num_contexts must be >= 1"):
@@ -84,6 +87,14 @@ class TestLongDocPermutatorConfig:
         with pytest.raises(ValueError, match="num_inflight_requests must be >= 1"):
             LongDocPermutatorConfig(num_inflight_requests=0)
 
+    def test_invalid_max_output_length_zero(self) -> None:
+        with pytest.raises(ValueError, match="max_output_length must be >= 1"):
+            LongDocPermutatorConfig(max_output_length=0)
+
+    def test_invalid_max_output_length_negative(self) -> None:
+        with pytest.raises(ValueError, match="max_output_length must be >= 1"):
+            LongDocPermutatorConfig(max_output_length=-1)
+
 
 # ---------------------------------------------------------------------------
 # LongDocPermutatorConfig.resolve
@@ -99,6 +110,7 @@ class TestLongDocPermutatorConfigResolve:
         assert cfg.num_permutations == 10
         assert cfg.vocab_size == 8000
         assert cfg.num_inflight_requests == 1
+        assert cfg.max_output_length == 128
 
     def test_resolve_custom(self) -> None:
         cfg = LongDocPermutatorConfig.resolve(
@@ -108,6 +120,7 @@ class TestLongDocPermutatorConfigResolve:
             num_permutations=4,
             vocab_size=500,
             num_inflight_requests=2,
+            max_output_length=1,
         )
         assert cfg.num_contexts == 3
         assert cfg.context_length == 200
@@ -115,6 +128,7 @@ class TestLongDocPermutatorConfigResolve:
         assert cfg.num_permutations == 4
         assert cfg.vocab_size == 500
         assert cfg.num_inflight_requests == 2
+        assert cfg.max_output_length == 1
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +408,12 @@ class TestLongDocPermutatorWarmup:
         assert "system" in roles
         assert "user" in roles
 
+    def test_warmup_ignores_max_output_length(self) -> None:
+        """Warmup keeps the sender's 1-token default whatever the config asks."""
+        w, sender, _, _ = _make_workload(_make_config(max_output_length=64))
+        asyncio.run(w.warmup())
+        assert "max_tokens" not in sender.send_warmup_request.await_args.kwargs
+
     def test_warmup_logs_progress(self) -> None:
         w, _, _, monitor = _make_workload()
         asyncio.run(w.warmup())
@@ -464,6 +484,25 @@ class TestLongDocPermutatorStep:
                 await asyncio.gather(*w._pending_tasks)
 
             assert sender.send_request.call_count == 1
+
+        asyncio.run(_run())
+
+    def test_step_passes_configured_max_output_length(self) -> None:
+        """The configured output length reaches the sender, not its default."""
+
+        async def _run() -> None:
+            cfg = _make_config(
+                num_contexts=2,
+                num_permutations=1,
+                max_output_length=1,
+            )
+            w, sender, _, _ = _make_workload(cfg)
+
+            await w.step(0.0)
+            if w._pending_tasks:
+                await asyncio.gather(*w._pending_tasks)
+
+            assert sender.send_request.await_args.kwargs["max_tokens"] == 1
 
         asyncio.run(_run())
 


### PR DESCRIPTION
DESCRIPTION
===========
## What this PR does / why we need it

The `long-doc-permutator` workload had no way to set its generation length. It called `RequestSender.send_request()` without `max_tokens`, so every permutation request silently decoded 128 tokens — the sender's signature default, not a deliberate choice — and `validate_max_output_length_supported()` rejected the workload outright if a user tried to set one.

That makes a prefill-only measurement impossible. The workload exists to stress blended KV reuse across reorderings of the same documents, which is a prefill concern; the 128 decode tokens per request add noise to `elapsed_time`, `output_throughput`, and the decode-speed percentiles without exercising anything the workload is about.

This adds `--ldp-max-output-length`, following the existing per-workload flag convention (`--ldqa-max-output-length`, `--mrc-output-length`):

- `max_output_length` field on `LongDocPermutatorConfig`, validated `>= 1`, threaded through `resolve()` into `send_request(max_tokens=...)`.
- `--ldp-max-output-length` registered in the existing ldp argument group.
- `long-doc-permutator` added to `_WORKLOADS_WITH_MAX_OUTPUT_LENGTH` so the validator no longer reports it as lacking the parameter.
- Matching `ConfigItem` in the interactive schema, which also gives it `--export-config` / `--config` round-tripping.
- Flag tables in `docs/design/.../bench-engine.md` and `docs/source/cli/bench.rst`.

## Special notes for your reviewers

The default stays 128 — the value the workload was already getting — so existing runs are unchanged. Use `--ldp-max-output-length 1` for a pure prefill/TTFT measurement, or pair a larger value with `--ignore-eos` for a reproducible decode phase. Warmup is untouched and still uses the sender's 1-token default.

Pre-existing behavior left alone, flagged in case a reviewer prefers otherwise: the guard in `command.py` fires on `--ldqa-max-output-length` but then only asks whether the *workload* has some max-output-length parameter. So `--ldqa-max-output-length N --workload long-doc-permutator` is accepted and ignored — the same looseness that already applied to `multi-round-chat` (which reads `--mrc-output-length`). Tightening the flag/workload pairing would change multi-round-chat too, so it felt out of scope.

Verified: `test_long_doc_permutator.py` + `test_create_workload.py` pass (70). The full `engine_bench` suite shows 45 failures in `test_prefix_suffix_tuner.py` and `test_random_prefill.py` — identical on a clean tree, untouched by this change. Also smoke-tested the real CLI end to end via `--export-config`.

## If applicable

- [x] this PR contains user facing changes — docs added
- [x] this PR contains unit tests