### PR TITLE
[MP][Perf] Improve the store/retrieve throughput for single head large block size models

### DIFF
--- a/csrc/cuda/mp_mem_kernels.cu
+++ b/csrc/cuda/mp_mem_kernels.cu
@@ -8,10 +8,12 @@ namespace {
  * Key logic in the kernel implementation:
  * 1. Each thread block is for (BS, NH, HS) part (i.e., a single block in the
  * paged buffer)
- * 2. Within a thread block, each warp is for a single head. Number of warps
- * in a thread block is equal to the number of heads (NH).
- * 3. Within a thread block, we do the loop over the BS (i.e., number of tokens
- * in the block) dimension.
+ * 2. The thread block is 3D: threadIdx.x strides over the transfer units
+ * within a head (at most 32 threads), threadIdx.y selects the head (one head
+ * per y index, and threadIdx.z partitions the BS dimension (i.e., number of
+ * tokens in the block).
+ * 3. Within a thread block, we do loop over the BS dimension with a stride of
+ * blockDim.z.
  * 4. The grid will take over (2, NB, NL) dimensions. No matter what the actual
  * layout in memory is, we will calculate the global offset for the start of the
  * block
@@ -197,6 +199,8 @@ __device__ void multi_layer_block_transfer_single_block(
                                   // in LMCache object
 ) {
   const int head_idx = threadIdx.y;
+  const int init_token_offset = threadIdx.z;
+  const int token_stride = blockDim.z;
   const int k_or_v = blockIdx.x;
   const int layer_idx = blockIdx.z;
 
@@ -231,7 +235,7 @@ __device__ void multi_layer_block_transfer_single_block(
     const size_t spt = shape_desc.scalars_per_token<ScalarType>();
     const size_t scale_units = 4 / sizeof(ScalarType);
     const size_t val_units = spt - scale_units;
-    for (int t = 0; t < shape_desc.bs; ++t) {
+    for (int t = init_token_offset; t < shape_desc.bs; t += token_stride) {
       ScalarType* eng_vals =
           paged_buffer_layer_ptr + engine_global_offset + t * val_units;
       ScalarType* eng_scale = paged_buffer_layer_ptr + engine_global_offset +
@@ -248,7 +252,8 @@ __device__ void multi_layer_block_transfer_single_block(
     return;
   }
 
-  for (int token_offset = 0; token_offset < shape_desc.bs; ++token_offset) {
+  for (int token_offset = init_token_offset; token_offset < shape_desc.bs;
+       token_offset += token_stride) {
     const size_t engine_local_offset =
         calculate_engine_local_offset<ScalarType, format>(token_offset,
                                                           head_idx, shape_desc);
@@ -405,8 +410,14 @@ void multi_layer_block_kv_transfer_templated(
                           static_cast<int>(sizeof(ScalarType));
   int thread_dim_x = std::min(elements_per_head, 32);
   int thread_dim_y = shape_desc.nh;
+  TORCH_CHECK(thread_dim_y <= 32, "Number of heads (", thread_dim_y,
+              ") exceeds max threads per block in y-dim (32). This"
+              " should never happen in normal LLMs");
+  int thread_dim_z =
+      std::min(shape_desc.bs, 1024 / (thread_dim_x * thread_dim_y));
+  thread_dim_z = std::min(thread_dim_z, 64);  // max threads per block in z-dim
 
-  dim3 block(thread_dim_x, thread_dim_y);
+  dim3 block(thread_dim_x, thread_dim_y, thread_dim_z);
   dim3 grid(shape_desc.kv_size, total_blocks, shape_desc.nl);
 
   if (direction == TransferDirection::H2D) {

--- a/tests/v1/test_mp_mem_kernels.py
+++ b/tests/v1/test_mp_mem_kernels.py
@@ -512,3 +512,140 @@ def test_block_transfer_skip_prefix(engine_kv_format, nl, nh, hs, is_mla, dtype)
             assert block.abs().sum().item() == 0, (
                 f"Skipped block {i}, layer {layer_idx} is not zero"
             )
+
+
+# ---------------------------------------------------------------------------
+# Large-block content-size case (e.g., DeepSeek indexer k-cache): NH == 1 and
+# BS much larger than one thread block can cover with a single token slice,
+# exercising the blockDim.z token partitioning in the transfer kernel. This
+# geometry cannot reuse FORMAT_PARAMS because the tests above hard-code
+# BS = 16 and TOKENS_PER_OBJECT = 256, while the kernel requires
+# blocks_per_object * bs == lmcache_chunk_size (so here one engine block
+# fills a whole memory object).
+# ---------------------------------------------------------------------------
+
+LARGE_BLOCK_NL = 20
+LARGE_BLOCK_NH = 1
+LARGE_BLOCK_BS = 1536
+LARGE_BLOCK_CS = 576
+# Keep NB small: each layer tensor is [NB, 1, 1536, 576] and there are
+# source + target copies of LARGE_BLOCK_NL layers on the GPU.
+LARGE_BLOCK_NB = 8
+LARGE_BLOCK_TOKENS_PER_OBJECT = LARGE_BLOCK_BS  # one engine block per object
+LARGE_BLOCK_TOTAL_BLOCKS = NUM_MEMORY_OBJECTS
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
+)
+@pytest.mark.parametrize(
+    "mem_device", [torch_device_type, "cpu"], ids=["mem_gpu", "mem_cpu"]
+)
+def test_block_transfer_roundtrip_large_block(dtype, mem_device):
+    """
+    D2H -> H2D roundtrip for the content-size HND format (NL_X_NB_NH_BS_CS)
+    with a single head and a large block size (NH=1, BS=1536, CS=576).
+
+    Unlike the BS=16 cases above, this launches the kernel with multiple
+    z-slices per thread block, so it verifies the strided token loop copies
+    every token exactly once.
+    """
+    device = torch.device(torch_device_type)
+    mem_dev = torch.device(mem_device)
+    kv_dim = 1  # content-size formats transfer with kv_size == 1
+    hidden_dim = LARGE_BLOCK_NH * LARGE_BLOCK_CS
+
+    source_vllm = create_vllm_tensors(
+        FMT_VLLM_CS_HND,
+        LARGE_BLOCK_NL,
+        LARGE_BLOCK_NB,
+        LARGE_BLOCK_BS,
+        LARGE_BLOCK_NH,
+        LARGE_BLOCK_CS,
+        dtype,
+        device,
+    )
+    target_vllm = create_zero_vllm_tensors(
+        FMT_VLLM_CS_HND,
+        LARGE_BLOCK_NL,
+        LARGE_BLOCK_NB,
+        LARGE_BLOCK_BS,
+        LARGE_BLOCK_NH,
+        LARGE_BLOCK_CS,
+        dtype,
+        device,
+    )
+    mem_objects = create_memory_objects(
+        kv_dim,
+        LARGE_BLOCK_NL,
+        LARGE_BLOCK_TOKENS_PER_OBJECT,
+        hidden_dim,
+        NUM_MEMORY_OBJECTS,
+        dtype,
+        mem_dev,
+    )
+
+    # Disjoint block IDs for D2H and H2D
+    rng_d2h = random.Random(42)
+    block_ids_d2h = rng_d2h.sample(range(LARGE_BLOCK_NB), LARGE_BLOCK_TOTAL_BLOCKS)
+    excluded = set(block_ids_d2h)
+    available = [i for i in range(LARGE_BLOCK_NB) if i not in excluded]
+    rng_h2d = random.Random(123)
+    block_ids_h2d = rng_h2d.sample(available, LARGE_BLOCK_TOTAL_BLOCKS)
+
+    # D2H: source -> mem_objects
+    call_block_kernel(
+        source_vllm,
+        mem_objects,
+        block_ids_d2h,
+        FMT_VLLM_CS_HND,
+        lmcache_native.TransferDirection.D2H,
+        LARGE_BLOCK_NL,
+        LARGE_BLOCK_NB,
+        LARGE_BLOCK_BS,
+        LARGE_BLOCK_NH,
+        LARGE_BLOCK_CS,
+        True,
+        LARGE_BLOCK_TOKENS_PER_OBJECT,
+    )
+    torch_dev.synchronize()
+
+    # H2D: mem_objects -> target
+    call_block_kernel(
+        target_vllm,
+        mem_objects,
+        block_ids_h2d,
+        FMT_VLLM_CS_HND,
+        lmcache_native.TransferDirection.H2D,
+        LARGE_BLOCK_NL,
+        LARGE_BLOCK_NB,
+        LARGE_BLOCK_BS,
+        LARGE_BLOCK_NH,
+        LARGE_BLOCK_CS,
+        True,
+        LARGE_BLOCK_TOKENS_PER_OBJECT,
+    )
+    torch_dev.synchronize()
+
+    # Verify: target[h2d_block] == source[d2h_block]
+    for i in range(LARGE_BLOCK_TOTAL_BLOCKS):
+        src_data = get_block_data(
+            source_vllm,
+            FMT_VLLM_CS_HND,
+            LARGE_BLOCK_NL,
+            LARGE_BLOCK_BS,
+            LARGE_BLOCK_NH,
+            block_ids_d2h[i],
+        )
+        tgt_data = get_block_data(
+            target_vllm,
+            FMT_VLLM_CS_HND,
+            LARGE_BLOCK_NL,
+            LARGE_BLOCK_BS,
+            LARGE_BLOCK_NH,
+            block_ids_h2d[i],
+        )
+        for layer_idx in range(LARGE_BLOCK_NL):
+            assert torch.equal(src_data[layer_idx], tgt_data[layer_idx]), (
+                f"Mismatch at block index {i}, layer {layer_idx}"
+            )


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

For example, Kimi K3 have 1536 tokens in the block with num head = 1 (MLA)

**Performance**: Kimi Linear on H200 (TP2)

| | Before | After |
|--------|--------|--------|
| Store throughput | 3.01GB/s | 14.66GB/s |
| Retrieve throughput | 17.78GB/s | 36.47GB/s |

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
