### PR TITLE
feat(operator): add runtimeClassName override to LMCacheEngine

### DIFF
--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -423,6 +423,16 @@ type LMCacheEngineSpec struct {
 	// +kubebuilder:validation:Enum=nvidia;amd
 	GPUVendor *string `json:"gpuVendor,omitempty"`
 
+	// runtimeClassName overrides the RuntimeClass for the engine pods. When unset,
+	// it is derived from gpuVendor: "nvidia" uses the NVIDIA GPU Operator's
+	// "nvidia" RuntimeClass, "amd" uses none (the default container runtime). Set
+	// it explicitly to run on a cluster whose GPU runtime is already the default
+	// (e.g. NVIDIA nodes without the GPU Operator, where no "nvidia" RuntimeClass
+	// object exists); an empty string omits runtimeClassName so pods use the
+	// default container runtime.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+
 	// image defines the container image to use.
 	// +optional
 	Image *ImageSpec `json:"image,omitempty"`

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -841,6 +841,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(ImageSpec)

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -3186,6 +3186,16 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              runtimeClassName:
+                description: |-
+                  runtimeClassName overrides the RuntimeClass for the engine pods. When unset,
+                  it is derived from gpuVendor: "nvidia" uses the NVIDIA GPU Operator's
+                  "nvidia" RuntimeClass, "amd" uses none (the default container runtime). Set
+                  it explicitly to run on a cluster whose GPU runtime is already the default
+                  (e.g. NVIDIA nodes without the GPU Operator, where no "nvidia" RuntimeClass
+                  object exists); an empty string omits runtimeClassName so pods use the
+                  default container runtime.
+                type: string
               server:
                 description: server defines server configuration.
                 properties:

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -96,6 +96,18 @@ func buildDaemonSetCore(
 		rc := nvidiaRuntimeClass
 		runtimeClassName = &rc
 	}
+	// An explicit spec.RuntimeClassName overrides the vendor-derived default; an
+	// empty string clears it so pods use the default container runtime. This is
+	// needed on NVIDIA clusters without the GPU Operator, where the "nvidia"
+	// RuntimeClass object is absent and the pods would otherwise be admission-rejected.
+	if spec.RuntimeClassName != nil {
+		if *spec.RuntimeClassName == "" {
+			runtimeClassName = nil
+		} else {
+			rc := *spec.RuntimeClassName
+			runtimeClassName = &rc
+		}
+	}
 	privileged := derefBool(spec.Privileged, false)
 
 	serverPort := derefInt32(getServerPort(spec), 5555)

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1439,6 +1439,41 @@ func TestBuildDaemonSet_GPUVendorAMD(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonSet_RuntimeClassNameOverride(t *testing.T) {
+	cases := []struct {
+		name      string
+		vendor    *string
+		override  *string
+		wantClass *string // nil => no runtimeClassName on the pod
+	}{
+		{"nvidia default keeps the nvidia RuntimeClass", nil, nil, ptr(nvidiaRuntimeClass)},
+		{"empty override clears it on nvidia (default runtime)", nil, ptr(""), nil},
+		{"non-empty override wins on nvidia", nil, ptr("customrc"), ptr("customrc")},
+		{"non-empty override wins on amd", ptr(lmcachev1alpha1.GPUVendorAMD), ptr("customrc"), ptr("customrc")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := minimalEngine()
+			if tc.vendor != nil {
+				engine.Spec.GPUVendor = tc.vendor
+			}
+			engine.Spec.RuntimeClassName = tc.override
+			engine.SetDefaults()
+
+			got := BuildDaemonSet(engine).Spec.Template.Spec.RuntimeClassName
+			if tc.wantClass == nil {
+				if got != nil {
+					t.Fatalf("expected no RuntimeClassName, got %q", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tc.wantClass {
+				t.Fatalf("expected RuntimeClassName=%q, got %v", *tc.wantClass, got)
+			}
+		})
+	}
+}
+
 func TestBuildDaemonSet_HostNetworkEnabled(t *testing.T) {
 	engine := minimalEngine()
 	engine.Spec.HostNetwork = ptr(true)


### PR DESCRIPTION
## What this PR does / why we need it
The operator forces `runtimeClassName: nvidia` on the engine pods whenever `gpuVendor` is `nvidia` (the default). That `nvidia` RuntimeClass object is created by the **NVIDIA GPU Operator** , so on NVIDIA clusters that serve GPUs **without the GPU Operator** (device plugin on containerd's default runtime), the object doesn't exist and every engine pod is **admission-rejected**, leaving the DaemonSet stuck at 0.

This PR adds an optional `spec.runtimeClassName` override: an empty string clears it so pods run on the **default container runtime**, while `gpuVendor` stays `nvidia` (keeps `NVIDIA_VISIBLE_DEVICES=all`, etc.). Unset = today's behavior, unchanged.

**New Behavior:**

| `runtimeClassName` set to | Result |
|---|---|
| *(unset / nil)* | vendor default — `nvidia` ⇒ `"nvidia"` class, `amd` ⇒ none (unchanged) |
| `""` (empty) | no runtimeClassName → default runtime (the Nebius fix) |
| `"foo"` | uses `foo` verbatim (works with any vendor) |

## Failure Example
On a Nebius 8xB200 cluster (containerd `default_runtime_name` is already `nvidia`, GPUs via the device plugin, **no GPU Operator**), the engine DaemonSet can't create any pods:

```nginx
Warning  FailedCreate  daemonset/tensormesh-engine
Error creating: pods "tensormesh-engine-" is forbidden: pod rejected: RuntimeClass "nvidia" not found

# daemonset.apps/tensormesh-engine   DESIRED 2   CURRENT 0   READY 0
# lmcacheengine ... phase: Pending   (ConfigValid=True, but 0/2 instances ready)
```

## Special notes for your reviewers
Add an optional override field and apply it after the vendor-derived default (nil = derive, "" = clear, "x" = use x). No behavior change unless the field is set.
```GO
operator/api/v1alpha1/lmcacheengine_types.go  (new field on LMCacheEngineSpec)

+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`

operator/internal/resources/daemonset.go  (buildDaemonSetCore)

#### BEFORE
	gpuVendor := derefString(spec.GPUVendor, lmcachev1alpha1.GPUVendorNvidia)
	var runtimeClassName *string
	if gpuVendor == lmcachev1alpha1.GPUVendorNvidia {
		rc := nvidiaRuntimeClass          // always "nvidia" — no way to opt out
		runtimeClassName = &rc
	}

#### AFTER  (+ explicit override)
	if gpuVendor == lmcachev1alpha1.GPUVendorNvidia {
		rc := nvidiaRuntimeClass
		runtimeClassName = &rc
	}
+	// explicit override wins; "" clears it -> default container runtime.
+	if spec.RuntimeClassName != nil {
+		if *spec.RuntimeClassName == "" {
+			runtimeClassName = nil
+		} else {
+			rc := *spec.RuntimeClassName
+			runtimeClassName = &rc
+		}
+	}
````
CRD + deepcopy regenerated via make manifests / make generate.

**If applicable**:
- [ x] this PR contains unit tests
