### PR TITLE
[Bug][Test] anchor extra_stats throughput tests to the wall clock

### DIFF
--- a/tests/v1/mp_observability/subscribers/logging/test_extra_stats.py
+++ b/tests/v1/mp_observability/subscribers/logging/test_extra_stats.py
@@ -112,15 +112,22 @@ class TestExtraStatsLoggingSubscriber:
 
     def test_store_window_logs_tokens_size_and_throughput(self):
         subs = ExtraStatsLoggingSubscriber(_INTERVAL).get_subscriptions()
+        # Anchor to the wall clock rather than a fabricated absolute value.
+        # ``_prune_pending`` drops pending starts older than
+        # ``_PENDING_MAX_AGE_SECONDS`` measured against ``time.time()``, so a
+        # constant like 100.0 is always stale and is discarded by the first
+        # flush that fires between the start and the end -- leaving the end
+        # uncorrelated and the throughput reported as ``n/a``.
+        t0 = time.time()
         with _capture_logs() as handler:
             subs[EventType.MP_STORE_START](
-                _start(EventType.MP_STORE_START, "req-1", 100.0)
+                _start(EventType.MP_STORE_START, "req-1", t0)
             )
             subs[EventType.MP_STORE_END](
                 _end(
                     EventType.MP_STORE_END,
                     "req-1",
-                    100.5,
+                    t0 + 0.5,
                     total_bytes=5_000_000_000,
                     num_tokens=24576,
                 )
@@ -138,15 +145,17 @@ class TestExtraStatsLoggingSubscriber:
 
     def test_retrieve_window_logs_tokens_size_and_throughput(self):
         subs = ExtraStatsLoggingSubscriber(_INTERVAL).get_subscriptions()
+        # Same wall-clock requirement as the store case above.
+        t0 = time.time()
         with _capture_logs() as handler:
             subs[EventType.MP_RETRIEVE_START](
-                _start(EventType.MP_RETRIEVE_START, "req-1", 200.0)
+                _start(EventType.MP_RETRIEVE_START, "req-1", t0)
             )
             subs[EventType.MP_RETRIEVE_END](
                 _end(
                     EventType.MP_RETRIEVE_END,
                     "req-1",
-                    200.25,
+                    t0 + 0.25,
                     total_bytes=2_000_000_000,
                     num_tokens=4096,
                 )


### PR DESCRIPTION
Refs #4566.

**What this PR does / why we need it**:

`test_store_window_logs_tokens_size_and_throughput` and `test_retrieve_window_logs_tokens_size_and_throughput` built their events from fabricated absolute timestamps — `100.0`/`100.5` and `200.0`/`200.25`, chosen so the arithmetic renders as `10.00GB/s` and `8.00GB/s`.

`_prune_pending` drops a pending START older than `_PENDING_MAX_AGE_SECONDS` measured against the wall clock:

```python
def _prune_pending(self) -> None:
    deadline = time.time() - _PENDING_MAX_AGE_SECONDS
```

`deadline` is around `1.79e9`, so a constant like `100.0` is always below it. A prune runs on every flush, and `_on_store_start` calls `_maybe_flush()` **after** recording the pending START. `_INTERVAL` in these tests is `0.05`, so whenever more than 50 ms passes between constructing the subscriber and delivering the first event, the flush fires, the START is pruned, and the later END finds nothing to correlate with. `dt` falls back to `0.0`, `timed` is `False`, and `_format_side` renders `n/a`.

The result is machine-speed dependent: it passes on a fast box and fails on a loaded one. The store case fails reliably on my machine on current `dev`:

```
AssertionError: assert 'store ops=1 tokens=24576 size=5.00GB avg_copy=10.00GB/s' in
  'L0<->L1 stats [cpu:0] last 0.1s: store ops=1 tokens=24576 size=5.00GB avg_copy=n/a | ...'
```

The retrieve test carries the identical pattern and passes today only because its timing happens not to trip the prune.

This anchors both to `time.time()`. The deltas — and therefore the asserted rates — are unchanged; the pending entry is simply recent enough to survive a prune.

**Special notes for your reviewers**:

**Production is not affected, and this deliberately does not touch it.** `EventBus.publish` stamps `Event.timestamp` from `time.time()`, so a real pending START is milliseconds old and never within 60 seconds of the deadline. The prune is doing exactly its job; only fabricated timestamps trip it.

There is a second possible fix — having `_on_store_start` / `_on_retrieve_start` call `_maybe_flush()` *before* recording the pending entry, so a flush can never prune a START recorded in the same call. That is arguably tidier on its own terms, but it changes production code to fix a test, so I did not take it. Happy to switch if you would rather fix it at that end.

Scope note: four other tests in this file use the same fabricated constants (`test_groups_by_device`, `test_no_flush_before_interval`, `test_failed_op_counts_zero_tokens`, `test_end_to_end_via_event_bus`). None of them asserts a throughput value, so their outcomes do not depend on the correlation succeeding, and I left them alone to keep the diff reviewable.

Verification. I checked the fix rather than assuming it, by forcing the condition the flake depends on — a 60 ms stall between constructing the subscriber and the first event:

```
OLD (fabricated 100.0 / 100.5)
  -> store ops=1 tokens=24576 size=5.00GB avg_copy=n/a          <- flake reproduced
NEW (time.time() anchored)
  -> store ops=1 tokens=24576 size=5.00GB avg_copy=10.00GB/s    <- fixed

With no stall, both report 10.00GB/s — which is why this hides on a fast machine.
```

`tests/v1/mp_observability/` is 389 passed, 1 skipped, 0 failed on this branch; on `dev` the store test fails. `pre-commit` passes on the changed file (ruff, ruff-format, isort, mypy, codespell, SPDX).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
