### PR TITLE
[MP] Make L2 LRU eviction byte-aware

### DIFF
--- a/docs/design/v1/mp_coordinator/persistence/README.md
+++ b/docs/design/v1/mp_coordinator/persistence/README.md
@@ -15,7 +15,7 @@ contract below and restores itself from its own section:
 | `KeyDirectory` | `key_directory` | A restarted MP server re-announces its L1, but nothing re-announces bytes already resting in L2 |
 | `CacheUsageManager` | `cache_usage` | Byte accounting for those same placements; quota enforcement is blind without it |
 | `EventGate` | `stream_cursors` | Fencing compares an arriving batch against a prior incarnation; with no cursor there is nothing to compare, and a restarted server's stale L1 slice is advertised forever |
-| `IsolatedLRUEvictionPolicy` | `lru_order` | Recency is position, not a timestamp |
+| `IsolatedLRUEvictionPolicy` | `lru_order` | Recency is positional; complete byte weights drive eviction |
 | `FleetEvictionController` | `pins` | Operator intent |
 | `QuotaManager` | `quotas` | Operator intent |
 

--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -100,6 +100,22 @@ class EvictionPolicy:
         """
         pass
 
+    def on_keys_created_with_sizes(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Notify the policy that sized keys have been created.
+
+        Policies that do not use object sizes inherit the compatibility
+        fallback, which delegates to :meth:`on_keys_created`.
+
+        Args:
+            keys: Keys that have been created.
+            sizes: Size in bytes for each key.
+        """
+        self.on_keys_created(keys)
+
     @abstractmethod
     def on_keys_touched(self, keys: list[ObjectKey]):
         """
@@ -120,6 +136,17 @@ class EvictionPolicy:
         """
         pass
 
+    def on_eviction_attempted(self, keys: list[ObjectKey]) -> None:
+        """Notify the policy that keys were submitted for eviction.
+
+        Policies may use this signal to keep an unremovable LRU head from
+        blocking other candidates. The default implementation preserves
+        compatibility for policies that do not track retry order.
+
+        Args:
+            keys: Keys submitted to an eviction destination.
+        """
+
     @abstractmethod
     def get_eviction_actions(
         self,
@@ -132,10 +159,10 @@ class EvictionPolicy:
 
         Args:
             expected_ratio (float): A hint indicating approximately what
-                fraction of tracked keys should be evicted. Value should be
-                in range [0.0, 1.0]. For example, 0.1 means roughly 10% of
-                keys should be evicted. This is a hint and the policy may
-                return more or fewer keys.
+                fraction of tracked eviction weight should be evicted. Policies
+                may use bytes when sizes are available and unit weight otherwise.
+                Value should be in range [0.0, 1.0]. This is a hint and the
+                policy may return more or fewer keys.
             key_eligible_filter: An optional callable that takes an ObjectKey
                 and returns True if the key is eligible for eviction. When
                 provided, keys for which the filter returns False will be
@@ -222,8 +249,12 @@ class L2EvictionPolicy(L2AdapterListener):
     def policy(self) -> EvictionPolicy:
         return self._policy
 
-    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]):
-        self._policy.on_keys_created(keys)
+    def on_l2_keys_stored(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        self._policy.on_keys_created_with_sizes(keys, sizes)
 
     def on_l2_keys_accessed(self, keys: list[ObjectKey]):
         self._policy.on_keys_touched(keys)

--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -54,8 +54,11 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         default_destination: EvictionDestination = EvictionDestination.DISCARD,
     ):
         self._lock = threading.Lock()
-        # cache_salt -> ordered {ObjectKey: None} (oldest first).
-        self._per_salt_order: dict[str, OrderedDict[ObjectKey, None]] = {}
+        # cache_salt -> ordered {ObjectKey: size} (oldest first).
+        self._per_salt_order: dict[str, OrderedDict[ObjectKey, int | None]] = {}
+        self._per_salt_total_size: dict[str, int] = {}
+        self._per_salt_total_size_squared: dict[str, int] = {}
+        self._per_salt_unknown_size_count: dict[str, int] = {}
         # Registered destinations (first one wins if any are registered,
         # matching LRUEvictionPolicy semantics).
         self._destinations: list[EvictionDestination] = []
@@ -70,18 +73,51 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
-            # Same prefix-match ordering rationale as ``LRUEvictionPolicy``:
-            # later keys in a request should be evicted first, so we
-            # insert in reverse to place the final key at the LRU head.
             for key in reversed(keys):
                 order = self._per_salt_order.get(key.cache_salt)
                 if order is None:
                     order = OrderedDict()
                     self._per_salt_order[key.cache_salt] = order
-                if key in order:
+                if key.cache_salt in self._per_salt_total_size:
+                    if key in order:
+                        order.move_to_end(key)
+                    else:
+                        order[key] = None
+                        self._per_salt_unknown_size_count[key.cache_salt] += 1
+                elif key in order:
                     order.move_to_end(key)
                 else:
                     order[key] = None
