### PR TITLE
docs: daily drift check — multi-process mode (2026-08-14)

### DIFF
--- a/docs/design/integration/vllm/lazy_offload.md
+++ b/docs/design/integration/vllm/lazy_offload.md
@@ -415,52 +415,69 @@ if self._pending_store_queue.should_offload:
 
 ### 2.4 Threshold Trigger Mechanism
 
-The threshold determines when buffered stores are flushed:
+The threshold determines when buffered stores are flushed. The
+current implementation counts **finished requests** waiting in the
+pending queue rather than a ratio of GPU blocks — buffering only
+graduates to an offload once whole requests have accumulated, which
+matches how the FIFO policy drains items request-by-request:
 
 ```
-threshold_ratio = configured percentage (e.g. 0.8)
-threshold_blocks = total_gpu_blocks * threshold_ratio
+threshold = configured number of finished requests (default 100)
 
 Trigger condition:
-    sum(num_gpu_blocks for all entries in queue) >= threshold_blocks
+    number of finished requests in the pending queue >= threshold
 ```
 
-When triggered, the queue is drained (partially or fully) and the
-resulting store ops are emitted in the connector metadata for the worker
-to execute.
+When triggered, the queue is drained (up to a per-call cap, see
+Section 2.5) and the resulting store ops are emitted in the connector
+metadata for the worker to execute.
 
-Configuration:
+Configuration (``kv_connector_extra_config`` keys read by
+``LMCacheMPConnector`` and ``LazyOffloadPendingStore``):
+
 ```
-lmcache.mp.lazy_offload = true/false          (default: false)
-lmcache.mp.lazy_offload_threshold = 0.8       (trigger when 80% of GPU blocks are buffered)
-lmcache.mp.lazy_offload_drain_ratio = 0.5     (drain 50% of queue when triggered)
+lmcache.mp.lazy_offload          = true/false   (default: false)
+lmcache.mp.lazy_offload_policy   = "FIFO"       (default: "FIFO"; only
+                                                policy currently registered)
+lmcache.mp.lazy_offload_threshold      = int    (default: 100; number of
+                                                finished requests that
+                                                trigger an offload under the
+                                                FIFO policy)
+lmcache.mp.lazy_offload_select_count   = int    (default: 10; maximum
+                                                number of finished pending
+                                                items popped per drain)
 ```
 
 ### 2.5 Drain Strategy
 
 When the threshold is reached, not all entries need to be drained at
-once. Options:
+once. Possible policies:
 
 - **FIFO drain**: Drain the oldest entries first (they hold the oldest
-  GPU blocks, most likely to be evicted soon).
-- **Partial drain**: Drain a fixed ratio (e.g. 50%) of the queue to
-  bring the buffered block count below the threshold.
+  GPU blocks, most likely to be evicted soon). **This is the only
+  policy currently implemented** (``FIFOOffloadPolicy`` under
+  ``lmcache/integration/vllm/lazy_offload_policy/fifo.py``).
 - **Priority drain**: Drain entries with the longest prefix first (higher
-  reuse probability).
+  reuse probability). Not implemented yet.
 
-FIFO with partial drain is the simplest and most predictable:
+The implemented FIFO policy pops up to ``lazy_offload_select_count``
+finished pending items in insertion order, and only once at least
+``lazy_offload_threshold`` finished requests have accumulated:
 
 ```python
-def drain(self, target_ratio: float = 0.5) -> list[PendingStoreEntry]:
-    target_blocks = int(self._total_buffered_blocks * target_ratio)
-    drained = []
-    drained_blocks = 0
-    while self._queue and drained_blocks < target_blocks:
-        entry = self._queue.popleft()
-        drained.append(entry)
-        drained_blocks += entry.num_gpu_blocks
-    self._total_buffered_blocks -= drained_blocks
-    return drained
+def pop_items_for_offload(self, count: int) -> list[PendingStoreItem]:
+    if count <= 0 or self._finished_requests_count < self._threshold:
+        return []
+
+    to_offload = []
+    for req_id in list(self._pending_items.keys()):
+        if self._pending_items[req_id].is_finished:
+            to_offload.append(self._pending_items[req_id])
+            del self._pending_items[req_id]
+            self._finished_requests_count -= 1
+        if len(to_offload) >= count:
+            break
+    return to_offload
 ```
 
 ### 2.6 GPU Block Protection: Touch and Free


### PR DESCRIPTION
## Summary

