### PR TITLE
feat(mp): add hash subdirectories to fs_native L2 adapter

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -2,6 +2,7 @@
 
 #include "connector.h"
 #include <cerrno>
+#include <cctype>
 #include <cstdint>
 #include <cstdio>
 #include <stdexcept>
@@ -85,6 +86,65 @@ std::string FSConnector::key_to_filename(const std::string& key) {
   return result;
 }
 
+std::string FSConnector::key_to_chunk_hash(const std::string& key) {
+  // Serialized ObjectKey format produced by the module-level
+  // _object_key_to_string() in native_connector_l2_adapter.py:
+  //   Unsalted: <model>@<kv_rank>@<object_group_id>@<chunk_hash>
+  //   Salted:   <model>@<kv_rank>@<object_group_id>@<chunk_hash>@<cache_salt>
+  size_t field_start = 0;
+  for (int field = 0; field < 3; ++field) {
+    size_t separator = key.find(KEY_SEP, field_start);
+    if (separator == std::string::npos) {
+      throw std::runtime_error(
+          "FSConnector: malformed key for hash subdirectories "
+          "(expected 4 or 5 '@'-separated fields): " +
+          key);
+    }
+    field_start = separator + 1;
+  }
+
+  size_t field_end = key.find(KEY_SEP, field_start);
+  if (field_end == std::string::npos) {
+    field_end = key.size();
+  } else if (key.find(KEY_SEP, field_end + 1) != std::string::npos) {
+    throw std::runtime_error(
+        "FSConnector: malformed key for hash subdirectories "
+        "(expected 4 or 5 '@'-separated fields): " +
+        key);
+  }
+
+  if (field_end == field_start) {
+    throw std::runtime_error("FSConnector: chunk hash must not be empty: " +
+                             key);
+  }
+  return key.substr(field_start, field_end - field_start);
+}
+
+std::filesystem::path FSConnector::key_to_file_path(
+    const WorkerFSConn& conn, const std::string& key) const {
+  std::filesystem::path file_path = conn.base_path;
+  if (hash_subdir_levels_ > 0) {
+    std::string chunk_hash = key_to_chunk_hash(key);
+    size_t prefix_size = static_cast<size_t>(hash_subdir_levels_) * 2;
+    if (chunk_hash.size() < prefix_size) {
+      throw std::runtime_error(
+          "FSConnector: chunk hash is too short for hash_subdir_levels=" +
+          std::to_string(hash_subdir_levels_) + ": " + chunk_hash);
+    }
+    for (size_t i = 0; i < prefix_size; ++i) {
+      if (!std::isxdigit(static_cast<unsigned char>(chunk_hash[i]))) {
+        throw std::runtime_error(
+            "FSConnector: chunk hash prefix must be hexadecimal: " +
+            chunk_hash);
+      }
+    }
+    for (int level = 0; level < hash_subdir_levels_; ++level) {
+      file_path /= chunk_hash.substr(static_cast<size_t>(level) * 2, 2);
+    }
+  }
+  return file_path / key_to_filename(key);
+}
+
 // ---------------------------------------------------------------
 // read/write helpers
 // ---------------------------------------------------------------
@@ -148,13 +208,14 @@ static bool try_enable_odirect(int& flags, const void* buf, size_t len,
 
 FSConnector::FSConnector(std::string base_path, int num_workers,
                          std::string relative_tmp_dir, bool use_odirect,
-                         size_t read_ahead_size)
+                         size_t read_ahead_size, int hash_subdir_levels)
     : ConnectorBase(num_workers),
       base_path_(std::move(base_path)),
       relative_tmp_dir_(std::move(relative_tmp_dir)),
       use_odirect_(use_odirect),
       disk_block_size_(0),
