### PR TITLE
[MP] Make L2 LRU eviction byte-aware

### DIFF
--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -62,6 +62,22 @@ class EvictionPolicy:
         """
         pass
 
+    def on_keys_created_with_sizes(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Notify the policy that sized keys have been created.
+
+        Policies that do not use object sizes inherit the compatibility
+        fallback, which delegates to :meth:`on_keys_created`.
+
+        Args:
+            keys: Keys that have been created.
+            sizes: Size in bytes for each key.
+        """
+        self.on_keys_created(keys)
+
     @abstractmethod
     def on_keys_touched(self, keys: list[ObjectKey]):
         """
@@ -94,10 +110,10 @@ class EvictionPolicy:
 
         Args:
             expected_ratio (float): A hint indicating approximately what
-                fraction of tracked keys should be evicted. Value should be
-                in range [0.0, 1.0]. For example, 0.1 means roughly 10% of
-                keys should be evicted. This is a hint and the policy may
-                return more or fewer keys.
+                fraction of tracked eviction weight should be evicted. Policies
+                may use bytes when sizes are available and unit weight otherwise.
+                Value should be in range [0.0, 1.0]. This is a hint and the
+                policy may return more or fewer keys.
             key_eligible_filter: An optional callable that takes an ObjectKey
                 and returns True if the key is eligible for eviction. When
                 provided, keys for which the filter returns False will be
@@ -184,8 +200,12 @@ class L2EvictionPolicy(L2AdapterListener):
     def policy(self) -> EvictionPolicy:
         return self._policy
 
-    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]):
-        self._policy.on_keys_created(keys)
+    def on_l2_keys_stored(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        self._policy.on_keys_created_with_sizes(keys, sizes)
 
     def on_l2_keys_accessed(self, keys: list[ObjectKey]):
         self._policy.on_keys_touched(keys)

--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -51,8 +51,10 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         default_destination: EvictionDestination = EvictionDestination.DISCARD,
     ):
         self._lock = threading.Lock()
-        # cache_salt -> ordered {ObjectKey: None} (oldest first).
-        self._per_salt_order: dict[str, OrderedDict[ObjectKey, None]] = {}
+        # cache_salt -> ordered {ObjectKey: size} (oldest first).
+        self._per_salt_order: dict[str, OrderedDict[ObjectKey, int | None]] = {}
+        self._per_salt_total_size: dict[str, int] = {}
+        self._per_salt_total_size_squared: dict[str, int] = {}
         # Registered destinations (first one wins if any are registered,
         # matching LRUEvictionPolicy semantics).
         self._destinations: list[EvictionDestination] = []
@@ -67,18 +69,47 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
-            # Same prefix-match ordering rationale as ``LRUEvictionPolicy``:
-            # later keys in a request should be evicted first, so we
-            # insert in reverse to place the final key at the LRU head.
             for key in reversed(keys):
                 order = self._per_salt_order.get(key.cache_salt)
                 if order is None:
                     order = OrderedDict()
                     self._per_salt_order[key.cache_salt] = order
-                if key in order:
+                if key.cache_salt in self._per_salt_total_size:
+                    self._store_sized_key(key.cache_salt, order, key, 1)
+                elif key in order:
                     order.move_to_end(key)
                 else:
                     order[key] = None
+
+    def on_keys_created_with_sizes(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Track newly created keys and their byte sizes per salt.
+
+        Args:
+            keys: Keys that have been created.
+            sizes: Size in bytes for each key.
+
+        Raises:
+            ValueError: If ``keys`` and ``sizes`` have different lengths.
+        """
+        if len(keys) != len(sizes):
+            raise ValueError("keys and sizes must have the same length")
+        if not keys:
+            return
+        with self._lock:
+            # Same prefix-match ordering rationale as ``LRUEvictionPolicy``:
+            # later keys in a request should be evicted first, so we
+            # insert in reverse to place the final key at the LRU head.
+            for key, size in zip(reversed(keys), reversed(sizes), strict=True):
+                order = self._per_salt_order.get(key.cache_salt)
+                if order is None:
+                    order = OrderedDict()
+                    self._per_salt_order[key.cache_salt] = order
+                self._enable_size_tracking(key.cache_salt, order)
+                self._store_sized_key(key.cache_salt, order, key, size)
 
     def on_keys_touched(self, keys: list[ObjectKey]) -> None:
         if not keys:
