### PR TITLE
[Fix] torch_ops: rebuild LMCache object pointers where they live

### DIFF
--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -81,6 +81,61 @@ def _get_copy_lib() -> Optional[ctypes.CDLL]:
     return _copy_lib
 
 
+# ``cudaMemoryType`` from driver_types.h; only device memory has to be treated
+# differently from what this module assumed before.
+_CUDA_MEMORY_TYPE_DEVICE = 2
+
+
+class _CudaPointerAttributes(ctypes.Structure):
+    """Leading fields of ``cudaPointerAttributes`` (CUDA >= 11.0).
+
+    The trailing padding keeps the buffer large enough for runtimes whose
+    struct carries additional fields after the four that are read here.
+    """
+
+    _fields_ = [
+        ("memory_type", ctypes.c_int),
+        ("device", ctypes.c_int),
+        ("device_pointer", ctypes.c_void_p),
+        ("host_pointer", ctypes.c_void_p),
+        ("_padding", ctypes.c_uint8 * 64),
+    ]
+
+
+def _device_of_ptr(ptr: int) -> torch.device:
+    """Return the device a raw pointer actually lives on.
+
+    Args:
+        ptr: Raw memory pointer as int.
+
+    Returns:
+        ``torch.device("cuda", ordinal)`` when the CUDA runtime reports device
+        memory, ``torch.device("cpu")`` otherwise -- including host memory
+        (registered or not), a failed query, a runtime that does not export
+        ``cudaPointerGetAttributes`` (ROCm exports the ``hip`` spelling with a
+        different struct layout), or no runtime at all. CPU is the safe answer
+        because it is what this module assumed unconditionally before.
+    """
+    lib = _get_copy_lib()
+    query = getattr(lib, "cudaPointerGetAttributes", None) if lib else None
+    if query is None:
+        return torch.device("cpu")
+    query.restype = ctypes.c_int
+    query.argtypes = [ctypes.POINTER(_CudaPointerAttributes), ctypes.c_void_p]
+    attributes = _CudaPointerAttributes()
+    err = query(ctypes.byref(attributes), ctypes.c_void_p(ptr))
+    if err != 0:
+        # Plain host allocations report an error on older runtimes. Clear it so
+        # an unrelated cudaGetLastError() does not pick up this query's failure.
+        clear_error = getattr(lib, "cudaGetLastError", None)
+        if clear_error is not None:
+            clear_error()
+        return torch.device("cpu")
+    if attributes.memory_type != _CUDA_MEMORY_TYPE_DEVICE:
+        return torch.device("cpu")
+    return torch.device("cuda", int(attributes.device))
+
+
 def _tensor_from_ptr(
     ptr: int,
     shape: tuple[int, ...],
@@ -1040,10 +1095,13 @@ def _normalize_lmcache_objects(
 ) -> list[torch.Tensor]:
     """Normalize LMCache object inputs to chunk tensors.
 
-    Accepts either a list of chunk tensors or a ``list[int]`` of raw CPU pointers.
+    Accepts either a list of chunk tensors or a ``list[int]`` of raw pointers.
     When a pointer list is provided *shape_desc*, *lmcache_chunk_size*,
     *engine_kv_format*, and *dtype* must be supplied so the tensors can be
-    reconstructed via :func:`_tensor_from_ptr` on the CPU.
+    reconstructed via :func:`_tensor_from_ptr`. Those pointers may be host or
+    device memory -- callers that stage through GPU buffers pass device
+    pointers -- so each one's residency is resolved with :func:`_device_of_ptr`
+    rather than assumed.
     """
     if not isinstance(lmcache_objects_ptrs, list):
         raise TypeError(
@@ -1055,7 +1113,7 @@ def _normalize_lmcache_objects(
     if isinstance(lmcache_objects_ptrs[0], torch.Tensor):
         return lmcache_objects_ptrs  # type: ignore[return-value]
     if isinstance(lmcache_objects_ptrs[0], int):
-        # Pointer mode: reconstruct chunk tensors (always on CPU).
+        # Pointer mode: reconstruct chunk tensors where the pointers actually live.
         if (
             shape_desc is None
             or lmcache_chunk_size is None
@@ -1079,7 +1137,7 @@ def _normalize_lmcache_objects(
         else:
             chunk_shape = (2, nl, chunk_tokens, nh * hs)
         return [
-            _tensor_from_ptr(ptr, chunk_shape, dtype, "cpu")
+            _tensor_from_ptr(ptr, chunk_shape, dtype, _device_of_ptr(ptr))
             for ptr in lmcache_objects_ptrs
         ]
     raise TypeError(

--- a/tests/v1/test_torch_ops.py
+++ b/tests/v1/test_torch_ops.py
@@ -3134,3 +3134,159 @@ def test_tensor_from_musa_ptr_fails_without_external_storage(
 
     with pytest.raises(RuntimeError, match="failed to construct"):
         _py_ops._tensor_from_musa_ptr(0x1000, (2, 3), torch.float16, fake_device, 12)
+
+
+# ==========================================
+# Pointer-mode device resolution
+# ==========================================
+#
+# ``_normalize_lmcache_objects`` rebuilds raw LMCache-object pointers into
+# chunk tensors. Some callers hand it host memory -- the compiled path pins
+# CPU chunks first -- and some hand it device memory, because the
+# multiprocess server stages the transfer through GPU buffers. So the wrap
+# has to follow the pointer: a device pointer rebuilt as a CPU tensor only
+# survives while the slice the kernel takes stays contiguous, and skipping a
+# block prefix is enough to break that.
+
+_requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Requires a CUDA device"
+)
+
+_PTR_NUM_LAYERS = 2
+_PTR_NUM_BLOCKS = 8
+_PTR_BLOCK_SIZE = 4
+_PTR_NUM_HEADS = 2
+_PTR_HEAD_SIZE = 8
+_PTR_BLOCKS_PER_CHUNK = 4
+_PTR_CHUNK_TOKENS = _PTR_BLOCKS_PER_CHUNK * _PTR_BLOCK_SIZE
+_PTR_HIDDEN = _PTR_NUM_HEADS * _PTR_HEAD_SIZE
+_PTR_DTYPE = torch.float32
+_PTR_FORMAT = lmcache_native.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+_PTR_CHUNK_SHAPE = (2, _PTR_NUM_LAYERS, _PTR_CHUNK_TOKENS, _PTR_HIDDEN)
+
+
+def _ptr_shape_desc() -> Any:
+    """Build the page-buffer descriptor for the pointer-mode fixtures."""
+    shape_desc = _py_ops.PageBufferShapeDesc()
+    shape_desc.kv_size = 2
+    shape_desc.nl = _PTR_NUM_LAYERS
+    shape_desc.nb = _PTR_NUM_BLOCKS
+    shape_desc.bs = _PTR_BLOCK_SIZE
+    shape_desc.nh = _PTR_NUM_HEADS
+    shape_desc.hs = _PTR_HEAD_SIZE
+    shape_desc.element_size = _PTR_DTYPE.itemsize
+    _py_ops.set_shape_desc_dtype(shape_desc, _PTR_DTYPE)
+    return shape_desc
+
+
+def _wrap_pointers(pointers: list[int]) -> list[torch.Tensor]:
+    """Run *pointers* through pointer-mode object normalization."""
+    return _py_ops._normalize_lmcache_objects(
+        pointers,
+        shape_desc=_ptr_shape_desc(),
+        lmcache_chunk_size=_PTR_CHUNK_TOKENS,
+        engine_kv_format=_PTR_FORMAT,
+        dtype=_PTR_DTYPE,
+    )
+
+
+@pytest.mark.cuda
+@_requires_cuda
+def test_normalize_lmcache_objects_follows_device_pointers() -> None:
+    """A device staging pointer is rebuilt on that device, not on the CPU."""
+    staging = torch.zeros(_PTR_CHUNK_SHAPE, dtype=_PTR_DTYPE, device="cuda")
+
+    wrapped = _wrap_pointers([staging.data_ptr()])
+
+    # Compare through a local: when the wrap is a CPU tensor over device
+    # memory, rendering it faults, and pytest renders the operands of the
+    # assertion that fails.
+    wrapped_chunk = wrapped[0]
+    wrapped_device = wrapped_chunk.device
+    assert wrapped_device == staging.device
+    assert wrapped_chunk.shape == staging.shape
+    assert wrapped_chunk.dtype == staging.dtype
+    # The wrap must be a view of the original allocation, not a copy of it.
+    wrapped_chunk.fill_(3)
+    device_sync("cuda")
+    assert torch.equal(staging, torch.full_like(staging, 3))
+
+
+@pytest.mark.cuda
+@_requires_cuda
+def test_normalize_lmcache_objects_keeps_host_pointers_on_cpu() -> None:
+    """Host staging stays on the CPU, and querying it leaves no CUDA error."""
+    pinned = torch.zeros(_PTR_CHUNK_SHAPE, dtype=_PTR_DTYPE).pin_memory()
+    plain = torch.zeros(_PTR_CHUNK_SHAPE, dtype=_PTR_DTYPE)
+
+    wrapped = _wrap_pointers([pinned.data_ptr(), plain.data_ptr()])
+
+    assert [tensor.device.type for tensor in wrapped] == ["cpu", "cpu"]
+    for tensor, original in zip(wrapped, (pinned, plain), strict=True):
+        tensor.fill_(5)
+        assert torch.equal(original, torch.full_like(original, 5))
+    # An unregistered pointer makes the runtime query fail on some versions;
+    # that error must not be left behind for the next CUDA call to trip on.
+    device_sync("cuda")
+    assert torch.ones(1, device="cuda").item() == 1.0
+
+
+@pytest.mark.cuda
+@_requires_cuda
+def test_multi_layer_block_kv_transfer_skips_prefix_with_device_objects() -> None:
+    """Device staging survives a transfer that skips a leading block.
+
+    The skipped prefix makes the object slice non-contiguous, so a CPU wrap of
+    a device pointer is dereferenced by host code here: before the pointer
+    residency was resolved this crashed the process instead of failing.
+    """
+    torch.manual_seed(123)
+    paged_shape = (
+        2,
+        _PTR_NUM_BLOCKS,
+        _PTR_BLOCK_SIZE,
+        _PTR_NUM_HEADS,
+        _PTR_HEAD_SIZE,
+    )
+    src = [
+        torch.randn(paged_shape, dtype=_PTR_DTYPE, device="cuda")
+        for _ in range(_PTR_NUM_LAYERS)
+    ]
+    dst = [torch.zeros_like(layer) for layer in src]
+    num_chunks = _PTR_NUM_BLOCKS // _PTR_BLOCKS_PER_CHUNK
+    staging = [
+        torch.zeros(_PTR_CHUNK_SHAPE, dtype=_PTR_DTYPE, device="cuda")
+        for _ in range(num_chunks)
+    ]
+    staging_ptrs = [chunk.data_ptr() for chunk in staging]
+    block_ids = torch.arange(_PTR_NUM_BLOCKS, dtype=torch.int64, device="cuda")
+    skip_prefix_n_blocks = 1
+
+    def _transfer(paged: list[torch.Tensor], direction: Any, skip_blocks: int) -> None:
+        _py_ops.multi_layer_block_kv_transfer(
+            torch.tensor(
+                [layer.data_ptr() for layer in paged],
+                dtype=torch.uint64,
+                device="cuda",
+            ),
+            staging_ptrs,
+            block_ids,
+            torch.device("cuda"),
+            direction,
+            _ptr_shape_desc(),
+            _PTR_CHUNK_TOKENS,
+            _PTR_FORMAT,
+            skip_blocks,
+        )
+
+    _transfer(src, lmcache_native.TransferDirection.D2H, 0)
+    device_sync("cuda")
+    _transfer(dst, lmcache_native.TransferDirection.H2D, skip_prefix_n_blocks)
+    device_sync("cuda")
+
+    for layer_src, layer_dst in zip(src, dst, strict=True):
+        assert torch.equal(
+            layer_src[:, skip_prefix_n_blocks:], layer_dst[:, skip_prefix_n_blocks:]
+        )
+        # The skipped blocks must be left untouched.
+        assert torch.count_nonzero(layer_dst[:, :skip_prefix_n_blocks]) == 0


### PR DESCRIPTION
**What this PR does / why we need it**:

In pointer mode, `_normalize_lmcache_objects` rebuilt every raw LMCache-object
pointer with the device hardcoded:

```python
_tensor_from_ptr(ptr, chunk_shape, dtype, "cpu")
```

The multiprocess server stages block transfers through GPU buffers and hands the
fallback those buffers' `data_ptr()` directly
(`lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py`,
`transfer_kv_per_object_group`), so the reconstruction produces a CPU tensor whose
storage is device memory.

Whether that explodes depends on `skip_prefix_n_blocks`:

- `0` — the object slice is contiguous, the copy degenerates into one
  `cudaMemcpy`, and unified addressing resolves the "host" pointer as device
  memory. Works, silently.
- `> 0` — the slice is not contiguous, so PyTorch makes it contiguous **on the
  CPU** first and host code dereferences device memory: SIGSEGV inside
  `direct_copy_kernel`, taking the whole cache server down mid-transfer. This is
  what #4155 reports.

Reproduced on a single GPU with the torch fallback (no compiled `cuda_ops`), 2
layers × 8 blocks, 2 CUDA staging chunks: `skip_prefix_n_blocks=0` round-trips
fine, `skip_prefix_n_blocks=1` dies with `Segmentation fault (core dumped)` right
after the D2H leg returns.

This resolves each pointer's real residency with `cudaPointerGetAttributes`,
loaded off the copy library `_get_copy_lib()` already caches, and passes that
device to `_tensor_from_ptr`. Only genuinely device-resident memory changes
behaviour. Host memory — pinned or not — a failed query, a runtime that does not
export the symbol, or no runtime at all all keep the CPU wrap this code assumed
unconditionally before.

**Special notes for your reviewers**:

- I deliberately did not thread the caller's `device` argument down into
  `_normalize_lmcache_objects`, even though `_normalize_paged_layers` next to it
  already receives it. `scenario_multi_layer_block_kv_transfer` in
  `tests/v1/test_torch_ops.py` passes **pinned CPU** chunk pointers together with
  `device="cuda"`, which is a legitimate combination on the compiled path (it pins
  CPU chunks precisely so the kernel can use them), and building those as device
  tensors would break the case that works today. Following the pointer is the only
  option that leaves both callers correct, and it keeps the signature aligned with
  the C++ binding.
- The failed-query path calls `cudaGetLastError()`. Older runtimes report an error
  for unregistered host pointers, and leaving it set would surface later in an
  unrelated CUDA call. Verified that the context stays healthy after querying a
  null pointer.
- ROCm exports `hipPointerGetAttributes` with a different struct layout, so the
  `getattr` lookup misses there and the behaviour is exactly today's. I have no
  ROCm device to test on — this matches the existing `TODO: ROCm path to be
  validated on real device` in the same file.
- Three tests were added at the end of `tests/v1/test_torch_ops.py`, marked
  `pytest.mark.cuda`. The first two go through `_normalize_lmcache_objects`
  directly, which is a private member; the file already does that for
  `_tensor_from_ptr`, and the reason to keep them at that level is that a
  regression then fails with a readable assertion instead of only as a process
  crash in the third test. The third test does the full public-API round trip with
  `skip_prefix_n_blocks=1` and is the one that segfaults without the fix — a
  regression will show up as a hard crash in CI rather than a failure, which is
  inherent to the bug.
- No pointer→device caching: pointers get freed and reused, so a cache would trade
  this crash for a harder one. The query is a microsecond-scale runtime call, and
  this path handles at most a handful of objects per invocation.
- Scope: #4155 also describes a wrap-shape rank mismatch for MiniMax-M3's
  MSA-indexer buffer (`(1, 57, 256, 128)` vs the 4D chunk shape built here) and
  suggests explicit stream ordering after moving to async tensor copies. Both are
  design calls about the shape/stream contract rather than this crash, so I left
  them alone and used `Refs`, not `Fixes`. The dtype inference the issue mentions
  looks already fixed on `dev` — `kv_layer_groups.py` sets the descriptor dtype via
  `set_shape_desc_dtype`, and my reproduction gets the correct bfloat16.
- Verified on a single B200 with the fallback path live (`NO_GPU_EXT=1`):
  `tests/v1/test_torch_ops.py` goes from `74 passed` to `77 passed`, and the
  neighbouring device/kernel/parity tests come out `136 passed, 12 skipped` with an
  empty failure-set difference against the unpatched tree.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
