### PR TITLE
[Fix][SDK] Clean up SDK context on graceful shutdown

### DIFF
--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -83,6 +83,8 @@ class LMCacheSDKContext:
             LMCacheSDKContext instance.
         """
         self._kind = kind
+        self._closed = False
+        self._engine_transfer_ctx: EngineDrivenTransferContext | None = None
         self._zmq_context = zmq.Context()
         self._mq_client = MessageQueueClient(url, self._zmq_context)
         self._mq_timeout = timeout
@@ -217,6 +219,11 @@ class LMCacheSDKContext:
             }
 
         transfer_ctx = create_transfer_context(self._kv_caches)
+        if not isinstance(transfer_ctx, EngineDrivenTransferContext):
+            raise LMCacheSDKError(
+                "SDK requires an engine-driven transfer context, got "
+                f"{type(transfer_ctx).__name__}."
+            )
         self.blocks_in_chunk = self._chunk_size // block_size
         layout_hints = LayoutHints(
             kv_layout="HND",
@@ -242,11 +249,9 @@ class LMCacheSDKContext:
             layout_hints=layout_hints,
         )
 
-        if not isinstance(transfer_ctx, EngineDrivenTransferContext):
-            raise LMCacheSDKError(
-                "SDK requires an engine-driven transfer context, got "
-                f"{type(transfer_ctx).__name__}."
-            )
+        # The wrapper borrows the inner context; retain its outer owner so
+        # close() can release SHM state and any async transfer resources.
+        self._engine_transfer_ctx = transfer_ctx
         self._transfer_ctx = ContiguousTransferWrapper(
             transfer_ctx.engine_driven_context, self._chunk_size
         )
@@ -267,8 +272,43 @@ class LMCacheSDKContext:
         return self._transfer_ctx
 
     def close(self) -> None:
-        """Close the MQ client and ZMQ context."""
-        self._mq_client.close()
+        """Unregister the SDK context and release all owned resources.
+
+        This method is idempotent. If the server does not acknowledge the
+        unregister request within the configured MQ timeout, local transfer,
+        MQ, and ZMQ resources are still released.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        transfer_ctx = self._engine_transfer_ctx
+        try:
+            if transfer_ctx is not None:
+                try:
+                    self._mq_client.submit_request(
+                        RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+                        [self.instance_id],
+                        get_response_class(
+                            RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+                        ),
+                    ).result(timeout=self._mq_timeout)
+                except TimeoutError:
+                    logger.warning(
+                        "LMCache server did not respond to SDK context unregister "
+                        "within %ss. Proceeding with shutdown.",
+                        self._mq_timeout,
+                    )
+        finally:
+            try:
+                self._engine_transfer_ctx = None
+                if transfer_ctx is not None:
+                    transfer_ctx.close()
+            finally:
+                try:
+                    self._mq_client.close()
+                finally:
+                    self._zmq_context.term()
 
     def maybe_submit_lookup_request(
         self,


### PR DESCRIPTION
**What this PR does / why we need it**:

`LMCacheSDKContext.register_caches()` registers an engine-driven context with the multiprocess server, while `close()` previously closed only the MQ client.

Process exit eventually reclaims client-local resources, and the server can reap stale registrations. However, a graceful `close()` should promptly release the server registration and owned transfer resources instead of deferring cleanup to process exit or stale-context reaping.

This PR:

- Retains the owning `EngineDrivenTransferContext` after registration succeeds.
- Rejects non-engine-driven transfer contexts before registering them.
- Unregisters the SDK context from the server during shutdown, with a bounded wait using the configured MQ timeout.
- Continues local cleanup if the unregister request times out.
- Closes the transfer context and MQ client, then terminates the SDK-owned ZMQ context.
- Makes repeated `close()` calls no-ops and preserves cleanup ordering with nested `finally` blocks.

**Special notes for your reviewers**:

- Abrupt process termination still relies on the server reaper; this change improves the normal graceful-shutdown path.
- The contiguous wrapper borrows the inner engine-driven context, while the retained outer transfer context owns its lifecycle and associated local resources.
- `ContiguousTransferWrapper` is unchanged.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