@@ -97,11 +128,22 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
                 order = self._per_salt_order.get(key.cache_salt)
                 if order is None:
                     continue
-                order.pop(key, None)
+                if key.cache_salt in self._per_salt_total_size:
+                    size = order.pop(key, None)
+                    if size is None:
+                        continue
+                    self._per_salt_total_size[key.cache_salt] -= size
+                    self._per_salt_total_size_squared[key.cache_salt] -= size * size
+                elif key in order:
+                    del order[key]
+                else:
+                    continue
                 if not order:
                     # Drop the empty bucket so ``list``/iteration
                     # snapshots stay compact.
                     del self._per_salt_order[key.cache_salt]
+                    self._per_salt_total_size.pop(key.cache_salt, None)
+                    self._per_salt_total_size_squared.pop(key.cache_salt, None)
 
     def get_eviction_actions(
         self,
@@ -118,10 +160,10 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         falling back to a global pool.
 
         Args:
-            expected_ratio: Fraction of the candidate pool to evict,
-                clamped to ``[0.0, 1.0]``. If the ratio rounds down to
-                zero and the pool is non-empty, at least one key is
-                returned (matches ``LRUEvictionPolicy``).
+            expected_ratio: Fraction of the bucket's tracked eviction weight
+                to evict, clamped to ``[0.0, 1.0]``. L2 keys are weighted by
+                bytes; callers without sizes use unit weight. If the target
+                rounds down to zero, at least one key is returned.
             key_eligible_filter: Optional predicate — keys failing the
                 filter (e.g. locked) are skipped.
             cache_salt: The salt whose bucket to evict from. Required.
@@ -143,25 +185,45 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
             )
         with self._lock:
             order = self._per_salt_order.get(cache_salt)
-            pool = list(order.keys()) if order else []
-
-            if not pool:
+            if not order:
                 return []
 
             expected_ratio = max(0.0, min(1.0, expected_ratio))
-            target_count = int(len(pool) * expected_ratio)
-            if expected_ratio > 0 and target_count == 0:
-                target_count = 1
-            if target_count == 0:
-                return []
-
             keys_to_evict: list[ObjectKey] = []
-            for key in pool:
-                if key_eligible_filter is not None and not key_eligible_filter(key):
-                    continue
-                keys_to_evict.append(key)
-                if len(keys_to_evict) >= target_count:
-                    break
+            # n * sum(size^2) == sum(size)^2 iff all sizes are equal.
+            if (
+                cache_salt not in self._per_salt_total_size
+                or len(order) * self._per_salt_total_size_squared[cache_salt]
+                == self._per_salt_total_size[cache_salt] ** 2
+            ):
+                target_count = int(len(order) * expected_ratio)
+                if expected_ratio > 0 and target_count == 0:
+                    target_count = 1
+                if target_count == 0:
+                    return []
+                for key in order:
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    keys_to_evict.append(key)
+                    if len(keys_to_evict) >= target_count:
+                        break
+            else:
+                target_size = int(
+                    self._per_salt_total_size[cache_salt] * expected_ratio
+                )
+                if expected_ratio > 0 and target_size == 0:
+                    target_size = 1
+                if target_size == 0:
+                    return []
+                selected_size = 0
+                for key, size in order.items():
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    assert size is not None
+                    keys_to_evict.append(key)
+                    selected_size += size
+                    if selected_size >= target_size:
+                        break
 
             if not keys_to_evict:
                 return []
@@ -189,3 +251,33 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         """Return the set of cache_salts with at least one tracked key."""
         with self._lock:
             return list(self._per_salt_order.keys())