+
+    def on_keys_created_with_sizes(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Track newly created keys and their byte sizes per salt.
+
+        Args:
+            keys: Keys that have been created.
+            sizes: Size in bytes for each key.
+
+        Raises:
+            ValueError: If ``keys`` and ``sizes`` have different lengths.
+        """
+        if len(keys) != len(sizes):
+            raise ValueError("keys and sizes must have the same length")
+        if not keys:
+            return
+        with self._lock:
+            # Same prefix-match ordering rationale as ``LRUEvictionPolicy``:
+            # later keys in a request should be evicted first, so we
+            # insert in reverse to place the final key at the LRU head.
+            for key, size in zip(reversed(keys), reversed(sizes), strict=True):
+                order = self._per_salt_order.get(key.cache_salt)
+                if order is None:
+                    order = OrderedDict()
+                    self._per_salt_order[key.cache_salt] = order
+                self._enable_size_tracking(key.cache_salt, order)
+                self._store_sized_key(key.cache_salt, order, key, size)
 
     def on_keys_touched(self, keys: list[ObjectKey]) -> None:
         if not keys:
@@ -100,11 +136,40 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
                 order = self._per_salt_order.get(key.cache_salt)
                 if order is None:
                     continue
-                order.pop(key, None)
+                if key.cache_salt in self._per_salt_total_size:
+                    if key not in order:
+                        continue
+                    size = order.pop(key)
+                    if size is None:
+                        self._per_salt_unknown_size_count[key.cache_salt] -= 1
+                    else:
+                        self._per_salt_total_size[key.cache_salt] -= size
+                        self._per_salt_total_size_squared[key.cache_salt] -= size * size
+                elif key in order:
+                    del order[key]
+                else:
+                    continue
                 if not order:
                     # Drop the empty bucket so ``list``/iteration
                     # snapshots stay compact.
                     del self._per_salt_order[key.cache_salt]
+                    self._per_salt_total_size.pop(key.cache_salt, None)
+                    self._per_salt_total_size_squared.pop(key.cache_salt, None)
+                    self._per_salt_unknown_size_count.pop(key.cache_salt, None)
+
+    def on_eviction_attempted(self, keys: list[ObjectKey]) -> None:
+        """Defer attempted keys within their salt buckets.
+
+        Args:
+            keys: Keys submitted to an eviction destination, in LRU order.
+        """
+        if not keys:
+            return
+        with self._lock:
+            for key in keys:
+                order = self._per_salt_order.get(key.cache_salt)
+                if order is not None and key in order:
+                    order.move_to_end(key)
 
     def get_eviction_actions(
         self,
@@ -121,10 +186,10 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         falling back to a global pool.
 
         Args:
-            expected_ratio: Fraction of the candidate pool to evict,
-                clamped to ``[0.0, 1.0]``. If the ratio rounds down to
-                zero and the pool is non-empty, at least one key is
-                returned (matches ``LRUEvictionPolicy``).
+            expected_ratio: Fraction of the bucket's tracked eviction weight
+                to evict, clamped to ``[0.0, 1.0]``. L2 keys are weighted by
+                bytes; callers without sizes use unit weight. If the target
+                rounds down to zero, at least one key is returned.
             key_eligible_filter: Optional predicate — keys failing the
                 filter (e.g. locked) are skipped.
             cache_salt: The salt whose bucket to evict from. Required.
@@ -146,25 +211,46 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
             )
         with self._lock:
             order = self._per_salt_order.get(cache_salt)
-            pool = list(order.keys()) if order else []
-
-            if not pool:
+            if not order:
                 return []
 
             expected_ratio = max(0.0, min(1.0, expected_ratio))
-            target_count = int(len(pool) * expected_ratio)
-            if expected_ratio > 0 and target_count == 0:
-                target_count = 1
-            if target_count == 0:
-                return []
-
             keys_to_evict: list[ObjectKey] = []
-            for key in pool:
-                if key_eligible_filter is not None and not key_eligible_filter(key):
-                    continue
-                keys_to_evict.append(key)
-                if len(keys_to_evict) >= target_count:
-                    break
+            # n * sum(size^2) == sum(size)^2 iff all sizes are equal.
+            if (
+                cache_salt not in self._per_salt_total_size
+                or self._per_salt_unknown_size_count[cache_salt] > 0
+                or len(order) * self._per_salt_total_size_squared[cache_salt]
+                == self._per_salt_total_size[cache_salt] ** 2
+            ):
+                target_count = int(len(order) * expected_ratio)
+                if expected_ratio > 0 and target_count == 0:
+                    target_count = 1
+                if target_count == 0:
+                    return []
+                for key in order:
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    keys_to_evict.append(key)
+                    if len(keys_to_evict) >= target_count:
+                        break
+            else:
+                target_size = int(
+                    self._per_salt_total_size[cache_salt] * expected_ratio
+                )
+                if expected_ratio > 0 and target_size == 0:
+                    target_size = 1
+                if target_size == 0:
+                    return []
+                selected_size = 0
+                for key, size in order.items():
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    assert size is not None
+                    keys_to_evict.append(key)
+                    selected_size += size
+                    if selected_size >= target_size:
+                        break
 
             if not keys_to_evict:
                 return []
@@ -205,21 +291,28 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         return "lru_order"
 
     def capture(self) -> Mapping[str, object]:
-        """Return each bucket's eviction order, least-recently-used first.
+        """Return each bucket's eviction order and optional byte weights.
 
-        The ordering *is* the state: recency lives in position, not in a
-        timestamp, so nothing outside this policy can reconstruct it.
+        Recency lives in position, not in a timestamp. Byte weights also
+        belong here because durable components restore independently.
 
         Returns:
-            ``{"buckets": {cache_salt: [key, ...]}}``, each list in
-            eviction order.
+            ``{"buckets": {cache_salt: [key, ...]}, "sizes":
+            {cache_salt: [size, ...]}}``. ``sizes`` contains only buckets
+            where every object size is known.
         """
         with self._lock:
             return {
                 "buckets": {
                     cache_salt: [encode_key(key) for key in order]
                     for cache_salt, order in self._per_salt_order.items()
-                }
+                },
+                "sizes": {
+                    cache_salt: list(order.values())
+                    for cache_salt, order in self._per_salt_order.items()
+                    if cache_salt in self._per_salt_total_size
+                    and self._per_salt_unknown_size_count[cache_salt] == 0
+                },
             }
 
     def restore(self, state: Mapping[str, object]) -> None:
