### PR TITLE
feat: discover out-of-tree device specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ uv pip install torch               # pre-requisite for CUDA extensions
 uv pip install -e . --no-build-isolation
 ```
 
+On this checkout, do not assume ``python`` is available on ``PATH`` or
+that ``python3`` points at the project interpreter: the local system
+``python3`` may still be Python 3.9 while LMCache development here uses
+``.venv/bin/python`` (Python 3.12). Run tests, docs, and pre-commit via
+``.venv/bin/python`` / ``.venv/bin/<tool>`` or ``uv run`` to avoid
+accidentally validating against the wrong interpreter.
+
 ## Build & Install
 
 ```bash
@@ -83,6 +90,12 @@ isort .                   # Import sorting (black profile, from_first=true)
 mypy --config-file=pyproject.toml   # Type checking
 codespell --toml pyproject.toml     # Spell checking
 ```
+
+On this macOS checkout, ``pre-commit run --all-files`` can fail before
+code evaluation if the Rust toolchain is missing because the repo's
+hooks invoke ``cargo fmt`` and ``cargo clippy`` for ``rust/``. Verify
+``cargo`` is installed before treating those hook failures as source
+regressions.
 
 C++/CUDA files use clang-format (Google style, 80-col). Rust code in `rust/` uses `cargo fmt` and `cargo clippy`.
 

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -47,7 +47,9 @@ Your PyTorch backend should support:
 Step 1: Add a ``FooDeviceSpec``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create ``lmcache/v1/platform/foo/__init__.py``:
+For an in-tree backend, create ``lmcache/v1/platform/foo/__init__.py``.
+For an out-of-tree backend wheel, put the class in your own package;
+LMCache only requires the class body shown below.
 
 .. code-block:: python
 
@@ -167,11 +169,51 @@ Key properties:
    PyTorch itself (like ``torch.cuda``) a plain
    ``torch.foo.is_available()`` is enough.
 
-That's it.  Defining these two classes is enough for auto-discovery —
-no global list or manual registration call is required.  All ops
+That's it.  Defining these two classes is enough for auto-discovery.
+For an in-tree backend there is no global list or manual registration
+call; LMCache will find the sub-package automatically.  All ops
 automatically route through the torch baseline in ``torch_ops.py``,
-which is not performant but is functionally applicable to any device that
-supports the standard PyTorch tensor surface.
+which is not performant but is functionally applicable to any device
+that supports the standard PyTorch tensor surface.
+
+Packaging an Out-of-Tree Backend Wheel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to maintain the backend in a separate repository, publish
+the ``DeviceSpec`` class through the ``lmcache.v1.device_specs`` entry
+point group.  Once that wheel is installed into the same environment
+as LMCache, LMCache discovers it automatically at process start.
+
+Example ``pyproject.toml`` for a vendor-maintained wheel:
+
+.. code-block:: toml
+
+    [project]
+    name = "lmcache-foo-device"
+    version = "0.1.0"
+    dependencies = ["lmcache"]
+
+    [project.entry-points."lmcache.v1.device_specs"]
+    foo = "vendor_lmcache_foo.device:FooDeviceSpec"
+
+Suggested package layout:
+
+.. code-block:: text
+
+    vendor_lmcache_foo/
+    ├── __init__.py
+    ├── device.py          # defines FooDeviceSpec
+    ├── device_ops.py      # defines FooDeviceOps
+    └── cache_context.py   # optional cache-context implementation
+
+Why this works:
+
+- LMCache imports the entry point, instantiates ``FooDeviceSpec``, and
+  adds it to the same device registry used by built-in backends.
+- ``FooDeviceSpec.ops_cls`` and other lazy properties can then import
+  the rest of your package on demand.
+- No LMCache source patch is needed as long as the wheel is installed
+  before the LMCache process starts.
 
 Verification
 ~~~~~~~~~~~~

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -13,13 +13,16 @@ packages so each can evolve independently:
 * :mod:`lmcache.v1.platform.cuda` -- CUDA-backed implementations.
 * :mod:`lmcache.v1.platform.cpu`  -- CPU-only fallbacks.
 
-KV-cache IPC wrappers and ``BaseCacheContext`` subclasses are
-discovered separately on first use via
-:mod:`lmcache.v1.utils.subclass_discovery`, keyed by each subclass'
-``device_type`` ClassVar.  Adding a new accelerator therefore
-requires *zero* edits to this module -- drop a new
-``platform/<backend>/`` package and it will be picked up
-automatically.
+Device backends are discovered from two sources:
+
+* in-tree ``platform/<backend>/`` packages inside LMCache;
+* installed wheels exposing a ``DeviceSpec`` entry point in the
+  ``lmcache.v1.device_specs`` group.
+
+KV-cache IPC wrappers and ``BaseCacheContext`` subclasses hang off the
+registered ``DeviceSpec`` for each backend, so adding a new
+accelerator requires *zero* edits to this module whether the backend
+lives in-tree or ships from an external wheel.
 """
 
 # Future
@@ -43,10 +46,11 @@ __all__ = [
 
 # Standard
 from typing import TYPE_CHECKING, Any
-import os
 
 # First Party
-from lmcache.logging import init_logger
+from lmcache.v1.platform._device_detect import (
+    _build_device_registry,
+)
 from lmcache.v1.platform._device_detect import (
     current_device_spec as _current_device_spec_fn,
 )
@@ -55,7 +59,6 @@ from lmcache.v1.platform._device_detect import (
     get_torch_device,
 )
 from lmcache.v1.platform.base.device_spec import DeviceSpec
-from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
 if TYPE_CHECKING:
     from lmcache.v1.platform.base.device_ops import DeviceOps
@@ -70,107 +73,12 @@ from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
 
-logger = init_logger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Resolve device ops
-# ---------------------------------------------------------------------------
-
-
-_DEVICE_REGISTRY: dict[str, DeviceSpec] = {
-    spec.device_type: spec
-    for spec in [
-        cls()
-        for cls in discover_subclasses(
-            "lmcache.v1.platform",
-            DeviceSpec,  # type: ignore[type-abstract]
-            module_filter=lambda name: not name.startswith(("_", "base")),
-            require_defined_in_module=True,
-            on_import_error=lambda name, exc: None,
-        )
-    ]
-}
-
-
-# ---------------------------------------------------------------------------
-# Device detection
-# ---------------------------------------------------------------------------
-
-
-def _detect_device() -> tuple[Any, str]:
-    """Detect the available accelerator via the device registry.
-
-    Returns:
-        tuple[Any, str]: A tuple of (torch_device_module, device_type_string).
-            When torch is not installed (CLI-only mode), returns
-            ``(None, "cpu")``.
-    """
-    try:
-        # Third Party
-        import torch
-    except ImportError as e:
-        logger.warning("load torch failed, error is %s", e)
-        return None, "cpu"  # fallback for CLI-only environments
-
-    # Check DEVICE_TYPE environment variable for forced device selection.
-    env_device_type = os.environ.get("DEVICE_TYPE")
-    if env_device_type is not None:
-        env_device_type = env_device_type.strip().lower()
-        spec = _DEVICE_REGISTRY.get(env_device_type)
-        if spec is not None and spec.is_available():
-            torch_module = getattr(torch, spec.torch_module_name, None)
-            if torch_module is not None:
-                return torch_module, spec.device_type
-            else:
-                logger.warning(
-                    "DEVICE_TYPE=%r is available but torch module [%s] not found, "
-                    "falling back to auto-detection.",
-                    env_device_type,
-                    spec.torch_module_name,
-                )
-        else:
-            logger.warning(
-                "DEVICE_TYPE=%r is not available or not registered, "
-                "falling back to auto-detection.",
-                env_device_type,
-            )
-
-    for spec in _DEVICE_REGISTRY.values():
-        # ``cpu`` is the tail fallback: even though ``CpuDeviceSpec`` now
-        # lives in the registry (so ``resolve_kv_wrapper_factory`` can bind
-        # its IPC wrapper), auto-detection must still prefer accelerators
-        # and let the ``StubCPUDevice`` branch below handle the no-accelerator
-        # case. ``DEVICE_TYPE=cpu`` remains an explicit opt-in above.
-        #
-        # Defence-in-depth pairs with the ``CpuDeviceSpec`` invariant that
-        # ``is_available()`` stays inherited (False); do not remove either
-        # side without updating the other.
-        if spec.device_type == "cpu":
-            continue
-        if not spec.is_available():
-            continue
-
-        torch_module = getattr(torch, spec.torch_module_name, None)
-        if torch_module is not None:
-            return torch_module, spec.device_type
-        else:
-            logger.warning(
-                "device [%s] is available, but torch module [%s] is not found.",
-                spec.device_type,
-                spec.torch_module_name,
-            )
-
-    # No accelerator found -- fall back to CPU stub
-    # First Party
-    from lmcache.v1.platform.cpu.stub_cpu_device import StubCPUDevice
-
-    return StubCPUDevice("cpu"), "cpu"
-
-
 # ---------------------------------------------------------------------------
 # KV-cache IPC wrapper resolution
 # ---------------------------------------------------------------------------
+_DEVICE_REGISTRY: dict[str, DeviceSpec] = _build_device_registry()
+
+
 def resolve_kv_wrapper_factory(device_type: str) -> Any:
     """Return the KV-cache IPC wrapper factory for *device_type*.
 
@@ -221,8 +129,9 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
     raise RuntimeError(
         f"No DeviceSpec registered for accelerator {device_type!r}; "
         "refusing to silently fall back to the torch baseline on "
-        "accelerator hardware. Ensure the platform sub-package for this "
-        "device is importable and defines a DeviceSpec."
+        "accelerator hardware. Ensure the backend is installed and "
+        "defines a DeviceSpec, either from an in-tree platform "
+        "sub-package or an lmcache.v1.device_specs entry point."
     )
 
 

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -11,12 +11,16 @@ that init chain.
 
 The registry of :class:`DeviceSpec` subclasses and the detected torch
 device module are both built lazily on first access and then cached
-process-wide.
+process-wide.  Registry entries may come from LMCache's in-tree
+``platform/<backend>/`` packages or from installed wheels publishing a
+``DeviceSpec`` entry point in the ``lmcache.v1.device_specs`` group.
 """
 
 # Standard
 from functools import lru_cache
+from importlib import metadata as importlib_metadata
 from typing import TYPE_CHECKING, Any
+import inspect
 import os
 
 # First Party
@@ -27,6 +31,8 @@ if TYPE_CHECKING:
     from lmcache.v1.platform.base.device_spec import DeviceSpec
 
 logger = init_logger(__name__)
+
+_DEVICE_SPEC_ENTRYPOINT_GROUP = "lmcache.v1.device_specs"
 
 
 # ---------------------------------------------------------------------------
@@ -45,19 +51,149 @@ def _build_device_registry() -> "dict[str, DeviceSpec]":
     from lmcache.v1.platform.base.device_spec import DeviceSpec
     from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
-    return {
-        spec.device_type: spec
-        for spec in [
-            cls()
-            for cls in discover_subclasses(
-                "lmcache.v1.platform",
-                DeviceSpec,  # type: ignore[type-abstract]
-                module_filter=lambda name: not name.startswith(("_", "base")),
-                require_defined_in_module=True,
-                on_import_error=lambda name, exc: None,
+    registry: dict[str, DeviceSpec] = {}
+
+    for cls in discover_subclasses(
+        "lmcache.v1.platform",
+        DeviceSpec,  # type: ignore[type-abstract]
+        module_filter=lambda name: not name.startswith(("_", "base")),
+        require_defined_in_module=True,
+        on_import_error=lambda name, exc: None,
+    ):
+        _register_device_spec(
+            registry,
+            cls(),
+            source=f"{cls.__module__}.{cls.__qualname__}",
+        )
+
+    for entry_point, spec in _iter_entry_point_device_specs(DeviceSpec):
+        _register_device_spec(
+            registry,
+            spec,
+            source=(
+                f"entry point {entry_point.group}:{entry_point.name}"
+                f" ({entry_point.value})"
+            ),
+        )
+
+    return registry
+
+
+def _iter_entry_point_device_specs(
+    base_class: "type[DeviceSpec]",
+) -> "list[tuple[Any, DeviceSpec]]":
+    """Load ``DeviceSpec`` objects exposed through installed entry points."""
+    discovered: list[tuple[Any, DeviceSpec]] = []
+
+    for entry_point in _select_entry_points(_DEVICE_SPEC_ENTRYPOINT_GROUP):
+        try:
+            loaded = entry_point.load()
+        except Exception as exc:
+            logger.warning(
+                "Failed to load device entry point %s:%s (%s): %s",
+                entry_point.group,
+                entry_point.name,
+                entry_point.value,
+                exc,
             )
-        ]
-    }
+            continue
+
+        spec = _coerce_entry_point_device_spec(entry_point, loaded, base_class)
+        if spec is not None:
+            discovered.append((entry_point, spec))
+
+    return discovered
+
+
+def _select_entry_points(group: str) -> list[Any]:
+    """Return entry points from *group* across Python 3.10-3.13 APIs."""
+    entry_points = importlib_metadata.entry_points()
+    select = getattr(entry_points, "select", None)
+    if callable(select):
+        return list(select(group=group))
+
+    legacy_get = getattr(entry_points, "get", None)
+    if callable(legacy_get):
+        return list(legacy_get(group, ()))
+
+    return []
+
+
+def _coerce_entry_point_device_spec(
+    entry_point: Any,
+    loaded: Any,
+    base_class: "type[DeviceSpec]",
+) -> "DeviceSpec | None":
+    """Normalize an entry point target to a concrete ``DeviceSpec`` instance."""
+    if inspect.isclass(loaded):
+        try:
+            is_subclass = issubclass(loaded, base_class)
+        except TypeError:
+            is_subclass = False
+        if not is_subclass:
+            logger.warning(
+                "Skipping device entry point %s:%s (%s): target is not a "
+                "DeviceSpec subclass.",
+                entry_point.group,
+                entry_point.name,
+                entry_point.value,
+            )
+            return None
+        if inspect.isabstract(loaded):
+            logger.warning(
+                "Skipping device entry point %s:%s (%s): DeviceSpec subclass "
+                "is abstract.",
+                entry_point.group,
+                entry_point.name,
+                entry_point.value,
+            )
+            return None
+        return loaded()
+
+    if isinstance(loaded, base_class):
+        return loaded
+
+    logger.warning(
+        "Skipping device entry point %s:%s (%s): target must resolve to a "
+        "DeviceSpec subclass or instance.",
+        entry_point.group,
+        entry_point.name,
+        entry_point.value,
+    )
+    return None
+
+
+def _register_device_spec(
+    registry: "dict[str, DeviceSpec]",
+    spec: "DeviceSpec",
+    *,
+    source: str,
+) -> None:
+    """Insert *spec* into *registry* unless a device_type collision exists."""
+    device_type = spec.device_type
+    if not device_type:
+        logger.warning("Skipping DeviceSpec from %s: device_type is empty.", source)
+        return
+
+    existing = registry.get(device_type)
+    if existing is not None:
+        logger.warning(
+            "Skipping DeviceSpec from %s: device_type %r is already provided by %s.",
+            source,
+            device_type,
+            f"{type(existing).__module__}.{type(existing).__qualname__}",
+        )
+        return
+
+    registry[device_type] = spec
+
+
+def _get_platform_device_registry() -> "dict[str, DeviceSpec]":
+    """Return the shared device registry owned by ``lmcache.v1.platform``."""
+    # First Party
+    import lmcache.v1.platform as platform_pkg
+
+    return platform_pkg._DEVICE_REGISTRY
 
 
 def _detect_device() -> tuple[Any, str]:
@@ -75,7 +211,7 @@ def _detect_device() -> tuple[Any, str]:
         logger.warning("load torch failed, error is %s", e)
         return None, "cpu"  # fallback for CLI-only environments
 
-    registry = _build_device_registry()
+    registry = _get_platform_device_registry()
 
     # Check DEVICE_TYPE environment variable for forced device selection.
     env_device_type = os.environ.get("DEVICE_TYPE")
@@ -128,7 +264,7 @@ def _detect_device() -> tuple[Any, str]:
 
 def get_device_spec(device_type: str) -> "DeviceSpec | None":
     """Return the :class:`DeviceSpec` registered for *device_type*, if any."""
-    return _build_device_registry().get(device_type)
+    return _get_platform_device_registry().get(device_type)
 
 
 @lru_cache(maxsize=1)

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -5,15 +5,21 @@ Each accelerator sub-package (``platform/cuda``, ``platform/musa``, ...)
 provides a concrete :class:`DeviceSpec` subclass that describes how to
 detect the device and which ops backend to load.
 
-The :mod:`~lmcache.v1.platform` module discovers these
-subclasses automatically at import time via ``pkgutil.iter_modules``:
-it imports each sub-package, inspects its module namespace for
-:class:`DeviceSpec` subclasses, instantiates them, and uses the
-resulting objects for device detection and backend selection.
+The :mod:`~lmcache.v1.platform` module discovers these subclasses
+automatically from two sources:
 
-No manual registration (e.g. ``DEVICE_SPEC = ...``) is required --
-simply defining the subclass in the sub-package's ``__init__.py`` is
-enough.
+* in-tree platform packages under ``lmcache.v1.platform`` via
+  ``pkgutil.iter_modules``;
+* installed wheels exposing ``DeviceSpec`` entry points in the
+  ``lmcache.v1.device_specs`` group.
+
+In both cases LMCache instantiates the discovered specifications and
+uses the resulting objects for device detection and backend selection.
+
+No manual registration call (e.g. ``DEVICE_SPEC = ...``) is required:
+define the subclass in the sub-package's ``__init__.py`` for in-tree
+backends, or publish it through the entry-point group above for an
+out-of-tree backend wheel.
 
 :class:`DeviceSpec` itself is instantiable and doubles as the fallback
 implementation used when no accelerator sub-package matches the
@@ -45,7 +51,9 @@ class DeviceSpec:
 
     Subclasses override the properties / methods below to describe a
     concrete accelerator.  Defining a concrete subclass in a platform
-    sub-package's ``__init__.py`` is sufficient for auto-discovery.
+    sub-package's ``__init__.py`` or exposing it via the
+    ``lmcache.v1.device_specs`` entry-point group is sufficient for
+    auto-discovery.
 
     Instantiating :class:`DeviceSpec` directly yields the fallback
     implementation with "no-op / all False" semantics -- this is the

--- a/tests/v1/platform/test_device_detect.py
+++ b/tests/v1/platform/test_device_detect.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for platform device discovery and shared registry wiring."""
+
+# Standard
+from collections.abc import Iterator
+from typing import Any
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform.base.device_ops import DeviceOps
+from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.cpu import CpuDeviceSpec
+import lmcache.v1.platform as platform_pkg
+import lmcache.v1.platform._device_detect as device_detect
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        value: str,
+        loaded: Any | None = None,
+        group: str = "lmcache.v1.device_specs",
+        exc: Exception | None = None,
+    ) -> None:
+        self.group = group
+        self.name = name
+        self.value = value
+        self._loaded = loaded
+        self._exc = exc
+
+    def load(self) -> Any:
+        if self._exc is not None:
+            raise self._exc
+        return self._loaded
+
+
+class _FakeEntryPoints(list[_FakeEntryPoint]):
+    """Collection exposing the ``select(group=...)`` API."""
+
+    def select(self, *, group: str) -> list[_FakeEntryPoint]:
+        return [entry_point for entry_point in self if entry_point.group == group]
+
+
+@pytest.fixture
+def clear_device_registry_cache() -> Iterator[None]:
+    """Keep the discovery cache isolated across tests."""
+    device_detect._build_device_registry.cache_clear()
+    try:
+        yield
+    finally:
+        device_detect._build_device_registry.cache_clear()
+
+
+def test_build_device_registry_loads_device_spec_from_entry_point(
+    clear_device_registry_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installed wheels can register a device backend through entry points."""
+
+    class PluginDeviceOps(DeviceOps):
+        device_type = "entrypoint-device"
+
+    class PluginDeviceSpec(DeviceSpec):
+        @property
+        def device_type(self) -> str:
+            return "entrypoint-device"
+
+        @property
+        def torch_module_name(self) -> str:
+            return "entrypoint_device"
+
+        @property
+        def ops_cls(self) -> type[DeviceOps]:
+            return PluginDeviceOps
+
+    monkeypatch.setattr(
+        device_detect.importlib_metadata,
+        "entry_points",
+        lambda: _FakeEntryPoints(
+            [
+                _FakeEntryPoint(
+                    name="entrypoint-device",
+                    value="fake.plugin:PluginDeviceSpec",
+                    loaded=PluginDeviceSpec,
+                )
+            ]
+        ),
+    )
+
+    registry = device_detect._build_device_registry()
+
+    spec = registry["entrypoint-device"]
+    assert isinstance(spec, PluginDeviceSpec)
+    assert type(spec.get_ops()) is PluginDeviceOps
+
+
+def test_build_device_registry_skips_invalid_entry_point_target(
+    clear_device_registry_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery warns and skips entry points that do not resolve to DeviceSpec."""
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        device_detect.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings.append(msg % args if args else msg),
+    )
+    monkeypatch.setattr(
+        device_detect.importlib_metadata,
+        "entry_points",
+        lambda: _FakeEntryPoints(
+            [
+                _FakeEntryPoint(
+                    name="broken-device",
+                    value="fake.plugin:not_a_spec",
+                    loaded=object(),
+                )
+            ]
+        ),
+    )
+
+    registry = device_detect._build_device_registry()
+
+    assert "broken-device" not in registry
+    assert any(
+        "must resolve to a DeviceSpec subclass or instance" in warning
+        for warning in warnings
+    )
+
+
+def test_build_device_registry_preserves_existing_device_type_on_collision(
+    clear_device_registry_cache: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External wheels must not override an existing built-in device type."""
+
+    class DuplicateCpuDeviceSpec(DeviceSpec):
+        @property
+        def device_type(self) -> str:
+            return "cpu"
+
+        @property
+        def torch_module_name(self) -> str:
+            return "cpu"
+
+    monkeypatch.setattr(
+        device_detect.importlib_metadata,
+        "entry_points",
+        lambda: _FakeEntryPoints(
+            [
+                _FakeEntryPoint(
+                    name="cpu",
+                    value="fake.plugin:DuplicateCpuDeviceSpec",
+                    loaded=DuplicateCpuDeviceSpec,
+                )
+            ]
+        ),
+    )
+
+    registry = device_detect._build_device_registry()
+
+    assert isinstance(registry["cpu"], CpuDeviceSpec)
+
+
+def test_get_device_spec_reads_shared_platform_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_device_detect.get_device_spec`` resolves through the shared registry."""
+
+    class SharedPluginDeviceSpec(DeviceSpec):
+        @property
+        def device_type(self) -> str:
+            return "shared-plugin"
+
+    spec = SharedPluginDeviceSpec()
+    monkeypatch.setattr(
+        platform_pkg,
+        "_DEVICE_REGISTRY",
+        {**platform_pkg._DEVICE_REGISTRY, spec.device_type: spec},
+    )
+
+    assert device_detect.get_device_spec(spec.device_type) is spec


### PR DESCRIPTION
## Summary
- discover `DeviceSpec` backends from installed `lmcache.v1.device_specs` entry points in addition to in-tree `lmcache.v1.platform` packages
- reuse the shared platform registry for device detection and backend resolution so external wheels behave like built-in platform backends
- document out-of-tree backend packaging, add registry tests, and record the local verification/toolchain pitfalls found during validation

## Testing
- `/Users/mbl/projects/LMCache/.venv/bin/python -m pytest tests/v1/platform/test_device_detect.py tests/v1/platform/test_device_ops.py`
- `/Users/mbl/projects/LMCache/.venv/bin/pre-commit run --all-files` (fails only because local `cargo` is not installed; Python hooks passed)
- `PATH="/Users/mbl/projects/LMCache/.venv/bin:$PATH" make clean html` from `docs/` (build completed, but the repo still has pre-existing Sphinx warnings/errors outside this change)

## Notes
- `tests/v1/platform/test_event_ipc.py tests/v1/platform/test_cache_context_dispatch.py` mostly pass, but `test_cuda_device_spec_exposes_cached_default_event_backend` still fails on this CPU-only host because it expects `torch_device_type == "cuda"`; this was not touched by the change.
