### PR TITLE
feat: support external device plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,12 +59,6 @@ pytest -xvs tests/v1/test_cache_engine.py
 pytest -xvs tests/v1/test_cache_engine.py::test_function_name
 ```
 
-On macOS arm64, the standard suite cannot fully collect because `triton` and
-`vllm` are unavailable on that platform. The first failures currently surface
-in `tests/v1/compute/attention/test_triton_kernels.py` and
-`tests/v1/test_pos_kernels.py`. Run targeted platform-independent test files
-locally and rely on Linux GPU CI for the full standard suite.
-
 Test dependencies: `uv pip install -r requirements/test.txt`
 
 Pytest marker: `@pytest.mark.no_shared_allocator` disables the shared-allocator monkeypatch for a test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,6 @@ uv pip install torch               # pre-requisite for CUDA extensions
 uv pip install -e . --no-build-isolation
 ```
 
-When using the repo's ``uv``-managed virtualenv without activating it first,
-do not assume ``python -m pip`` works: this environment may not include the
-``pip`` module. Prefer ``uv pip install --python .venv/bin/python ...`` for
-one-off installs (including docs/test dependencies).
-
 ## Build & Install
 
 ```bash
@@ -176,11 +171,6 @@ cd docs
 make clean
 make html
 ```
-
-If you are running the docs build without activating ``.venv`` first, export
-``SPHINXBUILD=/abs/path/to/.venv/bin/sphinx-build`` (or prepend
-``.venv/bin`` to ``PATH``) before invoking ``make``; otherwise the Makefile
-may fail with ``sphinx-build: command not found``.
 
 The build must complete **without errors or warnings**. Review the generated HTML in `docs/build/html/` to confirm formatting, links, and examples render correctly. You can preview locally with:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ uv pip install torch               # pre-requisite for CUDA extensions
 uv pip install -e . --no-build-isolation
 ```
 
+When using the repo's ``uv``-managed virtualenv without activating it first,
+do not assume ``python -m pip`` works: this environment may not include the
+``pip`` module. Prefer ``uv pip install --python .venv/bin/python ...`` for
+one-off installs (including docs/test dependencies).
+
 ## Build & Install
 
 ```bash
@@ -171,6 +176,11 @@ cd docs
 make clean
 make html
 ```
+
+If you are running the docs build without activating ``.venv`` first, export
+``SPHINXBUILD=/abs/path/to/.venv/bin/sphinx-build`` (or prepend
+``.venv/bin`` to ``PATH``) before invoking ``make``; otherwise the Makefile
+may fail with ``sphinx-build: command not found``.
 
 The build must complete **without errors or warnings**. Review the generated HTML in `docs/build/html/` to confirm formatting, links, and examples render correctly. You can preview locally with:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,12 @@ pytest -xvs tests/v1/test_cache_engine.py
 pytest -xvs tests/v1/test_cache_engine.py::test_function_name
 ```
 
+On macOS arm64, the standard suite cannot fully collect because `triton` and
+`vllm` are unavailable on that platform. The first failures currently surface
+in `tests/v1/compute/attention/test_triton_kernels.py` and
+`tests/v1/test_pos_kernels.py`. Run targeted platform-independent test files
+locally and rely on Linux GPU CI for the full standard suite.
+
 Test dependencies: `uv pip install -r requirements/test.txt`
 
 Pytest marker: `@pytest.mark.no_shared_allocator` disables the shared-allocator monkeypatch for a test.

--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -20,8 +20,9 @@ multiprocess (MP) mode.
 │                                 "hpu"/"cpu"; auto-discoverable) │
 │                                                                 │
 │  [Registry Discovery Point]                                     │
-│  DeviceSpec subclasses are auto-discovered under                │
-│  lmcache.v1.platform and selected by availability.              │
+│  Built-in DeviceSpecs are discovered under lmcache.v1.platform; │
+│  wheel plugins use the lmcache.device_plugins entry-point group.│
+│  Both sources share one registry and availability selection.    │
 │  The DEVICE_TYPE env var forces the detector to prefer one      │
 │  registered device_type when multiple are available.            │
 │                                                                 │
@@ -216,19 +217,17 @@ which is wrong for that backend's actual KV cache layout.
 
 ## Adding New Hardware
 
-1. Add a ``DeviceSpec`` subclass under
-   ``lmcache/v1/platform/<device>/__init__.py``.  Override ``ops_cls``
-   to return your ``DeviceOps`` subclass (or inherit the base which
-   returns ``DeviceOps`` itself for pure torch baseline).
-2. Add a ``DeviceOps`` subclass under
-   ``lmcache/v1/platform/<device>/device_ops.py``.  Override
-   ``ensure_native()`` to bind your compiled extension (or leave it
-   empty for pure torch baseline).
-3. Verify with MP ``engine_driven`` mode (see the :doc:`developer guide
-   <../source/developer_guide/extending_lmcache/adding_a_new_device_backend>`).
-4. (Optional) Add ``ipc_wrapper_cls`` and ``create_cache_context()``
-   overrides on your ``DeviceSpec`` for LMCache-driven transfer.
+1. Create an independent Python project with a ``DeviceSpec`` subclass and,
+   when needed, a ``DeviceOps`` subclass.
+2. Publish the ``DeviceSpec`` class through the
+   ``lmcache.device_plugins`` entry-point group and build a wheel.
+3. Install the wheel beside LMCache and verify with MP ``engine_driven`` mode
+   (see the [developer guide](../source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst)).
+4. Optionally add ``ipc_wrapper_cls``, ``event_ipc_backend``, and
+   ``create_cache_context()`` implementations for LMCache-driven transfer.
 
-No edits to ``lmcache/__init__.py`` or global backend candidate lists
-are required. Users can set ``DEVICE_TYPE=<device_type>`` at runtime to
-force selection of a registered device when multiple are available.
+No LMCache repository change is required. Users can set
+``DEVICE_TYPE=<device_type>`` at runtime to force selection when multiple
+devices are available. See the
+[external device plugin design](v1/platform/device-plugin-architecture.md)
+for the package contract, conflict policy, and failure behavior.

--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -217,17 +217,25 @@ which is wrong for that backend's actual KV cache layout.
 
 ## Adding New Hardware
 
-1. Create an independent Python project with a ``DeviceSpec`` subclass and,
-   when needed, a ``DeviceOps`` subclass.
-2. Publish the ``DeviceSpec`` class through the
-   ``lmcache.device_plugins`` entry-point group and build a wheel.
-3. Install the wheel beside LMCache and verify with MP ``engine_driven`` mode
-   (see the [developer guide](../source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst)).
-4. Optionally add ``ipc_wrapper_cls``, ``event_ipc_backend``, and
-   ``create_cache_context()`` implementations for LMCache-driven transfer.
+Device vendors choose one of two ownership models:
 
-No LMCache repository change is required. Users can set
-``DEVICE_TYPE=<device_type>`` at runtime to force selection when multiple
-devices are available. See the
+- **In-tree:** contribute the `DeviceSpec`, `DeviceOps`, tests, and optional
+  IPC capabilities under `lmcache/v1/platform/<device>/`. Subclass discovery
+  finds the backend without a registration list. This model ships and tests
+  the device on the LMCache release cadence.
+- **External wheel:** maintain the same interfaces in a vendor repository and
+  publish the `DeviceSpec` through the `lmcache.device_plugins` entry-point
+  group. This model lets the vendor own its release cadence and native binary
+  distribution without an LMCache code change.
+
+Both models enter the same registry and dispatch paths. Start with MP
+`engine_driven` mode, then optionally add `ipc_wrapper_cls`,
+`event_ipc_backend`, and `create_cache_context()` implementations for
+LMCache-driven transfer. Users can set `DEVICE_TYPE=<device_type>` at runtime
+to force selection when multiple devices are available.
+
+See the
+[developer guide](../source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst)
+for both integration procedures. The
 [external device plugin design](v1/platform/device-plugin-architecture.md)
-for the package contract, conflict policy, and failure behavior.
+defines the wheel package contract, conflict policy, and failure behavior.

--- a/docs/design/v1/platform/device-plugin-architecture.md
+++ b/docs/design/v1/platform/device-plugin-architecture.md
@@ -1,0 +1,112 @@
+# External Device Plugin Architecture
+
+## Goal
+
+Hardware vendors can integrate a new LMCache device backend from an
+independently versioned wheel. LMCache discovers the wheel at runtime, so the
+vendor can ship fixes and native binaries without adding vendor code or a
+device-name list to the LMCache repository.
+
+The plugin boundary is a `DeviceSpec` subclass. Existing dispatch paths then
+resolve operations, IPC wrappers, event IPC, pinning, and cache contexts from
+that same object; plugins do not need separate registration hooks for each
+capability.
+
+## Package Contract
+
+An external distribution publishes an entry point in the
+`lmcache.device_plugins` group:
+
+```toml
+[project.entry-points."lmcache.device_plugins"]
+foo = "lmcache_foo.device:FooDeviceSpec"
+```
+
+The loaded object must satisfy all of these rules:
+
+1. It is a concrete subclass of
+   `lmcache.v1.platform.base.device_spec.DeviceSpec`, not an instance or
+   factory.
+2. It has a no-argument constructor.
+3. Its `device_type` is a non-empty lowercase string equal to the entry-point
+   name.
+4. Its import and constructor do not require the device to be present.
+   Hardware probing belongs in `is_available()`.
+
+The entry-point module loads while `lmcache.v1.platform` is initializing. It
+must import interfaces from `lmcache.v1.platform.base` and lazy-load heavier
+modules from properties such as `ops_cls`, `ipc_wrapper_cls`, and
+`event_ipc_backend`. This keeps discovery free of native-library requirements
+and avoids platform initialization cycles.
+
+## Discovery and Dispatch
+
+```text
+first platform access
+        |
+        v
+scan lmcache.v1.platform subpackages ------> built-in DeviceSpec instances
+        |
+        v
+read importlib.metadata entry points ------> external DeviceSpec instances
+        |                                    group: lmcache.device_plugins
+        v
+merge by device_type (built-ins win)
+        |
+        +--> DEVICE_TYPE=<name> preference, when set and available
+        |
+        +--> otherwise first available accelerator
+        |
+        v
+one cached DeviceSpec instance
+        |
+        +--> torch device module
+        +--> DeviceOps singleton
+        +--> IPC wrapper / event IPC / pinning / cache context
+```
+
+`_build_device_registry()` owns the single process-wide registry used by both
+device detection and backend resolution. This is important because
+`DeviceSpec` caches its `DeviceOps` and pin-memory backend instances. Separate
+registries would create different capability objects for detection and use.
+
+The registry and detected device are process-lifetime caches. Installing or
+removing a plugin requires restarting every LMCache and serving-engine process.
+
+## Ordering, Conflicts, and Failure Isolation
+
+Built-in device specs are registered before external specs. An external wheel
+with a built-in `device_type` is ignored, preventing package installation from
+silently replacing LMCache's CUDA, CPU, or other bundled behavior.
+
+External entry points are sorted by `(name, value)` before loading. If multiple
+distributions claim the same new `device_type`, the first valid entry wins and
+later entries are logged and ignored. Operators should remove the duplicate;
+the ordering is deterministic but duplicate ownership is not a supported
+extension model.
+
+Each external entry point has an independent failure boundary. Load,
+validation, and construction exceptions produce a warning and skip only that
+plugin. This keeps CLI and CPU fallback behavior available when an optional
+vendor runtime or shared library is absent. Exceptions from `is_available()`
+remain the plugin's responsibility: implementations should catch vendor probe
+errors and return `False`.
+
+## Compatibility and Trust
+
+`DeviceSpec` and `DeviceOps` are Python interfaces imported from LMCache, so a
+plugin wheel must declare and test an appropriate LMCache dependency range.
+Native extensions remain owned and versioned by the vendor wheel and should be
+loaded lazily by `DeviceOps.ensure_native()`.
+
+Python entry points execute installed package code in the LMCache process.
+They are an extensibility mechanism, not a sandbox; deployment environments
+must trust installed device-plugin distributions.
+
+## Non-goals
+
+- Hot installation or registry refresh in a running process.
+- Overriding a built-in LMCache device backend.
+- Selecting among multiple implementations for one `device_type`.
+- Guaranteeing ABI compatibility for native extensions outside the version
+  range declared by the plugin.

--- a/docs/design/v1/platform/device-plugin-architecture.md
+++ b/docs/design/v1/platform/device-plugin-architecture.md
@@ -7,6 +7,12 @@ independently versioned wheel. LMCache discovers the wheel at runtime, so the
 vendor can ship fixes and native binaries without adding vendor code or a
 device-name list to the LMCache repository.
 
+This is an alternative to the existing in-tree model, not a replacement for
+it. Vendors can still contribute a backend under
+`lmcache/v1/platform/<device>/` when joint maintenance and the LMCache release
+cadence are preferable. Both models implement the same interfaces and merge
+into the same runtime registry.
+
 The plugin boundary is a `DeviceSpec` subclass. Existing dispatch paths then
 resolve operations, IPC wrappers, event IPC, pinning, and cache contexts from
 that same object; plugins do not need separate registration hooks for each

--- a/docs/design/v1/platform/device-plugin-architecture.md
+++ b/docs/design/v1/platform/device-plugin-architecture.md
@@ -34,8 +34,9 @@ The loaded object must satisfy all of these rules:
    `lmcache.v1.platform.base.device_spec.DeviceSpec`, not an instance or
    factory.
 2. It has a no-argument constructor.
-3. Its `device_type` is a non-empty lowercase string equal to the entry-point
-   name.
+3. Its `device_type` and `backend_name` are non-empty lowercase strings. The
+   entry-point name equals `backend_name`; `device_type` may be shared by
+   multiple backends when torch exposes them through the same device category.
 4. Its import and constructor do not require the device to be present.
    Hardware probing belongs in `is_available()`.
 
@@ -57,11 +58,13 @@ scan lmcache.v1.platform subpackages ------> built-in DeviceSpec instances
 read importlib.metadata entry points ------> external DeviceSpec instances
         |                                    group: lmcache.device_plugins
         v
-merge by device_type (built-ins win)
+index by unique backend_name, then group by device_type
         |
-        +--> DEVICE_TYPE=<name> preference, when set and available
+        +--> LMCACHE_DEVICE_BACKEND=<name> exact selection, when set
         |
-        +--> otherwise first available accelerator
+        +--> DEVICE_TYPE=<type> limits selection to one torch category
+        |
+        +--> otherwise scan categories and select their only available backend
         |
         v
 one cached DeviceSpec instance
