### PR TITLE
[Logging] Convert f-string log to %s lazy formatting

### DIFF
--- a/lmcache/v1/storage_backend/__init__.py
+++ b/lmcache/v1/storage_backend/__init__.py
@@ -326,7 +326,7 @@ def CreateStorageBackends(
             if not isinstance(backend, LocalCPUBackend):
                 audited_backend = AuditBackend(backend)
                 audited_backends[name] = audited_backend
-                logger.info(f"Wrapped {name} with AuditBackend")
+                logger.info("Wrapped %s with AuditBackend", name)
             else:
                 audited_backends[name] = backend
                 logger.info(f"Do not wrap {name} as it is a LocalCPUBackend")


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Convert `logger.info(f"Wrapped {name} with AuditBackend")` to `logger.info("Wrapped %s with AuditBackend", name)` for consistency with the project's preferred lazy %-style logging. This also avoids eager string interpolation when the log level is filtered out.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
