### PR TITLE
[Fix] cache_engine: keep retrieve_layer yielding on a total miss

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1102,16 +1102,20 @@ class LMCacheEngine:
 
         yield None
 
-        # synchronize the last layer
-        next(mem_obj_consumer)
+        # `mem_obj_consumer` and `to_count_down` are only bound in the branch
+        # above, so there is nothing to synchronize or unpin when the lookup
+        # found no chunk at all.
+        if keys:
+            # synchronize the last layer
+            next(mem_obj_consumer)
 
-        # Unpin any disk-loaded staging objects now that the device-side sync
-        # has been enqueued (mem_obj_consumer advanced past its sync point).
-        # Without this, pin_count stays at 1 forever and the CPU staging pool
-        # fills up, causing the next retrieve to deadlock inside allocate().
-        for mem_obj in to_count_down:
-            if mem_obj.is_pinned:
-                mem_obj.unpin()
+            # Unpin any disk-loaded staging objects now that the device-side sync
+            # has been enqueued (mem_obj_consumer advanced past its sync point).
+            # Without this, pin_count stays at 1 forever and the CPU staging pool
+            # fills up, causing the next retrieve to deadlock inside allocate().
+            for mem_obj in to_count_down:
+                if mem_obj.is_pinned:
+                    mem_obj.unpin()
 
         retrieved_tokens = torch.sum(ret_mask)
         self.stats_monitor.on_retrieve_finished(monitor_req_id, retrieved_tokens)