@@ -71,25 +74,31 @@ one cached DeviceSpec instance
         +--> IPC wrapper / event IPC / pinning / cache context
 ```
 
-`_build_device_registry()` owns the single process-wide registry used by both
-device detection and backend resolution. This is important because
-`DeviceSpec` caches its `DeviceOps` and pin-memory backend instances. Separate
-registries would create different capability objects for detection and use.
+`_build_backend_registry()` owns the process-wide `DeviceSpec` instances,
+indexed by `backend_name`. `_build_device_registry()` groups those same
+instances by `device_type`. Both device detection and backend resolution use
+these registries. This is important because `DeviceSpec` caches its `DeviceOps`
+and pin-memory backend instances; constructing separate specs would create
+different capability objects for detection and use.
 
 The registry and detected device are process-lifetime caches. Installing or
 removing a plugin requires restarting every LMCache and serving-engine process.
 
 ## Ordering, Conflicts, and Failure Isolation
 
-Built-in device specs are registered before external specs. An external wheel
-with a built-in `device_type` is ignored, preventing package installation from
-silently replacing LMCache's CUDA, CPU, or other bundled behavior.
+Built-in device specs are registered before external specs. External entry
+points are sorted by `(name, value)` before loading. If multiple specs claim the
+same `backend_name`, the first valid entry wins and later entries are logged and
+ignored. This prevents an external wheel from silently replacing a bundled
+backend with the same identity.
 
-External entry points are sorted by `(name, value)` before loading. If multiple
-distributions claim the same new `device_type`, the first valid entry wins and
-later entries are logged and ignored. Operators should remove the duplicate;
-the ordering is deterministic but duplicate ownership is not a supported
-extension model.
+Multiple backends may intentionally share one `device_type`. If exactly one of
+them reports `is_available()`, LMCache selects it automatically. If more than
+one reports available, LMCache raises an actionable error instead of choosing
+by registration order; operators can select the intended implementation with
+`LMCACHE_DEVICE_BACKEND`. CUDA and ROCm are the built-in example: both use
+torch's `cuda` device type, while mutually exclusive runtime checks select the
+`cuda` or `rocm` backend without an environment variable.
 
 Each external entry point has an independent failure boundary. Load,
 validation, and construction exceptions produce a warning and skip only that
@@ -112,7 +121,8 @@ must trust installed device-plugin distributions.
 ## Non-goals
 
 - Hot installation or registry refresh in a running process.
-- Overriding a built-in LMCache device backend.
-- Selecting among multiple implementations for one `device_type`.
+- Silently overriding an existing `backend_name`.
+- Priority-based automatic selection when multiple implementations for one
+  `device_type` report available simultaneously.
 - Guaranteeing ABI compatibility for native extensions outside the version
   range declared by the plugin.

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -443,10 +443,11 @@ handle transfer can still opt into LMCache-driven explicitly (below).
 
 .. note::
 
-   ROCm is not a separate backend: under PyTorch a ROCm GPU reports
-   ``device_type == "cuda"`` and reuses ``CudaIPCWrapper`` (CUDA IPC)
-   for the LMCache-driven path, so it works in AUTO mode with no extra
-   setup.  There is currently no dedicated ``platform/rocm`` package.
+   Under PyTorch a ROCm GPU reports ``device_type == "cuda"``. LMCache
+   registers a distinct ``RocmDeviceSpec`` with ``backend_name == "rocm"``
+   while reusing the CUDA platform's ops, cache context, and IPC wrapper.
+   CUDA and ROCm availability checks are mutually exclusive, so AUTO mode
+   selects the correct backend without extra configuration.
 
 When the caller (or ``LMCACHE_MP_TRANSFER_MODE``) explicitly requests
 ``lmcache_driven``, ``_build_lmcache_driven_context`` performs two hard

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -4,15 +4,23 @@ Adding a New Device Backend
 ===========================
 
 This guide explains how to add a **new accelerator** to LMCache in
-**Multiprocess (MP) mode** without modifying the LMCache repository. A device
-vendor maintains an independent Python project, publishes a wheel, and
-registers its backend through Python package metadata. Installing that wheel
-in the same environment as LMCache makes the device available at the next
-process start.
+**Multiprocess (MP) mode**. Device vendors can choose either supported
+ownership model:
 
-**For basic users:** read :ref:`Part 1 <part-1-basic>` only — packaging a
-``DeviceSpec`` and a ``DeviceOps`` subclass is all you need to use the built-in
-torch baseline ops.
+- **In-tree integration:** contribute and maintain the backend under
+  ``lmcache/v1/platform/<device>/`` in the LMCache repository. This fits
+  backends that should ship, test, and release with LMCache.
+- **External wheel integration:** maintain the backend in a vendor repository
+  and publish a wheel through the ``lmcache.device_plugins`` entry-point
+  group. This fits backends that need an independent release cadence or own
+  native-package distribution.
+
+Both models implement the same ``DeviceSpec`` and ``DeviceOps`` interfaces
+and use the same runtime detection and dispatch paths.
+
+**For basic users:** read :ref:`Part 1 <part-1-basic>` only — a ``DeviceSpec``
+and a ``DeviceOps`` subclass are all you need to use the built-in torch
+baseline ops.
 
 **For advanced users:** continue to :ref:`Part 2 <part-2-performance>`
 for native ops and advanced transfer modes.
@@ -48,8 +56,25 @@ Your PyTorch backend should support:
 
 - ``tensor.to(device)`` / ``tensor.cpu()`` (host↔device transfers)
 
-Step 1: Create an independent Python project
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Step 1: Choose the ownership model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Option A — integrate in the LMCache repository
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Create a platform package directly in LMCache::
+
+    lmcache/v1/platform/foo/
+    ├── __init__.py
+    └── device_ops.py
+
+Define ``FooDeviceSpec`` in ``__init__.py``. LMCache scans its built-in
+platform packages, so this option needs no entry point or registration list.
+Submit the code, tests, and device documentation in an LMCache PR; after
+merge, the backend follows the LMCache release lifecycle.
+
+Option B — maintain an external wheel
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use a ``src`` layout so the wheel owns only its vendor namespace::
 
@@ -90,7 +115,12 @@ incompatible interface changes should be caught by that dependency range.
 Step 2: Implement ``FooDeviceSpec``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create ``src/lmcache_foo/device.py``:
+Create the spec in the location selected in Step 1:
+
+- In-tree: ``lmcache/v1/platform/foo/__init__.py``.
+- External wheel: ``src/lmcache_foo/device.py``.
+
+The implementation is the same in both layouts:
 
 .. code-block:: python
 
@@ -120,7 +150,7 @@ Create ``src/lmcache_foo/device.py``:
 
         @property
         def ops_cls(self) -> type[DeviceOps]:
-            from lmcache_foo.device_ops import FooDeviceOps
+            from .device_ops import FooDeviceOps
 
             return FooDeviceOps
 
@@ -133,14 +163,17 @@ Create ``src/lmcache_foo/device.py``:
             except Exception:
                 return False
 
-The entry-point target must be the class itself, not a class instance or a
-factory. The class must have a no-argument constructor. LMCache instantiates
-it once per process and caches it.
+For an external wheel, the entry-point target must be the class itself, not a
+class instance or factory. For either model, the class must have a no-argument
+constructor; LMCache instantiates it once per process and caches it.
 
 Step 3: Implement ``FooDeviceOps``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create ``src/lmcache_foo/device_ops.py``:
+Create ``device_ops.py`` next to the spec package:
+
+- In-tree: ``lmcache/v1/platform/foo/device_ops.py``.
+- External wheel: ``src/lmcache_foo/device_ops.py``.
 
 .. code-block:: python
 
@@ -165,7 +198,7 @@ Create ``src/lmcache_foo/device_ops.py``:
 
    If you have no native extension yet, leave ``ensure_native`` as a no-op.
    The torch baseline handles everything. See :ref:`Part 2
-   <part-2-performance>` when the vendor wheel also ships native code.
+   <part-2-performance>` when the backend also ships native code.
 
 Key properties:
 
@@ -202,11 +235,16 @@ Key properties:
    PyTorch itself (like ``torch.cuda``) a plain
    ``torch.foo.is_available()`` is enough.
 
-Step 4: Build and install the wheel
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Step 4: Install the selected integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Build the project with any PEP 517 frontend, then install the wheel in the
-same Python environment as LMCache and the serving engine:
+For an in-tree backend, build or install LMCache normally from the branch
+containing the platform package. Once merged and released, users receive the
+backend with LMCache itself.
+
+For an external backend, build the vendor project with any PEP 517 frontend,
+then install its wheel in the same Python environment as LMCache and the
+serving engine:
 
 .. code-block:: bash
 
@@ -214,18 +252,18 @@ same Python environment as LMCache and the serving engine:
     python -m build --wheel
     python -m pip install dist/lmcache_foo_device-0.1.0-py3-none-any.whl
 
-Restart every LMCache and serving-engine process after installation. Entry
-points are read when the platform registry is first built and are cached for
-the lifetime of the process.
+Restart every LMCache and serving-engine process after installing either
+integration. The platform registry is built once and cached for the lifetime
+of each process.
 
-No global list, environment path, or LMCache source edit is required. All ops
-route through ``torch_ops.py`` until the plugin overrides them.
+Neither model requires editing a global device-name list. All ops route
+through ``torch_ops.py`` until the backend overrides them.
 
-Plugin loading rules
-~~~~~~~~~~~~~~~~~~~~
+External wheel loading rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- LMCache discovers built-in backends first, then installed entry points.
-  A plugin cannot replace an existing built-in ``device_type``.
+- LMCache discovers in-tree backends first, then installed entry points. An
+  external wheel cannot replace an existing in-tree ``device_type``.
 - Entry-point names and ``DeviceSpec.device_type`` values must match and use a
   non-empty lowercase string. Duplicate external device types are ignored
   after the first deterministic match.
@@ -292,8 +330,9 @@ baseline is active.
 Debugging checklist:
 
 - [ ] ``torch.foo.is_available()`` returns ``True``.
-- [ ] ``importlib.metadata.entry_points(group="lmcache.device_plugins")``
-  includes ``foo`` and points to ``FooDeviceSpec``.
+- [ ] For an external wheel,
+  ``importlib.metadata.entry_points(group="lmcache.device_plugins")`` includes
+  ``foo`` and points to ``FooDeviceSpec``.
 - [ ] Set ``DEVICE_TYPE=foo`` to force selection if not picked up
   automatically.
 - [ ] Engine-driven transfer works end-to-end (check the LMCache logs
@@ -410,8 +449,9 @@ checks — both must succeed, otherwise the factory raises
    lacks IPC handle transfer).
 
 Separately, the LMCache-driven server module also requires a
-``BaseCacheContext`` subclass in the plugin package (for example,
-``lmcache_foo/cache_context.py``) **and** a matching
+``BaseCacheContext`` subclass next to the backend (for example,
+``lmcache/v1/platform/foo/cache_context.py`` in-tree or
+``lmcache_foo/cache_context.py`` externally) **and** a matching
 ``DeviceSpec.create_cache_context`` override that lazy-imports and
 instantiates it.  The platform-agnostic factory
 ``lmcache.v1.platform.cache_context.create_cache_context`` dispatches
@@ -438,7 +478,7 @@ event-IPC backend.  The capability is declared by
 * CUDA-style event APIs can use
   ``DefaultEventIPCBackend(event_module=..., device_type=...)``.
 * Devices with a different event ABI should implement an
-  ``EventIPCBackend`` in their own plugin package.
+  ``EventIPCBackend`` next to their in-tree or external backend.
 * Concrete device specs should cache the backend because request futures
   may query this property repeatedly.
 
@@ -512,7 +552,7 @@ Override these methods in your ``DeviceSpec``:
             Lazy import so the accelerator-specific module is only
             pulled in when the LMCache-driven path is actually used.
             """
-            from lmcache_foo.ipc_wrapper import FooIPCWrapper
+            from .ipc_wrapper import FooIPCWrapper
 
             return FooIPCWrapper
 
@@ -534,7 +574,7 @@ Override these methods in your ``DeviceSpec``:
             Required for LMCache-driven mode; the base-class default
             raises ``NotImplementedError``.
             """
-            from lmcache_foo.cache_context import FooCacheContext
+            from .cache_context import FooCacheContext
 
             return FooCacheContext(*args, **kwargs)
 

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -4,11 +4,15 @@ Adding a New Device Backend
 ===========================
 
 This guide explains how to add a **new accelerator** to LMCache in
-**Multiprocess (MP) mode**.
+**Multiprocess (MP) mode** without modifying the LMCache repository. A device
+vendor maintains an independent Python project, publishes a wheel, and
+registers its backend through Python package metadata. Installing that wheel
+in the same environment as LMCache makes the device available at the next
+process start.
 
-**For basic users:** read :ref:`Part 1 <part-1-basic>` only — adding a
-``DeviceSpec`` and a ``DeviceOps`` subclass is all you need to get your
-device working with the built-in torch baseline ops.
+**For basic users:** read :ref:`Part 1 <part-1-basic>` only — packaging a
+``DeviceSpec`` and a ``DeviceOps`` subclass is all you need to use the built-in
+torch baseline ops.
 
 **For advanced users:** continue to :ref:`Part 2 <part-2-performance>`
 for native ops and advanced transfer modes.
@@ -44,15 +48,54 @@ Your PyTorch backend should support:
 
 - ``tensor.to(device)`` / ``tensor.cpu()`` (host↔device transfers)
 
-Step 1: Add a ``FooDeviceSpec``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Step 1: Create an independent Python project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Create ``lmcache/v1/platform/foo/__init__.py``:
+Use a ``src`` layout so the wheel owns only its vendor namespace::
+
+    lmcache-foo-device/
+    ├── pyproject.toml
+    └── src/
+        └── lmcache_foo/
+            ├── __init__.py
+            ├── device.py
+            └── device_ops.py
+
+The project must declare one entry point in the
+``lmcache.device_plugins`` group. Its name is the lowercase
+``DeviceSpec.device_type`` and its value points to the ``DeviceSpec`` class:
+
+.. code-block:: toml
+
+    # pyproject.toml
+    [build-system]
+    requires = ["setuptools>=77", "wheel"]
+    build-backend = "setuptools.build_meta"
+
+    [project]
+    name = "lmcache-foo-device"
+    version = "0.1.0"
+    dependencies = ["lmcache"]
+
+    [project.entry-points."lmcache.device_plugins"]
+    foo = "lmcache_foo.device:FooDeviceSpec"
+
+    [tool.setuptools.packages.find]
+    where = ["src"]
+
+Pin ``lmcache`` to the version range tested by your plugin before publishing
+it. LMCache treats ``DeviceSpec`` and ``DeviceOps`` as the plugin interface;
+incompatible interface changes should be caught by that dependency range.
+
+Step 2: Implement ``FooDeviceSpec``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create ``src/lmcache_foo/device.py``:
 
 .. code-block:: python
 
     # SPDX-License-Identifier: Apache-2.0
-    """Foo-specific platform primitives."""
+    """LMCache platform registration for Foo devices."""
 
     from __future__ import annotations
 
@@ -77,7 +120,7 @@ Create ``lmcache/v1/platform/foo/__init__.py``:
 
         @property
         def ops_cls(self) -> type[DeviceOps]:
-            from lmcache.v1.platform.foo.device_ops import FooDeviceOps
+            from lmcache_foo.device_ops import FooDeviceOps
 
             return FooDeviceOps
 
@@ -90,10 +133,14 @@ Create ``lmcache/v1/platform/foo/__init__.py``:
             except Exception:
                 return False
 
-Step 2: Add a ``FooDeviceOps``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The entry-point target must be the class itself, not a class instance or a
+factory. The class must have a no-argument constructor. LMCache instantiates
+it once per process and caches it.
 
-Create ``lmcache/v1/platform/foo/device_ops.py``:
+Step 3: Implement ``FooDeviceOps``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create ``src/lmcache_foo/device_ops.py``:
 
 .. code-block:: python
 
@@ -104,33 +151,21 @@ Create ``lmcache/v1/platform/foo/device_ops.py``:
 
     from typing import ClassVar
 
-    from lmcache.logging import init_logger
     from lmcache.v1.platform.base.device_ops import DeviceOps
-
-    logger = init_logger(__name__)
 
 
     class FooDeviceOps(DeviceOps):
         device_type: ClassVar[str] = "foo"
 
         def ensure_native(self) -> None:
-            if self._native_bound:
-                return
-            self._native_bound = True
-            try:
-                import foo_device.ops as native
-            except ImportError:
-                logger.warning(
-                    "foo native ops not found; FooDeviceOps stays on "
-                    "the torch baseline for all ops."
-                )
-                return
-            self.bind_native(native)
+            """Keep the torch baseline until native ops are available."""
+            return None
 
 .. note::
 
-   If you have no native extension yet, simply leave ``ensure_native``
-   as a no-op (just ``pass``).  The torch baseline handles everything.
+   If you have no native extension yet, leave ``ensure_native`` as a no-op.
+   The torch baseline handles everything. See :ref:`Part 2
+   <part-2-performance>` when the vendor wheel also ships native code.
 
 Key properties:
 
@@ -167,11 +202,42 @@ Key properties:
    PyTorch itself (like ``torch.cuda``) a plain
    ``torch.foo.is_available()`` is enough.
 
