### PR TITLE
[MP][Feat]Add Device-Resident-L1 Support

### DIFF
--- a/docs/design/v1/distributed/memory_manager/device-resident-l1.md
+++ b/docs/design/v1/distributed/memory_manager/device-resident-l1.md
@@ -1,0 +1,311 @@
+# Device-Resident L1 Memory Manager Design
+
+This document describes the device-resident L1 tier: a backend-agnostic
+framework that lets L1 entries hold GPU/device memory objects directly, so
+retrieve serves via D2D instead of H2D. The framework is shipped without a
+concrete backend; backends register by implementing the
+`DeviceMemoryPool` protocol and adding an `_init_<backend>_pools` branch.
+
+## Goals
+
+- Give L1 the ability to hold device-resident `MemoryObj`s (not just CPU
+  pinned-DRAM or GDS slab files).
+- Keep the framework backend-agnostic: `DeviceResidentL1MemoryManager` interacts
+  with device pools only through the `DeviceMemoryPool` protocol and never
+  imports backend-specific types at module level.
+- Add a `device_reserve_write` path that produces device objects directly,
+  eliminating the CPU-placeholder-then-replace pattern used by the previous
+  zero-touch adapter approach.
+- Keep the existing `reserve_write` path and all existing adapters
+  unchanged — device L1 is opt-in per adapter via `AdapterDescriptor.l1_tier`.
+- Ship the framework first (this PR), then add backends in follow-up PRs.
+
+## Components
+
+`lmcache/v1/distributed/memory_manager/device_l1_memory_manager.py` defines
+two public symbols:
+
+- `DeviceMemoryPool` — a `@runtime_checkable` `Protocol` that abstracts a
+  per-device DMA-registered memory pool. A backend implements five methods:
+  `allocate`, `free`, `batched_free`, `wait_for_available`, `get_free_bytes`.
+- `DeviceResidentL1MemoryManager` — the L1 tier object. It holds a
+  `dict[int, DeviceMemoryPool]` (one pool per device id), routes allocation
+  by `kv_rank`, implements backpressure, and delegates CPU-fallback objects
+  to an internal `L1MemoryManager`.
+
+`lmcache/v1/distributed/l1_manager.py` selects
+`DeviceResidentL1MemoryManager` when `config.device_resident_l1_config` is set, alongside
+the existing GDS and Device-DAX branches. It exposes two new methods:
+
+- `device_reserve_write` — like `reserve_write`, but allocates from the
+  device pool and creates `L1ObjectState` with a device-resident tensor.
+- `has_device_l1` — returns `True` when the backing manager is a
+  `DeviceResidentL1MemoryManager`.
+
+`lmcache/v1/distributed/storage_controllers/store_policy.py` adds the
+`l1_tier` field to `AdapterDescriptor` (default `"cpu"`).
+
+`lmcache/v1/distributed/storage_controllers/prefetch_controller.py` routes
+reserve calls by adapter L1 tier in `_reserve_load_buffers`.
+
+`lmcache/v1/distributed/config.py` adds `DeviceResidentL1Config` and the
+`device_resident_l1_config` field on `L1ManagerConfig`.
+
+`lmcache/v1/distributed/api.py` adds `L1BackendType.DEVICE`.
+
+## DeviceMemoryPool Protocol
+
+```python
+@runtime_checkable
+class DeviceMemoryPool(Protocol):
+    def allocate(self, *, shapes, dtypes, fmt) -> MemoryObj | None: ...
+    def free(self, memory_obj: MemoryObj) -> None: ...
+    def batched_free(self, memory_objs: list[MemoryObj]) -> None: ...
+    def wait_for_available(self, required_bytes: int, timeout: float) -> bool: ...
+    def get_free_bytes(self) -> int: ...
+```
+
+A pool owns one device's worth of pre-allocated, DMA-registered device
+memory plus the backend-specific DMA handle. Backends implement this
+protocol via structural typing — no inheritance is required. A backend
+registers itself by adding an `_init_<backend>_pools` method to
+`DeviceResidentL1MemoryManager` and a matching `elif` branch in
+`_init_device_pools`.
+
+This PR ships with no backend. The `"phx"` branch raises
+`NotImplementedError` as a placeholder; a follow-up PR will implement it.
+
+## DeviceResidentL1MemoryManager
+
+### Pool Ownership
+
+The manager holds a single `dict[int, DeviceMemoryPool]` keyed by device
+id. Each pool internally owns its DMA handle and base pointer — there is
+no separate allocator/cache/base-pointer dict triplet.
+
+### Initialization Order
+
+`__init__` validates the backend and creates device pools *before*
+allocating CPU memory:
+
+1. Store `device_resident_l1_config`.
+2. Call `_init_device_pools(config)` — fails fast on unknown/unimplemented
+   backend without wasting CPU memory.
+3. Create the internal `L1MemoryManager(memory_config)` for CPU-fallback
+   objects.
+
+### Allocation
+
+`allocate_device(layout_desc, count, kv_rank)` routes `kv_rank` to a device
+id via `_kv_rank_to_device` (default: `device_ids[kv_rank %
+len(device_ids)]`), then:
+
+1. `wait_for_available(size_per_obj * count, timeout=1.0)` — backpressure.
+2. Allocate one-by-one from the pool.
+3. On any failure, roll back partial allocation and return
+   `(L1Error.OUT_OF_MEMORY, [])` — all-or-nothing, no per-key fallback.
+
+`allocate(layout_desc, count)` delegates to the CPU manager for
+CPU-fallback objects (satisfies `L1ManagerProtocol`).
+
+### Free Routing
+
+`free(mem_objs)` inspects each object's `raw_tensor.device.type`:
+
+- Device objects (`!= "cpu"`) → `obj.parent().free(obj)`. The parent is
+  the `DeviceMemoryPool` that allocated the object (set by the backend
+  allocator during `allocate`). The pool's `free` notifies any
+  `wait_for_available` waiter.
+- CPU objects → `self._cpu_manager.free(cpu_objs)`.
+
+If a device object has no parent (should not happen), a warning is logged
+and the object is leaked rather than crashing.
+
+### kv_rank → Device Mapping
+
+`_kv_rank_to_device(kv_rank)` returns
+`device_ids[kv_rank % len(device_ids)]`. Returns `-1` when no devices are
+configured (which causes `allocate_device` to return OOM). Backends or
+configs may override this mapping in follow-up PRs.
+
+## L1Manager Integration
+
+### Tier Selection
+
+`L1Manager.__init__` adds a new `elif` branch after GDS and Device-DAX:
+
+```python
+elif config.device_resident_l1_config is not None:
+    self._memory_manager = DeviceResidentL1MemoryManager(
+        config.memory_config, config.device_resident_l1_config
+    )
+```
+
+Device L1 co-exists with the CPU tier (unlike GDS/Device-DAX, which are
+mutually exclusive): the `DeviceResidentL1MemoryManager` holds its own device
+pools but delegates CPU-fallback allocation to an internal
+`L1MemoryManager`.
+
+### device_reserve_write
+
+```python
+@l1_mgr_synchronized
+def device_reserve_write(
+    self,
+    keys: list[ObjectKey],
+    is_temporary: list[bool],
+    layout_desc: MemoryLayoutDesc,
+    kv_rank: int,
+) -> dict[ObjectKey, L1OperationResult]
+```
+
+Like `reserve_write(mode="new")`, but allocates from the device pool:
+
+1. Filter out keys that already exist (return `KEY_NOT_WRITABLE`).
+2. Call `allocate_device(layout_desc, count, kv_rank)`.
+3. On OOM: return `OUT_OF_MEMORY` for all keys, free any partial
+   allocation.
+4. On success: create `L1ObjectState` with the device `MemoryObj`,
+   write-lock it, publish `L1_WRITE_RESERVED` event (same as
+   `reserve_write`).
+
+All-or-nothing: if the pool is exhausted after backpressure timeout, all
+keys return `OUT_OF_MEMORY`. The caller (prefetch controller) abandons the
+batch — no per-key POSIX fallback.
+
+### has_device_l1
+
+```python
+def has_device_l1(self) -> bool:
+    return isinstance(self._memory_manager, DeviceResidentL1MemoryManager)
+```
+
+Callers check this before calling `device_reserve_write`.
+
+## AdapterDescriptor.l1_tier
+
+```python
+@dataclass(frozen=True)
+class AdapterDescriptor:
+    index: int
+    config: L2AdapterConfigBase
+    l1_tier: str = "cpu"   # "cpu" | "device"
+```
+
+All existing adapters default to `"cpu"` and keep their current behaviour.
+A backend-specific adapter (e.g. PHX, in a follow-up PR) sets
+`l1_tier="device"` at registration time.
+
+## Prefetch Controller Routing
+
+`_reserve_load_buffers` now takes `trimmed_plan: dict[int, Bitmap]` (the
+per-adapter load plan) in addition to the merged `keys_to_reserve`. For
+each group of keys (grouped by `object_group_id`), it splits by L1 tier:
+
+- **Device path** (`desc.l1_tier == "device"` and `has_device_l1()`):
+  `device_reserve_write(keys, is_temporary, layout_desc, kv_rank)`.
+- **CPU path** (default): `reserve_write(keys, is_temporary, layout_desc,
+  mode="new")` — the existing path, unchanged.
+
+The two paths are fully isolated: the CPU path is identical to before,
+and the device path is only reached when an adapter explicitly declares
+`l1_tier="device"` *and* the L1 manager has a device tier.
+
+This PR ships no adapter with `l1_tier="device"`, so the device branch is
+never triggered — **zero behaviour change**.
+
+## Configuration
+
+```python
+@dataclass
+class DeviceResidentL1Config:
+    backend: str = ""           # "" = no backend yet; "phx" in follow-up PR
+    device_ids: list[int] = field(default_factory=list)
+    buffer_size_mb: int = 2048
+    use_direct_io: bool = True
+
+@dataclass
+class L1ManagerConfig:
+    memory_config: L1MemoryManagerConfig
+    gds_l1_config: GdsL1Config | None = None
+    device_resident_l1_config: DeviceResidentL1Config | None = None  # new
+    ...
+```
+
+Config inference (deriving `DeviceResidentL1Config` from an L2 adapter config)
+is deferred to the follow-up PR that adds the first backend. This PR
+provides the config dataclass and the `L1ManagerConfig` field only.
+
+## Layering Boundary
+
+| Layer | Visible Types | Reason |
+|---|---|---|
+| `DeviceResidentL1MemoryManager` (this PR) | `DeviceMemoryPool` protocol only | Backend-agnostic; adding a backend does not change this class (only adds an `_init_*_pools` branch) |
+| `_init_<backend>_pools` (follow-up PRs) | Backend-specific types | Lazy import inside the method; backend details stay local |
+| Backend-specific L2 adapter (follow-up PRs) | Pool's backend-specific attributes | The adapter knows its own backend; accessing `.base_pointer` / `.phx_cache` is appropriate there |
+| Concrete pool implementation (follow-up PRs) | No inheritance needed | Structural typing: implement five methods |
+
+## Failure Paths
+
+| Scenario | Behaviour | Result |
+|---|---|---|
+| DMA short read (partial load failure) | Failed key's bitmap bit = 0; device obj stays in L1 (write-locked) → `finish_write` fails → framework deletes entry → `free()` routes back to device pool | No leak |
+| `device_reserve_write` pool exhausted | Returns OOM → prefetch controller emits `L2_PREFETCH_FAILED` + abandons batch | Clean failure |
+| Entry evicted before retrieve | Temporary entry `delete()` → `free()` → device pool回收 | No leak |
+| Retrieve never happens (request abort) | Temporary device entry lingers in L1 → DMA buffer pinned | Known residual risk (same as previous approach); mitigation: periodic sweep of stale temporary entries |
+| vLLM crash | Retrieve traffic → 0 → temporary entries linger → buffer exhaustion → batch abandon | Clean degradation |
+| Multi-read-lock (TP/MLA) | `finish_read` unlocks all → count reaches 0 → delete entry → recycle | Equivalent |
+| Mixed adapters (redis + device) | Each routes through its own reserve path | Isolated |
+| Store path | `serde_wrapper` calls `reserve_write` (CPU), unaffected | Zero impact |
+| This PR (no device adapter) | All `l1_tier` default `"cpu"`, `device_reserve_write` never called | **Zero behaviour change** |
+
+## Verification
+
+`tests/v1/distributed/test_device_l1_framework.py` unit-tests the
+framework with a `MockDeviceMemoryPool`:
+
+- `DeviceMemoryPool` protocol structural typing (mock satisfies, plain
+  object does not).
+- `DeviceResidentL1MemoryManager`: backend validation (empty → `ValueError`,
+  `"phx"` → `NotImplementedError`), free routing (device → pool,
+  CPU → CPU manager, mixed), `kv_rank`-to-device mapping.
+- `DeviceResidentL1Config` defaults and construction.
+- `AdapterDescriptor.l1_tier` default (`"cpu"`) and explicit
+  (`"device"`).
+- `L1BackendType.DEVICE` exists.
+
+Existing distributed tests (968 passed, 41 skipped) confirm zero
+regression — all existing adapters keep `l1_tier="cpu"` and follow the
+unchanged `reserve_write` path.
+
+## Backend Registration (Follow-up PRs)
+
+A new backend registers in three steps:
+
+1. Implement a pool class satisfying `DeviceMemoryPool` (five methods).
+2. Add `_init_<backend>_pools(self, config)` to `DeviceResidentL1MemoryManager`
+   with lazy imports.
+3. Add an `elif` branch in `_init_device_pools`.
+4. (Optional) Set `l1_tier="device"` on the adapter's
+   `AdapterDescriptor` at registration.
+5. (Optional) Add config inference in `config.py` to derive
+   `DeviceResidentL1Config(backend="<name>")` from the L2 adapter config.
+
+No changes to `DeviceResidentL1MemoryManager` class body, `L1Manager`,
+`prefetch_controller`, or `store_policy` are needed — the framework is
+extensible by construction.
+
+## Current Limits
+
+- No backend shipped. The `"phx"` branch raises `NotImplementedError`.
+- Config inference is not wired: `device_resident_l1_config` defaults to `None`,
+  so `DeviceResidentL1MemoryManager` is never instantiated unless a follow-up PR
+  adds inference.
+- `get_memory_usage` returns approximate values (device pools do not yet
+  report total capacity through the protocol; backends should override if
+  precision is needed).
+- `get_l1_memory_desc` returns `None`: device pools are not a single
+  registerable CPU region, so P2P/NIXL transfer registration is not
+  supported for device L1 (same as Device-DAX L1).
+- No periodic sweep of stale temporary device entries (retrieve never
+  happens): a follow-up can add a TTL-based sweeper.

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -48,6 +48,7 @@ class L1BackendType(str, enum.Enum):
     DRAM = "dram"
     DEVDAX = "devdax"
     GDS = "gds"