--- a/tests/v1/test_cache_engine_layerwise_contract.py
+++ b/tests/v1/test_cache_engine_layerwise_contract.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generator-contract tests for ``LMCacheEngine.retrieve_layer``.
+
+``retrieve_layer`` returns a generator that its callers advance a fixed number
+of times: once per model layer, once more to finalize the GPU connector, and a
+final time to receive the boolean mask of retrieved tokens. That is
+``num_layers + 2`` advances in total, and it is the same on both the vLLM path
+(``LMCacheConnectorV1Impl.wait_for_layer_load``) and the layerwise benchmark
+path (``_layerwise_retrieve_vllm_contract``).
+
+Callers cannot know in advance whether the lookup will hit -- with async
+loading the decision is made by the scheduler and the retrieve happens later on
+the worker -- so every exit path of the generator has to yield the same number
+of values.
+"""
+
+# Standard
+from typing import Optional
+import shutil
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache import torch_dev, torch_device_type
+from lmcache.utils import mock_up_broadcast_fn, mock_up_broadcast_object_fn
+from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.gpu_connector.gpu_connectors import (
+    VLLMPagedMemLayerwiseGPUConnector,
+)
+
+# Local
+from .utils import (
+    check_paged_kv_cache_equal,
+    dumb_metadata,
+    generate_kv_cache_paged_list_tensors,
+    generate_tokens,
+)
+
+pytestmark = [
+    pytest.mark.cuda,
+    pytest.mark.skipif(
+        not (torch_dev.is_available() and torch_device_type == "cuda"),
+        reason="Requires CUDA backend",
+    ),
+]
+
+_NUM_LAYERS = 4
+_CHUNK_SIZE = 256
+_NUM_HEADS = 8
+_HEAD_DIM = 128
+_BLOCK_SIZE = 16
+_NUM_BLOCKS = 256
+_DTYPE = torch.bfloat16
+_DISK_PATH = "local/disk_test/local_disk/"
+
+
+def _create_engine(autorelease_v1, backend: str = "cpu") -> LMCacheEngine:
+    """Build a layerwise engine on top of ``backend``.
+
+    :param autorelease_v1: The fixture that destroys the engine afterwards.
+
+    :param str backend: A ``from_legacy`` backend name. ``"local_cpu_disk"``
+        adds a disk tier, which is what makes a retrieve load through CPU
+        staging objects that have to be unpinned afterwards.
+    """
+    if "disk" in backend:
+        shutil.rmtree(_DISK_PATH, ignore_errors=True)
+    cfg = LMCacheEngineConfig.from_legacy(
+        chunk_size=_CHUNK_SIZE,
+        backend=backend,
+        use_layerwise=True,
+    )
+    connector = VLLMPagedMemLayerwiseGPUConnector(
+        _NUM_HEADS * _HEAD_DIM,
+        _NUM_LAYERS,
+        use_gpu=True,
+        chunk_size=_CHUNK_SIZE,
+        dtype=_DTYPE,
+        device=torch.device(torch_device_type),
+    )
+    kv_shape = (_NUM_LAYERS, 2, _CHUNK_SIZE, _NUM_HEADS, _HEAD_DIM)
+    return autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            dumb_metadata(kv_shape),
+            connector,
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
+    )
+
+
+def _pump(retriever, num_layers: int = _NUM_LAYERS) -> list[Optional[torch.Tensor]]:
+    """Advance a ``retrieve_layer`` generator the way its callers do.
+
+    :param retriever: The generator returned by ``retrieve_layer``.
+
+    :param int num_layers: The number of model layers.
+
+    return: The ``num_layers + 2`` yielded values, in order.
+    """
+    return [next(retriever) for _ in range(num_layers + 2)]
+
+
+def _wait_for_store(engine: LMCacheEngine, tokens: torch.Tensor, expected: int) -> None:
+    """Block until an asynchronous store is visible to ``lookup``."""
+    deadline = time.time() + 30
+    hit = engine.lookup(tokens)
+    while hit != expected:
+        if time.time() > deadline:
+            raise TimeoutError(f"store did not finish: expected {expected}, got {hit}")
+        time.sleep(0.01)
+        hit = engine.lookup(tokens)
+
+
+def _drop_cpu_tier(engine: LMCacheEngine, tokens: torch.Tensor, expected: int) -> None:
+    """Leave ``tokens`` on disk only, so a retrieve has to load through staging.
+
+    ``clear`` skips objects that are still pinned by the store that just
+    finished, so it is retried until the CPU tier really holds none of these
+    tokens. A partially cleared tier would put the chunks in two different
+    locations, which layerwise retrieval rejects outright.
+    """
+    storage_manager = engine.storage_manager
+    assert storage_manager is not None
+    deadline = time.time() + 30
+    while True:
+        storage_manager.clear(locations=["LocalCPUBackend"])
+        on_disk = engine.lookup(tokens, search_range=["LocalDiskBackend"])
+        in_cpu = engine.lookup(tokens, search_range=["LocalCPUBackend"])
+        if on_disk == expected and in_cpu == 0:
+            return
+        if time.time() > deadline:
+            raise TimeoutError(
+                f"tokens are not disk-only: on disk {on_disk}/{expected}, "
+                f"still in CPU {in_cpu}"
+            )
+        time.sleep(0.01)
+
+
+def _paged_kv_cache() -> list[torch.Tensor]:
+    return generate_kv_cache_paged_list_tensors(
+        _NUM_BLOCKS,
+        torch.device(torch_device_type),
+        _BLOCK_SIZE,
+        _DTYPE,
+        num_layers=_NUM_LAYERS,
+        head_size=_HEAD_DIM,
+    )
+
+
+def _slot_mapping(num_tokens: int) -> torch.Tensor:
+    """Pick ``num_tokens`` distinct slots out of the paged KV cache."""
+    return torch.randperm(
+        _NUM_BLOCKS * _BLOCK_SIZE, device=torch.device(torch_device_type)
+    )[:num_tokens]
+
+
+def _store_layerwise(
+    engine: LMCacheEngine,
+    tokens: torch.Tensor,
+    kvcaches: list[torch.Tensor],
+    slot_mapping: torch.Tensor,
+) -> None:
+    """Store ``tokens`` through the layerwise contract, then wait for it."""
+    storer = engine.store_layer(
+        tokens.tolist(),
+        mask=torch.ones(len(tokens), dtype=torch.bool, device=slot_mapping.device),
+        kvcaches=kvcaches,
+        slot_mapping=slot_mapping,
+        offset=0,
+        sync=True,
+    )
+    for _ in range(_NUM_LAYERS + 1):
+        next(storer)
+    _wait_for_store(engine, tokens, len(tokens))
+
+
+@pytest.mark.parametrize("backend", ["cpu", "local_cpu_disk"])
+def test_retrieve_layer_total_miss_completes_with_empty_mask(autorelease_v1, backend):
+    """A retrieve for tokens that are not cached must still yield in full.
+
+    Before the fix the last advance raised ``UnboundLocalError`` because the
+    variables the tail of the generator touches are only bound when at least
+    one chunk was found.
+    """
+    engine = _create_engine(autorelease_v1, backend)
+    tokens = generate_tokens(_CHUNK_SIZE * 2, torch_device_type)
+    assert engine.lookup(tokens) == 0
+
+    retriever = engine.retrieve_layer(tokens)
+    yielded = _pump(retriever)
+
+    assert all(value is None for value in yielded[:-1])
+    ret_mask = yielded[-1]
+    assert isinstance(ret_mask, torch.Tensor)
+    assert ret_mask.dtype == torch.bool
+    assert ret_mask.numel() == len(tokens)
+    assert not bool(ret_mask.any())
+    with pytest.raises(StopIteration):
+        next(retriever)
+
+
+def test_retrieve_layer_reports_miss_when_first_chunk_disappears(autorelease_v1):
+    """The lookup-then-retrieve race, which is how this happens in production.
+
+    The scheduler decides to load based on ``lookup``; the worker calls
+    ``retrieve_layer`` later. Anything evicted in between turns a hit into a
+    miss. ``retrieve_layer`` stops at the first chunk it cannot find, so
+    losing the first chunk alone is enough to make the whole retrieve empty,
+    even though the remaining chunks are still cached.
+    """
+    engine = _create_engine(autorelease_v1)
+    tokens = generate_tokens(_CHUNK_SIZE * 3, torch_device_type)
+    src_kv = _paged_kv_cache()
+    dst_kv = _paged_kv_cache()
+    slot_mapping = _slot_mapping(len(tokens))
+
+    _store_layerwise(engine, tokens, src_kv, slot_mapping)
+    assert engine.lookup(tokens) == len(tokens)
+
+    chunk_keys = [
+        key for _, _, key in engine.token_database.process_tokens(tokens=tokens)
+    ]
+    assert len(chunk_keys) == 3
+    cpu_backend = engine.storage_manager.storage_backends["LocalCPUBackend"]
+    for layer_key in chunk_keys[0].split_layers(_NUM_LAYERS):
+        assert cpu_backend.remove(layer_key)
+
+    retriever = engine.retrieve_layer(
+        tokens, kvcaches=dst_kv, slot_mapping=slot_mapping, sync=True
+    )
+    yielded = _pump(retriever)
+
+    ret_mask = yielded[-1]
+    assert isinstance(ret_mask, torch.Tensor)
+    assert not bool(ret_mask.any())
+    with pytest.raises(StopIteration):
+        next(retriever)
+
+
+def test_retrieve_layer_partial_hit_stops_at_the_missing_chunk(autorelease_v1):
+    """Losing a later chunk keeps the earlier ones, and the mask says so.
+
+    The counterpart of the test above: the retrieve walks chunks in order and
+    stops at the first one it cannot find, so a hit prefix is still loaded and
+    the returned mask covers exactly that prefix.
+    """
+    engine = _create_engine(autorelease_v1)
+    tokens = generate_tokens(_CHUNK_SIZE * 3, torch_device_type)
+    src_kv = _paged_kv_cache()
+    dst_kv = _paged_kv_cache()
+    slot_mapping = _slot_mapping(len(tokens))
+
+    _store_layerwise(engine, tokens, src_kv, slot_mapping)
+
+    chunk_keys = [
+        key for _, _, key in engine.token_database.process_tokens(tokens=tokens)
+    ]
+    cpu_backend = engine.storage_manager.storage_backends["LocalCPUBackend"]
+    for layer_key in chunk_keys[-1].split_layers(_NUM_LAYERS):
+        assert cpu_backend.remove(layer_key)
+
+    retriever = engine.retrieve_layer(
+        tokens, kvcaches=dst_kv, slot_mapping=slot_mapping, sync=True
+    )
+    yielded = _pump(retriever)
+
+    hit_tokens = _CHUNK_SIZE * 2
+    assert int(yielded[0]) == hit_tokens
+    ret_mask = yielded[-1]
+    assert isinstance(ret_mask, torch.Tensor)
+    assert bool(ret_mask[:hit_tokens].all())
+    assert not bool(ret_mask[hit_tokens:].any())
+    with pytest.raises(StopIteration):
+        next(retriever)
+
+    check_paged_kv_cache_equal(
+        src_kv,
+        dst_kv,
+        slot_mapping[:hit_tokens],
+        num_heads=_NUM_HEADS,
+        head_size=_HEAD_DIM,
+    )
+
+
+@pytest.mark.parametrize("backend", ["cpu", "local_cpu_disk"])
+def test_retrieve_layer_hit_restores_kv_cache(autorelease_v1, backend):
+    """The hit path: same number of yields, and the KV cache is restored.
+
+    This also pins the first yield, which is the retrieved token count that
+    the SGLang integration reads instead of calling ``lookup``.
+
+    The disk tier matters because those loads go through pinned CPU staging
+    objects: the unpin loop that moves with this change is what keeps the
+    staging pool from starving, and the last assertion is what notices.
+    """
+    engine = _create_engine(autorelease_v1, backend)
+    tokens = generate_tokens(_CHUNK_SIZE * 2, torch_device_type)
+    src_kv = _paged_kv_cache()
+    dst_kv = _paged_kv_cache()
+    slot_mapping = _slot_mapping(len(tokens))
+
+    _store_layerwise(engine, tokens, src_kv, slot_mapping)
+    if "disk" in backend:
+        _drop_cpu_tier(engine, tokens, len(tokens))
+
+    retriever = engine.retrieve_layer(
+        tokens, kvcaches=dst_kv, slot_mapping=slot_mapping, sync=True
+    )
+    yielded = _pump(retriever)
+
+    assert int(yielded[0]) == len(tokens)
+    ret_mask = yielded[-1]
+    assert isinstance(ret_mask, torch.Tensor)
+    assert bool(ret_mask.all())
+    with pytest.raises(StopIteration):
+        next(retriever)
+
+    check_paged_kv_cache_equal(
+        src_kv,
+        dst_kv,
+        slot_mapping,
+        num_heads=_NUM_HEADS,
+        head_size=_HEAD_DIM,
+    )
+
+    # Nothing may stay pinned: on the disk tier every object the retrieve
+    # loaded arrives pinned, and the tail of the generator is what releases
+    # them. A leaked pin exhausts the staging pool on a later allocate().
+    cpu_backend = engine.storage_manager.storage_backends["LocalCPUBackend"]
+    assert not any(
+        memory_obj.is_pinned for memory_obj in list(cpu_backend.hot_cache.values())
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

`LMCacheEngine.retrieve_layer` is a generator, and its callers advance it a fixed
number of times — once per layer, once to finalize the GPU connector, and once more
to receive the mask of retrieved tokens. That is `num_layers + 2` advances.

The hit path yields `num_layers + 2` values. The miss path yields `num_layers + 1`,
and the one it is missing sits right before the tail of the generator, which
calls `next(mem_obj_consumer)` and iterates `to_count_down`. Both names are only
bound inside the `if keys:` branch, so the last advance raises:

```
UnboundLocalError: cannot access local variable 'mem_obj_consumer' where it is
not associated with a value
lmcache/v1/cache_engine.py:1106
```

`to_count_down` is the second one; it was added later by the unpin fix.

Callers cannot avoid this, because they commit to the number of advances before
they know whether the lookup hit. `vllm_v1_adapter.py` advances twice at
`:855`/`:856` and once per layer in `wait_for_layer_load`, then asserts at `:988`
that the last value is not `None` — which is exactly the mask only the hit path
reaches. `blender.py:125-152` does the same count. So any caller that works on a
hit crashes on a total miss. (`sglang_adapter.py:285` happens to be safe: it
returns early when the retrievable token count is not above the offset.)

In production the lookup that decides whether to load runs on the scheduler while
the retrieve runs later on the worker, so anything evicted in between turns a hit
into a miss — the race described in #4133. Since the chunk loop breaks on the
first chunk it cannot find, losing only the first chunk is enough to empty the
whole retrieve.

The fix guards the tail with `if keys:`, so both exits reach `yield ret_mask` and
a miss returns an all-False mask, which is what the docstring already promises.

**Special notes for your reviewers**:

- The engine had no test coverage for `retrieve_layer` at all, so this adds
  `tests/v1/test_cache_engine_layerwise_contract.py` with four tests, six cases.
  Two reproduce the crash (nothing ever stored; and three chunks stored, then the
  first chunk's layer keys removed to simulate the eviction race). The other two
  pass before and after the change on purpose — they pin the hit path and the
  partial-hit prefix, so the yield count cannot drift apart again.
- The total-miss and hit tests are parametrized over `cpu` and `local_cpu_disk`
  because the change also moves the `to_count_down` unpin loop. On a CPU-only
  backend that list is populated but nothing in it is pinned, so the loop is a
  no-op and a regression there would go unnoticed; with the disk tier the load
  goes through pinned CPU staging objects (verified: 8 of 8 pinned, versus 0 of 8
  on CPU-only). The disk case therefore stores, clears the CPU tier until the
  tokens are provably disk-only, retrieves, and then asserts that nothing was
  left pinned — a leaked pin would exhaust the staging pool in a later
  `allocate()` rather than fail anywhere near its cause.
- The tests follow the docstring contract rather than the implementation: they
  advance the generator `num_layers + 2` times and then assert `StopIteration`,
  so a change in either direction fails. They only touch public members
  (`token_database.process_tokens`, `storage_backends[...]`, `hot_cache`,
  `remove`, `storage_manager.clear`), mirroring what `tests/v1/test_cache_engine.py`
  already does.
- The layerwise connector needs `use_gpu=True`, since `engine_kv_format` is only
  set on that path, so the module is marked `pytest.mark.cuda` and skips without
  a CUDA backend.
- One related inconsistency I deliberately left alone: the unhealthy-engine early
  return at `:1003-1006` yields the mask once and returns, which is also a
  different arity from the normal path. It has a different cause (health check,
  not lookup outcome), so it seemed better not to mix it into this PR. Happy to
  follow up if you would like it handled the same way.
- This is the code path @scober described in #899, which was closed as completed
  in 2025 while the path itself stayed: "there is still a code path in
  `retrieve_layer` that calls `next` on an uninitialized variable".
- Verified on a single B200: the six new cases go from `3 failed, 3 passed` to
  `6 passed`, and `tests/v1/test_cache_engine.py` + `tests/v1/test_gpu_connector.py`
  alongside them come out `105 passed, 1 skipped`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
