### PR TITLE
[Fix] Fix GDS stream registration for contexts on non-current devices

### DIFF
--- a/lmcache/v1/gpu_connector/gds_context.py
+++ b/lmcache/v1/gpu_connector/gds_context.py
@@ -150,18 +150,21 @@ class GDSContext:
 
     # --- Public API ---------------------------------------------------
 
-    def register_gpu_buffer(self, buffer: torch.Tensor) -> None:
-        """Register a staging buffer (and its stream) with the GDS library.
+    def register_gpu_buffer(
+        self, buffer: torch.Tensor, stream: "torch.cuda.Stream"
+    ) -> None:
+        """Register a staging buffer and its transfer stream with the GDS library.
 
         Registered as contiguous <=16 MiB regions (the GDS buffer-registration
         cap); :meth:`transfer_async` splits transfers at these boundaries.
 
         Args:
             buffer: Contiguous GPU staging buffer, 4 KiB-aligned in size.
+            stream: The CUDA stream all DMAs for ``buffer`` will run on.
         """
         if not self.initialized:
             return
-        raw_stream = torch_dev.current_stream().cuda_stream
+        raw_stream = stream.cuda_stream
         buf = buffer.view(torch.uint8)
         nbytes = buf.numel()
         with self._registry_lock:
@@ -173,15 +176,17 @@ class GDSContext:
                     buf[start : min(start + _MAX_CUFILE_REGION, nbytes)]
                 )
 
-    def deregister_gpu_buffer(self, buffer: torch.Tensor) -> None:
+    def deregister_gpu_buffer(
+        self, buffer: torch.Tensor, stream: "torch.cuda.Stream"
+    ) -> None:
         """Reverse of :meth:`register_gpu_buffer`: deregister its regions + stream.
 
         Args:
             buffer: The buffer passed to :meth:`register_gpu_buffer`.
+            stream: The stream passed to :meth:`register_gpu_buffer`.
         """
         if not self.initialized:
             return
-        stream = torch_dev.current_stream()
         raw_stream = stream.cuda_stream
         # No in-flight DMA on this stream may still reference the buffer.
         stream.synchronize()
@@ -222,17 +227,28 @@ class GDSContext:
             gpu_buffer: A slice of a registered staging buffer; its first
                 ``get_size()`` bytes are transferred.
             direction: :attr:`SlabDirection.READ` or ``.WRITE``.
+
+        Raises:
+            RuntimeError: If the calling thread's current stream was never
+                passed to :meth:`register_gpu_buffer`.
         """
         slab_op = (
             self._slab_read if direction is SlabDirection.READ else self._slab_write
         )
+        stream_handle = self._require_registered_stream()
         nbytes = memory_obj.get_size()
         buf = gpu_buffer.view(torch.uint8)
         pos = 0
         while pos < nbytes:
             base_ptr, dev_offset, region_nbytes = self._resolve_buffer(buf[pos:])
             seg_len = min(nbytes - pos, region_nbytes - dev_offset)
-            slab_op(memory_obj.slab_offset + pos, seg_len, dev_offset, base_ptr)
+            slab_op(
+                memory_obj.slab_offset + pos,
+                seg_len,
+                dev_offset,
+                base_ptr,
+                stream_handle,
+            )
             pos += seg_len
 
     def close(self) -> None:
@@ -389,25 +405,49 @@ class GDSContext:
         offset = ptr - base
         return base, offset, nbytes
 
+    def _require_registered_stream(self) -> int:
+        """Return the current stream's raw handle, requiring it be registered.
+
+        Raises:
+            RuntimeError: If the current stream was never passed to
+                :meth:`register_gpu_buffer`.
+        """
+        stream_handle = torch_dev.current_stream().cuda_stream
+        with self._registry_lock:
+            if stream_handle not in self._registered_streams:
+                raise RuntimeError(
+                    f"GDSContext: current stream 0x{stream_handle:x} is not "
+                    "registered via register_gpu_buffer."
+                )
+        return stream_handle
+
     def _slab_read(
-        self, slab_offset: int, size: int, dev_offset: int, buf_base: int
+        self,
+        slab_offset: int,
+        size: int,
+        dev_offset: int,
+        buf_base: int,
+        stream_handle: int,
     ) -> None:
         """Submit one async GDS read against the slab handle (stream-ordered)."""
         if self._slab_handle is None:
             raise RuntimeError("GDSContext._slab_read: slab handle not open")
