### PR TITLE
fix: correct log and raise calls that drop their message at runtime (#4539)

### DIFF
--- a/lmcache/v1/storage_backend/connector/mock_adapter.py
+++ b/lmcache/v1/storage_backend/connector/mock_adapter.py
@@ -36,8 +36,8 @@ class MockConnectorAdapter(ConnectorAdapter):
             capacity_gb = int(parsed.netloc)
         except ValueError as e:
             raise ValueError(
-                f"Invalid capacity '{parsed.netloc}' for",
-                " mock connector; must be an integer (GB).",
+                f"Invalid capacity '{parsed.netloc}' for"
+                " mock connector; must be an integer (GB)."
             ) from e
 
         params = parse_qs(parsed.query) if parsed.query else {}

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -264,8 +264,9 @@ class MockConnector(RemoteConnector):
         for i, mock_obj in enumerate(mock_objs):
             if mock_obj is None:
                 logger.warning(
-                    f"Mock object is None on {i}",
-                    f" out of {len(mock_objs)} objects",
+                    "Mock object is None on %d out of %d objects",
+                    i,
+                    len(mock_objs),
                 )
                 break
             metadata = mock_obj.metadata
@@ -276,8 +277,10 @@ class MockConnector(RemoteConnector):
             )
             if memory_obj is None:
                 logger.warning(
-                    "Failed to allocate memory even with",
-                    f" busy loop on {i} out of {len(mock_objs)} objects",
+                    "Failed to allocate memory even with busy loop on %d out of "
+                    "%d objects",
+                    i,
+                    len(mock_objs),
                 )
                 break
             memory_objs.append(memory_obj)

--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -78,8 +78,8 @@ class AsyncLRU:
             alloc_size = mock_obj.num_bytes
             if alloc_size > self.capacity:
                 raise ValueError(
-                    f"Allocation size {alloc_size} is",
-                    " greater than capacity {self.capacity}",
+                    f"Allocation size {alloc_size} is"
+                    f" greater than capacity {self.capacity}"
                 )
             if key in self.dict:
                 self.dict.move_to_end(key)

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -152,7 +152,9 @@ class PeerInfo:
         try:
             self.lookup_socket.close(linger=0)
         except Exception as e:
-            logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
+            logger.error(
+                "Failed to close peer %s lookup socket: %s", self.peer_init_url, e
+            )
         self.lookup_socket = new_lookup_socket
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ select = [
     #"G",
     # flake8-self (private member access)
     "SLF",
+    # pylint: logging format string arg count (too many / too few args)
+    "PLE1205",
+    "PLE1206",
 ]
 ignore = [
     # star imports

--- a/tests/v1/distributed/test_mock_connector_logging.py
+++ b/tests/v1/distributed/test_mock_connector_logging.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import asyncio
+import logging
+
+# First Party
+from lmcache.v1.storage_backend.connector import mock_connector
+from lmcache.v1.storage_backend.connector.mock_connector import MockConnector
+
+
+class _RecordingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class _FakeLRU:
+    def __init__(self, objs):
+        self._objs = objs
+
+    async def batched_get(self, keys):
+        return self._objs
+
+
+class _FakePressureManager:
+    async def on_batched_get(self, mock_objs):
+        return None
+
+
+def test_batched_get_missing_object_logs_render():
+    """Regression for #4539 case 2.
+
+    ``_batched_get`` warned with ``logger.warning(f"...{i}", f" ...{n}")``. The
+    stray comma turned the message tail into a positional arg, so rendering the
+    record as ``msg % args`` raised ``TypeError`` inside the logging machinery
+    and the intended message was dropped. Ruff PLE1205/PLE1206 cannot see
+    through the f-string here, so guard the format string with a test that
+    renders every emitted record.
+    """
+    handler = _RecordingHandler()
+    logger = mock_connector.logger
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        conn = MockConnector.__new__(MockConnector)
+        conn.lru_store = _FakeLRU([None])
+        conn.pressure_manager = _FakePressureManager()
+
+        result = asyncio.run(conn._batched_get(["dummy-key"]))
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+    assert result == []
+    # getMessage() would raise TypeError before the fix; it must render cleanly.
+    messages = [record.getMessage() for record in handler.records]
+    assert "Mock object is None on 0 out of 1 objects" in messages


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #4539.

Three `logger.*` calls pass more positional arguments than their format string consumes. `logging` renders a record lazily as `msg % args`, so each raises `TypeError: not all arguments converted during string formatting` **inside** the logging machinery. Python's logging swallows that and prints a `--- Logging error ---` traceback to stderr instead — **the intended message is never emitted**. All three sit on failure paths, which is exactly where losing the message hurts most.

**1. `lmcache/v1/storage_backend/p2p_backend.py`** — one `%s` placeholder, two args. The caught exception `e` had no placeholder and was silently dropped:

```python
-logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
+logger.error(
+    "Failed to close peer %s lookup socket: %s", self.peer_init_url, e
+)
```

**2 & 3. `lmcache/v1/storage_backend/connector/mock_connector.py`** — a stray comma where implicit string concatenation was intended. This truncated the message and turned its tail into an argument. Both rewritten as `%`-format.

## Preventing regressions

`PLE1205` / `PLE1206` (logging too-many / too-few args) were not in the ruff `select` list. Enabling **only** those two rules reports **exactly the two statically-visible cases and nothing else repo-wide**, so they turn on with no extra cleanup:

```
$ ruff check --select PLE1205,PLE1206 .
All checks passed!     # after this PR; 2 errors before it
```

Ruff cannot see through the f-string in the second `mock_connector.py` case, so a small regression test (`tests/v1/distributed/test_mock_connector_logging.py`) renders every emitted record and asserts the message survives — `record.getMessage()` raises `TypeError` before the fix.

`G` (flake8-logging-format) is deliberately left commented out; it reports hundreds of findings from the f-string logging still being migrated, and is out of scope here.

## Verification

- `ruff check --select PLE1205,PLE1206 .` → clean (pinned ruff 0.11.7).
- `ruff format --check` → clean.
- Extracted the real `_batched_get` (old vs new) and drove it against fakes: the old version's `getMessage()` raises `TypeError` (message dropped); the new version renders `Mock object is None on 0 out of 1 objects`.

---

## Update: two `raise` sites with the same defect

While confirming the ruff rules cover the file, two `ValueError` raises turned up with the
identical comma-instead-of-concatenation mistake. `PLE1205`/`PLE1206` only inspect logging
calls, so neither rule catches them:

`lmcache/v1/storage_backend/connector/mock_adapter.py`

```python
raise ValueError(
    f"Invalid capacity '{parsed.netloc}' for",
    " mock connector; must be an integer (GB).",
) from e
```

`lmcache/v1/storage_backend/connector/mock_connector.py` (`AsyncLRU.put`)

```python
raise ValueError(
    f"Allocation size {alloc_size} is",
    " greater than capacity {self.capacity}",
)
```

The comma makes each half a separate exception argument, so the rendered message is a tuple
repr; the second half of the `AsyncLRU.put` message is also missing its `f` prefix, so the
capacity is never interpolated:

```
before  ('Allocation size 5 is', ' greater than capacity {self.capacity}')
after   Allocation size 5 is greater than capacity 3
```

Both are fixed by dropping the comma (and adding the missing `f`), which is a pure message
change. `ruff check` and `ruff format --check` stay clean on both files with the pinned
0.11.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

