### PR TITLE
fix(sglang): distinguish single-head MHA from MLA

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -86,8 +86,9 @@ def _wrap_sglang_kv_caches(
     single flat ``KVCache`` so it fits upstream's wire
     ``KVCache`` payload type. The daemon's
     :func:`normalize_kv_and_discover_format` recognizes this shape from
-    ``EngineType.SGLANG`` plus a ``tokens_per_block`` ``LayoutHints`` field
-    and splits it back at its midpoint before format detection.
+    ``EngineType.SGLANG`` plus ``tokens_per_block`` and ``kv_list_layout``
+    ``LayoutHints`` fields, then splits it back at its midpoint before format
+    detection.
 
     Raises:
         ValueError: If the pools are empty, use different devices, or the
@@ -215,7 +216,8 @@ class LMCacheMPConnector:
         # ([K_layers, V_layers]); we flatten it on the wire to fit
         # ``KVCache = list[DeviceIPCWrapper]``. The daemon recognizes the
         # SGLang-MHA flat-of-2NL pattern from ``EngineType.SGLANG`` plus the
-        # ``tokens_per_block`` hint and un-flattens + reshapes per layer.
+        # ``tokens_per_block`` and ``kv_list_layout`` hints, then un-flattens
+        # and reshapes per layer.
         # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the
         # empty list -- which the server treats as one group spanning all layers
         # (matching the vLLM non-hybrid and TensorRT-LLM register paths).
@@ -228,7 +230,7 @@ class LMCacheMPConnector:
                 self.model_name,
                 self.tp_size,
                 EngineType.SGLANG,
-                {"tokens_per_block": self.page_size},
+                {"tokens_per_block": self.page_size, "kv_list_layout": "k_v"},
                 [],
             ],
         ).result(timeout=self._mq_timeout)

--- a/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
@@ -27,15 +27,18 @@ class SGLANG_Detector(EngineDetector):
         layout_hints: LayoutHints,
     ) -> "tuple[Optional[lmcache_native.EngineKVFormat], DiscoverableKVCache]":
         # MP path: a flat list[2*NL] of 3-D tensors (K layers then V layers)
-        # plus a tokens_per_block hint. Regroup into [K_layers, V_layers] and
-        # reshape each (PBS, NH, HS) -> (NB, BS, NH, HS).
+        # plus explicit K/V-list-layout and tokens-per-block hints. Regroup
+        # into [K_layers, V_layers] and reshape each
+        # (PBS, NH, HS) -> (NB, BS, NH, HS). The explicit layout hint is
+        # required because NH can be 1 after tensor parallelism, which is
+        # otherwise indistinguishable by shape from SGLang MLA.
         if (
             isinstance(kv_caches, list)
             and len(kv_caches) > 0
             and len(kv_caches) % 2 == 0
             and isinstance(kv_caches[0], torch.Tensor)
             and kv_caches[0].dim() == 3
-            and kv_caches[0].shape[1] > 1
+            and layout_hints.get("kv_list_layout") == "k_v"
             and "tokens_per_block" in layout_hints
         ):
             block_size = layout_hints["tokens_per_block"]