-        stream_handle = torch_dev.current_stream().cuda_stream
         sub = self._slab_handle.read_async(
             buf_base, size, slab_offset, dev_offset, stream_handle
         )
         self._record_submission(sub)
 
     def _slab_write(
-        self, slab_offset: int, size: int, dev_offset: int, buf_base: int
+        self,
+        slab_offset: int,
+        size: int,
+        dev_offset: int,
+        buf_base: int,
+        stream_handle: int,
     ) -> None:
         """Submit one async GDS write against the slab handle (stream-ordered)."""
         if self._slab_handle is None:
             raise RuntimeError("GDSContext._slab_write: slab handle not open")
-        stream_handle = torch_dev.current_stream().cuda_stream
         sub = self._slab_handle.write_async(
             buf_base, size, slab_offset, dev_offset, stream_handle
         )

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -413,10 +413,10 @@ class GPUCacheContext(BaseCacheContext):
         # GPU streams
         self.cuda_stream_ = torch_dev.Stream(device=self.device_)
 
-        # Register the staging buffer with the GDS cuFile context on the
-        # context's CUDA stream.
-        with torch_dev.stream(self.cuda_stream_):
-            get_gds_context().register_gpu_buffer(self._temp_buffer.buffer)
+        with torch_dev.device(self.device_):
+            get_gds_context().register_gpu_buffer(
+                self._temp_buffer.buffer, self.cuda_stream_
+            )
 
         # Third Party
         import cupy
@@ -437,8 +437,10 @@ class GPUCacheContext(BaseCacheContext):
         """
         Deregister this context's GDS staging buffer (reverse of __init__).
         """
-        with torch_dev.stream(self.cuda_stream_):
-            get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
+        with torch_dev.device(self.device_):
+            get_gds_context().deregister_gpu_buffer(
+                self._temp_buffer.buffer, self.cuda_stream_
+            )
 
     @property
     def stream(self) -> Any:

--- a/tests/v1/gpu_connector/test_gds_context.py
+++ b/tests/v1/gpu_connector/test_gds_context.py
@@ -275,7 +275,7 @@ class TestRegisterGpuBuffer:
         registered = []
         monkeypatch.setattr(ca, "register_buffer", registered.append)
         # GDS off -> registers nothing, makes no cuFile calls.
-        ctx.register_gpu_buffer(torch.empty(4096, dtype=torch.uint8))
+        ctx.register_gpu_buffer(torch.empty(4096, dtype=torch.uint8), _fake_stream(7))
         assert registered == []
 
     def test_splits_buffer_into_regions(self, monkeypatch):
@@ -289,15 +289,28 @@ class TestRegisterGpuBuffer:
             lambda buf: sizes.append(buf.numel() * buf.element_size()),
         )
         monkeypatch.setattr(ca, "register_stream", lambda raw: None)
-        monkeypatch.setattr(torch_dev, "current_stream", lambda: _fake_stream(0))
 
         # The whole buffer is registered in <=16 MiB regions, irrespective of
         # any chunk/slot layout. A 40 MiB buffer -> 16 + 16 + 8 MiB.
         # A CPU tensor is fine: the cuFile calls are mocked.
         buf = torch.empty(40 << 20, dtype=torch.uint8)
-        ctx.register_gpu_buffer(buf)
+        ctx.register_gpu_buffer(buf, _fake_stream(7))
 
         assert sizes == [16 << 20, 16 << 20, 8 << 20]
+
+    def test_registers_passed_stream_not_ambient_stream(self, monkeypatch):
+        """Registration uses the stream argument, never the ambient current
+        stream (regression test for issue #4589)."""
+        ctx = GDSContext()
+        ctx.initialized = True
+        reg_str: list[int] = []
+        monkeypatch.setattr(ca, "register_buffer", lambda b: None)
+        monkeypatch.setattr(ca, "register_stream", reg_str.append)
+        monkeypatch.setattr(torch_dev, "current_stream", lambda: _fake_stream(0))
+
+        ctx.register_gpu_buffer(torch.empty(4096, dtype=torch.uint8), _fake_stream(42))
+
+        assert reg_str == [42]
 
 
 class TestUgdsInitialization:
