### PR TITLE
[Coordinator] Add cache-event source abstraction

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -66,6 +66,8 @@ lmcache/v1/mp_coordinator/
     __init__.py
     event_gate.py       # EventGate: incarnation fencing, seq dedup, gap detection
     event_broadcaster.py  # fans admitted events to the registered consumers
+    event_source.py     # source lifecycle/status contract
+    http_event_source.py  # non-durable POST /events push source
   discovery.py          # Registry + package scan, shared by views and controllers
   views/                # read models of the fleet: what is cached, and how much
     __init__.py         # build_views: scans this package
@@ -180,10 +182,15 @@ Every fact the coordinator holds about fleet cache contents arrives
 through this layer, which decides **what** is admitted and **who** sees
 it. It holds no cache state itself. See [ingest.md](ingest.md).
 
+- `event_source.py` — common source lifecycle/status contract.
+- `http_event_source.py` — `HttpCacheEventSource`, today's non-durable
+  `POST /events` push adapter. Future durable sources use the same
+  `EventGate.ingest_batches` method but own their transport lifecycle
+  separately.
 - `event_gate.py` — the admission point for every source. Owns the
   per-emitter stream cursor: incarnation fencing (a restart voids the
-  emitter's L1 facts), `seq` dedup, gap detection. `ingest()` for a live
-  emitter stream, `reconcile()` for a scan that has no stream position.
+  emitter's L1 facts), `seq` dedup, and gap detection. Scan sources
+  without stream positions are deliberately unsupported.
 - `event_broadcaster.py` — fans admitted batches (and fence
   notifications) to its registered `CacheEventConsumer`s: the key
   directory and the eviction manager. Adding a consumer is a wiring

--- a/docs/design/v1/mp_coordinator/cache_events.md
+++ b/docs/design/v1/mp_coordinator/cache_events.md
@@ -22,23 +22,31 @@ storage layer ──► EventBus ──► CacheEventSubscriber ──► CacheE
                   thread)      seq, batching)
 ```
 
-- **`CacheEventSink`** — `publish(batches)` with **at-least-once**
-  delivery, preserving list order within and across calls. That is the
-  entire transport contract, and it is deliberately weak: the directory
-  already absorbs everything a real transport does wrong. Redelivery is
-  deduplicated by the per-instance `seq` cursor, loss surfaces as a
-  `seq` gap that marks the instance's slice stale until the stream is
-  replayed, and restarts are fenced by `incarnation`. A sink never needs exactly-once or global ordering.
+- **`CacheEventSink`** — `publish(batches)`, preserving list order within
+  and across successful calls. Redelivery is safe: the per-instance `seq`
+  cursor deduplicates it, and restarts are fenced by `incarnation`.
+  Delivery loss surfaces as a `seq` gap. A durable source can replay
+  retained events; HTTP cannot repair an event dropped before the
+  coordinator accepted it. A sink never needs exactly-once or global
+  ordering.
 - **`HttpCacheEventSink`** — the first sink: one
   `POST /events` per flush, batches in list order. Failures
-  raise `CacheEventPublishError`; the caller decides retry vs drop
-  (both are safe, see above).
+  raise `CacheEventPublishError`. Retrying is safe; the current subscriber
+  drops a failed drained list, consumes its sequence numbers, and leaves a
+  gap that marks the coordinator view stale.
 - A future **Kafka sink** produces to a topic with the message key set
   to `instance_id`, so one partition carries one instance's stream —
   partition FIFO is exactly the per-instance FIFO the directory needs.
   The coordinator side gains a consumer that feeds
   the coordinator's `EventGate`; the subscriber and producers are
   untouched.
+
+On the coordinator side, transport adapters converge at
+`EventGate.ingest_batches`. The current
+`HttpCacheEventSource` is explicitly non-durable and advertises no replay
+capability. Gate cursors (`instance_id` / `incarnation` / `seq`) remain
+separate from a future durable transport's seek position (for example
+Kafka partition offsets).
 
 ## Batching and sequencing (inside the subscriber)
 
@@ -58,8 +66,9 @@ One `CacheEventSubscriber` per MP-server process owns the buffer, the
 - **`seq` is consumed even when publish fails.** A failed flush drops
   the drained list (bounding memory while the coordinator is down) but
   keeps the `seq` numbers it assigned. The directory sees a gap and
-  sets `gap_detected` for the instance — the honest signal that events
-  were lost and the slice needs an event-stream replay to reconcile.
+  sets `gap_detected` for the instance when a later batch arrives — the
+  honest signal that events were lost. Replay can reconcile the gap only
+  if a durable transport retained the failed batch; HTTP did not.
   Reusing the seqs instead would hide partial-delivery ambiguity (an
   HTTP timeout after the coordinator applied the batch).
 - **`incarnation` = server start time** (`int(time.time())` at
@@ -141,13 +150,14 @@ listener plumbing or a dedicated flush task:
   store completions) is delivered within one tick of the interval
   elapsing instead of waiting for the next request. The sink posts
   synchronously with a short timeout (a slow coordinator briefly
-  stalls the drain, bounded by the timeout; overflow beyond the bus's
-  bounded queue is dropped and surfaces as a `seq` gap → replay).
+  stalls the drain, bounded by the timeout). Overflow beyond the bus's
+  bounded queue happens before the subscriber assigns `seq`, so it is
+  logged by the bus but is not detectable as a gate sequence gap.
 - **Coupling.** The stream requires the bus: enabling
   `--coordinator-event-reporting` together with
-  `--disable-observability` is rejected at startup. Bus-level drops
-  under overload are acceptable by the same argument as transport loss —
-  the directory is eventually consistent soft state.
+  `--disable-observability` is rejected at startup. Bus-level drops under
+  overload remain possible; the directory is eventually consistent soft
+  state, but the loss is not currently self-healing.
 
 ## L1 media
 
@@ -178,10 +188,10 @@ event-driven flushes (default 1s).
 
 ## Known limitations (follow-ups)
 
-- **Bus overflow drops events silently** (bounded queue, rate-limited
-  warning); the resulting `seq` gap marks the instance's slice stale.
-  Reconstruction is by replaying the event stream (durable-transport
-  retention) — wiring that replay up is future work.
+- **Bus overflow drops events before sequencing** (bounded queue,
+  rate-limited warning), so the gate cannot detect the loss. A durable
+  transport also cannot replay an event that never reached its producer;
+  producer retry/backpressure or a local spool is separate future work.
 - **The flush pump is coupled to the eviction loop's tick** — decouple
   it (e.g. a bus-owned periodic hook) so tail freshness does not depend
   on that loop's cadence.

--- a/docs/design/v1/mp_coordinator/ingest.md
+++ b/docs/design/v1/mp_coordinator/ingest.md
@@ -1,6 +1,8 @@
 # Cache-event ingest
 
 Modules: `lmcache/v1/mp_coordinator/ingest/`
+ - `event_source.py` — source lifecycle/status contract
+ - `http_event_source.py` — non-durable `POST /events` push source
  - `event_gate.py` — `EventGate`: admission (fencing, dedup, gap detection)
  - `event_broadcaster.py` — `CacheEventBroadcaster` + the `CacheEventConsumer` protocol
 Contract vocabulary: `lmcache/v1/mp_coordinator/api.py`
@@ -12,11 +14,12 @@ it decides **what** is admitted (the gate) and **who** sees it (the
 broadcaster). Neither holds cache state — the consumers do.
 
 ```