--- a/lmcache/v1/gpu_connector/kv_format/types.py
+++ b/lmcache/v1/gpu_connector/kv_format/types.py
@@ -40,13 +40,17 @@ class LayoutHints(TypedDict, total=False):
         tokens_per_block: Tokens per paged block. Used by TRT-LLM (to
             reshape its pool tensor) and by SGLang MHA (to split the
             folded ``page_buffer_size`` dimension into separate
-            ``num_blocks`` and ``block_size``). Presence of this field
-            on a SGLang registration is what triggers the daemon-side
-            depth-1 -> depth-2 un-flatten + 3-D -> 4-D reshape.
+            ``num_blocks`` and ``block_size``).
+        kv_list_layout: Outer SGLang KV-cache list organization. ``"k_v"``
+            identifies a flat registration containing equal K and V layer
+            halves; combined with ``tokens_per_block``, it triggers
+            daemon-side un-flattening and 3-D to 4-D reshaping even when
+            tensor parallelism leaves one KV head per rank.
         head_dim: Per-head dimension. Used by TRT-LLM (same).
     """
 
     kv_layout: Literal["NHD", "HND"]
     num_kv_heads: int
     tokens_per_block: int
+    kv_list_layout: Literal["k_v"]
     head_dim: int

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -16,6 +16,7 @@ import torch
 from lmcache import torch_device_type
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.kv_format import detect_format, extract_kv_cache_shapes
+from lmcache.v1.gpu_connector.kv_format.types import LayoutHints
 import lmcache.lmcache_native as lmcache_native
 
 NB, NL, BS, NH, HS = 7, 5, 3, 2, 4
@@ -107,16 +108,38 @@ def test_sglang_mha_depth2_fused():
 
 
 def test_sglang_mha_mp_reshape():
-    # MP path: flat list of 2*NL 3-D tensors + tokens_per_block hint;
-    # detection should un-flatten + reshape to the 4-D inner MP format.
+    # MP path: flat list of 2*NL 3-D tensors + explicit split-K/V and
+    # tokens-per-block hints; detection should un-flatten + reshape to the
+    # 4-D inner MP format.
     if not hasattr(F, "TWO_X_NL_X_NB_BS_NH_HS"):
         pytest.skip("extension lacks TWO_X_NL_X_NB_BS_NH_HS")
     flat = [_t(NB * BS, NH, HS) for _ in range(2 * NL)]
-    fmt, out = detect_format(flat, EngineType.SGLANG, {"tokens_per_block": BS})
+    hints = {"tokens_per_block": BS, "kv_list_layout": "k_v"}
+    fmt, out = detect_format(flat, EngineType.SGLANG, hints)
     assert fmt == F.TWO_X_NL_X_NB_BS_NH_HS
     # Canonical depth-2 [K_layers, V_layers], inner reshaped to 4-D.
     assert len(out) == 2 and len(out[0]) == NL
     assert tuple(out[0][0].shape) == (NB, BS, NH, HS)
+
+
+def test_sglang_mha_mp_single_head_is_not_mla() -> None:
+    """TP may reduce split K/V to one head without changing its MHA layout."""
+    flat = [_t(NB * BS, 1, HS) for _ in range(2 * NL)]
+    hints: LayoutHints = {"tokens_per_block": BS, "kv_list_layout": "k_v"}
+    fmt, out = detect_format(flat, EngineType.SGLANG, hints)
+    assert fmt == F.TWO_X_NL_X_NB_BS_NH_HS
+    assert isinstance(out, list)
+    assert isinstance(out[0], list)
+    assert isinstance(out[0][0], torch.Tensor)
+    assert tuple(out[0][0].shape) == (NB, BS, 1, HS)
+
+
+def test_sglang_mha_mp_rejects_non_divisible_page_buffer() -> None:
+    """Split K/V registration rejects invalid paged-buffer geometry."""
+    flat = [_t(NB * BS + 1, 1, HS) for _ in range(2 * NL)]
+    hints: LayoutHints = {"tokens_per_block": BS, "kv_list_layout": "k_v"}
+    with pytest.raises(ValueError, match="not divisible"):
+        detect_format(flat, EngineType.SGLANG, hints)
 
 
 def test_trtllm_cross_layer_6d():

--- a/tests/v1/gpu_connector/test_normalize_per_layer_formats.py
+++ b/tests/v1/gpu_connector/test_normalize_per_layer_formats.py
@@ -30,7 +30,10 @@ def test_sglang_kv_list_uniform():
     # K/V-split format, so it is returned whole -- never sliced per layer.
     flat = [_t(NB * BS, NH, HS) for _ in range(2 * NL)]
     normalized, formats = normalize_and_discover_per_layer_formats(
-        flat, (), EngineType.SGLANG, {"tokens_per_block": BS}
+        flat,
+        (),
+        EngineType.SGLANG,
+        {"tokens_per_block": BS, "kv_list_layout": "k_v"},
     )
     assert len(normalized) == 2 and len(normalized[0]) == NL
     assert tuple(normalized[0][0].shape) == (NB, BS, NH, HS)

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -197,6 +197,71 @@ def test_wrap_sglang_kv_caches_rejects_mismatched_layers() -> None:
         )
 
 
+def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
+    """Registration identifies flat single-head pools as split K/V MHA."""
+    adapter_mod, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
+    mq_client = object()
+    requests: list[tuple[object, list[object]]] = []
+
+    class FakeHeartbeatThread:
+        def __init__(
+            self,
+            mq_client: object,
+            health_event: threading.Event,
+            interval: float,
+            instance_id: int | None,
+        ) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "zmq",
+        SimpleNamespace(Context=SimpleNamespace(instance=lambda: object())),
+    )
+    monkeypatch.setattr(
+        adapter_mod,
+        "MessageQueueClient",
+        lambda _endpoint, _context: mq_client,
+    )
+    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
+    monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
+    monkeypatch.setattr(
+        adapter_mod,
+        "get_device_spec",
+        lambda _device_type: SimpleNamespace(is_handle_transfer_available=lambda: True),
+    )
+    monkeypatch.setattr(adapter_mod, "wrap_one_kv_cache", lambda tensor: tensor)
+
+    def send_request(
+        _client: object, request_type: object, payload: list[object]
+    ) -> object:
+        requests.append((request_type, payload))
+        return SimpleNamespace(result=MagicMock(return_value=None))
+
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_request)
+
+    k_pool = [torch.empty(4, 1, 8) for _ in range(2)]
+    v_pool = [torch.empty(4, 1, 8) for _ in range(2)]
+    LMCacheMPConnector(
+        sgl_config=SimpleNamespace(model_path="test-model"),
+        tp_size=1,
+        rank=0,
+        page_size=2,
+        host="127.0.0.1",
+        port=5556,
+        k_pool=k_pool,
+        v_pool=v_pool,
+    )
+
+    assert len(requests) == 1
+    request_type, payload = requests[0]
+    assert request_type == adapter_mod.RequestType.REGISTER_KV_CACHE
+    assert payload[5] == {"tokens_per_block": 2, "kv_list_layout": "k_v"}
+
+
 @pytest.mark.parametrize(
     ("k_pool", "v_pool", "message"),
     [


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fix SGLang MP KV format detection for models such as Qwen3-30B-A3B, where tensor parallelism can leave one KV head per rank. Add an explicit split_kv layout hint so single-head MHA is not misclassified as MLA, with regression tests covering registration and format detection.

**Special notes for your reviewers**:
tiny modification, most of the code are added test.

**If applicable**:

- [ ] this PR contains user facing changes 
- [ ] this PR contains unit tests --test added
