### PR TITLE
[Bugfix][CLI][L2 Bench] Use L1-relative memory object addresses

### DIFF
--- a/lmcache/cli/commands/bench/l2_adapter_bench/data.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/data.py
@@ -128,7 +128,7 @@ def make_memory_objects(
         metadata = MemoryObjMetadata(
             shape=torch.Size([data_size]),
             dtype=torch.uint8,
-            address=raw_tensor.data_ptr(),
+            address=start,
             phy_size=data_size * raw_tensor.element_size(),
             fmt=MemoryFormat.KV_2LTD,
             ref_count=1,

--- a/tests/cli/commands/bench/l2_adapter_bench/test_data.py
+++ b/tests/cli/commands/bench/l2_adapter_bench/test_data.py
@@ -42,6 +42,8 @@ def test_make_memory_objects_uses_shared_l1_range() -> None:
     assert len(objects) == 2
     assert objects[0].raw_data.data_ptr() == buffer.data_ptr() + 1024
     assert objects[1].raw_data.data_ptr() == buffer.data_ptr() + 2048
+    assert objects[0].meta.address == 1024
+    assert objects[1].meta.address == 2048
     assert torch.all(objects[0].raw_data == 0)
     assert torch.all(objects[1].raw_data == 1)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The L2 benchmark creates memory objects as views into a shared, registered L1 buffer. It previously stored each object's absolute virtual address in `MemoryObjMetadata.address`.

NIXL adapters interpret this field as a byte offset within the registered L1 buffer. Using an absolute address can therefore produce invalid page indices and cause NIXL store or load operations to fail.

This PR:

- Stores each object's buffer-relative byte offset instead of its absolute virtual address.
- Adds regression assertions verifying the expected metadata offsets.

**Special notes for your reviewers**:

This change is limited to L2 benchmark data construction. The NIXL adapters are unchanged. Production LMCache allocators already use buffer-relative addresses, so this makes the benchmark follow the existing address contract.

Validation:

```bash
pytest -xvs tests/cli/commands/bench/l2_adapter_bench/test_data.py
```
Result: `4 passed`.

All applicable pre-commit checks passed for the changed files.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests (`tests/cli/commands/bench/l2_adapter_bench/test_data.py`)