@@ -231,15 +324,72 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         Args:
             state: A :meth:`capture` value, as decoded from the
                 checkpoint holding it.
+
+        Raises:
+            ValueError: If a bucket has a different number of keys and sizes.
         """
         buckets = cast("Mapping[str, list[object]]", state["buckets"])
+        sizes = cast("Mapping[str, list[int]]", state.get("sizes", {}))
         with self._lock:
-            self._per_salt_order = {
-                cache_salt: OrderedDict(
-                    (decode_key(encoded), None) for encoded in ordered
+            restored_order: dict[str, OrderedDict[ObjectKey, int | None]] = {}
+            restored_total_size: dict[str, int] = {}
+            restored_total_size_squared: dict[str, int] = {}
+            restored_unknown_size_count: dict[str, int] = {}
+            for cache_salt, ordered in buckets.items():
+                bucket_sizes = sizes.get(cache_salt)
+                if bucket_sizes is None:
+                    restored_order[cache_salt] = OrderedDict(
+                        (decode_key(encoded), None) for encoded in ordered
+                    )
+                    continue
+                if len(bucket_sizes) != len(ordered):
+                    raise ValueError(
+                        f"bucket {cache_salt!r} has {len(ordered)} keys but "
+                        f"{len(bucket_sizes)} sizes"
+                    )
+                restored_order[cache_salt] = OrderedDict(
+                    (decode_key(encoded), size)
+                    for encoded, size in zip(ordered, bucket_sizes, strict=True)
                 )
-                for cache_salt, ordered in buckets.items()
-            }
+                restored_total_size[cache_salt] = sum(bucket_sizes)
+                restored_total_size_squared[cache_salt] = sum(
+                    size * size for size in bucket_sizes
+                )
+                restored_unknown_size_count[cache_salt] = 0
+            self._per_salt_order = restored_order
+            self._per_salt_total_size = restored_total_size
+            self._per_salt_total_size_squared = restored_total_size_squared
+            self._per_salt_unknown_size_count = restored_unknown_size_count
 
+    # -- Internals ----------------------------------------------------------------
 
-# -- Internals ----------------------------------------------------------------
+    def _enable_size_tracking(
+        self,
+        cache_salt: str,
+        order: OrderedDict[ObjectKey, int | None],
+    ) -> None:
+        if cache_salt in self._per_salt_total_size:
+            return
+        self._per_salt_total_size[cache_salt] = 0
+        self._per_salt_total_size_squared[cache_salt] = 0
+        self._per_salt_unknown_size_count[cache_salt] = len(order)
+
+    def _store_sized_key(
+        self,
+        cache_salt: str,
+        order: OrderedDict[ObjectKey, int | None],
+        key: ObjectKey,
+        size: int,
+    ) -> None:
+        if key in order:
+            old_size = order[key]
+            if old_size is None:
+                self._per_salt_unknown_size_count[cache_salt] -= 1
+            else:
+                self._per_salt_total_size[cache_salt] -= old_size
+                self._per_salt_total_size_squared[cache_salt] -= old_size * old_size
+            order.move_to_end(key)
+
+        order[key] = size
+        self._per_salt_total_size[cache_salt] += size
+        self._per_salt_total_size_squared[cache_salt] += size * size

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -30,7 +30,7 @@ class LRUEvictionPolicy(EvictionPolicy):
 
     Attributes:
         _lock: Threading lock for thread-safe operations
-        _order: OrderedDict maintaining LRU order (most recent at end)
+        _order: OrderedDict maintaining LRU order and object sizes
         _destinations: List of registered eviction destinations
         _default_destination: The default destination for eviction actions
     """
@@ -50,7 +50,10 @@ class LRUEvictionPolicy(EvictionPolicy):
         self._lock = threading.Lock()
 
         # OrderedDict to maintain LRU order - keys at the beginning are oldest
