### PR TITLE
[Platform][MUSA] Add lazy pinned memory support

### DIFF
--- a/lmcache/v1/gpu_connector/musa_connectors.py
+++ b/lmcache/v1/gpu_connector/musa_connectors.py
@@ -29,6 +29,7 @@ from lmcache.v1.gpu_connector.utils import (
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.memory_allocators.gpu_memory_allocator import GPUMemoryAllocator
+from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
@@ -55,6 +56,91 @@ ALLOWED_FORMAT_TRANSITIONS = {
     (MemoryFormat.KV_MLA_FMT, MemoryFormat.KV_MLA_FMT),
     (MemoryFormat.KV_T2D, MemoryFormat.KV_MLA_FMT),
 }
+
+
+def _copy_tensor_at_pin_boundaries(
+    dest: torch.Tensor,
+    src: torch.Tensor,
+    memory_obj: MemoryObj,
+) -> None:
+    """Copy a host tensor without crossing lazy registration ranges.
+
+    Args:
+        dest: Destination tensor.
+        src: Source tensor with the same number of bytes as ``dest``.
+        memory_obj: Host memory object participating in the transfer.
+
+    Returns:
+        None.
+
+    Raises:
+        ValueError: If a lazy transfer has mismatched sizes, noncontiguous
+            tensors, or does not contain exactly one tensor in ``memory_obj``.
+    """
+    if not isinstance(memory_obj.parent(), LazyMemoryAllocator):
+        dest.copy_(src, non_blocking=True)
+        return
+    if dest.nbytes != src.nbytes:
+        raise ValueError(
+            f"MUSA copy size mismatch: dest={dest.nbytes}, src={src.nbytes}"
+        )
+    if not dest.is_contiguous() or not src.is_contiguous():
+        raise ValueError("Lazy MUSA transfers require contiguous tensors")
+
+    memory_start = memory_obj.data_ptr
+    memory_end = memory_start + memory_obj.get_size()
+    src_start = src.data_ptr()
+    dest_start = dest.data_ptr()
+    src_is_host = memory_start <= src_start and src_start + src.nbytes <= memory_end
+    dest_is_host = memory_start <= dest_start and dest_start + dest.nbytes <= memory_end
+    if src_is_host == dest_is_host:
+        raise ValueError(
+            "Lazy MUSA copy must have exactly one tensor in the memory object"
+        )
+
+    host_start = src_start if src_is_host else dest_start
+    host_offset = memory_obj.meta.address + host_start - memory_start
+    chunk_size = LazyMemoryAllocator.PIN_CHUNK_SIZE
+    dest_bytes = dest.view(torch.uint8).flatten()
+    src_bytes = src.view(torch.uint8).flatten()
+    copied = 0
+    while copied < src.nbytes:
+        bytes_to_boundary = chunk_size - ((host_offset + copied) % chunk_size)
+        copy_size = min(src.nbytes - copied, bytes_to_boundary)
+        dest_bytes[copied : copied + copy_size].copy_(
+            src_bytes[copied : copied + copy_size],
+            non_blocking=True,
+        )
+        copied += copy_size
+
+
+def _to_musa_at_pin_boundaries(
+    tensor: torch.Tensor,
+    memory_obj: MemoryObj,
+    device: torch.device,
+) -> torch.Tensor:
+    """Move a host tensor to MUSA without crossing lazy registration ranges.
+
+    Args:
+        tensor: Source tensor owned by ``memory_obj``.
+        memory_obj: Memory object that identifies lazy allocator ownership and
+            the host offset.
+        device: Destination MUSA device.
+
+    Returns:
+        ``tensor`` when already on ``device``; otherwise, a tensor on ``device``
+        containing the copied data.
+
+    Raises:
+        ValueError: If lazy-copy validation fails.
+    """
+    if tensor.device == device:
+        return tensor
+    if not isinstance(memory_obj.parent(), LazyMemoryAllocator):
+        return tensor.to(device, non_blocking=True)
+    musa_tensor = torch.empty_like(tensor, device=device)
+    _copy_tensor_at_pin_boundaries(musa_tensor, tensor, memory_obj)
+    return musa_tensor
 
 
 class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
@@ -162,15 +248,27 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
         )
 
         if self.use_mla:
-            tmp = memory_obj.tensor[0].to(self.device, non_blocking=True)
+            tmp = _to_musa_at_pin_boundaries(
+                memory_obj.tensor[0],
+                memory_obj,
+                self.device,
+            )
             total_blocks = self.num_blocks * self.block_size
             for i, kvcache in enumerate(self.kvcaches):
                 kvcache.view(total_blocks, self.head_size).index_copy_(
                     0, slices, tmp[i, skip_prefix_n_tokens:]
                 )
         else:
-            tmp_k = memory_obj.tensor[0].to(self.device, non_blocking=True)
-            tmp_v = memory_obj.tensor[1].to(self.device, non_blocking=True)
+            tmp_k = _to_musa_at_pin_boundaries(
+                memory_obj.tensor[0],
+                memory_obj,
+                self.device,
+            )
+            tmp_v = _to_musa_at_pin_boundaries(
+                memory_obj.tensor[1],
+                memory_obj,
+                self.device,
+            )
             total_blocks = self.num_blocks * self.block_size
             d = self.num_heads * self.head_size
             for i, (kcache, vcache) in enumerate(self.kvcaches):
@@ -260,7 +358,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
                 ]
             )
             tmp = torch.stack([tmp_k, tmp_v])
-        memory_obj.tensor.copy_(tmp, non_blocking=True)
+        _copy_tensor_at_pin_boundaries(memory_obj.tensor, tmp, memory_obj)
 
         if memory_obj.tensor.device.type != "musa":
             torch.musa.synchronize()  # type: ignore[attr-defined]
@@ -536,6 +634,10 @@ class VLLMPagedMemLayerwiseMUSAConnector(GPUConnectorInterface):
                 return t.to(self.device, non_blocking=True)
             return t
 
+        def _ensure_musa_memory(mem: MemoryObj) -> torch.Tensor:
+            assert mem.tensor is not None
+            return _to_musa_at_pin_boundaries(mem.tensor, mem, self.device)
+
         slot_mapping_chunks = [
             slot_mapping[s:e] for s, e in zip(starts, ends, strict=False)
         ]
@@ -608,7 +710,7 @@ class VLLMPagedMemLayerwiseMUSAConnector(GPUConnectorInterface):
                             n = int(e - s)
                             if n <= 0:
                                 continue
-                            src = _ensure_musa(mem.tensor)
+                            src = _ensure_musa_memory(mem)
                             staged[cursor : cursor + n].copy_(src, non_blocking=True)
                             cursor += n
 