+    DEVICE = "device"
 
 
 class TrimPolicy(enum.Enum):

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -186,6 +186,41 @@ class GdsL1Config:
 
 
 @dataclass
+class DeviceResidentL1Config:
+    """Configuration for the device-resident L1 tier.
+
+    When present on :class:`L1ManagerConfig`, the L1 tier gains the ability
+    to hold device-resident (e.g. GPU) memory objects directly — retrieve
+    serves via D2D instead of H2D. This is useful when an L2 adapter can DMA
+    directly into device memory (e.g. NVMe-to-GPU direct read).
+
+    Backend-agnostic: ``backend`` selects the concrete pool implementation.
+    This PR provides the config framework only; a follow-up PR adds the
+    ``"phx"`` backend implementation.
+
+    The device tier co-exists with the CPU pinned-DRAM tier (unlike GDS,
+    which is mutually exclusive): CPU objs go through the normal CPU slab,
+    device objs go through the device pool, and :meth:`free` routes by
+    ``obj.parent()``.
+    """
+
+    backend: str = ""
+    """Device pool backend name (e.g. ``"phx"``). Empty string means no
+    backend implemented yet — ``_init_device_pools`` will raise
+    ``NotImplementedError`` at construction time if set."""
+
+    device_ids: list[int] = field(default_factory=list)
+    """CUDA/HIP device ids that own device memory pools. One pool is
+    created per device id."""
+
+    buffer_size_mb: int = 2048
+    """Per-device pool size in MiB."""
+
+    use_direct_io: bool = True
+    """Open files with ``O_DIRECT`` (required for DMA fast path)."""
+
+
+@dataclass
 class L1ManagerConfig:
     """
     Special config for the L1 Object/Key manager
@@ -197,6 +232,11 @@ class L1ManagerConfig:
     gds_l1_config: "GdsL1Config | None" = None
     """ Optional GDS L1 tier. When set, the GDS slab is the L1 medium
     (mutually exclusive with the pinned-DRAM tier in ``memory_config``). """
+
+    device_resident_l1_config: "DeviceResidentL1Config | None" = None
+    """ Optional device-resident L1 tier. When set, the L1 tier can hold
+    device memory objects directly (retrieve via D2D). Co-exists with the
+    CPU pinned-DRAM tier. A follow-up PR adds the ``"phx"`` backend."""
 
     write_ttl_seconds: int = field(default=600)
     """ Time to live for each object's write lock. Default is 600s (10 minutes). """

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -233,10 +233,12 @@ class L1ManagerConfig:
     """ Optional GDS L1 tier. When set, the GDS slab is the L1 medium
     (mutually exclusive with the pinned-DRAM tier in ``memory_config``). """
 
+    # TODO(MonthFall): implement the ``"phx"`` device pool backend
+    # (``_init_phx_pools``) in a follow-up PR.
     device_resident_l1_config: "DeviceResidentL1Config | None" = None
     """ Optional device-resident L1 tier. When set, the L1 tier can hold
     device memory objects directly (retrieve via D2D). Co-exists with the
-    CPU pinned-DRAM tier. A follow-up PR adds the ``"phx"`` backend."""
+    CPU pinned-DRAM tier."""
 
     write_ttl_seconds: int = field(default=600)
     """ Time to live for each object's write lock. Default is 600s (10 minutes). """

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -23,6 +23,9 @@ from lmcache.v1.distributed.memory_manager import (
 from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
     DevDaxL1MemoryManager,
 )
+from lmcache.v1.distributed.memory_manager.device_resident_l1_memory_manager import (
+    DeviceResidentL1MemoryManager,
+)
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
@@ -193,6 +196,9 @@ class L1Manager:
 
         # GDS, Device-DAX, and CPU L1 are mutually exclusive tiers. Each tier
         # owns its backing allocator instead of branching inside the CPU path.
+        # Device L1 (DeviceResidentL1MemoryManager) co-exists with the CPU tier: it
+        # holds its own device pools but delegates CPU-fallback allocation to
+        # the CPU L1MemoryManager internally.
         self._memory_manager: L1ManagerProtocol
         if config.gds_l1_config is not None:
             self._memory_manager = GDSL1MemoryManager(config.gds_l1_config)
@@ -200,6 +206,15 @@ class L1Manager:
         elif config.memory_config.devdax_path:
             self._memory_manager = DevDaxL1MemoryManager(config.memory_config)
             logger.info("L1Manager: Device-DAX L1 tier enabled; CPU-only L1 disabled")
