### PR TITLE
docs: daily drift check — multi-process mode (2026-08-18)

### DIFF
--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -394,14 +394,20 @@ tiers selected at startup (all satisfy ``L1ManagerProtocol``):
   device as the full L1 arena; a hybrid configuration uses DRAM first and
   spills overflow allocations into Device-DAX. See the *L1 Memory Manager*
   section of :doc:`configuration` for the accepted knobs.
-- ``GDSL1MemoryManager`` -- an NVMe slab file when ``--gds-l1-path`` is set.
-  The bytes live on disk; reads/writes DMA directly between the GPU staging
-  buffer and the slab, driven by the process-global ``GDSContext``
-  (``gpu_connector/gds_context.py``) and dispatched from ``gpu_ops``. The DMA
-  backend is selected by platform via ``gpu_connector/_gds_async.py`` --
-  cuFile (``libcufile.so``) on NVIDIA and hipFile (``libhipfile.so``) on AMD
-  ROCm; see the *GDS L1 Tier* section of :doc:`configuration` for the
-  vendor-specific requirements. The CPU tier is disabled in this mode.
+- ``GDSL1MemoryManager`` -- an NVMe-backed L1 slab when ``--gds-l1-path`` is
+  set. cuFile and hipFile back the slab as a file at
+  ``<path>/lmcache_gds_slab.bin``; the opt-in uGDS backend instead maps the
+  slab onto a raw character device such as ``/dev/ugds_drv0``, in which case
+  ``--gds-l1-path`` names that device. Reads/writes DMA directly between the
+  GPU staging buffer and the slab, driven by the process-global
+  ``GDSContext`` (``gpu_connector/gds_context.py``) and dispatched from
+  ``gpu_ops``. The DMA backend is chosen by ``--gds-l1-backend`` and
+  dispatched through ``gpu_connector/_gds_async.py``: ``auto`` picks cuFile
+  (``libcufile.so``) on NVIDIA CUDA and hipFile (``libhipfile.so``) on AMD
+  ROCm, while ``ugds`` (``libugds.so``) opts into the user-space GPUDirect
+  path on either platform. See the *GDS L1 Tier* section of
+  :doc:`configuration` for the vendor-specific requirements. The CPU tier is
+  disabled in this mode.
 
 L2 Adapters
 ~~~~~~~~~~~

--- a/docs/source/mp/l2_storage/index.rst
+++ b/docs/source/mp/l2_storage/index.rst
@@ -4,9 +4,13 @@ Secondary KV Storage
 LMCache multiprocess mode supports a two-tier storage architecture:
 
 - **L1 (fast tier)** -- CPU memory by default, or an NVMe slab via GPUDirect
-  Storage (cuFile) when ``--gds-l1-path`` is set, managed by the L1 Manager.
-  All KV cache chunks live here during active use. (Byte-array L2 adapters are
-  unsupported under the GDS L1 tier, which exposes no L1 memory buffer.)
+  Storage (cuFile on NVIDIA CUDA, hipFile on AMD ROCm, or the opt-in uGDS
+  user-space backend on either platform) when ``--gds-l1-path`` is set,
+  managed by the L1 Manager. The backend is chosen with
+  ``--gds-l1-backend``; see the *GDS L1 Tier* section of
+  :doc:`../configuration` for platform requirements. All KV cache chunks
+  live here during active use. (Byte-array L2 adapters are unsupported
+  under the GDS L1 tier, which exposes no L1 memory buffer.)
 - **L2 (persistent)** -- Durable storage backends (NIXL-based or plain
   file-system/raw-block).  The StoreController asynchronously pushes data from L1
   to L2, and the PrefetchController loads data from L2 back into L1 on


### PR DESCRIPTION
## Summary

Daily docs drift check against `upstream/dev` at
[`af38cbf`](https://github.com/LMCache/LMCache/commit/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707),
focused on multi-process mode. Two user-facing overviews of the GDS L1
tier were stale after [#4420 "Add optional uGDS backend for GDS L1 tier"](https://github.com/LMCache/LMCache/pull/4420)
merged today; both fixes are docs-only.

**`docs/source/`**

- `docs/source/mp/index.rst` — the Memory Managers list under *L1 Managers*
  described `GDSL1MemoryManager` as an "NVMe slab file" whose backend was
  "selected by platform" between cuFile and hipFile. Now inaccurate on
  three counts: uGDS is a real third backend, backend selection goes
  through the new `--gds-l1-backend` flag (not by-platform detection), and
  the uGDS slab is a raw character device rather than a slab file.
- `docs/source/mp/l2_storage/index.rst` — the L1 tier bullet still called
  GDS L1 "GPUDirect Storage (cuFile)", omitting both hipFile (shipped
  earlier) and today's uGDS.

**`docs/design/`**

- No new design-doc drift found today. #4420 does not update any
  `docs/design/` page; the design tree does not currently host a GDS L1
  design page to drift against.

## Recent MP-touching upstream commits reviewed against docs

Since the previous drift-check base at
[`e8f9381`](https://github.com/LMCache/LMCache/commit/e8f938189d42875abf469f25a34765659e0f9c2d),
these commits landed on `dev`; the docs impact each carries is listed
below:

| Commit | Docs impact reviewed |
| --- | --- |
| [`bbab139`](https://github.com/LMCache/LMCache/commit/bbab139f4f79f44f2f843f6b22d9d45d12685af6) — `[Coordinator] Remove environment-variable config in favor of CLI flags (#4619)` | The PR already rewrote `docs/source/mp/coordinator.rst`, `docs/source/cli/coordinator.rst`, `docs/design/cli/commands.md`, and `docs/design/v1/mp_coordinator/README.md` in the same commit. `LMCACHE_MP_COORDINATOR_*` is now unreferenced under `docs/source/*.rst` and `docs/design/`; the only remaining hits are in the auto-generated `docs/source/locale/zh_CN/**/*.po` translation files, which are out of scope here. |
| [`0632295`](https://github.com/LMCache/LMCache/commit/063229555038b6e904589407aa773f84ad480da7) — `[MP][Coordinator] Add metrics export infrastructure (#4389)` | The PR added `--disable-metrics` / `--otlp-endpoint` rows and prose to `docs/source/mp/coordinator.rst`, `docs/source/cli/coordinator.rst`, `docs/source/mp/observability/{index,metrics}.rst`, and `docs/design/v1/mp_observability/METRICS.md`; the doc surface matches the shipped CLI flags. |
| [`ac2f9cf`](https://github.com/LMCache/LMCache/commit/ac2f9cf3e19aa9282df61a5e0769227ae41cf225) — `[Feat] Add optional uGDS backend for GDS L1 tier (#4420)` | Adds `--gds-l1-backend` (`auto` / `cufile` / `hipfile` / `ugds`). The PR only updated the dedicated *GDS L1 Tier* section of `docs/source/mp/configuration.rst`, leaving the two L1-tier overviews above stale. **Addressed in this PR.** |
| [`3247c00`](https://github.com/LMCache/LMCache/commit/3247c008c771830a52c801706aa3a4f57c68d166) — `[Refactor] remove unused allocator package exports (#4598)` | No `docs/` reference to `lmcache.v1.memory_allocators.<AllocatorClass>` package-level exports. No drift. |
| [`b679822`](https://github.com/LMCache/LMCache/commit/b679822880b7b368ab4261c13ca0c35c5ff5739f) — `[Bugfix][CLI] Don't count timed-out rounds in L2 bench stats (#4599)` | Docs updated in-commit under `docs/source/cli/bench.rst`. |
| [`4a662f4`](https://github.com/LMCache/LMCache/commit/4a662f4a495a46be5fd9b74945de3d28cc5979cc) — `[Test] Add lazy offload end to end test for FIFO policy (#4567)` | Buildkite test additions only; no user-facing docs implicated. |
| [`af38cbf`](https://github.com/LMCache/LMCache/commit/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707) — `[Logging] Convert f-string log to %s lazy formatting (#4625)` | One-line lazy-format fix; no doc surface. |
| [`5703ad9`](https://github.com/LMCache/LMCache/commit/5703ad9e14a2c1f0c7f6c9027a09f4dd6d0e2c9c) — `[SDK] Update token dropping example readme to add link to Google Colab (#4548)` | Example README only; not in scope. |
| [`7a82ac3`](https://github.com/LMCache/LMCache/commit/7a82ac3a4c1b1c2a2f2acabfdfd8f5f77b71ccb0) — `fix(operator): scale engine startup-probe window to L1 size (#4576)` | Operator (Helm) code fix; no `docs/source/` impact. |
| [`48dd4df`](https://github.com/LMCache/LMCache/commit/48dd4df9c8b8b76f0f24073d80fefa2e07d5a4b0) — `[Bugfix] fix amd ut test failed (#4594)` | AMD unit-test fix; no docs. |

## Evidence

### `docs/source/mp/index.rst` (before this PR)

Lines
[397–404 @ dev@af38cbf](https://github.com/LMCache/LMCache/blob/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707/docs/source/mp/index.rst#L397-L404)
read:

> ``GDSL1MemoryManager`` -- an NVMe slab file when ``--gds-l1-path`` is set.
> The bytes live on disk; reads/writes DMA directly between the GPU staging
> buffer and the slab, driven by the process-global ``GDSContext``
> (``gpu_connector/gds_context.py``) and dispatched from ``gpu_ops``. The DMA
> backend is selected by platform via ``gpu_connector/_gds_async.py`` --
> cuFile (``libcufile.so``) on NVIDIA and hipFile (``libhipfile.so``) on AMD
> ROCm; see the *GDS L1 Tier* section of :doc:`configuration` for the
> vendor-specific requirements. The CPU tier is disabled in this mode.

### `docs/source/mp/l2_storage/index.rst` (before this PR)

Lines
[6–9 @ dev@af38cbf](https://github.com/LMCache/LMCache/blob/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707/docs/source/mp/l2_storage/index.rst#L6-L9)
read:

> - **L1 (fast tier)** -- CPU memory by default, or an NVMe slab via GPUDirect
>   Storage (cuFile) when ``--gds-l1-path`` is set, managed by the L1 Manager.

### Actual code

- `_gds_async.py` accepts four backend choices — `auto` / `cufile` / `hipfile` / `ugds` — and dispatches to `_cufile_async`, `_hipfile_async`, or `_ugds_async`:
  [lmcache/v1/gpu_connector/_gds_async.py L29–L70 @ dev@af38cbf](https://github.com/LMCache/LMCache/blob/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707/lmcache/v1/gpu_connector/_gds_async.py#L29-L70).
- The GDS L1 argument group registers `--gds-l1-path`, `--gds-l1-use-direct-io`, and `--gds-l1-backend` (`choices=("auto", "cufile", "hipfile", "ugds")`, `default="auto"`), and documents that "`ugds` can be used on either platform with a matching libugds.so and treats `--gds-l1-path` as `/dev/ugds_drvX`":
  [lmcache/v1/distributed/config.py L414–L444 @ dev@af38cbf](https://github.com/LMCache/LMCache/blob/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707/lmcache/v1/distributed/config.py#L414-L444).
- The uGDS backend module exists at
  [lmcache/v1/gpu_connector/_ugds_async.py @ dev@af38cbf](https://github.com/LMCache/LMCache/blob/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707/lmcache/v1/gpu_connector/_ugds_async.py).
- The current, matching version of the *GDS L1 Tier* section of
  `docs/source/mp/configuration.rst` — which this PR aligns the two
  overviews with — is at
  [L275–L344 @ dev@af38cbf](https://github.com/LMCache/LMCache/blob/af38cbf3c3b8d7fa88763bd1cdaa6939ec465707/docs/source/mp/configuration.rst#L275-L344).

## Proposed fix

Applied in this PR's diff:

- `docs/source/mp/index.rst` — rewrite the `GDSL1MemoryManager` bullet
  to name all three backends, point at `--gds-l1-backend` as the
  selector, and note that `--gds-l1-path` is a raw character device
  (e.g. `/dev/ugds_drv0`) under uGDS versus the `<path>/lmcache_gds_slab.bin`
  slab file under cuFile/hipFile.
- `docs/source/mp/l2_storage/index.rst` — expand the L1 tier bullet to
  name cuFile / hipFile / uGDS and cross-reference the *GDS L1 Tier*
  section of `configuration.rst` for platform requirements.

No code changes; docs only.

## Not fixed in this PR

- The Chinese localization files
  `docs/source/locale/zh_CN/LC_MESSAGES/{mp,cli}/coordinator.po`
  still carry the old `LMCACHE_MP_COORDINATOR_*` env-var strings from
  before #4619; regenerating and re-translating these is out of scope
  for the daily English-docs drift check.
- The still-open user-facing lazy-offload gap in
  `docs/source/mp/configuration.rst` is already handled by
  [#4596](https://github.com/LMCache/LMCache/pull/4596); not
  duplicated here.
- The pre-existing `docs/design/integration/vllm/lazy_offload.md`
  staleness is tracked by
  [#4570](https://github.com/LMCache/LMCache/pull/4570); not
  re-touched here.

## Notes

Auto-generated by the daily docs drift-check routine. **Human review
required before merge.** Kept as **draft**; not marked "Ready for
review." No code files touched. Deduplicated against prior open
drift-check PRs (#4596, #4570, #4519, #4480, #4462, #4455); today's
finding is the L1-tier-overview coverage of the new `--gds-l1-backend`
uGDS option, which none of them touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuTenoFGibDwk2sqGwpx7y)_