Daily docs drift check against `upstream/dev` at
[`baa2135`](https://github.com/LMCache/LMCache/commit/baa213502f7da5ec4b74050a6dc2bc74efa52d3a),
focused on multi-process mode. One doc-only inconsistency found
today, in `docs/design/` (the vLLM MP-connector lazy-offload design
doc).

**`docs/source/`**

- No new user-facing drift found today. (`lmcache.mp.lazy_offload*`
  keys added by #4434 are not yet mentioned in
  `docs/source/mp/configuration.rst`'s ``kv_connector_extra_config``
  table — flagged as a gap under *Not fixed in this PR* below, but
  not touched here since user-facing coverage of the new feature is
  a broader editorial decision than a routine drift fix.)

**`docs/design/`**

- `docs/design/integration/vllm/lazy_offload.md`: the Configuration
  block in *Section 2.4 Threshold Trigger Mechanism* and the drain
  pseudo-code in *Section 2.5 Drain Strategy* were written from the
  pre-implementation design (PR #4196, 2026-08-05) and are stale
  after the actual `[MP] support lazy offload` merge
  ([#4434](https://github.com/LMCache/LMCache/pull/4434),
  2026-08-14). The shipped extra-config keys, their semantics, and
  their defaults do not match what the design doc describes.

## Evidence

### Design doc (before this PR)

Configuration block —
[docs/design/integration/vllm/lazy_offload.md L432–L437 @ dev@baa2135](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/docs/design/integration/vllm/lazy_offload.md#L432-L437):

```
lmcache.mp.lazy_offload = true/false          (default: false)
lmcache.mp.lazy_offload_threshold = 0.8       (trigger when 80% of GPU blocks are buffered)
lmcache.mp.lazy_offload_drain_ratio = 0.5     (drain 50% of queue when triggered)
```

Trigger formula —
[docs/design/integration/vllm/lazy_offload.md L420–L426](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/docs/design/integration/vllm/lazy_offload.md#L420-L426):

> `threshold_ratio = configured percentage (e.g. 0.8)` / `threshold_blocks = total_gpu_blocks * threshold_ratio` / trigger when `sum(num_gpu_blocks for all entries in queue) >= threshold_blocks`.

Drain pseudo-code —
[L453–L464](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/docs/design/integration/vllm/lazy_offload.md#L453-L464)
shows a hypothetical `PendingStoreQueue.drain(target_ratio=0.5)` that
pops entries until `drained_blocks >= total_buffered_blocks * target_ratio`.

### Actual code

- `LMCacheMPConnector` reads `lmcache.mp.lazy_offload` from
  `kv_connector_extra_config`, default **`False`** —
  [lmcache/integration/vllm/lmcache_mp_connector.py L330–L331 @ dev@baa2135](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/lmcache/integration/vllm/lmcache_mp_connector.py#L330-L331).
  (This one matches the design doc — kept unchanged.)
- `FIFOOffloadPolicy` reads
  `lmcache.mp.lazy_offload_threshold` as an **integer count of
  finished requests**, default **`100`**, not a fractional block ratio —
  [lmcache/integration/vllm/lazy_offload_policy/fifo.py L34–L37 @ dev@baa2135](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/lmcache/integration/vllm/lazy_offload_policy/fifo.py#L34-L37).
  The trigger is `self._finished_requests_count >= self._threshold` at
  [fifo.py L86–L98](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/lmcache/integration/vllm/lazy_offload_policy/fifo.py#L86-L98).
- `LazyOffloadPendingStore` uses
  `lmcache.mp.lazy_offload_select_count` (default **`10`**) as the
  per-call cap on how many finished pending items are popped, and
  `lmcache.mp.lazy_offload_policy` (default **`"FIFO"`**) to select
  the offload policy —
  [lmcache/integration/vllm/lazy_offload_pending_store.py L44–L46, L94–L100 @ dev@baa2135](https://github.com/LMCache/LMCache/blob/baa213502f7da5ec4b74050a6dc2bc74efa52d3a/lmcache/integration/vllm/lazy_offload_pending_store.py#L44-L46).
- No `lmcache.mp.lazy_offload_drain_ratio` key exists in the tree:
  ```
  $ grep -rn 'lazy_offload_drain_ratio' lmcache/ tests/
  (no matches)
  ```

So four things are stale in the design doc: the `_threshold` unit
and default, the missing `_select_count` / `_policy` keys, the
nonexistent `_drain_ratio` key, and the pseudo-code that references
a `PendingStoreQueue` type / `drain(target_ratio)` signature that
never landed. The trigger *formula* in the boxed text is also
inconsistent with the shipped `finished_requests_count >= threshold`
condition.

## Proposed fix

Applied in this PR's diff:

- `docs/design/integration/vllm/lazy_offload.md` — rewrite the
  Configuration block in Section 2.4 to list the four shipped keys
  (`lazy_offload`, `lazy_offload_policy`, `lazy_offload_threshold`,
  `lazy_offload_select_count`) with their real types, defaults, and
  meanings, and reword the boxed trigger formula so it matches the
  shipped `finished_requests_count >= threshold` condition.
- Section 2.5 Drain Strategy — trim the flavor list to the two
  policies that meaningfully apply (FIFO is what shipped;
  priority-based is called out as not yet implemented), and replace
  the `PendingStoreQueue.drain()` pseudo-code with the actual
  `FIFOOffloadPolicy.pop_items_for_offload(count)` body.

No code changes; docs only.

## Not fixed in this PR

- `docs/source/mp/configuration.rst` — the
  `kv_connector_extra_config` "Connector `extra_config` Keys" table
  does not yet list the new `lmcache.mp.lazy_offload*` keys. That's a
  documentation gap for the shipped `LMCacheMPConnector` behavior,
  but adding a new user-facing description of an opt-in performance
  feature is a broader editorial decision than a routine drift-fix,
  so leaving it for a follow-up.
- Other pre-existing `blend_server_v2.py` references in
  `docs/design/` (called out in [#4519](https://github.com/LMCache/LMCache/pull/4519))
  were not re-touched here.

## Notes

Auto-generated by the daily docs drift-check routine. **Human review
required before merge.** Kept as **draft**; not marked "Ready for
review." No code files touched. Deduplicated against prior open
drift-check PRs (#4519, #4480, #4462, #4455, #4435, #4421, #4401,
#4378, #4361, #4304); today's finding is the lazy-offload design
doc, which none of them touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_0128nvkN7CBkHcFBiAYvdwLf)_