+        elif config.device_resident_l1_config is not None:
+            self._memory_manager = DeviceResidentL1MemoryManager(
+                config.memory_config, config.device_resident_l1_config
+            )
+            logger.info(
+                "L1Manager: device-resident L1 tier enabled (backend=%s); "
+                "CPU pinned-DRAM L1 retained for CPU-fallback objects",
+                config.device_resident_l1_config.backend,
+            )
         else:
             self._memory_manager = L1MemoryManager(config.memory_config)
 
@@ -531,6 +546,106 @@ class L1Manager:
             )
         )
         return ret
+
+    @l1_mgr_synchronized
+    def device_reserve_write(
+        self,
+        keys: list[ObjectKey],
+        is_temporary: list[bool],
+        layout_desc: MemoryLayoutDesc,
+        kv_rank: int,
+    ) -> dict[ObjectKey, L1OperationResult]:
+        """Reserve write access with a device-resident MemoryObj.
+
+        Like :meth:`reserve_write`, but allocates the MemoryObj from the
+        device pool (via
+        :meth:`DeviceResidentL1MemoryManager.allocate_device`) instead of the CPU
+        slab. The resulting :class:`L1ObjectState` holds a device-resident
+        tensor, so retrieve serves via D2D instead of H2D.
+
+        Only available when :meth:`has_device_l1` returns ``True``. Callers
+        should check before use.
+
+        All-or-nothing: if the device pool is exhausted (after backpressure
+        timeout), all keys return ``L1Error.OUT_OF_MEMORY``. There is no
+        per-key fallback — the caller should abandon the batch and retry
+        later (or fall back to a CPU-L1 adapter).
+
+        Args:
+            keys: The list of object keys to reserve write access for.
+            is_temporary: Whether each key is temporary (read-once-then-free).
+            layout_desc: The memory layout description for the objects.
+            kv_rank: Used to route to the correct device.
+
+        Returns:
+            A dictionary mapping each object key to a tuple of
+            (L1Error, Optional[MemoryObj]).
+
+        Errors:
+            KEY_NOT_WRITABLE: The key already exists (always-new mode).
+            OUT_OF_MEMORY: Device pool exhausted after backpressure timeout.
+        """
+        assert isinstance(self._memory_manager, DeviceResidentL1MemoryManager), (
+            "device_reserve_write requires DeviceResidentL1MemoryManager; "
+            "check has_device_l1() before calling."
+        )
+        ret: dict[ObjectKey, L1OperationResult] = {}
+        successful_keys: list[ObjectKey] = []
+
+        # Filter out existing keys (always-new mode like reserve_write mode="new")
+        need_to_allocate: list[tuple[ObjectKey, bool]] = []
+        for key, is_temp in zip(keys, is_temporary, strict=False):
+            entry = self._objects.get(key, None)
+            if entry is not None:
+                ret[key] = (L1Error.KEY_NOT_WRITABLE, None)
+                continue
+            need_to_allocate.append((key, is_temp))
+
+        if len(need_to_allocate) == 0:
+            return ret
+
+        err, allocated_objs = self._memory_manager.allocate_device(
+            layout_desc, len(need_to_allocate), kv_rank
+        )
+
+        if err != L1Error.SUCCESS:
+            for key, _ in need_to_allocate:
+                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+            # Free the memory if partial allocation succeeded
+            if allocated_objs:
+                self._memory_manager.free(allocated_objs)
+        else:
+            for (key, is_temp), mem_obj in zip(
+                need_to_allocate, allocated_objs, strict=False
+            ):
+                self._objects[key] = L1ObjectState(
+                    memory_obj=mem_obj,
+                    write_lock=TTLLock(self._write_ttl_seconds),
+                    read_lock=TTLLock(self._read_ttl_seconds),
+                    is_temporary=is_temp,
+                )
+                self._objects[key].write_lock.lock()
+                ret[key] = (L1Error.SUCCESS, mem_obj)
+                successful_keys.append(key)
+
+        for listener in self._registered_listeners:
+            listener.on_l1_keys_reserved_write(successful_keys)
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_WRITE_RESERVED,
+                metadata={"keys": successful_keys},
+            )
+        )
+        return ret
+
+    def has_device_l1(self) -> bool:
+        """Whether this L1Manager has a device-resident tier.
+
+        Returns:
+            ``True`` if the backing memory manager is a
+            :class:`DeviceResidentL1MemoryManager`, ``False`` otherwise.
+        """
+        return isinstance(self._memory_manager, DeviceResidentL1MemoryManager)
 
     @l1_mgr_synchronized
     def finish_write(

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -954,6 +954,23 @@ class L1Manager:
         """
         return self._memory_manager.get_memory_usage()
 
+    def get_device_memory_usage(self) -> dict[int, tuple[int, int]]:
+        """Get per-device memory usage of the device-resident tier, if any.
+
+        Delegates to
+        :meth:`DeviceResidentL1MemoryManager.get_device_memory_usage`.
+        For observability only — the eviction controller keys on
+        :meth:`get_memory_usage` (the CPU tier).
+
+        Returns:
+            ``{device_id: (used_bytes, total_bytes)}``, or an empty dict
+            when no device-resident tier is enabled.
+        """
+        getter = getattr(self._memory_manager, "get_device_memory_usage", None)
+        if getter is None:
+            return {}
+        return getter()
+
     def get_l1_memory_desc(self):
         """Return an L1MemoryDesc describing the underlying L1 memory buffer."""
         return self._memory_manager.get_l1_memory_desc()

--- a/lmcache/v1/distributed/memory_manager/__init__.py
+++ b/lmcache/v1/distributed/memory_manager/__init__.py
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """L1 memory managers for the distributed cache.
 
-Two interchangeable tiers behind :class:`L1ManagerProtocol`:
+Interchangeable tiers behind :class:`L1ManagerProtocol`:
 
 - :class:`L1MemoryManager` -- CPU pinned-DRAM slab.
 - :class:`DevDaxL1MemoryManager` -- Device-DAX-backed L1 slab.
 - :class:`GDSL1MemoryManager` -- GDS slab file (cuFile DMA).
+- :class:`DeviceResidentL1MemoryManager` -- device-resident L1.
 """
 
 # First Party
 from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
     DevDaxL1MemoryManager,
+)
+from lmcache.v1.distributed.memory_manager.device_resident_l1_memory_manager import (
+    DeviceMemoryPool,
+    DeviceResidentL1MemoryManager,
 )
 from lmcache.v1.distributed.memory_manager.gds_l1_memory_manager import (
     GDSL1MemoryManager,
@@ -23,6 +28,8 @@ from lmcache.v1.distributed.memory_manager.l1_memory_manager import (
 
 __all__ = [
     "DevDaxL1MemoryManager",
+    "DeviceResidentL1MemoryManager",
+    "DeviceMemoryPool",
     "GDSL1MemoryManager",
     "L1ManagerProtocol",
     "L1MemoryManager",

--- a/lmcache/v1/distributed/memory_manager/device_resident_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/device_resident_l1_memory_manager.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Device-resident L1 memory manager.
+
+Provides a device-resident L1 tier where L1 entries hold GPU/device memory
+objects directly (instead of CPU pinned-DRAM). Retrieve serves via D2D
+copy rather than H2D, which is useful when the L2 adapter can DMA directly
+into device memory (e.g. NVMe-to-GPU direct read).
+
+The manager is **backend-agnostic**: it interacts with device memory pools
+through the :class:`DeviceMemoryPool` protocol. Concrete backends implement
+this protocol and are instantiated in ``_init_<backend>_pools`` methods.
+
+This PR provides the framework only — no backend is implemented yet. A
+follow-up PR will add the PHX backend (``_init_phx_pools``).
+"""
+
+# Standard
+from typing import Protocol, runtime_checkable
+
+# First Party
+from lmcache.integration.vllm.utils import get_size_bytes
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import L1BackendType, MemoryLayoutDesc
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.memory_management import MemoryObj
+
+logger = init_logger(__name__)
+
+
+@runtime_checkable
+class DeviceMemoryPool(Protocol):
+    """Backend-agnostic device memory pool for DMA-capable L1 tiers.
+
+    A pool owns one device's worth of pre-allocated, DMA-registered device
+    memory plus the backend-specific DMA handle. Backends implement this
+    protocol; :class:`DeviceResidentL1MemoryManager` interacts only through this
+    interface.
+
+    A backend registers itself by adding an ``_init_<backend>_pools`` method
+    to :class:`DeviceResidentL1MemoryManager` that populates ``_device_pools`` with
+    concrete pool instances satisfying this protocol.
+    """
+
+    def allocate(
+        self,
+        *,
+        shapes,
+        dtypes,
+        fmt,
+    ) -> "MemoryObj | None":
+        """Allocate one device MemoryObj.  None if pool exhausted."""
+        ...
+
+    def free(self, memory_obj: MemoryObj) -> None:
+        """Free one device MemoryObj back to the pool."""
+        ...
+
+    def batched_free(self, memory_objs: list[MemoryObj]) -> None:
+        """Free multiple device MemoryObjs."""
+        ...
+
+    def wait_for_available(self, required_bytes: int, timeout: float) -> bool:
+        """Block until ≥ required_bytes free, or timeout.
+
+        Returns True if space is available, False on timeout.
+        """
+        ...
+
+    def get_free_bytes(self) -> int:
+        """Return current free bytes in the pool."""
+        ...
+
+
+class DeviceResidentL1MemoryManager:
+    """L1 memory manager for the device-resident tier.
+
+    Holds device memory pools (one per configured device, behind the
+    :class:`DeviceMemoryPool` protocol) and routes allocation/free by device.
+    CPU objs continue through the normal CPU slab path.
+
+    Backend-agnostic: specific pool implementations are selected by
+    :attr:`DeviceResidentL1Config.backend` and instantiated in
+    ``_init_<backend>_pools``. This class never imports backend types at
+    module level — backends are registered as new ``_init_*_pools`` methods
+    are added (a follow-up PR adds ``_init_phx_pools``).
+
+    This manager is the sole ``_memory_manager`` instance of
+    :class:`~lmcache.v1.distributed.l1_manager.L1Manager` when the
+    device-resident tier is enabled. It serves **both** L1 tiers:
+
+    - **CPU tier**: ``reserve_write`` (used by CPU-L1 adapters like
+      redis/s3/disk, and by the store path via ``serde_wrapper``)
+      allocates through the internal CPU :class:`L1MemoryManager`.
+    - **Device tier**: ``device_reserve_write`` (used by device-L1
+      adapters) allocates through :meth:`allocate_device`.
+
+    :meth:`free` routes by ``obj.raw_tensor.device.type``: device objs go
+    back to their parent :class:`DeviceMemoryPool`, CPU objs go back to
+    the CPU slab.
+
+    This manager satisfies :class:`L1ManagerProtocol` so that
+    :class:`~lmcache.v1.distributed.l1_manager.L1Manager` can hold it behind
+    one type.
+    """
+
+    def __init__(self, memory_config, device_resident_l1_config) -> None:
+        """Create the manager.
+
+        Args:
+            memory_config: CPU memory config (for the internal CPU tier).
+            device_resident_l1_config: Device-resident L1 configuration
+                (backend, device_ids, buffer_size_mb, etc.).
+        """
+        # Lazy import to avoid circular dependency at module level
+        # First Party
+        from lmcache.v1.distributed.config import DeviceResidentL1Config
+        from lmcache.v1.distributed.memory_manager.l1_memory_manager import (
+            L1MemoryManager,
+        )
+
+        self._device_resident_l1_config: DeviceResidentL1Config = (
+            device_resident_l1_config
+        )
+        # Single dict: dev_id → pool (pool internally holds DMA handle + base_ptr)
+        self._device_pools: dict[int, DeviceMemoryPool] = {}
+        # Validate backend + create device pools *before* allocating CPU
+        # memory, so a misconfigured backend fails fast without wasting
+        # resources.
+        self._init_device_pools(device_resident_l1_config)
+        # Hold a CPU L1 manager for the CPU tier: reserve_write (CPU-L1
+        # adapters + store path) allocates through it, and free() routes
+        # CPU objs back to it.
+        self._cpu_manager = L1MemoryManager(memory_config)
+
+    def _init_device_pools(self, config) -> None:
+        """Dispatch to backend-specific pool initializer.
+
+        This PR ships with no backends.
+        New backends register here as ``elif`` branches.
+        """
+        backend = config.backend
+        if backend == "phx":
+            raise NotImplementedError(
+                "PHX backend is implemented in a follow-up PR. "
+                "This PR provides the framework only."
+            )
+        # elif backend == "gds":
+        #     self._init_gds_pools(config)
+        else:
+            raise ValueError(f"Unsupported device-resident L1 backend: {backend!r}")
+
+    def allocate(
+        self, layout_desc: MemoryLayoutDesc, count: int
+    ) -> tuple[L1Error, list[MemoryObj]]:
+        """Allocate ``count`` CPU memory objects.
+
+        This serves the **CPU tier**: ``L1Manager.reserve_write`` (used by
+        CPU-L1 adapters and the store path) calls this method. Device
+        allocation goes through :meth:`allocate_device` (which takes a
+        ``kv_rank`` for device routing).
+
+        Delegates to the internal CPU :class:`L1MemoryManager`.
+
+        Args:
+            layout_desc: Layout descriptor for the objects.
+            count: Number of objects to allocate.
+
+        Returns:
+            ``(L1Error.SUCCESS, objects)`` on success, otherwise
+            ``(L1Error.OUT_OF_MEMORY, [])``.
+        """
+        return self._cpu_manager.allocate(layout_desc, count)
+
+    def allocate_device(
+        self,
+        layout_desc: MemoryLayoutDesc,
+        count: int,
+        kv_rank: int,
+    ) -> tuple[L1Error, list[MemoryObj]]:
+        """Allocate device-resident MemoryObjs for the given kv_rank.
+
+        Routes ``kv_rank`` to a device id, then allocates from that device's
+        pool. Implements backpressure: blocks until pool space is available
+        or timeout.
+
+        Args:
+            layout_desc: Layout descriptor for the objects.
+            count: Number of objects to allocate.
+            kv_rank: Used to route to the correct device.
+
+        Returns:
+            ``(L1Error.SUCCESS, objects)`` on success.
+            ``(L1Error.OUT_OF_MEMORY, [])`` on timeout/pool exhausted
+            (all-or-nothing: partial allocation is freed before returning).
+        """
+        dev_id = self._kv_rank_to_device(kv_rank)
+        pool = self._device_pools.get(dev_id)
+        if pool is None:
+            logger.warning(
+                "DeviceResidentL1MemoryManager: no device pool for device %d "
+                "(kv_rank=%d)",
+                dev_id,
+                kv_rank,
+            )
+            return L1Error.OUT_OF_MEMORY, []
+
+        # Backpressure: wait for pool space before allocating
+        size_per_obj = get_size_bytes(layout_desc.shapes, layout_desc.dtypes)
+        required = size_per_obj * count
+        if not pool.wait_for_available(required, timeout=1.0):
+            return L1Error.OUT_OF_MEMORY, []
+
+        # Allocate one-by-one (pool may not have batched_allocate)
+        objects: list[MemoryObj] = []
+        for _ in range(count):
+            obj = pool.allocate(
+                shapes=layout_desc.shapes,
+                dtypes=layout_desc.dtypes,
+                fmt=None,
+            )
+            if obj is None:
+                # Roll back partial allocation
+                for o in objects:
+                    pool.free(o)
+                return L1Error.OUT_OF_MEMORY, []
+            objects.append(obj)
+
+        return L1Error.SUCCESS, objects
+
+    def free(self, mem_objs: list[MemoryObj]) -> L1Error:
+        """Free a mix of CPU and device memory objects.
+
+        This is the unified free path for both tiers: ``L1Manager`` calls
+        this method for all frees (``finish_read``, ``delete``, ``clear``,
+        ``close``, and OOM rollback). Routing is by
+        ``obj.raw_tensor.device.type``:
+
+        - Device objs (``!= "cpu"``): ``obj.parent().free(obj)`` — routes
+          back to the :class:`DeviceMemoryPool` that allocated it. The
+          pool's ``free`` notifies any ``wait_for_available`` waiter.
+        - CPU objs: batched to ``self._cpu_manager.free()`` — returns to
+          the CPU slab.
+
+        Args:
+            mem_objs: Objects to free (may be a mix of CPU and device).
+
+        Returns:
+            ``L1Error.SUCCESS``.
+        """
+        cpu_objs: list[MemoryObj] = []
+        for o in mem_objs:
+            if o is None:
+                continue
+            try:
+                rt = o.raw_tensor
+            except Exception:
+                rt = None
+            if rt is not None and rt.device.type != "cpu":
+                parent = o.parent()
+                if parent is not None:
+                    parent.free(o)  # DeviceMemoryPool.free
+                else:
+                    logger.warning(
+                        "DeviceResidentL1MemoryManager: device MemoryObj has no "
+                        "parent allocator; cannot free, leaking device "
+                        "memory"
+                    )
+            else:
+                cpu_objs.append(o)
+        if cpu_objs:
+            self._cpu_manager.free(cpu_objs)
+        return L1Error.SUCCESS
+
+    def get_backend_type(self, memory_obj: MemoryObj) -> L1BackendType:
+        """Return the storage medium backing ``memory_obj``.
+
+        Args:
+            memory_obj: An object allocated by this manager.
+
+        Returns:
+            ``L1BackendType.DRAM`` for CPU objects,
+            ``L1BackendType.DEVICE`` for device objects.
+        """
+        try:
+            rt = memory_obj.raw_tensor
+            if rt is not None and rt.device.type != "cpu":
+                return L1BackendType.DEVICE
+        except Exception:
+            pass
+        return L1BackendType.DRAM
+
+    def get_memory_usage(self) -> tuple[int, int]:
+        """Return ``(used_bytes, total_bytes)`` for device pools.
+
+        Only device pool usage is reported here. CPU tier usage is tracked
+        separately by the internal ``_cpu_manager``.
+
+        Note: this currently returns ``(0, sum_of_free_bytes)`` because the
+        :class:`DeviceMemoryPool` protocol only exposes ``get_free_bytes``,
+        not total capacity. Backend pools that track total capacity should
+        override this method for accurate reporting.
+        """
+        total_used = 0
+        total_capacity = 0
+        for pool in self._device_pools.values():
+            free = pool.get_free_bytes()
+            # We don't track total per-pool directly; approximate via
+            # used = total - free. Backend pools should override this if
+            # they track total capacity.
+            total_used += 0  # Updated by backend
+            total_capacity += free
+        return total_used, total_capacity
+
+    def get_l1_memory_desc(self) -> "L1MemoryDesc | None":
+        """Return ``None``: device pools are not a single registerable region.
+
+        Device memory is owned by per-device pools behind the
+        :class:`DeviceMemoryPool` protocol, not a single contiguous buffer
+        that can be described by :class:`L1MemoryDesc`. P2P/NIXL transfer
+        registration is therefore not supported for the device tier.
+        """
+        return None
+
+    def close(self) -> None:
+        """Release all device pool resources.
+
+        Backend pools are responsible for their own cleanup (unregistering
+        DMA mappings, closing device handles, etc.). The CPU manager is
+        closed by :class:`L1Manager` separately.
+        """
+        for dev_id, pool in self._device_pools.items():
+            if hasattr(pool, "close"):
+                try:
+                    pool.close()
+                except Exception:
+                    logger.warning(
+                        "DeviceResidentL1MemoryManager: failed to close "
+                        "pool for device %d",
+                        dev_id,
+                        exc_info=True,
+                    )
+        self._device_pools.clear()
+
+    def memcheck(self) -> bool:
+        """Check allocator consistency across all device pools.
+
+        Logs the free bytes of each device pool. Returns ``True`` always
+        (backends with leak detection should override this for real checks).
+        """
+        for dev_id, pool in self._device_pools.items():
+            free = pool.get_free_bytes()
+            logger.info(
+                "DeviceResidentL1MemoryManager: device %d free bytes: %d",
+                dev_id,
+                free,
+            )
+        return True
+
+    def _kv_rank_to_device(self, kv_rank: int) -> int:
+        """Map a kv_rank to a device id.
+
+        Default: ``kv_rank % num_devices``. Backends or configs may
+        override this mapping. If no devices are configured, returns -1
+        (which will cause ``allocate_device`` to return OOM).
+
+        Args:
+            kv_rank: The KV rank to map.
+
+        Returns:
+            The device id for this kv_rank.
+        """
+        device_ids = self._device_resident_l1_config.device_ids
+        if not device_ids:
+            return -1
+        return device_ids[kv_rank % len(device_ids)]

--- a/lmcache/v1/distributed/memory_manager/device_resident_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/device_resident_l1_memory_manager.py
@@ -71,6 +71,14 @@ class DeviceMemoryPool(Protocol):
         """Return current free bytes in the pool."""
         ...
 
+    def get_total_bytes(self) -> int:
+        """Return the pool's total capacity in bytes.
+
+        Used with :meth:`get_free_bytes` to derive usage
+        (``used = total - free``) for observability.
+        """
+        ...
+
 
 class DeviceResidentL1MemoryManager:
     """L1 memory manager for the device-resident tier.
@@ -291,26 +299,47 @@ class DeviceResidentL1MemoryManager:
         return L1BackendType.DRAM
 
     def get_memory_usage(self) -> tuple[int, int]:
-        """Return ``(used_bytes, total_bytes)`` for device pools.
+        """Return ``(used_bytes, total_bytes)`` of the **CPU tier**.
 
-        Only device pool usage is reported here. CPU tier usage is tracked
-        separately by the internal ``_cpu_manager``.
+        Delegates to the internal CPU :class:`L1MemoryManager`. This is the
+        value :class:`L1Manager` gauges and the eviction controller consume
+        as the L1 usage signal, and eviction candidates are always CPU
+        objects — so it must reflect the CPU tier the evictor actually
+        acts on.
 
-        Note: this currently returns ``(0, sum_of_free_bytes)`` because the
-        :class:`DeviceMemoryPool` protocol only exposes ``get_free_bytes``,
-        not total capacity. Backend pools that track total capacity should
-        override this method for accurate reporting.
+        The device tier is deliberately **excluded**: device-resident
+        entries are temporary (freed on ``finish_read`` once the read locks
+        drain) and are managed by per-pool backpressure, not by eviction.
+        Folding their transient footprint into this ratio would spuriously
+        raise the watermark and evict CPU objects when the correct response
+        to a full device pool is to wait for backpressure. Device pool
+        usage is reported separately via :meth:`get_device_memory_usage`.
+
+        Returns:
+            ``(used_bytes, total_bytes)`` of the CPU pinned-DRAM tier.
         """
-        total_used = 0
-        total_capacity = 0
-        for pool in self._device_pools.values():
-            free = pool.get_free_bytes()
-            # We don't track total per-pool directly; approximate via
-            # used = total - free. Backend pools should override this if
-            # they track total capacity.
-            total_used += 0  # Updated by backend
-            total_capacity += free
-        return total_used, total_capacity
+        return self._cpu_manager.get_memory_usage()
+
+    def get_device_memory_usage(self) -> dict[int, tuple[int, int]]:
+        """Return per-device ``(used_bytes, total_bytes)`` of device pools.
+
+        For observability (gauges / status reporting) only — not consumed
+        by the eviction controller. Per-pool usage is derived as
+        ``total - free``; backpressure (``wait_for_available``) is the
+        mechanism that bounds device-pool usage. Per-device granularity is
+        intentional: each pool backpressures independently, so an
+        aggregated sum could hide a single exhausted pool behind healthy
+        ones.
+
+        Returns:
+            ``{device_id: (used_bytes, total_bytes)}`` keyed by device id;
+            empty dict when no pools are configured.
+        """
+        usage: dict[int, tuple[int, int]] = {}
+        for dev_id, pool in self._device_pools.items():
+            capacity = pool.get_total_bytes()
+            usage[dev_id] = (capacity - pool.get_free_bytes(), capacity)
+        return usage
 
     def get_l1_memory_desc(self) -> "L1MemoryDesc | None":
         """Return ``None``: device pools are not a single registerable region.
@@ -326,8 +355,12 @@ class DeviceResidentL1MemoryManager:
         """Release all device pool resources.
 
         Backend pools are responsible for their own cleanup (unregistering
-        DMA mappings, closing device handles, etc.). The CPU manager is
-        closed by :class:`L1Manager` separately.
+        DMA mappings, closing device handles, etc.).
+
+        The internal CPU manager is closed here as well:
+        :meth:`L1Manager.close` only calls ``close()`` once on its single
+        ``_memory_manager`` (this class), so the CPU slab / SHM path must
+        be released through this cascade on shutdown.
         """
         for dev_id, pool in self._device_pools.items():
             if hasattr(pool, "close"):
@@ -341,6 +374,7 @@ class DeviceResidentL1MemoryManager:
                         exc_info=True,
                     )
         self._device_pools.clear()
+        self._cpu_manager.close()
 
     def memcheck(self) -> bool:
         """Check allocator consistency across all device pools.

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -1014,7 +1014,7 @@ class PrefetchController(StorageControllerInterface):
         keys_to_reserve = merge_bitmaps(trimmed_plan.values(), num_keys).gather(
             request.keys
         )
