### PR TITLE
fix(local_disk): release reserved disk space on external removals (#4546)

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -274,6 +274,13 @@ class LocalDiskBackend(StorageBackendInterface):
             os.remove(path)
 
             if force:
+                # The internal eviction loop in `submit_put_task` already
+                # deducts the chunk before calling `batched_remove(...,
+                # force=False)`; every other caller reaches us with the default
+                # `force=True` and must release the reservation here, otherwise
+                # `current_cache_size` only ever grows and the capacity gate in
+                # `submit_put_task` eventually rejects every put.
+                self.current_cache_size -= size
                 self.cache_policy.update_on_force_evict(key)
 
         # Push kv evict msg with batching

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -609,3 +609,97 @@ class TestBatchedGetBlocking:
         results = local_disk_backend.batched_get_blocking([])
         assert results == []
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestDiskSpaceAccounting:
+    """Tests for the `current_cache_size` reservation counter."""
+
+    _SHAPE = torch.Size([28, 2, 256, 8, 128])
+    _DTYPE = torch.bfloat16
+    _CHUNK = 1024 * 1024
+
+    def _admit(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+        size: int,
+    ) -> None:
+        """Register *key* the way an accepted put does.
+
+        `submit_put_task` reserves `size` against the disk budget, then the
+        completed write bumps `usage` and registers the chunk via `insert_key`.
+        """
+        backend.current_cache_size += size
+        backend.cache_policy.update_on_put(key)
+        path = backend._key_to_path(key)
+        with open(path, "wb") as f:
+            f.write(b"\0")
+        backend.usage += size
+        backend.insert_key(
+            key,
+            size=size,
+            shape=self._SHAPE,
+            dtype=self._DTYPE,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+
+    def test_force_remove_releases_the_reservation(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A remove that did not come from the eviction loop frees its space."""
+        keys = [create_test_key(i) for i in range(300, 304)]
+        for key in keys:
+            self._admit(local_disk_backend, key, self._CHUNK)
+        assert local_disk_backend.current_cache_size == len(keys) * self._CHUNK
+
+        # StorageManager.remove / batched_remove both default to force=True.
+        assert local_disk_backend.batched_remove(keys) == len(keys)
+
+        assert local_disk_backend.dict == {}
+        assert local_disk_backend.usage == 0
+        assert local_disk_backend.current_cache_size == 0
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_eviction_loop_removal_is_not_double_counted(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """force=False means the caller already deducted; don't deduct twice."""
+        key = create_test_key(310)
+        self._admit(local_disk_backend, key, self._CHUNK)
+
+        # Replay what the eviction loop in submit_put_task does: deduct the
+        # chunk itself, then remove it with force=False.
+        local_disk_backend.current_cache_size -= local_disk_backend.dict[key].size
+        assert local_disk_backend.batched_remove([key], force=False) == 1
+
+        assert local_disk_backend.current_cache_size == 0
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_puts_are_still_accepted_after_external_removes(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """The capacity gate must not lock an empty disk out of new puts."""
+        local_disk_backend.max_cache_size = 4 * self._CHUNK
+
+        for cycle in range(3):
+            keys = [create_test_key(320 + cycle * 10 + i) for i in range(4)]
+            for key in keys:
+                self._admit(local_disk_backend, key, self._CHUNK)
+            local_disk_backend.batched_remove(keys)
+
+        assert local_disk_backend.dict == {}
+
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.get_physical_size.return_value = self._CHUNK
+        with patch.object(local_disk_backend.disk_worker, "submit_task"):
+            with patch(
+                "lmcache.v1.storage_backend.local_disk_backend"
+                ".asyncio.run_coroutine_threadsafe"
+            ):
+                local_disk_backend.submit_put_task(create_test_key(399), memory_obj)
+
+        assert local_disk_backend.current_cache_size == self._CHUNK
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4546.

`LocalDiskBackend` gates every put on `self.current_cache_size`, but only its
*internal* eviction loop ever decrements that counter. `remove()` shrinks
`self.usage`, drops the entry from `self.dict` and unlinks the file — and
leaves `current_cache_size` untouched:

```python
self.usage -= size
self.stats_monitor.update_local_storage_usage(self.usage)
os.remove(path)
if force:
    self.cache_policy.update_on_force_evict(key)     # <- no size release
```

The eviction loop in `submit_put_task` gets away with this because it deducts
the chunk itself before calling `self.batched_remove(evict_keys, force=False)`.
Every removal that originates *outside* the backend uses the default
`force=True` and is never accounted for — `StorageManager.remove` /
`batched_remove` are called with the default by `LMCacheEngine.clear()`,
`move()`, `compress()` / `decompress()`, and the remove-after-retrieve path in
the PD-disaggregation receiver role.

The drift is monotonic and never recovers within the process lifetime. Once the
phantom usage exceeds `max_local_disk_size`, the `while self.current_cache_size
+ required_size > self.max_cache_size` gate finds nothing left to evict
(`self.dict` is genuinely empty), so `submit_put_task` returns `None` and
**every subsequent disk put is silently dropped on an empty disk**.

The fix releases the reservation in the existing `if force:` branch — precisely
the set of callers the eviction loop has *not* already accounted for — so the
internal eviction path is bit-for-bit unchanged and cannot double-deduct.

**Special notes for your reviewers**:

I can't run this repo's suite locally (no CUDA host), so I verified the change
by extracting the real `LocalDiskBackend.remove` / `submit_put_task` and
`StorageBackendInterface.batched_remove` from the source with `ast` and
executing them verbatim against stub collaborators, before and after the patch.
Budget 10 MiB, chunks 2 MiB:

| scenario | `dev` (e8f9381) | with this PR |
|---|---|---|
| 5 puts, then `batched_remove(keys)` (force=True) | `dict` 0, `usage` 0 MiB, **reserved 10 MiB** | `dict` 0, `usage` 0 MiB, **reserved 0 MiB** |
| eviction loop evicts `a` to admit `c` | `dict` `['b','c']`, reserved 4 MiB | `dict` `['b','c']`, reserved 4 MiB *(identical)* |
| 10 × (fill, then clear), then one more put | **put rejected**, reserved 10 MiB | put accepted, reserved 2 MiB |

The middle row is the regression guard: the `force=False` path produces
byte-identical numbers, so the eviction loop's existing deduction is not
doubled.

The three added tests cover the same three cases against the real backend via
the existing `local_disk_backend` fixture. `ruff check` and `ruff format`
(v0.11.7, the pinned pre-commit rev) are clean on both changed files.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