-That's it.  Defining these two classes is enough for auto-discovery —
-no global list or manual registration call is required.  All ops
-automatically route through the torch baseline in ``torch_ops.py``,
-which is not performant but is functionally applicable to any device that
-supports the standard PyTorch tensor surface.
+Step 4: Build and install the wheel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Build the project with any PEP 517 frontend, then install the wheel in the
+same Python environment as LMCache and the serving engine:
+
+.. code-block:: bash
+
+    python -m pip install build
+    python -m build --wheel
+    python -m pip install dist/lmcache_foo_device-0.1.0-py3-none-any.whl
+
+Restart every LMCache and serving-engine process after installation. Entry
+points are read when the platform registry is first built and are cached for
+the lifetime of the process.
+
+No global list, environment path, or LMCache source edit is required. All ops
+route through ``torch_ops.py`` until the plugin overrides them.
+
+Plugin loading rules
+~~~~~~~~~~~~~~~~~~~~
+
+- LMCache discovers built-in backends first, then installed entry points.
+  A plugin cannot replace an existing built-in ``device_type``.
+- Entry-point names and ``DeviceSpec.device_type`` values must match and use a
+  non-empty lowercase string. Duplicate external device types are ignored
+  after the first deterministic match.
+- A plugin that cannot be imported, resolves to the wrong object type, or
+  raises during construction is logged and skipped. Other devices remain
+  usable.
+- Entry-point modules are imported while the platform registry initializes.
+  Import base interfaces such as
+  ``lmcache.v1.platform.base.device_spec.DeviceSpec`` directly and keep ops,
+  native libraries, IPC wrappers, and cache contexts behind lazy properties.
+- Installed entry-point packages are executable Python code. Only install
+  wheels from sources you trust.
 
 Verification
 ~~~~~~~~~~~~
@@ -216,23 +282,20 @@ instead of auto-detecting:
    additional capability checks.  For the ``lmcache_driven`` mode
    (IPC zero-copy), see :ref:`Advanced transfer mode <part-2-performance>`.
 
-Check the LMCache logs — without a native extension you should see::
+Check the LMCache logs::
 
     torch_dev=..., torch_device_type=foo
-    foo native ops not found; FooDeviceOps stays on the torch baseline for all ops.
 
 This confirms your ``DeviceSpec`` was discovered and the torch
-baseline is active.  Once you provide a native extension and
-``ensure_native`` succeeds, the warning disappears and ops call through
-your compiled kernels.
+baseline is active.
 
 Debugging checklist:
 
 - [ ] ``torch.foo.is_available()`` returns ``True``.
+- [ ] ``importlib.metadata.entry_points(group="lmcache.device_plugins")``
+  includes ``foo`` and points to ``FooDeviceSpec``.
 - [ ] Set ``DEVICE_TYPE=foo`` to force selection if not picked up
   automatically.
-- [ ] Log shows either the "stays on torch baseline" warning (no native
-  ops) or silent success (native ops bound).
 - [ ] Engine-driven transfer works end-to-end (check the LMCache logs
   to confirm whether the SHM or Pickle sub-path is chosen — both
   should succeed).
@@ -347,8 +410,8 @@ checks — both must succeed, otherwise the factory raises
    lacks IPC handle transfer).
 
 Separately, the LMCache-driven server module also requires a
-``BaseCacheContext`` subclass under
-``lmcache/v1/platform/foo/cache_context.py`` **and** a matching
+``BaseCacheContext`` subclass in the plugin package (for example,
+``lmcache_foo/cache_context.py``) **and** a matching
 ``DeviceSpec.create_cache_context`` override that lazy-imports and
 instantiates it.  The platform-agnostic factory
 ``lmcache.v1.platform.cache_context.create_cache_context`` dispatches
@@ -375,7 +438,7 @@ event-IPC backend.  The capability is declared by
 * CUDA-style event APIs can use
   ``DefaultEventIPCBackend(event_module=..., device_type=...)``.
 * Devices with a different event ABI should implement an
-  ``EventIPCBackend`` in their own ``lmcache/v1/platform/foo/`` package.
+  ``EventIPCBackend`` in their own plugin package.
 * Concrete device specs should cache the backend because request futures
   may query this property repeatedly.
 
@@ -449,7 +512,7 @@ Override these methods in your ``DeviceSpec``:
             Lazy import so the accelerator-specific module is only
             pulled in when the LMCache-driven path is actually used.
             """
-            from lmcache.v1.platform.foo.ipc_wrapper import FooIPCWrapper
+            from lmcache_foo.ipc_wrapper import FooIPCWrapper
 
             return FooIPCWrapper
 
@@ -471,7 +534,7 @@ Override these methods in your ``DeviceSpec``:
             Required for LMCache-driven mode; the base-class default
             raises ``NotImplementedError``.
             """
-            from lmcache.v1.platform.foo.cache_context import FooCacheContext
+            from lmcache_foo.cache_context import FooCacheContext
 
             return FooCacheContext(*args, **kwargs)
 
@@ -501,7 +564,8 @@ References
    * - Event IPC base
      - ``lmcache/v1/platform/base/event_ipc.py``
    * - Backend loading (``resolve_device_ops`` / ``_detect_device``)
-     - ``lmcache/v1/platform/__init__.py``
+     - ``lmcache/v1/platform/_device_detect.py`` and
+       ``lmcache/v1/platform/__init__.py``
    * - Package-level ``device_ops`` resolution
      - ``lmcache/__init__.py``
    * - Cache context base

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -301,13 +301,14 @@ default is ``lmcache_driven``):
         --supported-transfer-mode engine_driven
 
 Run vLLM with MP connector. If you want a specific torch device category, set
-``DEVICE_TYPE``. If multiple LMCache backends share that device type, set
-``LMCACHE_DEVICE_BACKEND`` as well to select the exact implementation:
+``DEVICE_TYPE``. Backends that share one device type are selected automatically
+when exactly one reports available. If multiple backends report available, set
+``LMCACHE_DEVICE_BACKEND`` to select the exact implementation:
 
 .. code-block:: bash
 
-    export DEVICE_TYPE=foo                    # optional; selects the torch-facing device type
-    export LMCACHE_DEVICE_BACKEND=foo        # optional; required only when multiple backends share one device_type
+    export DEVICE_TYPE=foo             # optional; selects the torch-facing device type
+    export LMCACHE_DEVICE_BACKEND=foo  # optional; disambiguates multiple available backends
 
     vllm serve <your-model> \
         --kv-transfer-config '{
@@ -345,8 +346,8 @@ Debugging checklist:
 - [ ] For an external wheel,
   ``importlib.metadata.entry_points(group="lmcache.device_plugins")`` includes
   ``foo`` and points to ``FooDeviceSpec``.
-- [ ] If another backend shares ``device_type="foo"``, set
-  ``LMCACHE_DEVICE_BACKEND=foo`` as well.
+- [ ] If another available backend shares ``device_type="foo"``, set
+  ``LMCACHE_DEVICE_BACKEND=foo`` to disambiguate them.
 - [ ] Set ``DEVICE_TYPE=foo`` to force the torch-facing device category if not
   picked up automatically.
 - [ ] Engine-driven transfer works end-to-end (check the LMCache logs

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -88,7 +88,7 @@ Use a ``src`` layout so the wheel owns only its vendor namespace::
 
 The project must declare one entry point in the
 ``lmcache.device_plugins`` group. Its name is the lowercase
-``DeviceSpec.device_type`` and its value points to the ``DeviceSpec`` class:
+``DeviceSpec.backend_name`` and its value points to the ``DeviceSpec`` class:
 
 .. code-block:: toml
 
@@ -142,6 +142,10 @@ The implementation is the same in both layouts:
 
         @property
         def device_type(self) -> str:
+            return "foo"
+
+        @property
+        def backend_name(self) -> str:
             return "foo"
 
         @property
@@ -211,6 +215,9 @@ Key properties:
    * - ``DeviceSpec.device_type``
      - yes
      - Device type string (e.g. ``"cuda"``, ``"musa"``, ``"xpu"``)
+   * - ``DeviceSpec.backend_name``
+     - yes
+     - Unique LMCache selector for one concrete backend implementation
    * - ``DeviceSpec.torch_module_name``
      - yes
      - Attribute on the ``torch`` package (e.g. ``"cuda"`` →
@@ -262,13 +269,14 @@ through ``torch_ops.py`` until the backend overrides them.
 External wheel loading rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- LMCache discovers in-tree backends first, then installed entry points. An
-  external wheel can replace an existing in-tree ``device_type``. This lets a
-  vendor ship backend fixes or specializations in a separate wheel without
-  forking LMCache.
-- Entry-point names and ``DeviceSpec.device_type`` values must match and use a
-  non-empty lowercase string. Duplicate external device types are ignored
-  after the first deterministic match.
+- ``DeviceSpec.device_type`` is the torch-facing device category (for example,
+  ``"cuda"``). Multiple backends may intentionally share one ``device_type``.
+- ``DeviceSpec.backend_name`` is the LMCache-specific selector for one concrete
+  backend implementation. It must be a unique, non-empty lowercase string.
+- For external wheels, the entry-point name must match
+  ``DeviceSpec.backend_name``.
+- Duplicate ``backend_name`` values are ignored after the first deterministic
+  match.
 - A plugin that cannot be imported, resolves to the wrong object type, or
   raises during construction is logged and skipped. Other devices remain
   usable.
@@ -292,13 +300,14 @@ default is ``lmcache_driven``):
     lmcache server --l1-size-gb 10 --eviction-policy LRU --port 5555 \
         --supported-transfer-mode engine_driven
 
-Run vLLM with MP connector.  If multiple accelerators are visible on
-the host, set ``DEVICE_TYPE`` to force LMCache to pick the new backend
-instead of auto-detecting:
+Run vLLM with MP connector. If you want a specific torch device category, set
+``DEVICE_TYPE``. If multiple LMCache backends share that device type, set
+``LMCACHE_DEVICE_BACKEND`` as well to select the exact implementation:
 
 .. code-block:: bash
 
-    export DEVICE_TYPE=foo            # optional; only when auto-detection picks the wrong device
+    export DEVICE_TYPE=foo                    # optional; selects the torch-facing device type
+    export LMCACHE_DEVICE_BACKEND=foo        # optional; required only when multiple backends share one device_type
 
     vllm serve <your-model> \
         --kv-transfer-config '{
@@ -327,7 +336,8 @@ Check the LMCache logs::
     torch_dev=..., torch_device_type=foo
 
 This confirms your ``DeviceSpec`` was discovered and the torch
-baseline is active.
+baseline is active. When ``LMCACHE_DEVICE_BACKEND`` is set, LMCache also binds
+the backend whose ``backend_name`` matches that value.
 
 Debugging checklist:
 
@@ -335,8 +345,10 @@ Debugging checklist:
 - [ ] For an external wheel,
   ``importlib.metadata.entry_points(group="lmcache.device_plugins")`` includes
   ``foo`` and points to ``FooDeviceSpec``.
-- [ ] Set ``DEVICE_TYPE=foo`` to force selection if not picked up
-  automatically.
+- [ ] If another backend shares ``device_type="foo"``, set
+  ``LMCACHE_DEVICE_BACKEND=foo`` as well.
+- [ ] Set ``DEVICE_TYPE=foo`` to force the torch-facing device category if not
+  picked up automatically.
 - [ ] Engine-driven transfer works end-to-end (check the LMCache logs
   to confirm whether the SHM or Pickle sub-path is chosen — both
   should succeed).

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -263,7 +263,9 @@ External wheel loading rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - LMCache discovers in-tree backends first, then installed entry points. An
-  external wheel cannot replace an existing in-tree ``device_type``.
+  external wheel can replace an existing in-tree ``device_type``. This lets a
+  vendor ship backend fixes or specializations in a separate wheel without
+  forking LMCache.
 - Entry-point names and ``DeviceSpec.device_type`` values must match and use a
   non-empty lowercase string. Duplicate external device types are ignored
   after the first deterministic match.

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -155,6 +155,12 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
         ]
         if len(compatible_candidates) == 1:
             return compatible_candidates[0]
