### PR TITLE
fix(mp): make the step event optional for devices without event IPC

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -59,6 +59,7 @@ from lmcache.integration.vllm.utils import (
     vllm_layout_hints,
 )
 from lmcache.utils import init_logger as lmcache_init_logger
+from lmcache.v1.platform import current_device_spec
 
 try:
     # First Party
@@ -535,8 +536,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if len(request_ids) == 0:
             return
 
-        event = torch_dev.Event(interprocess=True)
-        event.record()
+        event = None
+        if current_device_spec.event_ipc_backend is not None:
+            event = torch_dev.Event(interprocess=True)
+            event.record()
 
         self.worker_adapter.batched_submit_retrieve_requests(
             request_ids, ops, event, cache_salts=cache_salts
@@ -611,8 +614,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 dispatch(self.dispatcher, "wait_for_save", event=None)
             return
 
-        event = torch_dev.Event(interprocess=True)
-        event.record()
+        event = None
+        if current_device_spec.event_ipc_backend is not None:
+            event = torch_dev.Event(interprocess=True)
+            event.record()
 
         self.worker_adapter.batched_submit_store_requests(
             request_ids, ops, event, cache_salts=cache_salts

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1400,7 +1400,7 @@ class LMCacheMPWorkerAdapter:
         self,
         request_id: str,
         op: LoadStoreOp,
-        event: _IpcEvent,
+        event: _IpcEvent | None,
         cache_salt: str = "",
     ):
         """
@@ -1409,8 +1409,8 @@ class LMCacheMPWorkerAdapter:
         Args:
             request_id: The ID of the request
             op: The LoadStoreOp describing the store operation.
-            event: The CUDA event that is recorded after the current
-                model inference step
+            event: The device event recorded after the current model
+                inference step, or ``None`` without event IPC
             cache_salt: Per-user isolation salt.
         """
         self._ensure_heartbeat_started()
@@ -1444,14 +1444,15 @@ class LMCacheMPWorkerAdapter:
             self.blocks_in_chunk,
         )
         self.store_futures[request_id] = future
-        self.store_events[request_id] = event
+        if event is not None:
+            self.store_events[request_id] = event
 
     @_lmcache_nvtx_annotate
     def submit_retrieve_request(
         self,
         request_id: str,
         op: LoadStoreOp,
-        event: _IpcEvent,
+        event: _IpcEvent | None,
         cache_salt: str = "",
     ) -> None:
         """
@@ -1464,8 +1465,8 @@ class LMCacheMPWorkerAdapter:
         Args:
             request_id: The ID of the request
             op: The LoadStoreOp describing the retrieve operation.
-            event: The CUDA event that is recorded after the current
-                model inference step
+            event: The device event recorded after the current model
+                inference step, or ``None`` without event IPC
             cache_salt: Per-user isolation salt.
         """
         self._ensure_heartbeat_started()
@@ -1499,14 +1500,15 @@ class LMCacheMPWorkerAdapter:
             skip_first_n_tokens=op.skip_first_n_tokens,
         )
         self.retrieve_futures[request_id] = (future, op.flat_block_ids)
-        self.retrieve_events[request_id] = event
+        if event is not None:
+            self.retrieve_events[request_id] = event
 
     @_lmcache_nvtx_annotate
     def batched_submit_store_requests(
         self,
         request_ids: list[str],
         ops: list[LoadStoreOp],
-        event: _IpcEvent,
+        event: _IpcEvent | None,
         cache_salts: list[str] | None = None,
     ):
         """
@@ -1516,8 +1518,8 @@ class LMCacheMPWorkerAdapter:
             request_ids: The IDs of the requests
             ops: The LoadStoreOps describing the store operations. Should have
                 the same length as request_ids
-            event: The CUDA event that is recorded after the current
-                model inference step
+            event: The device event recorded after the current model
+                inference step, or ``None`` without event IPC
             cache_salts: Per-user isolation salts, one per request. If None,
                 all requests use cache_salt="". The list length should be the same as
                 request_ids.
@@ -1532,7 +1534,7 @@ class LMCacheMPWorkerAdapter:
         self,
         request_ids: list[str],
         ops: list[LoadStoreOp],
-        event: _IpcEvent,
+        event: _IpcEvent | None,
         cache_salts: list[str] | None = None,
     ):
         """
@@ -1542,8 +1544,8 @@ class LMCacheMPWorkerAdapter:
             request_ids: The IDs of the requests
             ops: The LoadStoreOps describing the retrieve operations. Should have
                 the same length as request_ids
-            event: The CUDA event that is recorded after the current
-                model inference step
+            event: The device event recorded after the current model
+                inference step, or ``None`` without event IPC
             cache_salts: Per-user isolation salts, one per request. If None,
                 all requests use cache_salt="". The list length should be same as
                 request_ids.

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -158,7 +158,7 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
         instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        _event: IPCEvent,
