### PR TITLE
fix(mp): fail fast on mixed-rank KV cache batches instead of hanging

### DIFF
--- a/lmcache/v1/platform/kv_wrap.py
+++ b/lmcache/v1/platform/kv_wrap.py
@@ -60,6 +60,23 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
             for i, (name, shape, dtype) in enumerate(kept_summary)
         ),
     )
+    # Wrapper factories assume one uniform geometry per batch; a mixed-rank
+    # batch previously blocked in the loop below with no exception (see #4608).
+    # List entries (e.g. Mamba state pairs) are left to the factories.
+    ranks: dict[int, list[str]] = {}
+    for name, tensor in kv_caches.items():
+        if isinstance(tensor, torch.Tensor):
+            ranks.setdefault(tensor.ndim, []).append(name)
+    if len(ranks) > 1:
+        detail = "; ".join(
+            f"rank {rank}: {len(names)} layer(s), e.g. {names[0]}"
+            for rank, names in sorted(ranks.items())
+        )
+        raise ValueError(
+            f"cannot wrap a KV cache batch with mixed tensor ranks: {detail}. "
+            "Registered layers must be normalized to one geometry first."
+        )
+
     logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
     # Per-iteration resource management: if wrapping the N-th tensor
     # raises, ``shm_unlink`` whatever earlier iterations already

--- a/tests/v1/platform/test_kv_wrap_uniformity.py
+++ b/tests/v1/platform/test_kv_wrap_uniformity.py
@@ -41,9 +41,7 @@ def test_mixed_rank_batch_raises_and_names_both_groups():
     """
     caches = {
         "layers.0.self_attn.attn": torch.zeros(ATTN, dtype=torch.bfloat16),
-        "layers.1.self_attn.attn.index_cache": torch.zeros(
-            INDEX, dtype=torch.bfloat16
-        ),
+        "layers.1.self_attn.attn.index_cache": torch.zeros(INDEX, dtype=torch.bfloat16),
     }
     with pytest.raises(ValueError, match="mixed tensor ranks") as excinfo:
         wrap_kv_caches(caches)

--- a/tests/v1/platform/test_kv_wrap_uniformity.py
+++ b/tests/v1/platform/test_kv_wrap_uniformity.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the mixed-rank guard in ``lmcache.v1.platform.kv_wrap``."""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.multiprocess.posix_shm import shm_unlink
+from lmcache.v1.platform.kv_wrap import wrap_kv_caches
+
+ATTN = (2, 1, 4, 8)
+INDEX = (2, 4, 4)
+
+
+def _release(wrappers):
+    for wrapper in wrappers:
+        name = getattr(wrapper, "shm_name", None)
+        if name is not None:
+            shm_unlink(name)
+
+
+def test_uniform_rank_batch_wraps():
+    """A single-geometry batch still wraps."""
+    caches = {
+        f"layers.{i}.self_attn.attn": torch.zeros(ATTN, dtype=torch.float32)
+        for i in range(2)
+    }
+    wrappers = wrap_kv_caches(caches)
+    try:
+        assert len(wrappers) == 2
+    finally:
+        _release(wrappers)
+
+
+def test_mixed_rank_batch_raises_and_names_both_groups():
+    """Mixed ranks raise, and the message identifies each group.
+
+    Mirrors MiniMax-M3: rank-4 ``self_attn.attn`` alongside rank-3
+    ``self_attn.attn.index_cache`` in one batch.
+    """
+    caches = {
+        "layers.0.self_attn.attn": torch.zeros(ATTN, dtype=torch.bfloat16),
+        "layers.1.self_attn.attn.index_cache": torch.zeros(
+            INDEX, dtype=torch.bfloat16
+        ),
+    }
+    with pytest.raises(ValueError, match="mixed tensor ranks") as excinfo:
+        wrap_kv_caches(caches)
+    message = str(excinfo.value)
+    assert "rank 3" in message and "rank 4" in message
+    assert "index_cache" in message
+
+
+def test_list_entries_are_not_rank_compared():
+    """Mamba-style list entries are left to the factories, not rank-checked."""
+    caches = {
+        "layers.0.self_attn.attn": torch.zeros(ATTN, dtype=torch.float32),
+        "layers.1.mixer": [torch.zeros((2, 4)), torch.zeros((2, 4, 4))],
+    }
+    try:
+        wrappers = wrap_kv_caches(caches)
+    except ValueError as exc:
+        assert "mixed tensor ranks" not in str(exc)
+    except Exception:
+        pass  # a factory may reject the list entry; out of scope here
+    else:
+        _release(wrappers)


### PR DESCRIPTION
## What this PR does / why we need it

`wrap_kv_caches` assumes one uniform tensor geometry per batch: the wrapper
factory is resolved per tensor via `resolve_kv_wrapper_factory(tensor.device.type)`
and none of the factories tolerates a batch that mixes ranks. Nothing enforced
that assumption, so a heterogeneous batch reached the per-tensor wrap loop and
**blocked there indefinitely with no exception raised**.

Models with non-uniform KV groups hit this. MiniMax-M3 registers 60 rank-4
attention caches alongside 57 rank-3 sparse-indexer caches in a single
`register_kv_caches` batch:

| rank | shape | name suffix | count |
|---:|---|---|---:|
| 4 | `(3559, 1, 128, 256)` | `self_attn.attn` | 60 |
| 3 | `(3559, 128, 128)` | `self_attn.attn.index_cache` | 57 |

The worker then hangs and the only visible symptom is the engine repeating
`No available shared memory broadcast block found in 60 seconds` until the
registration timeout fires, which points away from the real cause. Full
investigation in #4608.

This adds a rank-uniformity check that raises `ValueError` naming each rank group
and an example layer, so the offending geometry is immediately identifiable.

**This does not add support for heterogeneous batches.** It converts an
undiagnosable hang into an actionable error. The same heterogeneity appears to
surface as a reshape error in #4263 and #4358, and as silent output corruption in
#4247, so a fail-fast guard here may help triage those too.

Non-tensor entries are excluded from the comparison: Mamba-style entries are
lists of state tensors and are deliberately left to the factories. A test pins
that behaviour so the guard cannot regress list-valued models.

## Special notes for your reviewers

I am unsure this is the shape you want, hence **draft**. Two open questions:

1. Should heterogeneous batches instead be normalized for non-Mamba models?
   `apply_kv_cache_group_edits` is gated on `kv_cache_config.has_mamba_layers`,
   so for a sparse-attention model like MiniMax-M3 the edits never run
   (`KV cache group edits applied` never logs) and the mixed batch passes
   straight through. A guard makes that failure legible but does not make the
   model work.
2. #4592 is restructuring this area with declarative KV layout descriptors. If
   that lands first, this guard may belong somewhere else, or be unnecessary.

Happy to rework, relocate, or close this if either answer makes it moot. I can
also test candidate fixes on 8x MI325X (gfx942) with MiniMax-M3.

## Testing

New `tests/v1/platform/test_kv_wrap_uniformity.py`, 3 tests, following the
existing `tests/v1/platform/test_cpu_shm.py` pattern (CPU tensors, no GPU
required):

- a uniform-rank batch still wraps and rolls back cleanly
- a rank-4 + rank-3 batch raises instead of hanging, and the error names both rank groups
- non-tensor (list) entries are not rank-compared

`4 passed` locally against an LMCache 0.5.3 install.

## If applicable

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Refs #4608