### PR TITLE
[good-first-issue] storage: use lazy logging in blackhole_adapter.py

### DIFF
--- a/lmcache/v1/storage_backend/connector/blackhole_adapter.py
+++ b/lmcache/v1/storage_backend/connector/blackhole_adapter.py
@@ -17,5 +17,5 @@ class BlackholeConnectorAdapter(ConnectorAdapter):
         # Local
         from .blackhole_connector import BlackholeConnector
 
-        logger.info(f"Creating Blackhole connector for URL: {context.url}")
+        logger.info("Creating Blackhole connector for URL: %s", context.url)
         return BlackholeConnector()


### PR DESCRIPTION
**What this PR does / why we need it**:
Refs #3372 

Convert the f-string logging call in 'blackhole_adapter.py' to  lazy `%s` formatting. This avoid eagerly formatting the message when INFO logging is disabled, while preserving the rendered log output and runtime behavior.

**Special notes for your reviewers**:

- This is my first PR to LMCache
- `ruff check --select G004 lmcache/v1/storage_backend/connector/blackhole_adapter.py` passes with 1 violation before the change and 0 after.
- No unit test was added because this changes only logging argument formatting. Control flow, return values, and rendered log tet are unchanged.
- `pre-commit run --files lmcache/v1/storage_backend/connector/blackhole_adapter.py` passes.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