@@ -663,7 +765,7 @@ class VLLMPagedMemLayerwiseMUSAConnector(GPUConnectorInterface):
                             n = int(e - s)
                             if n <= 0:
                                 continue
-                            src = _ensure_musa(mem.tensor)
+                            src = _ensure_musa_memory(mem)
                             sl = slot_mapping_full[cursor : cursor + n]
                             sl = _ensure_musa(sl)
                             cursor += n
@@ -761,10 +863,13 @@ class VLLMPagedMemLayerwiseMUSAConnector(GPUConnectorInterface):
                         assert mem.tensor is not None
                         sl = slot_mapping_on_device[s:e]
                         gathered = src_flat.index_select(0, sl)
-                        mem.tensor.copy_(
-                            gathered.to(mem.tensor.device),
-                            non_blocking=True,
-                        )
+                        if isinstance(mem.parent(), LazyMemoryAllocator):
+                            _copy_tensor_at_pin_boundaries(mem.tensor, gathered, mem)
+                        else:
+                            mem.tensor.copy_(
+                                gathered.to(mem.tensor.device),
+                                non_blocking=True,
+                            )
 
                     target_fmt = MemoryFormat.KV_MLA_FMT
                     for mem in mem_layer:
@@ -780,7 +885,17 @@ class VLLMPagedMemLayerwiseMUSAConnector(GPUConnectorInterface):
                         k = src_k_flat.index_select(0, sl)
                         v = src_v_flat.index_select(0, sl)
 
-                        if mem.tensor.shape[0] == 2:
+                        if isinstance(mem.parent(), LazyMemoryAllocator):
+                            if mem.tensor.shape[0] == 2:
+                                gathered = torch.stack((k, v))
+                            elif mem.tensor.dim() >= 2 and mem.tensor.shape[1] == 2:
+                                gathered = torch.stack((k, v), dim=1)
+                            else:
+                                raise ValueError(
+                                    f"Unrecognized KV tensor layout: {mem.tensor.shape}"
+                                )
+                            _copy_tensor_at_pin_boundaries(mem.tensor, gathered, mem)
+                        elif mem.tensor.shape[0] == 2:
                             mem.tensor[0].copy_(
                                 k.to(mem.tensor.device), non_blocking=True
                             )

--- a/lmcache/v1/platform/musa/__init__.py
+++ b/lmcache/v1/platform/musa/__init__.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 # First Party
 from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
+from lmcache.v1.platform.musa.pin_memory import MusaPinMemoryBackend
 
 if TYPE_CHECKING:
     # First Party
@@ -41,6 +43,15 @@ class MusaDeviceSpec(DeviceSpec):
         from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
 
         return MusaDeviceOps
+
+    @property
+    def pin_memory_backend(self) -> type[PinMemoryBackend] | None:
+        """Return the TorchMUSA-backed host-memory pinning adapter.
+
+        Returns:
+            The MUSA pin-memory backend class.
+        """
+        return MusaPinMemoryBackend
 
     @property
     def ipc_wrapper_cls(self) -> type[DeviceIPCWrapper] | None:

--- a/lmcache/v1/platform/musa/device_ops.py
+++ b/lmcache/v1/platform/musa/device_ops.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 # Standard
 from typing import ClassVar
+import ctypes
 
 # Third Party
 import torch
@@ -224,6 +225,36 @@ def _synchronize_stream_pointer(stream_ptr: int) -> None:
         ) from exc
 
 
+def _host_byte_tensor_from_pointer(ptr: int, nbytes: int) -> torch.Tensor:
+    """Create a non-owning CPU byte tensor for a host pointer span.
+
+    Args:
+        ptr: Raw host pointer at the start of the span.
+        nbytes: Number of bytes exposed by the tensor.
+
+    Returns:
+        A one-dimensional CPU byte tensor that aliases the host span.
+    """
+    buffer_type = ctypes.c_uint8 * nbytes
+    return torch.frombuffer(buffer_type.from_address(ptr), dtype=torch.uint8)
+
+
+def _current_musa_device() -> torch.device:
+    """Return the current TorchMUSA device without synchronizing it.
+
+    Returns:
+        The current MUSA device.
+
+    Raises:
+        RuntimeError: If TorchMUSA does not expose ``current_device``.
+    """
+    musa = getattr(torch, "musa", None)
+    current_device = getattr(musa, "current_device", None)
+    if not callable(current_device):
+        raise RuntimeError("torch.musa.current_device is unavailable")
+    return torch.device("musa", int(current_device()))
+
+
 class TorchMusaBlockTransfer:
     """Execute block transfer with the TorchMUSA-compatible torch backend."""
 
@@ -372,6 +403,96 @@ class MusaDeviceOps(DeviceOps):
     """MUSA block-transfer and stream-ordering operations."""
 
     device_type: ClassVar[str] = "musa"