+
+        default_candidates = [
+            spec for spec in candidates if spec.backend_name == device_type
+        ]
+        if len(default_candidates) == 1:
+            return default_candidates[0]
     if device_type in ("", "cpu"):
         return _FALLBACK_CPU_SPEC
     raise RuntimeError(

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -15,7 +15,8 @@ sub-packages so each can evolve independently:
 
 Third-party accelerators can ship a :class:`DeviceSpec` subclass in a
 separate wheel and register it through the ``lmcache.device_plugins`` Python
-entry-point group. No LMCache source changes are required.
+entry-point group. This complements the built-in integration model for
+backends maintained directly in the LMCache repository.
 """
 
 # Future

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 import os
 
 # First Party
+from lmcache.logging import init_logger
 from lmcache.v1.platform._device_detect import (
     DEVICE_BACKEND_ENV_VAR,
     _build_backend_registry,
@@ -69,6 +70,8 @@ from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
 from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
+
+logger = init_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Resolve device ops
@@ -131,6 +134,9 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
         return candidates[0]
 
     if len(candidates) > 1:
+        candidate_backend_names = ", ".join(
+            sorted(spec.backend_name for spec in candidates)
+        )
         explicit_backend = os.environ.get(DEVICE_BACKEND_ENV_VAR, "").strip().lower()
         if explicit_backend:
             dev_spec = _DEVICE_REGISTRY.get(explicit_backend)
@@ -139,6 +145,13 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
 
         available_candidates = [spec for spec in candidates if spec.is_available()]
         if len(available_candidates) == 1:
+            logger.info(
+                "Auto-selected backend [%s] for accelerator %r from candidate "
+                "backends [%s].",
+                available_candidates[0].backend_name,
+                device_type,
+                candidate_backend_names,
+            )
             return available_candidates[0]
         if len(available_candidates) > 1:
             backend_names = ", ".join(

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -150,12 +150,6 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
                 f"{DEVICE_BACKEND_ENV_VAR}=<backend_name> to choose one explicitly."
             )
 
-        compatible_candidates = [
-            spec for spec in candidates if spec.is_runtime_compatible()
-        ]
-        if len(compatible_candidates) == 1:
-            return compatible_candidates[0]
-
         default_candidates = [
             spec for spec in candidates if spec.backend_name == device_type
         ]

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -40,9 +40,12 @@ __all__ = [
 
 # Standard
 from typing import TYPE_CHECKING, Any
+import os
 
 # First Party
 from lmcache.v1.platform._device_detect import (
+    DEVICE_BACKEND_ENV_VAR,
+    _build_backend_registry,
     _build_device_registry,
 )
 from lmcache.v1.platform._device_detect import (
@@ -72,10 +75,10 @@ from lmcache.v1.platform.event_notifier import (
 # ---------------------------------------------------------------------------
 
 
-# Keep the historical private name as an alias for existing internal tests and
-# downstream diagnostics. Both detection and resolution now share the same
-# DeviceSpec instances, including external plugins.
-_DEVICE_REGISTRY: dict[str, DeviceSpec] = _build_device_registry()
+# Keep the historical private name for the backend-name registry so existing
+# tests and downstream diagnostics can still inspect the resolved spec table.
+_DEVICE_REGISTRY: dict[str, DeviceSpec] = _build_backend_registry()
+_DEVICE_TYPE_REGISTRY: dict[str, tuple[DeviceSpec, ...]] = _build_device_registry()
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +102,7 @@ def resolve_kv_wrapper_factory(device_type: str) -> Any:
     Raises:
         ValueError: If no spec / wrapper is registered for *device_type*.
     """
-    spec = _DEVICE_REGISTRY.get(device_type)
+    spec = _resolve_device_spec(device_type)
     wrapper_cls = spec.ipc_wrapper_cls if spec is not None else None
     if wrapper_cls is None:
         raise ValueError(
@@ -123,9 +126,29 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
     Raises:
         RuntimeError: If an accelerator device has no registered spec.
     """
-    dev_spec = _DEVICE_REGISTRY.get(device_type)
-    if dev_spec is not None:
-        return dev_spec
+    candidates = _DEVICE_TYPE_REGISTRY.get(device_type, ())
+    if len(candidates) == 1:
+        return candidates[0]
+
+    if len(candidates) > 1:
+        explicit_backend = os.environ.get(DEVICE_BACKEND_ENV_VAR, "").strip().lower()
+        if explicit_backend:
+            dev_spec = _DEVICE_REGISTRY.get(explicit_backend)
+            if dev_spec is not None and dev_spec.device_type == device_type:
+                return dev_spec
+
+        available_candidates = [spec for spec in candidates if spec.is_available()]
+        if len(available_candidates) == 1:
+            return available_candidates[0]
+        if len(available_candidates) > 1:
+            backend_names = ", ".join(
+                sorted(spec.backend_name for spec in available_candidates)
+            )
+            raise RuntimeError(
+                f"Multiple DeviceSpec backends are available for accelerator "
+                f"{device_type!r}: {backend_names}. Set "
+                f"{DEVICE_BACKEND_ENV_VAR}=<backend_name> to choose one explicitly."
+            )
     if device_type in ("", "cpu"):
         return _FALLBACK_CPU_SPEC
     raise RuntimeError(

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -149,6 +149,12 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
                 f"{device_type!r}: {backend_names}. Set "
                 f"{DEVICE_BACKEND_ENV_VAR}=<backend_name> to choose one explicitly."
             )
+
+        compatible_candidates = [
+            spec for spec in candidates if spec.is_runtime_compatible()
+        ]
+        if len(compatible_candidates) == 1:
+            return compatible_candidates[0]
     if device_type in ("", "cpu"):
         return _FALLBACK_CPU_SPEC
     raise RuntimeError(

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -7,19 +7,15 @@ signal background loops from other threads.  On Linux it is backed by
 ``os.eventfd``; on macOS / other POSIX systems it falls back to
 ``os.pipe``.  Callers never touch ``os.eventfd`` directly.
 
-Accelerator- and OS-specific implementations live in dedicated sub-
-packages so each can evolve independently:
+Built-in accelerator- and OS-specific implementations live in dedicated
+sub-packages so each can evolve independently:
 
 * :mod:`lmcache.v1.platform.cuda` -- CUDA-backed implementations.
 * :mod:`lmcache.v1.platform.cpu`  -- CPU-only fallbacks.
 
-KV-cache IPC wrappers and ``BaseCacheContext`` subclasses are
-discovered separately on first use via
-:mod:`lmcache.v1.utils.subclass_discovery`, keyed by each subclass'
-``device_type`` ClassVar.  Adding a new accelerator therefore
-requires *zero* edits to this module -- drop a new
-``platform/<backend>/`` package and it will be picked up
-automatically.
+Third-party accelerators can ship a :class:`DeviceSpec` subclass in a
+separate wheel and register it through the ``lmcache.device_plugins`` Python
+entry-point group. No LMCache source changes are required.
 """
 
 # Future
@@ -43,10 +39,11 @@ __all__ = [
 
 # Standard
 from typing import TYPE_CHECKING, Any
-import os
 
 # First Party
-from lmcache.logging import init_logger
+from lmcache.v1.platform._device_detect import (
+    _build_device_registry,
+)
 from lmcache.v1.platform._device_detect import (
     current_device_spec as _current_device_spec_fn,
 )
@@ -55,7 +52,6 @@ from lmcache.v1.platform._device_detect import (
     get_torch_device,
 )
 from lmcache.v1.platform.base.device_spec import DeviceSpec
-from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
 if TYPE_CHECKING:
     from lmcache.v1.platform.base.device_ops import DeviceOps
@@ -70,102 +66,15 @@ from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
 
-logger = init_logger(__name__)
-
-
 # ---------------------------------------------------------------------------
 # Resolve device ops
 # ---------------------------------------------------------------------------
 
 
-_DEVICE_REGISTRY: dict[str, DeviceSpec] = {
-    spec.device_type: spec
-    for spec in [
-        cls()
-        for cls in discover_subclasses(
-            "lmcache.v1.platform",
-            DeviceSpec,  # type: ignore[type-abstract]
-            module_filter=lambda name: not name.startswith(("_", "base")),
-            require_defined_in_module=True,
-            on_import_error=lambda name, exc: None,
-        )
-    ]
-}
-
-
-# ---------------------------------------------------------------------------
-# Device detection
-# ---------------------------------------------------------------------------
-
-
-def _detect_device() -> tuple[Any, str]:
-    """Detect the available accelerator via the device registry.
-
-    Returns:
-        tuple[Any, str]: A tuple of (torch_device_module, device_type_string).
-            When torch is not installed (CLI-only mode), returns
-            ``(None, "cpu")``.
-    """
-    try:
-        # Third Party
-        import torch
-    except ImportError as e:
-        logger.warning("load torch failed, error is %s", e)
-        return None, "cpu"  # fallback for CLI-only environments
-
-    # Check DEVICE_TYPE environment variable for forced device selection.
-    env_device_type = os.environ.get("DEVICE_TYPE")
-    if env_device_type is not None:
-        env_device_type = env_device_type.strip().lower()
-        spec = _DEVICE_REGISTRY.get(env_device_type)
-        if spec is not None and spec.is_available():
-            torch_module = getattr(torch, spec.torch_module_name, None)
-            if torch_module is not None:
-                return torch_module, spec.device_type
-            else:
-                logger.warning(
-                    "DEVICE_TYPE=%r is available but torch module [%s] not found, "
-                    "falling back to auto-detection.",
-                    env_device_type,
-                    spec.torch_module_name,
-                )
-        else:
-            logger.warning(
-                "DEVICE_TYPE=%r is not available or not registered, "
-                "falling back to auto-detection.",
-                env_device_type,
-            )
-
-    for spec in _DEVICE_REGISTRY.values():
-        # ``cpu`` is the tail fallback: even though ``CpuDeviceSpec`` now
-        # lives in the registry (so ``resolve_kv_wrapper_factory`` can bind
-        # its IPC wrapper), auto-detection must still prefer accelerators
-        # and let the ``StubCPUDevice`` branch below handle the no-accelerator
-        # case. ``DEVICE_TYPE=cpu`` remains an explicit opt-in above.
-        #
-        # Defence-in-depth pairs with the ``CpuDeviceSpec`` invariant that
-        # ``is_available()`` stays inherited (False); do not remove either
-        # side without updating the other.
-        if spec.device_type == "cpu":
-            continue
-        if not spec.is_available():
-            continue
-
-        torch_module = getattr(torch, spec.torch_module_name, None)
-        if torch_module is not None:
-            return torch_module, spec.device_type
-        else:
-            logger.warning(
-                "device [%s] is available, but torch module [%s] is not found.",
-                spec.device_type,
-                spec.torch_module_name,
-            )
-
-    # No accelerator found -- fall back to CPU stub
-    # First Party
-    from lmcache.v1.platform.cpu.stub_cpu_device import StubCPUDevice
-
-    return StubCPUDevice("cpu"), "cpu"
+# Keep the historical private name as an alias for existing internal tests and
+# downstream diagnostics. Both detection and resolution now share the same
+# DeviceSpec instances, including external plugins.
+_DEVICE_REGISTRY: dict[str, DeviceSpec] = _build_device_registry()
 
 
 # ---------------------------------------------------------------------------
@@ -221,8 +130,8 @@ def _resolve_device_spec(device_type: str) -> DeviceSpec:
     raise RuntimeError(
         f"No DeviceSpec registered for accelerator {device_type!r}; "
         "refusing to silently fall back to the torch baseline on "
-        "accelerator hardware. Ensure the platform sub-package for this "
-        "device is importable and defines a DeviceSpec."
+        "accelerator hardware. Ensure a built-in backend or an installed "
+        "lmcache.device_plugins entry point defines this device."
     )
 
 

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -11,7 +11,7 @@ that init chain.
 
 The registry combines the :class:`DeviceSpec` subclasses shipped with
 LMCache and external subclasses published through the
-``lmcache.device_plugins`` Python entry-point group.  The registry and the
+``lmcache.device_plugins`` Python entry-point group. The registry and the
 detected torch device module are both built lazily on first access and then
 cached process-wide.
 """
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 DEVICE_PLUGIN_ENTRY_POINT_GROUP = "lmcache.device_plugins"
+DEVICE_BACKEND_ENV_VAR = "LMCACHE_DEVICE_BACKEND"
 
 
 # ---------------------------------------------------------------------------
@@ -39,13 +40,19 @@ DEVICE_PLUGIN_ENTRY_POINT_GROUP = "lmcache.device_plugins"
 # ---------------------------------------------------------------------------
 
 
+def _validate_spec_name(name: str, *, field_name: str) -> None:
+    """Validate a DeviceSpec identifier used in env vars and registries."""
+    if not isinstance(name, str) or not name or name != name.lower():
+        raise ValueError(f"{field_name} must be a non-empty lowercase string")
+
+
 def _load_external_device_specs() -> "list[DeviceSpec]":
     """Load external device specifications from Python entry points.
 
-    Each entry point must use its device type as its name and resolve to a
-    concrete :class:`DeviceSpec` subclass with a no-argument constructor.
-    Invalid or broken plugins are skipped so that an unrelated installed
-    package cannot prevent LMCache from starting.
+    Each entry point must use the backend's unique ``backend_name`` as its
+    name and resolve to a concrete :class:`DeviceSpec` subclass with a
+    no-argument constructor. Invalid or broken plugins are skipped so that an
+    unrelated installed package cannot prevent LMCache from starting.
 
     Returns:
         Device specifications loaded successfully from installed plugins.
@@ -70,17 +77,13 @@ def _load_external_device_specs() -> "list[DeviceSpec]":
             spec = spec_cls()
             if not isinstance(spec, DeviceSpec):
                 raise TypeError("entry point must construct a DeviceSpec instance")
-            device_type = spec.device_type
-            if (
-                not isinstance(device_type, str)
-                or not device_type
-                or device_type != device_type.lower()
-            ):
-                raise ValueError("device_type must be a non-empty lowercase string")
-            if device_type != entry_point.name:
+
+            _validate_spec_name(spec.device_type, field_name="device_type")
+            _validate_spec_name(spec.backend_name, field_name="backend_name")
+            if spec.backend_name != entry_point.name:
                 raise ValueError(
-                    "entry-point name must match DeviceSpec.device_type "
-                    f"({entry_point.name!r} != {device_type!r})"
+                    "entry-point name must match DeviceSpec.backend_name "
+                    f"({entry_point.name!r} != {spec.backend_name!r})"
                 )
         except Exception as exc:
             logger.warning(
@@ -95,24 +98,20 @@ def _load_external_device_specs() -> "list[DeviceSpec]":
 
 
 @lru_cache(maxsize=1)
-def _build_device_registry() -> "dict[str, DeviceSpec]":
-    """Discover and instantiate built-in and external device specifications.
+def _build_backend_registry() -> "dict[str, DeviceSpec]":
+    """Discover and index registered specs by unique backend name.
 
-    Discovery is deferred until first use so importing this module
-    stays cheap and side-effect free. Built-in specifications provide the
-    default registry entries, then installed plugins are layered on top.
-    When an external wheel reuses an existing ``device_type``, the external
-    spec takes precedence so vendors can ship fixes or specialized behavior
-    without forking LMCache. If multiple wheels claim the same
-    ``device_type``, the first deterministic match wins.
+    Discovery is deferred until first use so importing this module stays cheap
+    and side-effect free. ``backend_name`` is LMCache's explicit backend
+    selector, so collisions are resolved deterministically and logged.
     """
     # First Party
     from lmcache.v1.platform.base.device_spec import DeviceSpec
     from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
-    registry = {
-        spec.device_type: spec
-        for spec in (
+    registry: dict[str, DeviceSpec] = {}
+    specs = [
+        *(
             cls()
             for cls in discover_subclasses(
                 "lmcache.v1.platform",
@@ -121,87 +120,155 @@ def _build_device_registry() -> "dict[str, DeviceSpec]":
                 require_defined_in_module=True,
                 on_import_error=lambda name, exc: None,
             )
-        )
-    }
-    external_device_types: set[str] = set()
-    for spec in _load_external_device_specs():
-        if spec.device_type in external_device_types:
+        ),
+        *_load_external_device_specs(),
+    ]
+    for spec in specs:
+        _validate_spec_name(spec.device_type, field_name="device_type")
+        _validate_spec_name(spec.backend_name, field_name="backend_name")
+        if spec.backend_name in registry:
             logger.warning(
-                "Ignoring duplicate LMCache device plugin for %r after the "
-                "first matching external wheel was registered",
-                spec.device_type,
+                "Ignoring DeviceSpec %s because backend_name %r is already "
+                "registered by %s",
+                type(spec).__qualname__,
+                spec.backend_name,
+                type(registry[spec.backend_name]).__qualname__,
             )
             continue
-        if spec.device_type in registry:
-            logger.info(
-                "LMCache device plugin for %r overrides the built-in device "
-                "spec for that device type",
-                spec.device_type,
-            )
-        registry[spec.device_type] = spec
-        external_device_types.add(spec.device_type)
+        registry[spec.backend_name] = spec
     return registry
 
 
-def _detect_device() -> tuple[Any, str]:
+@lru_cache(maxsize=1)
+def _build_device_registry() -> "dict[str, tuple[DeviceSpec, ...]]":
+    """Group registered specs by torch-facing ``device_type``."""
+    registry: dict[str, list[DeviceSpec]] = {}
+    for spec in _build_backend_registry().values():
+        registry.setdefault(spec.device_type, []).append(spec)
+    return {device_type: tuple(specs) for device_type, specs in registry.items()}
+
+
+def _get_env_choice(env_var_name: str) -> "str | None":
+    """Return a normalized explicit env choice, or ``None`` when unset."""
+    value = os.environ.get(env_var_name)
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _resolve_explicit_backend(
+    torch: Any,
+    backend_name: str,
+) -> "tuple[Any, DeviceSpec]":
+    """Resolve an explicitly requested backend by unique backend name."""
+    spec = _build_backend_registry().get(backend_name)
+    if spec is None:
+        available_backends = ", ".join(sorted(_build_backend_registry()))
+        raise RuntimeError(
+            f"{DEVICE_BACKEND_ENV_VAR}={backend_name!r} is not registered. "
+            f"Available backends: {available_backends or '<none>'}."
+        )
+    if not spec.is_available():
+        raise RuntimeError(
+            f"{DEVICE_BACKEND_ENV_VAR}={backend_name!r} is registered but not "
+            "available on this host."
+        )
+
+    torch_module = getattr(torch, spec.torch_module_name, None)
+    if torch_module is None:
+        raise RuntimeError(
+            f"{DEVICE_BACKEND_ENV_VAR}={backend_name!r} resolved to "
+            f"device_type={spec.device_type!r}, but torch has no module "
+            f"{spec.torch_module_name!r}."
+        )
+    return torch_module, spec
+
+
+def _resolve_device_type_candidates(
+    torch: Any,
+    device_type: str,
+) -> "tuple[Any, DeviceSpec] | None":
+    """Resolve a ``device_type`` to exactly one available spec, if possible."""
+    candidates = _build_device_registry().get(device_type, ())
+    if not candidates:
+        return None
+
+    available_candidates: list[tuple[Any, DeviceSpec]] = []
+    for spec in candidates:
+        if not spec.is_available():
+            continue
+
+        torch_module = getattr(torch, spec.torch_module_name, None)
+        if torch_module is None:
+            logger.warning(
+                "backend [%s] for device [%s] is available, but torch module "
+                "[%s] is not found.",
+                spec.backend_name,
+                spec.device_type,
+                spec.torch_module_name,
+            )
+            continue
+        available_candidates.append((torch_module, spec))
+
+    if len(available_candidates) == 1:
+        return available_candidates[0]
+
+    if len(available_candidates) > 1:
+        backend_names = ", ".join(
+            sorted(spec.backend_name for _, spec in available_candidates)
+        )
+        raise RuntimeError(
+            f"Multiple LMCache backends are available for device_type "
+            f"{device_type!r}: {backend_names}. Set "
+            f"{DEVICE_BACKEND_ENV_VAR}=<backend_name> to choose one explicitly."
+        )
+    return None
+
+
+def _detect_device() -> "tuple[Any, str, str | None]":
     """Detect the available accelerator via the device registry.
 
     Returns:
-        tuple[Any, str]: A tuple of (torch_device_module, device_type_string).
-            When torch is not installed (CLI-only mode), returns
-            ``(None, "cpu")``.
+        tuple[Any, str, str | None]: ``(torch_device_module, device_type,
+            backend_name)``. When torch is not installed (CLI-only mode),
+            returns ``(None, "cpu", None)``.
     """
     try:
         # Third Party
         import torch
     except ImportError as e:
         logger.warning("load torch failed, error is %s", e)
-        return None, "cpu"  # fallback for CLI-only environments
+        return None, "cpu", None  # fallback for CLI-only environments
 
-    registry = _build_device_registry()
+    env_backend_name = _get_env_choice(DEVICE_BACKEND_ENV_VAR)
+    if env_backend_name is not None:
+        torch_module, spec = _resolve_explicit_backend(torch, env_backend_name)
+        return torch_module, spec.device_type, spec.backend_name
 
-    # Check DEVICE_TYPE environment variable for forced device selection.
-    env_device_type = os.environ.get("DEVICE_TYPE")
+    env_device_type = _get_env_choice("DEVICE_TYPE")
     if env_device_type is not None:
-        env_device_type = env_device_type.strip().lower()
-        spec = registry.get(env_device_type)
-        if spec is not None and spec.is_available():
-            torch_module = getattr(torch, spec.torch_module_name, None)
-            if torch_module is not None:
-                return torch_module, spec.device_type
-            else:
-                logger.warning(
-                    "DEVICE_TYPE=%r is available but torch module [%s] not found, "
-                    "falling back to auto-detection.",
-                    env_device_type,
-                    spec.torch_module_name,
-                )
-        else:
-            logger.warning(
-                "DEVICE_TYPE=%r is not available or not registered, "
-                "falling back to auto-detection.",
-                env_device_type,
-            )
+        resolved = _resolve_device_type_candidates(torch, env_device_type)
+        if resolved is not None:
+            torch_module, spec = resolved
+            return torch_module, spec.device_type, spec.backend_name
+        logger.warning(
+            "DEVICE_TYPE=%r is not available or not registered, "
+            "falling back to auto-detection.",
+            env_device_type,
+        )
 
-    for spec in registry.values():
-        if not spec.is_available():
-            continue
-
-        torch_module = getattr(torch, spec.torch_module_name, None)
-        if torch_module is not None:
-            return torch_module, spec.device_type
-        else:
-            logger.warning(
-                "device [%s] is available, but torch module [%s] is not found.",
-                spec.device_type,
-                spec.torch_module_name,
-            )
+    for device_type in _build_device_registry():
+        resolved = _resolve_device_type_candidates(torch, device_type)
+        if resolved is not None:
+            torch_module, spec = resolved
+            return torch_module, spec.device_type, spec.backend_name
 
     # No accelerator found -- fall back to CPU stub
     # First Party
     from lmcache.v1.platform.cpu.stub_cpu_device import StubCPUDevice
 
-    return StubCPUDevice("cpu"), "cpu"
+    return StubCPUDevice("cpu"), "cpu", None
 
 
 # ---------------------------------------------------------------------------
@@ -210,8 +277,23 @@ def _detect_device() -> tuple[Any, str]:
 
 
 def get_device_spec(device_type: str) -> "DeviceSpec | None":
-    """Return the :class:`DeviceSpec` registered for *device_type*, if any."""
-    return _build_device_registry().get(device_type)
+    """Return the resolved :class:`DeviceSpec` for *device_type*, if any."""
+    specs = _build_device_registry().get(device_type, ())
+    if not specs:
+        return None
+    if len(specs) == 1:
+        return specs[0]
+
+    env_backend_name = _get_env_choice(DEVICE_BACKEND_ENV_VAR)
+    if env_backend_name is not None:
+        spec = _build_backend_registry().get(env_backend_name)
+        if spec is not None and spec.device_type == device_type:
+            return spec
+
+    available_specs = [spec for spec in specs if spec.is_available()]
+    if len(available_specs) == 1:
+        return available_specs[0]
+    return None
 
 
 @lru_cache(maxsize=1)
@@ -222,7 +304,7 @@ def get_torch_device() -> tuple[Any, str]:
     import this helper at module top level: no work is performed until
     the tuple is actually needed.
     """
-    torch_dev, torch_device_type = _detect_device()
+    torch_dev, torch_device_type, _ = _detect_device()
     logger.info("torch_dev=%s, torch_device_type=%s", torch_dev, torch_device_type)
     return torch_dev, torch_device_type
 
@@ -237,8 +319,10 @@ def current_device_spec() -> "DeviceSpec":
     # First Party
     from lmcache.v1.platform.base.device_spec import DeviceSpec
 
-    _, device_type = get_torch_device()
-    spec = get_device_spec(device_type)
+    _, device_type, backend_name = _detect_device()
+    spec = _build_backend_registry().get(backend_name) if backend_name else None
+    if spec is None:
+        spec = get_device_spec(device_type)
     if spec is None:
         if device_type != "cpu":
             logger.warning(

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -294,10 +294,6 @@ def get_device_spec(device_type: str) -> "DeviceSpec | None":
     if len(available_specs) == 1:
         return available_specs[0]
 
-    compatible_specs = [spec for spec in specs if spec.is_runtime_compatible()]
-    if len(compatible_specs) == 1:
-        return compatible_specs[0]
-
     default_specs = [spec for spec in specs if spec.backend_name == device_type]
     if len(default_specs) == 1:
         return default_specs[0]

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -99,9 +99,12 @@ def _build_device_registry() -> "dict[str, DeviceSpec]":
     """Discover and instantiate built-in and external device specifications.
 
     Discovery is deferred until first use so importing this module
-    stays cheap and side-effect free. Built-in specifications win name
-    collisions; this prevents an installed wheel from replacing LMCache's
-    implementation for an existing device type.
+    stays cheap and side-effect free. Built-in specifications provide the
+    default registry entries, then installed plugins are layered on top.
+    When an external wheel reuses an existing ``device_type``, the external
+    spec takes precedence so vendors can ship fixes or specialized behavior
+    without forking LMCache. If multiple wheels claim the same
+    ``device_type``, the first deterministic match wins.
     """
     # First Party
     from lmcache.v1.platform.base.device_spec import DeviceSpec
@@ -120,15 +123,23 @@ def _build_device_registry() -> "dict[str, DeviceSpec]":
             )
         )
     }
+    external_device_types: set[str] = set()
     for spec in _load_external_device_specs():
-        if spec.device_type in registry:
+        if spec.device_type in external_device_types:
             logger.warning(
-                "Ignoring LMCache device plugin for %r because that device "
-                "type is already registered",
+                "Ignoring duplicate LMCache device plugin for %r after the "
+                "first matching external wheel was registered",
                 spec.device_type,
             )
             continue
+        if spec.device_type in registry:
+            logger.info(
+                "LMCache device plugin for %r overrides the built-in device "
+                "spec for that device type",
+                spec.device_type,
+            )
         registry[spec.device_type] = spec
+        external_device_types.add(spec.device_type)
     return registry
 
 

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -297,6 +297,10 @@ def get_device_spec(device_type: str) -> "DeviceSpec | None":
     compatible_specs = [spec for spec in specs if spec.is_runtime_compatible()]
     if len(compatible_specs) == 1:
         return compatible_specs[0]
+
+    default_specs = [spec for spec in specs if spec.backend_name == device_type]
+    if len(default_specs) == 1:
+        return default_specs[0]
     return None
 
 

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -293,6 +293,10 @@ def get_device_spec(device_type: str) -> "DeviceSpec | None":
     available_specs = [spec for spec in specs if spec.is_available()]
     if len(available_specs) == 1:
         return available_specs[0]
+
+    compatible_specs = [spec for spec in specs if spec.is_runtime_compatible()]
+    if len(compatible_specs) == 1:
+        return compatible_specs[0]
     return None
 
 

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -9,14 +9,17 @@ import cycle -- ``platform/__init__.py`` itself pulls in
 that ``torch_ops`` needs from the platform package must live *outside*
 that init chain.
 
-The registry of :class:`DeviceSpec` subclasses and the detected torch
-device module are both built lazily on first access and then cached
-process-wide.
+The registry combines the :class:`DeviceSpec` subclasses shipped with
+LMCache and external subclasses published through the
+``lmcache.device_plugins`` Python entry-point group.  The registry and the
+detected torch device module are both built lazily on first access and then
+cached process-wide.
 """
 
 # Standard
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
+import importlib.metadata
 import os
 
 # First Party
@@ -28,26 +31,85 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+DEVICE_PLUGIN_ENTRY_POINT_GROUP = "lmcache.device_plugins"
+
 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
 
 
+def _load_external_device_specs() -> "list[DeviceSpec]":
+    """Load external device specifications from Python entry points.
+
+    Each entry point must use its device type as its name and resolve to a
+    concrete :class:`DeviceSpec` subclass with a no-argument constructor.
+    Invalid or broken plugins are skipped so that an unrelated installed
+    package cannot prevent LMCache from starting.
+
+    Returns:
+        Device specifications loaded successfully from installed plugins.
+    """
+    # First Party
+    from lmcache.v1.platform.base.device_spec import DeviceSpec
+
+    specs: list[DeviceSpec] = []
+    entry_points = importlib.metadata.entry_points(
+        group=DEVICE_PLUGIN_ENTRY_POINT_GROUP
+    )
+    for entry_point in sorted(entry_points, key=lambda item: (item.name, item.value)):
+        try:
+            spec_cls = entry_point.load()
+            if (
+                not isinstance(spec_cls, type)
+                or spec_cls is DeviceSpec
+                or not issubclass(spec_cls, DeviceSpec)
+            ):
+                raise TypeError("entry point must resolve to a DeviceSpec subclass")
+
+            spec = spec_cls()
+            if not isinstance(spec, DeviceSpec):
+                raise TypeError("entry point must construct a DeviceSpec instance")
+            device_type = spec.device_type
+            if (
+                not isinstance(device_type, str)
+                or not device_type
+                or device_type != device_type.lower()
+            ):
+                raise ValueError("device_type must be a non-empty lowercase string")
+            if device_type != entry_point.name:
+                raise ValueError(
+                    "entry-point name must match DeviceSpec.device_type "
+                    f"({entry_point.name!r} != {device_type!r})"
+                )
+        except Exception as exc:
+            logger.warning(
+                "Failed to load LMCache device plugin %r (%s): %s",
+                entry_point.name,
+                entry_point.value,
+                exc,
+            )
+            continue
+        specs.append(spec)
+    return specs
+
+
 @lru_cache(maxsize=1)
 def _build_device_registry() -> "dict[str, DeviceSpec]":
-    """Discover and instantiate every :class:`DeviceSpec` subclass.
+    """Discover and instantiate built-in and external device specifications.
 
     Discovery is deferred until first use so importing this module
-    stays cheap and side-effect free.
+    stays cheap and side-effect free. Built-in specifications win name
+    collisions; this prevents an installed wheel from replacing LMCache's
+    implementation for an existing device type.
     """
     # First Party
     from lmcache.v1.platform.base.device_spec import DeviceSpec
     from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
-    return {
+    registry = {
         spec.device_type: spec
-        for spec in [
+        for spec in (
             cls()
             for cls in discover_subclasses(
                 "lmcache.v1.platform",
@@ -56,8 +118,18 @@ def _build_device_registry() -> "dict[str, DeviceSpec]":
                 require_defined_in_module=True,
                 on_import_error=lambda name, exc: None,
             )
-        ]
+        )
     }
+    for spec in _load_external_device_specs():
+        if spec.device_type in registry:
+            logger.warning(
+                "Ignoring LMCache device plugin for %r because that device "
+                "type is already registered",
+                spec.device_type,
+            )
+            continue
+        registry[spec.device_type] = spec
+    return registry
 
 
 def _detect_device() -> tuple[Any, str]:
@@ -149,7 +221,7 @@ def current_device_spec() -> "DeviceSpec":
     """Return the :class:`DeviceSpec` for the detected device.
 
     Falls back to a bare ``DeviceSpec()`` (no-op / all False semantics)
-    when no accelerator sub-package matches.
+    when no registered accelerator backend matches.
     """
     # First Party
     from lmcache.v1.platform.base.device_spec import DeviceSpec

--- a/lmcache/v1/platform/base/__init__.py
+++ b/lmcache/v1/platform/base/__init__.py
@@ -3,7 +3,6 @@
 
 This sub-package groups the abstract base classes shared by every
 accelerator backend (``cuda``, ``cpu``, ``musa``, ``hpu``, ``xpu``,
-...).  Concrete backends subclass these types in their own
-sub-packages; discovery of those subclasses lives in
-:mod:`lmcache.v1.platform`.
+...). Concrete backends subclass these types in built-in sub-packages or
+external device-plugin wheels; discovery lives in :mod:`lmcache.v1.platform`.
 """

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Base class for platform device specification.
 
-Each accelerator sub-package (``platform/cuda``, ``platform/musa``, ...)
-provides a concrete :class:`DeviceSpec` subclass that describes how to
-detect the device and which ops backend to load.
+Each built-in accelerator sub-package (``platform/cuda``, ``platform/musa``,
+...) provides a concrete :class:`DeviceSpec` subclass that describes how to
+detect the device and which ops backend to load. External packages can expose
+the same class through the ``lmcache.device_plugins`` Python entry-point group.
 
 The :mod:`~lmcache.v1.platform` module discovers these
 subclasses automatically at import time via ``pkgutil.iter_modules``:
@@ -11,9 +12,9 @@ it imports each sub-package, inspects its module namespace for
 :class:`DeviceSpec` subclasses, instantiates them, and uses the
 resulting objects for device detection and backend selection.
 
-No manual registration (e.g. ``DEVICE_SPEC = ...``) is required --
-simply defining the subclass in the sub-package's ``__init__.py`` is
-enough.
+No manual registration call is required. Built-in implementations are found
+from their sub-package; external implementations are found from installed
+package metadata.
 
 :class:`DeviceSpec` itself is instantiable and doubles as the fallback
 implementation used when no accelerator sub-package matches the
@@ -44,8 +45,9 @@ class DeviceSpec:
     """Description of a hardware accelerator backend.
 
     Subclasses override the properties / methods below to describe a
-    concrete accelerator.  Defining a concrete subclass in a platform
-    sub-package's ``__init__.py`` is sufficient for auto-discovery.
+    concrete accelerator. Built-in subclasses are auto-discovered from the
+    platform package, while external subclasses are registered as Python
+    entry points.
 
     Instantiating :class:`DeviceSpec` directly yields the fallback
     implementation with "no-op / all False" semantics -- this is the

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -139,6 +139,15 @@ class DeviceSpec:
         """
         return False
 
+    def is_runtime_compatible(self) -> bool:
+        """Return whether this backend matches the installed torch runtime.
+
+        Unlike :meth:`is_available`, this does not require usable hardware.
+        Backends sharing a torch device type can override it so explicit
+        device lookups remain deterministic on hosts without accelerators.
+        """
+        return True
+
     def is_handle_transfer_available(self) -> bool:
         """Return ``True`` when the device is usable for handle transfer."""
         # TODO(chunxiaozheng): implement on subclasses

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -139,15 +139,6 @@ class DeviceSpec:
         """
         return False
 
-    def is_runtime_compatible(self) -> bool:
-        """Return whether this backend matches the installed torch runtime.
-
-        Unlike :meth:`is_available`, this does not require usable hardware.
-        Backends sharing a torch device type can override it so explicit
-        device lookups remain deterministic on hosts without accelerators.
-        """
-        return True
-
     def is_handle_transfer_available(self) -> bool:
         """Return ``True`` when the device is usable for handle transfer."""
         # TODO(chunxiaozheng): implement on subclasses

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -71,6 +71,22 @@ class DeviceSpec:
         return ""
 
     @property
+    def backend_name(self) -> str:
+        """Unique LMCache backend identifier for explicit backend selection.
+
+        ``device_type`` is tied to torch device naming, so multiple specs may
+        legitimately share it (for example, two different implementations of
+        ``"cuda"``). ``backend_name`` is the LMCache-specific disambiguator for
+        those cases and must therefore be unique across all registered specs.
+
+        The base implementation reuses :attr:`device_type`, which keeps today's
+        built-in backends unchanged. Specialised backends that share a
+        ``device_type`` with another implementation should override this with a
+        distinct lowercase name.
+        """
+        return self.device_type
+
+    @property
     def torch_module_name(self) -> str:
         """Attribute name on the ``torch`` package for the device module.
 

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -11,14 +11,13 @@ The concrete implementations live in their respective sub-packages:
 :func:`create_cache_context` keeps the dispatch out of the call site
 in :mod:`lmcache.v1.multiprocess.server`. Selection is data-driven
 and delegated to the :class:`~lmcache.v1.platform.base.device_spec.
-DeviceSpec` registry maintained by :mod:`lmcache.v1.platform`: each
-backend sub-package ships a ``DeviceSpec`` subclass whose
+DeviceSpec` registry maintained by :mod:`lmcache.v1.platform`: each built-in
+backend sub-package or external device plugin ships a ``DeviceSpec`` whose
 ``create_cache_context`` hook lazy-imports and instantiates the
 matching :class:`~lmcache.v1.platform.base.cache_context.
 BaseCacheContext`. Adding a new accelerator therefore requires
-*zero* edits to this module -- just implement
-``DeviceSpec.create_cache_context`` in the sub-package's
-``__init__.py``.
+*zero* edits to this module -- implement the hook in the built-in backend or
+external plugin.
 """
 
 # Future
@@ -111,8 +110,8 @@ def create_cache_context(
     if spec is None:
         raise ValueError(
             "No cache-context class registered for device type %r. "
-            "Make sure ``lmcache.v1.platform.<backend>.__init__`` "
-            "ships a DeviceSpec subclass whose ``create_cache_context`` "
+            "Make sure a built-in backend or installed lmcache.device_plugins "
+            "entry point provides a DeviceSpec whose ``create_cache_context`` "
             "hook returns a BaseCacheContext instance." % device_type
         )
     return spec.create_cache_context(

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -79,7 +79,8 @@ class CudaDeviceSpec(DeviceSpec):
             # Third Party
             import torch
 
-            return torch.cuda.is_available() and torch.version.hip is None
+            hip_version = getattr(getattr(torch, "version", None), "hip", None)
+            return torch.cuda.is_available() and hip_version is None
         except Exception:
             return False
 

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -79,7 +79,7 @@ class CudaDeviceSpec(DeviceSpec):
             # Third Party
             import torch
 
-            return torch.cuda.is_available() and torch.version.hip is None
+            return torch.cuda.is_available()
         except Exception:
             return False
 

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -79,20 +79,13 @@ class CudaDeviceSpec(DeviceSpec):
             # Third Party
             import torch
 
-            return torch.cuda.is_available() and self.is_runtime_compatible()
-        except Exception:
-            return False
-
-    def is_runtime_compatible(self) -> bool:
-        """Return whether torch exposes a CUDA runtime."""
-        try:
-            # Third Party
-            import torch
-
             torch_version = getattr(torch, "version", None)
             if torch_version is None:
-                return True
-            return getattr(torch_version, "cuda", None) is not None
+                return torch.cuda.is_available()
+            return (
+                torch.cuda.is_available()
+                and getattr(torch_version, "cuda", None) is not None
+            )
         except Exception:
             return False
 

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -84,12 +84,15 @@ class CudaDeviceSpec(DeviceSpec):
             return False
 
     def is_runtime_compatible(self) -> bool:
-        """Return whether torch uses the CUDA rather than HIP runtime."""
+        """Return whether torch exposes a CUDA runtime."""
         try:
             # Third Party
             import torch
 
-            return getattr(getattr(torch, "version", None), "hip", None) is None
+            torch_version = getattr(torch, "version", None)
+            if torch_version is None:
+                return True
+            return getattr(torch_version, "cuda", None) is not None
         except Exception:
             return False
 

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -79,8 +79,17 @@ class CudaDeviceSpec(DeviceSpec):
             # Third Party
             import torch
 
-            hip_version = getattr(getattr(torch, "version", None), "hip", None)
-            return torch.cuda.is_available() and hip_version is None
+            return torch.cuda.is_available() and self.is_runtime_compatible()
+        except Exception:
+            return False
+
+    def is_runtime_compatible(self) -> bool:
+        """Return whether torch uses the CUDA rather than HIP runtime."""
+        try:
+            # Third Party
+            import torch
+
+            return getattr(getattr(torch, "version", None), "hip", None) is None
         except Exception:
             return False
 

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -79,7 +79,7 @@ class CudaDeviceSpec(DeviceSpec):
             # Third Party
             import torch
 
-            return torch.cuda.is_available()
+            return torch.cuda.is_available() and torch.version.hip is None
         except Exception:
             return False
 

--- a/lmcache/v1/platform/kv_wrap.py
+++ b/lmcache/v1/platform/kv_wrap.py
@@ -28,10 +28,9 @@ logger = init_logger(__name__)
 def wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
     """Dispatch by ``tensor.device.type`` via the platform registry.
 
-    Concrete factories are auto-discovered from ``DeviceIPCWrapper``
-    subclasses under ``lmcache.v1.platform``, so this call site stays
-    free of if/elif chains and new accelerators plug in by shipping a
-    sibling wrapper class.
+    Concrete factories are supplied by the registered ``DeviceSpec`` objects,
+    so this call site stays free of if/elif chains and external accelerators
+    can provide their wrapper from an installed device-plugin wheel.
     """
     return resolve_kv_wrapper_factory(tensor.device.type)(tensor)
 

--- a/lmcache/v1/platform/rocm/__init__.py
+++ b/lmcache/v1/platform/rocm/__init__.py
@@ -19,6 +19,7 @@ class RocmDeviceSpec(CudaDeviceSpec):
             # Third Party
             import torch
 
-            return torch.cuda.is_available() and torch.version.hip is not None
+            hip_version = getattr(getattr(torch, "version", None), "hip", None)
+            return torch.cuda.is_available() and hip_version is not None
         except Exception:
             return False

--- a/lmcache/v1/platform/rocm/__init__.py
+++ b/lmcache/v1/platform/rocm/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ROCm platform primitives built on PyTorch's CUDA-compatible surface."""
+
+# First Party
+from lmcache.v1.platform.cuda import CudaDeviceSpec
+
+
+class RocmDeviceSpec(CudaDeviceSpec):
+    """ROCm device specification for the detection registry."""
+
+    @property
+    def backend_name(self) -> str:
+        """Return the LMCache-specific ROCm backend selector."""
+        return "rocm"
+
+    def is_available(self) -> bool:
+        """Check ROCm availability through PyTorch's ``torch.cuda`` API."""
+        try:
+            # Third Party
+            import torch
+
+            return torch.cuda.is_available() and torch.version.hip is not None
+        except Exception:
+            return False

--- a/lmcache/v1/platform/rocm/__init__.py
+++ b/lmcache/v1/platform/rocm/__init__.py
@@ -19,16 +19,9 @@ class RocmDeviceSpec(CudaDeviceSpec):
             # Third Party
             import torch
 
-            return torch.cuda.is_available() and self.is_runtime_compatible()
-        except Exception:
-            return False
-
-    def is_runtime_compatible(self) -> bool:
-        """Return whether torch uses the HIP runtime."""
-        try:
-            # Third Party
-            import torch
-
-            return getattr(getattr(torch, "version", None), "hip", None) is not None
+            return (
+                torch.cuda.is_available()
+                and getattr(getattr(torch, "version", None), "hip", None) is not None
+            )
         except Exception:
             return False

--- a/lmcache/v1/platform/rocm/__init__.py
+++ b/lmcache/v1/platform/rocm/__init__.py
@@ -19,7 +19,16 @@ class RocmDeviceSpec(CudaDeviceSpec):
             # Third Party
             import torch
 
-            hip_version = getattr(getattr(torch, "version", None), "hip", None)
-            return torch.cuda.is_available() and hip_version is not None
+            return torch.cuda.is_available() and self.is_runtime_compatible()
+        except Exception:
+            return False
+
+    def is_runtime_compatible(self) -> bool:
+        """Return whether torch uses the HIP runtime."""
+        try:
+            # Third Party
+            import torch
+
+            return getattr(getattr(torch, "version", None), "hip", None) is not None
         except Exception:
             return False

--- a/tests/v1/platform/rbln/test_rbln_support.py
+++ b/tests/v1/platform/rbln/test_rbln_support.py
@@ -122,8 +122,9 @@ def test_detect_device_selects_rbln_when_forced(
     monkeypatch.setenv("DEVICE_TYPE", "rbln")
     stub = _StubTorch(SimpleNamespace(is_available=lambda: True))
     with patch.dict("sys.modules", {"torch": stub}):
-        torch_dev, device_type = _detect_device()
+        torch_dev, device_type, backend_name = _detect_device()
     assert device_type == "rbln"
+    assert backend_name == "rbln"
     assert torch_dev is stub.rbln
 
 

--- a/tests/v1/platform/test_device_ops.py
+++ b/tests/v1/platform/test_device_ops.py
@@ -50,12 +50,15 @@ _OP_NAMES: tuple[str, ...] = tuple(
 @pytest.fixture
 def isolated_registry() -> Any:
     """Snapshot the device-spec table so tests can install fakes safely."""
-    saved = dict(platform_pkg._DEVICE_REGISTRY)
+    saved_backends = dict(platform_pkg._DEVICE_REGISTRY)
+    saved_device_types = dict(platform_pkg._DEVICE_TYPE_REGISTRY)
     try:
-        yield saved
+        yield saved_backends, saved_device_types
     finally:
         platform_pkg._DEVICE_REGISTRY.clear()
-        platform_pkg._DEVICE_REGISTRY.update(saved)
+        platform_pkg._DEVICE_REGISTRY.update(saved_backends)
+        platform_pkg._DEVICE_TYPE_REGISTRY.clear()
+        platform_pkg._DEVICE_TYPE_REGISTRY.update(saved_device_types)
 
 
 # -- Contract --------------------------------------------------------------
@@ -85,10 +88,11 @@ def test_base_class_has_python_fallback_types() -> None:
 
 def test_every_registered_device_has_all_ops(isolated_registry: Any) -> None:
     """Each discovered DeviceSpec resolves an ops instance with all ops."""
-    for device_type, spec in isolated_registry.items():
+    backend_registry, _ = isolated_registry
+    for backend_name, spec in backend_registry.items():
         ops = spec.ops_cls()
         for name in _OP_NAMES:
-            assert callable(getattr(ops, name)), (device_type, name)
+            assert callable(getattr(ops, name)), (backend_name, name)
 
 
 # -- Dispatch (MRO) --------------------------------------------------------
@@ -307,8 +311,11 @@ def test_resolve_device_ops_returns_cached_singleton() -> None:
 def test_cpu_without_registered_spec_falls_back_to_base_device_ops(
     isolated_registry: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    table = {k: v for k, v in isolated_registry.items() if k != "cpu"}
-    monkeypatch.setattr(platform_pkg, "_DEVICE_REGISTRY", table)
+    backend_registry, device_type_registry = isolated_registry
+    backend_table = {k: v for k, v in backend_registry.items() if k != "cpu"}
+    device_type_table = {k: v for k, v in device_type_registry.items() if k != "cpu"}
+    monkeypatch.setattr(platform_pkg, "_DEVICE_REGISTRY", backend_table)
+    monkeypatch.setattr(platform_pkg, "_DEVICE_TYPE_REGISTRY", device_type_table)
     assert type(resolve_device_ops("cpu")) is DeviceOps
 
 
@@ -320,8 +327,15 @@ def test_unregistered_accelerator_fails_fast(
     isolated_registry: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A requested accelerator with no registered class is a hard error."""
-    table = {k: v for k, v in isolated_registry.items() if k != torch_device_type}
-    monkeypatch.setattr(platform_pkg, "_DEVICE_REGISTRY", table)
+    backend_registry, device_type_registry = isolated_registry
+    backend_table = {
+        k: v for k, v in backend_registry.items() if k != torch_device_type
+    }
+    device_type_table = {
+        k: v for k, v in device_type_registry.items() if k != torch_device_type
+    }
+    monkeypatch.setattr(platform_pkg, "_DEVICE_REGISTRY", backend_table)
+    monkeypatch.setattr(platform_pkg, "_DEVICE_TYPE_REGISTRY", device_type_table)
     with pytest.raises(
         RuntimeError,
         match="refusing to silently fall back to the torch baseline",
@@ -354,9 +368,16 @@ def test_new_device_needs_zero_resolver_edits(
         def ops_cls(self) -> "type[DeviceOps]":
             return DummyDeviceOps
 
+    backend_registry, device_type_registry = isolated_registry
+    dummy_spec = DummyDeviceSpec()
     monkeypatch.setattr(
         platform_pkg,
         "_DEVICE_REGISTRY",
-        {**isolated_registry, "dummy": DummyDeviceSpec()},
+        {**backend_registry, "dummy": dummy_spec},
+    )
+    monkeypatch.setattr(
+        platform_pkg,
+        "_DEVICE_TYPE_REGISTRY",
+        {**device_type_registry, "dummy": (dummy_spec,)},
     )
     assert type(resolve_device_ops("dummy")) is DummyDeviceOps

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -407,3 +407,27 @@ def test_cuda_device_type_auto_selects_runtime_backend(
     assert device_type == "cuda"
     assert backend_name == expected_backend_name
     assert isinstance(_device_detect.current_device_spec(), expected_spec_type)
+
+
+@pytest.mark.parametrize(
+    ("hip_version", "expected_spec_type"),
+    [
+        (None, CudaDeviceSpec),
+        ("7.2", RocmDeviceSpec),
+    ],
+)
+def test_cuda_device_type_resolves_runtime_backend_without_hardware(
+    monkeypatch: pytest.MonkeyPatch,
+    hip_version: str | None,
+    expected_spec_type: type[DeviceSpec],
+) -> None:
+    """Explicit cuda lookups use the torch runtime when no GPU is available."""
+    _set_entry_points(monkeypatch, [])
+
+    # Third Party
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.version, "hip", hip_version)
+
+    assert isinstance(_device_detect.get_device_spec("cuda"), expected_spec_type)

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -105,17 +105,11 @@ def reset_device_registry_cache() -> Any:
     """Keep the process-wide registry cache isolated between tests."""
     backend_registry_builder = _device_detect._build_backend_registry
     device_registry_builder = _device_detect._build_device_registry
-    torch_device_getter = _device_detect.get_torch_device
-    current_spec_getter = _device_detect.current_device_spec
     backend_registry_builder.cache_clear()
     device_registry_builder.cache_clear()
-    torch_device_getter.cache_clear()
-    current_spec_getter.cache_clear()
     yield
     backend_registry_builder.cache_clear()
     device_registry_builder.cache_clear()
-    torch_device_getter.cache_clear()
-    current_spec_getter.cache_clear()
 
 
 def _set_entry_points(
@@ -406,7 +400,9 @@ def test_cuda_device_type_auto_selects_runtime_backend(
     assert torch_module is torch.cuda
     assert device_type == "cuda"
     assert backend_name == expected_backend_name
-    assert isinstance(_device_detect.current_device_spec(), expected_spec_type)
+    assert isinstance(
+        _device_detect._build_backend_registry()[backend_name], expected_spec_type
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for wheel-installed device plugins discovered by entry point."""
+
+# Standard
+from collections.abc import Callable
+from typing import Any
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform import _device_detect
+from lmcache.v1.platform.base.device_spec import DeviceSpec
+
+
+class _ExternalDeviceSpec(DeviceSpec):
+    """Valid external device specification used by discovery tests."""
+
+    @property
+    def device_type(self) -> str:
+        """Return the entry-point name used by the test plugin."""
+        return "external"
+
+    @property
+    def torch_module_name(self) -> str:
+        """Return the test torch module name."""
+        return "external"
+
+
+class _CpuOverrideDeviceSpec(DeviceSpec):
+    """External specification that attempts to replace the built-in CPU."""
+
+    @property
+    def device_type(self) -> str:
+        """Return the colliding built-in device type."""
+        return "cpu"
+
+
+class _FakeEntryPoint:
+    """Small importlib.metadata.EntryPoint stand-in."""
+
+    def __init__(self, name: str, value: str, loader: Callable[[], Any]) -> None:
+        self.name = name
+        self.value = value
+        self._loader = loader
+
+    def load(self) -> Any:
+        """Return or raise from the configured plugin loader."""
+        return self._loader()
+
+
+@pytest.fixture(autouse=True)
+def reset_device_registry_cache() -> Any:
+    """Keep the process-wide registry cache isolated between tests."""
+    registry_builder = _device_detect._build_device_registry
+    registry_builder.cache_clear()
+    yield
+    registry_builder.cache_clear()
+
+
+def _set_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+    entry_points: list[_FakeEntryPoint],
+) -> None:
+    """Replace installed entry-point discovery with a deterministic list."""
+
+    def fake_entry_points(*, group: str) -> list[_FakeEntryPoint]:
+        assert group == _device_detect.DEVICE_PLUGIN_ENTRY_POINT_GROUP
+        return entry_points
+
+    monkeypatch.setattr(
+        _device_detect.importlib.metadata,
+        "entry_points",
+        fake_entry_points,
+    )
+
+
+def test_external_device_spec_is_added_to_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid wheel entry point contributes its DeviceSpec at runtime."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "external",
+                "lmcache_external:ExternalDeviceSpec",
+                lambda: _ExternalDeviceSpec,
+            )
+        ],
+    )
+
+    registry = _device_detect._build_device_registry()
+
+    assert isinstance(registry["external"], _ExternalDeviceSpec)
+    assert _device_detect.get_device_spec("external") is registry["external"]
+
+
+@pytest.mark.parametrize(
+    ("name", "loader"),
+    [
+        ("external", lambda: object),
+        ("wrong-name", lambda: _ExternalDeviceSpec),
+    ],
+)
+def test_invalid_device_plugin_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    loader: Callable[[], Any],
+) -> None:
+    """Malformed entry points cannot prevent built-in registry creation."""
+    _set_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(name, "broken_plugin:device", loader)],
+    )
+
+    registry = _device_detect._build_device_registry()
+
+    assert "external" not in registry
+    assert "wrong-name" not in registry
+    assert "cpu" in registry
+
+
+def test_plugin_import_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception raised while importing one plugin is contained."""
+
+    def fail_to_load() -> Any:
+        raise ImportError("missing vendor runtime")
+
+    _set_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint("external", "broken_plugin:device", fail_to_load)],
+    )
+
+    registry = _device_detect._build_device_registry()
+
+    assert "external" not in registry
+    assert "cpu" in registry
+
+
+def test_builtin_device_wins_plugin_name_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An installed package cannot replace an LMCache built-in backend."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "cpu",
+                "lmcache_external:CpuOverrideDeviceSpec",
+                lambda: _CpuOverrideDeviceSpec,
+            )
+        ],
+    )
+
+    registry = _device_detect._build_device_registry()
+
+    assert not isinstance(registry["cpu"], _CpuOverrideDeviceSpec)
+
+
+def test_external_device_participates_in_runtime_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registered external spec is selected by the normal detector."""
+    spec = _ExternalDeviceSpec()
+    monkeypatch.setattr(spec, "is_available", lambda: True)
+    monkeypatch.setattr(
+        _device_detect,
+        "_build_device_registry",
+        lambda: {"external": spec},
+    )
+
+    # Third Party
+    import torch
+
+    external_torch_module = object()
+    monkeypatch.setattr(torch, "external", external_torch_module, raising=False)
+    monkeypatch.setenv("DEVICE_TYPE", "external")
+
+    torch_module, device_type = _device_detect._detect_device()
+
+    assert torch_module is external_torch_module
+    assert device_type == "external"

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -12,6 +12,8 @@ import pytest
 # First Party
 from lmcache.v1.platform import _device_detect
 from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.cuda import CudaDeviceSpec
+from lmcache.v1.platform.rocm import RocmDeviceSpec
 
 
 class _ExternalDeviceSpec(DeviceSpec):
@@ -369,3 +371,33 @@ def test_external_device_participates_in_runtime_detection(
     assert torch_module is external_torch_module
     assert device_type == "external"
     assert backend_name == "external"
+
+
+@pytest.mark.parametrize(
+    ("hip_version", "expected_spec_type", "expected_backend_name"),
+    [
+        (None, CudaDeviceSpec, "cuda"),
+        ("7.2", RocmDeviceSpec, "rocm"),
+    ],
+)
+def test_cuda_device_type_auto_selects_runtime_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    hip_version: str | None,
+    expected_spec_type: type[DeviceSpec],
+    expected_backend_name: str,
+) -> None:
+    """CUDA and ROCm builds select one backend for torch's cuda device type."""
+    _set_entry_points(monkeypatch, [])
+
+    # Third Party
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "hip", hip_version)
+
+    torch_module, device_type, backend_name = _device_detect._detect_device()
+
+    assert torch_module is torch.cuda
+    assert device_type == "cuda"
+    assert backend_name == expected_backend_name
+    assert isinstance(_device_detect.current_device_spec(), expected_spec_type)

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -36,6 +36,15 @@ class _CpuOverrideDeviceSpec(DeviceSpec):
         return "cpu"
 
 
+class _ExternalDeviceSpecOverride(DeviceSpec):
+    """Second external specification for deterministic duplicate handling."""
+
+    @property
+    def device_type(self) -> str:
+        """Return the colliding external device type."""
+        return "external"
+
+
 class _FakeEntryPoint:
     """Small importlib.metadata.EntryPoint stand-in."""
 
@@ -138,10 +147,10 @@ def test_plugin_import_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) -> No
     assert "cpu" in registry
 
 
-def test_builtin_device_wins_plugin_name_collision(
+def test_external_device_overrides_builtin_name_collision(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An installed package cannot replace an LMCache built-in backend."""
+    """An installed package can override an LMCache built-in backend."""
     _set_entry_points(
         monkeypatch,
         [
@@ -155,7 +164,32 @@ def test_builtin_device_wins_plugin_name_collision(
 
     registry = _device_detect._build_device_registry()
 
-    assert not isinstance(registry["cpu"], _CpuOverrideDeviceSpec)
+    assert isinstance(registry["cpu"], _CpuOverrideDeviceSpec)
+
+
+def test_first_external_device_wins_duplicate_name_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate external wheels resolve deterministically to the first match."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "external",
+                "plugin_a:ExternalDeviceSpec",
+                lambda: _ExternalDeviceSpec,
+            ),
+            _FakeEntryPoint(
+                "external",
+                "plugin_b:ExternalDeviceSpecOverride",
+                lambda: _ExternalDeviceSpecOverride,
+            ),
+        ],
+    )
+
+    registry = _device_detect._build_device_registry()
+
+    assert isinstance(registry["external"], _ExternalDeviceSpec)
 
 
 def test_external_device_participates_in_runtime_detection(

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -346,7 +346,8 @@ def test_get_device_spec_uses_explicit_backend_with_shared_device_type(
 def test_external_device_participates_in_runtime_detection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A registered external spec is selected by the normal detector."""
+    """An explicit external device type resolves through normal detection."""
+    monkeypatch.setenv("DEVICE_TYPE", "external")
     _set_entry_points(
         monkeypatch,
         [

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -4,7 +4,6 @@
 # Standard
 import sys
 from collections.abc import Callable
-from types import SimpleNamespace
 from typing import Any
 
 # Third Party
@@ -84,25 +83,6 @@ class _SharedVendorBDeviceSpec(DeviceSpec):
     def torch_module_name(self) -> str:
         """Return the shared torch module name."""
         return "shared"
-
-
-class _RocmDeviceSpec(DeviceSpec):
-    """External spec that shares torch's ``cuda`` device type."""
-
-    @property
-    def device_type(self) -> str:
-        """Return the torch-facing device type shared with CUDA."""
-        return "cuda"
-
-    @property
-    def backend_name(self) -> str:
-        """Return the ROCm backend selector."""
-        return "rocm"
-
-    @property
-    def torch_module_name(self) -> str:
-        """Return the torch module name shared with CUDA."""
-        return "cuda"
 
 
 class _FakeEntryPoint:
@@ -389,32 +369,3 @@ def test_external_device_participates_in_runtime_detection(
     assert torch_module is external_torch_module
     assert device_type == "external"
     assert backend_name == "external"
-
-
-def test_rocm_backend_can_auto_select_shared_cuda_device_type(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A ROCm torch build should not leave the built-in CUDA backend eligible."""
-    _set_entry_points(
-        monkeypatch,
-        [
-            _FakeEntryPoint(
-                "rocm",
-                "plugin_rocm:RocmDeviceSpec",
-                lambda: _RocmDeviceSpec,
-            )
-        ],
-    )
-    monkeypatch.setattr(_RocmDeviceSpec, "is_available", lambda self: True)
-
-    stub_torch = SimpleNamespace(
-        cuda=SimpleNamespace(is_available=lambda: True),
-        version=SimpleNamespace(hip="7.2"),
-    )
-    monkeypatch.setitem(sys.modules, "torch", stub_torch)
-
-    torch_module, device_type, backend_name = _device_detect._detect_device()
-
-    assert torch_module is stub_torch.cuda
-    assert device_type == "cuda"
-    assert backend_name == "rocm"

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -374,14 +374,20 @@ def test_external_device_participates_in_runtime_detection(
 
 
 @pytest.mark.parametrize(
-    ("hip_version", "expected_spec_type", "expected_backend_name"),
+    (
+        "cuda_version",
+        "hip_version",
+        "expected_spec_type",
+        "expected_backend_name",
+    ),
     [
-        (None, CudaDeviceSpec, "cuda"),
-        ("7.2", RocmDeviceSpec, "rocm"),
+        ("13.0", None, CudaDeviceSpec, "cuda"),
+        (None, "7.2", RocmDeviceSpec, "rocm"),
     ],
 )
 def test_cuda_device_type_auto_selects_runtime_backend(
     monkeypatch: pytest.MonkeyPatch,
+    cuda_version: str | None,
     hip_version: str | None,
     expected_spec_type: type[DeviceSpec],
     expected_backend_name: str,
@@ -393,6 +399,7 @@ def test_cuda_device_type_auto_selects_runtime_backend(
     import torch
 
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.version, "cuda", cuda_version)
     monkeypatch.setattr(torch.version, "hip", hip_version)
 
     torch_module, device_type, backend_name = _device_detect._detect_device()
@@ -406,14 +413,16 @@ def test_cuda_device_type_auto_selects_runtime_backend(
 
 
 @pytest.mark.parametrize(
-    ("hip_version", "expected_spec_type"),
+    ("cuda_version", "hip_version", "expected_spec_type"),
     [
-        (None, CudaDeviceSpec),
-        ("7.2", RocmDeviceSpec),
+        ("13.0", None, CudaDeviceSpec),
+        (None, "7.2", RocmDeviceSpec),
+        (None, None, CudaDeviceSpec),
     ],
 )
 def test_cuda_device_type_resolves_runtime_backend_without_hardware(
     monkeypatch: pytest.MonkeyPatch,
+    cuda_version: str | None,
     hip_version: str | None,
     expected_spec_type: type[DeviceSpec],
 ) -> None:
@@ -424,6 +433,7 @@ def test_cuda_device_type_resolves_runtime_backend_without_hardware(
     import torch
 
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.version, "cuda", cuda_version)
     monkeypatch.setattr(torch.version, "hip", hip_version)
 
     assert isinstance(_device_detect.get_device_spec("cuda"), expected_spec_type)

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -105,11 +105,17 @@ def reset_device_registry_cache() -> Any:
     """Keep the process-wide registry cache isolated between tests."""
     backend_registry_builder = _device_detect._build_backend_registry
     device_registry_builder = _device_detect._build_device_registry
+    torch_device_getter = _device_detect.get_torch_device
+    current_spec_getter = _device_detect.current_device_spec
     backend_registry_builder.cache_clear()
     device_registry_builder.cache_clear()
+    torch_device_getter.cache_clear()
+    current_spec_getter.cache_clear()
     yield
     backend_registry_builder.cache_clear()
     device_registry_builder.cache_clear()
+    torch_device_getter.cache_clear()
+    current_spec_getter.cache_clear()
 
 
 def _set_entry_points(

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -2,7 +2,6 @@
 """Tests for wheel-installed device plugins discovered by entry point."""
 
 # Standard
-import sys
 from collections.abc import Callable
 from typing import Any
 

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -18,7 +18,12 @@ class _ExternalDeviceSpec(DeviceSpec):
 
     @property
     def device_type(self) -> str:
-        """Return the entry-point name used by the test plugin."""
+        """Return the torch-facing device type used by the test plugin."""
+        return "external"
+
+    @property
+    def backend_name(self) -> str:
+        """Return the explicit backend selector for the test plugin."""
         return "external"
 
     @property
@@ -27,22 +32,56 @@ class _ExternalDeviceSpec(DeviceSpec):
         return "external"
 
 
-class _CpuOverrideDeviceSpec(DeviceSpec):
-    """External specification that attempts to replace the built-in CPU."""
-
-    @property
-    def device_type(self) -> str:
-        """Return the colliding built-in device type."""
-        return "cpu"
-
-
 class _ExternalDeviceSpecOverride(DeviceSpec):
-    """Second external specification for deterministic duplicate handling."""
+    """Second external specification that reuses the same backend name."""
 
     @property
     def device_type(self) -> str:
-        """Return the colliding external device type."""
+        """Return a different device type to prove backend-name uniqueness."""
+        return "other"
+
+    @property
+    def backend_name(self) -> str:
+        """Return the colliding backend name."""
         return "external"
+
+
+class _SharedVendorADeviceSpec(DeviceSpec):
+    """External spec that shares a device type with another backend."""
+
+    @property
+    def device_type(self) -> str:
+        """Return the shared device type."""
+        return "shared"
+
+    @property
+    def backend_name(self) -> str:
+        """Return the first backend selector."""
+        return "vendor-a"
+
+    @property
+    def torch_module_name(self) -> str:
+        """Return the shared torch module name."""
+        return "shared"
+
+
+class _SharedVendorBDeviceSpec(DeviceSpec):
+    """Second external spec for the same device type."""
+
+    @property
+    def device_type(self) -> str:
+        """Return the shared device type."""
+        return "shared"
+
+    @property
+    def backend_name(self) -> str:
+        """Return the second backend selector."""
+        return "vendor-b"
+
+    @property
+    def torch_module_name(self) -> str:
+        """Return the shared torch module name."""
+        return "shared"
 
 
 class _FakeEntryPoint:
@@ -61,10 +100,13 @@ class _FakeEntryPoint:
 @pytest.fixture(autouse=True)
 def reset_device_registry_cache() -> Any:
     """Keep the process-wide registry cache isolated between tests."""
-    registry_builder = _device_detect._build_device_registry
-    registry_builder.cache_clear()
+    backend_registry_builder = _device_detect._build_backend_registry
+    device_registry_builder = _device_detect._build_device_registry
+    backend_registry_builder.cache_clear()
+    device_registry_builder.cache_clear()
     yield
-    registry_builder.cache_clear()
+    backend_registry_builder.cache_clear()
+    device_registry_builder.cache_clear()
 
 
 def _set_entry_points(
@@ -84,7 +126,7 @@ def _set_entry_points(
     )
 
 
-def test_external_device_spec_is_added_to_registry(
+def test_external_device_spec_is_added_to_registries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A valid wheel entry point contributes its DeviceSpec at runtime."""
@@ -99,10 +141,12 @@ def test_external_device_spec_is_added_to_registry(
         ],
     )
 
-    registry = _device_detect._build_device_registry()
+    backend_registry = _device_detect._build_backend_registry()
+    device_registry = _device_detect._build_device_registry()
 
-    assert isinstance(registry["external"], _ExternalDeviceSpec)
-    assert _device_detect.get_device_spec("external") is registry["external"]
+    assert isinstance(backend_registry["external"], _ExternalDeviceSpec)
+    assert device_registry["external"] == (backend_registry["external"],)
+    assert _device_detect.get_device_spec("external") is backend_registry["external"]
 
 
 @pytest.mark.parametrize(
@@ -123,11 +167,11 @@ def test_invalid_device_plugin_is_skipped(
         [_FakeEntryPoint(name, "broken_plugin:device", loader)],
     )
 
-    registry = _device_detect._build_device_registry()
+    backend_registry = _device_detect._build_backend_registry()
 
-    assert "external" not in registry
-    assert "wrong-name" not in registry
-    assert "cpu" in registry
+    assert "external" not in backend_registry
+    assert "wrong-name" not in backend_registry
+    assert "cpu" in backend_registry
 
 
 def test_plugin_import_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -141,36 +185,16 @@ def test_plugin_import_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) -> No
         [_FakeEntryPoint("external", "broken_plugin:device", fail_to_load)],
     )
 
-    registry = _device_detect._build_device_registry()
+    backend_registry = _device_detect._build_backend_registry()
 
-    assert "external" not in registry
-    assert "cpu" in registry
+    assert "external" not in backend_registry
+    assert "cpu" in backend_registry
 
 
-def test_external_device_overrides_builtin_name_collision(
+def test_duplicate_backend_name_is_ignored_after_first(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An installed package can override an LMCache built-in backend."""
-    _set_entry_points(
-        monkeypatch,
-        [
-            _FakeEntryPoint(
-                "cpu",
-                "lmcache_external:CpuOverrideDeviceSpec",
-                lambda: _CpuOverrideDeviceSpec,
-            )
-        ],
-    )
-
-    registry = _device_detect._build_device_registry()
-
-    assert isinstance(registry["cpu"], _CpuOverrideDeviceSpec)
-
-
-def test_first_external_device_wins_duplicate_name_collision(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Duplicate external wheels resolve deterministically to the first match."""
+    """Backends must be unique even when device types differ."""
     _set_entry_points(
         monkeypatch,
         [
@@ -187,31 +211,160 @@ def test_first_external_device_wins_duplicate_name_collision(
         ],
     )
 
-    registry = _device_detect._build_device_registry()
+    backend_registry = _device_detect._build_backend_registry()
 
-    assert isinstance(registry["external"], _ExternalDeviceSpec)
+    assert isinstance(backend_registry["external"], _ExternalDeviceSpec)
+
+
+def test_same_device_type_can_register_multiple_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Different backends can intentionally share one torch device type."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "vendor-a",
+                "plugin_a:SharedVendorADeviceSpec",
+                lambda: _SharedVendorADeviceSpec,
+            ),
+            _FakeEntryPoint(
+                "vendor-b",
+                "plugin_b:SharedVendorBDeviceSpec",
+                lambda: _SharedVendorBDeviceSpec,
+            ),
+        ],
+    )
+
+    backend_registry = _device_detect._build_backend_registry()
+    device_registry = _device_detect._build_device_registry()
+
+    assert isinstance(backend_registry["vendor-a"], _SharedVendorADeviceSpec)
+    assert isinstance(backend_registry["vendor-b"], _SharedVendorBDeviceSpec)
+    assert device_registry["shared"] == (
+        backend_registry["vendor-a"],
+        backend_registry["vendor-b"],
+    )
+
+
+def test_explicit_backend_selects_requested_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend env var disambiguates shared device types explicitly."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "vendor-a",
+                "plugin_a:SharedVendorADeviceSpec",
+                lambda: _SharedVendorADeviceSpec,
+            ),
+            _FakeEntryPoint(
+                "vendor-b",
+                "plugin_b:SharedVendorBDeviceSpec",
+                lambda: _SharedVendorBDeviceSpec,
+            ),
+        ],
+    )
+    monkeypatch.setattr(_SharedVendorADeviceSpec, "is_available", lambda self: True)
+    monkeypatch.setattr(_SharedVendorBDeviceSpec, "is_available", lambda self: True)
+
+    # Third Party
+    import torch
+
+    shared_torch_module = object()
+    monkeypatch.setattr(torch, "shared", shared_torch_module, raising=False)
+    monkeypatch.setenv(_device_detect.DEVICE_BACKEND_ENV_VAR, "vendor-b")
+
+    torch_module, device_type, backend_name = _device_detect._detect_device()
+
+    assert torch_module is shared_torch_module
+    assert device_type == "shared"
+    assert backend_name == "vendor-b"
+
+
+def test_explicit_device_type_with_multiple_backends_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DEVICE_TYPE alone is insufficient when multiple backends are available."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "vendor-a",
+                "plugin_a:SharedVendorADeviceSpec",
+                lambda: _SharedVendorADeviceSpec,
+            ),
+            _FakeEntryPoint(
+                "vendor-b",
+                "plugin_b:SharedVendorBDeviceSpec",
+                lambda: _SharedVendorBDeviceSpec,
+            ),
+        ],
+    )
+    monkeypatch.setattr(_SharedVendorADeviceSpec, "is_available", lambda self: True)
+    monkeypatch.setattr(_SharedVendorBDeviceSpec, "is_available", lambda self: True)
+
+    # Third Party
+    import torch
+
+    monkeypatch.setattr(torch, "shared", object(), raising=False)
+    monkeypatch.setenv("DEVICE_TYPE", "shared")
+
+    with pytest.raises(RuntimeError, match="LMCACHE_DEVICE_BACKEND"):
+        _device_detect._detect_device()
+
+
+def test_get_device_spec_uses_explicit_backend_with_shared_device_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared device types resolve through the explicit backend selector."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "vendor-a",
+                "plugin_a:SharedVendorADeviceSpec",
+                lambda: _SharedVendorADeviceSpec,
+            ),
+            _FakeEntryPoint(
+                "vendor-b",
+                "plugin_b:SharedVendorBDeviceSpec",
+                lambda: _SharedVendorBDeviceSpec,
+            ),
+        ],
+    )
+    monkeypatch.setenv(_device_detect.DEVICE_BACKEND_ENV_VAR, "vendor-b")
+
+    spec = _device_detect.get_device_spec("shared")
+
+    assert isinstance(spec, _SharedVendorBDeviceSpec)
 
 
 def test_external_device_participates_in_runtime_detection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A registered external spec is selected by the normal detector."""
-    spec = _ExternalDeviceSpec()
-    monkeypatch.setattr(spec, "is_available", lambda: True)
-    monkeypatch.setattr(
-        _device_detect,
-        "_build_device_registry",
-        lambda: {"external": spec},
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "external",
+                "lmcache_external:ExternalDeviceSpec",
+                lambda: _ExternalDeviceSpec,
+            )
+        ],
     )
+    monkeypatch.setattr(_ExternalDeviceSpec, "is_available", lambda self: True)
 
     # Third Party
     import torch
 
     external_torch_module = object()
     monkeypatch.setattr(torch, "external", external_torch_module, raising=False)
-    monkeypatch.setenv("DEVICE_TYPE", "external")
 
-    torch_module, device_type = _device_detect._detect_device()
+    torch_module, device_type, backend_name = _device_detect._detect_device()
 
     assert torch_module is external_torch_module
     assert device_type == "external"
+    assert backend_name == "external"

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -2,7 +2,9 @@
 """Tests for wheel-installed device plugins discovered by entry point."""
 
 # Standard
+import sys
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 
 # Third Party
@@ -82,6 +84,25 @@ class _SharedVendorBDeviceSpec(DeviceSpec):
     def torch_module_name(self) -> str:
         """Return the shared torch module name."""
         return "shared"
+
+
+class _RocmDeviceSpec(DeviceSpec):
+    """External spec that shares torch's ``cuda`` device type."""
+
+    @property
+    def device_type(self) -> str:
+        """Return the torch-facing device type shared with CUDA."""
+        return "cuda"
+
+    @property
+    def backend_name(self) -> str:
+        """Return the ROCm backend selector."""
+        return "rocm"
+
+    @property
+    def torch_module_name(self) -> str:
+        """Return the torch module name shared with CUDA."""
+        return "cuda"
 
 
 class _FakeEntryPoint:
