### PR TITLE
[Build] add Iluvatar CoreX CUDA-compatible vendor support

### DIFF
--- a/csrc/cuda/mem_kernels.cu
+++ b/csrc/cuda/mem_kernels.cu
@@ -6,9 +6,10 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <algorithm>
+// USE_ILUVATAR is injected by IluvatarProfile (same pattern as USE_ROCM).
 #ifdef USE_ROCM
   #include <hip/hip_fp8.h>
-#else
+#elif !defined(USE_ILUVATAR)
   #include <cuda_fp8.h>
 #endif
 

--- a/csrc/cuda/mp_mem_kernels.cu
+++ b/csrc/cuda/mp_mem_kernels.cu
@@ -149,8 +149,9 @@ __device__ inline size_t calculate_lmcache_local_offset(
   return head_idx * scalars_per_head + token_offset * scalars_per_token;
 }
 
+// USE_ILUVATAR: CoreX rejects PTX ld/st.global.cs; use plain uint4 I/O.
 __device__ inline uint4 ld_cs(const uint4* addr) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) && !defined(USE_ILUVATAR)
   uint4 val;
   asm volatile("ld.global.cs.v4.u32 {%0, %1, %2, %3}, [%4];"
                : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
@@ -162,7 +163,7 @@ __device__ inline uint4 ld_cs(const uint4* addr) {
 }
 
 __device__ inline void st_cs(uint4* addr, uint4 val) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) && !defined(USE_ILUVATAR)
   asm volatile("st.global.cs.v4.u32 [%0], {%1, %2, %3, %4};"
                :
                : "l"(addr), "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w));

--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -244,9 +244,8 @@ documented case.
 |-------|----------|
 | Runtime | `torch_device_type == "cuda"` → existing `CudaDeviceSpec`, `lmcache.cuda_ops` |
 | Vendor / model | `torch.cuda.get_device_name()` contains `"Iluvatar"` (e.g. `Iluvatar BI-V150`); helper `lmcache.v1.platform.cuda.is_iluvatar_device` |
-| Build | `setup_extensions/build_profiles/iluvatar.py` (`BUILD_WITH_ILUVATAR=1`); injects `USE_ILUVATAR` (same pattern as ROCm's `USE_ROCM`) |
+| Build | `setup_extensions/build_profiles/iluvatar.py` (`BUILD_WITH_ILUVATAR=1`); injects `USE_ILUVATAR` |
 | Kernels | Skip NVIDIA-only `#include <cuda_fp8.h>` and PTX `ld/st.global.cs` under `USE_ILUVATAR` |
-| Contrast with MUSA | MUSA adds a **new** `device_type="musa"` / `MusaDeviceSpec`.  Do not copy that path for CUDA-compatible vendors. |
 
 Headless / CI builds without a CoreX GPU should set `BUILD_WITH_ILUVATAR=1`
 explicitly.  Auto-detect requires `nvcc` **and** an Iluvatar device name;

--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -232,3 +232,23 @@ which is wrong for that backend's actual KV cache layout.
 No edits to ``lmcache/__init__.py`` or global backend candidate lists
 are required. Users can set ``DEVICE_TYPE=<device_type>`` at runtime to
 force selection of a registered device when multiple are available.
+
+## CUDA-compatible vendors (Iluvatar)
+
+Some accelerators are **CUDA-API compatible** (`torch.cuda`, same MP AUTO
+routing to LMCacheDriven) and must **not** introduce a new
+`device_type` / `DeviceSpec` identity.  Iluvatar CoreX is the first
+documented case.
+
+| Layer | Behavior |
+|-------|----------|
+| Runtime | `torch_device_type == "cuda"` → existing `CudaDeviceSpec`, `lmcache.cuda_ops` |
+| Vendor / model | `torch.cuda.get_device_name()` contains `"Iluvatar"` (e.g. `Iluvatar BI-V150`); helper `lmcache.v1.platform.cuda.is_iluvatar_device` |
+| Build | `setup_extensions/build_profiles/iluvatar.py` (`BUILD_WITH_ILUVATAR=1`); injects `USE_ILUVATAR` (same pattern as ROCm's `USE_ROCM`) |
+| Kernels | Skip NVIDIA-only `#include <cuda_fp8.h>` and PTX `ld/st.global.cs` under `USE_ILUVATAR` |
+| Contrast with MUSA | MUSA adds a **new** `device_type="musa"` / `MusaDeviceSpec`.  Do not copy that path for CUDA-compatible vendors. |
+
+Headless / CI builds without a CoreX GPU should set `BUILD_WITH_ILUVATAR=1`
+explicitly.  Auto-detect requires `nvcc` **and** an Iluvatar device name;
+`CudaProfile.detect()` stays `nvcc`-only, and `BuildPolicy` prefers a
+non-`cuda` profile when multiple profiles match.

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -24,6 +24,16 @@ torch baseline ops layer (``lmcache/v1/platform/torch_ops.py``) that
 works on any device supporting standard PyTorch tensor operations —
 **no custom kernels required**.
 
+**CUDA-compatible accelerators.** If the device already exposes
+``torch.cuda`` (for example Iluvatar CoreX), do **not** add a new
+``device_type`` / ``DeviceSpec``.  Keep ``CudaDeviceSpec`` so MP
+``AUTO`` still routes to LMCacheDriven.  Build ``lmcache.cuda_ops``
+with ``BUILD_WITH_ILUVATAR=1`` (injects ``USE_ILUVATAR``, same pattern
+as ``USE_ROCM``).  Vendor checks use
+:func:`lmcache.v1.platform.cuda.is_iluvatar_device`.  See
+``docs/design/ARCHITECTURE_MULTI_HARDWARE.md`` section
+"CUDA-compatible vendors (Iluvatar)".
+
 Prerequisites
 ~~~~~~~~~~~~~
 

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -239,4 +239,19 @@ def resolve_device_ops(device_type: str) -> DeviceOps:
 
 torch_dev, torch_device_type = get_torch_device()
 
+# Optional vendor note: Iluvatar CoreX keeps device_type="cuda".
+if torch_device_type == "cuda":
+    try:
+        # First Party
+        from lmcache.v1.platform.cuda import is_iluvatar_device
+
+        if is_iluvatar_device():
+            logger.info(
+                "Detected Iluvatar CUDA-compatible device "
+                "(torch_device_type remains 'cuda')"
+            )
+    except Exception as exc:
+        # Vendor probe must never block platform init (optional info only).
+        logger.debug("Iluvatar vendor probe skipped: %s", exc)
+
 current_device_spec: DeviceSpec = _current_device_spec_fn()

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -19,13 +19,45 @@ if TYPE_CHECKING:
     from lmcache.v1.platform.base.event_ipc import EventIPCBackend
     from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
 
+
+def is_iluvatar_device(device_index: int | None = None) -> bool:
+    """Return True when ``torch.cuda.get_device_name`` contains ``Iluvatar``.
+
+    CoreX reports names like ``Iluvatar BI-V150``.  Matching is
+    case-sensitive.  This does **not** change ``torch_device_type``;
+    callers stay on the CUDA ``DeviceSpec`` path.
+
+    Args:
+        device_index: CUDA ordinal.  When ``None``, uses the current device.
+
+    Returns:
+        True on Iluvatar CoreX, False when CUDA is unavailable, the name
+        does not contain ``Iluvatar``, or the query fails.
+    """
+    try:
+        # Third Party
+        import torch
+
+        if not torch.cuda.is_available():
+            return False
+        index = torch.cuda.current_device() if device_index is None else device_index
+        return "Iluvatar" in torch.cuda.get_device_name(index)
+    except Exception:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Device detection registry entry
 # ---------------------------------------------------------------------------
 
 
 class CudaDeviceSpec(DeviceSpec):
-    """CUDA device specification for the detection registry."""
+    """CUDA device specification for the detection registry.
+
+    CUDA-compatible vendors such as Iluvatar CoreX also use this spec:
+    ``device_type`` / ``torch_module_name`` remain ``"cuda"``.  Use
+    :func:`is_iluvatar_device` for vendor/model checks.
+    """
 
     _event_backend_cache: "EventIPCBackend | None" = None
 

--- a/setup_extensions/build_profiles/__init__.py
+++ b/setup_extensions/build_profiles/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Base classes for the platform extension build pattern.
 
-Each hardware platform (CUDA, ROCm, SYCL, MUSA, ...) implements
+Each hardware platform (CUDA, ROCm, SYCL, MUSA, Iluvatar, ...) implements
 :class:`BuildProfile`.
 The :class:`BuildPolicy` orchestrates auto-detection, fallback, and building.
 """

--- a/setup_extensions/build_profiles/iluvatar.py
+++ b/setup_extensions/build_profiles/iluvatar.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Iluvatar CoreX CUDA-compatible GPU backend profile.
+
+Iluvatar exposes a CUDA-compatible toolchain (``nvcc`` under CoreX) and a
+``torch.cuda`` runtime.  Runtime ``device_type`` therefore stays ``"cuda"``;
+this profile only injects ``USE_ILUVATAR`` (same pattern as ``USE_ROCM``) so
+``lmcache.cuda_ops`` builds without NVIDIA-only ``cuda_fp8.h`` / PTX ``.cs``
+asm.
+
+Preferred explicit selection::
+
+    BUILD_WITH_ILUVATAR=1 pip install -e .
+
+Auto-detect uses the same criterion as
+:func:`lmcache.v1.platform.cuda.is_iluvatar_device` (``get_device_name``
+contains ``Iluvatar``) plus an ``nvcc`` toolchain.  ``setup.py`` must not
+import the ``lmcache`` package (that runs ``cuda_ops`` init), so the check is
+inlined here.  Headless / no-GPU builds should set ``BUILD_WITH_ILUVATAR=1``.
+"""
+
+# Standard
+from typing import TYPE_CHECKING
+import shutil
+
+if TYPE_CHECKING:
+    # Third Party
+    from setuptools.extension import Extension
+
+# First Party
+from setup_extensions.build_profiles.cuda import (
+    CSRC_DIR,
+    ENABLE_CXX11_ABI,
+    CudaProfile,
+)
+
+# Same sources as CudaProfile.build(); kept local so cuda.py stays untouched.
+_CUDA_OPS_SOURCES: list[str] = [
+    "csrc/cuda/pybind.cpp",
+    "csrc/cuda/mem_kernels.cu",
+    "csrc/cuda/mp_mem_kernels.cu",
+    "csrc/cuda/blend_kernels.cu",
+    "csrc/cuda/cal_cdf.cu",
+    "csrc/cuda/ac_enc.cu",
+    "csrc/cuda/ac_dec.cu",
+    "csrc/cuda/pos_kernels.cu",
+    "csrc/cuda/mem_alloc.cpp",
+    "csrc/cuda/utils.cpp",
+    "csrc/cuda/event_recorder.cpp",
+    "csrc/cuda/completion_recorder.cpp",
+]
+
+
+def _is_iluvatar_cuda_device() -> bool:
+    """Return True when ``torch.cuda.get_device_name`` contains ``Iluvatar``.
+
+    Same criterion as :func:`lmcache.v1.platform.cuda.is_iluvatar_device`.
+    Kept local so :meth:`IluvatarProfile.detect` can run from ``setup.py``
+    without importing ``lmcache``.
+    """
+    try:
+        # Third Party
+        import torch
+
+        if not torch.cuda.is_available():
+            return False
+        name = torch.cuda.get_device_name(torch.cuda.current_device())
+        return "Iluvatar" in name
+    except Exception:
+        return False
+
+
+class IluvatarProfile(CudaProfile):
+    """CUDA-compatible Iluvatar CoreX build profile for ``lmcache.cuda_ops``.
+
+    Reuses CUDA sources/requirements; injects ``USE_ILUVATAR=1`` like ROCm's
+    ``USE_ROCM``.
+    """
+
+    name = "iluvatar"
+    env_var = "BUILD_WITH_ILUVATAR"
+
+    def detect(self) -> bool:
+        """Detect Iluvatar when ``nvcc`` exists and the CUDA device is CoreX."""
+        if shutil.which("nvcc") is None:
+            return False
+        return _is_iluvatar_cuda_device()
+
+    def build(self) -> tuple[list["Extension"], dict]:
+        """Build CUDA-compatible extensions with ``USE_ILUVATAR`` defined."""
+        # Third Party
+        from torch.utils import cpp_extension
+
+        print("Building Iluvatar (CUDA-compatible) extensions (USE_ILUVATAR=1)")
+        flag_cxx_abi = (
+            "-D_GLIBCXX_USE_CXX11_ABI=1"
+            if ENABLE_CXX11_ABI
+            else "-D_GLIBCXX_USE_CXX11_ABI=0"
+        )
+        use_iluvatar = "-DUSE_ILUVATAR=1"
+        ext_modules = [
+            cpp_extension.CUDAExtension(
+                "lmcache.cuda_ops",
+                sources=list(_CUDA_OPS_SOURCES),
+                include_dirs=[CSRC_DIR],
+                define_macros=[("USE_ILUVATAR", "1")],
+                extra_compile_args={
+                    "cxx": [flag_cxx_abi, "-std=c++17", use_iluvatar],
+                    "nvcc": [flag_cxx_abi, use_iluvatar],
+                },
+            ),
+        ]
+        cmdclass = {"build_ext": cpp_extension.BuildExtension}
+        return ext_modules, cmdclass

--- a/setup_extensions/policy.py
+++ b/setup_extensions/policy.py
@@ -177,10 +177,24 @@ class BuildPolicy:
         # Phase 2: auto-detect with fallback
         # ---------------------------------------------------------------
         print("No profile explicitly selected, auto-detecting...")
-        for profile in self._platforms:
-            if profile.detect():
+        detected = [profile for profile in self._platforms if profile.detect()]
+        if detected:
+            # Several CUDA-API toolchains expose ``nvcc`` (NVIDIA + Iluvatar
+            # CoreX).  Prefer a more specific non-``cuda`` profile when
+            # multiple match so vendor profiles do not need to patch
+            # ``CudaProfile.detect()``.
+            preferred = [p for p in detected if p.name != "cuda"]
+            profile = preferred[0] if preferred else detected[0]
+            if len(detected) > 1:
+                names = ", ".join(p.name for p in detected)
+                print(
+                    "Auto-detected profile: %s "
+                    "(multiple matched: %s; preferring non-cuda when present)"
+                    % (profile.name, names)
+                )
+            else:
                 print("Auto-detected profile: %s" % profile.name)
-                return profile
+            return profile
 
         # ---------------------------------------------------------------
         # Phase 3: nothing found

--- a/tests/v1/platform/test_iluvatar_vendor.py
+++ b/tests/v1/platform/test_iluvatar_vendor.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for CUDA-compatible Iluvatar detection.
+
+Hardware smoke (manual, on BI-V150 after ``BUILD_WITH_ILUVATAR=1`` build)::
+
+    from lmcache.v1.platform import torch_device_type
+    from lmcache.v1.platform.cuda import is_iluvatar_device
+    assert torch_device_type == "cuda"
+    assert is_iluvatar_device()
+"""
+
+# Standard
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+import sys
+
+# Third Party
+import pytest
+
+
+def _is_iluvatar_device_from_name(name: str | None) -> bool:
+    """Mirror the name-match used by :func:`is_iluvatar_device`."""
+    return name is not None and "Iluvatar" in name
+
+
+def test_is_iluvatar_device_true_for_corex_name() -> None:
+    assert _is_iluvatar_device_from_name("Iluvatar BI-V150") is True
+
+
+def test_is_iluvatar_device_false_for_nvidia_name() -> None:
+    assert _is_iluvatar_device_from_name("NVIDIA A100-SXM4-40GB") is False
+
+
+def test_is_iluvatar_device_false_when_no_name() -> None:
+    assert _is_iluvatar_device_from_name(None) is False
+
+
+def test_is_iluvatar_device_case_sensitive_token() -> None:
+    """Vendor match is case-sensitive on the ``Iluvatar`` token."""
+    assert _is_iluvatar_device_from_name("iluvatar BI-V150") is False
+
+
+def test_is_iluvatar_device_uses_torch_get_device_name() -> None:
+    mock_torch = MagicMock()
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.cuda.get_device_name.return_value = "Iluvatar BI-V150"
+
+    with patch.dict(sys.modules, {"torch": mock_torch}):
+        # First Party
+        from lmcache.v1.platform.cuda import is_iluvatar_device
+
+        assert is_iluvatar_device(0) is True
+        mock_torch.cuda.get_device_name.assert_called_with(0)
+
+
+def test_is_iluvatar_device_false_when_cuda_unavailable() -> None:
+    mock_torch = MagicMock()
+    mock_torch.cuda.is_available.return_value = False
+
+    with patch.dict(sys.modules, {"torch": mock_torch}):
+        # First Party
+        from lmcache.v1.platform.cuda import is_iluvatar_device
+
+        assert is_iluvatar_device() is False
+
+
+def test_iluvatar_profile_detect_true_when_device_name_is_iluvatar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_torch = MagicMock()
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.cuda.current_device.return_value = 0
+    mock_torch.cuda.get_device_name.return_value = "Iluvatar BI-V150"
+
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.iluvatar.shutil.which",
+        lambda name: "/usr/bin/nvcc" if name == "nvcc" else None,
+    )
+    with patch.dict(sys.modules, {"torch": mock_torch}):
+        # First Party
+        from setup_extensions.build_profiles.iluvatar import IluvatarProfile
+
+        assert IluvatarProfile().detect() is True
+
+
+def test_iluvatar_profile_detect_false_for_nvidia_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_torch = MagicMock()
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.cuda.current_device.return_value = 0
+    mock_torch.cuda.get_device_name.return_value = "NVIDIA A100-SXM4-80GB"
+
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.iluvatar.shutil.which",
+        lambda name: "/usr/bin/nvcc" if name == "nvcc" else None,
+    )
+    with patch.dict(sys.modules, {"torch": mock_torch}):
+        # First Party
+        from setup_extensions.build_profiles.iluvatar import IluvatarProfile
+
+        assert IluvatarProfile().detect() is False
+
+
+def test_build_policy_auto_detects_iluvatar_from_device_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-detect (no BUILD_WITH_*) picks iluvatar when the GPU name matches."""
+    monkeypatch.delenv("BUILD_WITH_ILUVATAR", raising=False)
+    monkeypatch.delenv("BUILD_WITH_CUDA", raising=False)
+
+    mock_torch = MagicMock()
+    mock_torch.cuda.is_available.return_value = True
+    mock_torch.cuda.current_device.return_value = 0
+    mock_torch.cuda.get_device_name.return_value = "Iluvatar BI-V150"
+
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.cuda.shutil.which",
+        lambda name: "/usr/bin/nvcc" if name == "nvcc" else None,
+    )
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.iluvatar.shutil.which",
+        lambda name: "/usr/bin/nvcc" if name == "nvcc" else None,
+    )
+    with patch.dict(sys.modules, {"torch": mock_torch}):
+        # First Party
+        from setup_extensions.policy import BuildPolicy
+
+        profile = BuildPolicy().resolve_profile()
+    assert profile is not None
+    assert profile.name == "iluvatar"
+
+
+def test_iluvatar_profile_injects_use_iluvatar_macro() -> None:
+    # First Party
+    from setup_extensions.build_profiles.iluvatar import IluvatarProfile
+
+    profile = IluvatarProfile()
+    captured: dict = {}
+
+    class _FakeExt:
+        def __init__(
+            self,
+            name,
+            sources,
+            define_macros=None,
+            extra_compile_args=None,
+            include_dirs=None,
+            **_kwargs,
+        ):
+            captured["name"] = name
+            captured["define_macros"] = define_macros
+            captured["extra_compile_args"] = extra_compile_args
+            captured["sources"] = sources
+            captured["include_dirs"] = include_dirs
+
+    fake_torch_utils = ModuleType("torch.utils")
+    fake_cpp = ModuleType("torch.utils.cpp_extension")
+    fake_cpp.CUDAExtension = _FakeExt
+    fake_cpp.BuildExtension = object
+    fake_torch_utils.cpp_extension = fake_cpp
+
+    with patch.dict(
+        sys.modules,
+        {
+            "torch": MagicMock(),
+            "torch.utils": fake_torch_utils,
+            "torch.utils.cpp_extension": fake_cpp,
+        },
+    ):
+        profile.build()
+
+    assert captured["name"] == "lmcache.cuda_ops"
+    assert captured["define_macros"] == [("USE_ILUVATAR", "1")]
+    assert "-DUSE_ILUVATAR=1" in captured["extra_compile_args"]["nvcc"]
+    assert "-DUSE_ILUVATAR=1" in captured["extra_compile_args"]["cxx"]
+    assert "csrc/cuda/blend_kernels.cu" in captured["sources"]
+    assert captured["include_dirs"]
+
+
+def test_build_policy_prefers_non_cuda_when_multiple_detect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cuda + Iluvatar both detecting must not pick plain cuda macros."""
+    # First Party
+    from setup_extensions.policy import BuildPolicy
+
+    monkeypatch.delenv("BUILD_WITH_CUDA", raising=False)
+    monkeypatch.delenv("BUILD_WITH_ILUVATAR", raising=False)
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.cuda.shutil.which",
+        lambda name: "/usr/bin/nvcc" if name == "nvcc" else None,
+    )
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.iluvatar.shutil.which",
+        lambda name: "/usr/bin/nvcc" if name == "nvcc" else None,
+    )
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.iluvatar._is_iluvatar_cuda_device",
+        lambda: True,
+    )
+
+    profile = BuildPolicy().resolve_profile()
+    assert profile is not None
+    assert profile.name == "iluvatar"
+
+
+def test_cuda_profile_detect_is_vendor_agnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CudaProfile only checks nvcc; multi-match preference lives in policy."""
+    # First Party
+    from setup_extensions.build_profiles.cuda import CudaProfile
+
+    monkeypatch.setenv("BUILD_WITH_ILUVATAR", "1")
+    monkeypatch.setattr(
+        "setup_extensions.build_profiles.cuda.shutil.which",
+        lambda _name: "/usr/bin/nvcc",
+    )
+    assert CudaProfile().detect() is True


### PR DESCRIPTION
**What this PR does / why we need it**:

Iluvatar (天数智芯 / Iluvatar CoreX) is GPU hardware from Iluvatar CoreX. Its accelerators (for example BI-V150, reported as `Iluvatar BI-V150`) expose a CUDA-compatible API (`torch.cuda`) and therefore keep LMCache's runtime `device_type="cuda"`, including MP AUTO routing to LMCacheDriven.

The CoreX toolchain cannot compile NVIDIA-only `cuda_fp8.h` or PTX `ld/st.global.cs`. This PR adds a CUDA-compatible vendor path without introducing a new `device_type` / `DeviceSpec`.

- Runtime stays `device_type="cuda"` (`CudaDeviceSpec`, `lmcache.cuda_ops`).
- Vendor identity is `torch.cuda.get_device_name()` containing `"Iluvatar"` (`is_iluvatar_device()`).
- Build: `BUILD_WITH_ILUVATAR=1` / `IluvatarProfile` injects `USE_ILUVATAR`.
- `CudaProfile.detect()` stays nvcc-only. When both CUDA and Iluvatar match, `BuildPolicy` prefers the non-`cuda` profile. Headless builds should set `BUILD_WITH_ILUVATAR=1`.

**Special notes for your reviewers**:

Do not add a new `device_type="iluvatar"`. That would break MP AUTO → LMCacheDriven.

`setup.py` must not import `lmcache` (that initializes `cuda_ops`), so the device-name check is inlined in `IluvatarProfile.detect()`.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests