### PR TITLE
docs: daily drift check — multi-process mode (2026-08-16)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -571,6 +571,34 @@ All connector-level options are passed through
        allowing L2-to-L1 KV staging to overlap with scheduler queue wait.
        Resumable requests are skipped because their token IDs may be incomplete
        at enqueue time.
+   * - ``lmcache.mp.lazy_offload``
+     - ``false``
+     - Defer scheduler-side store submissions instead of emitting them on
+       every scheduler step. When ``true``, per-request store metadata is
+       queued in a pending buffer and only released to the worker once the
+       configured policy fires (see the ``lazy_offload_policy`` /
+       ``lazy_offload_threshold`` / ``lazy_offload_select_count`` keys
+       below). Opt-in throughput/scheduling optimization; requires the
+       scheduler-side GPU block pool to be bound (done automatically by the
+       ``LMCacheMPConnector`` when the flag is set).
+   * - ``lmcache.mp.lazy_offload_policy``
+     - ``"FIFO"``
+     - Only used when ``lmcache.mp.lazy_offload`` is ``true``. Selects the
+       drain policy for the pending-store buffer. The only shipped choice is
+       ``"FIFO"`` (offload finished requests in insertion order); any other
+       value raises ``ValueError`` on connector construction.
+   * - ``lmcache.mp.lazy_offload_threshold``
+     - ``100``
+     - Only used when ``lmcache.mp.lazy_offload`` is ``true``. Integer count
+       of **finished** pending requests that must accumulate before the FIFO
+       policy releases a batch; ``pop_items_for_offload`` returns an empty
+       list until ``finished_requests_count >= threshold``. This is a request
+       count, not a fraction of GPU blocks.
+   * - ``lmcache.mp.lazy_offload_select_count``
+     - ``10``
+     - Only used when ``lmcache.mp.lazy_offload`` is ``true``. Maximum number
+       of finished pending requests popped from the buffer per scheduler
+       step once the threshold fires.
    * - ``lmcache.mp.mp_transfer_mode``
      - ``auto``
      - Routing mode for the worker -> server transfer context. One of


### PR DESCRIPTION
## Summary

Daily docs drift check against `upstream/dev` at
[`e8f9381`](https://github.com/LMCache/LMCache/commit/e8f938189d42875abf469f25a34765659e0f9c2d),
focused on multi-process mode. One user-facing inconsistency
addressed today, in `docs/source/mp/configuration.rst` (the
`LMCacheMPConnector` extra-config table).

**`docs/source/`**

- `docs/source/mp/configuration.rst` — the "Connector `extra_config`
  Keys" table under *vLLM Client Configuration* does not list the
  four `lmcache.mp.lazy_offload*` keys read by the shipped
  `LMCacheMPConnector` / `LazyOffloadPendingStore` /
  `FIFOOffloadPolicy` from PR
  [#4434](https://github.com/LMCache/LMCache/pull/4434) (merged
  2026-08-14). Users enabling lazy offload today have no
  user-facing documentation of what values the extra-config keys
  accept or what they default to. This is a `docs/source/` gap
  explicitly deferred by the prior drift-check PR
  [#4570](https://github.com/LMCache/LMCache/pull/4570) — filling
  it here.

**`docs/design/`**

- No new design-doc drift found today. The pre-existing
  `docs/design/integration/vllm/lazy_offload.md` staleness (the
  design doc's `threshold` / `drain_ratio` semantics don't match
  the shipped policy) is already tracked by open PR
  [#4570](https://github.com/LMCache/LMCache/pull/4570) — not
  re-touched here.

## Evidence

### Missing keys in the docs (before this PR)

`docs/source/mp/configuration.rst` — the *Connector `extra_config`
Keys* table at
[L529–L582 @ dev@e8f9381](https://github.com/LMCache/LMCache/blob/e8f938189d42875abf469f25a34765659e0f9c2d/docs/source/mp/configuration.rst#L529-L582)
lists `server_urls`, `host`, `port`, `mq_timeout`,
`heartbeat_interval`, `eager_prefetch`, and `mp_transfer_mode`, but
nothing for `lazy_offload*`. `git grep -n lazy_offload
docs/source/` on `dev@e8f9381` returns zero matches.

### Actual code (each key is read by the connector on every scheduler init)

- `LMCacheMPConnector` reads `lmcache.mp.lazy_offload` from
  `kv_connector_extra_config`, default `False`, at
  [lmcache/integration/vllm/lmcache_mp_connector.py L328–L331 @ dev@e8f9381](https://github.com/LMCache/LMCache/blob/e8f938189d42875abf469f25a34765659e0f9c2d/lmcache/integration/vllm/lmcache_mp_connector.py#L328-L331):

  ```python
  self.lazy_offload = vllm_config.kv_transfer_config.get_from_extra_config(
      "lmcache.mp.lazy_offload", False
  )
  ```

- `LazyOffloadPendingStore` reads `lmcache.mp.lazy_offload_policy`
  (default `"FIFO"`) and `lmcache.mp.lazy_offload_select_count`
  (default `10`) at
  [lmcache/integration/vllm/lazy_offload_pending_store.py L40–L46 @ dev@e8f9381](https://github.com/LMCache/LMCache/blob/e8f938189d42875abf469f25a34765659e0f9c2d/lmcache/integration/vllm/lazy_offload_pending_store.py#L40-L46)
  and
  [L92–L101](https://github.com/LMCache/LMCache/blob/e8f938189d42875abf469f25a34765659e0f9c2d/lmcache/integration/vllm/lazy_offload_pending_store.py#L92-L101).
  Any policy string other than `"FIFO"` raises
  `ValueError(f"Unknown offload policy: {policy}")`.
- `FIFOOffloadPolicy` reads `lmcache.mp.lazy_offload_threshold` as
  an integer count of finished requests, default `100`, at
  [lmcache/integration/vllm/lazy_offload_policy/fifo.py L34–L40 @ dev@e8f9381](https://github.com/LMCache/LMCache/blob/e8f938189d42875abf469f25a34765659e0f9c2d/lmcache/integration/vllm/lazy_offload_policy/fifo.py#L34-L40).
  The trigger is `self._finished_requests_count >= self._threshold`
  at
  [fifo.py L79–L98](https://github.com/LMCache/LMCache/blob/e8f938189d42875abf469f25a34765659e0f9c2d/lmcache/integration/vllm/lazy_offload_policy/fifo.py#L79-L98).

## Proposed fix

Applied in this PR's diff:

- `docs/source/mp/configuration.rst` — add four rows to the
  *Connector `extra_config` Keys* list-table (`lazy_offload`,
  `lazy_offload_policy`, `lazy_offload_threshold`,
  `lazy_offload_select_count`) with the shipped defaults and
  semantics (finished-request count threshold, per-step pop cap,
  FIFO-only policy). The rows are placed between `eager_prefetch`
  and `mp_transfer_mode` so all the throughput-shaping options
  cluster together in the table.

No code changes; docs only.

## Not fixed in this PR

- The stale `docs/design/integration/vllm/lazy_offload.md`
  Configuration block and drain-strategy pseudo-code are already
  addressed by open PR
  [#4570](https://github.com/LMCache/LMCache/pull/4570); not
  duplicated here.

## Notes

Auto-generated by the daily docs drift-check routine. **Human
review required before merge.** Kept as **draft**; not marked
"Ready for review." No code files touched. Deduplicated against
prior open drift-check PRs (#4570, #4519, #4480, #4462, #4455);
today's finding is the user-facing lazy-offload config coverage,
which none of them address.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHgCWhsgbtqrQfymHReqcV)_