### PR TITLE
fix(vllm/mp): mark failed retrieves as load errors so the engine recomputes

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1553,6 +1553,53 @@ class LMCacheMPWorkerAdapter:
         for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
             self.submit_retrieve_request(request_id, op, event, cache_salt=salt)
 
+    def _poll_finished_retrieves(self) -> set[str]:
+        """Poll retrieve futures, failing closed on unsuccessful retrieves.
+
+        A retrieve future that resolves ``False`` (or raises) means the
+        server did not write the op's GPU blocks. Reporting the request
+        finished without recording the failed span would ACK the load as
+        successful: the engine would then decode over blocks the server
+        never wrote (stale or uninitialized KV), producing silently wrong
+        tokens (#2865, #3388). The failed op's block ids are added to
+        ``error_block_ids`` so ``get_block_ids_with_load_errors`` makes the
+        scheduler invalidate and recompute them, matching the contract the
+        unhealthy drain path already follows. The server collapses per-key
+        results into a single bool, so flagging the whole op span is
+        conservative-correct for partial failures too; finer-grained
+        recovery is tracked in #2898.
+
+        Returns:
+            The request ids whose retrieve future settled in this call.
+        """
+        finished_retrieves: set[str] = set()
+        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+            if not r_future.query():
+                continue
+
+            try:
+                r_result = r_future.result(timeout=60)
+            except Exception:
+                # A raising future must not escape get_finished (that would
+                # abort the engine step); contain it as a failed retrieve.
+                logger.exception(
+                    "Retrieve future raised for request_id=%s; "
+                    "treating it as a failed retrieve.",
+                    request_id,
+                )
+                r_result = False
+            finished_retrieves.add(request_id)
+
+            if not r_result:
+                self.error_block_ids.update(r_block_ids)
+                logger.error(
+                    "Retrieve failed for request_id=%s: %d block id(s) "
+                    "flagged for engine recompute.",
+                    request_id,
+                    len(r_block_ids),
+                )
+        return finished_retrieves
+
     def _process_finished_stores(
         self,
         finished_req_ids_from_lmcache: set[str],
@@ -1637,7 +1684,6 @@ class LMCacheMPWorkerAdapter:
             return ret_stores, finished_retrieves
 
         finished_stores = set()
-        finished_retrieves = set()
         for request_id, s_future in self.store_futures.items():
             if not s_future.query():
                 continue
@@ -1652,20 +1698,7 @@ class LMCacheMPWorkerAdapter:
                     request_id,
                 )
 
-        for request_id, (r_future, _) in self.retrieve_futures.items():
-            if not r_future.query():
-                continue
-
-            r_result = r_future.result(timeout=60)
-            finished_retrieves.add(request_id)
-
-            if not r_result:
-                logger.error(
-                    "Something went wrong when processing the "
-                    "retrieve request for request_id=%s, result=%s",
-                    request_id,
-                    r_result,
-                )
+        finished_retrieves = self._poll_finished_retrieves()
 
         # Remove the finished requests from the tracking dicts
         for request_id in finished_stores:
@@ -1757,7 +1790,6 @@ class LMCacheMPWorkerAdapter:
             return None, finished_retrieves
 
         finished_stores = set()
-        finished_retrieves = set()
         for request_id, s_future in self.store_futures.items():
             if not s_future.query():
                 continue
@@ -1772,20 +1804,7 @@ class LMCacheMPWorkerAdapter:
                     request_id,
                 )
 