-        self._order: OrderedDict[ObjectKey, None] = OrderedDict()
+        self._order: OrderedDict[ObjectKey, int | None] = OrderedDict()
+        self._total_size: int | None = None
+        self._total_size_squared: int | None = None
+        self._unknown_size_count = 0
 
         # List of registered eviction destinations
         self._destinations: list[EvictionDestination] = []
@@ -69,7 +72,7 @@ class LRUEvictionPolicy(EvictionPolicy):
             if destination not in self._destinations:
                 self._destinations.append(destination)
 
-    def on_keys_created(self, keys: list[ObjectKey]):
+    def on_keys_created(self, keys: list[ObjectKey]) -> None:
         """
         Notify the eviction policy that new keys have been created.
         New keys are added as most recently used.
@@ -80,18 +83,47 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
-            # NOTE: for the request, the later keys should be evicted first.
-            # For example, the request has (key1, key2, key3), if we first
-            # evict key1, due to prefix match, key2 and key3 will not be hit.
+            if self._total_size is None:
+                for key in reversed(keys):
+                    if key in self._order:
+                        self._order.move_to_end(key)
+                    else:
+                        self._order[key] = None
+                return
             for key in reversed(keys):
-                # If key already exists, move it to the end (most recently used)
                 if key in self._order:
                     self._order.move_to_end(key)
                 else:
-                    # Add new key at the end (most recently used)
                     self._order[key] = None
+                    self._unknown_size_count += 1
 
-    def on_keys_touched(self, keys: list[ObjectKey]):
+    def on_keys_created_with_sizes(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Track newly created keys and their eviction weights.
+
+        Args:
+            keys: Keys that have been created.
+            sizes: Size in bytes for each key.
+
+        Raises:
+            ValueError: If ``keys`` and ``sizes`` have different lengths.
+        """
+        if len(keys) != len(sizes):
+            raise ValueError("keys and sizes must have the same length")
+        if not keys:
+            return
+        with self._lock:
+            self._enable_size_tracking()
+            # NOTE: for the request, the later keys should be evicted first.
+            # For example, the request has (key1, key2, key3), if we first
+            # evict key1, due to prefix match, key2 and key3 will not be hit.
+            for key, size in zip(reversed(keys), reversed(sizes), strict=True):
+                self._store_sized_key(key, size)
+
+    def on_keys_touched(self, keys: list[ObjectKey]) -> None:
         """
         Notify the eviction policy that keys have been accessed.
         Touched keys are moved to the most recently used position.
@@ -109,7 +141,7 @@ class LRUEvictionPolicy(EvictionPolicy):
                     # Move to end (most recently used)
                     self._order.move_to_end(key)
 
-    def on_keys_removed(self, keys: list[ObjectKey]):
+    def on_keys_removed(self, keys: list[ObjectKey]) -> None:
         """
         Notify the eviction policy that keys have been deleted.
         Deleted keys are removed from tracking.
@@ -120,10 +152,35 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
+            if self._total_size is None:
+                for key in keys:
+                    if key in self._order:
+                        del self._order[key]
+                return
+
             for key in keys:
-                # Remove from LRU order tracking
+                if key not in self._order:
+                    continue
+                size = self._order.pop(key)
+                if size is None:
+                    self._unknown_size_count -= 1
+                else:
+                    self._total_size -= size
+                    assert self._total_size_squared is not None
+                    self._total_size_squared -= size * size
+
+    def on_eviction_attempted(self, keys: list[ObjectKey]) -> None:
+        """Defer attempted keys so a failed LRU head cannot block progress.
+
+        Args:
+            keys: Keys submitted to an eviction destination, in LRU order.
+        """
+        if not keys:
+            return
+        with self._lock:
+            for key in keys:
                 if key in self._order:
