### PR TITLE
feat(kv_format): declarative KV layout descriptor with EngineKVFormat bijection (RFC #3560, step 1)

### DIFF
--- a/lmcache/v1/gpu_connector/kv_format/descriptor.py
+++ b/lmcache/v1/gpu_connector/kv_format/descriptor.py
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Declarative KV-cache layout descriptor (RFC #3560, step 1).
+
+A :class:`KVLayoutDescriptor` states a physical KV-cache layout as data: an
+ordered partition of the logical axes (``KV``, ``L``, ``B``, ``N``, ``H``,
+``C``) into physical tensor dimensions, plus the list grouping, the K/V packing
+mode, dtypes, sparse per-dim stride overrides, and an optional quantization
+spec. Everything the classification predicates answer today (``is_mla``,
+``is_hnd``, the structural shape, ...) is derived from that structure instead
+of being declared per format.
+
+This module is **additive**: ``EngineKVFormat`` stays the authoritative
+currency everywhere in LMCache, and nothing existing changes behavior. The
+compat shim is the bijection at the bottom -- ``from_engine_kv_format`` /
+``to_engine_kv_format`` map every current enum member to a canonical
+descriptor and back, pinned by
+``tests/v1/gpu_connector/test_kv_layout_descriptor.py`` in the style of
+``test_kv_format_classification.py``. Later steps can emit descriptors from
+detection and derive the enum as a view without changing this contract.
+
+The module deliberately imports neither ``torch`` nor the compiled
+``lmcache.lmcache_native`` extension at module level (the one use is a lazy
+import inside :func:`to_engine_kv_format`), so the descriptor vocabulary
+stays usable in contexts where the native extension is absent.
+"""
+
+# Standard
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # First Party
+    import lmcache.lmcache_native as lmcache_native
+
+
+class Axis(Enum):
+    """Logical KV-cache axes (RFC #3560 coordinates plus ``KV``).
+
+    ``N`` is the addressing unit inside a block: tokens per block for paged
+    attention caches, number of recurrent states (1) for state-space caches.
+    ``C`` is the per-head state content: ``head_size`` for split K/V,
+    ``2 * head_size`` when K/V are fused into the content dim.
+    """
+
+    KV = "KV"  # the K/V pair
+    L = "L"  # layers
+    B = "B"  # blocks / pages
+    N = "N"  # tokens per block / number of states
+    H = "H"  # KV heads
+    C = "C"  # per-head state content
+
+
+class Grouping(Enum):
+    """How the layout groups tensors outside the per-tensor dims.
+
+    The list levels carry logical axes that therefore must not appear in
+    ``dims``: ``PER_LAYER`` carries ``L``; ``KV_LISTS`` carries ``KV`` and
+    ``L``.
+    """
+
+    SINGLE_TENSOR = "single_tensor"  # everything in one tensor
+    PER_LAYER = "per_layer"  # list[NL] of per-layer tensors
+    KV_LISTS = "kv_lists"  # [key_layers, value_layers] two-list form
+
+
+class KVPacking(Enum):
+    """Where the K/V pair lives relative to the per-token content."""
+
+    # K and V are separately addressable: KV is a real axis, either its own
+    # dim outside the token content or the KV_LISTS list level. kv_size == 2.
+    SPLIT = "split"
+    # K and V are packed inside the per-token content region (at or after
+    # both N's and H's dims), so a token's KV is one contiguous run and
+    # kv_size == 1.
+    FUSED = "fused"
+    # One shared plane, no K/V distinction (MLA latent cache). KV does not
+    # appear in dims. kv_size == 1.
+    SHARED = "shared"
+
+
+class ScalePlacement(Enum):
+    """Where a quantized cache stores its scales relative to the values."""
+
+    # Per block: all tokens' values first, then all tokens' scales
+    # (the DSA indexer k-cache's [BS x values][BS x scales] page regions).
+    BLOCK_REGION = "block_region"
+    # In-band inside each head's widened row (vLLM fp8 per-token-head).
+    INLINE_PER_HEAD = "inline_per_head"
+
+
+@dataclass(frozen=True)
+class QuantSpec:
+    """Quantization facts for a cache whose bytes are not plain elements.
+
+    Attributes:
+        scale_dtype: Dtype of the stored scales, e.g. ``"float32"``.
+        values_per_scale: Number of quantized values covered by one scale.
+        placement: Where the scales sit relative to the values.
+    """
+
+    scale_dtype: str
+    values_per_scale: int
+    placement: ScalePlacement
+
+
+# ``storage_dtype`` value for canonical (enum-derived) descriptors: the enum
+# does not constrain the element type, a concrete registration fills it.
+DTYPE_UNSPECIFIED = ""
+
+_EMPTY_STRIDES: Mapping[int, int] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class KVLayoutDescriptor:
+    """A physical KV-cache layout stated as data.
+
+    Attributes:
+        extents: Sizes of logical axes, where known. Canonical descriptors
+            carry only the structurally forced entries (``KV``, ``H`` for MLA,
+            ``C`` for the fixed-width indexer cache); a descriptor built from
+            a concrete registration binds every axis it materializes.
+        dims: Physical dims of one tensor, outermost first. Each entry is a
+            tuple of logical axes folded row-major into that dim: ``(B, N)``
+            is SGLang's fused page-buffer dim, ``(KV, C)`` is the unified
+            content dim. A one-axis tuple is a plain dim; the empty tuple is
+            a materialized size-1 dim that carries no logical axis (the
+            RBLN singleton). Axes carried by the ``grouping`` list levels
+            (``L`` for PER_LAYER, ``KV`` and ``L`` for KV_LISTS) must not
+            appear.
+        grouping: List structure around the tensor(s), see :class:`Grouping`.
+        kv_packing: Where the K/V pair lives, see :class:`KVPacking`.
+        storage_dtype: What ``tensor.dtype`` reports, e.g. ``"uint8"``.
+            :data:`DTYPE_UNSPECIFIED` in canonical descriptors.
+        logical_dtype: What the bytes mean when it differs from
+            ``storage_dtype`` (quantized caches), else ``None``.
+        dim_strides: Sparse per-dim physical strides in storage elements,
+            keyed by index into ``dims``. A missing key means tight. This
+            generalizes the transfer path's ``block_stride_elems`` (dim-0
+            padding for pool-sharing layouts) to any padded dim.
+        quant: Quantization facts, or ``None`` for plain caches.
+
+    Raises:
+        ValueError: If the structure is inconsistent (duplicate axes, axes
+            that the grouping or packing forbids in ``dims``, out-of-range
+            ``dim_strides`` keys, non-positive extents).
+    """
+
+    extents: Mapping[Axis, int]
+    dims: tuple[tuple[Axis, ...], ...]
+    grouping: Grouping
+    kv_packing: KVPacking
+    storage_dtype: str
+    logical_dtype: str | None = None
+    dim_strides: Mapping[int, int] = field(default_factory=lambda: _EMPTY_STRIDES)
+    quant: QuantSpec | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "extents", MappingProxyType(dict(self.extents)))
+        object.__setattr__(
+            self, "dim_strides", MappingProxyType(dict(self.dim_strides))
+        )
+        self._validate()
+
+    def _validate(self) -> None:
+        seen: set[Axis] = set()
+        for fold in self.dims:
+            if not isinstance(fold, tuple):
+                raise ValueError(f"dims entries must be tuples, got {fold!r}")
+            for axis in fold:
+                if not isinstance(axis, Axis):
+                    raise ValueError(f"dims may only contain Axis, got {axis!r}")
+                if axis in seen:
+                    raise ValueError(f"axis {axis} appears in more than one dim")
+                seen.add(axis)
+
+        if Axis.C not in seen:
+            raise ValueError("the content axis C must be materialized in dims")
+
+        carried = {
+            Grouping.SINGLE_TENSOR: frozenset[Axis](),
+            Grouping.PER_LAYER: frozenset({Axis.L}),
+            Grouping.KV_LISTS: frozenset({Axis.KV, Axis.L}),
+        }[self.grouping]
+        overlap = carried & seen
+        if overlap:
+            raise ValueError(
+                f"{self.grouping} carries {sorted(a.name for a in overlap)} at "
+                "the list level; the axis must not also appear in dims"
+            )
+
+        if self.kv_packing is KVPacking.SHARED and Axis.KV in seen:
+            raise ValueError("SHARED packing must not materialize a KV axis")
+        if self.kv_packing is KVPacking.SPLIT:
+            if self.grouping is not Grouping.KV_LISTS and Axis.KV not in seen:
+                raise ValueError(
+                    "SPLIT packing needs a KV axis in dims (or KV_LISTS grouping)"
+                )
+        if self.kv_packing is KVPacking.FUSED:
+            kv_dim = self.axis_dim(Axis.KV)
+            if kv_dim is None:
+                raise ValueError("FUSED packing needs the KV axis in dims")
+            for axis in (Axis.N, Axis.H):
+                axis_dim = self.axis_dim(axis)
+                if axis_dim is not None and axis_dim > kv_dim:
+                    raise ValueError(
+                        f"FUSED packing puts KV inside the content region, but "
+                        f"{axis.name}'s dim {axis_dim} comes after KV's {kv_dim}"
+                    )
+
+        for dim_idx in self.dim_strides:
+            if not 0 <= dim_idx < len(self.dims):
+                raise ValueError(
+                    f"dim_strides key {dim_idx} out of range for {len(self.dims)} dims"
+                )
+        for axis, extent in self.extents.items():
+            if not isinstance(axis, Axis):
+                raise ValueError(f"extents keys must be Axis, got {axis!r}")
+            if extent <= 0:
+                raise ValueError(f"extent of {axis.name} must be positive: {extent}")
+
+    # ── Structure accessors ────────────────────────────────────────────
+
+    def axis_dim(self, axis: Axis) -> int | None:
+        """Return the index of the dim whose fold contains *axis*, or None.
+
+        Args:
+            axis: The logical axis to locate.
+
+        Returns:
+            The 0-based index into ``dims``, or ``None`` when the axis is not
+            materialized in this tensor (carried by a list level, dropped, or
+            packed away).
+        """
+        for dim_idx, fold in enumerate(self.dims):
+            if axis in fold:
+                return dim_idx
+        return None
+
+    def dim_extent(self, dim_idx: int) -> int:
+        """Return the size of physical dim *dim_idx* (product of its fold).
+
+        Args:
+            dim_idx: Index into ``dims``.
+
+        Returns:
+            The dim's extent; the empty fold has extent 1.
+
+        Raises:
+            ValueError: If any axis in the fold has no bound extent.
+        """
+        size = 1
+        for axis in self.dims[dim_idx]:
+            if axis not in self.extents:
+                raise ValueError(f"axis {axis.name} has no bound extent")
+            size *= self.extents[axis]
+        return size
+
+    def resolved_strides(self) -> tuple[int, ...]:
+        """Return per-dim strides in storage elements, innermost tight.
+
+        Strides are resolved outermost-last: each dim's stride is its inner
+        neighbor's stride times that neighbor's extent, unless ``dim_strides``
+        overrides it. An override therefore also shifts every dim outside it,
+        which is how one ``B``-stride entry describes a per-layer view into a
+        padded multi-layer pool.
+
+        Returns:
+            One stride per entry of ``dims``, outermost first.
+
+        Raises:
+            ValueError: If any materialized axis has no bound extent.
+        """
+        strides = [0] * len(self.dims)
+        inner = 1
+        for dim_idx in range(len(self.dims) - 1, -1, -1):
+            strides[dim_idx] = self.dim_strides.get(dim_idx, inner)
+            inner = strides[dim_idx] * self.dim_extent(dim_idx)
+        return tuple(strides)
+
+    # ── Derived classification facts ───────────────────────────────────
+    # One definition each, derived from structure. The canonical descriptors
+    # reproduce the per-format facts pinned in csrc/engine_kv_format.h and on
+    # the KVFormatSpec classes (see the round-trip test).
+
+    @property
+    def is_cross_layer(self) -> bool:
+        """All layers in one fused tensor."""
+        return self.grouping is Grouping.SINGLE_TENSOR
+
+    @property
+    def is_kv_list(self) -> bool:
+        """Keys and values in two top-level lists."""
+        return self.grouping is Grouping.KV_LISTS
+
+    @property
+    def is_layer_list(self) -> bool:
+        """One list entry per layer."""
+        return self.grouping is Grouping.PER_LAYER
+
+    @property
+    def is_mla(self) -> bool:
+        """Single shared latent plane, no K/V split."""
+        return self.kv_packing is KVPacking.SHARED
+
+    @property
+    def is_hnd(self) -> bool:
+        """Heads stored before block tokens within a tensor."""
+        h_dim = self.axis_dim(Axis.H)
+        n_dim = self.axis_dim(Axis.N)
+        return h_dim is not None and n_dim is not None and h_dim < n_dim
+
+    @property
+    def is_fused_packed(self) -> bool:
+        """K/V packed inside the per-token content region."""
+        return self.kv_packing is KVPacking.FUSED
+
+    @property
+    def is_two_major(self) -> bool:
+        """The size-2 K/V axis precedes the block axis within the tensor."""
+        if self.kv_packing is not KVPacking.SPLIT:
+            return False
+        kv_dim = self.axis_dim(Axis.KV)
+        b_dim = self.axis_dim(Axis.B)
+        return kv_dim is not None and b_dim is not None and kv_dim < b_dim
+
+    @property
+    def is_pbs_fused(self) -> bool:
+        """Blocks and tokens folded into one page-buffer axis."""
+        return any(Axis.B in fold and Axis.N in fold for fold in self.dims)
+
+    @property
+    def kv_size(self) -> int:
+        """Number of separately addressed K/V planes: 2 for SPLIT, else 1."""
+        return 2 if self.kv_packing is KVPacking.SPLIT else 1
+
+
+# ── Bijection with EngineKVFormat ──────────────────────────────────────
+# One canonical descriptor per current enum member, keyed by member name (the
+# native and pure-Python enums are distinct types with the same names, cf.
+# specs/registry.py). Canonical descriptors bind only structurally forced
+# extents; dtype stays DTYPE_UNSPECIFIED except where the format itself pins
+# it (the blocked-scale indexer cache).
+
+_KV = Axis.KV
+_L = Axis.L
+_B = Axis.B
+_N = Axis.N
+_H = Axis.H
+_C = Axis.C
+
+_SPLIT_EXTENTS: Mapping[Axis, int] = MappingProxyType({_KV: 2})
+_MLA_EXTENTS: Mapping[Axis, int] = MappingProxyType({_KV: 1, _H: 1})
+
+
+def _split(
+    dims: tuple[tuple[Axis, ...], ...],
+    grouping: Grouping,
+) -> KVLayoutDescriptor:
+    """Build a canonical split-K/V descriptor.
+
+    Args:
+        dims: Physical dims, outermost first.
+        grouping: List structure around the tensor(s).
+
+    Returns:
+        The canonical descriptor with ``KV`` extent 2 and unbound dtype.
+    """
+    return KVLayoutDescriptor(
+        extents=_SPLIT_EXTENTS,
+        dims=dims,
+        grouping=grouping,
+        kv_packing=KVPacking.SPLIT,
+        storage_dtype=DTYPE_UNSPECIFIED,
+    )
+
+
+def _fused(dims: tuple[tuple[Axis, ...], ...]) -> KVLayoutDescriptor:
+    """Build a canonical fused-K/V per-layer descriptor.
+
+    Args:
+        dims: Physical dims, outermost first, with ``KV`` in the content
+            region.
+
+    Returns:
+        The canonical descriptor with ``KV`` extent 2 and unbound dtype.
+    """
+    return KVLayoutDescriptor(
+        extents=_SPLIT_EXTENTS,
+        dims=dims,
+        grouping=Grouping.PER_LAYER,
+        kv_packing=KVPacking.FUSED,
+        storage_dtype=DTYPE_UNSPECIFIED,
+    )
+
+
+ENGINE_KV_FORMAT_DESCRIPTORS: Mapping[str, KVLayoutDescriptor] = MappingProxyType(
+    {
+        # vLLM cross-layer pool: [NB, NL, 2, BS, NH, HS] in one tensor.
+        "NB_NL_TWO_BS_NH_HS": _split(
+            ((_B,), (_L,), (_KV,), (_N,), (_H,), (_C,)), Grouping.SINGLE_TENSOR
+        ),
+        # vLLM flash attention: NL x [2, NB, BS, NH, HS].
+        "NL_X_TWO_NB_BS_NH_HS": _split(
+            ((_KV,), (_B,), (_N,), (_H,), (_C,)), Grouping.PER_LAYER
+        ),
+        # vLLM flash infer: NL x [NB, 2, BS, NH, HS].
+        "NL_X_NB_TWO_BS_NH_HS": _split(
+            ((_B,), (_KV,), (_N,), (_H,), (_C,)), Grouping.PER_LAYER
+        ),
+        # vLLM MLA: NL x [NB, BS, HS], head axis dropped.
+        "NL_X_NB_BS_HS": KVLayoutDescriptor(
+            extents=_MLA_EXTENTS,
+            dims=((_B,), (_N,), (_C,)),
+            grouping=Grouping.PER_LAYER,
+            kv_packing=KVPacking.SHARED,
+            storage_dtype=DTYPE_UNSPECIFIED,
+        ),
+        # SGLang MHA: 2 x NL x [PBS, NH, HS], page buffer fused.
+        "TWO_X_NL_X_NBBS_NH_HS": _split(((_B, _N), (_H,), (_C,)), Grouping.KV_LISTS),
+        # SGLang MLA: NL x [PBS, 1, HS], latent head materialized as 1.
+        "NL_X_NBBS_ONE_HS": KVLayoutDescriptor(
+            extents=_MLA_EXTENTS,
+            dims=((_B, _N), (_H,), (_C,)),
+            grouping=Grouping.PER_LAYER,
+            kv_packing=KVPacking.SHARED,
+            storage_dtype=DTYPE_UNSPECIFIED,
+        ),
+        # vLLM flash attention HND: NL x [2, NB, NH, BS, HS].
+        "NL_X_TWO_NB_NH_BS_HS": _split(
+            ((_KV,), (_B,), (_H,), (_N,), (_C,)), Grouping.PER_LAYER
+        ),
+        # vLLM flash infer HND: NL x [NB, 2, NH, BS, HS].
+        "NL_X_NB_TWO_NH_BS_HS": _split(
+            ((_B,), (_KV,), (_H,), (_N,), (_C,)), Grouping.PER_LAYER
+        ),
+        # TRT-LLM cross-layer HND: [NB, NL, 2, NH, BS, HS] in one tensor.
+        "NB_NL_TWO_NH_BS_HS": _split(
+            ((_B,), (_L,), (_KV,), (_H,), (_N,), (_C,)), Grouping.SINGLE_TENSOR
+        ),
+        # SGLang MHA via the MP daemon: 2 x NL x [NB, BS, NH, HS].
+        "TWO_X_NL_X_NB_BS_NH_HS": _split(
+            ((_B,), (_N,), (_H,), (_C,)), Grouping.KV_LISTS
+        ),
+        # DEPRECATED fused HND: NL x [NB, NH, BS, 2, HS], K/V axis materialized.
+        "NL_X_NB_NH_BS_TWO_HS": _fused(((_B,), (_H,), (_N,), (_KV,), (_C,))),
+        # DEPRECATED fused NHD: NL x [NB, BS, NH, 2, HS].
+        "NL_X_NB_BS_NH_TWO_HS": _fused(((_B,), (_N,), (_H,), (_KV,), (_C,))),
+        # vLLM unified KV cache HND: NL x [NB, NH, BS, CS], CS = (KV, C) folded.
+        "NL_X_NB_NH_BS_CS": _fused(((_B,), (_H,), (_N,), (_KV, _C))),
+        # vLLM unified KV cache NHD: NL x [NB, BS, NH, CS].
+        "NL_X_NB_BS_NH_CS": _fused(((_B,), (_N,), (_H,), (_KV, _C))),
+        # vLLM DSA indexer k-cache: NL x [NB, BS, 132] uint8; per block all
+        # tokens' 128 fp8 values then all tokens' fp32 scales, so per-token
+        # addressing does not exist and C's 132 is a format constant.
+        "NL_X_NB_BSV_BSS": KVLayoutDescriptor(
+            extents=MappingProxyType({_KV: 1, _H: 1, _C: 132}),
+            dims=((_B,), (_N,), (_C,)),
+            grouping=Grouping.PER_LAYER,
+            kv_packing=KVPacking.SHARED,
+            storage_dtype="uint8",
+            logical_dtype="float8_e4m3fn",
+            quant=QuantSpec(
+                scale_dtype="float32",
+                values_per_scale=128,
+                placement=ScalePlacement.BLOCK_REGION,
+            ),
+        ),
+        # vLLM-RBLN HND: NL x [2, NB, NH, 1, BS, HS]; the empty fold is the
+        # backend-required singleton between heads and tokens.
+        "NL_X_TWO_NB_NH_ONE_BS_HS": _split(
+            ((_KV,), (_B,), (_H,), (), (_N,), (_C,)), Grouping.PER_LAYER
+        ),
+    }
+)
+
+
+def _structural_key(
+    desc: KVLayoutDescriptor,
+) -> tuple[Grouping, KVPacking, tuple[tuple[Axis, ...], ...], ScalePlacement | None]:
+    """Return the part of a descriptor the enum can represent.
+
+    Args:
+        desc: The descriptor to project.
+
+    Returns:
+        ``(grouping, kv_packing, dims, scale placement)``. Extents, dtypes
+        and stride overrides are dropped: the enum is a lossy view, so any
+        concrete descriptor sharing a canonical structure projects to that
+        member.
+    """
+    return (
+        desc.grouping,
+        desc.kv_packing,
+        desc.dims,
+        desc.quant.placement if desc.quant is not None else None,
+    )
+
+
+_NAME_BY_STRUCTURE: Mapping[
+    tuple[Grouping, KVPacking, tuple[tuple[Axis, ...], ...], ScalePlacement | None],
+    str,
+] = MappingProxyType(
+    {_structural_key(desc): name for name, desc in ENGINE_KV_FORMAT_DESCRIPTORS.items()}
+)
+
+
+def from_engine_kv_format(
+    fmt: "lmcache_native.EngineKVFormat",
+) -> KVLayoutDescriptor:
+    """Return the canonical descriptor for an ``EngineKVFormat`` member.
+
+    Args:
+        fmt: An ``EngineKVFormat`` member (native or pure-Python fallback;
+            only its ``name`` is read).
+
+    Returns:
+        The canonical :class:`KVLayoutDescriptor` for the member.
+
+    Raises:
+        ValueError: If the member has no descriptor (a new format must be
+            added to ``ENGINE_KV_FORMAT_DESCRIPTORS`` deliberately).
+    """
+    desc = ENGINE_KV_FORMAT_DESCRIPTORS.get(fmt.name)
+    if desc is None:
+        raise ValueError(f"EngineKVFormat member without a descriptor: {fmt}")
+    return desc
+
+
+def to_engine_kv_format_name(desc: KVLayoutDescriptor) -> str:
+    """Return the ``EngineKVFormat`` member name matching a descriptor.
+
+    Matching is structural (grouping, packing, dims, scale placement), so a
+    concrete descriptor with bound extents, dtypes or stride overrides maps
+    to the same member as its canonical template.
+
+    Args:
+        desc: The descriptor to classify.
+
+    Returns:
+        The matching member name.
+
+    Raises:
+        ValueError: If no current member has this structure.
+    """
+    name = _NAME_BY_STRUCTURE.get(_structural_key(desc))
+    if name is None:
+        raise ValueError(
+            f"no EngineKVFormat member for layout {desc.grouping.value} / "
+            f"{desc.kv_packing.value} with dims {desc.dims}"
+        )
+    return name
+
+
+def to_engine_kv_format(desc: KVLayoutDescriptor) -> "lmcache_native.EngineKVFormat":
+    """Return the ``EngineKVFormat`` member matching a descriptor.
+
+    The native extension is imported lazily so that this module stays
+    importable without it; use :func:`to_engine_kv_format_name` where the
+    member name suffices.
+
+    Args:
+        desc: The descriptor to classify.
+
+    Returns:
+        The matching native ``EngineKVFormat`` member.
+
+    Raises:
+        ValueError: If no current member has this structure.
+    """
+    # First Party
+    import lmcache.lmcache_native as lmcache_native
+
+    return getattr(lmcache_native.EngineKVFormat, to_engine_kv_format_name(desc))

--- a/lmcache/v1/gpu_connector/kv_format/descriptor.py
+++ b/lmcache/v1/gpu_connector/kv_format/descriptor.py
@@ -9,6 +9,15 @@ spec. Everything the classification predicates answer today (``is_mla``,
 ``is_hnd``, the structural shape, ...) is derived from that structure instead
 of being declared per format.
 
+The single-letter axes are the letters of vLLM's standardized ``KVCacheLayout``
+names, which ``lmcache.v1.gpu_connector.kv_format.types.KVLayoutName`` adopts
+(``LBHNC``, ``BLNHC``, ...): a standardized name spells one ordering of these
+axes, see :func:`kv_layout_axes`. Its blocks-first members (``BLHNC`` /
+``BLNHC``) are not new structures: a per-layer view into a blocks-first pool
+has the unified-cache dims with ``B``'s stride spanning every layer's bytes,
+which is one ``dim_strides`` entry here (:func:`with_block_stride`) and
+``block_stride_elems`` on the transfer path.
+
 This module is **additive**: ``EngineKVFormat`` stays the authoritative
 currency everywhere in LMCache, and nothing existing changes behavior. The
 compat shim is the bijection at the bottom -- ``from_engine_kv_format`` /
@@ -26,7 +35,7 @@ stays usable in contexts where the native extension is absent.
 
 # Standard
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -39,6 +48,9 @@ if TYPE_CHECKING:
 class Axis(Enum):
     """Logical KV-cache axes (RFC #3560 coordinates plus ``KV``).
 
+    ``L``, ``B``, ``H``, ``N``, ``C`` are the letters of vLLM's standardized
+    layout names (``LBHNC`` is layers, blocks, heads, tokens, content), so a
+    standardized name spells an ordering of these axes.
     ``N`` is the addressing unit inside a block: tokens per block for paged
     attention caches, number of recurrent states (1) for state-space caches.
     ``C`` is the per-head state content: ``head_size`` for split K/V,
@@ -53,17 +65,70 @@ class Axis(Enum):
     C = "C"  # per-head state content
 
 
+# The five axes a standardized layout name orders (``KV`` is never spelled).
+_TENSOR_AXES: frozenset[Axis] = frozenset({Axis.L, Axis.B, Axis.H, Axis.N, Axis.C})
+
+# LMCache's pre-standardization names, as vLLM's standardized spellings.
+_KV_LAYOUT_ALIASES: Mapping[str, str] = MappingProxyType(
+    {"NHD": "LBNHC", "HND": "LBHNC"}
+)
+
+
+def kv_layout_axes(kv_layout: str) -> tuple[Axis, ...]:
+    """Return the axis order a KV layout name spells, outermost first.
+
+    Accepts vLLM's standardized ``KVCacheLayout`` names, i.e. every ordering
+    of the letters ``L``, ``B``, ``H``, ``N``, ``C``, and LMCache's
+    ``KVLayoutName`` aliases ``NHD`` (``LBNHC``) and ``HND`` (``LBHNC``).
+    Whether LMCache can transfer a layout is a separate question answered by
+    ``lmcache.integration.vllm.utils.translate_vllm_kv_cache_layout``; this
+    only reads the name.
+
+    Args:
+        kv_layout: A standardized layout name or one of the two aliases.
+
+    Returns:
+        The five axes in the order the name lists them.
+
+    Raises:
+        ValueError: If the name is not an ordering of the five letters.
+    """
+    spelled = _KV_LAYOUT_ALIASES.get(kv_layout, kv_layout)
+    try:
+        axes = tuple(Axis(letter) for letter in spelled)
+    except ValueError:
+        axes = ()
+    if len(axes) != len(_TENSOR_AXES) or set(axes) != _TENSOR_AXES:
+        raise ValueError(
+            f"KV layout name {kv_layout!r} is not an ordering of L, B, H, N, C "
+            "(or the NHD / HND aliases)"
+        )
+    return axes
+
+
 class Grouping(Enum):
     """How the layout groups tensors outside the per-tensor dims.
 
     The list levels carry logical axes that therefore must not appear in
     ``dims``: ``PER_LAYER`` carries ``L``; ``KV_LISTS`` carries ``KV`` and
-    ``L``.
+    ``L``; ``PER_LAYER_KV_PAIRS`` carries ``L`` and ``KV``.
     """
 
     SINGLE_TENSOR = "single_tensor"  # everything in one tensor
     PER_LAYER = "per_layer"  # list[NL] of per-layer tensors
     KV_LISTS = "kv_lists"  # [key_layers, value_layers] two-list form
+    PER_LAYER_KV_PAIRS = "per_layer_kv_pairs"  # list[NL] of (K, V) tensor pairs
+
+
+# Axes each grouping carries at its list levels.
+_CARRIED_AXES: Mapping[Grouping, frozenset[Axis]] = MappingProxyType(
+    {
+        Grouping.SINGLE_TENSOR: frozenset(),
+        Grouping.PER_LAYER: frozenset({Axis.L}),
+        Grouping.KV_LISTS: frozenset({Axis.KV, Axis.L}),
+        Grouping.PER_LAYER_KV_PAIRS: frozenset({Axis.L, Axis.KV}),
+    }
+)
 
 
 class KVPacking(Enum):
@@ -139,7 +204,8 @@ class KVLayoutDescriptor:
         dim_strides: Sparse per-dim physical strides in storage elements,
             keyed by index into ``dims``. A missing key means tight. This
             generalizes the transfer path's ``block_stride_elems`` (dim-0
-            padding for pool-sharing layouts) to any padded dim.
+            padding for pool-sharing layouts, see :func:`with_block_stride`)
+            to any padded dim.
         quant: Quantization facts, or ``None`` for plain caches.
 
     Raises:
@@ -179,11 +245,7 @@ class KVLayoutDescriptor:
         if Axis.C not in seen:
             raise ValueError("the content axis C must be materialized in dims")
 
-        carried = {
-            Grouping.SINGLE_TENSOR: frozenset[Axis](),
-            Grouping.PER_LAYER: frozenset({Axis.L}),
-            Grouping.KV_LISTS: frozenset({Axis.KV, Axis.L}),
-        }[self.grouping]
+        carried = _CARRIED_AXES[self.grouping]
         overlap = carried & seen
         if overlap:
             raise ValueError(
@@ -191,13 +253,16 @@ class KVLayoutDescriptor:
                 "the list level; the axis must not also appear in dims"
             )
 
-        if self.kv_packing is KVPacking.SHARED and Axis.KV in seen:
-            raise ValueError("SHARED packing must not materialize a KV axis")
-        if self.kv_packing is KVPacking.SPLIT:
-            if self.grouping is not Grouping.KV_LISTS and Axis.KV not in seen:
-                raise ValueError(
-                    "SPLIT packing needs a KV axis in dims (or KV_LISTS grouping)"
-                )
+        has_kv = Axis.KV in seen or Axis.KV in carried
+        if self.kv_packing is KVPacking.SHARED and has_kv:
+            raise ValueError(
+                "SHARED packing must not carry a KV axis, in dims or at a list level"
+            )
+        if self.kv_packing is KVPacking.SPLIT and not has_kv:
+            raise ValueError(
+                "SPLIT packing needs a KV axis in dims or at a list level "
+                "(KV_LISTS or PER_LAYER_KV_PAIRS grouping)"
+            )
         if self.kv_packing is KVPacking.FUSED:
             kv_dim = self.axis_dim(Axis.KV)
             if kv_dim is None:
@@ -297,8 +362,8 @@ class KVLayoutDescriptor:
 
     @property
     def is_layer_list(self) -> bool:
-        """One list entry per layer."""
-        return self.grouping is Grouping.PER_LAYER
+        """One list entry per layer (a tensor or a (K, V) pair)."""
+        return self.grouping in (Grouping.PER_LAYER, Grouping.PER_LAYER_KV_PAIRS)
 
     @property
     def is_mla(self) -> bool:
@@ -332,9 +397,59 @@ class KVLayoutDescriptor:
         return any(Axis.B in fold and Axis.N in fold for fold in self.dims)
 
     @property
+    def is_kv_second_tuple(self) -> bool:
+        """Each per-layer list entry is a (K, V) pair of tensors."""
+        return self.grouping is Grouping.PER_LAYER_KV_PAIRS
+
+    @property
     def kv_size(self) -> int:
         """Number of separately addressed K/V planes: 2 for SPLIT, else 1."""
         return 2 if self.kv_packing is KVPacking.SPLIT else 1
+
+
+# ── Stride overrides ───────────────────────────────────────────────────
+
+
+def with_block_stride(
+    desc: KVLayoutDescriptor, block_stride_elems: int
+) -> KVLayoutDescriptor:
+    """Return *desc* with the block axis's physical stride overridden.
+
+    This is the descriptor form of the transfer path's ``block_stride_elems``
+    (``resolve_block_stride_and_log_layout`` reads it from a per-layer view's
+    ``stride(0)``): a view into a pool that packs other layers or groups
+    between consecutive blocks -- vLLM's blocks-first ``BLHNC`` / ``BLNHC``
+    layouts, HMA-shared pools, kvcached -- keeps its canonical structure and
+    therefore its ``EngineKVFormat`` member; only ``B``'s stride changes.
+
+    Args:
+        desc: A descriptor that materializes ``B`` as a plain dim.
+        block_stride_elems: Storage elements between consecutive blocks.
+            ``0`` means tight, as on the transfer path, and removes any
+            existing override.
+
+    Returns:
+        A new descriptor equal to *desc* except for ``B``'s ``dim_strides``
+        entry.
+
+    Raises:
+        ValueError: If *desc* folds ``B`` with another axis (the SGLang
+            page-buffer dim), does not materialize ``B``, or
+            ``block_stride_elems`` is negative.
+    """
+    if block_stride_elems < 0:
+        raise ValueError(
+            f"block_stride_elems must be non-negative: {block_stride_elems}"
+        )
+    b_dim = desc.axis_dim(Axis.B)
+    if b_dim is None or desc.dims[b_dim] != (Axis.B,):
+        raise ValueError(f"with_block_stride needs B as a plain dim, got {desc.dims}")
+    strides = dict(desc.dim_strides)
+    if block_stride_elems == 0:
+        strides.pop(b_dim, None)
+    else:
+        strides[b_dim] = block_stride_elems
+    return replace(desc, dim_strides=strides)
 
 
 # ── Bijection with EngineKVFormat ──────────────────────────────────────
@@ -472,6 +587,12 @@ ENGINE_KV_FORMAT_DESCRIPTORS: Mapping[str, KVLayoutDescriptor] = MappingProxyTyp
         # backend-required singleton between heads and tokens.
         "NL_X_TWO_NB_NH_ONE_BS_HS": _split(
             ((_KV,), (_B,), (_H,), (), (_N,), (_C,)), Grouping.PER_LAYER
+        ),
+        # vLLM-Ascend per-layer (K, V) tuples: NL x 2 x [NB, BS, NH, HS]. The
+        # pair is a list level, so KV precedes B outside the tensor and
+        # is_two_major stays False.
+        "NL_X_TWO_X_NB_BS_NH_HS": _split(
+            ((_B,), (_N,), (_H,), (_C,)), Grouping.PER_LAYER_KV_PAIRS
         ),
     }
 )