+
+    def _enable_size_tracking(
+        self,
+        cache_salt: str,
+        order: OrderedDict[ObjectKey, int | None],
+    ) -> None:
+        if cache_salt in self._per_salt_total_size:
+            return
+        self._per_salt_total_size[cache_salt] = len(order)
+        self._per_salt_total_size_squared[cache_salt] = len(order)
+        for key in order:
+            order[key] = 1
+
+    def _store_sized_key(
+        self,
+        cache_salt: str,
+        order: OrderedDict[ObjectKey, int | None],
+        key: ObjectKey,
+        size: int,
+    ) -> None:
+        if key in order:
+            old_size = order[key]
+            assert old_size is not None
+            self._per_salt_total_size[cache_salt] -= old_size
+            self._per_salt_total_size_squared[cache_salt] -= old_size * old_size
+            order.move_to_end(key)
+
+        order[key] = size
+        self._per_salt_total_size[cache_salt] += size
+        self._per_salt_total_size_squared[cache_salt] += size * size

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -30,7 +30,7 @@ class LRUEvictionPolicy(EvictionPolicy):
 
     Attributes:
         _lock: Threading lock for thread-safe operations
-        _order: OrderedDict maintaining LRU order (most recent at end)
+        _order: OrderedDict maintaining LRU order and object sizes
         _destinations: List of registered eviction destinations
         _default_destination: The default destination for eviction actions
     """
@@ -50,7 +50,9 @@ class LRUEvictionPolicy(EvictionPolicy):
         self._lock = threading.Lock()
 
         # OrderedDict to maintain LRU order - keys at the beginning are oldest
-        self._order: OrderedDict[ObjectKey, None] = OrderedDict()
+        self._order: OrderedDict[ObjectKey, int | None] = OrderedDict()
+        self._total_size: int | None = None
+        self._total_size_squared: int | None = None
 
         # List of registered eviction destinations
         self._destinations: list[EvictionDestination] = []
@@ -69,7 +71,7 @@ class LRUEvictionPolicy(EvictionPolicy):
             if destination not in self._destinations:
                 self._destinations.append(destination)
 
-    def on_keys_created(self, keys: list[ObjectKey]):
+    def on_keys_created(self, keys: list[ObjectKey]) -> None:
         """
         Notify the eviction policy that new keys have been created.
         New keys are added as most recently used.