-                    del self._order[key]
+                    self._order.move_to_end(key)
 
     def get_eviction_actions(
         self,
@@ -137,8 +194,9 @@ class LRUEvictionPolicy(EvictionPolicy):
 
         Args:
             expected_ratio (float): A hint indicating approximately what fraction
-                of tracked keys should be evicted. Value should be in range [0.0, 1.0].
-                For example, 0.1 means roughly 10% of keys should be evicted.
+                of tracked eviction weight should be evicted. L2 keys are weighted
+                by bytes; callers without sizes use unit weight. Value should be in
+                range [0.0, 1.0].
             key_eligible_filter: An optional callable that takes an ObjectKey
                 and returns True if the key is eligible for eviction. When
                 provided, keys for which the filter returns False will be
@@ -164,28 +222,37 @@ class LRUEvictionPolicy(EvictionPolicy):
             # Clamp expected_ratio to valid range
             expected_ratio = max(0.0, min(1.0, expected_ratio))
 
-            # Calculate target number of keys to evict based on ratio
-            target_count = int(len(self._order) * expected_ratio)
-
-            # Ensure at least 1 key if ratio > 0 and we have keys
-            if expected_ratio > 0 and target_count == 0 and len(self._order) > 0:
-                target_count = 1
-
-            if target_count == 0:
-                return []
-
-            # Get keys in LRU order (from beginning - least recently used),
-            # skipping keys that fail the filter (e.g. locked keys).
             keys_to_evict: list[ObjectKey] = []
-
-            for key in self._order:
-                if key_eligible_filter is not None and not key_eligible_filter(key):
-                    # Skip keys that are not eligible for eviction
-                    # (e.g. currently locked by read/write operations)
-                    continue
-                keys_to_evict.append(key)
-                if len(keys_to_evict) >= target_count:
-                    break
+            if self._sizes_are_uniform():
+                # Preserve the original count-based rounding exactly when
+                # object sizes do not differ.
+                target_count = int(len(self._order) * expected_ratio)
+                if expected_ratio > 0 and target_count == 0:
+                    target_count = 1
+                if target_count == 0:
+                    return []
+                for key in self._order:
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    keys_to_evict.append(key)
+                    if len(keys_to_evict) >= target_count:
+                        break
+            else:
+                assert self._total_size is not None
+                target_size = int(self._total_size * expected_ratio)
+                if expected_ratio > 0 and target_size == 0:
+                    target_size = 1
+                if target_size == 0:
+                    return []
+                selected_size = 0
+                for key, size in self._order.items():
+                    if key_eligible_filter is not None and not key_eligible_filter(key):
+                        continue
+                    assert size is not None
+                    keys_to_evict.append(key)
+                    selected_size += size
+                    if selected_size >= target_size:
+                        break
 
             if not keys_to_evict:
                 return []
@@ -242,3 +309,36 @@ class LRUEvictionPolicy(EvictionPolicy):
                     break
 
             return candidates
+
+    def _enable_size_tracking(self) -> None:
+        if self._total_size is not None:
+            return
+        self._total_size = 0
+        self._total_size_squared = 0
+        self._unknown_size_count = len(self._order)
+
+    def _store_sized_key(self, key: ObjectKey, size: int) -> None:
+        assert self._total_size is not None
+        assert self._total_size_squared is not None
+        if key in self._order:
+            old_size = self._order[key]
+            if old_size is None:
+                self._unknown_size_count -= 1
+            else:
+                self._total_size -= old_size
+                self._total_size_squared -= old_size * old_size
+            self._order.move_to_end(key)
+
+        self._order[key] = size
+        self._total_size += size
+        self._total_size_squared += size * size
+
+    def _sizes_are_uniform(self) -> bool:
+        """Use count mode for unknown or uniform object sizes."""
+        if self._total_size is None or self._unknown_size_count:
+            return True
+        assert self._total_size_squared is not None
+        return (
+            len(self._order) * self._total_size_squared
+            == self._total_size * self._total_size
+        )

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -303,12 +303,22 @@ class L2EvictionController(StorageControllerInterface):
     def _eviction_loop(self):
         while not self._stop_flag.is_set():
             time.sleep(1)
-            # Hold the lock across the whole pass so remove_adapter_state
-            # cannot detach (and the caller close) an adapter while we are
-            # calling into it.
-            with self._states_lock:
-                for state in self._adapter_states:
+            self._run_eviction_pass()
+
+    def _run_eviction_pass(self) -> None:
+        # Hold the lock across the whole pass so remove_adapter_state
+        # cannot detach (and the caller close) an adapter while we are
+        # calling into it.
+        with self._states_lock:
+            for state in self._adapter_states:
+                try:
                     self._check_and_evict(state)
+                except Exception:
+                    logger.exception(
+                        "L2 eviction failed for adapter_id=%d; "
+                        "retrying on the next pass.",
+                        state.adapter_id,
+                    )
 
     def _check_and_evict(self, state: L2AdapterEvictionState):
         if state.eviction_policy.support_isolation and self._quota_manager is not None:
@@ -342,6 +352,7 @@ class L2EvictionController(StorageControllerInterface):
         )
         actions = state.eviction_policy.get_eviction_actions(eviction_ratio)
         for action in actions:
+            state.eviction_policy.on_eviction_attempted(action.keys)
             self._execute_eviction_action(state.adapter, action)
 
     def _check_and_evict_by_cache_salt(self, state: L2AdapterEvictionState):
@@ -398,6 +409,7 @@ class L2EvictionController(StorageControllerInterface):
                 pending.setdefault(action.destination, []).extend(action.keys)
 
         for destination, keys in pending.items():
+            state.eviction_policy.on_eviction_attempted(keys)
             self._execute_eviction_action(
                 state.adapter,
                 EvictionAction(keys=keys, destination=destination),

--- a/tests/v1/distributed/test_cache_salt_l2_eviction.py
+++ b/tests/v1/distributed/test_cache_salt_l2_eviction.py
@@ -174,6 +174,56 @@ class TestOverQuotaEviction:
             "bob was within quota — nothing should have moved"
         )
 
