### PR TITLE
fix(cache-simulator): correct percentile calculation

### DIFF
--- a/lmcache/tools/cache_simulator/simulator.py
+++ b/lmcache/tools/cache_simulator/simulator.py
@@ -328,8 +328,8 @@ def _percentiles(values: list[float], pcts: list[int]) -> dict[str, float]:
     n = len(s)
     result = {}
     for p in pcts:
-        idx = min(int(p / 100 * n), n - 1)
-        result[f"p{p}"] = s[idx]
+        rank = math.ceil(p * n / 100.0)
+        result[f"p{p}"] = s[max(rank, 1) - 1]
     return result
 
 

--- a/tests/tools/test_cache_simulator.py
+++ b/tests/tools/test_cache_simulator.py
@@ -12,10 +12,12 @@ import pytest
 # First Party
 from lmcache.tools.cache_simulator.lru_cache import LRUCache, LRUCacheFast
 from lmcache.tools.cache_simulator.simulator import (
+    _percentiles,
     compute_kv_bytes_per_chunk,
     load_lookup_events,
     simulate,
 )
+
 
 # ---------------------------------------------------------------------------
 # LRUCacheFast
@@ -330,3 +332,33 @@ class TestSimulate:
     def test_invalid_kv_bytes_raises(self):
         with pytest.raises(ValueError):
             simulate([], cache_capacity_bytes=100, kv_bytes_per_chunk=0)
+
+
+def test_percentiles_whole_rank():
+    values = [float(i) for i in range(1, 101)]
+
+    result = _percentiles(values, [25, 50, 75, 90, 99])
+
+    assert result == {
+        "p25": 25.0,
+        "p50": 50.0,
+        "p75": 75.0,
+        "p90": 90.0,
+        "p99": 99.0,
+    }
+
+
+def test_percentiles_fractional_rank():
+    values = [float(i) for i in range(1, 11)]
+
+    result = _percentiles(values, [25])
+
+    assert result == {"p25": 3.0}
+
+
+def test_percentiles_avoids_floating_point_rank_error():
+    values = [float(i) for i in range(1, 101)]
+
+    result = _percentiles(values, [7])
+
+    assert result == {"p7": 7.0}


### PR DESCRIPTION
## Summary

Fix the cache simulator percentile calculation to use 1-based nearest-rank semantics correctly before indexing the sorted 0-based sample list.

The calculation now uses `math.ceil(p * n / 100.0)` and subtracts one when indexing. Multiplication is performed before division to avoid floating-point rounding turning an exact whole rank into the next rank.

Adds regression coverage for:
- whole-rank percentiles
- fractional ranks
- the floating-point inexact-division case

Fixes #4440

## Validation

- `python -m pytest tests/tools/test_cache_simulator.py -k percentiles -v --confcutdir=tests/tools` — 3 passed
- `python -m pytest tests/tools/test_cache_simulator.py -q --confcutdir=tests/tools` — 29 passed
- `python -m ruff check lmcache/tools/cache_simulator/simulator.py tests/tools/test_cache_simulator.py` — all checks passed
- `python -m ruff format --check lmcache/tools/cache_simulator/simulator.py tests/tools/test_cache_simulator.py` — both files already formatted
- Full `tests/tools/test_cache_simulator.py` run on Windows: 25 passed, 4 existing `TestLoadLookupEvents` tests fail because they hard-code `/tmp`, which resolves to missing `C:\tmp` on Windows. The percentile tests all pass.
- [AMD Buildkite #11203](https://buildkite.com/lmcache/unit-tests-amd/builds/11203) fails in `tests/v1/gpu_connector/test_kv_format_classification.py::test_classification_matches_golden`. This is the known, branch-independent AMD CI failure tracked in #4572; this PR does not touch GPU connector or native format-classification code.