### PR TITLE
fix(mp): harden worker heartbeat liveness

### DIFF
--- a/docs/design/v1/multiprocess/worker_liveness.md
+++ b/docs/design/v1/multiprocess/worker_liveness.md
@@ -150,6 +150,16 @@ re-registers only on a genuine recovery edge (Section 6.2). A retrieve dropped
 while the server is unhealthy is still reported via `get_finished` so async loads
 cannot hang.
 
+The worker adapter accepts `lmcache.mp.heartbeat_interval` (default `10.0` seconds)
+for the PING cadence and `lmcache.mp.heartbeat_timeout` (default `0.0`) for the
+response deadline. A non-positive timeout inherits the interval, preserving
+legacy behavior. Deployments whose NORMAL pool can run longer than the desired
+PING cadence may set a larger timeout—for example, a 5-second interval with a
+30-second timeout—without reducing how often live workers refresh `last_seen`.
+While a PING is blocked, the refresh gap can reach `interval + timeout`, so the
+server's worker reap timeout must exceed that bound. This setting is consumed
+by the worker adapter; scheduler-adapter heartbeat behavior is unchanged.
+
 ### 6.2 Recovery after a reap
 
 ```

--- a/docs/design/v1/multiprocess/worker_liveness.md
+++ b/docs/design/v1/multiprocess/worker_liveness.md
@@ -22,26 +22,26 @@ The server already receives a periodic signal from every actively serving worker
 the heartbeat PING. The design adds the worker's `instance_id` to that message,
 stamps `last_seen` on the per-instance entries that already exist, and runs one
 periodic scan that reaps entries silent longer than a timeout via the same cleanup
-as a client unregister. The heartbeat keeps its lazy start (first store/retrieve)
-and starts healthy; a live worker pings every interval, refreshing its `last_seen`,
-so it is never reaped while alive. Entries that never produced a liveness signal
-fall under a generous registration grace. Recovery reuses existing client
-machinery: on a genuine outage the heartbeat's pings fail, clearing `health_event`;
-when the server returns the unhealthy-to-healthy edge fires the recover callback,
-which re-registers — a noop when the entry survived.
+as a client unregister. The heartbeat starts immediately after successful KV-cache
+registration and starts healthy; a live worker pings every interval, refreshing
+its `last_seen`, so it is never reaped while alive. Entries that never produced a
+liveness signal fall under a generous registration grace. Recovery reuses
+existing client machinery: on a genuine outage the heartbeat's pings fail,
+clearing `health_event`; when the server returns, the unhealthy-to-healthy edge
+fires the recover callback, which re-registers — a noop when the entry survived.
 
 ```
 engine worker adapter                            MP server
 +---------------------------+                   +--------------------------------------+
 | HeartbeatThread           |   PING [id]       | ManagementModule                     |
 |  (instance_id, 10s)  -----+------------------>|  ping(id) -> touch_instance(id)      |
-|  lazy start on first req, |   (NORMAL pool)   |  reaper thread (scan = timeout/4)    |
+|  start after registration |   (NORMAL pool)   |  reaper thread (scan = timeout/4)    |
 |   (starts healthy)        |                   |   -> reap_stale_instances(           |
 |  unhealthy->healthy edge  |                   |        timeout, registration_grace)  |
 |   -> re-register callback |   REGISTER        |   -> drop_instance_state(id) fan-out |
 |                           +------------------>|        |                |            |
 | register_kv_caches        |   STORE/RETRIEVE  |        v                v            |
-|  (no pings until traffic) |   (refresh too)   | LMCacheDriven/          BlendV3      |
+|  then start heartbeat      |   (refresh too)   | LMCacheDriven/          BlendV3      |
 |                           |                   |  EngineDriven           (CB rope     |
 |                           |                   |  TransferModule          dropped)    |
 |                           |                   |  Entry{.., last_seen,               |
@@ -78,10 +78,11 @@ Every id-carrying request reads the same field, so no other payloads change.
 `last_seen: float` (`time.monotonic()`) and `has_liveness_signal: bool`, latched
 only by PING. The flag selects the staleness window: an entry that has pinged
 provably runs the heartbeat protocol and is judged on the reap timeout; one that
-never pinged (e.g. still warming under lazy start) is judged on the generous
-registration grace. `last_seen` is refreshed by PING (`touch_instance`: refresh
-if present, never insert), register (create and NOOP paths), and every transfer
-path, so a worker mid-transfer is never reaped; traffic never latches the flag.
+never pinged (for example, an older client or interrupted registration) is judged
+on the generous registration grace. `last_seen` is refreshed by PING
+(`touch_instance`: refresh if present, never insert), register (create and NOOP
+paths), and every transfer path, so a worker mid-transfer is never reaped; traffic
+never latches the flag.
 
 ### 5.2 Locking
 
@@ -139,16 +140,18 @@ the worker adapter warns at startup when `3 x interval` exceeds the 30 s floor.
 
 ## 6. Adapter Side
 
-### 6.1 Lazy start
+### 6.1 Post-registration start
 
-The heartbeat keeps its lazy start on first store/retrieve — no pings during
-warmup; the registration grace covers that window. It starts healthy (the event
-is set at construction), so the first store/retrieve is not gated. A live worker
-then pings every interval, refreshing its server-side `last_seen`, so it is never
-reaped while alive — no re-registration is needed at start. The recover callback
-re-registers only on a genuine recovery edge (Section 6.2). A retrieve dropped
-while the server is unhealthy is still reported via `get_finished` so async loads
-cannot hang.
+The heartbeat starts immediately after the first successful KV-cache registration.
+vLLM performs this registration while initializing the KV cache, before model
+warmup and CUDA graph capture. Starting here intentionally keeps the registered
+context live through that potentially long startup phase and prevents it from
+aging out before the first request. The heartbeat starts healthy (the event is
+set at construction), so the first store/retrieve is not gated. Store/retrieve
+retain an idempotent start call
+for compatibility. The recover callback re-registers only on a genuine recovery
+edge (Section 6.2). A retrieve dropped while the server is unhealthy is still
+reported via `get_finished` so async loads cannot hang.
 
 The worker adapter accepts `lmcache.mp.heartbeat_interval` (default `10.0` seconds)
 for the PING cadence and `lmcache.mp.heartbeat_timeout` (default `0.0`) for the
@@ -186,8 +189,8 @@ stop is already requested — a straggling cycle cannot re-create a ghost contex
 | Scenario | Behavior |
 |---|---|
 | Worker crash (SIGKILL, no UNREGISTER) after serving | Pings stop; reaped within ~`timeout + timeout/4`. Context, IPC handles, layout-desc refcount, and non-GPU strategy released via the same cleanup as a clean unregister; blend rope state dropped via the reap listener. The bug being fixed. |
-| Worker crash during warmup (registered, never pinged) | Reaped on the registration grace. Bounded leak instead of a permanent one. |
-| Worker alive but never pinged, idle past the grace | Reaped while alive only if it never pinged (heartbeat never started). Once the heartbeat is running, pings refresh `last_seen` every interval, so a live worker is never reaped regardless of traffic. |
+| Worker crash during or immediately after registration, before the first ping | Reaped on the registration grace. Bounded leak instead of a permanent one. |
+| Older worker alive but never pinged, idle past the grace | Reaped while alive only if it never adopts the heartbeat protocol. Current workers start heartbeat after registration and refresh `last_seen` regardless of traffic. |
 | Heartbeat thread starved, worker transferring | Store/retrieve/prepare/commit refresh `last_seen`; never reaped. |
 | Partition shorter than the reap window | No reap. On heal, the recover callback re-registers; the NOOP path refreshes `last_seen`; zero context churn. |
 | Worker crash + restart | The new process gets a fresh uuid-derived id and a fresh entry; the dead id is reaped independently. No PID-reuse aliasing. |

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -383,7 +383,7 @@ class HeartbeatThread(PeriodicThread):
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         instance_id: int | None = None,
         timeout: float = 0.0,
-    ):
+    ) -> None:
         """
         Args:
             mq_client: The message queue client used to send PING requests.
@@ -1175,10 +1175,9 @@ class LMCacheMPWorkerAdapter:
         self._health_event = threading.Event()
         self._health_event.set()
 
-        # Heartbeat thread is created but NOT started yet.
-        # It will be lazily started on the first store or retrieve
-        # request, by which time vLLM is fully ready (model loaded,
-        # KV caches allocated, warmup & CUDA graph capture done).
+        # Start heartbeat after the first successful KV-cache registration.
+        # vLLM can register before model warmup and CUDA graph capture; eager
+        # pings keep that registered context live through the startup phase.
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat_timeout = heartbeat_timeout
         self._heartbeat: HeartbeatThread | None = None
@@ -1286,6 +1285,7 @@ class LMCacheMPWorkerAdapter:
         self.kv_caches = kv_caches
         self.engine_group_infos = list(engine_group_infos)
         self._send_register_kv_caches_request(kv_caches)
+        self._ensure_heartbeat_started()
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
         return expand_engine_block_ids(self.engine_group_infos, op.block_ids)
@@ -1335,14 +1335,15 @@ class LMCacheMPWorkerAdapter:
             ) from None
 
     def _ensure_heartbeat_started(self) -> None:
-        """Lazily start the heartbeat thread on first store/retrieve.
+        """Start the heartbeat thread once registration has succeeded.
 
         The heartbeat starts healthy (the event was set at construction). A
         live worker pings every interval, refreshing its server-side
         ``last_seen``, so it is never reaped while alive -- no re-registration
-        is needed at startup, and the first store/retrieve is not gated. The
-        recover callback still re-registers on a genuine unhealthy->healthy
-        edge (server restart).
+        is needed at startup, and the first store/retrieve is not gated.
+        Store/retrieve paths also call this method as an idempotent safeguard.
+        The recover callback still re-registers on a genuine
+        unhealthy->healthy edge (server restart).
         """
         if self._heartbeat is not None:
             return

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -57,6 +57,9 @@ class ExtraConfigDefault(enum.Enum):
     # Interval (seconds) between periodic heartbeat pings
     # to the server.
     heartbeat_interval = 10.0