+    def test_failed_oversized_delete_rotates_to_smaller_keys(
+        self, isolated_lru_setup, monkeypatch
+    ):
+        """A failed oversized LRU head cannot monopolize later passes."""
+        adapter, _, qm, controller, state = isolated_lru_setup
+        oversized = _key(0, "alice")
+        alternatives = [_key(i, "alice") for i in range(1, 101)]
+        qm.set_quota("alice", 1)
+        _store_sync(adapter, oversized, _memory_obj(100))
+        for key in alternatives:
+            _store_sync(adapter, key, _memory_obj(1))
+
+        attempts: list[list[ObjectKey]] = []
+        monkeypatch.setattr(
+            adapter, "delete", lambda selected: attempts.append(selected)
+        )
+
+        controller._check_and_evict(state)
+        controller._check_and_evict(state)
+
+        assert attempts[0] == [oversized]
+        assert attempts[1] == alternatives
+
+    def test_raising_delete_does_not_stop_later_passes(
+        self, isolated_lru_setup, monkeypatch
+    ):
+        """A raised delete is isolated and the next pass makes progress."""
+        adapter, _, qm, controller, _ = isolated_lru_setup
+        oversized = _key(0, "alice")
+        alternatives = [_key(i, "alice") for i in range(1, 101)]
+        qm.set_quota("alice", 1)
+        _store_sync(adapter, oversized, _memory_obj(100))
+        for key in alternatives:
+            _store_sync(adapter, key, _memory_obj(1))
+
+        attempts: list[list[ObjectKey]] = []
+
+        def flaky_delete(selected):
+            attempts.append(selected)
+            if len(attempts) == 1:
+                raise RuntimeError("delete failed")
+
+        monkeypatch.setattr(adapter, "delete", flaky_delete)
+
+        controller._run_eviction_pass()
+        controller._run_eviction_pass()
+
+        assert attempts[0] == [oversized]
+        assert attempts[1] == alternatives
+
     def test_unregistered_salt_gets_wiped(self, isolated_lru_setup):
         """A salt with no quota entry is fully evicted on the next
         cycle (allowlist semantics)."""

--- a/tests/v1/distributed/test_isolated_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_isolated_lru_eviction_policy.py
@@ -101,6 +101,119 @@ class TestScopedEviction:
 
 
 class TestEvictionAmount:
+    def test_equal_sizes_preserve_count_based_rounding(self):
+        """Uniform objects keep the original floor-based victim count."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(3)]
+        p.on_keys_created_with_sizes(keys, [4] * len(keys))
+
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert len(actions[0].keys) == 1
+
+    def test_variable_sizes_control_eviction_amount_per_salt(self):
+        """Each salt evicts the minimal LRU prefix reaching its byte target."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(4)]
+        for key, size in zip(keys, [1, 1, 8, 8], strict=True):
+            p.on_keys_created_with_sizes([key], [size])
+
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == keys[:3]
+
+    def test_failed_oversized_victim_does_not_block_bucket_progress(self):
+        """An attempted victim is deferred within its own salt bucket."""
+        p = IsolatedLRUEvictionPolicy()
+        oversized = _key(0, "alice")
+        alternatives = [_key(i, "alice") for i in range(1, 101)]
+        for key, size in zip(
+            [oversized, *alternatives],
+            [320, *([1] * 100)],
+            strict=True,
+        ):
+            p.on_keys_created_with_sizes([key], [size])
+
+        first = p.get_eviction_actions(0.2, cache_salt="alice")[0].keys
+        p.on_eviction_attempted(first)
+        second = p.get_eviction_actions(0.2, cache_salt="alice")[0].keys
+
+        assert first == [oversized]
+        assert second == alternatives[:84]
+
+    def test_other_salts_do_not_change_byte_target(self):
+        """A large object in another salt must not affect this bucket."""
+        p = IsolatedLRUEvictionPolicy()
+        alice = [_key(i, "alice") for i in range(4)]
+        for key, size in zip(alice, [1, 1, 8, 8], strict=True):
+            p.on_keys_created_with_sizes([key], [size])
+        p.on_keys_created_with_sizes([_key(100, "bob")], [1024])
+
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == alice[:3]
+
+    def test_size_refresh_updates_bucket_accounting(self):
+        """Re-storing a key replaces its old size in the correct bucket."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(2)]
+        p.on_keys_created_with_sizes(keys, [1, 9])
+
+        p.on_keys_created_with_sizes([keys[1]], [1])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_unsized_refresh_preserves_known_size(self):
+        """An unsized notification must not replace a bucket's byte weight."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(2)]
+        p.on_keys_created_with_sizes([keys[0]], [1])
+        p.on_keys_created_with_sizes([keys[1]], [9])
+
+        p.on_keys_created([keys[1]])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == keys
+
+    def test_byte_mode_starts_after_last_unknown_size_arrives(self):
+        """A bucket switches from count to byte mode only when complete."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(2)]
+        p.on_keys_created(keys)
+        p.on_keys_created_with_sizes([keys[0]], [1])
+
+        partial = p.get_eviction_actions(0.5, cache_salt="alice")
+        p.on_keys_created_with_sizes([keys[1]], [9])
+        complete = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert partial[0].keys == [keys[1]]
+        assert complete[0].keys == keys
+        assert p.capture()["sizes"]["alice"] == [1, 9]
+
+    def test_removal_updates_bucket_accounting(self):
+        """Removed objects no longer contribute to a bucket's byte target."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(3)]
+        for key, size in zip(keys, [1, 9, 2], strict=True):
+            p.on_keys_created_with_sizes([key], [size])
+
+        p.on_keys_removed([keys[1]])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_uniform_rounding_is_restored_after_removal(self):
+        """Removing the odd-sized object restores count-based rounding."""
+        p = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(4)]
+        p.on_keys_created_with_sizes(keys, [4, 8, 4, 4])
+
+        p.on_keys_removed([keys[1]])
+        actions = p.get_eviction_actions(0.5, cache_salt="alice")
+
+        assert len(actions[0].keys) == 1
+
     def test_at_least_one_when_ratio_positive(self):
         """Matches ``LRUEvictionPolicy`` — a positive ratio that rounds
         to zero still yields one eviction so the caller makes forward
@@ -160,3 +273,38 @@ class TestDurableState:
         assert [key.chunk_hash for key in victims[0].keys] == [
             ObjectKey.IntHash2Bytes(2)
         ]
+
+    def test_restore_preserves_heterogeneous_byte_weights(self):
+        """A checkpoint round trip must retain byte-aware victim selection."""
+        policy = IsolatedLRUEvictionPolicy()
+        keys = [_key(i, "alice") for i in range(4)]
+        for key, size in zip(keys, [1, 1, 8, 8], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        restored = IsolatedLRUEvictionPolicy()
+        restored.restore(policy.capture())
+
+        assert restored.capture() == policy.capture()
+        actions = restored.get_eviction_actions(0.5, cache_salt="alice")
+        assert actions[0].keys == keys[:3]
+
+    def test_partial_sizes_stay_in_count_mode_across_restore(self):
+        """Unknown weights are not serialized as byte sizes."""
+        keys = [_key(i, "alice") for i in range(101)]
+        legacy_state = {
+            "buckets": {"alice": [encode_key(key) for key in keys]},
+        }
+        policy = IsolatedLRUEvictionPolicy()
+        policy.restore(legacy_state)
+        policy.on_keys_created_with_sizes([keys[-1]], [512])
+
+        actions = policy.get_eviction_actions(0.2, cache_salt="alice")
+        captured = policy.capture()
+
+        assert len(actions[0].keys) == 20
+        assert "alice" not in captured["sizes"]
+
+        restored = IsolatedLRUEvictionPolicy()
+        restored.restore(captured)
+        restored_actions = restored.get_eviction_actions(0.2, cache_salt="alice")
+        assert len(restored_actions[0].keys) == 20

--- a/tests/v1/distributed/test_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_lru_eviction_policy.py
@@ -11,9 +11,11 @@ These tests verify the basic functionality of the LRUEvictionPolicy:
 """
 
 # Third Party