+        _event: IPCEvent | None,
         blocks_in_chunk: int,
     ) -> MessagingFuture:
         """Three-phase async store (prepare, gather and commit all in background).
@@ -258,7 +258,10 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
 
                     # --- Phase 2: gather (GPU->CPU copy on copy stream) ---
                     with torch.inference_mode(), torch_dev.stream(self._copy_stream):
-                        _event.wait(stream=self._copy_stream)
+                        # Without event IPC there is no producer event to
+                        # wait on; ordering falls to the caller.
+                        if _event is not None:
+                            _event.wait(stream=self._copy_stream)
 
                         gather_paged_kv_to_cpu(
                             kv_caches,

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -329,7 +329,7 @@ class TransferContext(ABC):
         instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        event: IPCEvent,
+        event: IPCEvent | None,
         blocks_in_chunk: int,
     ) -> MessagingFuture:
         """Submit a store request and return a completion future.
@@ -340,7 +340,7 @@ class TransferContext(ABC):
             instance_id: Worker process instance identifier.
             kv_caches: Worker KV cache tensors keyed by layer name.
             block_ids: vLLM block IDs to store, indexed by LMCache KV group id.
-            event: Synchronization event object.
+            event: Synchronization event object, or ``None`` without event IPC.
             blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
 
         Returns:
@@ -358,7 +358,7 @@ class TransferContext(ABC):
         instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        event: IPCEvent,
+        event: IPCEvent | None,
         blocks_in_chunk: int,
         skip_first_n_tokens: int = 0,
     ) -> MessagingFuture:
@@ -371,7 +371,7 @@ class TransferContext(ABC):
             kv_caches: Worker KV cache tensors keyed by layer name.
             block_ids: vLLM block IDs to retrieve into, indexed by LMCache KV
                 group id.
-            event: Synchronization event object.
+            event: Synchronization event object, or ``None`` without event IPC.
             blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
             skip_first_n_tokens: Number of initial tokens to skip when writing.
 
@@ -505,7 +505,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        event: IPCEvent,
+        event: IPCEvent | None,
         _blocks_in_chunk: int,
     ) -> MessagingFuture:
         """Submit a handle-based store ordered by ``event``.
@@ -536,6 +536,12 @@ class LMCacheDrivenTransferContext(TransferContext):
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_store()."
+            )
+        if event is None:
+            raise RuntimeError(
+                "LMCache-driven transfer needs a device event to order the "
+                "engine's KV writes, but the caller passed none -- this "
+                "device declares no DeviceSpec.event_ipc_backend."
             )
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._send_request(
@@ -578,7 +584,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         instance_id: int,
         _kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        event: IPCEvent,
+        event: IPCEvent | None,
         _blocks_in_chunk: int,
         skip_first_n_tokens: int = 0,
     ) -> MessagingFuture:
@@ -611,6 +617,12 @@ class LMCacheDrivenTransferContext(TransferContext):
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_retrieve()."
+            )
+        if event is None:
+            raise RuntimeError(
+                "LMCache-driven transfer needs a device event to order the "
+                "engine's KV writes, but the caller passed none -- this "
+                "device declares no DeviceSpec.event_ipc_backend."
             )
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._send_request(
@@ -755,7 +767,7 @@ class EngineDrivenTransferContext(TransferContext):
         instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        _event: IPCEvent,
+        _event: IPCEvent | None,
         blocks_in_chunk: int,
     ) -> MessagingFuture:
         if self._engine_driven_context is None:
@@ -797,7 +809,7 @@ class EngineDrivenTransferContext(TransferContext):
         instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
-        _event: IPCEvent,
+        _event: IPCEvent | None,
         blocks_in_chunk: int,
         skip_first_n_tokens: int = 0,
     ) -> MessagingFuture:

--- a/tests/v1/test_mp_connector_optional_event.py
+++ b/tests/v1/test_mp_connector_optional_event.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The MP connector submit paths pass ``None`` when the device has no event IPC."""
+
+# Standard
+from types import SimpleNamespace
+from typing import Literal
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
+
+# First Party
+from lmcache.integration.vllm import lmcache_mp_connector  # noqa: E402
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
+    LMCacheMPConnectorMetadata,
+    LMCacheMPRequestMetadata,
+)
+from lmcache.integration.vllm.vllm_multi_process_adapter import (  # noqa: E402
+    LoadStoreOp,
+)
+
+
+class _RecordingEvent:
+    """Minimal stand-in for a CUDA-like interprocess event."""
+
+    def __init__(self, interprocess: bool = False):
+        self.interprocess = interprocess
+        self.recorded = False
+
+    def record(self) -> None:
+        self.recorded = True
+
+
+def _connector(
+    monkeypatch, direction: Literal["STORE", "RETRIEVE"]
+) -> tuple[object, MagicMock]:
+    """Build a connector with just the attributes the submit paths read."""
+    conn = lmcache_mp_connector.LMCacheMPConnector.__new__(
+        lmcache_mp_connector.LMCacheMPConnector
+    )
+    metadata = LMCacheMPConnectorMetadata()
+    metadata.add_request_metadata(
+        LMCacheMPRequestMetadata(
+            request_id="req-0",
+            direction=direction,
+            op=LoadStoreOp(token_ids=[], block_ids=[[0]]),
+        )
+    )
+    adapter = MagicMock()
+    monkeypatch.setattr(
+        conn, "_get_connector_metadata", lambda: metadata, raising=False
+    )
+    monkeypatch.setattr(conn, "worker_adapter", adapter, raising=False)
+    monkeypatch.setattr(conn, "dispatcher", None, raising=False)
+    return conn, adapter
+
+
+def _set_event_ipc_backend(monkeypatch, backend: object | None) -> None:
+    monkeypatch.setattr(
+        lmcache_mp_connector,
+        "current_device_spec",
+        SimpleNamespace(event_ipc_backend=backend),
+    )
+
+
+@pytest.mark.parametrize("has_backend", [True, False])
+def test_wait_for_save_event_follows_device_capability(monkeypatch, has_backend):
+    conn, adapter = _connector(monkeypatch, "STORE")
+    _set_event_ipc_backend(monkeypatch, object() if has_backend else None)
+    monkeypatch.setattr(
+        lmcache_mp_connector, "torch_dev", SimpleNamespace(Event=_RecordingEvent)
+    )
+
+    conn.wait_for_save()
+
+    event = adapter.batched_submit_store_requests.call_args.args[2]
+    if has_backend:
+        assert isinstance(event, _RecordingEvent)
+        assert event.interprocess and event.recorded
+    else:
+        assert event is None
+
+
+@pytest.mark.parametrize("has_backend", [True, False])
+def test_start_load_kv_event_follows_device_capability(monkeypatch, has_backend):
+    conn, adapter = _connector(monkeypatch, "RETRIEVE")
+    _set_event_ipc_backend(monkeypatch, object() if has_backend else None)
+    monkeypatch.setattr(
+        lmcache_mp_connector, "torch_dev", SimpleNamespace(Event=_RecordingEvent)
+    )
+
+    conn.start_load_kv(forward_context=None)
+
+    event = adapter.batched_submit_retrieve_requests.call_args.args[2]
+    if has_backend:
+        assert isinstance(event, _RecordingEvent)
+        assert event.interprocess and event.recorded
+    else:
+        assert event is None
+
+
+def test_no_event_class_on_device_without_backend(monkeypatch):
+    """The device module need not expose Event at all (e.g. torch_rbln)."""
+    conn, adapter = _connector(monkeypatch, "STORE")
+    _set_event_ipc_backend(monkeypatch, None)
+    monkeypatch.setattr(lmcache_mp_connector, "torch_dev", SimpleNamespace())
+
+    conn.wait_for_save()
+
+    assert adapter.batched_submit_store_requests.call_args.args[2] is None