--- a/tests/v1/gpu_connector/test_kv_layout_descriptor.py
+++ b/tests/v1/gpu_connector/test_kv_layout_descriptor.py
@@ -9,13 +9,24 @@ member (checked exhaustively, not sampled), and that the facts *derived* from
 descriptor structure reproduce the facts *declared* on the specs. A new enum
 member fails ``test_every_format_has_descriptor`` until it gets a descriptor,
 mirroring how ``test_every_format_is_pinned`` guards the golden tables.
+
+The last two tests tie the descriptor to the ``KVLayoutName`` vocabulary
+(``test_blocks_first_detection.py``): a standardized name is an axis order,
+and a blocks-first per-layer view is the unified-cache entry plus one block
+stride override, projecting onto the member ``detect_format`` returns.
 """
 
 # Third Party
 import pytest
+import torch
 
 # First Party
-from lmcache.v1.gpu_connector.kv_format import describe_shape, get_spec_class
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.kv_format import (
+    describe_shape,
+    detect_format,
+    get_spec_class,
+)
 from lmcache.v1.gpu_connector.kv_format.descriptor import (
     ENGINE_KV_FORMAT_DESCRIPTORS,
     Axis,
@@ -23,12 +34,24 @@ from lmcache.v1.gpu_connector.kv_format.descriptor import (
     KVLayoutDescriptor,
     KVPacking,
     from_engine_kv_format,
+    kv_layout_axes,
     to_engine_kv_format,
     to_engine_kv_format_name,
+    with_block_stride,
 )
+from lmcache.v1.gpu_connector.kv_format.types import KV_LAYOUT_NAMES
 import lmcache.lmcache_native as lmcache_native
 
 F = lmcache_native.EngineKVFormat
+
+# The member vLLM's unified (fused K/V) per-layer cache classifies as under
+# each kv_layout hint LMCache accepts (kv_format/detectors/vllm.py).
+UNIFIED_MEMBER_BY_KV_LAYOUT = {
+    "NHD": "NL_X_NB_BS_NH_CS",
+    "HND": "NL_X_NB_NH_BS_CS",
+    "BLNHC": "NL_X_NB_BS_NH_CS",
+    "BLHNC": "NL_X_NB_NH_BS_CS",
+}
 
 
 def _all_formats():
@@ -80,6 +103,7 @@ def test_derived_facts_match_spec_facts():
             spec.is_fused_packed,
             spec.is_two_major,
             spec.is_pbs_fused,
+            spec.is_kv_second_tuple,
         )
         derived = (
             desc.is_cross_layer,
@@ -90,6 +114,7 @@ def test_derived_facts_match_spec_facts():
             desc.is_fused_packed,
             desc.is_two_major,
             desc.is_pbs_fused,
+            desc.is_kv_second_tuple,
         )
         assert derived == declared, f"{fmt}: derived {derived}, declared {declared}"
 
@@ -154,6 +179,14 @@ def test_stride_override_describes_padded_pool_view():
     )
 
 
+def test_with_block_stride_needs_a_plain_block_dim():
+    # SGLang folds B with N into the page-buffer dim: no single B stride.
+    with pytest.raises(ValueError, match="plain dim"):
+        with_block_stride(ENGINE_KV_FORMAT_DESCRIPTORS["TWO_X_NL_X_NBBS_NH_HS"], 64)
+    with pytest.raises(ValueError, match="non-negative"):
+        with_block_stride(ENGINE_KV_FORMAT_DESCRIPTORS["NL_X_NB_BS_HS"], -1)
+
+
 def test_validation_rejects_inconsistent_structures():
     def build(**overrides):
         kwargs = dict(
@@ -175,12 +208,22 @@ def test_validation_rejects_inconsistent_structures():
     # The grouping already carries the axis at a list level.
     with pytest.raises(ValueError, match="list level"):
         build(dims=((Axis.L,), (Axis.KV,), (Axis.B,), (Axis.C,)))
-    # SHARED must not materialize KV.
+    # SHARED must not carry KV, in dims or at a list level.
     with pytest.raises(ValueError, match="SHARED"):
         build(kv_packing=KVPacking.SHARED)
-    # SPLIT needs a KV axis somewhere.
+    with pytest.raises(ValueError, match="SHARED"):
+        build(
+            kv_packing=KVPacking.SHARED,
+            grouping=Grouping.KV_LISTS,
+            dims=((Axis.B,), (Axis.N,), (Axis.H,), (Axis.C,)),
+        )
+    # SPLIT needs a KV axis somewhere; a (K, V) pair list level suffices.
     with pytest.raises(ValueError, match="SPLIT"):
         build(dims=((Axis.B,), (Axis.N,), (Axis.H,), (Axis.C,)))
+    build(
+        grouping=Grouping.PER_LAYER_KV_PAIRS,
+        dims=((Axis.B,), (Axis.N,), (Axis.H,), (Axis.C,)),
+    )
     # FUSED requires KV inside the content region (after N and H).
     with pytest.raises(ValueError, match="FUSED"):
         build(
@@ -206,3 +249,63 @@ def test_unknown_structure_raises():
     )
     with pytest.raises(ValueError, match="no EngineKVFormat member"):
         to_engine_kv_format_name(desc)
+
+
+def test_kv_layout_names_spell_axis_orders():
+    # KVLayoutName and Axis are the same letters: every accepted name is an
+    # ordering of L, B, H, N, C, and the facts the detector derives from name
+    # compares are axis-order facts on the descriptor side.
+    assert set(KV_LAYOUT_NAMES) == set(UNIFIED_MEMBER_BY_KV_LAYOUT)
+    for name in KV_LAYOUT_NAMES:
+        axes = kv_layout_axes(name)
+        assert set(axes) == {Axis.L, Axis.B, Axis.H, Axis.N, Axis.C}, name
+        desc = ENGINE_KV_FORMAT_DESCRIPTORS[UNIFIED_MEMBER_BY_KV_LAYOUT[name]]
+        assert (axes.index(Axis.H) < axes.index(Axis.N)) == desc.is_hnd, name
+        # Blocks-first is B outside L: a per-layer view's block step then
+        # spans every layer, so exactly these names need a B stride override.
+        blocks_first = axes.index(Axis.B) < axes.index(Axis.L)
+        assert blocks_first == (name in ("BLHNC", "BLNHC")), name
+    # vLLM's spellings of LMCache's legacy names.
+    assert kv_layout_axes("LBNHC") == kv_layout_axes("NHD")
+    assert kv_layout_axes("LBHNC") == kv_layout_axes("HND")
+    # A heads-outermost name is vocabulary too; its order shows why
+    # translate_vllm_kv_cache_layout rejects it: H outside B fragments each
+    # block's content per head.
+    axes = kv_layout_axes("LHBNC")
+    assert axes.index(Axis.H) < axes.index(Axis.B)
+    for bad in ("LBHN", "LBHNCX", "LBHNN", "NDH", ""):
+        with pytest.raises(ValueError, match="ordering"):
+            kv_layout_axes(bad)
+
+
+@pytest.mark.parametrize("kv_layout", ["BLHNC", "BLNHC"])
+def test_blocks_first_view_is_unified_entry_plus_block_stride(kv_layout):
+    # vLLM's blocks-first layouts classify as the unified-cache members with
+    # the block step in stride(0), which resolve_block_stride_and_log_layout
+    # hands the kernels as block_stride_elems. In descriptor terms that is the
+    # canonical entry plus one B stride override: it resolves to the view's
+    # torch strides and projects onto the member detect_format returns.
+    nb, nl, nh, bs, cs = 6, 3, 2, 4, 8
+    inner = (nh, bs, cs) if kv_layout == "BLHNC" else (bs, nh, cs)
+    pool = torch.zeros(nb, nl, *inner)
+    views = [pool[:, layer] for layer in range(nl)]
+    fmt, _ = detect_format(views, EngineType.VLLM, {"kv_layout": kv_layout})
+    assert fmt.name == UNIFIED_MEMBER_BY_KV_LAYOUT[kv_layout]
+
+    canonical = ENGINE_KV_FORMAT_DESCRIPTORS[fmt.name]
+    compact = KVLayoutDescriptor(
+        extents={Axis.KV: 2, Axis.B: nb, Axis.N: bs, Axis.H: nh, Axis.C: cs // 2},
+        dims=canonical.dims,
+        grouping=canonical.grouping,
+        kv_packing=canonical.kv_packing,
+        storage_dtype="float32",
+    )
+    view = with_block_stride(compact, views[0].stride(0))
+    assert view.resolved_strides() == views[0].stride()
+    assert dict(view.dim_strides) == {0: nl * nh * bs * cs}
+    assert to_engine_kv_format(view) == fmt
+    # A layer-compact cache under the same declaration is the tight variant,
+    # and 0 means tight as block_stride_elems does on the transfer path.
+    assert compact.resolved_strides() == torch.zeros(nb, *inner).stride()
+    assert to_engine_kv_format(compact) == fmt
+    assert with_block_stride(view, 0) == compact

--- a/tests/v1/gpu_connector/test_kv_layout_descriptor.py
+++ b/tests/v1/gpu_connector/test_kv_layout_descriptor.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Round-trip tests for the KV layout descriptor bijection (RFC #3560 step 1).
+
+Companion to ``test_kv_format_classification.py``: that file pins the
+per-format facts declared on the specs and in ``csrc/engine_kv_format.h``;
+this file pins that every ``EngineKVFormat`` member has exactly one canonical
+:class:`KVLayoutDescriptor`, that the mapping round-trips both ways for every
+member (checked exhaustively, not sampled), and that the facts *derived* from
+descriptor structure reproduce the facts *declared* on the specs. A new enum
+member fails ``test_every_format_has_descriptor`` until it gets a descriptor,
+mirroring how ``test_every_format_is_pinned`` guards the golden tables.
+"""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.gpu_connector.kv_format import describe_shape, get_spec_class
+from lmcache.v1.gpu_connector.kv_format.descriptor import (
+    ENGINE_KV_FORMAT_DESCRIPTORS,
+    Axis,
+    Grouping,
+    KVLayoutDescriptor,
+    KVPacking,
+    from_engine_kv_format,
+    to_engine_kv_format,
+    to_engine_kv_format_name,
+)
+import lmcache.lmcache_native as lmcache_native
+
+F = lmcache_native.EngineKVFormat
+
+
+def _all_formats():
+    return [v for v in vars(F).values() if isinstance(v, F)]
+
+
+def test_every_format_has_descriptor():
+    # A new EngineKVFormat must get a canonical descriptor deliberately.
+    assert {fmt.name for fmt in _all_formats()} == set(ENGINE_KV_FORMAT_DESCRIPTORS)
+
+
+def test_round_trip_holds_for_every_format():
+    # Exhaustive in both directions: enum -> descriptor -> the same enum
+    # member, and canonical descriptor -> name -> the same descriptor.
+    for fmt in _all_formats():
+        desc = from_engine_kv_format(fmt)
+        assert to_engine_kv_format(desc) == fmt, fmt
+        assert to_engine_kv_format_name(desc) == fmt.name, fmt
+    for name, desc in ENGINE_KV_FORMAT_DESCRIPTORS.items():
+        assert from_engine_kv_format(getattr(F, name)) is desc
+
+
+def test_descriptors_are_structurally_distinct():
+    # The mapping is a bijection: no two members may share a structure.
+    def structure(desc: KVLayoutDescriptor):
+        return (desc.grouping, desc.kv_packing, desc.dims, desc.quant)
+
+    names = list(ENGINE_KV_FORMAT_DESCRIPTORS)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            da = ENGINE_KV_FORMAT_DESCRIPTORS[a]
+            db = ENGINE_KV_FORMAT_DESCRIPTORS[b]
+            assert structure(da) != structure(db), f"{a} and {b} share a structure"
+
+
+def test_derived_facts_match_spec_facts():
+    # The spec classes declare each format's facts (mirrored in
+    # csrc/engine_kv_format.h); the descriptor derives the same facts from
+    # structure. Both routes must agree for every member.
+    for fmt in _all_formats():
+        spec = get_spec_class(fmt)
+        desc = from_engine_kv_format(fmt)
+        declared = (
+            spec.is_cross_layer,
+            spec.is_kv_list,
+            spec.is_layer_list,
+            spec.is_mla,
+            spec.is_hnd,
+            spec.is_fused_packed,
+            spec.is_two_major,
+            spec.is_pbs_fused,
+        )
+        derived = (
+            desc.is_cross_layer,
+            desc.is_kv_list,
+            desc.is_layer_list,
+            desc.is_mla,
+            desc.is_hnd,
+            desc.is_fused_packed,
+            desc.is_two_major,
+            desc.is_pbs_fused,
+        )
+        assert derived == declared, f"{fmt}: derived {derived}, declared {declared}"
+
+
+def test_kv_size_matches_packing():
+    # kv_size == 1 exactly for shared (MLA) and fused-packed formats.
+    for fmt in _all_formats():
+        spec = get_spec_class(fmt)
+        desc = from_engine_kv_format(fmt)
+        expected = 1 if (spec.is_mla or spec.is_fused_packed) else 2
+        assert desc.kv_size == expected, fmt
+
+
+def test_dims_rank_matches_shape_grammar():
+    # describe_shape renders the per-entry tensor rank from the enum name;
+    # the descriptor's dims must have the same rank (folds included: NBBS is
+    # one dim, ONE is one dim, CS is one dim).
+    for fmt in _all_formats():
+        desc = from_engine_kv_format(fmt)
+        inner = describe_shape(fmt).rsplit("[", 1)[1].rstrip("]")
+        rank = len(inner.split(", "))
+        assert len(desc.dims) == rank, f"{fmt}: {describe_shape(fmt)} vs {desc.dims}"
+
+
+def test_stride_override_describes_padded_pool_view():
+    # The kvcached per-layer view: one [NB, 2, BS, NH, HS] view per layer
+    # into a contiguous [NB, NL, 2, BS, NH, HS] pool, so the block axis
+    # strides over all NL layers. One dim_strides entry states that.
+    nl, nb, bs, nh, hs = 4, 8, 16, 2, 64
+    desc = KVLayoutDescriptor(
+        extents={Axis.KV: 2, Axis.B: nb, Axis.N: bs, Axis.H: nh, Axis.C: hs},
+        dims=((Axis.B,), (Axis.KV,), (Axis.N,), (Axis.H,), (Axis.C,)),
+        grouping=Grouping.PER_LAYER,
+        kv_packing=KVPacking.SPLIT,
+        storage_dtype="bfloat16",
+        dim_strides={0: nl * 2 * bs * nh * hs},
+    )
+    assert desc.resolved_strides() == (
+        nl * 2 * bs * nh * hs,  # B: overridden, spans all layers
+        bs * nh * hs,  # KV: tight
+        nh * hs,  # N: tight
+        hs,  # H: tight
+        1,  # C: tight
+    )
+    # Structural matching ignores the override: it is still the flash-infer
+    # per-layer member.
+    assert to_engine_kv_format_name(desc) == "NL_X_NB_TWO_BS_NH_HS"
+    # Tight variant of the same structure resolves without the override.
+    tight = KVLayoutDescriptor(
+        extents={Axis.KV: 2, Axis.B: nb, Axis.N: bs, Axis.H: nh, Axis.C: hs},
+        dims=((Axis.B,), (Axis.KV,), (Axis.N,), (Axis.H,), (Axis.C,)),
+        grouping=Grouping.PER_LAYER,
+        kv_packing=KVPacking.SPLIT,
+        storage_dtype="bfloat16",
+    )
+    assert tight.resolved_strides() == (
+        2 * bs * nh * hs,
+        bs * nh * hs,
+        nh * hs,
+        hs,
+        1,
+    )
+
+
+def test_validation_rejects_inconsistent_structures():
+    def build(**overrides):
+        kwargs = dict(
+            extents={},
+            dims=((Axis.B,), (Axis.KV,), (Axis.N,), (Axis.H,), (Axis.C,)),
+            grouping=Grouping.PER_LAYER,
+            kv_packing=KVPacking.SPLIT,
+            storage_dtype="",
+        )
+        kwargs.update(overrides)
+        return KVLayoutDescriptor(**kwargs)
+
+    # Duplicate axis across dims.
+    with pytest.raises(ValueError, match="more than one dim"):
+        build(dims=((Axis.B,), (Axis.B,), (Axis.C,)))
+    # Missing content axis.
+    with pytest.raises(ValueError, match="content axis C"):
+        build(dims=((Axis.KV,), (Axis.B,), (Axis.N,), (Axis.H,)))
+    # The grouping already carries the axis at a list level.
+    with pytest.raises(ValueError, match="list level"):
+        build(dims=((Axis.L,), (Axis.KV,), (Axis.B,), (Axis.C,)))
+    # SHARED must not materialize KV.
+    with pytest.raises(ValueError, match="SHARED"):
+        build(kv_packing=KVPacking.SHARED)
+    # SPLIT needs a KV axis somewhere.
+    with pytest.raises(ValueError, match="SPLIT"):
+        build(dims=((Axis.B,), (Axis.N,), (Axis.H,), (Axis.C,)))
+    # FUSED requires KV inside the content region (after N and H).
+    with pytest.raises(ValueError, match="FUSED"):
+        build(
+            kv_packing=KVPacking.FUSED,
+            dims=((Axis.KV,), (Axis.B,), (Axis.N,), (Axis.H,), (Axis.C,)),
+        )
+    # Stride override for a dim that does not exist.
+    with pytest.raises(ValueError, match="out of range"):
+        build(dim_strides={7: 128})
+    # Extents must be positive.
+    with pytest.raises(ValueError, match="positive"):
+        build(extents={Axis.B: 0})
+
+
+def test_unknown_structure_raises():
+    # The LMCache-side 2LTD chunk layout has no EngineKVFormat member.
+    desc = KVLayoutDescriptor(
+        extents={Axis.KV: 2},
+        dims=((Axis.KV,), (Axis.L,), (Axis.B, Axis.N), (Axis.H, Axis.C)),
+        grouping=Grouping.SINGLE_TENSOR,
+        kv_packing=KVPacking.SPLIT,
+        storage_dtype="",
+    )
+    with pytest.raises(ValueError, match="no EngineKVFormat member"):
+        to_engine_kv_format_name(desc)