@@ -457,14 +470,14 @@ class TestResolveBuffer:
         ctx.initialized = True
         monkeypatch.setattr(ca, "register_buffer", lambda b: None)
         monkeypatch.setattr(ca, "register_stream", lambda raw: None)
-        monkeypatch.setattr(torch_dev, "current_stream", lambda: _fake_stream(0))
-        ctx.register_gpu_buffer(buf)
+        monkeypatch.setattr(torch_dev, "current_stream", lambda: _fake_stream(7))
+        ctx.register_gpu_buffer(buf, _fake_stream(7))
         resolved: list[tuple[int, int]] = []
         monkeypatch.setattr(
             ctx,
             "_slab_write",
-            lambda slab_offset, size, dev_offset, buf_base: resolved.append(
-                (buf_base, dev_offset)
+            lambda slab_offset, size, dev_offset, buf_base, stream_handle: (
+                resolved.append((buf_base, dev_offset))
             ),
         )
         return ctx, resolved
@@ -495,27 +508,18 @@ class TestPerStreamRegistration:
         monkeypatch.setattr(ca, "register_stream", reg_str.append)
         monkeypatch.setattr(ca, "deregister_stream", dereg_str.append)
 
-        def use_stream(handle: int):
-            monkeypatch.setattr(
-                torch_dev, "current_stream", lambda: _fake_stream(handle)
-            )
-
         buf_a = torch.empty(24 << 20, dtype=torch.uint8)  # 2 regions on stream 11
         buf_b = torch.empty(4096, dtype=torch.uint8)  # 1 region on stream 22
-        use_stream(11)
-        ctx.register_gpu_buffer(buf_a)
-        use_stream(22)
-        ctx.register_gpu_buffer(buf_b)
+        ctx.register_gpu_buffer(buf_a, _fake_stream(11))
+        ctx.register_gpu_buffer(buf_b, _fake_stream(22))
         # Each distinct stream registered exactly once.
         assert reg_str == [11, 22]
 
         # Deregistering buf_b frees stream 22's only region -> stream 22 dropped.
-        use_stream(22)
-        ctx.deregister_gpu_buffer(buf_b)
+        ctx.deregister_gpu_buffer(buf_b, _fake_stream(22))
         assert dereg_str == [22]
         # Stream 11 still has 2 regions (24 MiB -> 16 + 8), so not yet dropped.
-        use_stream(11)
-        ctx.deregister_gpu_buffer(buf_a)
+        ctx.deregister_gpu_buffer(buf_a, _fake_stream(11))
         assert dereg_str == [22, 11]
         assert len(dereg_buf) == 3  # all three slots deregistered
 
@@ -561,6 +565,47 @@ def test_ugds_context_roundtrip():
         ctx.close()
 
 
+class TestSubmissionStreamInvariant:
+    """DMA submissions must run with a registered stream current and fail
+    loudly otherwise (issue #4589)."""
+
+    def _ctx_with_fake_slab(self, monkeypatch, buf: torch.Tensor):
+        ctx = GDSContext()
+        ctx.initialized = True
+        monkeypatch.setattr(ca, "register_buffer", lambda b: None)
+        monkeypatch.setattr(ca, "register_stream", lambda raw: None)
+        ctx.register_gpu_buffer(buf, _fake_stream(11))
+        submitted: list[int] = []
+
+        def fake_write_async(base, size, foff, doff, stream) -> ca.Submission:
+            submitted.append(stream)
+            return ca.Submission(size=size, file_offset=foff, buf_offset=doff)
+
+        monkeypatch.setattr(
+            ctx, "_slab_handle", SimpleNamespace(write_async=fake_write_async)
+        )
+        return ctx, submitted
+
+    def test_transfer_on_unregistered_stream_raises(self, monkeypatch):
+        buf = torch.empty(4096, dtype=torch.uint8)
+        ctx, submitted = self._ctx_with_fake_slab(monkeypatch, buf)
+        mem_obj = SimpleNamespace(get_size=lambda: 4096, slab_offset=0)
+
+        monkeypatch.setattr(torch_dev, "current_stream", lambda: _fake_stream(99))
+        with pytest.raises(RuntimeError, match="not registered"):
+            ctx.transfer_async(mem_obj, buf, SlabDirection.WRITE)
+        assert submitted == []
+
+    def test_transfer_on_registered_stream_submits(self, monkeypatch):
+        buf = torch.empty(4096, dtype=torch.uint8)
+        ctx, submitted = self._ctx_with_fake_slab(monkeypatch, buf)
+        mem_obj = SimpleNamespace(get_size=lambda: 4096, slab_offset=0)
+
+        monkeypatch.setattr(torch_dev, "current_stream", lambda: _fake_stream(11))
+        ctx.transfer_async(mem_obj, buf, SlabDirection.WRITE)
+        assert submitted == [11]
+
+
 @requires_gds
 def test_gds_two_stream_write_read(gds_slab_dir: Path):
     """Verify independent chunk writes and reads on two GPU streams."""
@@ -574,7 +619,7 @@ def test_gds_two_stream_write_read(gds_slab_dir: Path):
         """Register a buffer on ``stream`` and write ``pattern`` to a chunk."""
         with torch.cuda.stream(stream):
             buf = torch.empty(chunk_bytes, dtype=torch.uint8, device="cuda")
-            ctx.register_gpu_buffer(buf)
+            ctx.register_gpu_buffer(buf, stream)
             err, objs = mgr.allocate(
                 MemoryLayoutDesc(
                     shapes=[torch.Size([chunk_bytes])], dtypes=[torch.uint8]
@@ -608,10 +653,9 @@ def test_gds_two_stream_write_read(gds_slab_dir: Path):
                 expected = torch.full((chunk_bytes,), pattern, dtype=torch.uint8)
                 assert torch.equal(buf.cpu(), expected)
 
-        # Deregister each buffer on its own stream.
+        # Deregister each buffer with its own stream.
         for stream, buf in ((stream_a, buf_a), (stream_b, buf_b)):
-            with torch.cuda.stream(stream):
-                ctx.deregister_gpu_buffer(buf)
+            ctx.deregister_gpu_buffer(buf, stream)
     finally:
         ctx.close()
 
@@ -624,8 +668,9 @@ def test_gds_write_read_roundtrip(gds_slab_dir: Path):
     ctx.initialize(cfg)
     try:
         chunk_bytes = 8 << 20
+        stream = torch.cuda.Stream()
         buf = torch.empty(chunk_bytes, dtype=torch.uint8, device="cuda")
-        ctx.register_gpu_buffer(buf)
+        ctx.register_gpu_buffer(buf, stream)
 
         mgr = GDSL1MemoryManager(cfg)
         err, objs = mgr.allocate(
@@ -636,14 +681,15 @@ def test_gds_write_read_roundtrip(gds_slab_dir: Path):
         mem_obj = objs[0]
         assert isinstance(mem_obj, GDSMemoryObject)
 
-        buf.fill_(0xAB)
-        torch.cuda.synchronize()
-        ctx.transfer_async(mem_obj, buf, SlabDirection.WRITE)
+        with torch.cuda.stream(stream):
+            buf.fill_(0xAB)
+            torch.cuda.synchronize()
+            ctx.transfer_async(mem_obj, buf, SlabDirection.WRITE)
 
-        buf.zero_()
-        torch.cuda.synchronize()
-        ctx.transfer_async(mem_obj, buf, SlabDirection.READ)
-        torch.cuda.synchronize()
+            buf.zero_()
+            torch.cuda.synchronize()
+            ctx.transfer_async(mem_obj, buf, SlabDirection.READ)
+            torch.cuda.synchronize()
 
         expected = torch.full((chunk_bytes,), 0xAB, dtype=torch.uint8)
         assert torch.equal(buf.cpu(), expected)
@@ -663,8 +709,9 @@ def test_gds_chunk_larger_than_region_roundtrip(gds_slab_dir: Path):
     ctx.initialize(cfg)
     try:
         chunk_bytes = 24 << 20  # > 16 MiB -> two registered regions / two DMAs
+        stream = torch.cuda.Stream()
         buf = torch.empty(chunk_bytes, dtype=torch.uint8, device="cuda")
-        ctx.register_gpu_buffer(buf)
+        ctx.register_gpu_buffer(buf, stream)
 
         mgr = GDSL1MemoryManager(cfg)
         err, objs = mgr.allocate(
@@ -679,14 +726,15 @@ def test_gds_chunk_larger_than_region_roundtrip(gds_slab_dir: Path):
         # second segment using the wrong slab offset) would corrupt the bytes
         # around the 16 MiB boundary, which a uniform fill would not catch.
         pattern = (torch.arange(chunk_bytes, dtype=torch.int64) % 251).to(torch.uint8)
-        buf.copy_(pattern.cuda())
-        torch.cuda.synchronize()
-        ctx.transfer_async(mem_obj, buf, SlabDirection.WRITE)
+        with torch.cuda.stream(stream):
+            buf.copy_(pattern.cuda())
+            torch.cuda.synchronize()
+            ctx.transfer_async(mem_obj, buf, SlabDirection.WRITE)
 
-        buf.zero_()
-        torch.cuda.synchronize()
-        ctx.transfer_async(mem_obj, buf, SlabDirection.READ)
-        torch.cuda.synchronize()
+            buf.zero_()
+            torch.cuda.synchronize()
+            ctx.transfer_async(mem_obj, buf, SlabDirection.READ)
+            torch.cuda.synchronize()
 
         assert torch.equal(buf.cpu(), pattern)
     finally:

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -79,6 +79,7 @@ class _GroupSpec:
 def _make_kv_tensors(
     specs: Sequence[_GroupSpec],
     num_blocks: int = 4,
+    device: torch.device = _DEVICE,
 ) -> list[torch.Tensor]:
     """Build non-MLA per-layer KV tensors shaped ``[2, NB, BS, NH, HS]``."""
     tensors: list[torch.Tensor] = []
@@ -92,7 +93,7 @@ def _make_kv_tensors(
                     spec.num_heads,
                     spec.head_size,
                     dtype=spec.dtype,
-                    device=_DEVICE,
+                    device=device,
                 )
             )
     return tensors
@@ -555,6 +556,45 @@ class TestGPUCacheContextReportStatus:
             assert group["slots_per_block"] == kernel_group.slots_per_block
             assert group["tokens_per_block"] == kernel_group.tokens_per_block
             assert 0 <= group["object_group_idx"] < manager.num_object_groups
+
+
+class TestGDSStreamRegistration:
+    """The context hands its own transfer stream to the GDS context, also when
+    constructed from a thread on another device (regression for issue #4589)."""
+
+    @pytest.mark.skipif(
+        torch.cuda.device_count() < 2,
+        reason="needs 2 CUDA devices to reproduce the device mismatch",
+    )
+    def test_registers_context_stream_from_foreign_device_thread(
+        self, monkeypatch
+    ) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector import _gds_async as ca
+        from lmcache.v1.gpu_connector.gds_context import get_gds_context
+
+        get_gds_context.cache_clear()
+        try:
+            gds = get_gds_context()
+            gds.initialized = True
+            registered_streams: list[int] = []
+            monkeypatch.setattr(ca, "register_buffer", lambda b: None)
+            monkeypatch.setattr(ca, "register_stream", registered_streams.append)
+
+            # A cuda:1 context constructed from a thread on cuda:0.
+            torch.cuda.set_device(0)
+            tensors = _make_kv_tensors(_SINGLE_GROUP, device=torch.device("cuda:1"))
+            kv_caches = [_FakeIPCWrapper(t) for t in tensors]
+            ctx = GPUCacheContext(
+                kv_caches,  # type: ignore
+                lmcache_tokens_per_chunk=256,
+                engine_group_infos=(),
+            )
+
+            assert ctx.stream.cuda_stream != 0
+            assert registered_streams == [ctx.stream.cuda_stream]
+        finally:
+            get_gds_context.cache_clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix https://github.com/LMCache/LMCache/issues/4589

Buffer registration read current_stream() without switching device (store/retrieve do both), so for TP>1 it registered device 0's stream with cuFile instead of the context's transfer stream. Now the stream is passed explicitly.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