-        for request_id, (r_future, _) in self.retrieve_futures.items():
-            if not r_future.query():
-                continue
-
-            r_result = r_future.result(timeout=60)
-            finished_retrieves.add(request_id)
-
-            if not r_result:
-                logger.error(
-                    "Something went wrong when processing the "
-                    "retrieve request for request_id=%s, result=%s",
-                    request_id,
-                    r_result,
-                )
+        finished_retrieves = self._poll_finished_retrieves()
 
         # Remove the finished requests from the tracking dicts
         for request_id in finished_stores:

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -525,6 +525,86 @@ def test_dropped_retrieve_reported_once_via_healthy_get_finished(
     assert finished_retrieves == set()
 
 
+def _submit_retrieve_with_future(
+    adapter: LMCacheMPWorkerAdapter,
+    request_id: str,
+    block_ids: list[list[int]],
+) -> MagicMock:
+    """Submit a retrieve through a stubbed transfer context and return the
+    settled-but-unresolved fake future controlling its outcome."""
+    r_future = MagicMock(name=f"retrieve_future_{request_id}")
+    r_future.query.return_value = True
+    transfer_ctx = MagicMock()
+    transfer_ctx.submit_retrieve.return_value = r_future
+    adapter.transfer_ctx = transfer_ctx
+    adapter.submit_retrieve_request(request_id, _op(block_ids), MagicMock())
+    return r_future
+
+
+def test_failed_retrieve_marks_blocks_as_load_errors(fake_adapter) -> None:
+    """A retrieve future resolving False must flag the op's blocks via
+    get_block_ids_with_load_errors so the scheduler recomputes them,
+    while the request is still reported finished exactly once. Without
+    the flag the engine decodes over GPU blocks the server never wrote
+    (silent corruption, #2865 / #3388)."""
+    adapter, _send_mock, _ = fake_adapter
+    r_future = _submit_retrieve_with_future(adapter, "req-1", [[3, 4]])
+    r_future.result.return_value = False
+
+    _ret_stores, finished_retrieves = adapter.get_finished(set())
+
+    assert finished_retrieves == {"req-1"}
+    assert adapter.get_block_ids_with_load_errors() == {3, 4}
+    # Drained: a second poll reports neither the request nor the blocks.
+    _ret_stores, finished_retrieves = adapter.get_finished(set())
+    assert finished_retrieves == set()
+    assert adapter.get_block_ids_with_load_errors() == set()
+
+
+def test_successful_retrieve_reports_no_load_errors(fake_adapter) -> None:
+    """A retrieve future resolving True must not flag any block."""
+    adapter, _send_mock, _ = fake_adapter
+    r_future = _submit_retrieve_with_future(adapter, "req-1", [[3, 4]])
+    r_future.result.return_value = True
+
+    _ret_stores, finished_retrieves = adapter.get_finished(set())
+
+    assert finished_retrieves == {"req-1"}
+    assert adapter.get_block_ids_with_load_errors() == set()
+
+
+def test_raising_retrieve_future_is_contained_and_marks_blocks(
+    fake_adapter,
+) -> None:
+    """A retrieve future that raises must not escape get_finished (that
+    would abort the engine step); it is treated as a failed retrieve:
+    request reported finished, blocks flagged for recompute."""
+    adapter, _send_mock, _ = fake_adapter
+    r_future = _submit_retrieve_with_future(adapter, "req-1", [[7]])
+    r_future.result.side_effect = RuntimeError("ipc event import failed")
+
+    _ret_stores, finished_retrieves = adapter.get_finished(set())
+
+    assert finished_retrieves == {"req-1"}
+    assert adapter.get_block_ids_with_load_errors() == {7}
+
+
+def test_failed_retrieve_marks_blocks_with_lazy_offload(fake_adapter) -> None:
+    """The lazy-offload variant of get_finished applies the same
+    fail-closed contract for failed retrieves."""
+    _adapter, _send_mock, _ = fake_adapter
+    adapter = _make_worker_adapter(
+        extra_config={"lmcache.mp.lazy_offload": True},
+    )
+    r_future = _submit_retrieve_with_future(adapter, "req-1", [[9, 10]])
+    r_future.result.return_value = False
+
+    _stores, finished_retrieves = adapter.get_finished_with_lazy_offload()
+
+    assert finished_retrieves == {"req-1"}
+    assert adapter.get_block_ids_with_load_errors() == {9, 10}
+
+
 def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     """shutdown() stops the heartbeat before sending UNREGISTER, so no
     stray heartbeat ping can race the closing mq_client."""


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #2865. Refs #3388, #4492, #2898.

When a multiprocess retrieve future resolves `False` — the server hit an eviction/lock race between lookup and retrieve, a load failure, or any exception in the `RETRIEVE` handler — `LMCacheMPWorkerAdapter.get_finished` logs the failure and then reports the request as a **successfully finished load**. The op's GPU blocks were never written, `get_block_ids_with_load_errors()` stays empty, and the engine decodes over stale or uninitialized KV: silently wrong tokens, HTTP 200, nothing in any log except the one ERROR line. The unhealthy drain path already flags exactly these blocks via `error_block_ids`; the ordinary `r_result=False` path drops them (`vllm_multi_process_adapter.py`, the loop formerly at `get_finished`, duplicated in `get_finished_with_lazy_offload`).

This PR makes the MP retrieve path fail closed:

1. The retrieve-polling loop is factored into a single `_poll_finished_retrieves()` used by both `get_finished` variants (they had drifted into duplicates; the module TODO already flags that).
2. A retrieve future resolving `False` adds the op's block ids to `error_block_ids`, so `get_block_ids_with_load_errors()` → `kv_connector_output.invalid_block_ids` → scheduler invalidation → recompute. Correctness over latency: a failed load becomes a recompute instead of corruption.
3. A **raising** retrieve future is contained as a failed retrieve instead of propagating out of `get_finished` and aborting the engine step.

The server collapses per-key results into a single bool today, so flagging the whole op span is conservative-correct for partial failures too. This is deliberately the **minimal correctness subset of #2898** (open since March, in merge conflicts since May): no protocol change, forward-compatible with that PR's finer-grained partial recovery — if/when #2898 lands, its per-key `failed_block_ids` simply replaces the whole-span flag.

**Duplicate search**: #2865 (this defect, open), #2898 (superset PR, stalled), #3388 (production report with the same one-hop analysis, marked stale), #1835 (the single-process equivalent that already landed), #4247 / #4492 (silent-corruption reports on the MP path where this missing hop makes every server-side failure invisible).

**Provenance / evidence**:
- #3388: Kimi K2.6, MLA, TP=8 — hundreds of `result=False` lines synchronised across 8 workers during customer-visible garbage output; the issue author proposed exactly this fix and #2865's author confirmed the missing `record_failed_blocks()` equivalence.
- Our cross-restart corroboration on #4492: 38/38 requests corrupted on a warm L2 after an engine restart (four-arm ladder, receipts with per-request rows: https://github.com/malaiwah/qwen38-27b-exl3/blob/main/receipts/lmcache-reuse-test.json). A follow-up receipt with the full root-cause reconciliation of those arms is being posted on both issues alongside this PR.
- An equivalent fail-closed guard has been running in our downstream fork build (`0.5.2+glm52dcp.4`, `local-inference-lab/LMCache`) under that battery.

**Tests**: added to `tests/v1/test_vllm_mp_adapter.py` in its existing stubbed-MQ style, CPU-only:
- `test_failed_retrieve_marks_blocks_as_load_errors` — fails on unpatched `dev` (`error_block_ids` stays empty);
- `test_raising_retrieve_future_is_contained_and_marks_blocks` — fails on unpatched `dev` (`RuntimeError` escapes `get_finished`);
- `test_failed_retrieve_marks_blocks_with_lazy_offload` — fails on unpatched `dev`;
- `test_successful_retrieve_reports_no_load_errors` — guard against over-flagging (passes before and after).

GPU end-to-end validation follows: we will re-run the pre-registered four-arm needle ladder from the receipts above (RTX 5090, hybrid GDN + full-attention model, `kv_both` + `fs_native` L2, chunk 1600) on a wheel carrying this patch and post the per-request rows here. We are also happy to run any additional arm a maintainer names (chunk size, `kv_role`, non-disk L2).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