-      read_ahead_size_(read_ahead_size) {
+      read_ahead_size_(read_ahead_size),
+      hash_subdir_levels_(hash_subdir_levels) {
   // Create base directory
   std::filesystem::create_directories(base_path_);
 
@@ -191,8 +252,7 @@ WorkerFSConn FSConnector::create_connection() {
 
 void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
                                 void* buf, size_t len, size_t chunk_size) {
-  std::string filename = key_to_filename(key);
-  auto file_path = conn.base_path / filename;
+  auto file_path = key_to_file_path(conn, key);
 
   int flags = O_RDONLY;
   bool do_odirect = conn.use_odirect &&
@@ -239,22 +299,39 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
 void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
                                 const void* buf, size_t len,
                                 size_t chunk_size) {
-  std::string filename = key_to_filename(key);
-  auto file_path = conn.base_path / filename;
+  auto file_path = key_to_file_path(conn, key);
 
   // Skip if already stored on disk
   if (std::filesystem::exists(file_path)) {
     return;
   }
 
+  // The cache is worker-local, so different workers may call
+  // create_directories() for the same bucket; concurrent calls are safe because
+  // the operation is idempotent.
+  if (hash_subdir_levels_ > 0) {
+    auto subdir = file_path.parent_path();
+    if (conn.prepared_hash_subdirs.find(subdir) ==
+        conn.prepared_hash_subdirs.end()) {
+      std::error_code ec;
+      std::filesystem::create_directories(subdir, ec);
+      if (ec) {
+        throw std::runtime_error("create hash subdirectories failed: " +
+                                 subdir.string() + ": " + ec.message());
+      }
+      conn.prepared_hash_subdirs.insert(std::move(subdir));
+    }
+  }
+
   // Determine temp file path
   std::filesystem::path tmp_path;
   if (!conn.tmp_dir.empty()) {
-    tmp_path = conn.tmp_dir / filename;
+    tmp_path = conn.tmp_dir / file_path.filename();
   } else {
     tmp_path = file_path;
-    tmp_path.replace_extension(TMP_EXT);
   }
+  // Keep the temporary path distinct before the atomic rename
+  tmp_path.replace_extension(TMP_EXT);
 
   int flags = O_CREAT | O_WRONLY | O_TRUNC;
   if (conn.use_odirect) {
@@ -290,14 +367,12 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
 }
 
 bool FSConnector::do_single_exists(WorkerFSConn& conn, const std::string& key) {
-  std::string filename = key_to_filename(key);
-  auto file_path = conn.base_path / filename;
+  auto file_path = key_to_file_path(conn, key);
   return std::filesystem::exists(file_path);
 }
 
 bool FSConnector::do_single_delete(WorkerFSConn& conn, const std::string& key) {
-  std::string filename = key_to_filename(key);
-  auto file_path = conn.base_path / filename;
+  auto file_path = key_to_file_path(conn, key);
   std::error_code ec;
   return std::filesystem::remove(file_path, ec);
 }

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <filesystem>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace lmcache {
@@ -30,13 +31,15 @@ struct WorkerFSConn {
   // If > 0, trigger filesystem readahead by issuing a small
   // initial read of this many bytes before reading the rest.
   size_t read_ahead_size = 0;
+  // Hash directories this worker has successfully ensured exist.
+  std::unordered_set<std::filesystem::path> prepared_hash_subdirs;
 };
 
 class FSConnector : public ConnectorBase<WorkerFSConn> {
  public:
   FSConnector(std::string base_path, int num_workers,
               std::string relative_tmp_dir = "", bool use_odirect = false,
-              size_t read_ahead_size = 0);
+              size_t read_ahead_size = 0, int hash_subdir_levels = 0);
   ~FSConnector() override;
 
  protected:
@@ -49,6 +52,15 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   bool do_single_delete(WorkerFSConn& conn, const std::string& key) override;
 
  private:
+  // Build the final path for a serialized key. When hash subdirectories are
+  // enabled, the current native wire format's chunk-hash field (parts[3])
+  // supplies two hex characters per directory level.
+  std::filesystem::path key_to_file_path(const WorkerFSConn& conn,
+                                         const std::string& key) const;
+
+  // Extract the chunk hash from the current 4/5-field native wire format.
+  static std::string key_to_chunk_hash(const std::string& key);
+
   // Build the filesystem-safe filename from a serialized key string.
   //
   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
@@ -74,6 +86,7 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   bool use_odirect_;
   size_t disk_block_size_;
   size_t read_ahead_size_;
+  int hash_subdir_levels_;
 };
 
 }  // namespace connector

--- a/csrc/storage_backends/fs/pybind.cpp
+++ b/csrc/storage_backends/fs/pybind.cpp
@@ -7,9 +7,9 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(lmcache_fs, m) {
   py::class_<lmcache::connector::FSConnector>(m, "LMCacheFSClient")
-      .def(py::init<std::string, int, std::string, bool, size_t>(),
+      .def(py::init<std::string, int, std::string, bool, size_t, int>(),
            py::arg("base_path"), py::arg("num_workers"),
            py::arg("relative_tmp_dir") = "", py::arg("use_odirect") = false,
-           py::arg("read_ahead_size") = 0)
+           py::arg("read_ahead_size") = 0, py::arg("hash_subdir_levels") = 0)
           LMCACHE_BIND_CONNECTOR_METHODS(lmcache::connector::FSConnector);
 }

--- a/docs/source/mp/l2_storage/fs_native.rst
+++ b/docs/source/mp/l2_storage/fs_native.rst
@@ -26,6 +26,17 @@ I/O queue depth on a single Python thread.
   for reads that use ``O_DIRECT`` because direct I/O bypasses the page cache.
 - ``max_capacity_gb`` (float, default ``0``): Maximum L2 capacity in GB
   for client-side usage tracking.  Default ``0`` disables tracking.
+- ``hash_subdir_levels`` (int, default ``0``): Number of hash-prefix
+  subdirectory levels. Allowed values are ``0``, ``1``, and ``2``. Each
+  level consumes two hexadecimal characters from the beginning of the
+  object's chunk hash directly; the connector does not hash the serialized
+  key or filename again. This produces these layouts:
+
+  - ``0``: ``<base_path>/<filename>``
+  - ``1``: ``<base_path>/<hash[:2]>/<filename>``
+  - ``2``: ``<base_path>/<hash[:2]>/<hash[2:4]>/<filename>``
+
+  Hash subdirectories are created on demand by store operations only.
 
 .. important::
 
@@ -55,6 +66,13 @@ I/O queue depth on a single Python thread.
    If unsure, start with ``use_odirect: false`` and confirm correctness
    before enabling ``O_DIRECT``.
 
+.. note::
+
+   ``hash_subdir_levels`` changes where files are located, and lookups do
+   not fall back to another layout. Changing it for an existing cache makes
+   files written with the previous value unreachable. Use a new empty cache
+   directory or clear the existing one before changing this setting.
+
 **Configuration examples:**
 
 .. code-block:: bash
@@ -67,6 +85,9 @@ I/O queue depth on a single Python thread.
 
     # O_DIRECT for real-disk benchmarking
     --l2-adapter '{"type": "fs_native", "base_path": "/data/lmcache/l2", "num_workers": 32, "use_odirect": true}'
+
+    # Spread files across a two-level chunk-hash prefix tree
+    --l2-adapter '{"type": "fs_native", "base_path": "/data/lmcache/l2", "hash_subdir_levels": 2}'
 
 **Buffer-only mode example.**  L1 acts as a pure write buffer that
 absorbs the peak burst of in-flight chunks while the C++ worker pool

--- a/lmcache/cli/commands/bench/l2_adapter_bench/data.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/data.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 # Standard
+import hashlib
 import select
 
 # Third Party
@@ -22,6 +23,7 @@ from lmcache.v1.memory_management import (
 from lmcache.v1.platform import consume_fd
 
 _KB = 1024
+_CHUNK_HASH_BYTES = 16
 
 
 def make_aligned_tensor(num_bytes: int, align_bytes: int = 1) -> torch.Tensor:
@@ -64,6 +66,10 @@ def make_object_keys(
     ``ObjectKey`` is a frozen dataclass with field order:
     (chunk_hash, model_name, kv_rank).
 
+    Sequential indices are hashed so prefix-based storage layouts exercise
+    multiple buckets. The mapping is deterministic, allowing separate store
+    and load benchmark runs to address the same objects.
+
     Args:
         num_keys: Number of keys to generate.
         model_name: Model name embedded in each key.
@@ -72,8 +78,10 @@ def make_object_keys(
     keys: list[ObjectKey] = []
     for i in range(num_keys):
         idx = key_offset + i
-        # chunk_hash: 16 bytes derived from index to guarantee uniqueness
-        chunk_hash = idx.to_bytes(16, "big")
+        chunk_hash = hashlib.blake2b(
+            idx.to_bytes(_CHUNK_HASH_BYTES, "big"),
+            digest_size=_CHUNK_HASH_BYTES,
+        ).digest()
         keys.append(
             ObjectKey(
                 chunk_hash=chunk_hash,

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -45,6 +45,8 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
     - use_odirect: bypass page cache via O_DIRECT.
     - read_ahead_size: trigger filesystem readahead by
       reading this many bytes first (optional).
+    - hash_subdir_levels: number of two-hex-character chunk-hash
+      subdirectory levels (0, 1, or 2; default 0).
     """
 
     def __init__(
@@ -55,13 +57,15 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         use_odirect: bool = False,
         read_ahead_size: Optional[int] = None,
         max_capacity_gb: float = 0,
-    ):
+        hash_subdir_levels: int = 0,
+    ) -> None:
         self.base_path = base_path
         self.num_workers = num_workers
         self.relative_tmp_dir = relative_tmp_dir
         self.use_odirect = use_odirect
         self.read_ahead_size = read_ahead_size
         self.max_capacity_gb = max_capacity_gb
+        self.hash_subdir_levels = hash_subdir_levels
 
     @classmethod
     def from_dict(cls, d: dict) -> "FSNativeL2AdapterConfig":
@@ -90,6 +94,10 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
             raise ValueError("max_capacity_gb must be a non-negative number")
 
+        hash_subdir_levels = d.get("hash_subdir_levels", 0)
+        if type(hash_subdir_levels) is not int or hash_subdir_levels not in (0, 1, 2):
+            raise ValueError("hash_subdir_levels must be one of 0, 1, or 2")
+
         return cls(
             base_path=base_path,
             num_workers=num_workers,
@@ -97,6 +105,7 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             use_odirect=use_odirect,
             read_ahead_size=read_ahead_size,
             max_capacity_gb=float(max_capacity_gb),
+            hash_subdir_levels=hash_subdir_levels,
         )
 
     @classmethod
@@ -116,7 +125,10 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             "first (optional)\n"
             "- max_capacity_gb (float): max L2 capacity "
             "in GB for usage tracking / eviction "
-            "(default 0 = disabled)"
+            "(default 0 = disabled)\n"
+            "- hash_subdir_levels (int): number of "
+            "two-hex-character chunk-hash subdirectory "
+            "levels, one of 0, 1, or 2 (default 0)"
         )
 
 
@@ -150,13 +162,16 @@ def _create_fs_native_l2_adapter(
         config.relative_tmp_dir,
         config.use_odirect,
         config.read_ahead_size or 0,
+        config.hash_subdir_levels,
     )
     logger.info(
-        "Created FS native L2 adapter: %s (workers=%d, odirect=%s, read_ahead=%s)",
+        "Created FS native L2 adapter: %s "
+        "(workers=%d, odirect=%s, read_ahead=%s, hash_subdir_levels=%d)",
         config.base_path,
         config.num_workers,
         config.use_odirect,
         config.read_ahead_size,
+        config.hash_subdir_levels,
     )
     return NativeConnectorL2Adapter(
         native_client,
@@ -167,6 +182,7 @@ def _create_fs_native_l2_adapter(
             "use_odirect": config.use_odirect,
             "num_workers": config.num_workers,
             "read_ahead_size": config.read_ahead_size,
+            "hash_subdir_levels": config.hash_subdir_levels,
         },
     )
 

--- a/tests/cli/commands/bench/l2_adapter_bench/test_data.py
+++ b/tests/cli/commands/bench/l2_adapter_bench/test_data.py
@@ -8,6 +8,7 @@ from lmcache.cli.commands.bench.l2_adapter_bench.data import (
     create_l1_memory_desc,
     make_aligned_tensor,
     make_memory_objects,
+    make_object_keys,
 )
 
 
@@ -27,6 +28,19 @@ def test_create_l1_memory_desc_uses_requested_alignment() -> None:
     assert desc.ptr == tensor.data_ptr()
     assert desc.size == 8192
     assert desc.align_bytes == 4096
+
+
+def test_make_object_keys_spread_hash_prefixes_deterministically() -> None:
+    keys = make_object_keys(512, key_offset=100)
+
+    assert keys == make_object_keys(512, key_offset=100)
+    assert len({key.chunk_hash for key in keys}) == len(keys)
+    assert all(len(key.chunk_hash) == 16 for key in keys)
+
+    level_one_prefixes = {key.chunk_hash[:1] for key in keys}
+    level_two_prefixes = {key.chunk_hash[:2] for key in keys}
+    assert len(level_one_prefixes) > 1
+    assert len(level_two_prefixes) > len(level_one_prefixes)
 
 
 def test_make_memory_objects_uses_shared_l1_range() -> None:

--- a/tests/v1/distributed/test_l2_adapter_factory.py
+++ b/tests/v1/distributed/test_l2_adapter_factory.py
@@ -882,12 +882,14 @@ class _FakeLMCacheFSClient:
         relative_tmp_dir="",
         use_odirect=False,
         read_ahead_size=0,
+        hash_subdir_levels=0,
     ):
         self.base_path = base_path
         self.num_workers = num_workers
         self.relative_tmp_dir = relative_tmp_dir
         self.use_odirect = use_odirect
         self.read_ahead_size = read_ahead_size
+        self.hash_subdir_levels = hash_subdir_levels
         self._efd = create_event_notifier()
         self._closed = False
 
@@ -973,6 +975,7 @@ class TestFSNativeAdapterFactory:
                 config.relative_tmp_dir,
                 config.use_odirect,
                 config.read_ahead_size or 0,
+                config.hash_subdir_levels,
             )
             # First Party
             from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
@@ -991,6 +994,7 @@ class TestFSNativeAdapterFactory:
                 relative_tmp_dir=".tmp",
                 use_odirect=True,
                 read_ahead_size=4096,
+                hash_subdir_levels=2,
             )
             adapter = create_l2_adapter_from_registry(cfg)
             assert captured["args"] == (
@@ -999,6 +1003,7 @@ class TestFSNativeAdapterFactory:
                 ".tmp",
                 True,
                 4096,
+                2,
             )
             adapter.close()
         finally:
@@ -1093,6 +1098,7 @@ class TestFSNativeAdapterFactory:
                 config.relative_tmp_dir,
                 config.use_odirect,
                 config.read_ahead_size or 0,
+                config.hash_subdir_levels,
             )
             # First Party
             from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
@@ -1134,5 +1140,6 @@ def _patched_fs_factory(config, l1_memory_desc=None):
         config.relative_tmp_dir,
         config.use_odirect,
         config.read_ahead_size or 0,
+        config.hash_subdir_levels,
     )
     return NativeConnectorL2Adapter(client)

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -969,6 +969,7 @@ class TestFSNativeL2AdapterConfig:
         assert config.relative_tmp_dir == ""
         assert config.use_odirect is False
         assert config.read_ahead_size is None
+        assert config.hash_subdir_levels == 0
 
     def test_from_dict_full(self):
         # First Party
@@ -984,6 +985,7 @@ class TestFSNativeL2AdapterConfig:
                 "relative_tmp_dir": ".tmp",
                 "use_odirect": True,
                 "read_ahead_size": 4096,
+                "hash_subdir_levels": 2,
             }
         )
         assert config.base_path == "/data/kv_cache"
@@ -991,6 +993,7 @@ class TestFSNativeL2AdapterConfig:
         assert config.relative_tmp_dir == ".tmp"
         assert config.use_odirect is True
         assert config.read_ahead_size == 4096
+        assert config.hash_subdir_levels == 2
 
     def test_from_dict_missing_base_path_raises(self):
         # First Party
@@ -1106,6 +1109,40 @@ class TestFSNativeL2AdapterConfig:
                 }
             )
 
+    @pytest.mark.parametrize("hash_subdir_levels", [0, 1, 2])
+    def test_from_dict_valid_hash_subdir_levels(self, hash_subdir_levels: int) -> None:
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+            FSNativeL2AdapterConfig,
+        )
+
+        config = FSNativeL2AdapterConfig.from_dict(
+            {
+                "type": "fs_native",
+                "base_path": "/tmp/x",
+                "hash_subdir_levels": hash_subdir_levels,
+            }
+        )
+        assert config.hash_subdir_levels == hash_subdir_levels
+
+    @pytest.mark.parametrize("hash_subdir_levels", [-1, 3, 1.0, "1", True, None])
+    def test_from_dict_invalid_hash_subdir_levels_raises(
+        self, hash_subdir_levels: object
+    ) -> None:
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+            FSNativeL2AdapterConfig,
+        )
+
+        with pytest.raises(ValueError, match="hash_subdir_levels"):
+            FSNativeL2AdapterConfig.from_dict(
+                {
+                    "type": "fs_native",
+                    "base_path": "/tmp/x",
+                    "hash_subdir_levels": hash_subdir_levels,
+                }
+            )
+
     def test_registered_as_fs_native(self):
         # First Party
         from lmcache.v1.distributed.l2_adapters.config import (
@@ -1126,6 +1163,7 @@ class TestFSNativeL2AdapterConfig:
         assert "num_workers" in h
         assert "use_odirect" in h
         assert "read_ahead_size" in h
+        assert "hash_subdir_levels" in h
 
     def test_type_name_lookup(self):
         # First Party

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -2,6 +2,7 @@
 """Tests for the native C++ filesystem connector."""
 
 # Standard
+from pathlib import Path
 from typing import Any
 import ctypes
 import os
@@ -80,6 +81,68 @@ def _submit_and_wait(
 ) -> tuple[int, bool, str, list[bool] | None]:
     future_id = getattr(client, method_name)([key], [view])
     return _wait_for_completion(client, future_id)
+
+
+def _expected_filename(key: str) -> str:
+    model, kv_rank, object_group_id, chunk_hash = key.split("@")
+    safe_model = model.replace("/", "-SEP-")
+    return f"{safe_model}@0x{kv_rank}@{object_group_id}@{chunk_hash}.data"
+
+
+def _expected_path(base_path: Path, key: str, hash_subdir_levels: int) -> Path:
+    chunk_hash = key.split("@")[3]
+    path = base_path
+    for level in range(hash_subdir_levels):
+        path /= chunk_hash[level * 2 : level * 2 + 2]
+    return path / _expected_filename(key)
+
+
+@pytest.mark.parametrize("hash_subdir_levels", [0, 1, 2])
+def test_hash_subdir_layout_round_trip_and_delete(
+    tmp_path: Path,
+    hash_subdir_levels: int,
+) -> None:
+    """All operations should use the configured chunk-hash path layout."""
+    chunk_hash = "a1b2c3d4e5f60718"
+    key = f"test_model@00000000@7@{chunk_hash}"
+    LMCacheFSClient = _import_fs_client()
+    client = LMCacheFSClient(
+        str(tmp_path),
+        1,
+        hash_subdir_levels=hash_subdir_levels,
+    )
+    source_data = bytearray(b"hash-subdirectory-test-data")
+    source = memoryview(source_data)
+    destination_data = bytearray(len(source_data))
+    destination = memoryview(destination_data)
+    expected_path = _expected_path(tmp_path, key, hash_subdir_levels)
+
+    try:
+        store = _submit_and_wait(client, "submit_batch_set", key, source)
+        assert store[1], store[2]
+        assert expected_path.is_file()
+
+        future_id = client.submit_batch_exists([key])
+        exists = _wait_for_completion(client, future_id)
+        assert exists[1], exists[2]
+        assert exists[3] == [True]
+
+        load = _submit_and_wait(client, "submit_batch_get", key, destination)
+        assert load[1], load[2]
+        assert load[3] == [True]
+        assert destination_data == source_data
+
+        future_id = client.submit_batch_delete([key])
+        delete = _wait_for_completion(client, future_id)
+        assert delete[1], delete[2]
+        assert delete[3] == [True]
+        assert not expected_path.exists()
+
+        future_id = client.submit_batch_exists([key])
+        exists = _wait_for_completion(client, future_id)
+        assert exists[3] == [False]
+    finally:
+        client.close()
 
 
 def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4617.

The `fs_native` L2 adapter currently stores all cache files directly under
`base_path`. Large flat directories can increase metadata overhead on some
filesystems.

This PR adds a configurable `hash_subdir_levels` option:

- `0` (default): `<base_path>/<filename>`
- `1`: `<base_path>/<hash[:2]>/<filename>`
- `2`: `<base_path>/<hash[:2]>/<hash[2:4]>/<filename>`

Each directory level uses two hexadecimal characters directly from the
object's chunk hash. Hash directories are created lazily and cached per native
worker to avoid repeated metadata checks.

The default remains `0` for backward compatibility. Changing the value for an
existing cache directory makes files stored with the previous layout
unreachable. Clear the cache directory or use a new empty `base_path` when
changing this setting.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests