### PR TITLE
fix(storage): let a tier that allocates its own objects run without a host pool

### DIFF
--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -321,8 +321,24 @@ class StorageManager:
                 allocator_backend = self.storage_backends["LocalCPUBackend"]
             else:
                 allocator_backend = self.storage_backends["MaruBackend"]
-        else:
+        elif "LocalCPUBackend" in self.storage_backends:
             allocator_backend = self.storage_backends["LocalCPUBackend"]
+        else:
+            # No host pool: a tier that allocates its own objects can serve.
+            allocator_backend = next(
+                (
+                    backend
+                    for backend in self.storage_backends.values()
+                    if isinstance(backend, AllocatorBackendInterface)
+                ),
+                None,
+            )  # type: ignore[assignment]
+            if allocator_backend is None:
+                raise RuntimeError(
+                    "No storage backend owns a memory allocator. Configure one "
+                    "(a host pool via max_local_cpu_size, or a tier that "
+                    "allocates its own objects) before storing."
+                )
         assert isinstance(allocator_backend, AllocatorBackendInterface)
         return allocator_backend
 

--- a/tests/v1/storage_backend/test_allocator_backend_selection.py
+++ b/tests/v1/storage_backend/test_allocator_backend_selection.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Allocator selection, including with no host pool registered."""
+
+# Standard
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
+from lmcache.v1.storage_backend.storage_manager import StorageManager
+
+
+def _backend(owns_allocator: bool) -> MagicMock:
+    spec = AllocatorBackendInterface if owns_allocator else object
+    return MagicMock(spec=spec)
+
+
+def _manager(names: list[str], enable_pd: bool = False) -> StorageManager:
+    manager = StorageManager.__new__(StorageManager)
+    manager.enable_pd = enable_pd
+    manager.storage_backends = OrderedDict(
+        (name, _backend(name != "PlainBackend")) for name in names
+    )
+    return manager
+
+
+def _selected(manager: StorageManager) -> str:
+    backend = manager._get_allocator_backend(MagicMock())  # noqa: SLF001
+    return next(n for n, b in manager.storage_backends.items() if b is backend)
+
+
+def test_host_pool_still_wins_when_present() -> None:
+    assert _selected(_manager(["LocalCPUBackend", "GdsBackend"])) == "LocalCPUBackend"
+
+
+def test_a_tier_that_owns_an_allocator_serves_without_a_host_pool() -> None:
+    assert _selected(_manager(["GdsBackend"])) == "GdsBackend"
+
+
+def test_first_registered_allocator_owner_wins() -> None:
+    assert _selected(_manager(["PlainBackend", "GdsBackend"])) == "GdsBackend"
+
+
+def test_pd_still_wins() -> None:
+    assert (
+        _selected(_manager(["PDBackend", "LocalCPUBackend"], enable_pd=True))
+        == "PDBackend"
+    )
+
+
+def test_no_allocator_anywhere_is_a_named_error() -> None:
+    with pytest.raises(RuntimeError, match="owns a memory allocator"):
+        _selected(_manager(["PlainBackend"]))


### PR DESCRIPTION
**What this PR does / why we need it**:

Running GDS without host offloading (`max_local_cpu_size: 0`) crashes at start-up:

```
File "lmcache/v1/storage_backend/storage_manager.py", line 325, in _get_allocator_backend
    allocator_backend = self.storage_backends["LocalCPUBackend"]
KeyError: 'LocalCPUBackend'
```

`CreateStorageBackends` registers `LocalCPUBackend` only when `max_local_cpu_size > 0`, but the selection ends in an unconditional lookup of it. Nothing else requires the pool — the write-back in `get` / `batched_get` is already guarded — and `GdsBackend` allocates from its own registered buffer, which `batched_put` uses via `backend.get_allocator_backend()`.

Fall back to the first backend that owns an allocator, and raise a named error when none does. P/D, Maru and the host pool keep their existing precedence, so nothing that works today changes.

**Special notes for your reviewers**:

- `local_cpu: false` alone does not hit this; that flag only disables the hot cache, while registration keys off `max_local_cpu_size`.
- The GDS unit tests are skipped without CUDA + cuFile, so this path had no coverage. The added tests use mocks and run on CPU.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
