### PR TITLE
fix(operator): scale engine startup-probe window to L1 size

### DIFF
--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -59,6 +59,26 @@ const (
 // master key, referenced as master_key_path in the serde config.
 const l2EncryptionKeyPath = l2EncryptionKeyMountDir + "/" + l2EncryptionKeyFileName
 
+// startupProbeDefaultFailureThreshold is the baseline startup-probe failure
+// count. With the probe's InitialDelaySeconds=5 and PeriodSeconds=5 this is a
+// ~155s startup window.
+const startupProbeDefaultFailureThreshold int32 = 30
+
+// startupProbeFailureThreshold scales the startup-probe window to L1 size: the
+// engine pre-pins all of L1 before binding its port, so budget ~1 GB/s of pinning
+// (window = FailureThreshold * 5s period), floored at the default.
+func startupProbeFailureThreshold(l1SizeGB float64) int32 {
+	const (
+		pinBudgetGBPerSec  = 1.0 // assumed worst-case L1 pin bandwidth
+		probePeriodSeconds = 5.0 // must match the startup probe's PeriodSeconds
+	)
+	scaled := int32(l1SizeGB / pinBudgetGBPerSec / probePeriodSeconds)
+	if scaled > startupProbeDefaultFailureThreshold {
+		return scaled
+	}
+	return startupProbeDefaultFailureThreshold
+}
+
 // BuildDaemonSet constructs a DaemonSet for the given LMCacheEngine.
 func BuildDaemonSet(engine *lmcachev1alpha1.LMCacheEngine) *appsv1.DaemonSet {
 	return buildDaemonSetCore(engine.Name, engine.Namespace, &engine.Spec, BuildContainerArgs(&engine.Spec), "lmcache/vllm-openai")
@@ -229,13 +249,16 @@ func buildDaemonSetCore(
 		Port: intstr.FromInt32(serverPort),
 	}
 
+	// Scale the startup window to the L1 pin time (see startupProbeFailureThreshold).
+	startupFailureThreshold := startupProbeFailureThreshold(spec.L1.SizeGB)
+
 	startupProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			TCPSocket: tcpProbe,
 		},
 		InitialDelaySeconds: 5,
 		PeriodSeconds:       5,
-		FailureThreshold:    30,
+		FailureThreshold:    startupFailureThreshold,
 	}
 
 	livenessProbe := &corev1.Probe{

--- a/operator/internal/resources/daemonset_test.go
+++ b/operator/internal/resources/daemonset_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import "testing"
+
+func TestStartupProbeFailureThreshold(t *testing.T) {
+	cases := []struct {
+		name     string
+		l1SizeGB float64
+		want     int32
+	}{
+		{"tiny is floored", 10, 30},
+		{"fractional is floored", 0.5, 30},
+		{"at floor boundary", 150, 30}, // 150/5 = 30, not greater than the floor
+		{"just above floor", 155, 31},  // 155/5 = 31
+		{"300GB", 300, 60},
+		{"1200GB", 1200, 240},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := startupProbeFailureThreshold(tc.l1SizeGB); got != tc.want {
+				t.Fatalf("startupProbeFailureThreshold(%v) = %d, want %d",
+					tc.l1SizeGB, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildDaemonSet_StartupProbeScalesWithL1(t *testing.T) {
+	cases := []struct {
+		name              string
+		l1SizeGB          float64
+		wantFailThreshold int32
+	}{
+		{"small L1 keeps the default window", 10, 30},
+		{"large L1 gets a proportional window", 1200, 240},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := minimalEngine()
+			engine.Spec.L1.SizeGB = tc.l1SizeGB
+
+			ds := BuildDaemonSet(engine)
+			containers := ds.Spec.Template.Spec.Containers
+			if len(containers) == 0 {
+				t.Fatalf("expected at least one container in the DaemonSet")
+			}
+			probe := containers[0].StartupProbe
+			if probe == nil {
+				t.Fatalf("expected a startup probe on the engine container")
+			}
+			if probe.FailureThreshold != tc.wantFailThreshold {
+				t.Fatalf("StartupProbe.FailureThreshold = %d, want %d",
+					probe.FailureThreshold, tc.wantFailThreshold)
+			}
+			// Only the threshold scales; the period and initial delay are unchanged.
+			if probe.PeriodSeconds != 5 {
+				t.Fatalf("StartupProbe.PeriodSeconds = %d, want 5", probe.PeriodSeconds)
+			}
+			if probe.InitialDelaySeconds != 5 {
+				t.Fatalf("StartupProbe.InitialDelaySeconds = %d, want 5",
+					probe.InitialDelaySeconds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it
The engine pre-pins its entire L1 (host RAM) before it binds the server port, so with a large l1.sizeGB the pod cannot pass the fixed `~155s` startup probe (`InitialDelay 5s + FailureThreshold 30 x Period 5s`) and is **SIGKILLed** mid-pin, crashlooping forever (~160 restarts at l1.sizeGB=1200 on 8xB200).

## Failure Example
Lmcache daemonsets pods can't get large L1 accepted .  I.e **70%-RAM target of a 1.7TB node** (**l1.sizeGB: 1200**) won't start: the engine pre-pins the entire L1 at startup before it opens its `:5555` probe port, and the operator's startup probe is fixed at ~155 s (delay 5 s + failure 30 × 5 s). The pin doesn't finish in that window, so kubelet SIGKILLs it (Exit 137) : 
The engine crashloops forever.
```nginx
Warning  Unhealthy   Startup probe failed: dial tcp 10.144.28.241:5555: connect: connection refused
Last State: Terminated   Reason: Error   Exit Code: 137   Restart Count: 158
LazyMemoryAllocator: Expanded ... total is 153600 MB / 1228800 MB (12.5%)   <- never got past ~12%
```

## Special notes for your reviewers
Scale the startup probe `FailureThreshold` with L1 size (~1 GB/s pin budget, floored at the previous 30) so large caches get a proportional startup window, small caches keep a tight one, and a stuck engine still fails fast.

```
operator/internal/resources/daemonset.go:232:

#### BEFOR
startupProbe := &corev1.Probe{
    ProbeHandler:        corev1.ProbeHandler{TCPSocket: tcpProbe},
    InitialDelaySeconds: 5,
    PeriodSeconds:       5,
    FailureThreshold:    30,     // 5 + 30×5 = ~155 s, hardcoded
}

## AFTER

-		FailureThreshold:    30,
+		FailureThreshold:    startupFailureThreshold,

 
/	The startup-probe FailureThreshold (>= startupProbeDefaultFailureThreshold).
func startupProbeFailureThreshold(l1SizeGB float64) int32 {
  const (
    pinBudgetGBPerSec  = 1.0 // assumed worst-case L1 pin bandwidth
    probePeriodSeconds = 5.0 // must match the startup probe's PeriodSeconds
  )
  scaled := int32(l1SizeGB / pinBudgetGBPerSec / probePeriodSeconds)
  if scaled > startupProbeDefaultFailureThreshold {
    return scaled
  }
  return startupProbeDefaultFailureThreshold
}
```

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