@@ -368,3 +389,32 @@ def test_external_device_participates_in_runtime_detection(
     assert torch_module is external_torch_module
     assert device_type == "external"
     assert backend_name == "external"
+
+
+def test_rocm_backend_can_auto_select_shared_cuda_device_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ROCm torch build should not leave the built-in CUDA backend eligible."""
+    _set_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(
+                "rocm",
+                "plugin_rocm:RocmDeviceSpec",
+                lambda: _RocmDeviceSpec,
+            )
+        ],
+    )
+    monkeypatch.setattr(_RocmDeviceSpec, "is_available", lambda self: True)
+
+    stub_torch = SimpleNamespace(
+        cuda=SimpleNamespace(is_available=lambda: True),
+        version=SimpleNamespace(hip="7.2"),
+    )
+    monkeypatch.setitem(sys.modules, "torch", stub_torch)
+
+    torch_module, device_type, backend_name = _device_detect._detect_device()
+
+    assert torch_module is stub_torch.cuda
+    assert device_type == "cuda"
+    assert backend_name == "rocm"

--- a/tests/v1/platform/test_device_plugins.py
+++ b/tests/v1/platform/test_device_plugins.py
@@ -413,20 +413,19 @@ def test_cuda_device_type_auto_selects_runtime_backend(
 
 
 @pytest.mark.parametrize(
-    ("cuda_version", "hip_version", "expected_spec_type"),
+    ("cuda_version", "hip_version"),
     [
-        ("13.0", None, CudaDeviceSpec),
-        (None, "7.2", RocmDeviceSpec),
-        (None, None, CudaDeviceSpec),
+        ("13.0", None),
+        (None, "7.2"),
+        (None, None),
     ],
 )
-def test_cuda_device_type_resolves_runtime_backend_without_hardware(
+def test_cuda_device_type_prefers_default_backend_without_hardware(
     monkeypatch: pytest.MonkeyPatch,
     cuda_version: str | None,
     hip_version: str | None,
-    expected_spec_type: type[DeviceSpec],
 ) -> None:
-    """Explicit cuda lookups use the torch runtime when no GPU is available."""
+    """Explicit cuda lookups stay deterministic even without a GPU."""
     _set_entry_points(monkeypatch, [])
 
     # Third Party
@@ -436,4 +435,4 @@ def test_cuda_device_type_resolves_runtime_backend_without_hardware(
     monkeypatch.setattr(torch.version, "cuda", cuda_version)
     monkeypatch.setattr(torch.version, "hip", hip_version)
 
-    assert isinstance(_device_detect.get_device_spec("cuda"), expected_spec_type)
+    assert isinstance(_device_detect.get_device_spec("cuda"), CudaDeviceSpec)

--- a/tests/v1/test_musa_support.py
+++ b/tests/v1/test_musa_support.py
@@ -119,7 +119,8 @@ def _detect_with_stub(stub: _StubTorch) -> tuple[Any, str]:
     from lmcache.v1.platform._device_detect import _detect_device
 
     with patch.dict("sys.modules", {"torch": stub}):
-        return _detect_device()
+        dev, name, _ = _detect_device()
+        return dev, name
 
 
 def test_detect_device_prefers_musa_when_available() -> None:


### PR DESCRIPTION
**What this PR does / why we need it**:

- Discovers external `DeviceSpec` classes from the `lmcache.device_plugins` Python entry-point group, allowing hardware vendors to ship independently versioned device-support wheels.
- Preserves the existing in-tree model under `lmcache/v1/platform/<device>/`; both integration models use the same interfaces and process-wide registry instances.
- Separates torch-facing `device_type` from the unique LMCache `backend_name`, so multiple concrete backends can intentionally share one torch device category.
- Resolves `LMCACHE_DEVICE_BACKEND` explicitly when set. Otherwise, LMCache automatically selects the only available backend for a `device_type` and raises an actionable error if multiple backends report available.
- Rejects duplicate `backend_name` registrations deterministically while allowing distinct backends to share a `device_type`.
- Adds a dedicated `RocmDeviceSpec`. CUDA and ROCm both use torch's `device_type="cuda"`, but mutually exclusive CUDA/ROCm runtime checks select the correct backend without requiring an environment variable.
- Validates plugin contracts, isolates entry-point load failures, and covers discovery, invalid plugins, duplicate backend names, shared device types, explicit selection, and runtime detection with unit tests.
- Documents the in-tree and external-wheel workflows, selection semantics, IPC capabilities, and ownership tradeoffs.

**Reviewer follow-up**:

- The CUDA/ROCm automatic-selection behavior was validated on MI355X with ROCm 7.2 and B300 with CUDA 13.0: each environment resolves exactly one backend without `LMCACHE_DEVICE_BACKEND`.
- `CudaDeviceSpec` checks the CUDA runtime through `torch.version.cuda`; HIP-specific detection remains isolated in `RocmDeviceSpec` through `torch.version.hip`.

**Validation**:

- `44 passed, 1 skipped` in the focused device plugin, DeviceOps, and RBLN platform suite.
- All Python, policy, formatting, codespell, clang-format, mypy, and Rust formatting pre-commit hooks passed. Rust clippy is Linux-only because `raw_block` depends on `io-uring`, so GPU/Linux CI is authoritative for that hook.
- Sphinx generated all HTML successfully. The full documentation baseline emitted 29 existing warnings; the changed device-backend guide emitted no warning.

**External XPU Validation**:

- Follow-up validation PR: `#4624` (`test: verify external native XPU device wheel in CI`), opened on top of this branch and targeting `dev`.
- Validation goal: remove in-tree XPU platform ownership from the validation branch, install LMCache plus an out-of-tree XPU device wheel, and prove that `lmcache.device_plugins` can restore working XPU support through the external plugin path introduced here.
- External plugin repo: `opendataio/lmcache_xpu_device_with_native`
- Published wheel used by CI: `v0.1.4`
- XPU CI result: `buildkite/unit-tests-xpu` passed in Build `#855`

Key evidence from Build `#855`:

- The job downloaded the external plugin source from `https://github.com/opendataio/lmcache_xpu_device_with_native/archive/refs/tags/v0.1.4.tar.gz`
- It built the native extension from the external repo as `lmcache_xpu_device_with_native.xpu_ops`
- The compile command used `-I/workspace/build/buildkite/csrc`, so shared LMCache headers were consumed from LMCache `csrc` through an include path rather than copied into the plugin repo
- The wheel build completed successfully:
  - `Successfully built lmcache_xpu_device_with_native-0.1.4-cp312-cp312-linux_x86_64.whl`
- The runtime validation completed successfully:
  - `external native xpu device plugin resolved successfully`
- The XPU shard then ran the XPU-related pytest suite and passed native-kernel coverage such as:
  - `tests/benchmarks/test_xpu_kernels_microbench.py::test_bench_cdf_sycl[256]`
  - `tests/benchmarks/test_xpu_kernels_microbench.py::test_bench_encode_sycl[64]`
  - `tests/benchmarks/test_xpu_kernels_microbench.py::test_bench_decode_sycl[256]`
  - `tests/benchmarks/test_xpu_kernels_microbench.py::test_bench_rope_sycl[4096]`

This validates that the external plugin-discovery mechanism in this PR is sufficient for a full XPU externalization path:

- XPU `DeviceSpec` / `DeviceOps` registration is resolved through `lmcache.device_plugins`
- the native SYCL extension is built and installed from the out-of-tree plugin package
- and the XPU CI path continues to work with XPU supplied externally rather than by LMCache main repo ownership

Related links:

- Validation PR: https://github.com/LMCache/LMCache/pull/4624
- External plugin repo: https://github.com/opendataio/lmcache_xpu_device_with_native
- External wheel release used in CI: https://github.com/opendataio/lmcache_xpu_device_with_native/releases/tag/v0.1.4
- XPU Buildkite build: https://buildkite.com/lmcache/unit-tests-xpu/builds/855

**If applicable**:

- [x] this PR contains user-facing changes - docs added
- [x] this PR contains unit tests
