### PR TITLE
fix(token_database): return after the degenerate-case yield in SegmentTokenDatabase

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -472,6 +472,7 @@ class SegmentTokenDatabase(TokenDatabase):
 
         if self.sep_len == 0 or len(tokens) < self.sep_len:
             yield tokens
+            return
 
         # Unfold into sliding windows
         # shape: (num_tokens-sep_len+1, sep_len)

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -155,3 +155,39 @@ def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:
         assert isinstance(hash_val, int), f"Expected int, got {type(hash_val)}"
         # Must fit in uint64 (msgpack range: 0 to 2**64 - 1)
         assert 0 <= hash_val <= 2**64 - 1
+
+
+def test_fast_split_shorter_than_separator():
+    """A sequence shorter than the separator is one whole chunk, not a crash.
+
+    Regression for the missing ``return`` in the degenerate-case guard of
+    ``SegmentTokenDatabase._fast_split_by_subtensor``: the guard yielded the
+    whole tensor but then fell through to ``tokens.unfold(0, sep_len, 1)``,
+    which raises ``RuntimeError`` when ``len(tokens) < sep_len``.
+    """
+    db = object.__new__(SegmentTokenDatabase)
+    db.sep_tokens = torch.tensor([100, 200, 300], device="cpu")
+    db.sep_len = 3
+
+    tokens = torch.tensor([1, 2], device="cpu")
+    chunks = list(db._fast_split_by_subtensor(tokens))
+
+    assert len(chunks) == 1
+    assert torch.equal(chunks[0], tokens)
+
+
+def test_fast_split_empty_separator():
+    """An empty separator yields the whole sequence unchanged.
+
+    With ``sep_len == 0`` the fall-through produced spurious empty and
+    single-token chunks; the guard must short-circuit instead.
+    """
+    db = object.__new__(SegmentTokenDatabase)
+    db.sep_tokens = torch.tensor([], dtype=torch.long, device="cpu")
+    db.sep_len = 0
+
+    tokens = torch.tensor([1, 2, 3, 4], device="cpu")
+    chunks = list(db._fast_split_by_subtensor(tokens))
+
+    assert len(chunks) == 1
+    assert torch.equal(chunks[0], tokens)


### PR DESCRIPTION
## What this PR does / why we need it

`SegmentTokenDatabase._fast_split_by_subtensor` is a generator. Its guard for
the degenerate cases — an empty separator (`sep_len == 0`) or a sequence
shorter than the separator (`len(tokens) < sep_len`) — yields the whole tensor
but is missing a `return`, so execution falls through into the sliding-window
path:

```python
if self.sep_len == 0 or len(tokens) < self.sep_len:
    yield tokens          # <-- no return

windows = tokens.unfold(0, self.sep_len, 1)
...
```

Consequences of the fall-through:

- **`len(tokens) < sep_len`** → `tokens.unfold(0, sep_len, 1)` raises
  `RuntimeError: maximum size for tensor at dimension 0 is N but size is M`.
- **`sep_len == 0`** → the whole tensor is yielded once and then the code also
  emits a stream of spurious empty and single-token chunks
  (e.g. `[1,2,3,4]` → `[[1,2,3,4], [], [1], [2], [3], [4], []]`).

This path is reachable whenever blending is enabled (`config.enable_blending`
selects `SegmentTokenDatabase`, `cache_engine.py`).

## Fix

Add an explicit `return` after the degenerate-case `yield`, so those inputs
produce exactly one chunk (the whole sequence). The normal separator-matching
path is untouched.

## Tests

Two regression tests that construct the object with `object.__new__` (no
tokenizer/HF download needed) and exercise both degenerate branches:

- `test_fast_split_shorter_than_separator` — was `RuntimeError`, now one chunk.
- `test_fast_split_empty_separator` — was 7 spurious chunks, now one chunk.

Both fail on `dev` and pass with this change; the existing separator-matching
behavior is unchanged.

Fixes #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
