### PR TITLE
[Coordinator] Remove environment-variable config in favor of CLI flags

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -67,10 +67,9 @@ lmcache coordinator \
     --health-check-interval 10
 ```
 
-Config resolves from `MPCoordinatorConfig.from_env()` (the
-`LMCACHE_MP_COORDINATOR_*` environment variables); any CLI flag that is supplied
-overrides the corresponding field. Each flag defaults to unset so env-only
-deployments keep working. See
+Config comes from the flags alone: `execute` builds an `MPCoordinatorConfig`
+from every flag that was supplied, and each flag defaults to unset so the
+dataclass default stands. The coordinator reads no environment variables. See
 [../v1/mp_coordinator/README.md](../v1/mp_coordinator/README.md).
 
 ### `lmcache describe`

--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -55,7 +55,7 @@ the relevant resource.
 lmcache/v1/mp_coordinator/
   app.py                # create_app + lifespan + router discovery + health/eviction loops
   __main__.py           # uvicorn entrypoint (`python -m lmcache.v1.mp_coordinator`)
-  config.py             # MPCoordinatorConfig (LMCACHE_MP_COORDINATOR_*)
+  config.py             # MPCoordinatorConfig (CLI flags only, no env vars)
   registry.py           # InstanceRegistry + MPInstance (pure membership)
   schemas.py            # Pydantic request/response models (shared wire contract)
   registrar.py          # mp-server-side register/heartbeat/deregister helpers
@@ -260,14 +260,12 @@ lmcache coordinator [--host HOST] [--port PORT] \
 
 (or, equivalently, `python -m lmcache.v1.mp_coordinator`).
 
-Configured via `LMCACHE_MP_COORDINATOR_*` environment variables — see
-`MPCoordinatorConfig` in `config.py`. The full env-var surface today is
-`HOST`, `PORT`, `INSTANCE_TIMEOUT`, `HEALTH_CHECK_INTERVAL`,
-`EVICTION_CHECK_INTERVAL`, `EVICTION_RATIO`, `TRIGGER_WATERMARK`,
-`CHUNK_SIZE`, `HASH_ALGORITHM`, `BLEND_PROBE_STRIDE`, and
-`TIMEOUT_KEEP_ALIVE`. The `lmcache coordinator` CLI
-flags override the matching env-derived field; unset flags fall back to the
-env vars and then the config defaults. See the
+Configured via CLI flags only — see `MPCoordinatorConfig` in `config.py`, whose
+field defaults are the single source of truth. An unset flag keeps its default;
+there are no coordinator environment variables. Both entrypoints share one flag
+set and one config path: `__main__.main()` builds a parser from
+`CoordinatorCommand.add_arguments` and hands the parsed args to
+`CoordinatorCommand.execute`. See the
 user-facing [`docs/source/mp/coordinator.rst`](../../../source/mp/coordinator.rst)
 for descriptions and defaults.
 

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -85,7 +85,7 @@ a coordinator only adds candidates.
 
 1. First call: run the local matcher **and** submit the coordinator query
    (request tokens). A per-lookup wall-clock deadline is armed
-   (`match_budget_s`, from `LMCACHE_COORDINATOR_BLEND_TIMEOUT`).
+   (`match_budget_s`, from the mp server's `--coordinator-blend-timeout`).
 2. After the prefix resolves, poll the coordinator **before** the sparse
    prefetch: defer while pending, give up at the deadline (then that
    lookup is local-only). The deadline — not just the per-request HTTP

--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -6,8 +6,9 @@ standalone HTTP service that tracks the MP server instances in a deployment. MP
 servers register with it and send periodic heartbeats; the coordinator evicts
 any instance whose heartbeat lapses past ``--instance-timeout``.
 
-It replaces ``python -m lmcache.v1.mp_coordinator``. The process runs in the
-foreground; stop it with ``Ctrl-C``.
+It is the preferred form of ``python -m lmcache.v1.mp_coordinator``, which still
+works and accepts the same flags. The process runs in the foreground; stop it
+with ``Ctrl-C``.
 
 .. code-block:: bash
 
@@ -82,21 +83,11 @@ Options
 Configuration
 -------------
 
-Every flag is optional. Unset flags fall back to the
-``LMCACHE_MP_COORDINATOR_*`` environment variables (``HOST``, ``PORT``,
-``INSTANCE_TIMEOUT``, ``HEALTH_CHECK_INTERVAL``, ``EVICTION_CHECK_INTERVAL``,
-``EVICTION_RATIO``, ``TRIGGER_WATERMARK``, ``CHUNK_SIZE``, ``HASH_ALGORITHM``,
-``BLEND_PROBE_STRIDE``, ``TIMEOUT_KEEP_ALIVE``, ``METRICS_ENABLED``,
-``OTLP_ENDPOINT``), and then to the built-in defaults. A supplied flag always
-overrides the matching env-derived value, so env-only deployments keep working
-unchanged.
+Every flag is optional; an unset flag keeps the built-in default listed above.
 
 Prometheus pull mode reuses the coordinator's existing HTTP server; it does not
 start a second server or reserve a separate Prometheus port. Metrics-disabled
 and OTLP push modes both return HTTP 404 from the local ``/metrics`` route.
-``ENABLE_BLEND_LOOKUP``, ``BLEND_PROBE_STRIDE``, ``TIMEOUT_KEEP_ALIVE``), and
-then to the built-in defaults. A supplied flag always overrides the matching
-env-derived value, so env-only deployments keep working unchanged.
 
 See :doc:`/mp/coordinator` for the active eviction loop.
 

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -25,87 +25,81 @@ Expected log output:
 
     LMCache INFO: MP coordinator listening on http://0.0.0.0:9300
 
-The CLI accepts ``--host``, ``--port``, ``--instance-timeout``,
-``--health-check-interval``, ``--eviction-check-interval``,
-``--eviction-ratio``, ``--trigger-watermark``, ``--chunk-size``,
-``--hash-algorithm``, ``--enable-blend-lookup``, ``--blend-probe-stride``,
-``--timeout-keep-alive``, ``--disable-metrics``, and ``--otlp-endpoint``;
-any flag overrides the matching environment variable below. See
-:doc:`/cli/coordinator` for details.
-Equivalently, the coordinator can still be launched as a module with
-``python3 -m lmcache.v1.mp_coordinator``.
+See :doc:`/cli/coordinator` for the full flag list. Equivalently, the
+coordinator can be launched as a module with
+``python3 -m lmcache.v1.mp_coordinator``, which accepts the same flags.
 
 Configuration
 -------------
 
-The coordinator is configured through ``LMCACHE_MP_COORDINATOR_*`` environment
-variables:
+The coordinator is configured through CLI flags only; every flag left unset
+keeps the default below.
 
 .. list-table::
    :header-rows: 1
    :widths: 38 14 48
 
-   * - Environment variable
+   * - Flag
      - Default
      - Description
-   * - ``LMCACHE_MP_COORDINATOR_HOST``
+   * - ``--host``
      - ``0.0.0.0``
      - Host the HTTP server binds to.
-   * - ``LMCACHE_MP_COORDINATOR_PORT``
+   * - ``--port``
      - ``9300``
      - Port the HTTP server binds to.
-   * - ``LMCACHE_MP_COORDINATOR_INSTANCE_TIMEOUT``
+   * - ``--instance-timeout``
      - ``30``
      - Seconds without a heartbeat after which a server is dropped from the
        fleet.
-   * - ``LMCACHE_MP_COORDINATOR_HEALTH_CHECK_INTERVAL``
+   * - ``--health-check-interval``
      - ``10``
      - Seconds between health-check sweeps that expire stale MP-server
        registrations. ``0`` disables the stale-instance eviction loop; it does
        **not** affect the ``/quota`` L2 eviction loop (see
-       ``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL`` below).
-   * - ``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL``
+       ``--eviction-check-interval`` below).
+   * - ``--eviction-check-interval``
      - ``5``
      - Seconds between L2 eviction sweeps. ``0`` disables the loop.
-   * - ``LMCACHE_MP_COORDINATOR_EVICTION_RATIO``
+   * - ``--eviction-ratio``
      - ``0.2``
      - Fraction of tracked keys (by count) to evict per cycle (0.0 to 1.0).
-   * - ``LMCACHE_MP_COORDINATOR_TRIGGER_WATERMARK``
+   * - ``--trigger-watermark``
      - ``1.0``
      - Eviction fires when usage reaches this fraction of the quota
        (0.0 exclusive to 1.0).
-   * - ``LMCACHE_MP_COORDINATOR_CHUNK_SIZE``
+   * - ``--chunk-size``
      - ``256``
      - Tokens per KV chunk: the CacheBlend match unit and the unit used to
        resolve pin ``token_ids`` to keys. Must equal the MP servers'
        ``--chunk-size``.
-   * - ``LMCACHE_MP_COORDINATOR_HASH_ALGORITHM``
+   * - ``--hash-algorithm``
      - ``blake3``
      - Token hash algorithm for pin key resolution. Must equal the MP servers'
        ``--hash-algorithm``. ``blake3`` is self-contained; other algorithms
        require vLLM importable in the coordinator process.
-   * - ``LMCACHE_MP_COORDINATOR_ENABLE_BLEND_LOOKUP``
-     - ``False``
+   * - ``--enable-blend-lookup``
+     - off
      - Index stored chunk content so ``POST /directory/blend-lookup`` can serve
        fleet CacheBlend reuse. Off by default: hashing content costs CPU on
        every store. Also requires the MP servers'
        ``--coordinator-event-reporting``.
-   * - ``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE``
+   * - ``--blend-probe-stride``
      - ``1``
      - Positions between CacheBlend match probes. ``1`` probes every offset
        for full recall. Ignored unless blend lookup is on.
-   * - ``LMCACHE_MP_COORDINATOR_TIMEOUT_KEEP_ALIVE``
+   * - ``--timeout-keep-alive``
      - ``10``
      - Seconds the HTTP server keeps idle connections open before closing
        them. Must be greater than the MP servers' heartbeat interval
        (default ``5``), otherwise heartbeat requests may hit a closing
        connection and fail with ``Server disconnected without sending a
        response``.
-   * - ``LMCACHE_MP_COORDINATOR_METRICS_ENABLED``
-     - ``True``
-     - Initialize OpenTelemetry metrics. Set to ``False`` to disable metrics;
-       the local ``/metrics`` endpoint then returns 404.
-   * - ``LMCACHE_MP_COORDINATOR_OTLP_ENDPOINT``
+   * - ``--disable-metrics``
+     - off
+     - Skip OpenTelemetry metrics initialization. Metrics are on by default;
+       pass this flag and the local ``/metrics`` endpoint returns 404.
+   * - ``--otlp-endpoint``
      - unset
      - OTLP gRPC endpoint for metrics push mode. When unset, Prometheus pull
        mode exposes ``/metrics`` on the coordinator HTTP port. When set, the
@@ -427,8 +421,7 @@ selects LRU keys to evict. Each batch carries the server's ``instance_id``,
 scoped to that instance, so replays are deduplicated and lost batches are
 detected.
 
-**Active eviction loop.** Every
-``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL`` seconds, the
+**Active eviction loop.** Every ``--eviction-check-interval`` seconds, the
 coordinator inspects per-salt usage against the registered quotas and,
 for any salt over the trigger watermark, picks LRU victims and
 dispatches a single ``DELETE /cache/objects`` to a uniformly random registered MP
@@ -1148,9 +1141,9 @@ a separate publish call. Both feeds default to off and both are required: the
 coordinator needs ``--enable-blend-lookup``, and every MP server whose chunks
 should be discoverable needs ``--coordinator-event-reporting`` (a server with a
 coordinator URL but no event reporting warns at startup and matches locally
-only). Matching is chunked at ``LMCACHE_MP_COORDINATOR_CHUNK_SIZE`` — which
-must equal the MP servers' ``--chunk-size`` — probing every
-``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE`` positions.
+only). Matching is chunked at the coordinator's ``--chunk-size`` — which must
+equal the MP servers' ``--chunk-size`` — probing every
+``--blend-probe-stride`` positions.
 
 **Request body:**
 

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -2,8 +2,8 @@
 """``lmcache coordinator`` — launch the LMCache mp coordinator (HTTP).
 
 The coordinator tracks mp server instances via a registry and evicts those
-whose heartbeats lapse. Configuration falls back to ``LMCACHE_MP_COORDINATOR_*``
-environment variables; CLI flags override them.
+whose heartbeats lapse. Configuration comes from CLI flags only; an unset flag
+leaves the corresponding :class:`MPCoordinatorConfig` default.
 """
 
 # Standard
@@ -38,9 +38,9 @@ class CoordinatorCommand(BaseCommand):
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         """Add coordinator-specific arguments to the parser.
 
-        Each flag defaults to ``None`` so that unset flags fall back to the
-        ``LMCACHE_MP_COORDINATOR_*`` environment variables (and then the
-        config defaults) in :meth:`execute`.
+        Each flag defaults to ``None`` so that :meth:`execute` can tell an
+        unset flag from an explicit one and leave the corresponding
+        :class:`MPCoordinatorConfig` default in place.
 
         Args:
             parser: The ``ArgumentParser`` for this subcommand.
@@ -169,8 +169,8 @@ class CoordinatorCommand(BaseCommand):
     def execute(self, args: argparse.Namespace) -> None:
         """Build the coordinator config and serve the app with uvicorn.
 
-        Resolves config from the environment, then overrides any field whose
-        corresponding CLI flag was supplied.
+        Builds the config from the supplied flags; every flag left unset keeps
+        its :class:`MPCoordinatorConfig` default.
 
         Args:
             args: Parsed CLI arguments.
@@ -179,7 +179,6 @@ class CoordinatorCommand(BaseCommand):
             SystemExit: When coordinator dependencies are not installed.
         """
         # Standard
-        import dataclasses
         import sys
 
         try:
@@ -200,9 +199,7 @@ class CoordinatorCommand(BaseCommand):
             )
             sys.exit(1)
 
-        config = MPCoordinatorConfig.from_env()
-
-        overrides = {
+        fields = {
             field: value
             for field, value in (
                 ("host", args.host),
@@ -222,9 +219,8 @@ class CoordinatorCommand(BaseCommand):
             if value is not None
         }
         if args.disable_metrics is not None:
-            overrides["metrics_enabled"] = not args.disable_metrics
-        if overrides:
-            config = dataclasses.replace(config, **overrides)
+            fields["metrics_enabled"] = not args.disable_metrics
+        config = MPCoordinatorConfig(**fields)
 
         init_coordinator_metrics(config)
         app = create_app(config)

--- a/lmcache/v1/mp_coordinator/__main__.py
+++ b/lmcache/v1/mp_coordinator/__main__.py
@@ -1,35 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
 """Entrypoint for the mp coordinator process.
 
-Run with ``python -m lmcache.v1.mp_coordinator``. Configuration is read from
-``LMCACHE_MP_COORDINATOR_*`` environment variables (see
-:class:`MPCoordinatorConfig`).
+Run with ``python -m lmcache.v1.mp_coordinator``. Accepts the same flags as
+``lmcache coordinator`` (see :class:`CoordinatorCommand`); an unset flag leaves
+the corresponding :class:`MPCoordinatorConfig` default.
 """
 
-# Third Party
-import uvicorn
+# Standard
+import argparse
 
 # First Party
-from lmcache.logging import init_logger
-from lmcache.v1.mp_coordinator.app import create_app
-from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
-from lmcache.v1.mp_coordinator.observability import init_coordinator_metrics
-
-logger = init_logger(__name__)
+from lmcache.cli.commands.coordinator import CoordinatorCommand
 
 
 def main() -> None:
-    """Build the coordinator app from the environment and serve it."""
-    config = MPCoordinatorConfig.from_env()
-    init_coordinator_metrics(config)
-    app = create_app(config)
-    uvicorn.run(
-        app,
-        host=config.host,
-        port=config.port,
-        log_level="info",
-        timeout_keep_alive=config.timeout_keep_alive,
+    """Parse coordinator flags and serve the app.
+
+    Delegates to :class:`CoordinatorCommand` so the module entrypoint and the
+    ``lmcache coordinator`` subcommand share one flag set and one config path.
+    """
+    command = CoordinatorCommand()
+    parser = argparse.ArgumentParser(
+        prog="python -m lmcache.v1.mp_coordinator",
+        description=command.help(),
     )
+    command.add_arguments(parser)
+    command.execute(parser.parse_args())
 
 
 if __name__ == "__main__":

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -16,7 +16,6 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from queue import Empty, Queue
-import os
 import threading
 
 # First Party
@@ -152,32 +151,37 @@ class BlendCoordinatorClient:
             self._client.close()
 
     @classmethod
-    def maybe_create(cls, url: str | None) -> "BlendCoordinatorClient | None":
+    def maybe_create(
+        cls,
+        url: str | None,
+        *,
+        timeout: float,
+        match_concurrency: int,
+    ) -> "BlendCoordinatorClient | None":
         """Build a started client for ``url``; an empty URL returns ``None``.
-
-        Timing knobs are read from the environment:
-        ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (seconds, default 1.0; used as
-        both the per-request HTTP timeout and the per-lookup match budget) and
-        ``LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY`` (default 8).
 
         Args:
             url: Coordinator base URL; empty or ``None`` disables the client.
+            timeout: Seconds used as both the per-request HTTP timeout and the
+                per-lookup match budget.
+            match_concurrency: Max match round-trips in flight at once.
 
         Returns:
             A started client, or ``None`` when ``url`` is empty (the blend
             module then runs purely local).
+
+        Raises:
+            ValueError: If ``match_concurrency`` is not positive.
         """
         url = (url or "").strip()
         if not url:
             return None
-        concurrency = int(os.getenv("LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY", "8"))
-        timeout = float(os.getenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "1.0"))
         logger.info("Blend coordinator client enabled -> %s", url)
         return cls(
             url,
             request_timeout=timeout,
             match_budget_s=timeout,
-            match_concurrency=concurrency,
+            match_concurrency=match_concurrency,
         )
 
     # -- daemon ------------------------------------------------------------

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -1,20 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Configuration for the mp coordinator process.
 
-A small, explicit, frozen dataclass with environment-variable loading
-(``LMCACHE_MP_COORDINATOR_*``).
+A small, explicit, frozen dataclass. Values come from ``lmcache coordinator``
+CLI flags (see :mod:`lmcache.cli.commands.coordinator`); unset flags leave the
+defaults below.
 """
 
 # Standard
 from dataclasses import dataclass
-import os
-
-# First Party
-from lmcache.logging import init_logger
-
-logger = init_logger(__name__)
-
-_ENV_PREFIX = "LMCACHE_MP_COORDINATOR_"
 
 
 @dataclass(frozen=True)
@@ -98,59 +91,3 @@ class MPCoordinatorConfig:
             raise ValueError("blend_probe_stride must be positive")
         if self.timeout_keep_alive <= 0:
             raise ValueError("timeout_keep_alive must be positive")
-
-    @classmethod
-    def from_env(cls) -> "MPCoordinatorConfig":
-        """Build a config from ``LMCACHE_MP_COORDINATOR_*`` environment variables.
-
-        Unset variables fall back to the dataclass defaults.
-
-        Returns:
-            A validated configuration instance.
-        """
-
-        def _str(name: str, default: str) -> str:
-            return os.getenv(f"{_ENV_PREFIX}{name}", default)
-
-        def _num(name: str, default: float, cast) -> float:
-            raw = os.getenv(f"{_ENV_PREFIX}{name}")
-            if raw is None:
-                return default
-            try:
-                return cast(raw)
-            except ValueError:
-                logger.warning(
-                    "Invalid %s%s=%r; using default %s", _ENV_PREFIX, name, raw, default
-                )
-                return default
-
-        def _bool(name: str, default: bool) -> bool:
-            raw = os.getenv(f"{_ENV_PREFIX}{name}")
-            if raw is None:
-                return default
-            return raw.strip().lower() in ("1", "true", "yes", "on")
-
-        return cls(
-            host=_str("HOST", cls.host),
-            port=int(_num("PORT", cls.port, int)),
-            instance_timeout=_num("INSTANCE_TIMEOUT", cls.instance_timeout, float),
-            health_check_interval=_num(
-                "HEALTH_CHECK_INTERVAL", cls.health_check_interval, float
-            ),
-            eviction_check_interval=_num(
-                "EVICTION_CHECK_INTERVAL", cls.eviction_check_interval, float
-            ),
-            eviction_ratio=_num("EVICTION_RATIO", cls.eviction_ratio, float),
-            trigger_watermark=_num("TRIGGER_WATERMARK", cls.trigger_watermark, float),
-            chunk_size=int(_num("CHUNK_SIZE", cls.chunk_size, int)),
-            hash_algorithm=_str("HASH_ALGORITHM", cls.hash_algorithm),
-            enable_blend_lookup=_bool("ENABLE_BLEND_LOOKUP", cls.enable_blend_lookup),
-            blend_probe_stride=int(
-                _num("BLEND_PROBE_STRIDE", cls.blend_probe_stride, int)
-            ),
-            timeout_keep_alive=int(
-                _num("TIMEOUT_KEEP_ALIVE", cls.timeout_keep_alive, int)
-            ),
-            metrics_enabled=_bool("METRICS_ENABLED", cls.metrics_enabled),
-            otlp_endpoint=os.getenv(f"{_ENV_PREFIX}OTLP_ENDPOINT"),
-        )

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -229,6 +229,14 @@ class CoordinatorConfig:
     event_flush_interval: float = 1.0
     """Seconds between cache-event flush attempts to the coordinator."""
 
+    blend_timeout: float = 1.0
+    """Seconds a fleet CacheBlend lookup may take: both the per-request HTTP
+    timeout and the per-lookup match budget of the blend coordinator client."""
+
+    blend_match_concurrency: int = 8
+    """Max fleet CacheBlend match round-trips the blend coordinator client keeps
+    in flight at once. Must be strictly positive."""
+
 
 DEFAULT_COORDINATOR_CONFIG = CoordinatorConfig()
 
@@ -568,9 +576,10 @@ def add_coordinator_args(
 ) -> argparse.ArgumentParser:
     """Add MP coordinator registration arguments to an existing parser.
 
-    Each flag falls back to its ``LMCACHE_COORDINATOR_*`` environment variable
-    so the server can be configured either way (the env var is convenient for
-    the Kubernetes downward API); an explicit flag wins over the env var.
+    The registration flags fall back to their ``LMCACHE_COORDINATOR_*``
+    environment variables so the server can be configured either way (the env
+    var is convenient for the Kubernetes downward API); an explicit flag wins
+    over the env var. The blend client flags have no env fallback.
 
     Args:
         parser: The argument parser to add arguments to.
@@ -619,6 +628,21 @@ def add_coordinator_args(
         help="Seconds between cache-event flush attempts (must be > 0). "
         "Defaults to LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL, then 1.0.",
     )
+    group.add_argument(
+        "--coordinator-blend-timeout",
+        type=float,
+        default=DEFAULT_COORDINATOR_CONFIG.blend_timeout,
+        help="Seconds a fleet CacheBlend lookup to the coordinator may take, "
+        "used as both the HTTP timeout and the per-lookup match budget "
+        f"(default: {DEFAULT_COORDINATOR_CONFIG.blend_timeout}).",
+    )
+    group.add_argument(
+        "--coordinator-blend-match-concurrency",
+        type=int,
+        default=DEFAULT_COORDINATOR_CONFIG.blend_match_concurrency,
+        help="Max fleet CacheBlend match round-trips in flight at once "
+        f"(default: {DEFAULT_COORDINATOR_CONFIG.blend_match_concurrency}).",
+    )
     # Deprecated pre-v0.5.3 aliases, hidden from --help. Released deployers
     # (operator <= v0.5.2, charts) still render these names into server args,
     # and rejecting them crashes the pod on startup. Remove once those
@@ -645,9 +669,11 @@ def parse_args_to_coordinator_config(
 ) -> CoordinatorConfig:
     """Convert parsed command line arguments to a CoordinatorConfig.
 
-    A flag value takes precedence over its environment variable. The heartbeat
-    interval is validated here so a malformed value fails fast at startup
-    (runtime best-effort only covers coordinator *reachability*, not config).
+    For the registration settings a flag value takes precedence over its
+    environment variable; the blend client settings come from their flags
+    alone. Timing values are validated here so a malformed one fails fast at
+    startup (runtime best-effort only covers coordinator *reachability*, not
+    config).
 
     The event-reporting flags also accept their deprecated pre-v0.5.3
     spellings (``--coordinator-l2-event-*``), logging a deprecation warning
@@ -661,8 +687,9 @@ def parse_args_to_coordinator_config(
         The configuration object.
 
     Raises:
-        ValueError: If the heartbeat interval or the event flush interval
-            is not a positive finite number.
+        ValueError: If the heartbeat interval, the event flush interval or the
+            blend timeout is not a positive finite number, or if the blend
+            match concurrency is less than 1.
     """
     url = (
         args.coordinator_url
@@ -736,10 +763,25 @@ def parse_args_to_coordinator_config(
             "got %s" % event_flush_interval
         )
 
+    blend_timeout = args.coordinator_blend_timeout
+    if not math.isfinite(blend_timeout) or blend_timeout <= 0:
+        raise ValueError(
+            "coordinator blend timeout must be a finite number > 0, "
+            "got %s" % blend_timeout
+        )
+    blend_match_concurrency = args.coordinator_blend_match_concurrency
+    if blend_match_concurrency < 1:
+        raise ValueError(
+            "coordinator blend match concurrency must be >= 1, "
+            "got %s" % blend_match_concurrency
+        )
+
     return CoordinatorConfig(
         url=url,
         advertise_ip=advertise_ip,
         heartbeat_interval=heartbeat_interval,
         event_reporting=event_reporting,
         event_flush_interval=event_flush_interval,
+        blend_timeout=blend_timeout,
+        blend_match_concurrency=blend_match_concurrency,
     )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -273,7 +273,9 @@ def _build_modules(
                 "LMCACHE_COORDINATOR_EVENT_REPORTING=true) to enable it."
             )
         coordinator = BlendCoordinatorClient.maybe_create(
-            coordinator_config.url if coordinator_config.event_reporting else ""
+            coordinator_config.url if coordinator_config.event_reporting else "",
+            timeout=coordinator_config.blend_timeout,
+            match_concurrency=coordinator_config.blend_match_concurrency,
         )
         blend_v3 = BlendV3Module(
             ctx,

--- a/tests/cli/commands/test_coordinator.py
+++ b/tests/cli/commands/test_coordinator.py
@@ -82,7 +82,7 @@ class TestCoordinatorCommandArguments:
         assert args.enable_blend_lookup is True
 
     def test_flags_default_to_none(self, parser):
-        """Unset flags default to None so env/config defaults win."""
+        """Unset flags default to None so the config defaults win."""
         args = parser.parse_args(["coordinator"])
         assert args.chunk_size is None
         assert args.hash_algorithm is None
@@ -140,4 +140,51 @@ class TestCoordinatorCommandExecute:
         assert captured["config"].blend_probe_stride == 2
         assert captured["config"].metrics_enabled is False
         assert captured["config"].otlp_endpoint == "http://collector:4317"
+        # Unset flags keep the config defaults.
+        assert captured["config"].host == MPCoordinatorConfig.host
+        assert captured["config"].port == MPCoordinatorConfig.port
         mock_init_metrics.assert_called_once_with(captured["config"])
+
+    def test_env_vars_ignored(self, cmd, monkeypatch):
+        """Config is CLI-only: LMCACHE_MP_COORDINATOR_* no longer has an effect."""
+        # First Party
+        from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+        monkeypatch.setenv("LMCACHE_MP_COORDINATOR_PORT", "7777")
+        monkeypatch.setenv("LMCACHE_MP_COORDINATOR_HOST", "10.0.0.1")
+        monkeypatch.setenv("LMCACHE_MP_COORDINATOR_OTLP_ENDPOINT", "http://x:4317")
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            instance_timeout=None,
+            health_check_interval=None,
+            eviction_check_interval=None,
+            eviction_ratio=None,
+            trigger_watermark=None,
+            chunk_size=None,
+            hash_algorithm=None,
+            enable_blend_lookup=None,
+            blend_probe_stride=None,
+            timeout_keep_alive=None,
+            disable_metrics=None,
+            otlp_endpoint=None,
+        )
+
+        captured = {}
+
+        def fake_create_app(config: MPCoordinatorConfig):
+            captured["config"] = config
+            return MagicMock()
+
+        with (
+            patch("uvicorn.run"),
+            patch("lmcache.v1.mp_coordinator.observability.init_coordinator_metrics"),
+            patch(
+                "lmcache.v1.mp_coordinator.app.create_app",
+                side_effect=fake_create_app,
+            ),
+        ):
+            cmd.execute(args)
+
+        assert captured["config"] == MPCoordinatorConfig()

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -169,22 +169,30 @@ def test_take_match_clears():
         client.close()
 
 
-def test_maybe_create(monkeypatch: pytest.MonkeyPatch):
-    assert BlendCoordinatorClient.maybe_create("") is None
-    assert BlendCoordinatorClient.maybe_create("   ") is None
-    assert BlendCoordinatorClient.maybe_create(None) is None
+def test_maybe_create():
+    kwargs = {"timeout": 1.0, "match_concurrency": 8}
+    assert BlendCoordinatorClient.maybe_create("", **kwargs) is None
+    assert BlendCoordinatorClient.maybe_create("   ", **kwargs) is None
+    assert BlendCoordinatorClient.maybe_create(None, **kwargs) is None
 
-    monkeypatch.delenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", raising=False)
-    client = BlendCoordinatorClient.maybe_create("http://coord:9300")
+    client = BlendCoordinatorClient.maybe_create("http://coord:9300", **kwargs)
     assert client is not None
-    assert client.match_budget_s == 1.0  # default timeout
+    assert client.match_budget_s == 1.0
     client.close()
 
-    monkeypatch.setenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "1.5")
-    client = BlendCoordinatorClient.maybe_create("http://coord:9300")
+    client = BlendCoordinatorClient.maybe_create(
+        "http://coord:9300", timeout=1.5, match_concurrency=2
+    )
     assert client is not None
-    assert client.match_budget_s == 1.5  # env override
+    assert client.match_budget_s == 1.5
     client.close()
+
+
+def test_maybe_create_rejects_bad_concurrency():
+    with pytest.raises(ValueError):
+        BlendCoordinatorClient.maybe_create(
+            "http://coord:9300", timeout=1.0, match_concurrency=0
+        )
 
 
 def test_pending_sentinel_distinct():

--- a/tests/v1/mp_coordinator/test_config.py
+++ b/tests/v1/mp_coordinator/test_config.py
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for MPCoordinatorConfig validation and env loading."""
-
-# Standard
-from unittest.mock import patch
-import os
+"""Unit tests for MPCoordinatorConfig validation."""
 
 # Third Party
 import pytest
@@ -26,42 +22,23 @@ def test_non_positive_intervals_rejected():
         MPCoordinatorConfig(health_check_interval=-1.0)
 
 
-def test_from_env_overrides_and_falls_back():
-    env = {
-        "LMCACHE_MP_COORDINATOR_HOST": "127.0.0.1",
-        "LMCACHE_MP_COORDINATOR_PORT": "7777",
-        "LMCACHE_MP_COORDINATOR_INSTANCE_TIMEOUT": "42",
-        "LMCACHE_MP_COORDINATOR_METRICS_ENABLED": "false",
-        "LMCACHE_MP_COORDINATOR_OTLP_ENDPOINT": "http://collector:4317",
-    }
-    with patch.dict(os.environ, env, clear=False):
-        config = MPCoordinatorConfig.from_env()
+def test_no_env_loading() -> None:
+    """Config is CLI-only: the env loader is gone, not merely unused."""
+    assert not hasattr(MPCoordinatorConfig, "from_env")
+
+
+def test_explicit_values_kept() -> None:
+    config = MPCoordinatorConfig(
+        host="127.0.0.1",
+        port=7777,
+        instance_timeout=42.0,
+        metrics_enabled=False,
+        otlp_endpoint="http://collector:4317",
+    )
     assert config.host == "127.0.0.1"
     assert config.port == 7777
     assert config.instance_timeout == 42.0
     assert config.metrics_enabled is False
     assert config.otlp_endpoint == "http://collector:4317"
-    # Unset variable keeps the default.
+    # Unspecified fields keep their defaults.
     assert config.health_check_interval == MPCoordinatorConfig.health_check_interval
-
-
-@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE"])
-def test_metrics_enabled_truthy_env_values(value: str) -> None:
-    with patch.dict(
-        os.environ,
-        {"LMCACHE_MP_COORDINATOR_METRICS_ENABLED": value},
-        clear=True,
-    ):
-        config = MPCoordinatorConfig.from_env()
-    assert config.metrics_enabled is True
-
-
-@pytest.mark.parametrize("value", ["0", "false", "no", "off", "invalid"])
-def test_metrics_enabled_falsy_env_values(value: str) -> None:
-    with patch.dict(
-        os.environ,
-        {"LMCACHE_MP_COORDINATOR_METRICS_ENABLED": value},
-        clear=True,
-    ):
-        config = MPCoordinatorConfig.from_env()
-    assert config.metrics_enabled is False

--- a/tests/v1/mp_coordinator/test_main.py
+++ b/tests/v1/mp_coordinator/test_main.py
@@ -1,49 +1,73 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the legacy MP coordinator module entrypoint."""
+"""Tests for the MP coordinator module entrypoint."""
 
 # Standard
 from unittest.mock import MagicMock, patch
+import sys
+
+# Third Party
+import pytest
 
 # First Party
 from lmcache.v1.mp_coordinator.__main__ import main
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 
 
-def test_main_initializes_metrics_before_serving() -> None:
-    config = MPCoordinatorConfig()
+def _serve(argv: list[str]) -> tuple[list[str], MPCoordinatorConfig, MagicMock]:
+    """Run ``main()`` with ``argv``, returning the call order, config and app."""
     app = MagicMock()
     calls: list[str] = []
+    captured: dict[str, MPCoordinatorConfig] = {}
 
-    def record_metrics(_: MPCoordinatorConfig) -> None:
+    def record_metrics(config: MPCoordinatorConfig) -> None:
         calls.append("metrics")
+        captured["config"] = config
 
-    def fake_create_app(_: MPCoordinatorConfig) -> MagicMock:
+    def fake_create_app(config: MPCoordinatorConfig) -> MagicMock:
         calls.append("app")
         return app
 
     with (
+        patch.object(sys, "argv", ["lmcache.v1.mp_coordinator", *argv]),
         patch(
-            "lmcache.v1.mp_coordinator.__main__.MPCoordinatorConfig.from_env",
-            return_value=config,
+            "lmcache.v1.mp_coordinator.observability.init_coordinator_metrics",
+            side_effect=record_metrics,
         ),
         patch(
-            "lmcache.v1.mp_coordinator.__main__.init_coordinator_metrics",
-            side_effect=record_metrics,
-        ) as mock_init_metrics,
-        patch(
-            "lmcache.v1.mp_coordinator.__main__.create_app",
+            "lmcache.v1.mp_coordinator.app.create_app",
             side_effect=fake_create_app,
         ),
-        patch("lmcache.v1.mp_coordinator.__main__.uvicorn.run") as mock_run,
+        patch("uvicorn.run") as mock_run,
     ):
         main()
+    return calls, captured["config"], mock_run
+
+
+def test_main_initializes_metrics_before_serving() -> None:
+    calls, config, mock_run = _serve([])
 
     assert calls == ["metrics", "app"]
-    mock_init_metrics.assert_called_once_with(config)
-    mock_run.assert_called_once_with(
-        app,
-        host=config.host,
-        port=config.port,
-        log_level="info",
-        timeout_keep_alive=config.timeout_keep_alive,
-    )
+    assert config == MPCoordinatorConfig()
+    mock_run.assert_called_once()
+    _, kwargs = mock_run.call_args
+    assert kwargs == {
+        "host": config.host,
+        "port": config.port,
+        "log_level": "info",
+        "timeout_keep_alive": config.timeout_keep_alive,
+    }
+
+
+def test_main_applies_flags() -> None:
+    """The module entrypoint accepts the same flags as ``lmcache coordinator``."""
+    _, config, _ = _serve(["--port", "9999", "--chunk-size", "512"])
+
+    assert config.port == 9999
+    assert config.chunk_size == 512
+    # Unset flags keep the config defaults.
+    assert config.host == MPCoordinatorConfig.host
+
+
+def test_main_rejects_unknown_flag() -> None:
+    with pytest.raises(SystemExit):
+        _serve(["--not-a-flag"])

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -51,6 +51,42 @@ def test_defaults_disable_registration():
     assert config.url == ""  # empty url => registration disabled
     assert config.advertise_ip == ""
     assert config.heartbeat_interval == 5.0
+    assert config.blend_timeout == 1.0
+    assert config.blend_match_concurrency == 8
+
+
+def test_blend_flags_are_parsed():
+    config = _parse(
+        [
+            "--coordinator-blend-timeout",
+            "2.5",
+            "--coordinator-blend-match-concurrency",
+            "4",
+        ]
+    )
+    assert config.blend_timeout == 2.5
+    assert config.blend_match_concurrency == 4
+
+
+@pytest.mark.parametrize("timeout", ["0", "-1", "nan", "inf"])
+def test_invalid_blend_timeout_rejected(timeout):
+    with pytest.raises(ValueError, match="blend timeout must be a finite number > 0"):
+        _parse(["--coordinator-blend-timeout", timeout])
+
+
+@pytest.mark.parametrize("concurrency", ["0", "-1"])
+def test_invalid_blend_concurrency_rejected(concurrency):
+    with pytest.raises(ValueError, match="blend match concurrency must be >= 1"):
+        _parse(["--coordinator-blend-match-concurrency", concurrency])
+
+
+def test_blend_flags_have_no_env_fallback(monkeypatch):
+    """The blend knobs are CLI-only; the old env names no longer apply."""
+    monkeypatch.setenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "9.5")
+    monkeypatch.setenv("LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY", "32")
+    config = _parse([])
+    assert config.blend_timeout == 1.0
+    assert config.blend_match_concurrency == 8
 
 
 def test_flags_are_parsed():


### PR DESCRIPTION
**What this PR does / why we need it**:

The mp coordinator had two configuration paths for the same 14 settings: `LMCACHE_MP_COORDINATOR_*` environment variables and the `lmcache coordinator` CLI flags that overrode them. This removes the environment path — `MPCoordinatorConfig.from_env()` is gone and the flags are now the only way to configure the coordinator, with the dataclass field defaults as the single source of truth.

Two blend client knobs (`LMCACHE_COORDINATOR_BLEND_TIMEOUT`, `LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY`) are read in the mp server process and had no CLI equivalent, so they become `--coordinator-blend-timeout` and `--coordinator-blend-match-concurrency` with the old env defaults. `python -m lmcache.v1.mp_coordinator` now parses the same flag set instead of reading the environment.

**Special notes for your reviewers**:

- The mp-server registration fallbacks (`LMCACHE_COORDINATOR_URL`, `_ADVERTISE_IP`, `_HEARTBEAT_INTERVAL`, `_EVENT_*`) are deliberately kept: the operator injects `_ADVERTISE_IP` from the Kubernetes downward API, so dropping it needs an operator change. Separate PR.
- Breaking for out-of-tree deployments that set `LMCACHE_MP_COORDINATOR_*` — nothing in this repo does. Flag spellings are unchanged, so migration is mechanical (`PORT=9300` → `--port 9300`, `METRICS_ENABLED=False` → `--disable-metrics`).
- The zh_CN `.po` catalogs still carry the old env names; they are generated and already stale on `dev`, so I left them for a translation sync.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