### PR DESCRIPTION
**Update 2026-09-02:** rebased onto dev after #4729; the registry now covers all 17 current members (`NL_X_TWO_X_NB_BS_NH_HS` from #3968 added, #4729 added no members) and the tests tie the descriptor to the `KVLayoutName` vocabulary. Details in [this comment](https://github.com/LMCache/LMCache/pull/4592#issuecomment-5511126608). Line and member counts below describe the original 16-member revision.

**What this PR does / why we need it**:

Refs #3560.

## Summary

Step 1 of the migration plan posted in #3560: a declarative `KVLayoutDescriptor` that states a physical KV-cache layout as data, plus a bijection with every current `EngineKVFormat` member, pinned by an exhaustive round-trip test. Additive only. No behavior change, no call-site changes, csrc untouched.

One correction to the design comment: the enum is now at 16 members, not 15. #4450 added `NL_X_TWO_NB_NH_ONE_BS_HS` (vLLM-RBLN) after the comment was written, which is the growth pattern the RFC names: a new (engine, backend) pair costing an enum member, a spec class, a `FormatFacts` row, and detector support, for a layout that differs from `NL_X_TWO_NB_NH_BS_HS` by one singleton dim. In descriptor terms that member is one empty fold.

## Changes

- `lmcache/v1/gpu_connector/kv_format/descriptor.py` (new, 576 lines):
  - `Axis` (`KV`, `L`, `B`, `N`, `H`, `C`), `Grouping` (`SINGLE_TENSOR` / `PER_LAYER` / `KV_LISTS`), `KVPacking` (`SPLIT` / `FUSED` / `SHARED`), `QuantSpec` with `ScalePlacement`.
  - `KVLayoutDescriptor`: frozen dataclass with `extents`, `dims` (ordered partition of axes into physical dims; a multi-axis tuple is a row-major fold, so SGLang's page-buffer dim is `(B, N)` and the unified content dim is `(KV, C)`; the empty tuple is a materialized singleton, which is all the RBLN format needs), `grouping`, `kv_packing`, `storage_dtype` / `logical_dtype`, sparse `dim_strides` overrides generalizing `block_stride_elems`, and `quant`. Structural consistency is validated at construction.
  - Every classification fact is derived from structure with one definition each: `is_hnd` = H's dim precedes N's, `is_mla` = `SHARED` packing, `is_pbs_fused` = some fold contains both B and N, `kv_size` = 2 iff `SPLIT`, etc.
  - `ENGINE_KV_FORMAT_DESCRIPTORS`: one canonical descriptor per member, keyed by member name (native and fallback enum types share names, same reason `specs/registry.py` indexes by value). The DSA indexer entry turns the magic constants into declared facts: `uint8` storage, `float8_e4m3fn` logical dtype, C extent 132, one `float32` scale per 128 values, `BLOCK_REGION` placement.
  - Compat shim: `from_engine_kv_format` / `to_engine_kv_format` / `to_engine_kv_format_name`. Matching is structural (grouping, packing, dims, scale placement), so a concrete descriptor with bound extents and stride overrides projects onto the same member as its canonical template. The module imports neither torch nor the compiled extension at module level; the enum stays the single source of truth for which formats exist.
- `tests/v1/gpu_connector/test_kv_layout_descriptor.py` (new, 208 lines), companion to `test_kv_format_classification.py`:
  - every member has a descriptor (a 17th member fails the test until mapped, mirroring `test_every_format_is_pinned`);
  - round-trip enum -> descriptor -> enum for all 16 members, exhaustive rather than sampled;
  - all 16 canonical descriptors are structurally distinct (bijectivity);
  - the 8 derived facts equal the declared `KVFormatSpec` facts for every member, so the descriptor, the spec classes, and `csrc/engine_kv_format.h` cannot drift;
  - `len(dims)` equals the tensor rank `describe_shape` renders from the enum name grammar;
  - one `dim_strides` entry reproduces the padded-pool per-layer view stride (the case `block_stride_elems` covers today);
  - construction rejects inconsistent structures; unmapped structures raise `ValueError`.

Direction follows maintainer precedent: #4431 moved the per-format facts from inline format lists onto the spec classes as data; #4515 (in flight, no file overlap with this PR) centralizes the transfer-path shape descriptors in `lmcache_native`. This PR continues the same movement one level up: the layout itself as data. Meanwhile the enum keeps growing: this week's #4586 adds a new SGLang DSA detection branch keyed on `uint8` plus last-dim divisibility by 132, the same magic constants the descriptor declares once.

Later steps per the #3560 plan (not in this PR): detection emits descriptors with the enum as a derived view, engine-supplied descriptors through extended `LayoutHints`, kernels consuming descriptor-derived `PageBufferShapeDesc`.

## Validation

On an M-series Mac, Python 3.13.3, torch 2.13.0 CPU, `lmcache_native` compiled from `csrc/lmcache_native` with clang:

- `pytest tests/v1/gpu_connector/`: 161 passed, 18 skipped (GPU-gated), including the 9 new tests and the untouched `test_kv_format_classification.py` golden suite.
- Standalone module load on a bare Python 3.14 with neither torch nor the extension installed: import succeeds, all 16 canonical descriptors build and classify.
- `ruff check`, `ruff format --check`, `mypy --config-file=pyproject.toml`: clean on both files.

**Special notes for your reviewers**:

The descriptor is intentionally unexported from the `kv_format` package facade until step 2 gives it a consumer; tests import the module path directly.

One deliberate deviation from coding standard 7.2 (no lazy imports): `to_engine_kv_format` imports `lmcache.lmcache_native` inside the function. A top-level import would defeat the module's extension-free importability (verified in the tests) and would also need `torch` imported first per the same section, which this module deliberately avoids. The module docstring documents this.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

