### PR TITLE
[Fix][MP] Serialize native connector deletes per key

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/l2_eviction.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_eviction.md
@@ -198,7 +198,7 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `RawBlockL2Adapter`        | ✓ (skips locked) | ✓ | stored, accessed, deleted |
 | `FSL2Adapter`              | ✓ (best-effort) | total only (no max cap) | stored, accessed, deleted |
-| `NativeConnectorL2Adapter` | ✓ (skips locked, via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
+| `NativeConnectorL2Adapter` | ✓ (serializes with lookup, via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, accessed, deleted |
 
 **Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:
 
@@ -208,6 +208,10 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 2. The adapter must be configured with `max_capacity_gb > 0` to enable client-side
    size tracking for `get_usage()`. Without it, `get_usage()` returns `(-1, -1)` and
    the eviction controller will not trigger.
+
+Lookup and delete submissions are serialized per key. An earlier lookup pins its
+keys before the delete eligibility check, while a lookup submitted after a delete
+treats the overlapping keys as misses until that delete completes.
 
 **Note on `FSL2Adapter`:** `delete()` and the listener events are implemented, so
 the base class tracks `total_bytes_used` from the store / delete notifications.

--- a/docs/design/v1/distributed/l2_adapters/l2_eviction.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_eviction.md
@@ -198,7 +198,7 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `RawBlockL2Adapter`        | ✓ (skips locked) | ✓ | stored, accessed, deleted |
 | `FSL2Adapter`              | ✓ (best-effort) | total only (no max cap) | stored, accessed, deleted |
-| `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
+| `NativeConnectorL2Adapter` | ✓ (skips locked, via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
 
 **Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:
 

--- a/docs/design/v1/distributed/l2_adapters/l2_eviction.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_eviction.md
@@ -198,7 +198,7 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `RawBlockL2Adapter`        | ✓ (skips locked) | ✓ | stored, accessed, deleted |
 | `FSL2Adapter`              | ✓ (best-effort) | total only (no max cap) | stored, accessed, deleted |
-| `NativeConnectorL2Adapter` | ✓ (serializes with lookup, via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, accessed, deleted |
+| `NativeConnectorL2Adapter` | ✓ (serializes with lookup/store, via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, accessed, deleted |
 
 **Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:
 
@@ -209,9 +209,18 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
    size tracking for `get_usage()`. Without it, `get_usage()` returns `(-1, -1)` and
    the eviction controller will not trigger.
 
-Lookup and delete submissions are serialized per key. An earlier lookup pins its
-keys before the delete eligibility check, while a lookup submitted after a delete
-treats the overlapping keys as misses until that delete completes.
+Lookup, store, and delete submissions are serialized per key. An earlier lookup
+or store pins its keys before the delete eligibility check, while a lookup
+submitted after a delete treats the overlapping keys as misses until that delete
+completes. A store batch with any key covered by a pending delete is deferred as
+a whole; after all overlaps complete (successfully or not), the batch is submitted
+from the delete completion path before another delete can interleave.
+
+A native delete that does not complete within 30 seconds remains quarantined
+until its required completion arrives. During that interval, later deletes skip
+the affected keys, lookups for those keys resolve as misses, and stores containing
+those keys fail so their buffers are not retained indefinitely. Store, lookup,
+load, and delete submissions for unrelated keys continue.
 
 **Note on `FSL2Adapter`:** `delete()` and the listener events are implemented, so
 the base class tracks `total_bytes_used` from the store / delete notifications.

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -12,9 +12,11 @@ Architecture:
     background demux thread that routes native completions to the right
     category based on a future_id → op_type mapping.
   - ObjectKey serialization and MemoryObj buffer extraction happen at the
-    submit call boundary.
-  - Locking is client-side (refcount dict) since remote backends don't have
-    our eviction concept.
+    submit call boundary, except for store batches deferred behind an
+    overlapping delete, which are serialized when that delete completes.
+  - Locking is client-side (refcount dicts) since remote backends don't have
+    our eviction concept: one tracks locks held by a completed lookup, three
+    more order store, lookup and delete submissions per key.
 """
 
 # Future
@@ -22,6 +24,7 @@ from __future__ import annotations
 
 # Standard
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any
 import select
 import threading
@@ -46,6 +49,17 @@ logger = init_logger(__name__)
 # and ``@`` in ``cache_salt`` are rejected by ObjectKey.__post_init__
 # so splitting on ``@`` is unambiguous.
 _KEY_SEP = "@"
+_DELETE_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class _DeferredStoreTask:
+    """Store task retained until overlapping native deletes finish."""
+
+    task_id: L2TaskId
+    keys: list[ObjectKey]
+    objects: list[MemoryObj]
+    sizes: list[int]
 
 
 def _object_key_to_string(key: ObjectKey) -> str:
@@ -143,6 +157,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         # Client-side lock tracking (refcount per key)
         self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+        # Store submissions that have not reached native completion. Delete
+        # skips these keys so it cannot remove a value being written.
+        self._pending_store_keys: dict[ObjectKey, int] = defaultdict(int)
+        # Whole store batches waiting for every overlapping delete to finish.
+        # Keeping MemoryObj references here preserves their buffers until the
+        # native connector accepts the task or a delete timeout fails it.
+        self._deferred_stores: dict[L2TaskId, _DeferredStoreTask] = {}
         # Lookup submissions that have not reached the demux completion path.
         # Delete checks this separately from completed lookup locks so a key
         # stays protected across the entire submit-to-completion window.
@@ -157,6 +178,11 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         # A later lookup reports these keys as misses so it cannot acquire a
         # stale lock before an earlier backend delete finishes.
         self._pending_delete_keys: dict[ObjectKey, int] = defaultdict(int)
+        # Keys whose native delete exceeded the synchronous wait timeout. New
+        # stores for these keys fail until the required late completion arrives.
+        # Pending-delete tracking continues to quarantine these keys from
+        # lookups and deletes, while unrelated operations continue normally.
+        self._timed_out_delete_keys: set[ObjectKey] = set()
 
         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
         # at delete time (the native completion only carries booleans, not
@@ -205,24 +231,58 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         keys: list[ObjectKey],
         objects: list[MemoryObj],
     ) -> L2TaskId:
-        key_strings = [_object_key_to_string(k) for k in keys]
-        memviews = [_obj_to_memoryview(obj) for obj in objects]
-        per_key_sizes = [obj.get_size() for obj in objects]
+        """Submit a store task without racing an earlier delete.
 
-        # Register pending op BEFORE submit to avoid race
-        # with demux thread. The native submit is
-        # non-blocking so holding the lock is brief.
+        The entire batch is deferred when any key overlaps a pending delete.
+        Its object buffers remain referenced until all overlaps finish and the
+        native connector accepts the batch. If an overlapping delete has timed
+        out, the task completes immediately with failure so its buffers are not
+        retained indefinitely.
+
+        Args:
+            keys: Object keys to store.
+            objects: Source memory objects corresponding positionally to
+                ``keys``.
+
+        Returns:
+            The task ID used to retrieve the eventual store result.
+
+        Raises:
+            Exception: Propagates errors raised by an immediate native store
+                submission. A deferred submission error is reported through a
+                failed store completion because the submit call has returned.
+        """
+        store_keys = list(keys)
+        store_objects = list(objects)
+        store_sizes = [obj.get_size() for obj in store_objects]
+
         with self._lock:
             task_id = self._get_next_task_id()
-            future_id = int(self._client.submit_batch_set(key_strings, memviews))
-            self._pending_ops[future_id] = (
-                self._OP_STORE,
+            if any(key in self._timed_out_delete_keys for key in store_keys):
+                self._complete_store_failure_locked(task_id)
+                return task_id
+
+            store_task = _DeferredStoreTask(
                 task_id,
-                len(keys),
-                None,
-                None,
+                store_keys,
+                store_objects,
+                store_sizes,
             )
-            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
+            for key in store_task.keys:
+                self._pending_store_keys[key] += 1
+
+            if any(
+                self._pending_delete_keys.get(key, 0) > 0 for key in store_task.keys
+            ):
+                self._deferred_stores[task_id] = store_task
+                return task_id
+
+            try:
+                self._submit_native_store_locked(store_task)
+            except Exception:
+                for key in store_task.keys:
+                    self._release_pending_store_key(key)
+                raise
 
         return task_id
 
@@ -340,11 +400,11 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     def delete(self, keys: list[ObjectKey]) -> None:
         """Delete a batch of keys from the remote backend.
 
-        Keys with a pending lookup, completed lookup lock, or earlier pending
-        delete are skipped. Protecting both lookup states prevents deletion
-        from lookup submission until the matching ``submit_unlock`` for a
-        found key. A later lookup treats keys submitted for deletion as misses
-        until the native completion arrives.
+        Keys with a pending store, pending lookup, completed lookup lock, or
+        earlier pending delete are skipped. Protecting both store/delete
+        directions prevents an older delete from removing a replacement and
+        prevents a newer delete from overtaking an in-flight store. A later
+        lookup treats keys submitted for deletion as misses until completion.
 
         Submits a batch delete for the remaining keys to the native
         connector and blocks until the demux thread signals completion
@@ -362,14 +422,15 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                 rejects the delete submission.
 
         Note:
-            A request that exceeds the caller's 30-second wait remains
-            registered until its required native completion arrives. Its keys
-            continue to resolve as misses; releasing them earlier would allow
-            a late delete to invalidate a newly acquired lookup lock.
+            A request that exceeds the caller's 30-second wait remains tracked
+            until its required native completion arrives. Until then, later
+            deletes skip its keys, lookups for its keys report misses, and
+            stores for its keys fail instead of waiting indefinitely. Store,
+            lookup, load, and delete submissions for unrelated keys continue.
 
         No-op if the connector does not expose ``submit_batch_delete``, if the
         key list is empty, or if every key is protected by an overlapping
-        lookup or delete.
+        store, lookup, or delete.
         """
         if not keys or not self._has_delete:
             return
@@ -378,7 +439,8 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             deletable = [
                 key
                 for key in keys
-                if self._pending_lookup_keys.get(key, 0) == 0
+                if self._pending_store_keys.get(key, 0) == 0
+                and self._pending_lookup_keys.get(key, 0) == 0
                 and self._locked_keys.get(key, 0) == 0
                 and self._pending_delete_keys.get(key, 0) == 0
             ]
@@ -400,19 +462,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             self._pending_delete_events[task_id] = done_event
 
         # Block until demux thread signals completion
-        if not done_event.wait(timeout=30.0):
+        if not done_event.wait(timeout=_DELETE_TIMEOUT_SECONDS):
             with self._lock:
-                # Keep the pending op and its per-key quarantine until the
-                # connector's required completion arrives. Dropping either
-                # here would reopen the delete-before-lookup race if the
-                # backend completes after this caller returns.
+                # The demux thread removes the future before firing listener
+                # callbacks and waking the waiter. If it already consumed this
+                # future, a timeout here is only a notification race.
+                if future_id not in self._pending_ops:
+                    return
+                error = (
+                    "Native connector delete timed out after "
+                    f"{_DELETE_TIMEOUT_SECONDS:g}s for {len(deletable)} keys"
+                )
                 self._pending_delete_events.pop(task_id, None)
-            logger.warning(
-                "delete() timed out after 30s for %d keys; "
-                "overlapping lookups will miss until completion",
-                len(deletable),
-            )
-            return
+                self._timed_out_delete_keys.update(deletable)
+                self._fail_deferred_stores_for_keys_locked(deletable)
+            logger.error(error)
 
         # ``_notify_keys_deleted`` is fired by the demux thread (with
         # accurate per-key sizes drawn from ``_key_sizes``) when the
@@ -470,6 +534,67 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         task_id = self._next_task_id
         self._next_task_id += 1
         return task_id
+
+    def _submit_native_store_locked(self, task: _DeferredStoreTask) -> None:
+        """Submit one store task while holding ``self._lock``."""
+        key_strings = [_object_key_to_string(key) for key in task.keys]
+        memviews = [_obj_to_memoryview(obj) for obj in task.objects]
+        future_id = int(self._client.submit_batch_set(key_strings, memviews))
+        self._pending_ops[future_id] = (
+            self._OP_STORE,
+            task.task_id,
+            len(task.keys),
+            task.keys,
+            None,
+        )
+        self._pending_store_sizes[future_id] = (task.keys, task.sizes)
+
+    def _submit_ready_deferred_stores_locked(self) -> None:
+        """Submit deferred batches whose delete overlaps are all complete."""
+        ready_task_ids = [
+            task_id
+            for task_id, task in self._deferred_stores.items()
+            if all(self._pending_delete_keys.get(key, 0) == 0 for key in task.keys)
+        ]
+        for task_id in ready_task_ids:
+            task = self._deferred_stores.pop(task_id)
+            try:
+                self._submit_native_store_locked(task)
+            except Exception:
+                logger.exception(
+                    "Deferred native store submission failed for task_id=%d",
+                    task.task_id,
+                )
+                for key in task.keys:
+                    self._release_pending_store_key(key)
+                self._complete_store_failure_locked(task.task_id)
+
+    def _complete_store_failure_locked(self, task_id: L2TaskId) -> None:
+        """Publish a failed store completion while holding ``self._lock``."""
+        self._completed_stores[task_id] = L2StoreResult(False, 0)
+        self._store_efd.notify()
+
+    def _fail_deferred_stores_for_keys_locked(self, keys: list[ObjectKey]) -> None:
+        """Fail deferred batches overlapping timed-out deletes."""
+        timed_out_keys = set(keys)
+        failed_task_ids = [
+            task_id
+            for task_id, task in self._deferred_stores.items()
+            if any(key in timed_out_keys for key in task.keys)
+        ]
+        for task_id in failed_task_ids:
+            task = self._deferred_stores.pop(task_id)
+            for key in task.keys:
+                self._release_pending_store_key(key)
+            self._complete_store_failure_locked(task.task_id)
+
+    def _release_pending_store_key(self, key: ObjectKey) -> None:
+        """Release one pending store refcount while holding ``self._lock``."""
+        count = self._pending_store_keys.get(key, 0)
+        if count <= 1:
+            self._pending_store_keys.pop(key, None)
+        else:
+            self._pending_store_keys[key] = count - 1
 
     def _release_pending_lookup_key(self, key: ObjectKey) -> None:
         """Release one pending lookup refcount while holding ``self._lock``."""
@@ -549,6 +674,9 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                     ) = entry
 
                     if op_type == self._OP_STORE:
+                        if op_keys is not None:
+                            for key in op_keys:
+                                self._release_pending_store_key(key)
                         store_info = self._pending_store_sizes.pop(fid, None)
                         task_bytes = 0
                         if ok and store_info is not None:
@@ -615,6 +743,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         if op_keys is not None:
                             for key in op_keys:
                                 self._release_pending_delete_key(key)
+                                self._timed_out_delete_keys.discard(key)
                         if result_bools is not None and op_keys is not None:
                             for key, deleted in zip(
                                 op_keys, result_bools, strict=False
@@ -629,6 +758,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         evt = self._pending_delete_events.pop(task_id, None)
                         if evt is not None:
                             delete_done_events.append(evt)
+                        self._submit_ready_deferred_stores_locked()
 
             # Fire listener notifications outside the lock so a slow
             # listener cannot stall further demux iterations.

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -122,12 +122,18 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         self._load_efd = create_event_notifier()
 
         # Pending ops: native future_id →
-        #   (op_type, task_id, num_keys, keys_for_locking)
-        # keys_for_locking is only set for lookup ops so
-        # we can apply locks
+        #   (op_type, task_id, result_size, op_keys, result_indices)
+        # result_indices maps lookup results back to the original batch when
+        # keys overlapping an earlier delete are omitted from the native call.
         self._pending_ops: dict[
             int,
-            tuple[str, L2TaskId, int, list[ObjectKey] | None],
+            tuple[
+                str,
+                L2TaskId,
+                int,
+                list[ObjectKey] | None,
+                list[int] | None,
+            ],
         ] = {}
 
         # Completed results (same pattern as MockL2Adapter)
@@ -137,12 +143,20 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         # Client-side lock tracking (refcount per key)
         self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+        # Lookup submissions that have not reached the demux completion path.
+        # Delete checks this separately from completed lookup locks so a key
+        # stays protected across the entire submit-to-completion window.
+        self._pending_lookup_keys: dict[ObjectKey, int] = defaultdict(int)
 
         # Delete capability detection
         self._has_delete = callable(getattr(native_client, "submit_batch_delete", None))
 
         # Pending delete events for synchronous delete() calls
         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+        # Delete submissions that have not reached the demux completion path.
+        # A later lookup reports these keys as misses so it cannot acquire a
+        # stale lock before an earlier backend delete finishes.
+        self._pending_delete_keys: dict[ObjectKey, int] = defaultdict(int)
 
         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
         # at delete time (the native completion only carries booleans, not
@@ -206,6 +220,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                 task_id,
                 len(keys),
                 None,
+                None,
             )
             self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
 
@@ -228,16 +243,49 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         keys: list[ObjectKey],
         group_layout_descs: dict[int, MemoryLayoutDesc],
     ) -> L2TaskId:
-        key_strings = [_object_key_to_string(k) for k in keys]
+        """Submit an existence lookup and lock keys reported as present.
+
+        Keys covered by an earlier in-flight delete are resolved as misses
+        without querying the backend. Other keys in the same batch are still
+        queried and mapped to their original bitmap positions.
+
+        Args:
+            keys: Object keys to look up and lock.
+            group_layout_descs: Per-object-group layout hints. Native
+                connectors currently ignore these hints.
+
+        Returns:
+            The task ID used to query the eventual lookup bitmap.
+
+        Raises:
+            Exception: Propagates errors raised when the native connector
+                rejects the lookup submission.
+        """
+        lookup_keys = list(keys)
 
         with self._lock:
             task_id = self._get_next_task_id()
+            result_indices = [
+                i
+                for i, key in enumerate(lookup_keys)
+                if self._pending_delete_keys.get(key, 0) == 0
+            ]
+            submitted_keys = [lookup_keys[i] for i in result_indices]
+            if not submitted_keys:
+                self._completed_lookups[task_id] = Bitmap(len(lookup_keys))
+                self._lookup_efd.notify()
+                return task_id
+
+            key_strings = [_object_key_to_string(k) for k in submitted_keys]
             future_id = int(self._client.submit_batch_exists(key_strings))
+            for key in submitted_keys:
+                self._pending_lookup_keys[key] += 1
             self._pending_ops[future_id] = (
                 self._OP_LOOKUP,
                 task_id,
-                len(keys),
-                list(keys),
+                len(lookup_keys),
+                submitted_keys,
+                result_indices,
             )
 
         return task_id
@@ -276,6 +324,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                 task_id,
                 len(keys),
                 list(keys),
+                None,
             )
 
         return task_id
@@ -291,50 +340,76 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     def delete(self, keys: list[ObjectKey]) -> None:
         """Delete a batch of keys from the remote backend.
 
-        Keys currently pinned by a lookup lock are skipped — deleting a
-        key mid-read would break the ``lookup_and_lock`` contract that a
-        found key stays resident until the matching ``submit_unlock``.
-        Same convention as the other L2 adapters (e.g. S3, Valkey).
+        Keys with a pending lookup, completed lookup lock, or earlier pending
+        delete are skipped. Protecting both lookup states prevents deletion
+        from lookup submission until the matching ``submit_unlock`` for a
+        found key. A later lookup treats keys submitted for deletion as misses
+        until the native completion arrives.
 
         Submits a batch delete for the remaining keys to the native
         connector and blocks until the demux thread signals completion
         (up to 30s timeout). Fires ``_notify_keys_deleted`` on success so
         eviction policy tracking stays in sync.
 
-        No-op if the connector does not expose ``submit_batch_delete``,
-        if the key list is empty, or if every key is locked.
+        Args:
+            keys: Object keys requested for deletion.
+
+        Returns:
+            None.
+
+        Raises:
+            Exception: Propagates errors raised when the native connector
+                rejects the delete submission.
+
+        Note:
+            A request that exceeds the caller's 30-second wait remains
+            registered until its required native completion arrives. Its keys
+            continue to resolve as misses; releasing them earlier would allow
+            a late delete to invalidate a newly acquired lookup lock.
+
+        No-op if the connector does not expose ``submit_batch_delete``, if the
+        key list is empty, or if every key is protected by an overlapping
+        lookup or delete.
         """
         if not keys or not self._has_delete:
             return
 
         with self._lock:
-            deletable = [k for k in keys if self._locked_keys.get(k, 0) == 0]
+            deletable = [
+                key
+                for key in keys
+                if self._pending_lookup_keys.get(key, 0) == 0
+                and self._locked_keys.get(key, 0) == 0
+                and self._pending_delete_keys.get(key, 0) == 0
+            ]
             if not deletable:
                 return
             done_event = threading.Event()
             key_strings = [_object_key_to_string(k) for k in deletable]
             task_id = self._get_next_task_id()
             future_id = int(self._client.submit_batch_delete(key_strings))
+            for key in deletable:
+                self._pending_delete_keys[key] += 1
             self._pending_ops[future_id] = (
                 self._OP_DELETE,
                 task_id,
                 len(deletable),
                 deletable,
+                None,
             )
             self._pending_delete_events[task_id] = done_event
 
         # Block until demux thread signals completion
         if not done_event.wait(timeout=30.0):
             with self._lock:
+                # Keep the pending op and its per-key quarantine until the
+                # connector's required completion arrives. Dropping either
+                # here would reopen the delete-before-lookup race if the
+                # backend completes after this caller returns.
                 self._pending_delete_events.pop(task_id, None)
-                # Note: _pending_ops entry may already be consumed
-                # by the demux thread; pop is safe either way.
-                for fid, entry in list(self._pending_ops.items()):
-                    if entry[1] == task_id:
-                        self._pending_ops.pop(fid, None)
-                        break
             logger.warning(
-                "delete() timed out after 30s for %d keys",
+                "delete() timed out after 30s for %d keys; "
+                "overlapping lookups will miss until completion",
                 len(deletable),
             )
             return
@@ -396,6 +471,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         self._next_task_id += 1
         return task_id
 
+    def _release_pending_lookup_key(self, key: ObjectKey) -> None:
+        """Release one pending lookup refcount while holding ``self._lock``."""
+        count = self._pending_lookup_keys.get(key, 0)
+        if count <= 1:
+            self._pending_lookup_keys.pop(key, None)
+        else:
+            self._pending_lookup_keys[key] = count - 1
+
+    def _release_pending_delete_key(self, key: ObjectKey) -> None:
+        """Release one pending delete refcount while holding ``self._lock``."""
+        count = self._pending_delete_keys.get(key, 0)
+        if count <= 1:
+            self._pending_delete_keys.pop(key, None)
+        else:
+            self._pending_delete_keys[key] = count - 1
+
     def _demux_loop(self) -> None:
         """Background thread that polls the native
         connector's eventfd, drains completions, and
@@ -453,7 +544,8 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         op_type,
                         task_id,
                         num_keys,
-                        lookup_keys,
+                        op_keys,
+                        result_indices,
                     ) = entry
 
                     if op_type == self._OP_STORE:
@@ -482,12 +574,20 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
                     elif op_type == self._OP_LOOKUP:
                         bitmap = Bitmap(num_keys)
-                        if ok and result_bools is not None:
-                            for i, found in enumerate(result_bools):
+                        if op_keys is not None and result_indices is not None:
+                            for i, (result_index, key) in enumerate(
+                                zip(result_indices, op_keys, strict=True)
+                            ):
+                                self._release_pending_lookup_key(key)
+                                found = (
+                                    ok
+                                    and result_bools is not None
+                                    and i < len(result_bools)
+                                    and result_bools[i]
+                                )
                                 if found:
-                                    bitmap.set(i)
-                                    if lookup_keys is not None:
-                                        self._locked_keys[lookup_keys[i]] += 1
+                                    bitmap.set(result_index)
+                                    self._locked_keys[key] += 1
                         self._completed_lookups[task_id] = bitmap
                         self._lookup_efd.notify()
 
@@ -498,25 +598,29 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                             for i, loaded in enumerate(result_bools):
                                 if loaded:
                                     bitmap.set(i)
-                                    if lookup_keys is not None:
-                                        loaded_keys.append(lookup_keys[i])
+                                    if op_keys is not None:
+                                        loaded_keys.append(op_keys[i])
                         elif ok:
                             # Fallback for connectors that
                             # do not report per-key results
                             for i in range(num_keys):
                                 bitmap.set(i)
-                            if lookup_keys is not None:
-                                loaded_keys.extend(lookup_keys)
+                            if op_keys is not None:
+                                loaded_keys.extend(op_keys)
                         keys_accessed.extend(loaded_keys)
                         self._completed_loads[task_id] = bitmap
                         self._load_efd.notify()
 
                     elif op_type == self._OP_DELETE:
-                        if result_bools is not None and lookup_keys is not None:
-                            for i, deleted in enumerate(result_bools):
+                        if op_keys is not None:
+                            for key in op_keys:
+                                self._release_pending_delete_key(key)
+                        if result_bools is not None and op_keys is not None:
+                            for key, deleted in zip(
+                                op_keys, result_bools, strict=False
+                            ):
                                 if not deleted:
                                     continue
-                                key = lookup_keys[i]
                                 # Only notify (with size) for keys we've
                                 # actually accounted for via a prior store.
                                 if key in self._key_sizes:

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -291,28 +291,35 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     def delete(self, keys: list[ObjectKey]) -> None:
         """Delete a batch of keys from the remote backend.
 
-        Submits a batch delete to the native connector and blocks
-        until the demux thread signals completion (up to 30s timeout).
-        Fires ``_notify_keys_deleted`` on success so eviction policy
-        tracking stays in sync.
+        Keys currently pinned by a lookup lock are skipped — deleting a
+        key mid-read would break the ``lookup_and_lock`` contract that a
+        found key stays resident until the matching ``submit_unlock``.
+        Same convention as the other L2 adapters (e.g. S3, Valkey).
 
-        No-op if the connector does not expose ``submit_batch_delete``
-        or if the key list is empty.
+        Submits a batch delete for the remaining keys to the native
+        connector and blocks until the demux thread signals completion
+        (up to 30s timeout). Fires ``_notify_keys_deleted`` on success so
+        eviction policy tracking stays in sync.
+
+        No-op if the connector does not expose ``submit_batch_delete``,
+        if the key list is empty, or if every key is locked.
         """
         if not keys or not self._has_delete:
             return
 
-        key_strings = [_object_key_to_string(k) for k in keys]
-        done_event = threading.Event()
-
         with self._lock:
+            deletable = [k for k in keys if self._locked_keys.get(k, 0) == 0]
+            if not deletable:
+                return
+            done_event = threading.Event()
+            key_strings = [_object_key_to_string(k) for k in deletable]
             task_id = self._get_next_task_id()
             future_id = int(self._client.submit_batch_delete(key_strings))
             self._pending_ops[future_id] = (
                 self._OP_DELETE,
                 task_id,
-                len(keys),
-                list(keys),
+                len(deletable),
+                deletable,
             )
             self._pending_delete_events[task_id] = done_event
 
@@ -328,7 +335,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         break
             logger.warning(
                 "delete() timed out after 30s for %d keys",
-                len(keys),
+                len(deletable),
             )
             return
 

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -50,11 +50,16 @@ class MockNativeConnector:
       - close()
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._efd = create_event_notifier()
         self._store: dict[str, bytes] = {}
         self._next_id = 1
         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+        self._defer_exists = False
+        self._deferred_exists: list[tuple[int, bool, str, list[bool] | None]] = []
+        self._defer_delete = False
+        self._deferred_deletes: list[tuple[int, list[str]]] = []
+        self._delete_submitted = threading.Event()
         self._lock = threading.Lock()
         self._closed = False
 
@@ -105,17 +110,83 @@ class MockNativeConnector:
         with self._lock:
             fid = self._next_id
             self._next_id += 1
+            defer_exists = self._defer_exists
 
         results = [key in self._store for key in keys]
-        self._push_completion(fid, True, "", results)
+        completion = (fid, True, "", results)
+        if defer_exists:
+            with self._lock:
+                self._deferred_exists.append(completion)
+        else:
+            self._push_completion(*completion)
 
         return fid
+
+    def defer_exists_completions(self) -> None:
+        """Hold future exists completions until explicitly released."""
+        with self._lock:
+            self._defer_exists = True
+
+    def release_next_exists_completion(self) -> None:
+        """Release one deferred exists completion."""
+        self._push_completion(*self._pop_deferred_exists_completion())
+
+    def release_next_exists_failure(self) -> None:
+        """Replace one deferred exists completion with a failed result."""
+        fid, _ok, _error, _results = self._pop_deferred_exists_completion()
+        self._push_completion(fid, False, "forced lookup failure", None)
+
+    def resume_exists_completions(self) -> None:
+        """Release all deferred exists completions and resume immediate delivery."""
+        with self._lock:
+            self._defer_exists = False
+            completions = self._deferred_exists
+            self._deferred_exists = []
+        for completion in completions:
+            self._push_completion(*completion)
 
     def submit_batch_delete(self, keys: list[str]) -> int:
         with self._lock:
             fid = self._next_id
             self._next_id += 1
+            if self._defer_delete:
+                self._deferred_deletes.append((fid, list(keys)))
+                self._delete_submitted.set()
+                return fid
 
+        self._complete_delete(fid, keys)
+        return fid
+
+    def defer_delete_completions(self) -> None:
+        """Hold future delete operations until explicitly released."""
+        with self._lock:
+            self._defer_delete = True
+            self._delete_submitted.clear()
+
+    def wait_for_delete_submission(self, timeout: float = 5.0) -> bool:
+        """Wait until a deferred delete has been submitted."""
+        return self._delete_submitted.wait(timeout=timeout)
+
+    def release_next_delete_completion(self) -> None:
+        """Execute and complete one deferred delete operation."""
+        fid, keys = self._pop_deferred_delete()
+        self._complete_delete(fid, keys)
+
+    def release_next_delete_failure(self) -> None:
+        """Complete one deferred delete as failed without removing keys."""
+        fid, keys = self._pop_deferred_delete()
+        self._push_completion(fid, False, "forced delete failure", [False] * len(keys))
+
+    def resume_delete_completions(self) -> None:
+        """Execute all deferred deletes and resume immediate delivery."""
+        with self._lock:
+            self._defer_delete = False
+            deferred = self._deferred_deletes
+            self._deferred_deletes = []
+        for fid, keys in deferred:
+            self._complete_delete(fid, keys)
+
+    def _complete_delete(self, fid: int, keys: list[str]) -> None:
         results = []
         for key in keys:
             if key in self._store:
@@ -124,8 +195,6 @@ class MockNativeConnector:
             else:
                 results.append(False)
         self._push_completion(fid, True, "", results)
-
-        return fid
 
     def drain_completions(self) -> list[tuple[int, bool, str, list[bool] | None]]:
         # Drain the eventfd
@@ -154,6 +223,23 @@ class MockNativeConnector:
             self._efd.notify()
         except OSError:
             pass
+
+    def _pop_deferred_exists_completion(
+        self,
+    ) -> tuple[int, bool, str, list[bool] | None]:
+        with self._lock:
+            if not self._deferred_exists:
+                raise RuntimeError("No deferred exists completion")
+            return self._deferred_exists.pop(0)
+
+    def _pop_deferred_delete(self) -> tuple[int, list[str]]:
+        with self._lock:
+            if not self._deferred_deletes:
+                raise RuntimeError("No deferred delete")
+            deferred = self._deferred_deletes.pop(0)
+            if not self._deferred_deletes:
+                self._delete_submitted.clear()
+            return deferred
 
 
 # =============================================================================
@@ -1310,6 +1396,179 @@ class TestDeleteRespectsLocks:
         adp.delete([key])
 
         assert adp.get_usage().total_bytes_used == stored_bytes
+
+
+class TestDeleteRespectsPendingLookups:
+    """Lookup submission must pin keys before completion is drained."""
+
+    def test_delete_skips_lookup_waiting_for_completion(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_exists_completions()
+            lookup_fd = adapter.get_lookup_and_lock_event_fd()
+            task_id = adapter.submit_lookup_and_lock_task([key], {0: _EMPTY_LAYOUT})
+
+            adapter.delete([key])
+
+            client.resume_exists_completions()
+            assert wait_for_event_fd(lookup_fd, timeout=5.0)
+            bitmap = adapter.query_lookup_and_lock_result(task_id)
+            assert bitmap is not None
+            assert bitmap.test(0) is True
+            adapter.submit_unlock([key])
+            assert _keys_present(adapter, [key]) == [True]
+        finally:
+            adapter.close()
+
+    def test_failed_lookup_releases_pending_pin(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_exists_completions()
+            lookup_fd = adapter.get_lookup_and_lock_event_fd()
+            task_id = adapter.submit_lookup_and_lock_task([key], {0: _EMPTY_LAYOUT})
+            client.release_next_exists_failure()
+            assert wait_for_event_fd(lookup_fd, timeout=5.0)
+            bitmap = adapter.query_lookup_and_lock_result(task_id)
+            assert bitmap is not None
+            assert bitmap.test(0) is False
+
+            client.resume_exists_completions()
+            adapter.delete([key])
+            assert _keys_present(adapter, [key]) == [False]
+        finally:
+            adapter.close()
+
+    def test_overlapping_lookups_keep_independent_pending_pins(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        try:
+            client.defer_exists_completions()
+            lookup_fd = adapter.get_lookup_and_lock_event_fd()
+            first_task = adapter.submit_lookup_and_lock_task([key], {0: _EMPTY_LAYOUT})
+            second_task = adapter.submit_lookup_and_lock_task([key], {0: _EMPTY_LAYOUT})
+
+            client.release_next_exists_completion()
+            assert wait_for_event_fd(lookup_fd, timeout=5.0)
+            first = adapter.query_lookup_and_lock_result(first_task)
+            assert first is not None
+            assert first.test(0) is False
+
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+            adapter.delete([key])
+
+            client.resume_exists_completions()
+            assert wait_for_event_fd(lookup_fd, timeout=5.0)
+            second = adapter.query_lookup_and_lock_result(second_task)
+            assert second is not None
+            assert second.test(0) is False
+            assert _keys_present(adapter, [key]) == [True]
+
+            adapter.delete([key])
+            assert _keys_present(adapter, [key]) == [False]
+        finally:
+            adapter.close()
+
+
+class TestLookupRespectsPendingDeletes:
+    """Lookups overlapping an earlier delete must not acquire stale locks."""
+
+    def test_lookup_treats_deleting_key_as_miss_in_mixed_batch(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        deleting_key = create_object_key(1)
+        retained_key = create_object_key(2)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([deleting_key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            lookup_fd = adapter.get_lookup_and_lock_event_fd()
+            adapter.submit_store_task(
+                [deleting_key, retained_key],
+                [create_memory_obj(), create_memory_obj()],
+            )
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_delete_completions()
+            delete_thread.start()
+            assert client.wait_for_delete_submission()
+
+            task_id = adapter.submit_lookup_and_lock_task(
+                [deleting_key, retained_key], {0: _EMPTY_LAYOUT}
+            )
+            assert wait_for_event_fd(lookup_fd, timeout=5.0)
+            bitmap = adapter.query_lookup_and_lock_result(task_id)
+            assert bitmap is not None
+            assert bitmap.test(0) is False
+            assert bitmap.test(1) is True
+            adapter.submit_unlock([retained_key])
+
+            client.release_next_delete_completion()
+            delete_thread.join(timeout=5.0)
+            assert not delete_thread.is_alive()
+        finally:
+            client.resume_delete_completions()
+            delete_thread.join(timeout=5.0)
+            adapter.close()
+
+    def test_failed_delete_releases_key_for_later_lookup(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            lookup_fd = adapter.get_lookup_and_lock_event_fd()
+            adapter.submit_store_task([key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_delete_completions()
+            delete_thread.start()
+            assert client.wait_for_delete_submission()
+
+            pending_task = adapter.submit_lookup_and_lock_task(
+                [key], {0: _EMPTY_LAYOUT}
+            )
+            assert wait_for_event_fd(lookup_fd, timeout=5.0)
+            pending_result = adapter.query_lookup_and_lock_result(pending_task)
+            assert pending_result is not None
+            assert pending_result.test(0) is False
+
+            client.release_next_delete_failure()
+            delete_thread.join(timeout=5.0)
+            assert not delete_thread.is_alive()
+
+            assert _keys_present(adapter, [key]) == [True]
+        finally:
+            client.resume_delete_completions()
+            delete_thread.join(timeout=5.0)
+            adapter.close()
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -23,6 +23,7 @@ from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
 )
 from lmcache.v1.memory_management import (
     MemoryFormat,
+    MemoryObj,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
@@ -1205,6 +1206,110 @@ class TestDeleteInterface:
         for i in range(3, 5):
             assert bitmap.test(i) is True
         adapter.submit_unlock(keys[3:])
+
+
+# =============================================================================
+# Delete / Lock Interaction Tests
+# =============================================================================
+
+
+def _store_and_lock(
+    adapter: NativeConnectorL2Adapter,
+    keys: list[ObjectKey],
+    objs: list[MemoryObj],
+) -> None:
+    """Store ``keys`` then acquire lookup locks on all of them."""
+    store_fd = adapter.get_store_event_fd()
+    lookup_fd = adapter.get_lookup_and_lock_event_fd()
+
+    adapter.submit_store_task(keys, objs)
+    assert wait_for_event_fd(store_fd, timeout=5.0)
+    adapter.pop_completed_store_tasks()
+
+    task_id = adapter.submit_lookup_and_lock_task(keys, {0: _EMPTY_LAYOUT})
+    assert wait_for_event_fd(lookup_fd, timeout=5.0)
+    bitmap = adapter.query_lookup_and_lock_result(task_id)
+    assert bitmap is not None
+    for i in range(len(keys)):
+        assert bitmap.test(i) is True
+
+
+def _keys_present(
+    adapter: NativeConnectorL2Adapter,
+    keys: list[ObjectKey],
+) -> list[bool]:
+    """Look up ``keys`` and immediately unlock, returning per-key presence."""
+    lookup_fd = adapter.get_lookup_and_lock_event_fd()
+    task_id = adapter.submit_lookup_and_lock_task(keys, {0: _EMPTY_LAYOUT})
+    assert wait_for_event_fd(lookup_fd, timeout=5.0)
+    bitmap = adapter.query_lookup_and_lock_result(task_id)
+    assert bitmap is not None
+    present = [bitmap.test(i) for i in range(len(keys))]
+    adapter.submit_unlock([k for k, ok in zip(keys, present, strict=True) if ok])
+    return present
+
+
+class TestDeleteRespectsLocks:
+    """``lookup_and_lock`` must pin a key against concurrent eviction.
+
+    Same convention as the S3 / Valkey / Bigtable / HFBucket adapters:
+    ``delete()`` skips keys with a non-zero lock refcount.
+    """
+
+    def test_delete_skips_locked_key(self, adapter):
+        key = create_object_key(1)
+        _store_and_lock(adapter, [key], [create_memory_obj()])
+
+        adapter.delete([key])
+
+        assert _keys_present(adapter, [key]) == [True]
+
+    def test_delete_locked_key_succeeds_after_unlock(self, adapter):
+        key = create_object_key(1)
+        _store_and_lock(adapter, [key], [create_memory_obj()])
+
+        adapter.delete([key])
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+
+        assert _keys_present(adapter, [key]) == [False]
+
+    def test_delete_partial_lock_batch(self, adapter_with_capacity):
+        """Only the unlocked key is deleted, and exactly its bytes are freed.
+
+        Distinct sizes matter here: the demux thread maps completion
+        results back onto the submitted key list positionally, so a
+        misaligned batch would free the wrong key's bytes while still
+        leaving the right set of keys present.
+        """
+        adp = adapter_with_capacity
+        keys = [create_object_key(i) for i in range(3)]
+        sizes = [50, 100, 150]
+        objs = [
+            create_memory_obj(size=s, fill_value=float(i)) for i, s in enumerate(sizes)
+        ]
+        _store_and_lock(adp, keys, objs)
+        total_before = adp.get_usage().total_bytes_used
+        # Release the lock on keys[1] only; keys[0] and keys[2] stay pinned.
+        adp.submit_unlock([keys[1]])
+
+        adp.delete(keys)
+
+        assert _keys_present(adp, keys) == [True, False, True]
+        freed = total_before - adp.get_usage().total_bytes_used
+        assert freed == objs[1].get_size()
+
+    def test_delete_locked_key_preserves_usage(self, adapter_with_capacity):
+        adp = adapter_with_capacity
+        key = create_object_key(1)
+        obj = create_memory_obj(size=100)
+        _store_and_lock(adp, [key], [obj])
+        stored_bytes = adp.get_usage().total_bytes_used
+        assert stored_bytes > 0
+
+        adp.delete([key])
+
+        assert adp.get_usage().total_bytes_used == stored_bytes
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -17,6 +17,7 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener
 from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
     NativeConnectorL2Adapter,
     _object_key_to_string,
@@ -55,6 +56,9 @@ class MockNativeConnector:
         self._store: dict[str, bytes] = {}
         self._next_id = 1
         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+        self._defer_set = False
+        self._deferred_sets: list[tuple[int, list[str], list[bytes]]] = []
+        self._set_submitted = threading.Event()
         self._defer_exists = False
         self._deferred_exists: list[tuple[int, bool, str, list[bool] | None]] = []
         self._defer_delete = False
@@ -70,15 +74,51 @@ class MockNativeConnector:
         with self._lock:
             fid = self._next_id
             self._next_id += 1
+            if self._defer_set:
+                payloads = [bytes(mv) for mv in memoryviews]
+                self._deferred_sets.append((fid, list(keys), payloads))
+                self._set_submitted.set()
+                return fid
 
+        self._complete_set(fid, keys, [bytes(mv) for mv in memoryviews])
+        return fid
+
+    def defer_set_completions(self) -> None:
+        """Hold future set operations until explicitly released."""
+        with self._lock:
+            self._defer_set = True
+            self._set_submitted.clear()
+
+    def wait_for_set_submission(self, timeout: float = 5.0) -> bool:
+        """Wait until a deferred set has been submitted."""
+        return self._set_submitted.wait(timeout=timeout)
+
+    def release_next_set_completion(self) -> None:
+        """Execute and complete one deferred set operation."""
+        fid, keys, payloads = self._pop_deferred_set()
+        self._complete_set(fid, keys, payloads)
+
+    def release_next_set_failure(self) -> None:
+        """Complete one deferred set as failed without storing keys."""
+        fid, _keys, _payloads = self._pop_deferred_set()
+        self._push_completion(fid, False, "forced set failure", None)
+
+    def resume_set_completions(self) -> None:
+        """Execute deferred sets and resume immediate delivery."""
+        with self._lock:
+            self._defer_set = False
+            deferred = self._deferred_sets
+            self._deferred_sets = []
+        for fid, keys, payloads in deferred:
+            self._complete_set(fid, keys, payloads)
+
+    def _complete_set(self, fid: int, keys: list[str], payloads: list[bytes]) -> None:
         try:
-            for key, mv in zip(keys, memoryviews, strict=False):
-                self._store[key] = bytes(mv)
+            for key, payload in zip(keys, payloads, strict=False):
+                self._store[key] = payload
             self._push_completion(fid, True, "", None)
         except Exception as e:
             self._push_completion(fid, False, str(e), None)
-
-        return fid
 
     def submit_batch_get(self, keys: list[str], memoryviews: list) -> int:
         with self._lock:
@@ -231,6 +271,15 @@ class MockNativeConnector:
             if not self._deferred_exists:
                 raise RuntimeError("No deferred exists completion")
             return self._deferred_exists.pop(0)
+
+    def _pop_deferred_set(self) -> tuple[int, list[str], list[bytes]]:
+        with self._lock:
+            if not self._deferred_sets:
+                raise RuntimeError("No deferred set")
+            deferred = self._deferred_sets.pop(0)
+            if not self._deferred_sets:
+                self._set_submitted.clear()
+            return deferred
 
     def _pop_deferred_delete(self) -> tuple[int, list[str]]:
         with self._lock:
@@ -1335,6 +1384,41 @@ def _keys_present(
     return present
 
 
+def _load_single_value(
+    adapter: NativeConnectorL2Adapter,
+    key: ObjectKey,
+    size: int,
+) -> torch.Tensor:
+    """Load one key and return its tensor after requiring a cache hit."""
+    load_fd = adapter.get_load_event_fd()
+    obj = create_memory_obj(size=size, fill_value=0.0)
+    task_id = adapter.submit_load_task([key], [obj])
+    assert wait_for_event_fd(load_fd, timeout=5.0)
+    bitmap = adapter.query_load_result(task_id)
+    assert bitmap is not None
+    assert bitmap.test(0) is True
+    return obj.tensor
+
+
+class BlockingDeleteListener(L2AdapterListener):
+    """Block delete notification after the native future is demultiplexed."""
+
+    def __init__(self) -> None:
+        self.delete_entered = threading.Event()
+        self.allow_delete = threading.Event()
+
+    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+        """Accept store notifications without blocking."""
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        """Accept access notifications without blocking."""
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
+        """Block until the test allows delete notification to finish."""
+        self.delete_entered.set()
+        self.allow_delete.wait(timeout=5.0)
+
+
 class TestDeleteRespectsLocks:
     """``lookup_and_lock`` must pin a key against concurrent eviction.
 
@@ -1529,7 +1613,8 @@ class TestLookupRespectsPendingDeletes:
             assert not delete_thread.is_alive()
         finally:
             client.resume_delete_completions()
-            delete_thread.join(timeout=5.0)
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
             adapter.close()
 
     def test_failed_delete_releases_key_for_later_lookup(self) -> None:
@@ -1567,7 +1652,359 @@ class TestLookupRespectsPendingDeletes:
             assert _keys_present(adapter, [key]) == [True]
         finally:
             client.resume_delete_completions()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
+            adapter.close()
+
+
+# =============================================================================
+# Store / Delete Ordering Tests
+# =============================================================================
+
+
+class TestStoreDeleteOrdering:
+    """Store and delete submissions must be ordered in both directions."""
+
+    def test_replacement_store_waits_for_delete_then_survives(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task(
+                [key], [create_memory_obj(size=32, fill_value=1.0)]
+            )
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_delete_completions()
+            delete_thread.start()
+            assert client.wait_for_delete_submission()
+
+            replacement_task = adapter.submit_store_task(
+                [key], [create_memory_obj(size=32, fill_value=2.0)]
+            )
+            assert not wait_for_event_fd(store_fd, timeout=0.1)
+
+            client.release_next_delete_completion()
             delete_thread.join(timeout=5.0)
+            assert not delete_thread.is_alive()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            result = adapter.pop_completed_store_tasks()[replacement_task]
+            assert result.is_successful()
+            assert torch.all(_load_single_value(adapter, key, 32) == 2.0)
+        finally:
+            client.resume_delete_completions()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
+            adapter.close()
+
+    def test_mixed_store_batch_waits_as_one_task(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        deleting_key = create_object_key(1)
+        other_key = create_object_key(2)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([deleting_key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([deleting_key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_delete_completions()
+            delete_thread.start()
+            assert client.wait_for_delete_submission()
+
+            task_id = adapter.submit_store_task(
+                [deleting_key, other_key],
+                [
+                    create_memory_obj(fill_value=3.0),
+                    create_memory_obj(fill_value=4.0),
+                ],
+            )
+            assert not wait_for_event_fd(store_fd, timeout=0.1)
+            assert _keys_present(adapter, [other_key]) == [False]
+
+            client.release_next_delete_completion()
+            delete_thread.join(timeout=5.0)
+            assert not delete_thread.is_alive()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert adapter.pop_completed_store_tasks()[task_id].is_successful()
+            assert _keys_present(adapter, [deleting_key, other_key]) == [True, True]
+        finally:
+            client.resume_delete_completions()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
+            adapter.close()
+
+    def test_failed_delete_releases_deferred_store(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task(
+                [key], [create_memory_obj(size=16, fill_value=1.0)]
+            )
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_delete_completions()
+            delete_thread.start()
+            assert client.wait_for_delete_submission()
+
+            replacement_task = adapter.submit_store_task(
+                [key], [create_memory_obj(size=16, fill_value=5.0)]
+            )
+            assert not wait_for_event_fd(store_fd, timeout=0.1)
+
+            client.release_next_delete_failure()
+            delete_thread.join(timeout=5.0)
+            assert not delete_thread.is_alive()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert adapter.pop_completed_store_tasks()[replacement_task].is_successful()
+            assert torch.all(_load_single_value(adapter, key, 16) == 5.0)
+        finally:
+            client.resume_delete_completions()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
+            adapter.close()
+
+    def test_delete_skips_pending_store_until_completion(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            client.defer_set_completions()
+            client.defer_delete_completions()
+            store_task = adapter.submit_store_task([key], [create_memory_obj()])
+            assert client.wait_for_set_submission()
+
+            delete_thread.start()
+            delete_thread.join(timeout=0.2)
+            assert not delete_thread.is_alive()
+            assert not client.wait_for_delete_submission(timeout=0.01)
+
+            client.release_next_set_completion()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert adapter.pop_completed_store_tasks()[store_task].is_successful()
+
+            client.resume_delete_completions()
+            adapter.delete([key])
+            assert _keys_present(adapter, [key]) == [False]
+        finally:
+            client.resume_set_completions()
+            client.resume_delete_completions()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
+            adapter.close()
+
+    def test_failed_store_releases_delete_quarantine(self) -> None:
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        key = create_object_key(1)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_set_completions()
+            client.defer_delete_completions()
+            store_task = adapter.submit_store_task([key], [create_memory_obj()])
+            assert client.wait_for_set_submission()
+
+            delete_thread.start()
+            delete_thread.join(timeout=0.2)
+            assert not delete_thread.is_alive()
+            assert not client.wait_for_delete_submission(timeout=0.01)
+
+            client.release_next_set_failure()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert not adapter.pop_completed_store_tasks()[store_task].is_successful()
+
+            client.resume_delete_completions()
+            adapter.delete([key])
+            assert _keys_present(adapter, [key]) == [False]
+        finally:
+            client.resume_set_completions()
+            client.resume_delete_completions()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
+            adapter.close()
+
+
+class TestDeleteTimeout:
+    """A delete timeout quarantines affected keys until late completion."""
+
+    def test_timeout_quarantines_only_affected_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "lmcache.v1.distributed.l2_adapters."
+            "native_connector_l2_adapter._DELETE_TIMEOUT_SECONDS",
+            0.5,
+        )
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        deleting_key = create_object_key(1)
+        unrelated_key = create_object_key(2)
+        listener = BlockingDeleteListener()
+        listener.allow_delete.set()
+        adapter.register_listener(listener)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([deleting_key],),
+            daemon=True,
+        )
+        unrelated_delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([unrelated_key],),
+            daemon=True,
+        )
+        recovered_delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([deleting_key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([deleting_key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            client.defer_delete_completions()
+            delete_thread.start()
+            assert client.wait_for_delete_submission()
+
+            deferred_task = adapter.submit_store_task(
+                [deleting_key], [create_memory_obj()]
+            )
+            delete_thread.join(timeout=2.0)
+            assert not delete_thread.is_alive()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            deferred_result = adapter.pop_completed_store_tasks()[deferred_task]
+            assert not deferred_result.is_successful()
+            assert deferred_result.bytes_transferred() == 0
+
+            affected_task = adapter.submit_store_task(
+                [deleting_key], [create_memory_obj()]
+            )
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert not adapter.pop_completed_store_tasks()[
+                affected_task
+            ].is_successful()
+
+            unrelated_task = adapter.submit_store_task(
+                [unrelated_key], [create_memory_obj(size=16, fill_value=3.0)]
+            )
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert adapter.pop_completed_store_tasks()[unrelated_task].is_successful()
+            assert _keys_present(adapter, [unrelated_key]) == [True]
+            assert torch.all(_load_single_value(adapter, unrelated_key, 16) == 3.0)
+
+            # Reset the submission event so the wait below observes this
+            # delete, not the one already queued for deleting_key.
+            client.defer_delete_completions()
+            unrelated_delete_thread.start()
+            assert client.wait_for_delete_submission()
+            unrelated_delete_thread.join(timeout=0.1)
+            assert unrelated_delete_thread.is_alive()
+
+            client.release_next_delete_completion()
+            assert listener.delete_entered.wait(timeout=5.0)
+            assert unrelated_delete_thread.is_alive()
+
+            client.release_next_delete_completion()
+            unrelated_delete_thread.join(timeout=5.0)
+            assert not unrelated_delete_thread.is_alive()
+            assert _keys_present(adapter, [unrelated_key]) == [False]
+
+            recovered_store = adapter.submit_store_task(
+                [deleting_key], [create_memory_obj()]
+            )
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert adapter.pop_completed_store_tasks()[recovered_store].is_successful()
+
+            recovered_delete_thread.start()
+            assert client.wait_for_delete_submission()
+            client.release_next_delete_completion()
+            recovered_delete_thread.join(timeout=5.0)
+            assert not recovered_delete_thread.is_alive()
+            assert _keys_present(adapter, [deleting_key]) == [False]
+        finally:
+            client.resume_delete_completions()
+            for thread in (
+                delete_thread,
+                unrelated_delete_thread,
+                recovered_delete_thread,
+            ):
+                if thread.ident is not None:
+                    thread.join(timeout=5.0)
+            adapter.close()
+
+    def test_consumed_delete_completion_does_not_trigger_timeout_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "lmcache.v1.distributed.l2_adapters."
+            "native_connector_l2_adapter._DELETE_TIMEOUT_SECONDS",
+            0.5,
+        )
+        client = MockNativeConnector()
+        adapter = NativeConnectorL2Adapter(client)
+        listener = BlockingDeleteListener()
+        adapter.register_listener(listener)
+        key = create_object_key(1)
+        delete_thread = threading.Thread(
+            target=adapter.delete,
+            args=([key],),
+            daemon=True,
+        )
+        try:
+            store_fd = adapter.get_store_event_fd()
+            adapter.submit_store_task([key], [create_memory_obj()])
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            adapter.pop_completed_store_tasks()
+
+            delete_thread.start()
+            assert listener.delete_entered.wait(timeout=5.0)
+            delete_thread.join(timeout=2.0)
+            assert not delete_thread.is_alive()
+
+            replacement_task = adapter.submit_store_task([key], [create_memory_obj()])
+            listener.allow_delete.set()
+            assert wait_for_event_fd(store_fd, timeout=5.0)
+            assert adapter.pop_completed_store_tasks()[replacement_task].is_successful()
+        finally:
+            listener.allow_delete.set()
+            if delete_thread.ident is not None:
+                delete_thread.join(timeout=5.0)
             adapter.close()
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`NativeConnectorL2Adapter` submits store, lookup and delete to the native client
with no ordering between them. `delete()` in particular ignored the client-side
lock refcount and issued `submit_batch_delete` for every key it was handed. A
key pinned by an in-flight `lookup_and_lock` could be removed from the backend
before the matching `load` ran, turning a reported hit into a load failure. The
refcount was recorded in `_locked_keys` on lookup completion but never read
back — `submit_unlock()` was its only reader.

The adapter contract already asks for this. `l2_eviction.md` lists it as a
requirement for adapters implementing eviction:

> **Implement `delete(keys)`** to remove keys from storage. Pinned keys (in use
> by an in-flight load) should be skipped; the eviction controller will retry
> them on the next cycle.

and `l2_adapters/overall.md` states the purpose of the lock:

> **Locking:** `lookup_and_lock` atomically checks which keys exist and acquires
> L2-side locks on found keys. This prevents L2 eviction between lookup and load.

Reading `_locked_keys` alone does not close the hole. The same unordered
submission path also lets a delete overtake an in-flight store, and lets a
lookup acquire a lock on a key whose delete has already been sent to the
backend. This PR serializes all three operations per key:

| Rule | Mechanism |
|---|---|
| Delete skips keys pinned by a completed lookup | `_locked_keys`, now read by `delete()` |
| Delete skips keys whose lookup was submitted but not yet demultiplexed | `_pending_lookup_keys`, held across the whole submit→completion window |
| Delete skips keys with an in-flight store | `_pending_store_keys` |
| Lookup reports keys with an in-flight delete as misses | `_pending_delete_keys`; the remaining keys are still queried and mapped back to their original bitmap positions |
| A store batch overlapping an in-flight delete is deferred as a whole, then submitted from the delete completion path before another delete can interleave | `_deferred_stores`, which retains the batch's `MemoryObj` references |

Skipped keys are not lost. `delete()` fires no `on_l2_keys_deleted` for them, so
`LRUEvictionPolicy` keeps the entries and the eviction controller re-picks them
on the next cycle.

**Delete timeout.** `delete()` still blocks on the native completion for 30s.
Previously a timeout discarded the pending op, so the late completion was
dropped as an unknown `future_id` and the keys' byte sizes were never reclaimed:
`get_usage()` stayed permanently inflated, and a later re-store of the same key
was then counted as zero bytes. The pending op is now retained so the late
completion still runs its accounting, and the affected keys are quarantined
until it arrives — later deletes skip those keys, lookups for them report
misses, and stores containing them fail immediately instead of holding their
buffers indefinitely. Store, lookup, load and delete submissions for unrelated
keys continue. A timeout that merely lost the wake-up race with the demux thread
is now detected and quarantines nothing.

`docs/design/v1/distributed/l2_adapters/l2_eviction.md` is updated with the
ordering rules and the timeout policy. Its `NativeConnectorL2Adapter`
support-matrix row is corrected at the same time: it also still omitted the
`accessed` listener event, which the adapter has always fired from the load
completion path.

**Special notes for your reviewers**:

`NativeConnectorL2Adapter` is the shared bridge, so this covers the FS native,
RESP, Aerospike, Mooncake and third-party plugin adapters at once.

Two behaviour changes are worth a second opinion:

1. A lookup can now report a miss for a key the backend still holds, for as long
   as an overlapping delete is in flight. This is the intended direction — a
   miss is recoverable, a lock handed out over a value that is about to
   disappear is not — but it is observable from the prefetch path.
2. Quarantine is per key: a delete that times out holds only its own keys, and
   eviction, stores and lookups for every other key keep running. If that
   completion never arrives, those keys stay unusable. That is deliberate — the
   adapter cannot tell whether the timed-out delete will still land, so
   accepting a new value for the key risks having it silently wiped. It is also
   strictly better than the previous behaviour, which dropped the pending op and
   left the byte accounting permanently wrong with no way to recover.

Tests: `tests/v1/distributed/test_native_connector_l2_adapter.py` grows from 79
to 95 cases, adding `TestDeleteRespectsLocks`,
`TestDeleteRespectsPendingLookups`, `TestLookupRespectsPendingDeletes`,
`TestStoreDeleteOrdering` and `TestDeleteTimeout`. They cover each ordering rule
in both directions, a failed lookup / store / delete releasing its pins, the
deferred-store resubmission path, and the timeout quarantine together with its
recovery once the late completion lands. The mock native connector gained
explicit per-operation deferral controls so every race is driven deterministically
rather than by sleeps.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