@@ -80,18 +82,43 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
+            if self._total_size is None:
+                for key in reversed(keys):
+                    if key in self._order:
+                        self._order.move_to_end(key)
+                    else:
+                        self._order[key] = None
+                return
+            for key in reversed(keys):
+                self._store_sized_key(key, 1)
+
+    def on_keys_created_with_sizes(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Track newly created keys and their eviction weights.
+
+        Args:
+            keys: Keys that have been created.
+            sizes: Size in bytes for each key.
+
+        Raises:
+            ValueError: If ``keys`` and ``sizes`` have different lengths.
+        """
+        if len(keys) != len(sizes):
+            raise ValueError("keys and sizes must have the same length")
+        if not keys:
+            return
+        with self._lock:
+            self._enable_size_tracking()
             # NOTE: for the request, the later keys should be evicted first.
             # For example, the request has (key1, key2, key3), if we first
             # evict key1, due to prefix match, key2 and key3 will not be hit.
-            for key in reversed(keys):
-                # If key already exists, move it to the end (most recently used)
-                if key in self._order:
-                    self._order.move_to_end(key)
-                else:
-                    # Add new key at the end (most recently used)
-                    self._order[key] = None
+            for key, size in zip(reversed(keys), reversed(sizes), strict=True):
+                self._store_sized_key(key, size)
 
-    def on_keys_touched(self, keys: list[ObjectKey]):
+    def on_keys_touched(self, keys: list[ObjectKey]) -> None:
         """
         Notify the eviction policy that keys have been accessed.
         Touched keys are moved to the most recently used position.
@@ -109,7 +136,7 @@ class LRUEvictionPolicy(EvictionPolicy):
                     # Move to end (most recently used)
                     self._order.move_to_end(key)
 
-    def on_keys_removed(self, keys: list[ObjectKey]):
+    def on_keys_removed(self, keys: list[ObjectKey]) -> None:
         """
         Notify the eviction policy that keys have been deleted.
         Deleted keys are removed from tracking.
@@ -120,10 +147,22 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
+            if self._total_size is None:
+                for key in keys:
+                    if key in self._order:
+                        del self._order[key]
+                return
+
+            removed_size = 0
+            removed_size_squared = 0
             for key in keys:
-                # Remove from LRU order tracking
-                if key in self._order:
-                    del self._order[key]
+                size = self._order.pop(key, None)
+                if size is not None:
+                    removed_size += size
+                    removed_size_squared += size * size
+            self._total_size -= removed_size
+            assert self._total_size_squared is not None
+            self._total_size_squared -= removed_size_squared
 
     def get_eviction_actions(
         self,
@@ -137,8 +176,9 @@ class LRUEvictionPolicy(EvictionPolicy):
 
         Args:
             expected_ratio (float): A hint indicating approximately what fraction
-                of tracked keys should be evicted. Value should be in range [0.0, 1.0].
-                For example, 0.1 means roughly 10% of keys should be evicted.
+                of tracked eviction weight should be evicted. L2 keys are weighted
+                by bytes; callers without sizes use unit weight. Value should be in
+                range [0.0, 1.0].
             key_eligible_filter: An optional callable that takes an ObjectKey
                 and returns True if the key is eligible for eviction. When
                 provided, keys for which the filter returns False will be
@@ -164,28 +204,37 @@ class LRUEvictionPolicy(EvictionPolicy):
             # Clamp expected_ratio to valid range
             expected_ratio = max(0.0, min(1.0, expected_ratio))
 
-            # Calculate target number of keys to evict based on ratio
-            target_count = int(len(self._order) * expected_ratio)
-
-            # Ensure at least 1 key if ratio > 0 and we have keys
-            if expected_ratio > 0 and target_count == 0 and len(self._order) > 0:
-                target_count = 1
-
-            if target_count == 0:
-                return []
-
-            # Get keys in LRU order (from beginning - least recently used),
-            # skipping keys that fail the filter (e.g. locked keys).
             keys_to_evict: list[ObjectKey] = []
-
-            for key in self._order:
-                if key_eligible_filter is not None and not key_eligible_filter(key):
-                    # Skip keys that are not eligible for eviction
-                    # (e.g. currently locked by read/write operations)
-                    continue
-                keys_to_evict.append(key)
-                if len(keys_to_evict) >= target_count:
-                    break
+            if self._sizes_are_uniform():
+                # Preserve the original count-based rounding exactly when
+                # object sizes do not differ.
+                target_count = int(len(self._order) * expected_ratio)
+                if expected_ratio > 0 and target_count == 0:
+                    target_count = 1
+                if target_count == 0:
+                    return []
+                for key in self._order:
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    keys_to_evict.append(key)
+                    if len(keys_to_evict) >= target_count:
+                        break
+            else:
+                assert self._total_size is not None
+                target_size = int(self._total_size * expected_ratio)
+                if expected_ratio > 0 and target_size == 0:
+                    target_size = 1
+                if target_size == 0:
+                    return []
+                selected_size = 0
+                for key, size in self._order.items():
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    assert size is not None
+                    keys_to_evict.append(key)
+                    selected_size += size
+                    if selected_size >= target_size:
+                        break
 
             if not keys_to_evict:
                 return []
@@ -242,3 +291,35 @@ class LRUEvictionPolicy(EvictionPolicy):
                     break
 
             return candidates
+
+    def _enable_size_tracking(self) -> None:
+        if self._total_size is not None:
+            return
+        self._total_size = len(self._order)
+        self._total_size_squared = len(self._order)
+        for key in self._order:
+            self._order[key] = 1
+
+    def _store_sized_key(self, key: ObjectKey, size: int) -> None:
+        assert self._total_size is not None
+        assert self._total_size_squared is not None
+        if key in self._order:
+            old_size = self._order[key]
+            assert old_size is not None
+            self._total_size -= old_size
+            self._total_size_squared -= old_size * old_size
+            self._order.move_to_end(key)
+
+        self._order[key] = size
+        self._total_size += size
+        self._total_size_squared += size * size
+
+    def _sizes_are_uniform(self) -> bool:
+        """Check uniformity using n * sum(size^2) == sum(size)^2."""
+        if self._total_size is None:
+            return True
+        assert self._total_size_squared is not None
+        return (
+            len(self._order) * self._total_size_squared
+            == self._total_size * self._total_size
+        )

--- a/tests/v1/distributed/test_isolated_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_isolated_lru_eviction_policy.py
@@ -100,6 +100,73 @@ class TestScopedEviction:
 
 
 class TestEvictionAmount:
+    def test_equal_sizes_preserve_count_based_rounding(self):
+        """Uniform objects keep the original floor-based victim count."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(3)]
+        p.on_keys_created_with_sizes(keys, [4] * len(keys))
+
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert len(actions[0].keys) == 1
+
+    def test_variable_sizes_control_eviction_amount_per_salt(self):
+        """Each salt evicts the minimal LRU prefix reaching its byte target."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(4)]
+        for key, size in zip(keys, [1, 1, 8, 8], strict=True):
+            p.on_keys_created_with_sizes([key], [size])
+
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == keys[:3]
+
+    def test_other_salts_do_not_change_byte_target(self):
+        """A large object in another salt must not affect this bucket."""
+        p = IsolatedLRUEvictionPolicy()
+        alice = [_key(i, "alice") for i in range(4)]
+        for key, size in zip(alice, [1, 1, 8, 8], strict=True):
+            p.on_keys_created_with_sizes([key], [size])
+        p.on_keys_created_with_sizes([_key(100, "bob")], [1024])
+
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == alice[:3]
+
+    def test_size_refresh_updates_bucket_accounting(self):
+        """Re-storing a key replaces its old size in the correct bucket."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(2)]
+        p.on_keys_created_with_sizes(keys, [1, 9])
+
+        p.on_keys_created_with_sizes([keys[1]], [1])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_removal_updates_bucket_accounting(self):
+        """Removed objects no longer contribute to a bucket's byte target."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(3)]
+        for key, size in zip(keys, [1, 9, 2], strict=True):
+            p.on_keys_created_with_sizes([key], [size])
+
+        p.on_keys_removed([keys[1]])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_uniform_rounding_is_restored_after_removal(self):
+        """Removing the odd-sized object restores count-based rounding."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(4)]
+        p.on_keys_created_with_sizes(keys, [4, 8, 4, 4])
+
+        p.on_keys_removed([keys[1]])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert len(actions[0].keys) == 1
+
     def test_at_least_one_when_ratio_positive(self):
         """Matches ``LRUEvictionPolicy`` — a positive ratio that rounds
         to zero still yields one eviction so the caller makes forward

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -11,9 +11,11 @@ These tests verify the basic functionality of the LRUEvictionPolicy:
 """
 
 # Third Party
+import pytest
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction import L2EvictionPolicy
 from lmcache.v1.distributed.eviction_policy import LRUEvictionPolicy
 from lmcache.v1.distributed.internal_api import (
     EvictionDestination,
@@ -191,6 +193,100 @@ class TestLRUEvictionPolicyRatio:
         # Ratio > 1 should be treated as 1
         actions = policy.get_eviction_actions(1.5)
         assert len(actions[0].keys) == 10
+
+
+# =============================================================================
+# Byte-weighted L2 Tests
+# =============================================================================
+
+
+class TestLRUEvictionPolicySizes:
+    """Tests for byte-weighted eviction when L2 reports object sizes."""
+
+    def test_variable_sizes_control_eviction_amount(self):
+        """Evict the minimal LRU prefix that reaches the byte target."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(4)]
+        for key, size in zip(keys, [1, 1, 8, 8], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == keys[:3]
+
+    def test_equal_sizes_preserve_count_based_result(self):
+        """Equal object sizes produce the same victims as count-based LRU."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(3)]
+        policy.on_keys_created_with_sizes(keys, [4] * len(keys))
+
+        actions = policy.get_eviction_actions(0.5)
+
+        assert len(actions[0].keys) == 1
+
+    def test_size_refresh_updates_byte_accounting(self):
+        """Re-storing a key replaces its old size and refreshes LRU order."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(2)]
+        policy.on_keys_created_with_sizes(keys, [1, 9])
+
+        policy.on_keys_created_with_sizes([keys[1]], [1])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_removal_updates_byte_accounting(self):
+        """Removed objects no longer contribute to the byte target."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(3)]
+        for key, size in zip(keys, [1, 9, 2], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        policy.on_keys_removed([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_mixed_history_keeps_byte_target_after_removal(self):
+        """A mixed-size policy keeps freeing at least the requested bytes."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(4)]
+        for key, size in zip(keys, [4, 8, 2, 4], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        policy.on_keys_removed([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[0], keys[2]]
+
+    def test_uniform_rounding_is_restored_after_removal(self):
+        """Removing the odd-sized object restores count-based rounding."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(4)]
+        policy.on_keys_created_with_sizes(keys, [4, 8, 4, 4])
+
+        policy.on_keys_removed([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert len(actions[0].keys) == 1
+
+    def test_l2_bridge_forwards_object_sizes(self):
+        """The L2 listener must not discard adapter-provided byte sizes."""
+        policy = LRUEvictionPolicy()
+        bridge = L2EvictionPolicy(policy)
+        keys = [make_key(i) for i in range(4)]
+        bridge.on_l2_keys_stored(keys, [8, 8, 1, 1])
+
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[3], keys[2], keys[1]]
+
+    def test_mismatched_sizes_are_rejected(self):
+        """Each reported key must have exactly one byte size."""
+        policy = LRUEvictionPolicy()
+
+        with pytest.raises(ValueError, match="same length"):
+            policy.on_keys_created_with_sizes([make_key(1)], [])
 
 
 # =============================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:

L2 adapters already report each stored object's byte size through
`on_l2_keys_stored`, but `L2EvictionPolicy` currently drops that information.
The LRU policies therefore interpret `eviction_ratio` as a fraction of key
count. That is accurate when objects are uniform, but with mixed object sizes it
can free too few bytes and require another controller pass, or free considerably
more data than requested.

This change forwards object sizes to the eviction policy and uses them as the
eviction weight for heterogeneous L2 objects. The policy computes a byte target
from the configured ratio, then takes the smallest LRU prefix that reaches that
target. Global LRU and per-`cache_salt` isolated LRU use the same rule.

Unsized callers keep unit weights. If the currently tracked objects all have the
same size, the policy takes the original count-based path, including its existing
floor rounding. Size refreshes and removals update both the byte total and the
uniform-size check.

One end-to-end reproduction used a 256 MiB Mock L2 cache with four 33 MiB objects
and one 66 MiB object (198 MiB total), a 0.6 high watermark, and a 0.25 eviction
ratio:

- The current policy selected one 33 MiB object. Usage remained at 0.6445, so the
  controller ran again about one second later.
- The byte-aware policy targeted 49.5 MiB and selected two 33 MiB objects in the
  first pass. Usage fell to 0.5156.

Across two interleaved baseline/patched runs, the baseline needed two eviction
passes both times (1.002-1.004 seconds apart); the patched policy needed one pass
both times. Every run ended with the same three objects and 132 MiB stored, so the
reduction did not come from evicting more data overall.

The workload used Qwen3.5-4B in BF16 with vLLM
`0.23.1rc1.dev753+g4875b4456.cu129`; TP=2 produced the 33 MiB objects and TP=1
produced the 66 MiB object. All eight requests completed successfully.

**Special notes for your reviewers**:

- The new `EvictionPolicy` method has a fallback to `on_keys_created`, so policies
  that do not consume sizes keep their current behavior.
- The policy retains one size per tracked L2 key and two integer aggregates per
  policy/bucket. Creating, refreshing, and removing a sized key adds constant-time
  integer accounting.
- Victim selection is still a single LRU-prefix walk. A heterogeneous workload may
  visit more keys when the oldest objects are small; this is required to meet the
  byte target.
- This PR does not claim a TTFT or throughput improvement. Request latency in the
  end-to-end run was noisy; the repeatable result is one fewer controller pass and
  delete call in the under-eviction case above.
- I checked the open PRs for related LRU/size work. #3859 adds capacity reporting
  to the FS adapter without changing victim selection, and #3909 restores S3 LRU
  state after restart. Neither changes the eviction ratio from key count to bytes.

Validation:

```text
python -m pytest test_lru_eviction_policy.py \
  test_isolated_lru_eviction_policy.py -q
54 passed

pre-commit: SPDX, isort, ruff, ruff-format, codespell, mypy
all passed on the five changed files

git diff --check
passed
```

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
