### PR TITLE
[MP][XPU] Use device-aware event for engine-driven multiprocess transfer

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -35,6 +35,7 @@ import zmq
 
 # First Party
 from lmcache import torch_dev
+from lmcache import torch_device_type
 from lmcache.banner import print_banner_once
 from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.kv_cache_group_edits import (
@@ -495,6 +496,36 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             )
         return
 
+    def _create_worker_ordering_event(self) -> "torch_dev.Event":
+        """Create the device event that orders worker-side KV transfers.
+
+        The event is recorded after the model step so the transfer path can
+        order KV copies against compute. Only the ``lmcache_driven`` (handle)
+        transfer path exports this event across processes, and that path is
+        selected exclusively for backends that provide an event-IPC backend
+        (CUDA). Those backends therefore require an interprocess-capable event.
+
+        Backends without an event-IPC backend (e.g. XPU) run the
+        ``engine_driven`` path, which performs the copy inside the worker and
+        orders it with a stream synchronize; the event is never exported, so a
+        plain device event is sufficient. Their device ``Event`` classes do not
+        accept ``interprocess=True`` (and cannot produce IPC handles), so
+        requesting one would fail.
+
+        Returns:
+            A recorded-capable device ``Event``: interprocess-capable when the
+            active backend supports event IPC, otherwise a plain device event.
+        """
+        # Lazy import: platform subclass discovery can import the connector
+        # before platform.__init__ finishes, so keep this out of module scope.
+        # First Party
+        from lmcache.v1.platform import get_device_spec
+
+        spec = get_device_spec(torch_device_type)
+        if spec is not None and spec.event_ipc_backend is not None:
+            return torch_dev.Event(interprocess=True)
+        return torch_dev.Event()
+
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
         """
         Start loading the KV cache from the connector to vLLM's paged
@@ -527,7 +558,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if len(request_ids) == 0:
             return
 
-        event = torch_dev.Event(interprocess=True)
+        event = self._create_worker_ordering_event()
         event.record()
 
         self.worker_adapter.batched_submit_retrieve_requests(
@@ -603,7 +634,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 dispatch(self.dispatcher, "wait_for_save", event=None)
             return
 
-        event = torch_dev.Event(interprocess=True)
+        event = self._create_worker_ordering_event()
         event.record()
 
         self.worker_adapter.batched_submit_store_requests(


### PR DESCRIPTION
The multiprocess connector (LMCacheMPConnector) unconditionally created `torch_dev.Event(interprocess=True)` in start_load_kv and save_kv_layer. `interprocess=True` is a CUDA-only capability: the XPU SYCL-backed event class does not accept the parameter and its ipc_handle() raises NotImplementedError, so the connector crashed on the first KV op on XPU.

The interprocess (exportable) event is only required by the `lmcache_driven` transfer path, which shares the event handle across processes. On XPU, create_transfer_context() already routes to the `engine_driven` path (only device_type == "cuda" selects lmcache_driven). The engine-driven path performs the copy inside the worker and orders it with torch_dev.synchronize(); the event object is not exported and is effectively ignored.

Add a device-aware factory, create_worker_ordering_event(), that returns an interprocess event on backends exposing the `interprocess` parameter (CUDA) and a plain device event otherwise (XPU). This unblocks the engine-driven multiprocess path on XPU without changing CUDA behavior.

Verified end-to-end on Intel XPU (Llama-3.1-8B, TP1): vLLM serve with LMCacheMPConnector reaches readiness with no interprocess-event error, auto-selects engine_driven, and a shared-prefix request produces an external KV cache hit (server retrieves stored tokens).

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
