### PR TITLE
[Bugfix][CLI] Don't count timed-out rounds in L2 bench stats

### DIFF
--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -1380,6 +1380,7 @@ Final summary (one section per exercised operation):
    --------------------------- Store -----------------------
    Operation:                        Store
    Rounds:                           1
+   Rounds timed out:                 0
    Keys / round:                     96
    Total keys:                       96
    Total success:                    96
@@ -1398,6 +1399,15 @@ Each operation section reports per-round duration statistics
 (avg / min / max / p50 / p99 / std), aggregate throughput
 (``avg_throughput_mbps`` -- 0 for ``Lookup`` since it has no payload),
 average key-rate (``avg_ops_per_sec``), and a per-key latency.
+
+``Rounds`` counts every round that was issued, and ``Rounds timed out``
+counts the subset that hit the wait timeout. A round that times out has
+no meaningful duration, so it is excluded from all duration and
+throughput statistics; the keys it issued still count toward
+``Total keys``, and the keys that did succeed before the timeout still
+count toward ``Total success``. When ``Rounds timed out`` is non-zero,
+read the duration and throughput figures as describing the rounds that
+completed.
 
 For ``Lookup``, three additional fields are reported when
 ``--lookup-max-hit-rate`` is non-zero or some keys were found:

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -639,7 +639,8 @@ def _emit_l2_adapter_metrics(
         section_id = f"op_{idx}"
         section = metrics.add_section(section_id, r.operation)
         section.add("operation", "Operation", r.operation)
-        section.add("rounds", "Rounds", len(r.round_durations))
+        section.add("rounds", "Rounds", r.attempted_rounds)
+        section.add("rounds_timed_out", "Rounds timed out", r.timed_out_rounds)
         section.add("keys_per_round", "Keys / round", r.keys_per_round)
         section.add("total_keys", "Total keys", r.total_keys)
         section.add("total_success", "Total success", r.total_success)

--- a/lmcache/cli/commands/bench/l2_adapter_bench/result.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/result.py
@@ -36,6 +36,11 @@ class BenchResult:
     carries ``num_keys`` keys. ``round_durations[r]`` is the wall-clock
     elapsed for the whole round (from issuing the first submit to all
     submits of that round completing).
+
+    A round that hits the wait timeout has no duration, so it is counted in
+    ``timed_out_rounds`` rather than appended to ``round_durations``. Its
+    partial ``success_counts`` entry is still recorded and it still counts
+    toward ``attempted_rounds``, so key accounting is unchanged.
     """
 
     operation: str
@@ -44,6 +49,8 @@ class BenchResult:
     data_size_bytes: int
     round_durations: list[float] = field(default_factory=list)
     success_counts: list[int] = field(default_factory=list)
+    # Rounds that hit the wait timeout and therefore have no duration.
+    timed_out_rounds: int = 0
     # Lookup-specific metadata (left as defaults for store/load).
     expected_max_hit_rate: float = 0.0
     expected_hit_count: int = 0
@@ -57,8 +64,13 @@ class BenchResult:
         return self.in_flight * self.num_keys
 
     @property
+    def attempted_rounds(self) -> int:
+        """Rounds issued, including those that timed out."""
+        return len(self.round_durations) + self.timed_out_rounds
+
+    @property
     def total_keys(self) -> int:
-        return self.keys_per_round * len(self.round_durations)
+        return self.keys_per_round * self.attempted_rounds
 
     @property
     def total_data_bytes_per_round(self) -> int:

--- a/lmcache/cli/commands/bench/l2_adapter_bench/runner.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/runner.py
@@ -182,7 +182,7 @@ def bench_store(
                 f"({len(completed)}/{len(task_ids)} tasks completed, "
                 f"success_keys={success_keys}/{in_flight * num_keys})"
             )
-            result.round_durations.append(float("inf"))
+            result.timed_out_rounds += 1
             result.success_counts.append(success_keys)
             continue
 
@@ -252,7 +252,7 @@ def bench_lookup(
                 f"({len(results)}/{len(task_ids)} tasks completed, "
                 f"found={total_found}/{in_flight * num_keys})"
             )
-            result.round_durations.append(float("inf"))
+            result.timed_out_rounds += 1
             result.success_counts.append(total_found)
             continue
 
@@ -318,7 +318,7 @@ def bench_load(
                 f"({len(results)}/{len(task_ids)} tasks completed, "
                 f"loaded={total_loaded}/{in_flight * num_keys})"
             )
-            result.round_durations.append(float("inf"))
+            result.timed_out_rounds += 1
             result.success_counts.append(total_loaded)
             continue
 

--- a/tests/cli/commands/bench/l2_adapter_bench/test_result.py
+++ b/tests/cli/commands/bench/l2_adapter_bench/test_result.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# First Party
+from lmcache.cli.commands.bench.l2_adapter_bench.result import BenchResult
+
+_MB = 1024 * 1024
+
+
+def _result(durations: list[float], timed_out: int = 0) -> BenchResult:
+    return BenchResult(
+        operation="store",
+        in_flight=1,
+        num_keys=64,
+        data_size_bytes=_MB,
+        round_durations=durations,
+        success_counts=[64] * (len(durations) + timed_out),
+        timed_out_rounds=timed_out,
+    )
+
+
+def test_timed_out_round_excluded_from_duration_and_throughput() -> None:
+    r = _result([0.10, 0.11, 0.09, 0.12], timed_out=1)
+
+    assert len(r.per_round_throughput_mbps) == 4
+    assert r.min_throughput_mbps > 0.0
+    assert r.max_duration == 0.12
+    assert r.std_duration > 0.0
+
+
+def test_timeout_does_not_change_key_accounting() -> None:
+    r = _result([0.10, 0.11, 0.09, 0.12], timed_out=1)
+
+    assert r.attempted_rounds == 5
+    assert r.total_keys == 320
+    assert r.actual_hit_rate == 1.0
+
+
+def test_all_rounds_timed_out_reports_zeros() -> None:
+    r = _result([], timed_out=3)
+
+    assert r.attempted_rounds == 3
+    assert r.avg_duration == 0.0
+    assert r.avg_throughput_mbps == 0.0
+    assert r.p99_duration == 0.0


### PR DESCRIPTION
**What this PR does / why we need it**:

`bench_store`, `bench_lookup` and `bench_load` all record a round that timed out as `float("inf")` seconds. That causes two problems.

`std_duration` runs `statistics.stdev` over those durations, and `inf` makes it raise. So the benchmark crashes at the end, when it prints the results.

The other one doesn't error at all. Throughput is `(bytes_per_round / _MB) / d`. With `d = inf` that gives exactly `0.0`, and the `d <= 0` check doesn't catch it. So a round that timed out gets counted as a round that ran at 0 MB/s, and the average comes out lower than it should be.

For example: durations `[0.10, 0.11, 0.09, timeout, 0.12]` at 64 MiB per round. It reports 493.25 MB/s. The four rounds that finished averaged 616.57. `min_throughput_mbps` reports `0.0`.

Now timeouts go into a `timed_out_rounds` counter instead. `attempted_rounds` keeps `total_keys` and `actual_hit_rate` at the same values as before, so only the duration and throughput numbers change.

**Special notes for your reviewers**:

`rounds` now counts every round that started, and I added a `rounds_timed_out` line next to it so the timeouts are visible. Happy to drop that if you'd rather leave the output as it was.

`result.py` didn't have any tests, so I added three.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