### PR DESCRIPTION
**What this PR does / why we need it**:

`LMCacheMPConnector.wait_for_save()` and `start_load_kv()` build the per-step event with `torch_dev.Event(interprocess=True)` — a CUDA-shaped call that not every device backend can serve.

`DeviceSpec` already models this capability: `event_ipc_backend` is `None` by default (`lmcache/v1/platform/base/device_spec.py`) and only the CUDA-like backends override it. The connector doesn't consult it, so on a backend that leaves it at the default the call raises — `AttributeError: module '...' has no attribute 'Event'` when the device module has no `Event` at all — and takes the forward step down with it. We hit exactly that bringing up mp mode on a device backend whose `torch_dev` has no `Event` type: engine startup succeeds, then the first request kills every worker.

The event is only meaningful to the transfer contexts that wait on it. `EngineDrivenTransferContext.submit_store()/submit_retrieve()` take it as `_event` and never use it — they call `torch_dev.synchronize()` instead — and that is exactly the path a device without event IPC runs, so passing `None` there loses nothing.

This PR consults the capability instead of assuming it:

- Both submit paths build and record the event only when `current_device_spec.event_ipc_backend` is set, and pass `None` otherwise.
- The event parameter is widened to `... | None` along the path it travels (worker adapter, `TransferContext.submit_store` / `submit_retrieve`), and the async engine-driven context skips the copy-stream wait when there is no event.
- The LMCache-driven context genuinely needs the event to order engine KV writes, so it now raises a specific error instead of failing later inside `export_event`.

**Special notes for your reviewers**:

- No behavior change on CUDA: with an event-IPC backend registered, the same event is built and recorded as before. The new tests assert both branches.
- `LMCacheMPWorkerAdapter.store_events` / `retrieve_events` keep their `dict[str, _IpcEvent]` type: they exist to keep the exporting event object alive, so a `None` entry would hold nothing and is simply not inserted.
- `AsyncEngineDrivenTransferContext` is unaffected on devices with no `Event` at all — `_supports_async_primitives()` already probes `torch_dev.Stream()`/`Event()` and falls back to the synchronous context. The `_event is None` branch is for devices that have local events but no *interprocess* ones.
- An alternative shape would be to route creation through `EventIPCBackend.create_event()`/`record_event()` rather than gate on it, but the connector has no device handle at these call sites, and the gate is what's needed to fix the crash. Happy to switch if you prefer the backend call.
- Verified end to end on the mp/engine-driven path (DP4, SHM transport): before the change the first request crashed all workers with the `AttributeError`; after it, store + cross-eviction restore complete and the served output is unchanged.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