-source                    ingest layer                     consumers
-─────────────────────────────────────────────────────────────────────────
-POST /events ──────────▶ EventGate.ingest ──▶ CacheEventBroadcaster
-  (live emitter stream)    fence / dedup /      .broadcast(batch) ────▶ KeyDirectory
-                           gap detect           .fence_instance(id) ──▶ FleetEvictionController
+source adapter                    ingest layer                 consumers
+──────────────────────────────────────────────────────────────────────────────
+POST /events ──▶ HttpCacheEventSource ──▶ EventGate ──▶ CacheEventBroadcaster
+ (HTTP push)      .ingest(batches)          fence /      .broadcast(batch) ────▶ KeyDirectory
+                                             dedup /       .fence_instance(id) ──▶ FleetEvictionController
+                                             gap detect
 ```
 
 ## Why a gate separate from the directory
@@ -62,10 +65,24 @@ the registry is still a follow-up; the method exists and is tested.)
 ## Sources
 
 `ingest` is the only door, and every source must carry a stream:
-`(instance_id, incarnation, seq)`. Today that is `POST /events`, fed by
+`(instance_id, incarnation, seq)`. Source adapters feed ordered batch
+lists to `EventGate.ingest_batches`, which reports the aggregate admitted /
+duplicate / stale counts.
+
+Today the adapter is `HttpCacheEventSource`, fed by `POST /events` from
 the MP-server `CacheEventSubscriber` (see
-[cache_events.md](cache_events.md)); a durable message-queue consumer
-would enter the same way, unchanged.
+[cache_events.md](cache_events.md)). It is a non-durable push source:
+FastAPI owns its request lifecycle, and the source cannot seek or replay
+events that failed before the coordinator accepted them. A future durable
+message-queue source enters through the same gate, so fencing, dedup, fan-out,
+and consumers do not change.
+
+The source lifecycle/status contract is deliberately smaller than a
+replayable-source contract. HTTP reports `replay_capability=none`; it does
+not implement a silent no-op `seek`. A durable source will add its own
+transport position and seek/lag contract when that position has a concrete
+representation. Transport positions (for example Kafka partition offsets)
+are separate from the gate's per-emitter seq cursors.
 
 A source that is a *scan* of current contents rather than a stream —
 the startup L2 resync that used to paginate `GET /cache/objects` — has

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -4,10 +4,11 @@
 The coordinator is a FastAPI app. Endpoints are auto-discovered from the
 ``http_apis`` package (the same convention as the mp server's HTTP API) and stay
 thin, operating on the shared collaborators carried on ``app.state``: ``config``,
-the view and controller registries, and the ingest layer's ``event_gate``.
+the view and controller registries, and the ingest layer's ``event_source`` /
+``event_gate``.
 The lifespan runs health-checking (eviction of instances whose heartbeats have
-lapsed) and the checkpoint timer, and starts and stops every controller --
-this file names no controller of its own.
+lapsed) and the checkpoint timer, and starts and stops the event source and
+every controller -- this file names no controller of its own.
 
 Adding a capability = a new ``http_apis/<name>_api.py`` router (auto-discovered)
 that uses those shared collaborators. A controller that ships outside this tree
@@ -37,6 +38,7 @@ from lmcache.v1.mp_coordinator.ingest.event_broadcaster import (
     CacheEventConsumer,
 )
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
+from lmcache.v1.mp_coordinator.ingest.http_event_source import HttpCacheEventSource
 from lmcache.v1.mp_coordinator.persistence.checkpoint import (
     load_checkpoint,
     save_checkpoint,
@@ -97,8 +99,8 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     token_hasher = TokenHasher(
         chunk_size=config.chunk_size, hash_algorithm=config.hash_algorithm
     )
-    # Ingest layer: the gate admits, the broadcaster fans out. Adding a
-    # consumer of the fleet's cache-event stream is a register call here.
+    # Ingest layer: the source feeds the gate, which admits before the
+    # broadcaster fans out. Adding a consumer is a register call here.
     event_broadcaster = CacheEventBroadcaster()
     # Views first: a controller acts on the batch a view has consumed.
     # Not everything discovered consumes, so the protocol decides.
@@ -109,6 +111,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     # to read across the consumers consistently.
     quiesce = QuiesceLock()
     event_gate = EventGate(event_broadcaster, quiesce)
+    event_source = HttpCacheEventSource(event_gate)
 
     # The gate is named because it is durable but is neither a view nor
     # a controller; everything else advertises its own state.
@@ -130,6 +133,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         controllers=controllers,
         token_hasher=token_hasher,
         event_gate=event_gate,
+        event_source=event_source,
         metadata_persister=metadata_persister,
     )
 
@@ -167,10 +171,11 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         """Start background work and unwind it in order on shutdown.
 
         Registration order is teardown order reversed, and the order is
-        load-bearing: timers stop before controllers so no checkpoint
-        races one settling, controllers before the final write so it
-        captures what they settled on, and the client closes last
-        because a draining controller is still using it.
+        load-bearing: timers stop before the source so no checkpoint races
+        ingestion, the source before controllers so no new work arrives while
+        they settle, controllers before the final write so it captures what
+        they settled on, and the client closes last because a draining
+        controller is still using it.
 
         A controller that raises on the way in is logged and skipped;
         the rest still run.
@@ -204,6 +209,8 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
                     logger.exception(
                         "Controller %s failed to start", type(controller).__name__
                     )
+            await event_source.start()
+            stack.push_async_callback(event_source.stop)
             # Nested, so they stop before the stack unwinds. Awaited too:
             # ``save_checkpoint`` runs in a thread a cancel cannot reach.
             timers = []

--- a/lmcache/v1/mp_coordinator/cache_events.py
+++ b/lmcache/v1/mp_coordinator/cache_events.py
@@ -50,9 +50,11 @@ class CacheEventPublishError(Exception):
 class CacheEventSink(ABC):
     """Transport seam for delivering cache-event batches to the directory.
 
-    Implementations provide at-least-once delivery and preserve batch
-    order within and across :meth:`publish` calls; the directory's seq
-    dedup, gap detection, and incarnation fencing absorb everything else.
+    Successful calls preserve batch order within and across
+    :meth:`publish` calls. Retrying an uncertain call is safe because the
+    gate deduplicates sequence numbers. Dropping a failed call consumes
+    sequence numbers and exposes a gap; a non-durable source such as HTTP
+    cannot repair it.
     """
 
     @abstractmethod
@@ -63,8 +65,9 @@ class CacheEventSink(ABC):
             batches: The batches to deliver.
 
         Raises:
-            CacheEventPublishError: If delivery failed. Retrying and
-                dropping are both safe (dedup / gap-flagged replay).
+            CacheEventPublishError: If delivery failed. Retrying is safe;
+                dropping may leave the coordinator's view stale. Replay can
+                repair only events already retained by a durable source.
         """
         raise NotImplementedError
 

--- a/lmcache/v1/mp_coordinator/http_apis/dependencies.py
+++ b/lmcache/v1/mp_coordinator/http_apis/dependencies.py
@@ -20,6 +20,7 @@ import httpx
 from lmcache.v1.mp_coordinator.controllers.base import Controller
 from lmcache.v1.mp_coordinator.discovery import Registry
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
+from lmcache.v1.mp_coordinator.ingest.http_event_source import HttpCacheEventSource
 from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
 from lmcache.v1.mp_coordinator.views.base import View
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
@@ -46,8 +47,9 @@ class CoordinatorContext:
             ``InstanceRegistry`` for fleet membership, and
             ``ServerConfigRegistry`` for the declared capacities a usage
             ratio divides by.
-        event_gate: Ingest entry point for the fleet cache-event stream
-            (``POST /events``).
+        event_gate: Admission authority after a source delivers cache events.
+        event_source: HTTP source adapter used by ``POST /events`` before
+            batches reach the gate.
         metadata_persister: Durable store for operator intent. Every
             handler that changes a pin or a quota must ``save`` so the
             change survives a restart.
@@ -57,6 +59,7 @@ class CoordinatorContext:
     token_hasher: TokenHasher
     views: Registry[View]
     event_gate: EventGate
+    event_source: HttpCacheEventSource
     metadata_persister: MetadataPersister
 
 

--- a/lmcache/v1/mp_coordinator/http_apis/events_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/events_api.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Cache-event ingest endpoint on the coordinator (fleet-level).
+"""HTTP cache-event source endpoint on the coordinator (fleet-level).
 
-The ``/events`` surface, thin over the :class:`EventGate`. Top-level
-rather than under ``/directory`` because the stream feeds every consumer
-of it, not one of them. See
+The ``/events`` surface is thin over :class:`HttpCacheEventSource`, which
+passes request-ordered batches through the common ingestor to
+:class:`EventGate`. It is top-level rather than under ``/directory``
+because the stream feeds every consumer of it, not one of them. See
 ``docs/design/v1/mp_coordinator/ingest.md``.
 """
 
@@ -12,7 +13,6 @@ from fastapi import APIRouter, Request
 
 # First Party
 from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
-from lmcache.v1.mp_coordinator.ingest.event_gate import IngestResult
 from lmcache.v1.mp_coordinator.schemas import CacheEventsRequest, CacheEventsResponse
 
 router = APIRouter()
@@ -33,18 +33,14 @@ async def report_cache_events(
 
     Args:
         body: The event batches to ingest.
+        request: The FastAPI request carrying the coordinator context.
 
     Returns:
         Counts of applied and dropped batches.
     """
-    event_gate = get_context(request).event_gate
-    response = CacheEventsResponse()
-    for batch in body.batches:
-        result = event_gate.ingest(batch)
-        if result == IngestResult.ADMITTED:
-            response.applied += 1
-        elif result == IngestResult.DUPLICATE:
-            response.duplicates += 1
-        else:
-            response.stale += 1
-    return response
+    summary = get_context(request).event_source.ingest(body.batches)
+    return CacheEventsResponse(
+        applied=summary.applied,
+        duplicates=summary.duplicates,
+        stale=summary.stale,
+    )

--- a/lmcache/v1/mp_coordinator/ingest/event_gate.py
+++ b/lmcache/v1/mp_coordinator/ingest/event_gate.py
@@ -2,8 +2,9 @@
 """Admission stage of the coordinator's cache-event ingest layer.
 
 Every cache event the coordinator acts on enters through
-:meth:`EventGate.ingest`, which owns the per-emitter stream cursor and
-decides what reaches the consumers holding the state.
+:meth:`EventGate.ingest` or :meth:`EventGate.ingest_batches`, which own
+the per-emitter stream cursor and decide what reaches the consumers
+holding the state.
 
 See ``docs/design/v1/mp_coordinator/ingest.md``.
 """
@@ -35,6 +36,21 @@ class IngestResult(str, Enum):
     ADMITTED = "admitted"
     DUPLICATE = "duplicate"
     STALE_INCARNATION = "stale_incarnation"
+
+
+@dataclass(frozen=True)
+class CacheEventIngestSummary:
+    """Aggregate outcomes from ingesting one ordered list of batches.
+
+    Attributes:
+        applied: Batches admitted and broadcast to consumers.
+        duplicates: Batches dropped because their sequence was already seen.
+        stale: Batches dropped because their incarnation was outdated.
+    """
+
+    applied: int = 0
+    duplicates: int = 0
+    stale: int = 0
 
 
 @dataclass(frozen=True)
@@ -119,6 +135,37 @@ class EventGate:
             cursor.last_seq = batch.seq
             self._broadcaster.broadcast(batch)
             return IngestResult.ADMITTED
+
+    def ingest_batches(self, batches: list[CacheEventBatch]) -> CacheEventIngestSummary:
+        """Offer ``batches`` to the gate in list order.
+
+        Args:
+            batches: Event batches ordered by their source.
+
+        Returns:
+            Counts of admitted, duplicate, and stale batches.
+
+        Raises:
+            RuntimeError: If :meth:`ingest` returns an unknown outcome.
+        """
+        applied = 0
+        duplicates = 0
+        stale = 0
+        for batch in batches:
+            result = self.ingest(batch)
+            if result == IngestResult.ADMITTED:
+                applied += 1
+            elif result == IngestResult.DUPLICATE:
+                duplicates += 1
+            elif result == IngestResult.STALE_INCARNATION:
+                stale += 1
+            else:
+                raise RuntimeError(f"unknown cache-event ingest result: {result!r}")
+        return CacheEventIngestSummary(
+            applied=applied,
+            duplicates=duplicates,
+            stale=stale,
+        )
 
     def drop_instance(self, instance_id: str) -> None:
         """Fence ``instance_id`` and forget its cursor, so a later

--- a/lmcache/v1/mp_coordinator/ingest/event_source.py
+++ b/lmcache/v1/mp_coordinator/ingest/event_source.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-neutral contract for coordinator cache-event sources.
+
+Sources deliver cache-event batches to :class:`EventGate`. The HTTP source
+is the first implementation; a durable source can later use the same gate
+without changing admission or consumers.
+
+See ``docs/design/v1/mp_coordinator/ingest.md``.
+"""
+
+# Standard
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+
+class EventReplayCapability(str, Enum):
+    """Replay capability advertised by a cache-event source."""
+
+    NONE = "none"
+    SEEKABLE = "seekable"
+
+
+@dataclass(frozen=True)
+class CacheEventSourceStatus:
+    """Status shared by cache-event source implementations.
+
+    Attributes:
+        source_name: Human-readable source identity.
+        replay_capability: Whether the source can seek retained events.
+    """
+
+    source_name: str
+    replay_capability: EventReplayCapability
+
+
+class CacheEventSource(Protocol):
+    """Lifecycle and status contract for a cache-event source."""
+
+    async def start(self) -> None:
+        """Start source-owned resources."""
+        ...
+
+    async def stop(self) -> None:
+        """Stop source-owned resources."""
+        ...
+
+    def status(self) -> CacheEventSourceStatus:
+        """Return the source identity and replay capability.
+
+        Returns:
+            The source's current status.
+        """
+        ...

--- a/lmcache/v1/mp_coordinator/ingest/http_event_source.py
+++ b/lmcache/v1/mp_coordinator/ingest/http_event_source.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP push implementation of the coordinator cache-event source."""
+
+# First Party
+from lmcache.v1.mp_coordinator.api import CacheEventBatch
+from lmcache.v1.mp_coordinator.ingest.event_gate import (
+    CacheEventIngestSummary,
+    EventGate,
+)
+from lmcache.v1.mp_coordinator.ingest.event_source import (
+    CacheEventSource,
+    CacheEventSourceStatus,
+    EventReplayCapability,
+)
+
+
+class HttpCacheEventSource(CacheEventSource):
+    """Non-durable HTTP push source for ``POST /events``.
+
+    HTTP owns no background resource and cannot seek or replay. Delivery
+    failures before the coordinator accepts a request therefore remain visible
+    only as sequence gaps at the gate.
+
+    Args:
+        event_gate: Admission authority for pushed event batches.
+    """
+
+    def __init__(self, event_gate: EventGate) -> None:
+        self._event_gate = event_gate
+
+    async def start(self) -> None:
+        """Start the source.
+
+        HTTP requests are served by FastAPI, so this implementation has no
+        source-owned resource to start.
+        """
+
+    async def stop(self) -> None:
+        """Stop the source.
+
+        HTTP requests are served by FastAPI, so this implementation has no
+        source-owned resource to stop.
+        """
+
+    def status(self) -> CacheEventSourceStatus:
+        """Return the HTTP source's non-replayable status.
+
+        Returns:
+            HTTP source identity with replay capability set to ``NONE``.
+        """
+        return CacheEventSourceStatus(
+            source_name="http",
+            replay_capability=EventReplayCapability.NONE,
+        )
+
+    def ingest(self, batches: list[CacheEventBatch]) -> CacheEventIngestSummary:
+        """Deliver one HTTP request's batches to the event gate.
+
+        Args:
+            batches: Event batches in request order.
+
+        Returns:
+            Counts of admitted, duplicate, and stale batches.
+        """
+        return self._event_gate.ingest_batches(batches)

--- a/tests/v1/mp_coordinator/test_event_gate.py
+++ b/tests/v1/mp_coordinator/test_event_gate.py
@@ -85,6 +85,56 @@ def test_gate_with_no_consumers_admits():
     assert _gate().ingest(_batch()) == IngestResult.ADMITTED
 
 
+def test_ingest_batches_forwards_in_source_order():
+    consumer = _RecordingConsumer()
+    gate = _gate(consumer)
+    first = _batch(incarnation=1, seq=1)
+    second = _batch(incarnation=1, seq=2)
+
+    summary = gate.ingest_batches([first, second])
+
+    assert summary.applied == 2
+    assert summary.duplicates == 0
+    assert summary.stale == 0
+    assert consumer.batches == [first, second]
+
+
+def test_ingest_batches_aggregates_outcomes():
+    consumer = _RecordingConsumer()
+    gate = _gate(consumer)
+    current = _batch(incarnation=2, seq=1)
+    fresh = _batch(incarnation=2, seq=2)
+
+    summary = gate.ingest_batches(
+        [
+            current,
+            _batch(incarnation=2, seq=1),
+            _batch(incarnation=1, seq=9),
+            fresh,
+        ]
+    )
+
+    assert summary.applied == 2
+    assert summary.duplicates == 1
+    assert summary.stale == 1
+    assert consumer.batches == [current, fresh]
+
+
+def test_ingest_batches_preserves_incarnation_fencing():
+    consumer = _RecordingConsumer()
+    gate = _gate(consumer)
+
+    summary = gate.ingest_batches(
+        [
+            _batch(incarnation=1, seq=1),
+            _batch(incarnation=2, seq=1),
+        ]
+    )
+
+    assert summary.applied == 2
+    assert consumer.fenced == ["node-a"]
+
+
 # -- Seq handling ------------------------------------------------------------
 
 

--- a/tests/v1/mp_coordinator/test_http_event_source.py
+++ b/tests/v1/mp_coordinator/test_http_event_source.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the coordinator's HTTP cache-event source."""
+
+# Standard
+import asyncio
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
+from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
+from lmcache.v1.mp_coordinator.ingest.event_source import EventReplayCapability
+from lmcache.v1.mp_coordinator.ingest.http_event_source import HttpCacheEventSource
+from lmcache.v1.mp_coordinator.persistence.quiesce import QuiesceLock
+
+
+class _RecordingConsumer:
+    """Consumer that records admitted batches."""
+
+    def __init__(self) -> None:
+        self.batches: list[CacheEventBatch] = []
+
+    def consume(self, batch: CacheEventBatch) -> None:
+        """Record an admitted batch."""
+        self.batches.append(batch)
+
+    def fence_instance(self, instance_id: str) -> None:
+        """Accept an instance fence without storing state."""
+
+
+def _source() -> tuple[HttpCacheEventSource, _RecordingConsumer]:
+    consumer = _RecordingConsumer()
+    broadcaster = CacheEventBroadcaster()
+    broadcaster.register_consumer(consumer)
+    gate = EventGate(broadcaster, QuiesceLock())
+    return HttpCacheEventSource(gate), consumer
+
+
+def _batch() -> CacheEventBatch:
+    key = ObjectKey(chunk_hash=b"hash", model_name="model", kv_rank=0)
+    return CacheEventBatch(
+        instance_id="node-a",
+        incarnation=1,
+        seq=1,
+        event_type=CacheEventType.STORE,
+        tier=Tier.L1,
+        backend="dram",
+        entries=[CacheEventEntry(key=key.to_encoded_object_key(), size_bytes=1024)],
+    )
+
+
+def test_http_source_delegates_to_event_gate() -> None:
+    source, consumer = _source()
+    batch = _batch()
+
+    summary = source.ingest([batch])
+
+    assert summary.applied == 1
+    assert summary.duplicates == 0
+    assert summary.stale == 0
+    assert consumer.batches == [batch]
+
+
+def test_http_source_reports_no_replay_capability() -> None:
+    source, _ = _source()
+
+    asyncio.run(source.start())
+    status = source.status()
+    asyncio.run(source.stop())
+
+    assert status.source_name == "http"
+    assert status.replay_capability == EventReplayCapability.NONE

--- a/tests/v1/mp_coordinator/test_integration.py
+++ b/tests/v1/mp_coordinator/test_integration.py
@@ -2,20 +2,29 @@
 """End-to-end test: a real uvicorn-served coordinator driven over HTTP.
 
 Exercises the REST API against a live server (real lifespan + sockets) the way
-an mp server will: register, heartbeat, deregister, with health-check eviction.
+an mp server will: membership, health-check eviction, and cache-event ingestion.
 """
 
 # Standard
+from dataclasses import asdict
 import socket as _socket
 import threading
 import time
 
 # Third Party
+from fastapi import FastAPI
 import requests
 import uvicorn
 
 # First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
 from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.cache_events import HttpCacheEventSink
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 
 
@@ -54,23 +63,54 @@ def _wait_until_instances_empty(base_url: str, timeout: float = 3.0) -> bool:
     return False
 
 
-def _serve(config: MPCoordinatorConfig):
-    """Start the coordinator in a background thread; return (server, thread)."""
+def _serve(
+    config: MPCoordinatorConfig,
+) -> tuple[uvicorn.Server, threading.Thread, FastAPI]:
+    """Start the coordinator in a background thread.
+
+    Args:
+        config: Coordinator configuration.
+
+    Returns:
+        The uvicorn server, its thread, and the served FastAPI app.
+    """
+    app = create_app(config)
     server = uvicorn.Server(
-        uvicorn.Config(
-            create_app(config), host=config.host, port=config.port, log_level="warning"
-        )
+        uvicorn.Config(app, host=config.host, port=config.port, log_level="warning")
     )
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
-    return server, thread
+    return server, thread, app
+
+
+def _key(hash_byte: int) -> ObjectKey:
+    """Build one integration-test object key."""
+    return ObjectKey(
+        chunk_hash=bytes([hash_byte]) * 4,
+        model_name="integration-model",
+        kv_rank=0,
+    )
+
+
+def _cache_event_batch(seq: int, hash_byte: int) -> CacheEventBatch:
+    """Build one L2 store batch for the real HTTP source."""
+    key = _key(hash_byte)
+    return CacheEventBatch(
+        instance_id="event-source-node",
+        incarnation=1,
+        seq=seq,
+        event_type=CacheEventType.STORE,
+        tier=Tier.L2,
+        backend="fs",
+        entries=[CacheEventEntry(key=key.to_encoded_object_key(), size_bytes=128)],
+    )
 
 
 def test_register_heartbeat_deregister_over_real_http():
     port = _free_port()
     base = f"http://127.0.0.1:{port}"
     config = MPCoordinatorConfig(host="127.0.0.1", port=port, health_check_interval=0.0)
-    server, thread = _serve(config)
+    server, thread, _ = _serve(config)
     try:
         _wait_until_up(base)
         body = {"instance_id": "i1", "ip": "127.0.0.1", "http_port": 9999}
@@ -101,7 +141,7 @@ def test_health_loop_evicts_stale_instance():
         instance_timeout=0.6,
         health_check_interval=0.2,
     )
-    server, thread = _serve(config)
+    server, thread, _ = _serve(config)
     try:
         _wait_until_up(base)
         body = {"instance_id": "ghost", "ip": "127.0.0.1", "http_port": 9999}
@@ -110,6 +150,68 @@ def test_health_loop_evicts_stale_instance():
 
         # Never heartbeat -> the health loop evicts it within a couple seconds.
         assert _wait_until_instances_empty(base, timeout=3.0)
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+
+
+def test_http_event_source_round_trip_over_real_http() -> None:
+    port = _free_port()
+    base = f"http://127.0.0.1:{port}"
+    config = MPCoordinatorConfig(
+        host="127.0.0.1",
+        port=port,
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+    )
+    server, thread, app = _serve(config)
+    try:
+        _wait_until_up(base)
+        sink = HttpCacheEventSink(base)
+        try:
+            sink.publish([_cache_event_batch(seq=1, hash_byte=1)])
+        finally:
+            sink.close()
+
+        response = requests.post(
+            f"{base}/directory/lookup",
+            json={"keys": [asdict(_key(1).to_encoded_object_key())]},
+            timeout=2,
+        )
+        response.raise_for_status()
+        [placement] = response.json()["results"][0]["placements"]
+        assert placement["instance_id"] == "event-source-node"
+        assert placement["tier"] == "l2"
+        assert app.state.ctx.event_source.status().source_name == "http"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+
+
+def test_http_event_source_marks_real_sequence_gap() -> None:
+    port = _free_port()
+    base = f"http://127.0.0.1:{port}"
+    config = MPCoordinatorConfig(
+        host="127.0.0.1",
+        port=port,
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+    )
+    server, thread, app = _serve(config)
+    try:
+        _wait_until_up(base)
+        sink = HttpCacheEventSink(base)
+        try:
+            sink.publish([_cache_event_batch(seq=1, hash_byte=1)])
+            sink.publish([_cache_event_batch(seq=3, hash_byte=3)])
+        finally:
+            sink.close()
+
+        stream = app.state.ctx.event_gate.stats()["event-source-node"]
+        assert stream.last_seq == 3
+        assert stream.gap_detected is True
+        [placements] = app.state.ctx.key_directory.lookup([_key(3)])
+        assert len(placements) == 1
     finally:
         server.should_exit = True
         thread.join(timeout=5.0)

--- a/tests/v1/mp_coordinator/test_integration.py
+++ b/tests/v1/mp_coordinator/test_integration.py
@@ -210,8 +210,13 @@ def test_http_event_source_marks_real_sequence_gap() -> None:
         stream = app.state.ctx.event_gate.stats()["event-source-node"]
         assert stream.last_seq == 3
         assert stream.gap_detected is True
-        [placements] = app.state.ctx.key_directory.lookup([_key(3)])
-        assert len(placements) == 1
+        response = requests.post(
+            f"{base}/directory/lookup",
+            json={"keys": [asdict(_key(3).to_encoded_object_key())]},
+            timeout=2,
+        )
+        response.raise_for_status()
+        assert len(response.json()["results"][0]["placements"]) == 1
     finally:
         server.should_exit = True
         thread.join(timeout=5.0)


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a transport-neutral cache-event source seam for the MP coordinator so the current HTTP path and future replayable transports share the same admission path.

- Adds a common cache-event ingestor above `EventGate` and a lifecycle/status source contract.
- Models `POST /events` as an explicitly non-durable HTTP source without changing its wire behavior.
- Clarifies that HTTP sequence gaps are detectable but not replayable, and that producer-side loss needs separate retry/spooling.
- Refs #4226 and #4522.

**Special notes for your reviewers**:

- This intentionally does not add Kafka/MQ, snapshot positions, readiness gating, configuration, or endpoint changes.
- Pre-commit hooks passed, including mypy, Ruff, isort, and codespell.
- All 290 MP coordinator tests passed, including real-uvicorn HTTP round-trip and sequence-gap integration tests.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