+    # Timeout (seconds) for each heartbeat PING. Zero preserves the
+    # historical behavior of using heartbeat_interval as the timeout.
+    heartbeat_timeout = 0.0
     # Routing mode for ``create_transfer_context``: ``auto`` keeps the
     # historical CUDA -> lmcache_driven / others -> engine_driven dispatch;
     # ``lmcache_driven`` forces the IPC / SHM zero-copy path where the
@@ -74,9 +77,9 @@ DEFAULT_HEARTBEAT_INTERVAL: float = ExtraConfigDefault.heartbeat_interval.value
 
 _EXTRA_CONFIG_KEY_PREFIX = "lmcache.mp."
 
-# Floor (seconds) of the MP server's worker reap timeout. It only covers the
-# default 10 s heartbeat interval (3 x 10 s); the adapter warns at startup
-# when 3 x heartbeat_interval exceeds it (server timeout must be raised too).
+# Floor (seconds) of the MP server's worker reap timeout. It covers the default
+# 10 s heartbeat interval (3 x 10 s); the adapter warns at startup when the
+# configured heartbeat refresh gap can exceed it.
 _SERVER_REAP_TIMEOUT_FLOOR_SECONDS: float = 30.0
 
 
@@ -379,6 +382,7 @@ class HeartbeatThread(PeriodicThread):
         health_event: threading.Event,
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         instance_id: int | None = None,
+        timeout: float = 0.0,
     ):
         """
         Args:
@@ -387,10 +391,12 @@ class HeartbeatThread(PeriodicThread):
                 Set when the server is healthy, cleared when unhealthy.
                 Adapters check this event to decide whether to proceed
                 with operations or enter degraded mode.
-            interval: Seconds between heartbeat pings and ping timeout.
+            interval: Seconds between heartbeat pings.
             instance_id: The worker's instance ID sent with each PING so the
                 server can refresh its liveness, or None for an untracked
                 prober (the scheduler adapter).
+            timeout: Seconds to wait for each PING response. A non-positive
+                value preserves legacy behavior by using ``interval``.
         """
         super().__init__(
             name="lmcache-heartbeat",
@@ -400,6 +406,7 @@ class HeartbeatThread(PeriodicThread):
         self._mq_client = mq_client
         self._health_event = health_event
         self._interval = interval
+        self._timeout = timeout if timeout > 0.0 else interval
         self._instance_id = instance_id
 
         # Optional callback invoked on the unhealthy->healthy edge,
@@ -440,7 +447,7 @@ class HeartbeatThread(PeriodicThread):
         """
         was_healthy = self._health_event.is_set()
         healthy = send_ping(
-            self._mq_client, timeout=self._interval, instance_id=self._instance_id
+            self._mq_client, timeout=self._timeout, instance_id=self._instance_id
         )
 
         if self.stop_requested:
@@ -1061,8 +1068,10 @@ class LMCacheMPWorkerAdapter:
             heartbeat_interval: Interval in seconds between heartbeat pings.
                 Ignored when ``extra_config`` is provided.
             extra_config: Optional dict with keys starting with
-                ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
-                provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
+                ``lmcache.mp.`` (for example, ``lmcache.mp.mq_timeout`` or
+                ``lmcache.mp.heartbeat_timeout``). When provided, it overrides
+                ``mq_timeout`` / ``heartbeat_interval`` and can independently
+                configure the heartbeat response timeout.
 
         Raises:
             TypeError: If the connector argument shape is unsupported.
@@ -1073,10 +1082,12 @@ class LMCacheMPWorkerAdapter:
             legacy_block_size,
             mq_timeout,
         )
+        heartbeat_timeout = 0.0
         if extra_config is not None:
             cfg = _resolve_extra_config(extra_config)
             mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
             heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+            heartbeat_timeout = cfg[ExtraConfigDefault.heartbeat_timeout.name]
             # Only treat ``mp_transfer_mode`` as an explicit override when
             # the user actually set it in extra_config; otherwise leave it
             # as ``None`` so ``create_transfer_context`` can still consult
@@ -1169,18 +1180,27 @@ class LMCacheMPWorkerAdapter:
         # request, by which time vLLM is fully ready (model loaded,
         # KV caches allocated, warmup & CUDA graph capture done).
         self._heartbeat_interval = heartbeat_interval
+        self._heartbeat_timeout = heartbeat_timeout
         self._heartbeat: HeartbeatThread | None = None
         self._heartbeat_lock = threading.Lock()
-        if 3 * heartbeat_interval > _SERVER_REAP_TIMEOUT_FLOOR_SECONDS:
+        effective_heartbeat_timeout = (
+            heartbeat_timeout if heartbeat_timeout > 0.0 else heartbeat_interval
+        )
+        heartbeat_refresh_gap = max(
+            3 * heartbeat_interval,
+            heartbeat_interval + effective_heartbeat_timeout,
+        )
+        if heartbeat_refresh_gap > _SERVER_REAP_TIMEOUT_FLOOR_SECONDS:
             logger.warning(
-                "lmcache.mp.heartbeat_interval is %.1fs, so 3 x "
-                "heartbeat_interval (%.1fs) exceeds the MP server's "
-                "default worker reap timeout floor (%.1fs). Raise the "
-                "server's worker reap timeout to at least 3 x the "
-                "heartbeat interval, or the server may reap this "
-                "worker between heartbeats.",
+                "LMCache heartbeat refresh gap can reach %.1fs with "
+                "heartbeat_interval=%.1fs and heartbeat_timeout=%.1fs, which "
+                "exceeds the MP server's default worker reap timeout floor "
+                "(%.1fs). Raise the server's worker reap timeout above the "
+                "refresh gap, or the server may reap this worker between "
+                "heartbeats.",
+                heartbeat_refresh_gap,
                 heartbeat_interval,
-                3 * heartbeat_interval,
+                effective_heartbeat_timeout,
                 _SERVER_REAP_TIMEOUT_FLOOR_SECONDS,
             )
 
@@ -1334,6 +1354,7 @@ class LMCacheMPWorkerAdapter:
                 health_event=self._health_event,
                 interval=self._heartbeat_interval,
                 instance_id=self.instance_id,
+                timeout=self._heartbeat_timeout,
             )
             heartbeat.register_recover_callback(self._reregister_kv_caches_callback)
             heartbeat.start()

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -48,6 +48,7 @@ class FakeHeartbeatThread:
         health_event: threading.Event | None = None,
         interval: float = 0.0,
         instance_id: int | None = None,
+        timeout: float = 0.0,
     ) -> None:
         self.mq_client = mq_client
         self.health_event = (
@@ -55,6 +56,7 @@ class FakeHeartbeatThread:
         )
         self.interval = interval
         self.instance_id = instance_id
+        self.timeout = timeout
         # Snapshot of the health event at construction time: lets tests
         # assert the adapter starts the heartbeat healthy (event still set).
         self.health_event_set_at_init = self.health_event.is_set()
@@ -472,6 +474,79 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
     assert event_state_during_callback == [False]
 
 
+def test_heartbeat_uses_timeout_independent_of_interval(monkeypatch) -> None:
+    """Heartbeat ping timeout can exceed its scheduling interval.
+
+    Large multiprocess transfers may occupy the server's NORMAL pool longer
+    than the desired heartbeat cadence. A separate timeout keeps liveness
+    checks frequent without treating expected queue latency as an outage.
+    """
+    observed_timeouts: list[float] = []
+    ping_observed = threading.Event()
+
+    def record_ping(
+        mq_client: object, timeout: float, instance_id: int | None = None
+    ) -> bool:
+        observed_timeouts.append(timeout)
+        ping_observed.set()
+        return True
+
+    monkeypatch.setattr(adapter_mod, "send_ping", record_ping)
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(
+        mq_client=MagicMock(name="mq_client"),
+        health_event=health_event,
+        interval=5.0,
+        timeout=30.0,
+    )
+
+    try:
+        heartbeat.start()
+        assert ping_observed.wait(timeout=10.0)
+    finally:
+        heartbeat.stop(timeout=10.0)
+
+    assert observed_timeouts
+    assert set(observed_timeouts) == {30.0}
+
+
+def test_heartbeat_timeout_defaults_to_interval(monkeypatch) -> None:
+    observed_timeouts: list[float] = []
+
+    def record_ping(
+        mq_client: object, timeout: float, instance_id: int | None = None
+    ) -> bool:
+        observed_timeouts.append(timeout)
+        return True
+
+    monkeypatch.setattr(adapter_mod, "send_ping", record_ping)
+    heartbeat = HeartbeatThread(
+        mq_client=MagicMock(name="mq_client"),
+        health_event=threading.Event(),
+        interval=7.0,
+    )
+
+    heartbeat._execute()
+
+    assert observed_timeouts == [7.0]
+
+
+def test_worker_heartbeat_uses_configured_timeout(fake_adapter) -> None:
+    adapter = _make_worker_adapter(
+        extra_config={
+            "lmcache.mp.heartbeat_interval": 5.0,
+            "lmcache.mp.heartbeat_timeout": 30.0,
+        }
+    )
+
+    adapter._ensure_heartbeat_started()
+
+    heartbeat = FakeHeartbeatThread.instances[-1]
+    assert heartbeat.interval == 5.0
+    assert heartbeat.timeout == 30.0
+
+
 def test_dropped_retrieve_reported_once_via_unhealthy_get_finished(
     fake_adapter,
 ) -> None:
@@ -714,6 +789,26 @@ def test_startup_warns_when_heartbeat_interval_exceeds_reap_floor(
     _make_worker_adapter(extra_config={"lmcache.mp.heartbeat_interval": 15})
 
     assert any("reap" in msg for msg in warnings)
+
+
+def test_startup_warns_when_heartbeat_timeout_exceeds_reap_floor(
+    fake_adapter, monkeypatch
+) -> None:
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        adapter_mod.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings.append(str(msg)),
+    )
+
+    _make_worker_adapter(
+        extra_config={
+            "lmcache.mp.heartbeat_interval": 5.0,
+            "lmcache.mp.heartbeat_timeout": 30.0,
+        }
+    )
+
+    assert any("refresh gap" in msg for msg in warnings)
 
 
 def test_startup_does_not_warn_for_default_heartbeat_interval(

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -204,6 +204,19 @@ def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
     assert args[1] == RequestType.REGISTER_KV_CACHE
 
 
+def test_register_kv_caches_starts_heartbeat_after_registration(fake_adapter):
+    """Successful registration immediately starts worker liveness refresh."""
+    adapter, _send_mock, _ = fake_adapter
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+
+    adapter.register_kv_caches({"layer.0": fake_tensor})
+
+    assert len(FakeHeartbeatThread.instances) == 1
+    heartbeat = FakeHeartbeatThread.instances[0]
+    assert heartbeat.calls == ["register_recover_callback", "start"]
+
+
 def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
     """Public register_kv_caches surfaces ConnectionError on MQ timeout."""
     adapter, _send_mock, future = fake_adapter


### PR DESCRIPTION
## Summary
- add an opt-in heartbeat response timeout independent of heartbeat cadence
- start the worker heartbeat immediately after successful KV-cache registration
- preserve interval-coupled timeout behavior by default and idempotent store/retrieve start calls
- document the response-timeout/reap-floor relationship and post-registration lifecycle

## Why
Using the heartbeat interval as the MQ response deadline couples two independent controls. A short cadence can then mark a healthy but busy NORMAL pool unhealthy. Separately, vLLM registers the cache before model warmup and CUDA graph capture; waiting for the first store/retrieve leaves that registered context without liveness pings throughout startup and any later idle period.

## Validation
- new eager-start regression was observed failing before the production change and passing afterward
- `tests/v1/test_vllm_mp_adapter.py`: 31 passed after rebasing onto current `upstream/dev`
- focused `ruff check`, `ruff format --check`, and `git diff --check` pass
- existing timeout qualification covered a busy NORMAL pool, idle periods longer than 120 seconds, a real outage, and recovery

## Compatibility
- `lmcache.mp.heartbeat_timeout <= 0` inherits the interval, preserving legacy behavior
- heartbeat starts only after successful cache registration
- idempotent start calls remain on store/retrieve for compatibility
- scheduler-adapter heartbeat behavior is unchanged
