### PR TITLE
fix(kv-events): stop KV-cache-store events from carrying an extra token (#4543)

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -315,6 +315,18 @@ def convert_tokens_to_list(
     )
 
 
+def convert_token_range_to_list(
+    tokens: Optional[Union[torch.Tensor, list[int]]], start: int, end: int
+) -> List[int]:
+    """Convert the half-open token range ``[start, end)`` to a list.
+
+    :class:`~lmcache.v1.token_database.TokenDatabase` yields half-open bounds,
+    while :func:`convert_tokens_to_list` is inclusive of its end index.  This
+    wrapper bridges the two so callers do not have to remember the difference.
+    """
+    return convert_tokens_to_list(tokens, start, end - 1)
+
+
 @dataclass
 class DiskCacheMetadata:
     path: str

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -37,7 +37,7 @@ from lmcache.utils import (
     CacheStoreEvent,
     _lmcache_nvtx_annotate,
     compress_slot_mapping,
-    convert_tokens_to_list,
+    convert_token_range_to_list,
 )
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager, EventStatus, EventType
@@ -532,7 +532,7 @@ class LMCacheEngine:
                         lora_name=None,
                     )
                     if tokens is not None:
-                        stored_event.token_ids = convert_tokens_to_list(
+                        stored_event.token_ids = convert_token_range_to_list(
                             tokens,
                             start,
                             end,
@@ -540,7 +540,10 @@ class LMCacheEngine:
                         if isinstance(tokens, torch.Tensor):
                             stored_event.medium = tokens.device
                     elif hashes is not None:
-                        stored_event.token_ids = hashes[start : end + 1]
+                        # ``hashes`` holds one entry per chunk, so it cannot be
+                        # sliced with token offsets; this chunk's hash is
+                        # exactly ``key.chunk_hash``.
+                        stored_event.token_ids = [key.chunk_hash]
                     logger.debug(
                         (
                             "Added kv cache event '%s' to kv cache events queue"
@@ -715,7 +718,7 @@ class LMCacheEngine:
                     lora_name=None,
                 )
                 if tokens is not None:
-                    stored_event.token_ids = convert_tokens_to_list(
+                    stored_event.token_ids = convert_token_range_to_list(
                         tokens,
                         start,
                         end,

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.utils import convert_token_range_to_list
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.token_database import ChunkedTokenDatabase, SegmentTokenDatabase
 
@@ -155,3 +156,46 @@ def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:
         assert isinstance(hash_val, int), f"Expected int, got {type(hash_val)}"
         # Must fit in uint64 (msgpack range: 0 to 2**64 - 1)
         assert 0 <= hash_val <= 2**64 - 1
+
+
+@pytest.mark.parametrize("chunk_size", [4, 16])
+def test_kv_event_token_ids_cover_exactly_one_chunk(chunk_size) -> None:
+    """The KV-event token slice must match the chunk it describes.
+
+    ``process_tokens`` yields half-open ``[start, end)`` bounds while
+    ``convert_tokens_to_list`` is inclusive of its end index, so passing ``end``
+    straight through appends the first token of the *next* chunk to every
+    non-final event and breaks ``len(token_ids) == block_size``.
+    """
+    cfg = LMCacheEngineConfig.from_legacy(
+        chunk_size=chunk_size, backend="cpu", save_unfull_chunk=True
+    )
+    db = ChunkedTokenDatabase(cfg, dumb_metadata())
+
+    tokens = list(range(chunk_size * 2 + chunk_size // 2))
+    results = list(db.process_tokens(tokens=tokens))
+    assert len(results) > 1  # need at least one non-final chunk
+
+    for start, end, _ in results:
+        token_ids = convert_token_range_to_list(tokens, start, end)
+        assert token_ids == tokens[start:end]
+        assert len(token_ids) == end - start
+
+
+def test_kv_event_chunk_hash_matches_supplied_hashes() -> None:
+    """In the hashes variant the event carries this chunk's hash.
+
+    ``hashes`` holds one entry per chunk while ``start``/``end`` are token
+    offsets, so slicing ``hashes`` with them selects the wrong entries (every
+    hash for the first chunk, none for later ones).
+    """
+    cfg = LMCacheEngineConfig.from_legacy(chunk_size=256, backend="cpu")
+    db = ChunkedTokenDatabase(cfg, dumb_metadata())
+
+    hashes = [1111, 2222, 3333]
+    offsets = [256, 256, 256]
+    results = list(db.process_tokens(hashes=hashes, offsets=offsets))
+
+    assert len(results) == len(hashes)
+    for (_, _, key), expected in zip(results, hashes, strict=False):
+        assert [key.chunk_hash] == [expected]


### PR DESCRIPTION
Fixes #4543.

`ChunkedTokenDatabase.process_tokens` yields half-open `[start, end)` bounds and every consumer treats them that way — except the KV-event path. `convert_tokens_to_list` is **inclusive** of its end index by design (`tokens[token_start : token_end + 1]`, pinned by `tests/test_utils.py`), and both store paths passed the exclusive `end` straight through.

## What was wrong

**1. Every non-final event carried `block_size + 1` tokens** (`cache_engine.py:535` and the layerwise path at `:718`)

With `chunk_size=4` and 10 tokens, on `dev` today:

```
start=0 end=4  block_size=4  len(token_ids)=5  ids=[0, 1, 2, 3, 4]   <-- spills into the next chunk
start=4 end=8  block_size=4  len(token_ids)=5  ids=[4, 5, 6, 7, 8]   <-- spills into the next chunk
start=8 end=10 block_size=2  len(token_ids)=2  ids=[8, 9]            (only correct because the slice clamps)
```

`CacheStoreEvent` mirrors vLLM's `BlockStored` and is published externally through `get_kv_events()`, so the event was self-inconsistent (`len(token_ids) != block_size`) and any subscriber recomputing block hashes from `token_ids` derived different hashes than LMCache stored under.

**2. The hashes variant indexed a per-chunk list with token offsets** (`cache_engine.py:543`)

```python
stored_event.token_ids = hashes[start : end + 1]
```

`hashes` has one entry per **chunk**; `start`/`end` are **token** offsets. Measured on `dev` with two 256-token chunks:

```
start=0   end=256  key.chunk_hash=1111  hashes[start:end+1] = [1111, 2222]   <-- both hashes
start=256 end=512  key.chunk_hash=2222  hashes[start:end+1] = []             <-- none
```

## The fix

- New `convert_token_range_to_list(tokens, start, end)` in `lmcache/utils.py` takes the half-open range the token database actually yields and delegates to the existing inclusive `convert_tokens_to_list`. Both KV-event sites now call it, so the off-by-one cannot be reintroduced at a third call site. `convert_tokens_to_list` itself is unchanged — its inclusive contract and its tests stay exactly as they are.
- The hashes variant now uses `[key.chunk_hash]`. In `process_tokens`' hashes branch the key is built by `_make_key_by_hash(hash_val, ...)`, so `key.chunk_hash` *is* this chunk's entry from `hashes` — no index arithmetic needed.

## Tests

Two CPU-only regression tests in `tests/v1/test_token_database.py`, driving the real `ChunkedTokenDatabase`:

- `test_kv_event_token_ids_cover_exactly_one_chunk` — asserts `token_ids == tokens[start:end]` and `len(token_ids) == end - start` for every chunk, parametrized over `chunk_size` 4 and 16.
- `test_kv_event_chunk_hash_matches_supplied_hashes` — asserts each event's hash is that chunk's entry.

Verified locally (Python 3.12, torch 2.5.1, CPU-only):

```
3 passed
```

and confirmed they actually guard the fix — reverting `convert_token_range_to_list` to pass `end` through makes both parametrizations of the first test fail:

```
FAILED test_kv_event_token_ids_cover_exactly_one_chunk[4]
FAILED test_kv_event_token_ids_cover_exactly_one_chunk[16]
2 failed, 1 passed
```

`tests/test_utils.py` (the `convert_tokens_to_list` pins) still passes, and `ruff==0.11.7` `check` + `format` from `.pre-commit-config.yaml` are clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