+import pytest
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction import L2EvictionPolicy
 from lmcache.v1.distributed.eviction_policy import LRUEvictionPolicy
 from lmcache.v1.distributed.internal_api import (
     EvictionDestination,
@@ -191,6 +193,142 @@ class TestLRUEvictionPolicyRatio:
         # Ratio > 1 should be treated as 1
         actions = policy.get_eviction_actions(1.5)
         assert len(actions[0].keys) == 10
+
+
+# =============================================================================
+# Byte-weighted L2 Tests
+# =============================================================================
+
+
+class TestLRUEvictionPolicySizes:
+    """Tests for byte-weighted eviction when L2 reports object sizes."""
+
+    def test_variable_sizes_control_eviction_amount(self):
+        """Evict the minimal LRU prefix that reaches the byte target."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(4)]
+        for key, size in zip(keys, [1, 1, 8, 8], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == keys[:3]
+
+    def test_failed_oversized_victim_does_not_block_lru_progress(self):
+        """An attempted victim is deferred until older alternatives are tried."""
+        policy = LRUEvictionPolicy()
+        oversized = make_key(0)
+        alternatives = [make_key(i) for i in range(1, 101)]
+        for key, size in zip(
+            [oversized, *alternatives],
+            [320, *([1] * 100)],
+            strict=True,
+        ):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        first = policy.get_eviction_actions(0.2)[0].keys
+        policy.on_eviction_attempted(first)
+        second = policy.get_eviction_actions(0.2)[0].keys
+
+        assert first == [oversized]
+        assert second == alternatives[:84]
+
+    def test_equal_sizes_preserve_count_based_result(self):
+        """Equal object sizes produce the same victims as count-based LRU."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(3)]
+        policy.on_keys_created_with_sizes(keys, [4] * len(keys))
+
+        actions = policy.get_eviction_actions(0.5)
+
+        assert len(actions[0].keys) == 1
+
+    def test_unknown_sizes_keep_count_based_result(self):
+        """A partial size report must not turn unknown weights into bytes."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(101)]
+        policy.on_keys_created(keys[:100])
+        policy.on_keys_created_with_sizes([keys[100]], [512])
+
+        actions = policy.get_eviction_actions(0.2)
+
+        assert len(actions[0].keys) == 20
+
+    def test_unsized_refresh_preserves_known_size(self):
+        """An unsized notification must not replace an existing byte weight."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(2)]
+        policy.on_keys_created_with_sizes([keys[0]], [1])
+        policy.on_keys_created_with_sizes([keys[1]], [9])
+
+        policy.on_keys_created([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == keys
+
+    def test_size_refresh_updates_byte_accounting(self):
+        """Re-storing a key replaces its old size and refreshes LRU order."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(2)]
+        policy.on_keys_created_with_sizes(keys, [1, 9])
+
+        policy.on_keys_created_with_sizes([keys[1]], [1])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_removal_updates_byte_accounting(self):
+        """Removed objects no longer contribute to the byte target."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(3)]
+        for key, size in zip(keys, [1, 9, 2], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        policy.on_keys_removed([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[0]]
+
+    def test_mixed_history_keeps_byte_target_after_removal(self):
+        """A mixed-size policy keeps freeing at least the requested bytes."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(4)]
+        for key, size in zip(keys, [4, 8, 2, 4], strict=True):
+            policy.on_keys_created_with_sizes([key], [size])
+
+        policy.on_keys_removed([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[0], keys[2]]
+
+    def test_uniform_rounding_is_restored_after_removal(self):
+        """Removing the odd-sized object restores count-based rounding."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(4)]
+        policy.on_keys_created_with_sizes(keys, [4, 8, 4, 4])
+
+        policy.on_keys_removed([keys[1]])
+        actions = policy.get_eviction_actions(0.5)
+
+        assert len(actions[0].keys) == 1
+
+    def test_l2_bridge_forwards_object_sizes(self):
+        """The L2 listener must not discard adapter-provided byte sizes."""
+        policy = LRUEvictionPolicy()
+        bridge = L2EvictionPolicy(policy)
+        keys = [make_key(i) for i in range(4)]
+        bridge.on_l2_keys_stored(keys, [8, 8, 1, 1])
+
+        actions = policy.get_eviction_actions(0.5)
+
+        assert actions[0].keys == [keys[3], keys[2], keys[1]]
+
+    def test_mismatched_sizes_are_rejected(self):
+        """Each reported key must have exactly one byte size."""
+        policy = LRUEvictionPolicy()
+
+        with pytest.raises(ValueError, match="same length"):
+            policy.on_keys_created_with_sizes([make_key(1)], [])
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

L2 adapters already report the byte size of each stored object, but the eviction
policy discarded it and interpreted `eviction_ratio` as a fraction of key count.
That works for uniform objects, but mixed-size KV objects can leave the cache
above its watermark or evict substantially more data than requested.

This change forwards L2 object sizes to the LRU policies. Sized, heterogeneous
workloads evict the smallest LRU prefix that reaches the byte target. Unsized
callers and uniform-size workloads retain the existing count-based behavior and
rounding. A bucket also stays in count mode while any object size is unknown.

The same accounting is maintained independently for each `cache_salt`. Size
refreshes and removals update the totals in constant time. Durable isolated-LRU
state includes size weights only for complete buckets; older order-only
checkpoints restore in count mode.

## Failed-delete progress

A persistent failure on an oversized LRU head could otherwise select the same
key on every controller pass and block smaller objects behind it. The controller
now moves attempted keys to the MRU end before calling the adapter. Successful
deletes still remove the keys through the normal adapter notification; a raised
or skipped delete cannot monopolize the next pass. Adapter exceptions are logged
per state so the background eviction thread continues running. The move is not
recorded as a cache access and does not change access metrics.

With a permanently failing 320 MiB head followed by 100 deletable 1 MiB objects
and `eviction_ratio=0.2`, five passes produced:

| Policy | Bytes freed |
| --- | ---: |
| Previous PR revision | 0 MiB |
| Current `dev` count policy | 64 MiB |
| Updated byte-aware policy | 100 MiB |

## End-to-end reproduction

Using a 256 MiB mock L2 cache containing four 33 MiB objects and one 66 MiB
object, with a 0.6 high watermark and a 0.25 eviction ratio:

- `dev` selected one 33 MiB object and needed a second controller pass.
- This change selected two 33 MiB objects and completed in one pass.

Both runs ended with the same three objects and 132 MiB stored. The workload
used Qwen3.5-4B BF16 with vLLM `0.23.1rc1.dev753+g4875b4456.cu129`.

## Scope

The eligible-key byte-target case raised in review was tested separately. No
current production caller combines real byte weights with an eligibility
filter: local L2 supplies sizes without a filter, while the filtered paths use
unit weights. An exact eligible-byte pre-pass fixed the synthetic case but made
the 1M-key reviewer workload 12.8% slower (731.4 ms to 825.0 ms median), so it is
not included here.

Related open PRs were checked. #3859 changes FS capacity reporting and #3909
restores S3 LRU state; neither changes victim selection from key count to bytes.

## Validation

```text
python -m pytest \
  tests/v1/distributed/test_lru_eviction_policy.py \
  tests/v1/distributed/test_isolated_lru_eviction_policy.py \
  tests/v1/distributed/test_cache_salt_l2_eviction.py \
  tests/v1/mp_coordinator/persistence/test_durable_components.py \
  tests/v1/mp_coordinator/persistence/test_restore_without_replay.py -q
79 passed

pre-commit: SPDX, isort, ruff, ruff-format, codespell, mypy
passed

git diff --check
passed
```

- [ ] This PR contains user-facing changes requiring documentation.
- [x] This PR contains unit tests.
