### PR TITLE
fix(sdk): return only generated tokens from output_tokens

### DIFF
--- a/lmcache/sdk/request.py
+++ b/lmcache/sdk/request.py
@@ -147,6 +147,7 @@ class LMCacheRequestStream:
         self.done: bool = False
         self._decoded: int = 0
         self._text_parts: list[str] = []
+        self._output_tokens: list[int] = []
         self._request_stream_id: str = str(uuid.uuid4())
         self._suffix_tokens: list[int] = []
 
@@ -173,7 +174,7 @@ class LMCacheRequestStream:
     @property
     def output_tokens(self) -> list[int]:
         """Return the concatenated generated tokens across all segments."""
-        return self.tokens
+        return self._output_tokens
 
     @property
     def is_done(self) -> bool:
@@ -222,6 +223,7 @@ class LMCacheRequestStream:
         finally:
             self._decoded += len(gen_tokens)
             self._text_parts.extend(gen_texts)
+            self._output_tokens.extend(gen_tokens)
             self.tokens.extend(gen_tokens)
 
         # produces less than max_tokens --> EOS

--- a/tests/sdk/test_request.py
+++ b/tests/sdk/test_request.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LMCacheRequestStream output-token accounting.
+
+These exercise the ``output_tokens`` contract: the property must return only
+the generated tokens, never the prompt or a KV-edited live sequence, and must
+stay consistent with ``decoded_tokens``.
+"""
+
+# First Party
+from lmcache.sdk.request import LMCacheRequestStream, TokenEvent
+
+
+def _two_token_completion(prompt_token_ids, sampling_params, cache_salt):
+    yield TokenEvent(token_id=30, text="x")
+    yield TokenEvent(token_id=31, text="y")
+
+
+def _make_stream(post_completion, prompt_token_ids):
+    return LMCacheRequestStream(
+        contexts=[],
+        post_completion=post_completion,
+        prompt_token_ids=prompt_token_ids,
+    )
+
+
+def test_output_tokens_excludes_prompt():
+    stream = _make_stream(_two_token_completion, [10, 20])
+    stream.generate({"max_tokens": 2})
+
+    assert stream.output_tokens == [30, 31]
+    assert len(stream.output_tokens) == stream.decoded_tokens
+
+
+def test_output_tokens_accumulate_across_generate_calls():
+    stream = _make_stream(_two_token_completion, [10, 20])
+    stream.generate({"max_tokens": 2})
+    stream.generate({"max_tokens": 2})
+
+    assert stream.output_tokens == [30, 31, 30, 31]
+    assert len(stream.output_tokens) == stream.decoded_tokens
+
+
+def test_output_tokens_empty_when_no_generation():
+    stream = _make_stream(lambda *_: iter(()), [1, 2, 3])
+    stream.generate({"max_tokens": 5})
+
+    assert stream.output_tokens == []
+    assert stream.decoded_tokens == 0
+
+
+def test_output_tokens_survive_a_replaced_live_sequence():
+    # update()/modify_kv() rebind self.tokens to the edited sequence; the
+    # generated-token history must not be affected by that.
+    stream = _make_stream(_two_token_completion, [10, 20])
+    stream.generate({"max_tokens": 2})
+    stream.tokens = [99, 98, 97]
+
+    assert stream.output_tokens == [30, 31]


### PR DESCRIPTION
### Summary

`LMCacheRequestStream.output_tokens` returns `self.tokens` — the entire live sequence (prompt + suffix + edited + generated tokens) — even though its docstring says it returns *"the concatenated generated tokens across all segments."* This breaks downstream token accounting for SDK users and is inconsistent with `decoded_tokens` and `output_text`, both of which already track only generated content.

```python
stream = LMCacheRequestStream(contexts=[], post_completion=pc, prompt_token_ids=[10, 20])
stream.generate({"max_tokens": 2})   # generates 30, 31
stream.output_tokens   # -> [10, 20, 30, 31]   (should be [30, 31])
stream.decoded_tokens  # -> 2
```

### Fix

Track generated token ids in a dedicated `_output_tokens` list, appended in `generate()` right next to `_text_parts` — mirroring how `output_text` is built. `output_tokens` now returns that list.

This keeps the invariant `len(output_tokens) == decoded_tokens` and is robust to `update()` / `modify_kv()` rebinding `self.tokens` to an edited sequence (the reporter's concern), because the generated-token history is accumulated at generation time and never re-derived from the live sequence.

### Tests

Adds `tests/sdk/test_request.py`:
- output excludes the prompt
- output accumulates across consecutive `generate()` calls
- zero-token generation yields `[]`
- generated history survives a replaced live sequence (KV edit)

Verified locally that the first test fails on `dev` (`[10, 20, 30, 31]`) and passes with this change. `ruff` (pinned v0.11.7) check and format are clean.

Fixes #4591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