+
+    def lmcache_memcpy_async(
+        self,
+        dest: int | torch.Tensor,
+        src: int | torch.Tensor,
+        nbytes: int,
+        direction: TransferDirection,
+        host_buffer_offset: int,
+        host_buffer_alignments: int,
+    ) -> None:
+        """Copy bytes between host and MUSA storage on the current stream.
+
+        Tensor operands retain the platform-independent torch fallback
+        semantics. For raw pointers, each submitted ``Tensor.copy_`` is
+        contained within one independently registered host-memory range. This
+        is required by MUSA even when two registered ranges are adjacent.
+
+        Args:
+            dest: Destination host/MUSA pointer or tensor.
+            src: Source host/MUSA pointer or tensor.
+            nbytes: Number of bytes to copy.
+            direction: Host-to-device or device-to-host transfer direction.
+            host_buffer_offset: Host pointer offset from the lazy allocator base.
+            host_buffer_alignments: Host registration granularity in bytes.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: If pointer and tensor operands are mixed.
+            ValueError: If the size, alignment, or direction is invalid.
+            RuntimeError: If TorchMUSA cannot expose the current device or a
+                non-owning tensor for the MUSA pointer.
+        """
+        if not isinstance(dest, int) or not isinstance(src, int):
+            torch_ops.lmcache_memcpy_async(
+                dest,
+                src,
+                nbytes,
+                direction,
+                host_buffer_offset,
+                host_buffer_alignments,
+            )
+            return
+
+        if nbytes < 0:
+            raise ValueError("nbytes must be non-negative")
+        if (
+            host_buffer_alignments <= 0
+            or (host_buffer_alignments & (host_buffer_alignments - 1)) != 0
+        ):
+            raise ValueError("host_buffer_alignments must be power of two")
+
+        direction_value = int(direction)
+        if direction_value == int(TransferDirection.H2D):
+            host_base = src
+            device_base = dest
+            is_h2d = True
+        elif direction_value == int(TransferDirection.D2H):
+            host_base = dest
+            device_base = src
+            is_h2d = False
+        else:
+            raise ValueError(f"Unsupported direction: {direction}")
+
+        if nbytes == 0:
+            return
+
+        device = _current_musa_device()
+        copied = 0
+        while copied < nbytes:
+            bytes_to_boundary = host_buffer_alignments - (
+                (host_buffer_offset + copied) % host_buffer_alignments
+            )
+            copy_size = min(nbytes - copied, bytes_to_boundary)
+            host_tensor = _host_byte_tensor_from_pointer(
+                host_base + copied,
+                copy_size,
+            )
+            device_tensor = construct_musa_tensor_from_data_pointer(
+                device_base + copied,
+                (copy_size,),
+                torch.uint8,
+                device,
+            )
+            if is_h2d:
+                device_tensor.copy_(host_tensor, non_blocking=True)
+            else:
+                host_tensor.copy_(device_tensor, non_blocking=True)
+            copied += copy_size
 
     def record_completion_on_stream(
         self,

--- a/lmcache/v1/platform/musa/native_kv_transfer.py
+++ b/lmcache/v1/platform/musa/native_kv_transfer.py
@@ -114,6 +114,13 @@ def try_native_multi_layer_block_kv_transfer(
         ``True`` when native dispatch completed and the caller should skip the
         torch fallback. ``False`` when the transfer is unsupported, disabled,
         unavailable, or rejected by the native module.
+
+    Notes:
+        Callers must stage lazy allocator-backed memory objects through
+        ``lmcache_memcpy_async_h2d`` or ``lmcache_memcpy_async_d2h`` before
+        entering this adapter. Its tensor-only interface does not retain the
+        allocator-relative host offset required to split copies at lazy pin
+        registration boundaries.
     """
     if not is_native_musa_kv_transfer_enabled():
         return False

--- a/lmcache/v1/platform/musa/pin_memory.py
+++ b/lmcache/v1/platform/musa/pin_memory.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA host-memory registration through the TorchMUSA runtime binding."""
+
+# Standard
+from typing import Protocol, cast
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
+
+logger = init_logger(__name__)
+
+
+class _MusaRuntime(Protocol):
+    """TorchMUSA runtime surface required for host-memory registration."""
+
+    def musaHostRegister(self, ptr: int, size: int, flags: int) -> int:
+        """Register one host-memory range."""
+        ...
+
+    def musaHostUnregister(self, ptr: int) -> int:
+        """Unregister one host-memory range."""
+        ...
+
+
+class MusaPinMemoryBackend(PinMemoryBackend):
+    """Host-memory pinning backed by ``torch.musa.musart()``.
+
+    The backend only probes for the two required runtime entry points during
+    construction. It does not query device availability or create a MUSA
+    context, so configuration parsing remains lightweight.
+    """
+
+    def __init__(self) -> None:
+        """Discover the TorchMUSA host register and unregister functions.
+
+        Missing or incomplete runtime bindings leave the backend unsupported;
+        discovery never raises an exception to the platform capability gate.
+        """
+        self._musart: _MusaRuntime | None = None
+
+        try:
+            musa = getattr(torch, "musa", None)
+            if musa is None:
+                raise AttributeError("torch.musa is unavailable")
+            musart = musa.musart()
+            if not callable(getattr(musart, "musaHostRegister", None)):
+                raise AttributeError("musaHostRegister is unavailable")
+            if not callable(getattr(musart, "musaHostUnregister", None)):
+                raise AttributeError("musaHostUnregister is unavailable")
+        except Exception as exc:
+            logger.debug(
+                "MusaPinMemoryBackend: TorchMUSA host registration unavailable: %s",
+                exc,
+            )
+            return
+
+        self._musart = cast(_MusaRuntime, musart)
+
+    def pin_memory(self, ptr: int, size: int, flags: int = 0) -> bool:
+        """Register a host memory region with the MUSA runtime.
+
+        Args:
+            ptr: Raw base pointer of the host memory region.
+            size: Number of bytes to register.
+            flags: ``musaHostRegister`` flags. Lazy allocation passes ``0x02``
+                (``musaHostRegisterMapped``).
+
+        Returns:
+            ``True`` only when ``musaHostRegister`` returns status zero.
+        """
+        musart = self._musart
+        if musart is None:
+            return False
+
+        try:
+            return int(musart.musaHostRegister(ptr, size, flags)) == 0
+        except Exception as exc:
+            logger.warning(
+                "musaHostRegister failed for ptr=%#x size=%d flags=%#x: %s",
+                ptr,
+                size,
+                flags,
+                exc,
+            )
+            return False
+
+    def unpin_memory(self, ptr: int) -> bool:
+        """Unregister a host memory region from the MUSA runtime.
+
+        Args:
+            ptr: Raw base pointer originally passed to :meth:`pin_memory`.
+
+        Returns:
+            ``True`` only when ``musaHostUnregister`` returns status zero.
+        """
+        musart = self._musart
+        if musart is None:
+            return False
+
+        try:
+            result = int(musart.musaHostUnregister(ptr))
+        except Exception as exc:
+            logger.warning("musaHostUnregister failed for ptr=%#x: %s", ptr, exc)
+            return False
+
+        if result != 0:
+            logger.warning(
+                "musaHostUnregister returned error code %d for ptr=%#x",
+                result,
+                ptr,
+            )
+            return False
+        return True
+
+    @property
+    def is_pin_supported(self) -> bool:
+        """Return whether both required TorchMUSA runtime functions exist.
+
+        Returns:
+            ``True`` when host registration and unregistration are callable.
+        """
+        return self._musart is not None

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -25,9 +25,9 @@ def _to_accelerator(memory_obj: MemoryObj) -> torch.Tensor:
         memory_obj: CacheGen input object containing the source tensor.
 
     Returns:
-        The input tensor on the configured accelerator. Lazy MUSA inputs are
-        copied through the boundary-aware staging helper; all other inputs
-        preserve the existing ``Tensor.to`` behavior.
+        The input tensor on the configured accelerator. Lazy allocator-backed
+        inputs are copied through the platform-specific staging helper; all
+        other inputs preserve the existing ``Tensor.to`` behavior.
 
     Raises:
         ValueError: If ``memory_obj`` does not contain a tensor.
@@ -35,9 +35,7 @@ def _to_accelerator(memory_obj: MemoryObj) -> torch.Tensor:
     tensor = memory_obj.tensor
     if tensor is None:
         raise ValueError("CacheGen input memory object does not contain a tensor")
-    if torch_device_type != "musa" or not isinstance(
-        memory_obj.parent(), LazyMemoryAllocator
-    ):
+    if not isinstance(memory_obj.parent(), LazyMemoryAllocator):
         return tensor.to(torch_device_type)
 
     device_tensor = torch.empty_like(tensor, device=torch_device_type)

--- a/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
+++ b/lmcache/v1/storage_backend/naive_serde/cachegen_encoder.py
@@ -8,12 +8,41 @@ from lmcache.logging import init_logger
 from lmcache.storage_backend.serde.cachegen_encoder import encode_function
 from lmcache.utils import _lmcache_nvtx_annotate
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.gpu_connector.gpu_ops import lmcache_memcpy_async_h2d
+from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.memory_management import BytesBufferMemoryObj, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.naive_serde.cachegen_basics import CacheGenConfig
 from lmcache.v1.storage_backend.naive_serde.serde import Serializer
 
 logger = init_logger(__name__)
+
+
+def _to_accelerator(memory_obj: MemoryObj) -> torch.Tensor:
+    """Move a CacheGen input tensor to its accelerator safely.
+
+    Args:
+        memory_obj: CacheGen input object containing the source tensor.
+
+    Returns:
+        The input tensor on the configured accelerator. Lazy MUSA inputs are
+        copied through the boundary-aware staging helper; all other inputs
+        preserve the existing ``Tensor.to`` behavior.
+
+    Raises:
+        ValueError: If ``memory_obj`` does not contain a tensor.
+    """
+    tensor = memory_obj.tensor
+    if tensor is None:
+        raise ValueError("CacheGen input memory object does not contain a tensor")
+    if torch_device_type != "musa" or not isinstance(
+        memory_obj.parent(), LazyMemoryAllocator
+    ):
+        return tensor.to(torch_device_type)
+
+    device_tensor = torch.empty_like(tensor, device=torch_device_type)
+    lmcache_memcpy_async_h2d(memory_obj, device_tensor)
+    return device_tensor
 
 
 class CacheGenSerializer(Serializer):
@@ -40,20 +69,21 @@ class CacheGenSerializer(Serializer):
     # TODO(Jiayi): A lot of memory copies can be avoided in this function.
     @_lmcache_nvtx_annotate
     def serialize(self, memory_obj: MemoryObj) -> BytesBufferMemoryObj:
-        """
-        Serialize a KV_2LTD MemoryObj to CACHEGEN_BINARY MemoryObj.
+        """Serialize a KV_2LTD memory object to CacheGen binary data.
 
-        Input:
-            memory_obj: the memory object to be serialized.
+        Args:
+            memory_obj: Memory object containing the KV tensor to encode.
 
         Returns:
-            MemoryObj: the serialized binary memory object.
+            The encoded CacheGen byte buffer.
+
+        Raises:
+            ValueError: If ``memory_obj`` does not contain a tensor.
         """
 
         # TODO(Jiayi): please avoid this copy by directly performing
         # serialization inside gpu connector.
-        assert memory_obj.tensor is not None
-        tensor = memory_obj.tensor.to(torch_device_type)
+        tensor = _to_accelerator(memory_obj)
 
         # Temporary fix for issue #83: encoder will have the default device 0
         # on all the ray workers. Need to set it to the correct device.

--- a/tests/v1/platform/musa/test_musa_pin_memory.py
+++ b/tests/v1/platform/musa/test_musa_pin_memory.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only and optional runtime tests for MUSA host-memory pinning."""
+
+# Standard
+from collections.abc import Callable
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed import config as distributed_config
+from lmcache.v1.distributed.config import L1MemoryManagerConfig
+from lmcache.v1.memory_allocators import lazy_memory_allocator
+from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.musa import MusaDeviceSpec
+from lmcache.v1.platform.musa import pin_memory as pin_memory_module
+from lmcache.v1.platform.musa.pin_memory import MusaPinMemoryBackend
+
+
+class _FakeMusart:
+    """Small TorchMUSA runtime double that records host-registration calls."""
+
+    def __init__(
+        self,
+        register_result: int | Exception = 0,
+        unregister_result: int | Exception = 0,
+    ) -> None:
+        self.register_result = register_result
+        self.unregister_result = unregister_result
+        self.register_calls: list[tuple[int, int, int]] = []
+        self.unregister_calls: list[int] = []
+
+    def musaHostRegister(self, ptr: int, size: int, flags: int) -> int:
+        """Record and emulate ``musaHostRegister``."""
+        self.register_calls.append((ptr, size, flags))
+        if isinstance(self.register_result, Exception):
+            raise self.register_result
+        return self.register_result
+
+    def musaHostUnregister(self, ptr: int) -> int:
+        """Record and emulate ``musaHostUnregister``."""
+        self.unregister_calls.append(ptr)
+        if isinstance(self.unregister_result, Exception):
+            raise self.unregister_result
+        return self.unregister_result
+
+
+def _install_musart(
+    monkeypatch: pytest.MonkeyPatch,
+    musart: object,
+) -> None:
+    """Expose a fake ``torch.musa.musart()`` binding for one test."""
+    monkeypatch.setattr(
+        torch,
+        "musa",
+        SimpleNamespace(musart=lambda: musart),
+        raising=False,
+    )
+
+
+def _capture_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: object,
+) -> list[str]:
+    """Replace one LMCache logger warning method with a message recorder."""
+    messages: list[str] = []
+
+    def _record(message: str, *args: object) -> None:
+        messages.append(message % args)
+
+    monkeypatch.setattr(logger, "warning", _record)
+    return messages
+
+
+def test_is_pin_supported_when_both_runtime_functions_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both host-registration entry points enable the MUSA capability."""
+    _install_musart(monkeypatch, _FakeMusart())
+
+    assert MusaPinMemoryBackend().is_pin_supported is True
+
+
+def test_is_not_pin_supported_when_musart_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing musart lookup is a safe unsupported result."""
+
+    def _raise() -> object:
+        raise RuntimeError("musart unavailable")
+
+    monkeypatch.setattr(
+        torch,
+        "musa",
+        SimpleNamespace(musart=_raise),
+        raising=False,
+    )
+
+    assert MusaPinMemoryBackend().is_pin_supported is False
+
+
+def test_is_not_pin_supported_when_register_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime without ``musaHostRegister`` is unsupported."""
+    _install_musart(
+        monkeypatch,
+        SimpleNamespace(musaHostUnregister=lambda ptr: 0),
+    )
+
+    assert MusaPinMemoryBackend().is_pin_supported is False
+
+
+def test_is_not_pin_supported_when_unregister_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime without ``musaHostUnregister`` is unsupported."""
+    _install_musart(
+        monkeypatch,
+        SimpleNamespace(musaHostRegister=lambda ptr, size, flags: 0),
+    )
+
+    assert MusaPinMemoryBackend().is_pin_supported is False
+
+
+def test_pin_memory_forwards_pointer_size_and_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host registration forwards its complete runtime contract unchanged."""
+    musart = _FakeMusart()
+    _install_musart(monkeypatch, musart)
+
+    assert MusaPinMemoryBackend().pin_memory(0x1000, 64 << 20, 0x02) is True
+    assert musart.register_calls == [(0x1000, 64 << 20, 0x02)]
+
+
+def test_pin_memory_returns_false_for_nonzero_runtime_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nonzero MUSA registration status is not reported as success."""
+    _install_musart(monkeypatch, _FakeMusart(register_result=1))
+
+    assert MusaPinMemoryBackend().pin_memory(0x1000, 4096, 0x02) is False
+
+
+def test_pin_memory_returns_false_when_runtime_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration exception is logged and safely mapped to ``False``."""
+    _install_musart(
+        monkeypatch,
+        _FakeMusart(register_result=RuntimeError("register failed")),
+    )
+    warnings = _capture_warnings(monkeypatch, pin_memory_module.logger)
+
+    result = MusaPinMemoryBackend().pin_memory(0x1234, 4096, 0x02)
+
+    assert result is False
+    assert "musaHostRegister failed" in warnings[0]
+    assert "ptr=0x1234" in warnings[0]
+
+
+def test_unpin_memory_forwards_base_pointer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host unregistration forwards the registered base pointer unchanged."""
+    musart = _FakeMusart()
+    _install_musart(monkeypatch, musart)
+
+    assert MusaPinMemoryBackend().unpin_memory(0x2000) is True
+    assert musart.unregister_calls == [0x2000]
+
+
+def test_unpin_memory_returns_false_for_nonzero_runtime_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nonzero unregistration status fails visibly."""
+    _install_musart(monkeypatch, _FakeMusart(unregister_result=713))
+    warnings = _capture_warnings(monkeypatch, pin_memory_module.logger)
+
+    result = MusaPinMemoryBackend().unpin_memory(0x2000)
+
+    assert result is False
+    assert "musaHostUnregister returned error code 713" in warnings[0]
+
+
+def test_unpin_memory_returns_false_when_runtime_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistration exception is logged and safely mapped to ``False``."""
+    _install_musart(
+        monkeypatch,
+        _FakeMusart(unregister_result=RuntimeError("unregister failed")),
+    )
+    warnings = _capture_warnings(monkeypatch, pin_memory_module.logger)
+
+    result = MusaPinMemoryBackend().unpin_memory(0x2345)
+
+    assert result is False
+    assert "musaHostUnregister failed" in warnings[0]
+    assert "ptr=0x2345" in warnings[0]
+
+
+def test_operations_return_false_when_backend_is_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupported backends never attempt or claim pinning operations."""
+    monkeypatch.delattr(torch, "musa", raising=False)
+    backend = MusaPinMemoryBackend()
+
+    assert backend.pin_memory(0x1000, 4096, 0x02) is False
+    assert backend.unpin_memory(0x1000) is False
+
+
+def test_musa_device_spec_uses_musa_pin_memory_backend() -> None:
+    """The MUSA device specification registers the MUSA pinning adapter."""
+    assert MusaDeviceSpec().pin_memory_backend is MusaPinMemoryBackend
+
+
+def test_musa_device_spec_reports_pin_support_from_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The device capability gate reflects the discovered TorchMUSA API."""
+    _install_musart(monkeypatch, _FakeMusart())
+
+    assert MusaDeviceSpec().is_pin_supported is True
+
+
+def test_musa_device_spec_does_not_affect_other_platforms() -> None:
+    """The fallback device specification remains safely unsupported."""
+    spec = DeviceSpec()
+
+    assert spec.pin_memory_backend is None
+    assert spec.is_pin_supported is False
+
+
+def test_lazy_config_remains_enabled_when_musa_backend_is_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A complete MUSA binding keeps requested lazy allocation enabled."""
+    _install_musart(monkeypatch, _FakeMusart())
+    monkeypatch.setattr(
+        distributed_config,
+        "current_device_spec",
+        MusaDeviceSpec(),
+    )
+
+    config = L1MemoryManagerConfig(size_in_bytes=1 << 30, use_lazy=True)
+
+    assert config.use_lazy is True
+
+
+def test_lazy_config_is_disabled_when_musa_binding_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An incomplete MUSA binding preserves the existing safe fallback."""
+    monkeypatch.delattr(torch, "musa", raising=False)
+    monkeypatch.setattr(
+        distributed_config,
+        "current_device_spec",
+        MusaDeviceSpec(),
+    )
+    warnings = _capture_warnings(monkeypatch, distributed_config.logger)
+
+    config = L1MemoryManagerConfig(size_in_bytes=1 << 30, use_lazy=True)
+
+    assert config.use_lazy is False
+    assert "Disabling l1-use-lazy" in warnings[0]
+
+
+def test_lazy_allocator_pins_and_unpins_only_successful_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lazy allocation uses mapped registration and joins before unpinning."""
+    chunk_size = 4096
+    events: list[str] = []
+
+    class _FakeDeviceSpec:
+        is_pin_supported = True
+
+        def __init__(self) -> None:
+            self.pin_results = iter((True, False, True))
+            self.pin_calls: list[tuple[int, int, int]] = []
+            self.unpin_calls: list[int] = []
+
+        def pin_memory(self, ptr: int, size: int, flags: int = 0) -> bool:
+            self.pin_calls.append((ptr, size, flags))
+            return next(self.pin_results)
+
+        def unpin_memory(self, ptr: int) -> bool:
+            events.append("unpin")
+            self.unpin_calls.append(ptr)
+            return True
+
+    class _InlineThread:
+        def __init__(
+            self,
+            *,
+            target: Callable[[], None],
+            daemon: bool,
+            name: str,
+        ) -> None:
+            self.target = target
+
+        def start(self) -> None:
+            self.target()
+
+        def join(self) -> None:
+            events.append("join")
+
+    fake_spec = _FakeDeviceSpec()
+    monkeypatch.setattr(lazy_memory_allocator, "current_device_spec", fake_spec)
+    monkeypatch.setattr(lazy_memory_allocator.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(
+        lazy_memory_allocator.LazyMemoryAllocator,
+        "PIN_CHUNK_SIZE",
+        chunk_size,
+    )
+    monkeypatch.setattr(
+        lazy_memory_allocator.LazyMemoryAllocator,
+        "COMMIT_SIZE",
+        2 * chunk_size,
+    )
+
+    allocator = lazy_memory_allocator.LazyMemoryAllocator(
+        init_size=chunk_size,
+        final_size=3 * chunk_size,
+        align_bytes=chunk_size,
+    )
+    events.clear()
+    allocator.close()
+
+    base_ptr = fake_spec.pin_calls[0][0]
+    assert fake_spec.pin_calls == [
+        (base_ptr, chunk_size, 0x02),
+        (base_ptr + chunk_size, chunk_size, 0x02),
+        (base_ptr + 2 * chunk_size, chunk_size, 0x02),
+    ]
+    assert fake_spec.unpin_calls == [base_ptr, base_ptr + 2 * chunk_size]
+    assert events == ["join", "unpin", "unpin"]
+
+
+@pytest.mark.musa
+def test_real_musa_runtime_registers_and_unregisters_64_mib() -> None:
+    """Optionally smoke-test one real 64 MiB MUSA registration lifecycle."""
+    pytest.importorskip("torch_musa")
+    backend = MusaPinMemoryBackend()
+    if not backend.is_pin_supported:
+        pytest.skip("TorchMUSA host-registration binding is unavailable")
+
+    buffer = torch.empty(64 << 20, dtype=torch.uint8, device="cpu")
+    ptr = buffer.data_ptr()
+    assert backend.pin_memory(ptr, buffer.nbytes, 0x02) is True
+    assert backend.unpin_memory(ptr) is True

--- a/tests/v1/platform/musa/test_musa_staging_copy.py
+++ b/tests/v1/platform/musa/test_musa_staging_copy.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for lazy MUSA copies at pin-registration boundaries."""
+
+# Standard
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.lmcache_native import TransferDirection
+from lmcache.v1.gpu_connector import gpu_ops, musa_connectors
+from lmcache.v1.gpu_connector.kv_format.detectors import vllm as vllm_detector
+from lmcache.v1.gpu_connector.musa_connectors import (
+    VLLMPagedMemLayerwiseMUSAConnector,
+    VLLMPagedMemMUSAConnectorV2,
+)
+from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.platform.musa import device_ops as musa_device_ops
+from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
+
+
+class _FakeMemoryObj:
+    """Minimal lazy-memory object surface consumed by ``gpu_ops``."""
+
+    def __init__(
+        self,
+        ptr: int,
+        size: int,
+        host_offset: int,
+        tensor: torch.Tensor | None = None,
+        fmt: MemoryFormat | None = None,
+    ) -> None:
+        self.data_ptr = ptr
+        self.raw_tensor = tensor if tensor is not None else object()
+        self.tensor = tensor
+        self.meta = SimpleNamespace(address=host_offset, fmt=fmt)
+        self.metadata = self.meta
+        self._size = size
+        self._parent = LazyMemoryAllocator.__new__(LazyMemoryAllocator)
+
+    def get_size(self) -> int:
+        """Return the represented host span in bytes."""
+        return self._size
+
+    def parent(self) -> LazyMemoryAllocator:
+        """Return a lazy allocator marker for the production branch."""
+        return self._parent
+
+
+class _FakeMusaStream:
+    """CPU-only stream double for public MUSA connector tests."""
+
+    def wait_stream(self, stream: object) -> None:
+        """Accept a stream dependency without device work."""
+
+    def synchronize(self) -> None:
+        """Accept a host synchronization without device work."""
+
+
+class _FakeMusaModule:
+    """CPU-only ``torch.musa`` surface used by connector generators."""
+
+    def Stream(self) -> _FakeMusaStream:
+        """Return a fake transfer stream."""
+        return _FakeMusaStream()
+
+    def current_stream(self) -> _FakeMusaStream:
+        """Return a fake current stream."""
+        return _FakeMusaStream()
+
+    def stream(self, stream: object) -> nullcontext[None]:
+        """Return a no-op stream context."""
+        return nullcontext()
+
+    def synchronize(self) -> None:
+        """Accept a device-wide synchronization without device work."""
+
+
+_FAKE_MUSA_DEVICE = SimpleNamespace(type="musa")
+
+
+class _FakeMusaTensor(torch.Tensor):
+    """CPU tensor subclass that reports a MUSA device for connector setup."""
+
+    @property
+    def device(self) -> SimpleNamespace:  # type: ignore[override]
+        """Report the fake MUSA device without requiring MUSA hardware."""
+        return _FAKE_MUSA_DEVICE
+
+
+def _install_fake_musa_pointer_views(
+    monkeypatch: pytest.MonkeyPatch,
+    device_buffer: torch.Tensor,
+) -> list[tuple[int, int]]:
+    """Map fake MUSA pointers to slices of one CPU tensor for unit tests."""
+    calls: list[tuple[int, int]] = []
+    device_base = device_buffer.data_ptr()
+    monkeypatch.setattr(
+        musa_device_ops,
+        "_current_musa_device",
+        lambda: torch.device("cpu"),
+    )
+
+    def _construct(
+        ptr: int,
+        shape: tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        assert dtype is torch.uint8
+        size = shape[0]
+        calls.append((ptr, size))
+        start = ptr - device_base
+        return device_buffer[start : start + size]
+
+    monkeypatch.setattr(
+        musa_device_ops,
+        "construct_musa_tensor_from_data_pointer",
+        _construct,
+    )
+    return calls
+
+
+def test_lazy_gpu_ops_h2d_uses_musa_boundary_splitting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public lazy H2D path delegates boundary splitting to MUSA ops."""
+    chunk_size = 16
+    start = chunk_size - 2
+    size = 2 * chunk_size + 5
+    host = torch.arange(4 * chunk_size, dtype=torch.uint8)
+    device = torch.zeros(4 * chunk_size, dtype=torch.uint8)
+    calls = _install_fake_musa_pointer_views(monkeypatch, device)
+    memory_tensor = host[start : start + size]
+    memory_obj = _FakeMemoryObj(
+        memory_tensor.data_ptr(),
+        memory_tensor.nbytes,
+        start,
+        tensor=memory_tensor,
+    )
+    monkeypatch.setattr(gpu_ops, "device_ops", MusaDeviceOps())
+    monkeypatch.setattr(LazyMemoryAllocator, "PIN_CHUNK_SIZE", chunk_size)
+
+    gpu_ops.lmcache_memcpy_async_h2d(
+        cast(MemoryObj, memory_obj),
+        device[:size],
+    )
+
+    assert [segment_size for _, segment_size in calls] == [2, 16, 16, 3]
+    assert torch.equal(device[:size], host[start : start + size])
+
+
+def test_lazy_gpu_ops_d2h_uses_musa_boundary_splitting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public lazy D2H path delegates boundary splitting to MUSA ops."""
+    chunk_size = 16
+    start = chunk_size - 3
+    size = chunk_size + 8
+    host = torch.zeros(4 * chunk_size, dtype=torch.uint8)
+    device = torch.arange(4 * chunk_size, dtype=torch.uint8)
+    calls = _install_fake_musa_pointer_views(monkeypatch, device)
+    memory_tensor = host[start : start + size]
+    memory_obj = _FakeMemoryObj(
+        memory_tensor.data_ptr(),
+        memory_tensor.nbytes,
+        start,
+        tensor=memory_tensor,
+    )
+    monkeypatch.setattr(gpu_ops, "device_ops", MusaDeviceOps())
+    monkeypatch.setattr(LazyMemoryAllocator, "PIN_CHUNK_SIZE", chunk_size)
+
+    gpu_ops.lmcache_memcpy_async_d2h(
+        device[:size],
+        cast(MemoryObj, memory_obj),
+    )
+
+    assert [segment_size for _, segment_size in calls] == [3, 16, 5]
+    assert torch.equal(host[start : start + size], device[:size])
+
+
+def test_musa_device_ops_preserves_tensor_copy_mode() -> None:
+    """MUSA ops retain the base operation's tensor-mode contract."""
+    source = torch.arange(16, dtype=torch.uint8)
+    destination = torch.zeros_like(source)
+
+    MusaDeviceOps().lmcache_memcpy_async(
+        destination,
+        source,
+        source.nbytes,
+        TransferDirection.H2D,
+        0,
+        16,
+    )
+
+    assert torch.equal(destination, source)
+
+
+def _install_cpu_musa_transfer_shims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[object, list[int]]:
+    """Run public connector paths on CPU while recording each tensor copy."""
+    segment_sizes: list[int] = []
+    original_copy = torch.Tensor.copy_
+    original_empty_like = torch.empty_like
+
+    def _recording_copy(
+        dest: torch.Tensor,
+        src: torch.Tensor,
+        non_blocking: bool = False,
+    ) -> torch.Tensor:
+        segment_sizes.append(dest.nbytes)
+        return original_copy(dest, src, non_blocking=non_blocking)
+
+    def _stay_on_cpu(
+        tensor: torch.Tensor,
+        *args: object,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        return tensor
+
+    def _cpu_empty_like(
+        tensor: torch.Tensor,
+        *args: object,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        kwargs.pop("device", None)
+        return original_empty_like(tensor, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "musa", _FakeMusaModule(), raising=False)
+    monkeypatch.setattr(torch.Tensor, "copy_", _recording_copy)
+    monkeypatch.setattr(torch.Tensor, "to", _stay_on_cpu)
+    monkeypatch.setattr(musa_connectors.torch, "empty_like", _cpu_empty_like)
+    return _FAKE_MUSA_DEVICE, segment_sizes
+
+
+def test_non_layerwise_musa_connector_splits_lazy_copies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public non-layerwise connector splits lazy H2D and D2H copies."""
+    chunk_size = 16
+    host_offset = chunk_size - 2
+    num_tokens = 80
+    _, segment_sizes = _install_cpu_musa_transfer_shims(monkeypatch)
+    monkeypatch.setattr(LazyMemoryAllocator, "PIN_CHUNK_SIZE", chunk_size)
+    monkeypatch.setattr(vllm_detector, "torch_device_type", "musa")
+
+    connector = VLLMPagedMemMUSAConnectorV2()
+
+    host = torch.arange(2 * num_tokens, dtype=torch.uint8).reshape(
+        2,
+        1,
+        num_tokens,
+        1,
+    )
+    memory_obj = _FakeMemoryObj(
+        host.data_ptr(),
+        host.nbytes,
+        host_offset,
+        tensor=host,
+        fmt=MemoryFormat.KV_2LTD,
+    )
+    slot_mapping = torch.arange(num_tokens, dtype=torch.long)
+    kvcaches = [
+        torch.zeros(2, 5, 16, 1, 1, dtype=torch.uint8).as_subclass(_FakeMusaTensor),
+    ]
+
+    connector.to_gpu(
+        cast(MemoryObj, memory_obj),
+        start=0,
+        end=num_tokens,
+        slot_mapping=slot_mapping,
+        kvcaches=kvcaches,
+    )
+
+    assert segment_sizes == 2 * [2, 16, 16, 16, 16, 14]
+    assert torch.equal(kvcaches[0][0].flatten(), host[0].flatten())
+    assert torch.equal(kvcaches[0][1].flatten(), host[1].flatten())
+
+    expected = host.clone()
+    host.zero_()
+    segment_sizes.clear()
+    connector.from_gpu(
+        cast(MemoryObj, memory_obj),
+        start=0,
+        end=num_tokens,
+        slot_mapping=slot_mapping,
+        kvcaches=kvcaches,
+    )
+
+    assert segment_sizes == 2 * [2] + 18 * [16] + 2 * [14]
+    assert torch.equal(host, expected)
+
+
+def test_layerwise_musa_connector_splits_lazy_copies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public layerwise connector splits lazy H2D and D2H copies."""
+    chunk_size = 16
+    host_offset = chunk_size - 2
+    num_tokens = 20
+    fake_device, segment_sizes = _install_cpu_musa_transfer_shims(monkeypatch)
+    monkeypatch.setattr(LazyMemoryAllocator, "PIN_CHUNK_SIZE", chunk_size)
+
+    connector = VLLMPagedMemLayerwiseMUSAConnector(
+        hidden_dim_size=1,
+        num_layers=1,
+        use_musa=False,
+        chunk_size=num_tokens,
+        dtype=torch.uint8,
+        device=fake_device,
+    )
+    host = torch.arange(2 * num_tokens, dtype=torch.uint8).reshape(
+        num_tokens,
+        2,
+        1,
+    )
+    memory_obj = _FakeMemoryObj(
+        host.data_ptr(),
+        host.nbytes,
+        host_offset,
+        tensor=host,
+        fmt=MemoryFormat.KV_T2D,
+    )
+    slot_mapping = torch.arange(num_tokens, dtype=torch.long)
+    kvcaches = [
+        torch.zeros(2, 5, 4, 1, 1, dtype=torch.uint8),
+    ]
+
+    consumer = connector.batched_to_gpu(
+        starts=[0],
+        ends=[num_tokens],
+        slot_mapping=slot_mapping,
+        sync=True,
+        kvcaches=kvcaches,
+    )
+    next(consumer)
+    consumer.send([cast(MemoryObj, memory_obj)])
+    consumer.close()
+
+    assert segment_sizes == [2, 16, 16, 6]
+    assert torch.equal(kvcaches[0][0].flatten(), host[:, 0].flatten())
+    assert torch.equal(kvcaches[0][1].flatten(), host[:, 1].flatten())
+
+    expected = host.clone()
+    segment_sizes.clear()
+    host.zero_()
+    producer = connector.batched_from_gpu(
+        [[cast(MemoryObj, memory_obj)]],
+        starts=[0],
+        ends=[num_tokens],
+        slot_mapping=slot_mapping,
+        sync=True,
+        kvcaches=kvcaches,
+    )
+    next(producer)
+    producer.close()
+
+    assert segment_sizes == [2, 16, 16, 6]
+    assert torch.equal(host, expected)

--- a/tests/v1/platform/musa/test_musa_staging_copy.py
+++ b/tests/v1/platform/musa/test_musa_staging_copy.py
@@ -22,6 +22,7 @@ from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocat
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.platform.musa import device_ops as musa_device_ops
 from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
+from lmcache.v1.storage_backend.naive_serde import cachegen_encoder
 
 
 class _FakeMemoryObj:
@@ -199,6 +200,69 @@ def test_musa_device_ops_preserves_tensor_copy_mode() -> None:
     )
 
     assert torch.equal(destination, source)
+
+
+def test_cachegen_uses_boundary_safe_copy_for_lazy_musa(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CacheGen uploads lazy MUSA inputs through the public staging helper."""
+    source = torch.arange(24, dtype=torch.float32).reshape(2, 1, 3, 4)
+    memory_obj = _FakeMemoryObj(
+        source.data_ptr(),
+        source.nbytes,
+        host_offset=14,
+        tensor=source,
+    )
+    copy_calls: list[tuple[object, torch.Tensor]] = []
+    encoded: dict[str, torch.Tensor] = {}
+    original_empty_like = torch.empty_like
+
+    def _cpu_empty_like(
+        tensor: torch.Tensor,
+        *args: object,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        kwargs.pop("device", None)
+        return original_empty_like(tensor, *args, **kwargs)
+
+    def _copy_to_device(obj: object, destination: torch.Tensor) -> None:
+        copy_calls.append((obj, destination))
+        destination.copy_(source)
+
+    def _encode(tensor: torch.Tensor, *_args: object) -> SimpleNamespace:
+        encoded["tensor"] = tensor.clone()
+        return SimpleNamespace(to_bytes=lambda: b"encoded")
+
+    monkeypatch.setattr(cachegen_encoder, "torch_device_type", "musa")
+    monkeypatch.setattr(cachegen_encoder.torch, "empty_like", _cpu_empty_like)
+    monkeypatch.setattr(
+        cachegen_encoder,
+        "lmcache_memcpy_async_h2d",
+        _copy_to_device,
+    )
+    monkeypatch.setattr(cachegen_encoder, "encode_function", _encode)
+    monkeypatch.setattr(cachegen_encoder.torch_dev, "current_device", lambda: None)
+
+    serializer = cachegen_encoder.CacheGenSerializer.__new__(
+        cachegen_encoder.CacheGenSerializer
+    )
+    serializer.cachegen_config = cast(
+        cachegen_encoder.CacheGenConfig,
+        SimpleNamespace(),
+    )
+    serializer.key_bins = torch.zeros(1)
+    serializer.value_bins = torch.zeros(1)
+    serializer.kv_shape = torch.Size([2, 1, 3, 2, 2])
+
+    result = serializer.serialize(cast(MemoryObj, memory_obj))
+
+    assert len(copy_calls) == 1
+    assert copy_calls[0][0] is memory_obj
+    assert torch.equal(
+        encoded["tensor"],
+        source.view(2, 1, 3, 2, 2).permute(1, 0, 2, 3, 4),
+    )
+    assert result.byte_array == b"encoded"
 
 
 def _install_cpu_musa_transfer_shims(

--- a/tests/v1/platform/musa/test_musa_staging_copy.py
+++ b/tests/v1/platform/musa/test_musa_staging_copy.py
@@ -202,10 +202,10 @@ def test_musa_device_ops_preserves_tensor_copy_mode() -> None:
     assert torch.equal(destination, source)
 
 
-def test_cachegen_uses_boundary_safe_copy_for_lazy_musa(
+def test_cachegen_uses_boundary_safe_copy_for_lazy_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CacheGen uploads lazy MUSA inputs through the public staging helper."""
+    """CacheGen stages lazy inputs independently of the accelerator name."""
     source = torch.arange(24, dtype=torch.float32).reshape(2, 1, 3, 4)
     memory_obj = _FakeMemoryObj(
         source.data_ptr(),
@@ -233,7 +233,7 @@ def test_cachegen_uses_boundary_safe_copy_for_lazy_musa(
         encoded["tensor"] = tensor.clone()
         return SimpleNamespace(to_bytes=lambda: b"encoded")
 
-    monkeypatch.setattr(cachegen_encoder, "torch_device_type", "musa")
+    monkeypatch.setattr(cachegen_encoder, "torch_device_type", "cuda")
     monkeypatch.setattr(cachegen_encoder.torch, "empty_like", _cpu_empty_like)
     monkeypatch.setattr(
         cachegen_encoder,

--- a/tests/v1/platform/test_device_ops.py
+++ b/tests/v1/platform/test_device_ops.py
@@ -113,6 +113,7 @@ def test_musa_overrides_transfer_and_stream_ordering_ops() -> None:
         if getattr(musa_mod.MusaDeviceOps, name) is not getattr(DeviceOps, name)
     ]
     assert overridden == [
+        "lmcache_memcpy_async",
         "multi_layer_block_kv_transfer",
         "record_completion_on_stream",
         "record_event_on_stream",


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Adds lazy pinned-memory support for the MUSA backend.

- Adds `MusaPinMemoryBackend` using `torch.musa.musart()` host registration APIs.
- Registers the backend through `MusaDeviceSpec`, allowing `l1-use-lazy` when the required runtime functions are available.
- Safely handles missing APIs, runtime exceptions, and nonzero return codes.
- Splits MUSA H2D/D2H transfers at lazy allocator pin-registration boundaries.
- Preserves the existing tensor-copy fallback and non-lazy transfer behavior.
- Adds CPU-only unit tests plus an optional real-MUSA smoke test.

This avoids disabling lazy L1 initialization on MUSA systems that support dynamic host-memory registration.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes 
- [X] this PR contains unit tests