-        reserved = self._reserve_load_buffers(request, keys_to_reserve)
+        reserved = self._reserve_load_buffers(request, keys_to_reserve, trimmed_plan)
         if len(reserved) < len(keys_to_reserve):
             self._finish_request(request)
             return
@@ -1035,6 +1035,7 @@ class PrefetchController(StorageControllerInterface):
         self,
         request: InFlightPrefetchRequest,
         keys_to_reserve: list[ObjectKey],
+        trimmed_plan: dict[int, Bitmap],
     ) -> set[ObjectKey]:
         """Reserve L1 write buffers for the keys to load from L2.
 
@@ -1046,6 +1047,12 @@ class PrefetchController(StorageControllerInterface):
                                           ^ L1 hit length               ^ L1+L2 hit
             |       -        |     -      |       -        |  loading   |     -      |
 
+        Reserves are routed by adapter L1 tier: adapters with
+        ``l1_tier == "device"`` get device-resident buffers via
+        :meth:`~lmcache.v1.distributed.l1_manager.L1Manager.device_reserve_write`;
+        all other adapters get CPU buffers via the existing ``reserve_write``
+        path. The two paths are fully isolated.
+
         Successful reservations are recorded on
         ``request.write_reserved_keys`` / ``request.write_reserved_objs``.
         Failures publish an ``L2_PREFETCH_FAILED`` event; the caller
@@ -1054,6 +1061,8 @@ class PrefetchController(StorageControllerInterface):
         Args:
             request: The in-flight request the buffers belong to.
             keys_to_reserve: Keys in the trimmed load plan, in prefix order.
+            trimmed_plan: Per-adapter bitmaps (used to determine which
+                adapter each key belongs to, for L1 tier routing).
 
         Returns:
             The subset of ``keys_to_reserve`` that now holds a write buffer.
@@ -1067,20 +1076,59 @@ class PrefetchController(StorageControllerInterface):
             )
         retention_map = dict(zip(keys_to_reserve, retentions, strict=True))
 
+        # Build a reverse map: key → adapter index, so we can route each key
+        # to its adapter's L1 tier without changing the reserve order.
+        key_to_adapter: dict[ObjectKey, int] = {}
+        for adapter_idx, plan_bitmap in trimmed_plan.items():
+            adapter_keys = plan_bitmap.gather(request.keys)
+            for k in adapter_keys:
+                key_to_adapter[k] = adapter_idx
+
+        # Determine whether device_reserve_write is available at all.
+        has_device_l1 = self._l1_manager.has_device_l1()
+
         # Batch reserve_write by object_group_id so each group uses its own
-        # tensor shapes.
+        # tensor shapes. Within a group, split by L1 tier (device vs cpu)
+        # so each sub-batch goes through the correct reserve path.
         write_results: dict[ObjectKey, tuple[L1Error, MemoryObj | None]] = {}
         by_group = sorted(keys_to_reserve, key=attrgetter("object_group_id"))
         for gid, group_iter in groupby(by_group, key=attrgetter("object_group_id")):
             group_keys = list(group_iter)
             gld = request.group_layout_descs[gid]
-            gr = self._l1_manager.reserve_write(
-                keys=group_keys,
-                is_temporary=[not retention_map[k] for k in group_keys],
-                layout_desc=gld,
-                mode="new",
-            )
-            write_results.update(gr)
+
+            # Split group keys by L1 tier
+            device_keys: list[ObjectKey] = []
+            cpu_keys: list[ObjectKey] = []
+            for k in group_keys:
+                k_adapter_idx = key_to_adapter.get(k)
+                if k_adapter_idx is None:
+                    cpu_keys.append(k)
+                    continue
+                desc = self._adapter_descriptors.get(k_adapter_idx)
+                if desc is not None and desc.l1_tier == "device" and has_device_l1:
+                    device_keys.append(k)
+                else:
+                    cpu_keys.append(k)
+
+            # Device path: device_reserve_write (kv_rank from first key)
+            if device_keys:
+                gr = self._l1_manager.device_reserve_write(
+                    keys=device_keys,
+                    is_temporary=[not retention_map[k] for k in device_keys],
+                    layout_desc=gld,
+                    kv_rank=device_keys[0].kv_rank,
+                )
+                write_results.update(gr)
+
+            # CPU path: existing reserve_write (unchanged)
+            if cpu_keys:
+                gr = self._l1_manager.reserve_write(
+                    keys=cpu_keys,
+                    is_temporary=[not retention_map[k] for k in cpu_keys],
+                    layout_desc=gld,
+                    mode="new",
+                )
+                write_results.update(gr)
 
         reserved: set[ObjectKey] = set()
         oom_keys: list[ObjectKey] = []

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -1110,15 +1110,22 @@ class PrefetchController(StorageControllerInterface):
                 else:
                     cpu_keys.append(k)
 
-            # Device path: device_reserve_write (kv_rank from first key)
+            # Device path: split by kv_rank so each sub-batch gets its
+            # buffers from its own device pool. The buffer must sit on the
+            # GPU that DMAs the data in (and serves the D2D retrieve), so a
+            # single routing decision cannot be shared across ranks.
             if device_keys:
-                gr = self._l1_manager.device_reserve_write(
-                    keys=device_keys,
-                    is_temporary=[not retention_map[k] for k in device_keys],
-                    layout_desc=gld,
-                    kv_rank=device_keys[0].kv_rank,
-                )
-                write_results.update(gr)
+                by_kv_rank: dict[int, list[ObjectKey]] = {}
+                for k in device_keys:
+                    by_kv_rank.setdefault(k.kv_rank, []).append(k)
+                for kv_rank, rank_keys in by_kv_rank.items():
+                    gr = self._l1_manager.device_reserve_write(
+                        keys=rank_keys,
+                        is_temporary=[not retention_map[k] for k in rank_keys],
+                        layout_desc=gld,
+                        kv_rank=kv_rank,
+                    )
+                    write_results.update(gr)
 
             # CPU path: existing reserve_write (unchanged)
             if cpu_keys:

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -33,6 +33,19 @@ class AdapterDescriptor:
     config: L2AdapterConfigBase
     """The adapter's configuration object."""
 
+    l1_tier: str = "cpu"
+    """Which L1 tier to reserve write buffers on for loads from this adapter.
+
+    - ``"cpu"`` (default): reserve CPU pinned-DRAM via ``reserve_write`` —
+      the standard path for all existing adapters (redis, s3, disk, ...).
+    - ``"device"``: reserve device-resident memory via
+      ``device_reserve_write`` — used by DMA-direct adapters (e.g. PHX) that
+      can read directly into device memory.
+
+    Defaults to ``"cpu"`` so all existing adapters keep their current
+    behaviour without any change.
+    """
+
     @property
     def type_name(self) -> str:
         """

--- a/tests/v1/distributed/test_device_l1_framework.py
+++ b/tests/v1/distributed/test_device_l1_framework.py
@@ -99,6 +99,10 @@ class MockDeviceMemoryPool:
         with self._lock:
             return self._free
 
+    def get_total_bytes(self) -> int:
+        """Return total capacity bytes."""
+        return self._total
+
 
 # ---------------------------------------------------------------------------
 # DeviceMemoryPool protocol structural typing
@@ -320,3 +324,213 @@ class TestL1BackendType:
 
         assert L1BackendType.DEVICE == "device"
         assert L1BackendType.DEVICE.value == "device"
+
+
+# ---------------------------------------------------------------------------
+# get_memory_usage / get_device_memory_usage accounting
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryUsageAccounting:
+    """get_memory_usage() must report the CPU tier (eviction semantics);
+    device pool usage is exposed separately via get_device_memory_usage().
+    """
+
+    @staticmethod
+    def _make_manager(pools, cpu_usage=(100, 200)):
+        """Build a manager bypassing __init__ (no backend in this PR)."""
+        # First Party
+        from lmcache.v1.distributed.memory_manager import (
+            device_resident_l1_memory_manager as drl1,
+        )
+
+        mgr = object.__new__(drl1.DeviceResidentL1MemoryManager)
+        mgr._device_pools = {i: p for i, p in enumerate(pools)}
+        mgr._cpu_manager = MagicMock()
+        mgr._cpu_manager.get_memory_usage.return_value = cpu_usage
+        return mgr
+
+    def test_get_memory_usage_reports_cpu_tier_only(self):
+        """get_memory_usage() must delegate to the CPU manager, even when
+        device pools hold allocations (device footprint is transient and
+        must not skew the eviction watermark)."""
+        pool = MockDeviceMemoryPool(total_bytes=1024)
+        pool.allocate(shapes=[torch.Size([256])], dtypes=[torch.float32])
+        mgr = self._make_manager(pools=[pool], cpu_usage=(100, 200))
+
+        assert mgr.get_memory_usage() == (100, 200)
+
+    def test_get_device_memory_usage_reports_per_device(self):
+        """get_device_memory_usage() must report per-device
+        ``(used, total)`` — aggregation could hide a single exhausted
+        pool behind healthy ones."""
+        pool0 = MockDeviceMemoryPool(total_bytes=1024)
+        pool1 = MockDeviceMemoryPool(total_bytes=2048)
+        # Allocate 128 bytes from pool0 (float32 x 32 elements)
+        pool0.allocate(shapes=[torch.Size([32])], dtypes=[torch.float32])
+        mgr = self._make_manager(pools=[pool0, pool1])
+
+        assert mgr.get_device_memory_usage() == {
+            0: (128, 1024),
+            1: (0, 2048),
+        }
+
+    def test_get_device_memory_usage_empty_pools(self):
+        """get_device_memory_usage() with no pools returns {}."""
+        mgr = self._make_manager(pools=[])
+        assert mgr.get_device_memory_usage() == {}
+
+
+# ---------------------------------------------------------------------------
+# L1Manager.get_device_memory_usage forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestL1ManagerDeviceUsageForwarding:
+    """L1Manager.get_device_memory_usage() forwards when the device-resident
+    tier is present and returns an empty dict otherwise.
+    """
+
+    def test_forwards_to_device_resident_manager(self):
+        """With a device-resident tier, L1Manager must forward the call."""
+        # First Party
+        from lmcache.v1.distributed.l1_manager import L1Manager
+
+        wrapper = object.__new__(L1Manager)
+        mm = MagicMock()
+        mm.get_device_memory_usage.return_value = {0: (42, 84)}
+        wrapper._memory_manager = mm
+
+        assert L1Manager.get_device_memory_usage(wrapper) == {0: (42, 84)}
+        mm.get_device_memory_usage.assert_called_once()
+
+    def test_plain_manager_reports_empty(self):
+        """Managers without the device tier must report {} via the
+        L1Manager forwarding wrapper (getattr-based probe)."""
+        # First Party
+        from lmcache.v1.distributed.l1_manager import L1Manager
+
+        wrapper = object.__new__(L1Manager)
+        wrapper._memory_manager = MagicMock(spec=[])  # no device API
+        assert L1Manager.get_device_memory_usage(wrapper) == {}
+
+
+# ---------------------------------------------------------------------------
+# PrefetchController._reserve_load_buffers: kv_rank split (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestReserveLoadBuffersKvRankSplit:
+    """Device keys must be split by kv_rank before device_reserve_write.
+
+    Regression test: the whole device batch used to inherit
+    ``device_keys[0].kv_rank``, so keys later in the batch could get
+    buffers from the wrong device pool (a single prefetch request can
+    span multiple kv_ranks).
+    """
+
+    @staticmethod
+    def _make_keys(n: int, num_ranks: int, gid: int = 7):
+        # First Party
+        from lmcache.v1.distributed.api import ObjectKey
+
+        return [
+            ObjectKey(
+                chunk_hash=bytes([i]),
+                model_name="test-model",
+                kv_rank=i % num_ranks,
+                object_group_id=gid,
+            )
+            for i in range(n)
+        ]
+
+    def test_device_keys_split_by_kv_rank(self):
+        """Each device_reserve_write batch must carry a single kv_rank."""
+        # First Party
+        from lmcache.v1.distributed.api import PrefetchMode
+        from lmcache.v1.distributed.error import L1Error
+        from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+            PrefetchController,
+        )
+
+        num_ranks = 3
+        keys = self._make_keys(n=6, num_ranks=num_ranks)
+
+        l1_manager = MagicMock()
+        l1_manager.has_device_l1.return_value = True
+
+        def fake_device_reserve_write(*, keys, is_temporary, layout_desc, kv_rank):
+            return {k: (L1Error.SUCCESS, MagicMock()) for k in keys}
+
+        l1_manager.device_reserve_write.side_effect = fake_device_reserve_write
+
+        controller = MagicMock()
+        controller._l1_manager = l1_manager
+        controller._adapter_descriptors = {0: MagicMock(l1_tier="device")}
+        controller._event_bus = MagicMock()
+
+        request = MagicMock()
+        request.mode = PrefetchMode.WARM  # skip retention policy
+        request.keys = keys
+        request.group_layout_descs = {7: MagicMock()}
+        request.write_reserved_keys = []
+        request.write_reserved_objs = {}
+
+        plan_bitmap = MagicMock()
+        plan_bitmap.gather.return_value = keys  # all keys on adapter 0
+
+        reserved = PrefetchController._reserve_load_buffers(
+            controller, request, keys, {0: plan_bitmap}
+        )
+
+        calls = l1_manager.device_reserve_write.call_args_list
+        assert len(calls) == num_ranks
+        seen_ranks: set[int] = set()
+        for call in calls:
+            batch_keys = call.kwargs["keys"]
+            batch_ranks = {k.kv_rank for k in batch_keys}
+            assert len(batch_ranks) == 1, (
+                f"device_reserve_write batch mixes kv_ranks: {batch_ranks}"
+            )
+            assert call.kwargs["kv_rank"] in batch_ranks
+            seen_ranks |= batch_ranks
+        assert seen_ranks == {0, 1, 2}
+
+        # All keys went through the device path; no CPU fallback reserve.
+        l1_manager.reserve_write.assert_not_called()
+        assert len(reserved) == len(keys)
+        assert set(request.write_reserved_keys) == set(keys)
+
+
+# ---------------------------------------------------------------------------
+# DeviceResidentL1MemoryManager.close(): cascade to the CPU manager
+# ---------------------------------------------------------------------------
+
+
+class TestCloseCascadesToCpuManager:
+    """close() must release the internal CPU manager too.
+
+    ``L1Manager.close()`` only calls ``close()`` once on its single
+    ``_memory_manager`` (this class), so the CPU slab / SHM path is only
+    released if close() cascades into ``_cpu_manager``.
+    """
+
+    def test_close_releases_cpu_manager(self):
+        """close() should close both device pools and the CPU manager."""
+        # First Party
+        from lmcache.v1.distributed.memory_manager import (
+            device_resident_l1_memory_manager as drl1,
+        )
+
+        pool = MagicMock()
+
+        # Bypass __init__ (no backend is implemented in this PR): patch the
+        # attributes close() consumes directly.
+        mgr = object.__new__(drl1.DeviceResidentL1MemoryManager)
+        mgr._device_pools = {0: pool}
+        mgr._cpu_manager = MagicMock()
+
+        mgr.close()
+
+        pool.close.assert_called_once()
+        mgr._cpu_manager.close.assert_called_once()

--- a/tests/v1/distributed/test_device_l1_framework.py
+++ b/tests/v1/distributed/test_device_l1_framework.py
@@ -59,9 +59,10 @@ class MockDeviceMemoryPool:
             obj = MagicMock()
             obj.get_size = MagicMock(return_value=size)
 
-            # Make raw_tensor a device tensor so free() routes correctly
-            raw = torch.empty(1, device=self._device)
-            obj.raw_tensor = raw
+            # Mock the raw tensor's device type — free() routes by
+            # raw_tensor.device.type, which is all these tests exercise.
+            # No real GPU/CUDA device is required (keeps CI green).
+            obj.raw_tensor.device.type = self._device.split(":")[0]  # "cuda"
             obj._size = size
             # Set parent to self so free() routes back
             obj.parent = MagicMock(return_value=self)

--- a/tests/v1/distributed/test_device_l1_framework.py
+++ b/tests/v1/distributed/test_device_l1_framework.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Device L1 memory manager framework (PR 1).
+
+These tests verify the backend-agnostic framework:
+- ``DeviceMemoryPool`` protocol structural typing
+- ``DeviceResidentL1MemoryManager`` allocate/free routing
+- ``L1Manager.device_reserve_write`` / ``has_device_l1``
+- ``AdapterDescriptor.l1_tier`` default and routing in prefetch_controller
+
+All tests use a mock pool implementation — no real backend is needed.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+import threading
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.config import DeviceResidentL1Config
+from lmcache.v1.distributed.memory_manager.device_resident_l1_memory_manager import (
+    DeviceMemoryPool,
+    DeviceResidentL1MemoryManager,
+)
+
+# ---------------------------------------------------------------------------
+# Mock device memory pool (satisfies DeviceMemoryPool protocol)
+# ---------------------------------------------------------------------------
+
+
+class MockDeviceMemoryPool:
+    """Mock device memory pool satisfying DeviceMemoryPool protocol.
+
+    Simulates a device pool with backpressure: ``wait_for_available`` blocks
+    until enough bytes are freed (or timeout).
+    """
+
+    def __init__(self, total_bytes: int, device: str = "cuda:0") -> None:
+        self._total = total_bytes
+        self._free = total_bytes
+        self._device = device
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._allocated: list = []
+
+    def allocate(self, *, shapes, dtypes, fmt=None):
+        """Allocate one device MemoryObj (mock)."""
+        with self._lock:
+            # Compute size from shapes/dtypes
+            size = sum(
+                s.numel() * d.itemsize for s, d in zip(shapes, dtypes, strict=False)
+            )
+            if self._free < size:
+                return None
+            self._free -= size
+            obj = MagicMock()
+            obj.get_size = MagicMock(return_value=size)
+
+            # Make raw_tensor a device tensor so free() routes correctly
+            raw = torch.empty(1, device=self._device)
+            obj.raw_tensor = raw
+            obj._size = size
+            # Set parent to self so free() routes back
+            obj.parent = MagicMock(return_value=self)
+            self._allocated.append(obj)
+            return obj
+
+    def free(self, memory_obj):
+        """Free one device MemoryObj."""
+        with self._lock:
+            if hasattr(memory_obj, "_size"):
+                self._free += memory_obj._size
+                self._cond.notify_all()
+                if memory_obj in self._allocated:
+                    self._allocated.remove(memory_obj)
+
+    def batched_free(self, memory_objs):
+        """Free multiple device MemoryObjs."""
+        for o in memory_objs:
+            self.free(o)
+
+    def wait_for_available(self, required_bytes: int, timeout: float) -> bool:
+        """Block until enough bytes are free, or timeout."""
+        with self._cond:
+            deadline = time.monotonic() + timeout
+            while self._free < required_bytes:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._cond.wait(remaining)
+            return True
+
+    def get_free_bytes(self) -> int:
+        """Return current free bytes."""
+        with self._lock:
+            return self._free
+
+
+# ---------------------------------------------------------------------------
+# DeviceMemoryPool protocol structural typing
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceMemoryPoolProtocol:
+    """Verify that DeviceMemoryPool is a runtime-checkable protocol."""
+
+    def test_mock_pool_satisfies_protocol(self):
+        """MockDeviceMemoryPool should satisfy DeviceMemoryPool protocol."""
+        pool = MockDeviceMemoryPool(total_bytes=1024 * 1024)
+        assert isinstance(pool, DeviceMemoryPool)
+
+    def test_non_pool_does_not_satisfy_protocol(self):
+        """A plain object should not satisfy DeviceMemoryPool protocol."""
+        assert not isinstance(object(), DeviceMemoryPool)
+        assert not isinstance(42, DeviceMemoryPool)
+
+
+# ---------------------------------------------------------------------------
+# DeviceResidentL1MemoryManager
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceResidentL1MemoryManager:
+    """Verify DeviceResidentL1MemoryManager pool management and free routing."""
+
+    def test_no_backend_raises_not_implemented(self):
+        """An empty backend should raise NotImplementedError."""
+        config = DeviceResidentL1Config(backend="", device_ids=[0])
+        # _init_device_pools is called in __init__, which should raise
+        with pytest.raises(ValueError, match="Unsupported device-resident L1 backend"):
+            DeviceResidentL1MemoryManager(
+                memory_config=MagicMock(),
+                device_resident_l1_config=config,
+            )
+
+    def test_phx_backend_not_implemented(self):
+        """The 'phx' backend should raise NotImplementedError (follow-up PR)."""
+        config = DeviceResidentL1Config(backend="phx", device_ids=[0])
+        with pytest.raises(NotImplementedError, match="follow-up PR"):
+            DeviceResidentL1MemoryManager(
+                memory_config=MagicMock(),
+                device_resident_l1_config=config,
+            )
+
+    def test_free_routes_device_objs_to_pool(self):
+        """free() should route device objs to their parent pool."""
+        pool = MockDeviceMemoryPool(total_bytes=1024 * 1024)
+        obj = pool.allocate(
+            shapes=[torch.Size([10])],
+            dtypes=[torch.float32],
+        )
+        assert obj is not None
+        assert pool.get_free_bytes() < 1024 * 1024  # allocated
+
+        # Create a manager with an injected pool (bypass __init__)
+        manager = DeviceResidentL1MemoryManager.__new__(DeviceResidentL1MemoryManager)
+        manager._device_resident_l1_config = DeviceResidentL1Config(
+            backend="phx", device_ids=[0]
+        )
+        manager._device_pools = {0: pool}
+        manager._cpu_manager = MagicMock()
+
+        # Free the device obj
+        manager.free([obj])
+        assert pool.get_free_bytes() == 1024 * 1024  # fully freed
+
+    def test_free_routes_cpu_objs_to_cpu_manager(self):
+        """free() should route CPU objs to the CPU manager."""
+        cpu_obj = MagicMock()
+        cpu_obj.raw_tensor = torch.empty(1)  # CPU tensor
+        cpu_obj.parent = MagicMock(return_value=None)
+
+        manager = DeviceResidentL1MemoryManager.__new__(DeviceResidentL1MemoryManager)
+        manager._device_resident_l1_config = DeviceResidentL1Config(
+            backend="phx", device_ids=[0]
+        )
+        manager._device_pools = {}
+        mock_cpu = MagicMock()
+        manager._cpu_manager = mock_cpu
+
+        manager.free([cpu_obj])
+        mock_cpu.free.assert_called_once_with([cpu_obj])
+
+    def test_free_handles_mixed_objs(self):
+        """free() should handle a mix of CPU and device objs."""
+        pool = MockDeviceMemoryPool(total_bytes=1024 * 1024)
+        dev_obj = pool.allocate(
+            shapes=[torch.Size([10])],
+            dtypes=[torch.float32],
+        )
+        cpu_obj = MagicMock()
+        cpu_obj.raw_tensor = torch.empty(1)
+        cpu_obj.parent = MagicMock(return_value=None)
+
+        manager = DeviceResidentL1MemoryManager.__new__(DeviceResidentL1MemoryManager)
+        manager._device_resident_l1_config = DeviceResidentL1Config(
+            backend="phx", device_ids=[0]
+        )
+        manager._device_pools = {0: pool}
+        mock_cpu = MagicMock()
+        manager._cpu_manager = mock_cpu
+
+        manager.free([dev_obj, cpu_obj])
+        assert pool.get_free_bytes() == 1024 * 1024  # device obj freed
+        mock_cpu.free.assert_called_once_with([cpu_obj])
+
+    def test_kv_rank_to_device_mapping(self):
+        """_kv_rank_to_device should map by modulo num_devices."""
+        manager = DeviceResidentL1MemoryManager.__new__(DeviceResidentL1MemoryManager)
+        manager._device_resident_l1_config = DeviceResidentL1Config(
+            backend="phx", device_ids=[3, 5, 7]
+        )
+        manager._device_pools = {}
+        manager._cpu_manager = MagicMock()
+
+        assert manager._kv_rank_to_device(0) == 3
+        assert manager._kv_rank_to_device(1) == 5
+        assert manager._kv_rank_to_device(2) == 7
+        assert manager._kv_rank_to_device(3) == 3  # wraps around
+
+    def test_kv_rank_to_device_empty_returns_minus_one(self):
+        """_kv_rank_to_device should return -1 when no devices configured."""
+        manager = DeviceResidentL1MemoryManager.__new__(DeviceResidentL1MemoryManager)
+        manager._device_resident_l1_config = DeviceResidentL1Config(
+            backend="phx", device_ids=[]
+        )
+        manager._device_pools = {}
+        manager._cpu_manager = MagicMock()
+
+        assert manager._kv_rank_to_device(0) == -1
+
+
+# ---------------------------------------------------------------------------
+# DeviceResidentL1Config
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceResidentL1Config:
+    """Verify DeviceResidentL1Config dataclass."""
+
+    def test_defaults(self):
+        """DeviceResidentL1Config should have sensible defaults."""
+        config = DeviceResidentL1Config()
+        assert config.backend == ""
+        assert config.device_ids == []
+        assert config.buffer_size_mb == 2048
+        assert config.use_direct_io is True
+
+    def test_construction(self):
+        """DeviceResidentL1Config should accept all fields."""
+        config = DeviceResidentL1Config(
+            backend="phx",
+            device_ids=[0, 1, 2],
+            buffer_size_mb=4096,
+            use_direct_io=False,
+        )
+        assert config.backend == "phx"
+        assert config.device_ids == [0, 1, 2]
+        assert config.buffer_size_mb == 4096
+        assert config.use_direct_io is False
+
+
+# ---------------------------------------------------------------------------
+# AdapterDescriptor.l1_tier
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterDescriptor:
+    """Verify AdapterDescriptor.l1_tier field."""
+
+    def test_default_l1_tier_is_cpu(self):
+        """AdapterDescriptor should default l1_tier to 'cpu'."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+            MockL2AdapterConfig,
+        )
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            AdapterDescriptor,
+        )
+
+        desc = AdapterDescriptor(
+            index=0, config=MockL2AdapterConfig(max_size_gb=1, mock_bandwidth_gb=1)
+        )
+        assert desc.l1_tier == "cpu"
+
+    def test_l1_tier_can_be_set_to_device(self):
+        """AdapterDescriptor should accept l1_tier='device'."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+            MockL2AdapterConfig,
+        )
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            AdapterDescriptor,
+        )
+
+        desc = AdapterDescriptor(
+            index=0,
+            config=MockL2AdapterConfig(max_size_gb=1, mock_bandwidth_gb=1),
+            l1_tier="device",
+        )
+        assert desc.l1_tier == "device"
+
+
+# ---------------------------------------------------------------------------
+# L1BackendType
+# ---------------------------------------------------------------------------
+
+
+class TestL1BackendType:
+    """Verify L1BackendType has DEVICE member."""
+
+    def test_device_backend_type_exists(self):
+        """L1BackendType should have a DEVICE member."""
+        # First Party
+        from lmcache.v1.distributed.api import L1BackendType
+
+        assert L1BackendType.DEVICE == "device"
+        assert L1BackendType.DEVICE.value == "device"


### PR DESCRIPTION
**What this PR does / why we need it**:

Kernel-bypass DMA technologies such as GPUDirect Storage (GDS), GPUDirect RDMA (GDR),  let peripherals (NVMe, RDMA NICs) DMA directly into GPU memory, bypassing the host CPU. 

This framework applies to **any DATA LOAD PATH that requires a GPU staging buffer** — the GPU staging buffer can be regard as a first-class L1, data in L2 storage (SSD、NIC for remote) will be DMA‘d into staging buffer L1 first and then be retrieved via a single D2D copy into the destination KV cache.
This staging buffer L1 is managed by the **Device-Resident-L1MemoryManager**

The major contribution of the Device-Resident-L1MemoryManager lies in its improved **compatibility**. It composes an internal CPU L1MemoryManager, enabling it to manage both DRAM L1 and staging buffer L1 simultaneously. This allows the GPUDirect path and other L2 adapters that rely on DRAM L1 to coexist. The existing GDS L1 and other L2 adapters that rely on DRAM L1 are mutually exclusive.

The Device-Resident-L1MemoryManager strictly isolates the management paths for both DRAM L1 and the staging buffer L1, ensuring they do not interfere with one another.

```mermaid
flowchart TD
    PC["PrefetchController._reserve_load_buffers<br>(routes by AdapterDescriptor.l1_tier)"]
    PC -->|cpu adapters| RW["reserve_write()"]
    PC -->|device adapters| DRW["device_reserve_write()"]
    RW --> L1["L1Manager<br>(single _memory_manager)"]
    DRW --> L1
    L1 --> MGR["DeviceResidentL1MemoryManager"]

    subgraph DRAM_PATH [DRAM L1 path]
        A["allocate()"]
        CM["_cpu_manager (CPU slab)"]
        A --> CM
    end
    subgraph DEV_PATH [Staging buffer L1 path]
        AD["allocate_device()"]
        DP["_device_pools (DMA-registered)"]
        AD --> DP
    end
    MGR --> A
    MGR --> AD
    CM --> CPU["CPU pinned-DRAM"]
    DP --> GPU["GPU staging buffer"]

    FR["free() unified entry<br>(routed by device.type)"]
    FR -->|CPU objs| CM
    FR -->|device objs| DP
```

Components:

- **`DeviceMemoryPool` protocol**: structural interface for per-device DMA-registered memory pools (`allocate` / `free` / `batched_free` / `wait_for_available` / `get_free_bytes`). Backends implement it without inheritance; a backend registers by adding an `_init_<backend>_pools` method.
- **`DeviceResidentL1MemoryManager`**: the L1 tier object. Holds device pools behind the protocol, routes allocation by `kv_rank` with backpressure, and serves **both** tiers — CPU objs (via the internal CPU `L1MemoryManager`) and device objs (via device pools). `free()` routes by `obj.raw_tensor.device.type`.
- **`L1Manager.device_reserve_write()`**: like `reserve_write` but allocates device-resident objects directly. Plus `has_device_l1()` query.
- **`AdapterDescriptor.l1_tier`**: declarative field (default `"cpu"`) — existing adapters keep their current behaviour unchanged.
- **`prefetch_controller` routing**: `_reserve_load_buffers` splits reserve calls by adapter L1 tier; the two paths are fully isolated.
- **`DeviceResidentL1Config`** + `L1ManagerConfig.device_resident_l1_config` field.

**Change breakdown** (~1240 lines, of which ~51% docs + tests):

| File | Lines | Type |
|---|---|---|
| `memory_manager/device_resident_l1_memory_manager.py` | +376 | **new** — protocol + manager |
| `tests/v1/distributed/test_device_l1_framework.py` | +321 | **new** — 14 unit tests (mock pool) |
| `docs/design/v1/distributed/memory_manager/device-resident-l1.md` | +311 | **new** — design doc |
| `l1_manager.py` | +115 | modified — `device_reserve_write` + `has_device_l1` + tier selection branch |
| `prefetch_controller.py` | +66/-10 | modified — reserve routing by adapter L1 tier |
| `config.py` | +40 | modified — `DeviceResidentL1Config` + field |
| `store_policy.py` | +13 | modified — `l1_tier` field |
| `memory_manager/__init__.py` | +9/-1 | modified — exports |
| `api.py` | +1 | modified — `L1BackendType.DEVICE` |

**Zero behaviour change**: this PR ships the framework only (no backend implementation). All adapters default to `l1_tier="cpu"`, `device_resident_l1_config` defaults to `None`, so the new code paths are never triggered until a backend registers itself.

**Special notes for your reviewers**:

- The framework is backend-agnostic by design: `DeviceResidentL1MemoryManager` never imports backend types at module level — backends are added as `_init_<backend>_pools` methods with lazy imports.
- Existing `reserve_write` / store path is untouched; the new `device_reserve_write` is a parallel method for full isolation.
- `device_reserve_write` is all-or-nothing: on device pool exhaustion (after backpressure timeout) all keys return `OUT_OF_MEMORY` and the caller abandons the batch.
- All 968 existing distributed tests pass unchanged; the 14 new tests use a mock pool (no hardware required).
- Design doc: `docs/design/v1/distributed/memory_manager/device-resident-l1.md`
- Follow-up: #4474

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
