### PR TITLE
fix(logging): pass the arguments these log calls actually render (#4539)

### DIFF
--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -264,8 +264,9 @@ class MockConnector(RemoteConnector):
         for i, mock_obj in enumerate(mock_objs):
             if mock_obj is None:
                 logger.warning(
-                    f"Mock object is None on {i}",
-                    f" out of {len(mock_objs)} objects",
+                    "Mock object is None on %d out of %d objects",
+                    i,
+                    len(mock_objs),
                 )
                 break
             metadata = mock_obj.metadata
@@ -276,8 +277,10 @@ class MockConnector(RemoteConnector):
             )
             if memory_obj is None:
                 logger.warning(
-                    "Failed to allocate memory even with",
-                    f" busy loop on {i} out of {len(mock_objs)} objects",
+                    "Failed to allocate memory even with busy loop on %d out of "
+                    "%d objects",
+                    i,
+                    len(mock_objs),
                 )
                 break
             memory_objs.append(memory_obj)

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -152,7 +152,9 @@ class PeerInfo:
         try:
             self.lookup_socket.close(linger=0)
         except Exception as e:
-            logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
+            logger.error(
+                "Failed to close peer %s lookup socket: %s", self.peer_init_url, e
+            )
         self.lookup_socket = new_lookup_socket
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ select = [
     # "I",
     # flake8-logging-format
     #"G",
+    # Pylint: logging call passes too many / too few arguments for its
+    # format string, which makes logging drop the message at runtime.
+    "PLE1205", "PLE1206",
     # flake8-self (private member access)
     "SLF",
 ]

--- a/tests/test_logging_format.py
+++ b/tests/test_logging_format.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guard logging calls against passing more arguments than they can render.
+
+``logging`` formats a record lazily as ``msg % args``.  A call that passes more
+positional arguments than its format string consumes raises ``TypeError``
+*inside* the logging machinery; logging swallows that and prints
+``--- Logging error ---`` to stderr, so the intended message is never emitted.
+
+``PLE1205``/``PLE1206`` are enabled in ``pyproject.toml`` and cover plain string
+literals, but ruff cannot count placeholders inside an f-string.  This test
+walks the AST so the f-string variant -- a stray comma where implicit string
+concatenation was intended -- stays covered as well.
+"""
+
+# Standard
+from pathlib import Path
+from typing import List, Optional
+import ast
+import re
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "lmcache"
+
+# Mirrors the `exclude` list in [tool.ruff] of pyproject.toml.
+EXCLUDED = ("lmcache_mp_connector_",)
+
+LOGGER_NAMES = frozenset({"logger", "log", "logging", "self"})
+LOG_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "exception", "critical"}
+)
+
+# A `%`-style conversion specifier, e.g. `%s`, `%-5.2f`, `%%`.
+CONVERSION = re.compile(r"%[-#0 +]*(?:\*|\d+)?(?:\.(?:\*|\d+))?[hlL]?([a-zA-Z%])")
+
+
+def _literal_text(node: ast.expr) -> Optional[str]:
+    """Return the literal text of a string node, or None if it is not one.
+
+    Args:
+        node: The AST node holding the logging call's message argument.
+
+    Returns:
+        The concatenation of the node's literal string parts, with the
+        interpolated slots of an f-string omitted (they contribute no `%`
+        conversions), or None when the node is not a string literal at all --
+        for example a name, a call, or a `"..." % value` expression whose
+        argument count cannot be checked statically.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+        return "".join(parts)
+    return None
+
+
+def _placeholder_count(text: str) -> Optional[int]:
+    """Count the arguments a `%`-style format string consumes.
+
+    Args:
+        text: The literal text of the message argument.
+
+    Returns:
+        The number of positional arguments the string consumes, or None when
+        the string uses mapping keys (`%(name)s`) or a `*` width, since those
+        consume a single mapping or a variable number of arguments.
+    """
+    if "%(" in text or "%*" in text:
+        return None
+    count = 0
+    for match in CONVERSION.finditer(text):
+        if match.group(1) == "%":
+            continue
+        count += 1
+    return count
+
+
+def _violations(tree: ast.Module) -> List[str]:
+    """Collect logging calls whose argument count cannot render.
+
+    Args:
+        tree: The parsed module to inspect.
+
+    Returns:
+        A list of human-readable descriptions, one per offending call.
+    """
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in LOG_METHODS:
+            continue
+        root = func.value
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        if not isinstance(root, ast.Name) or root.id not in LOGGER_NAMES:
+            continue
+        if not node.args or any(isinstance(a, ast.Starred) for a in node.args):
+            continue
+        text = _literal_text(node.args[0])
+        if text is None:
+            continue
+        expected = _placeholder_count(text)
+        if expected is None:
+            continue
+        supplied = len(node.args) - 1
+        if supplied != expected:
+            found.append(
+                f"line {node.lineno}: {func.attr}() consumes {expected} "
+                f"argument(s) but {supplied} were passed"
+            )
+    return found
+
+
+def _source_files() -> List[Path]:
+    """Return the package sources this guard applies to.
+
+    Returns:
+        Every `.py` file under `lmcache/`, minus the paths excluded from ruff.
+    """
+    return sorted(
+        path
+        for path in PACKAGE_ROOT.rglob("*.py")
+        if not any(marker in path.name for marker in EXCLUDED)
+    )
+
+
+def test_logging_arguments_match_format_string():
+    """Every logging call must pass exactly as many arguments as it renders."""
+    reported = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = path.relative_to(PACKAGE_ROOT.parent)
+        reported.extend(f"{rel}:{entry}" for entry in _violations(tree))
+    assert not reported, "logging calls that drop their message:\n  " + "\n  ".join(
+        reported
+    )
+
+
+def test_guard_detects_a_stray_comma_in_an_f_string_call():
+    """The guard catches the f-string variant ruff's PLE1205 cannot see."""
+    tree = ast.parse(
+        "logger.warning(\n"
+        '    f"Mock object is None on {i}",\n'
+        '    f" out of {len(mock_objs)} objects",\n'
+        ")\n"
+    )
+    assert len(_violations(tree)) == 1
+
+
+def test_guard_accepts_a_well_formed_call():
+    """A message whose placeholders match its arguments is not reported."""
+    tree = ast.parse('logger.error("closing %s failed: %s", url, exc)')
+    assert _violations(tree) == []


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4539

Three `logger.*` calls in `lmcache/` pass more positional arguments than their format string consumes. `logging` renders a record lazily as `msg % args`, so each of these raises `TypeError: not all arguments converted during string formatting` *inside* the logging machinery. Python's logging catches that and prints `--- Logging error ---` plus a traceback to stderr instead — **the intended message is never emitted**. All three sit on failure paths, which is exactly where losing the message hurts most.

**1. `lmcache/v1/storage_backend/p2p_backend.py:155`** — two arguments, one placeholder, so the caught exception was silently dropped:

```python
except Exception as e:
    logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
```

The exception is now rendered by its own placeholder.

**2 & 3. `lmcache/v1/storage_backend/connector/mock_connector.py:266,278`** — a stray comma where implicit string concatenation was intended, so each message was truncated and its tail silently became an argument:

```python
logger.warning(
    f"Mock object is None on {i}",
    f" out of {len(mock_objs)} objects",
)
```

Both are rejoined into one message and converted to `%`-format, matching the deferred-formatting convention the repo is migrating to.

**Special notes for your reviewers**:

Two layers guard against a regression:

- **`PLE1205`/`PLE1206` added to `[tool.ruff.lint] select`.** These were not previously selected. With them enabled, `ruff check .` (v0.11.7, the `.pre-commit-config.yaml` pin) is clean repo-wide — the only two findings were the plain-string cases fixed here, so no additional cleanup rides along. The full `G` ruleset stays out of scope: it still reports ~500 findings from the f-string logging migration that is in progress.

- **`tests/test_logging_format.py`.** Ruff cannot count placeholders inside an f-string, so case 2 above is invisible to `PLE1205`. A small AST walk over `lmcache/` compares each logging call's placeholder count against its positional-argument count, which covers the f-string variant too. Two unit tests pin the guard itself (it flags the stray-comma shape, and leaves a well-formed call alone).

Verified against the tree at `e8f9381`:

| | `test_logging_arguments_match_format_string` |
|---|---|
| before the source fix | **FAILS** — reports all 3 call sites, including the 2 f-string ones ruff misses |
| after the source fix | **PASSES** |

`ruff check`, `ruff format --diff` and `isort --diff` are clean on all four files.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
