### PR TITLE
[Fix] Fall back to njit(cache=False) when numba's disk cache is unavailable

### DIFF
--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -16,11 +16,11 @@ from typing import Any, Callable
 import os
 
 # Third Party
-from numba import njit
 import numpy as np
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.numba_utils import njit_cached
 
 logger = init_logger(__name__)
 
@@ -243,7 +243,7 @@ class TokenHasher:
 ### Functions for fast rolling/chunk hash and dict lookup
 
 
-@njit(cache=True)
+@njit_cached
 def rolling_hash_windows_numba(
     arr_u64: np.ndarray, k: int, base: np.uint64
 ) -> np.ndarray:
@@ -307,7 +307,7 @@ def rolling_hash_windows_numba(
     return out
 
 
-@njit(cache=True)
+@njit_cached
 def chunk_hash_windows_numba(arr_u64, k, base):
     """Compute polynomial hashes over non-overlapping (chunked) windows.
 
@@ -351,7 +351,7 @@ def chunk_hash_windows_numba(arr_u64, k, base):
     return out
 
 
-@njit(cache=True)
+@njit_cached
 def update_table_id_numba(
     hashes_u64: np.ndarray,
     table_id_i64: np.ndarray,
@@ -388,7 +388,7 @@ def update_table_id_numba(
         table_id_i64[idx] = vals_to_update[i]
 
 
-@njit(cache=True)
+@njit_cached
 def unique_hits_direct_id_numba(
     hashes_u64: np.ndarray, table_id_i64: np.ndarray, mask_u64: np.uint64, num_ids: int
 ) -> np.ndarray:

--- a/lmcache/v1/numba_utils.py
+++ b/lmcache/v1/numba_utils.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numba JIT helpers with a graceful disk-cache fallback."""
+
+# Standard
+from typing import Callable
+
+# Third Party
+from numba import njit
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+_cache_fallback_warned = False
+
+
+def njit_cached(func: Callable) -> Callable:
+    """Compile ``func`` with ``njit(cache=True)``, falling back to
+    ``cache=False`` (with a one-time warning) when no writable cache
+    directory is available.
+
+    Args:
+        func: The Python function to JIT-compile.
+
+    Returns:
+        The numba-compiled dispatcher wrapping ``func``.
+    """
+    try:
+        return njit(cache=True)(func)
+    except RuntimeError as exc:
+        global _cache_fallback_warned
+        if not _cache_fallback_warned:
+            _cache_fallback_warned = True
+            logger.warning(
+                "Numba disk caching is unavailable (%s). Falling back to "
+                "cache=False; JIT-compiled functions will be recompiled in "
+                "each new process. Set NUMBA_CACHE_DIR to a writable "
+                "directory to restore disk caching.",
+                exc,
+            )
+        return njit(cache=False)(func)

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -17,7 +17,6 @@ import threading
 import warnings
 
 # Third Party
-from numba import njit
 import numpy as np
 import torch
 
@@ -31,6 +30,7 @@ from lmcache.lmcache_native import (
     is_mla,
 )
 from lmcache.logging import init_logger
+from lmcache.v1.numba_utils import njit_cached
 from lmcache.v1.platform._device_detect import (
     current_device_spec,
     get_torch_device,
@@ -2219,7 +2219,7 @@ def lmcache_memcpy_async(
         _copy_bytes_with_tensor(dest, src, nbytes)
 
 
-@njit(cache=True)
+@njit_cached
 def _encode_single_channel(
     cdf_layer_c,  # np.uint32 [lp]
     sym_channel,  # np.uint8 [n_tokens]
@@ -2339,7 +2339,7 @@ def encode_fast_new(cdf, input_sym, output_buffer, output_lengths):
     output_lengths.copy_(torch.from_numpy(out_len_np))
 
 
-@njit(cache=True)
+@njit_cached
 def _decode_single_channel(
     cdf_layer_c,
     bs_np,

--- a/tests/v1/test_numba_utils.py
+++ b/tests/v1/test_numba_utils.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for lmcache.v1.numba_utils."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1 import numba_utils
+
+
+def test_njit_cached_falls_back_when_disk_cache_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """njit_cached falls back to cache=False and stays functional."""
+    real_njit = numba_utils.njit
+    requested_cache_flags: list[bool] = []
+
+    def fake_njit(cache: bool):
+        requested_cache_flags.append(cache)
+        if cache:
+            raise RuntimeError(
+                "cannot cache function 'f': no locator available for file 'f.py'"
+            )
+        return real_njit(cache=False)
+
+    monkeypatch.setattr(numba_utils, "njit", fake_njit)
+
+    @numba_utils.njit_cached
+    def add_one(x: int) -> int:
+        return x + 1
+
+    assert requested_cache_flags == [True, False]
+    assert add_one(41) == 42


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix https://github.com/LMCache/LMCache/issues/4597

When running as a non-root user without NUMBA_CACHE_DIR set, numba cannot find a writable cache directory and startup crashes; fall back to njit(cache=False) so the server still starts

**Special notes for your reviewers**:



**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
