### PR TITLE
[feat] coordinator memory pressure api

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -41,6 +41,8 @@ shape.
 | `GET /cache/prefetches/{instance_id}/{request_id}` | operator/scheduler | poll a warm prefetch |
 | `POST/DELETE /cache/pins` | operator | pin / unpin keys against fleet-wide eviction |
 | `POST /cache/delete` | operator | delete cached objects on a named server |
+| `GET /instances/usage` | operator/scheduler | fleet memory view: per-server, per-module usage vs declared capacity |
+| `GET /instances/{instance_id}/usage` | operator/scheduler | one server's memory compartments |
 
 For server-initiated work (fleet-wide eviction, warm prefetch) a coordinator
 router resolves an instance's address from the registry (`ip` + `http_port`)
@@ -62,6 +64,7 @@ lmcache/v1/mp_coordinator/
   key_directory.py      # KeyDirectory: placements + token bindings (a cache-event consumer)
   blend_index.py      # BlendIndex: fragment (blend) lookup over those bindings
   blend_client.py       # mp-server-side fragment-lookup query client
+  server_config.py      # ServerConfigRegistry: per-server module capacities (from registration)
   ingest/
     __init__.py
     event_gate.py       # EventGate: incarnation fencing, seq dedup, gap detection
@@ -80,6 +83,7 @@ lmcache/v1/mp_coordinator/
     cache_api.py        # /cache/prefetches, /cache/pins, /cache/delete
     events_api.py       # /events (fleet cache-event ingest)
     directory_api.py    # /directory/lookup, /directory/blend-lookup, /directory/keys, ...
+    instances_usage_api.py  # /instances/usage, /instances/{id}/usage
 ```
 
 ## Request flow
@@ -212,6 +216,34 @@ it. The one coupling is pins, and it runs the way you'd want: a pin's
 entire meaning is "exempt from eviction", so the pin set is eviction
 state that the cache-control endpoints write, not the reverse.
 
+
+## Fleet memory pressure (`server_config.py`)
+
+`GET /instances/usage` answers how full each server's memory compartments
+are, by joining two halves that ride the same channel at very different
+rates: **usage** from `CacheUsageManager.get_bytes_by_instance`, already
+maintained off the admitted cache-event stream, and **capacity** from
+`capacity_reports` on `POST /events`. Capacity is configuration — it changes
+at boot and at reconfiguration, not per event — so a server reports it once
+at startup and again on each change, each report a whole declaration fenced
+by `(incarnation, revision)`.
+
+The endpoint adds no usage tracking of its own: the per-instance,
+per-backend rollup it needs is exactly what the usage manager publishes.
+
+`ServerConfigRegistry` holds the declarations. It lives outside
+`registry.py` because that file is membership only; a capacity is not a way
+to reach a server.
+
+Two properties the endpoint depends on. Shared backends (one S3 bucket
+mounted by N servers) are counted **once** for the fleet, never summed —
+the same empty-owner convention the key directory uses. And `usage_ratio` is
+`null`, not a sentinel, whenever no capacity was declared: that is the
+common case for `fs` / `mooncake` / `p2p` / `sagemaker`, which expose no
+capacity knob at all.
+
+Read-only — it never evicts, throttles, or pushes. See
+[memory_pressure.md](memory_pressure.md).
 
 ## Fleet CacheBlend lookup (`blend_index.py`)
 

--- a/docs/design/v1/mp_coordinator/memory_pressure.md
+++ b/docs/design/v1/mp_coordinator/memory_pressure.md
@@ -1,0 +1,247 @@
+# Fleet Memory Pressure
+
+A coordinator-level read-only view of how full each MP server's memory
+compartments are. It joins two things the coordinator holds separately: byte
+usage derived from the admitted cache-event stream, and capacity declared by
+each server on that same stream. Neither is a pressure reading on its own.
+
+Code: `lmcache/v1/mp_coordinator/controllers/usage_manager.py` (usage view),
+`lmcache/v1/mp_coordinator/server_config.py` (capacity registry),
+`lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py` (REST endpoints),
+`lmcache/v1/distributed/storage_manager.py` (MP-server capacity source),
+`lmcache/v1/mp_coordinator/cache_events.py` (MP-server declaration).
+
+## Why
+
+The coordinator can already say how many bytes a tier holds. It cannot say
+whether that is a lot, because nothing tells it how many bytes the tier *can*
+hold. Pressure is `used / capacity`, and the cache-event stream carries only
+the numerator.
+
+The usage half needs no new tracking. `CacheUsageManager` already rolls the
+admitted cache-event stream up per `(instance_id, backend)` for both tiers —
+`get_bytes_by_instance(tier)` — which is exactly the axis a pressure reading
+needs. This capability adds only the denominator.
+
+## How capacity reaches the coordinator
+
+Capacity is a **`config` cache event**, so it travels the one ingest path
+every other event does and the registry is a `CacheEventConsumer` like the
+key directory and the usage manager. One declaration is one `config` batch
+per compartment, all sharing a `capacity_revision`.
+
+`StorageManager` publishes `SM_CAPACITY_CHANGED` on the observability bus and
+the cache-event subscriber ships it on its next flush. It fires:
+
+- **After every successful registration**, via the `on_registered` hook
+  `keep_registered` calls, wired to `publish_capacity()`. This covers the
+  first registration — without which a server that never reconfigures would
+  never declare at all — and, critically, every *re*-registration. The
+  coordinator holds declarations in memory only, so a restarted one has
+  forgotten them; re-registration is the single event that tells a server its
+  declaration may be gone. Nothing else would resend it, and the fleet view
+  would sit at `declared_capacity: false` indefinitely.
+- **On every topology change** — adapter added, removed, or reconfigured.
+
+Registration deliberately carries no capacity in its *body*. One path means
+the coordinator cannot hold a declaration that disagrees with the event
+stream, and it closes a real hole: registration and event reporting are
+separately configurable, so a server registering without event reporting used
+to declare capacity whose usage never arrived, making every compartment read
+as a confident `0.0` instead of unknown.
+
+A declaration is always the **whole topology**, never a delta. That is what
+makes the lossy channel acceptable: a dropped batch is repaired by the next
+declaration, where a dropped byte delta would be permanent. The emitter also
+keeps an unsent declaration across a publish failure.
+
+`(incarnation, capacity_revision)` groups batches into declarations. A newer
+stamp starts a fresh set, an equal one extends it, an older one is dropped.
+
+The revision is assigned by the **cache-event subscriber**, not by
+`StorageManager`. That is deliberate and it is why no lock is involved: the
+bus drains on one thread, so the subscriber's revision counter needs no more
+protection than its `seq` counter already has, and the number cannot come
+apart from the topology it labels. `StorageManager`'s publishers are
+concurrent -- registration publishes from the event loop while a worker may
+be adding an adapter -- so a counter there would need a lock and could still
+tag an older topology with a newer number. Coalescing falls out for free: two
+publishes merged into one flush share one revision instead of burning two.
+**That is what retires a compartment**: a declaration omitting it simply
+never re-adds it, which is how a deleted L2 adapter stops being reported.
+Incarnation fencing and seq dedup come from the gate, so nothing here
+duplicates them.
+
+Two consequences worth knowing:
+
+- `config` batches share the seq space with placements, so the emitter's one
+  counter covers both and a reused seq is dropped as a duplicate.
+- The registry cannot reject a compartment declared twice inside one
+  declaration — it never sees the whole list — so it upserts and the last
+  batch wins. `_build_capacities` derives one entry per medium and adapter,
+  so a correct producer cannot do it.
+
+The batch envelope carries a declaration on `tier`, `backend`, `shared`,
+plus `capacity_bytes` and `capacity_revision`; `entries` is required empty.
+That empty-entries invariant is what makes the other consumers safe: the key
+directory, usage manager, and eviction controller are all entries-driven, so
+a `config` batch is a no-op for each without any of them knowing the type
+exists.
+
+## Why capacity is its own event type
+
+Capacity is configuration: it changes when a server boots and when it is
+reconfigured, not once per cache operation. Reusing `store` would mean
+inventing a placement for something that has no key; emitting it per
+operation would republish an unchanging number thousands of times a second.
+A distinct type emitted on change keeps the volume proportional to what
+actually varies and leaves the placement types untouched.
+
+The cost is two fields on `CacheEventBatch` that only `config` reads, so
+every placement batch carries them as zeros on the wire.
+
+## Architecture
+
+```
+MP server                                   Coordinator
+─────────                                   ───────────
+StorageManager.publish_capacity()
+  L1: get_configured_capacity_bytes(l1_config)
+      → one entry per backing medium
+  L2: per adapter, total_capacity_bytes
+      + shared flag from its config
+        │
+        │  subscriber: ModuleMemoryCapacity → config CacheEventBatch
+        ▼
+  POST /events ─────────▶ EventGate ─▶  ServerConfigRegistry.consume()
+   (config batches)                       one set per (incarnation, revision)
+                                                    │
+L2 adapter / L1 manager publish                     │  capacity
+  l1.* / l2.* on the event bus                      │
+        │                                           │
+        ▼                                           │
+  CacheEventSubscriber (cache_events.md)            │
+        │                                           │
+        ▼                                           │
+  POST /events ─────────────────────▶  EventGate (ingest.md)                │
+                                          └─ CacheEventBroadcaster          │
+                                             ├─ KeyDirectory                │
+                                             ├─ FleetEvictionController     │
+                                             └─ CacheUsageManager  ─────────┤
+                                                  (instance, tier, backend) │
+                                                                    usage   │
+                                                                            ▼
+                                              GET /instances/usage  joins both
+                                              GET /instances/{instance_id}/usage
+```
+
+## The compartment axis
+
+A "module" is a compartment that owns bytes: the L1 pool of one backing
+medium, or one L2 adapter. Identity is `(tier, backend)` — the same axis
+cache events tag placements with, so a declaration and a usage total join
+without translation.
+
+L1 capacity is reported **per medium** because one tier can span several: a
+hybrid Device-DAX tier backs objects with both `devdax` and `dram`, and
+`L1ObjectMeta.backend` tags each placement accordingly. Flattening it to one
+total would leave two compartments of usage sharing one denominator.
+
+## Capacity is the configured size, not the live heap
+
+`get_configured_capacity_bytes()` is the denominator rather than
+`get_memory_usage()[1]`. On the default lazy allocator that total is the
+**currently grown heap**: it starts small and grows on demand, so a freshly
+booted server would report itself nearly full and then appear to drain as the
+pool warms. The configured size is stable from boot and is the only sound
+denominator.
+
+| Manager | `get_memory_usage()[1]` | `get_configured_capacity_bytes()` |
+| --- | --- | --- |
+| `L1MemoryManager` (default, lazy) | grown heap | `{dram: size_in_bytes}` |
+| `GDSL1MemoryManager` | configured slab | `{gds: size_in_bytes}` |
+| `DevDaxL1MemoryManager` | live active arenas | `{devdax: …}` + `{dram: …}` when hybrid |
+
+`L1Manager.report_status()` exposes the same value as
+`memory_configured_bytes` so the status dict and the capacity API cannot
+drift. `memory_total_bytes` keeps its existing meaning for existing consumers.
+
+## Shared pools are counted once
+
+An adapter with `shared=True` is storage several instances mount — one S3
+bucket, one CXL region. Its bytes and its capacity are fleet-scoped. Summing
+them across the N servers that report them would overstate both by N, and the
+result looks plausible, which is worse than an obvious error.
+
+The usage tracker follows the same convention the key directory and the
+per-salt view use: shared placements are keyed under an empty owner
+(`SHARED_OWNER`), so they are counted once and attributed to no instance.
+`GET /instances/usage` reports them under `shared_modules`, never inside an
+instance.
+
+Capacity for a shared pool is resolved across every server that declares it.
+Declarations should agree; when they do not, the pool is reported as
+undeclared rather than picking one, since preferring a value would make the
+reading depend on registration order.
+
+## Unknown is a value
+
+`capacity_bytes == 0` means the server declares no limit. This is the
+**common** case, not an edge case: `fs`, `mooncake`, `p2p`, and `sagemaker`
+return `0` unconditionally with no configuration knob at all.
+
+So `usage_ratio` is `null` — not `0.0`, not `-1.0` — whenever there is no
+capacity to divide by. A number there would be read as a real occupancy, and
+a fleet view that treats capacity-less backends as empty reports "healthy"
+regardless of what is happening.
+
+Ratios above `1.0` are **not clamped**. A tier holding more than its declared
+cap means the declaration disagrees with what the tier admitted, and hiding
+that would hide a misconfiguration.
+
+## Lifecycle
+
+- **Registration** records membership only. Capacity follows on the event
+  stream, so a just-registered server reads as `declared_capacity: false`
+  until its first report lands. A report replaces the set wholesale: a
+  server that dropped an adapter must not keep the old compartment's
+  capacity.
+- **Fencing** discards the instance's **L1** bytes. L1 lives in the reporting
+  process and dies with it; L2 bytes outlive the reporter and leave only
+  through `DELETE`. Three paths reach it: a higher incarnation arriving on
+  the stream (restart), the stale-eviction loop (heartbeat timeout), and
+  `DELETE /instances/{id}` (clean shutdown). That last one used to be
+  missing, so a server that left cleanly kept reporting L1 bytes forever —
+  the eviction loop could never reach it, having already been removed from
+  the registry.
+- **Deregistration** also drops the capacity declaration. A departed server's
+  caps describe a process that no longer exists, and keeping them would grow
+  without bound across a churning fleet. Its surviving L2 bytes are still
+  reported, without a ratio.
+
+The registry is also a `DurableComponent`, like every other event consumer.
+Its section is `server_config` and its type is `CHECKPOINT`: declarations are
+derived from the event stream, and every server redeclares on registration,
+so they are rebuildable. A capture carries each declaration's
+`(incarnation, revision)` stamp with it -- without that, a restored registry
+would start from scratch and accept a straggler from before the capture,
+regressing the topology it had just loaded.
+
+An instance appears in `GET /instances/usage` when it is registered, when it
+holds bytes, or when it has declared capacity — so a deregistered server whose
+L2 placements survive is not silently dropped.
+
+## Scope
+
+Read-only. This never evicts, throttles, or pushes. There is no derived
+pressure level, no smoothing, no trend, and no ranking: while most L2
+backends have no declared capacity, a normalized `LOW`/`HIGH`/`CRITICAL`
+score would be confidently wrong on the majority of deployments. Bytes,
+capacity-where-known, and an explicit unknown are what the data supports
+today.
+
+Named follow-ups: `lmcache describe` should prefer `memory_configured_bytes`
+over `memory_total_bytes` (it currently prints the grown heap as "L1
+capacity"); forwarding `L1_ALLOCATION_FAILED` to the coordinator would give a
+directly-measured pressure signal rather than an inferred ratio; a derived
+level becomes reasonable once capacity declaration is widespread.

--- a/docs/design/v1/mp_coordinator/memory_pressure.md
+++ b/docs/design/v1/mp_coordinator/memory_pressure.md
@@ -1,247 +1,189 @@
-# Fleet Memory Pressure
+# Fleet Memory Usage
 
-A coordinator-level read-only view of how full each MP server's memory
-compartments are. It joins two things the coordinator holds separately: byte
-usage derived from the admitted cache-event stream, and capacity declared by
-each server on that same stream. Neither is a pressure reading on its own.
+How full is each MP server? The coordinator already knows how many bytes a
+tier holds; it does not know how many that tier *can* hold. This adds the
+denominator and joins the two.
 
-Code: `lmcache/v1/mp_coordinator/controllers/usage_manager.py` (usage view),
-`lmcache/v1/mp_coordinator/server_config.py` (capacity registry),
-`lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py` (REST endpoints),
-`lmcache/v1/distributed/storage_manager.py` (MP-server capacity source),
-`lmcache/v1/mp_coordinator/cache_events.py` (MP-server declaration).
+`used / capacity`, per compartment, read-only:
 
-## Why
+    GET /instances/usage                  the whole fleet
+    GET /instances/{instance_id}/usage    one server
 
-The coordinator can already say how many bytes a tier holds. It cannot say
-whether that is a lot, because nothing tells it how many bytes the tier *can*
-hold. Pressure is `used / capacity`, and the cache-event stream carries only
-the numerator.
+Code: `server_config.py` (capacity registry),
+`http_apis/instances_usage_api.py` (endpoints),
+`controllers/usage_manager.py` (usage, pre-existing),
+`cache_events.py` + `distributed/storage_manager.py` (MP-server side).
 
-The usage half needs no new tracking. `CacheUsageManager` already rolls the
-admitted cache-event stream up per `(instance_id, backend)` for both tiers —
-`get_bytes_by_instance(tier)` — which is exactly the axis a pressure reading
-needs. This capability adds only the denominator.
+## Workflow
 
-## How capacity reaches the coordinator
-
-Capacity is a **`config` cache event**, so it travels the one ingest path
-every other event does and the registry is a `CacheEventConsumer` like the
-key directory and the usage manager. One declaration is one `config` batch
-per compartment, all sharing a `capacity_revision`.
-
-`StorageManager` publishes `SM_CAPACITY_CHANGED` on the observability bus and
-the cache-event subscriber ships it on its next flush. It fires:
-
-- **After every successful registration**, via the `on_registered` hook
-  `keep_registered` calls, wired to `publish_capacity()`. This covers the
-  first registration — without which a server that never reconfigures would
-  never declare at all — and, critically, every *re*-registration. The
-  coordinator holds declarations in memory only, so a restarted one has
-  forgotten them; re-registration is the single event that tells a server its
-  declaration may be gone. Nothing else would resend it, and the fleet view
-  would sit at `declared_capacity: false` indefinitely.
-- **On every topology change** — adapter added, removed, or reconfigured.
-
-Registration deliberately carries no capacity in its *body*. One path means
-the coordinator cannot hold a declaration that disagrees with the event
-stream, and it closes a real hole: registration and event reporting are
-separately configurable, so a server registering without event reporting used
-to declare capacity whose usage never arrived, making every compartment read
-as a confident `0.0` instead of unknown.
-
-A declaration is always the **whole topology**, never a delta. That is what
-makes the lossy channel acceptable: a dropped batch is repaired by the next
-declaration, where a dropped byte delta would be permanent. The emitter also
-keeps an unsent declaration across a publish failure.
-
-`(incarnation, capacity_revision)` groups batches into declarations. A newer
-stamp starts a fresh set, an equal one extends it, an older one is dropped.
-
-The revision is assigned by the **cache-event subscriber**, not by
-`StorageManager`. That is deliberate and it is why no lock is involved: the
-bus drains on one thread, so the subscriber's revision counter needs no more
-protection than its `seq` counter already has, and the number cannot come
-apart from the topology it labels. `StorageManager`'s publishers are
-concurrent -- registration publishes from the event loop while a worker may
-be adding an adapter -- so a counter there would need a lock and could still
-tag an older topology with a newer number. Coalescing falls out for free: two
-publishes merged into one flush share one revision instead of burning two.
-**That is what retires a compartment**: a declaration omitting it simply
-never re-adds it, which is how a deleted L2 adapter stops being reported.
-Incarnation fencing and seq dedup come from the gate, so nothing here
-duplicates them.
-
-Two consequences worth knowing:
-
-- `config` batches share the seq space with placements, so the emitter's one
-  counter covers both and a reused seq is dropped as a duplicate.
-- The registry cannot reject a compartment declared twice inside one
-  declaration — it never sees the whole list — so it upserts and the last
-  batch wins. `_build_capacities` derives one entry per medium and adapter,
-  so a correct producer cannot do it.
-
-The batch envelope carries a declaration on `tier`, `backend`, `shared`,
-plus `capacity_bytes` and `capacity_revision`; `entries` is required empty.
-That empty-entries invariant is what makes the other consumers safe: the key
-directory, usage manager, and eviction controller are all entries-driven, so
-a `config` batch is a no-op for each without any of them knowing the type
-exists.
-
-## Why capacity is its own event type
-
-Capacity is configuration: it changes when a server boots and when it is
-reconfigured, not once per cache operation. Reusing `store` would mean
-inventing a placement for something that has no key; emitting it per
-operation would republish an unchanging number thousands of times a second.
-A distinct type emitted on change keeps the volume proportional to what
-actually varies and leaves the placement types untouched.
-
-The cost is two fields on `CacheEventBatch` that only `config` reads, so
-every placement batch carries them as zeros on the wire.
-
-## Architecture
-
-```
-MP server                                   Coordinator
-─────────                                   ───────────
-StorageManager.publish_capacity()
-  L1: get_configured_capacity_bytes(l1_config)
-      → one entry per backing medium
-  L2: per adapter, total_capacity_bytes
-      + shared flag from its config
-        │
-        │  subscriber: ModuleMemoryCapacity → config CacheEventBatch
-        ▼
-  POST /events ─────────▶ EventGate ─▶  ServerConfigRegistry.consume()
-   (config batches)                       one set per (incarnation, revision)
-                                                    │
-L2 adapter / L1 manager publish                     │  capacity
-  l1.* / l2.* on the event bus                      │
-        │                                           │
-        ▼                                           │
-  CacheEventSubscriber (cache_events.md)            │
-        │                                           │
-        ▼                                           │
-  POST /events ─────────────────────▶  EventGate (ingest.md)                │
-                                          └─ CacheEventBroadcaster          │
-                                             ├─ KeyDirectory                │
-                                             ├─ FleetEvictionController     │
-                                             └─ CacheUsageManager  ─────────┤
-                                                  (instance, tier, backend) │
-                                                                    usage   │
-                                                                            ▼
-                                              GET /instances/usage  joins both
-                                              GET /instances/{instance_id}/usage
-```
-
-## The compartment axis
-
-A "module" is a compartment that owns bytes: the L1 pool of one backing
+A **compartment** is one thing that owns bytes: the L1 pool of one backing
 medium, or one L2 adapter. Identity is `(tier, backend)` — the same axis
-cache events tag placements with, so a declaration and a usage total join
-without translation.
+cache events already tag placements with, so the two halves join without
+translation.
 
-L1 capacity is reported **per medium** because one tier can span several: a
-hybrid Device-DAX tier backs objects with both `devdax` and `dram`, and
-`L1ObjectMeta.backend` tags each placement accordingly. Flattening it to one
-total would leave two compartments of usage sharing one denominator.
+**Declaring capacity** (MP server → coordinator):
+
+1. Something changes: the server registers, or an L2 adapter is added,
+   removed, or reconfigured.
+2. `StorageManager.publish_capacity()` builds the topology —
+   `get_configured_capacity_bytes()` for L1 per medium, each adapter's
+   `get_usage().total_capacity_bytes` for L2 — and publishes
+   `SM_CAPACITY_CHANGED` on the observability bus.
+3. `CacheEventSubscriber` turns it into one `config` batch per compartment,
+   all stamped with one `capacity_revision`, and flushes them with whatever
+   placement batches are pending.
+4. `EventGate` admits them like any other batch: incarnation fencing, seq
+   dedup, gap detection.
+5. `ServerConfigRegistry.consume()` groups them by
+   `(incarnation, capacity_revision)`.
+
+**Reporting usage** (unchanged, pre-existing): `l1.*` / `l2.*` events →
+`EventGate` → `CacheUsageManager`, rolled up per `(instance, tier, backend)`.
+
+**Reading**: the endpoint calls `get_bytes_by_instance()` for the numerator
+and `server_config.get_all()` for the denominator, and divides.
+
+```
+MP server                                Coordinator
+─────────                                ───────────
+publish_capacity()
+  L1: per backing medium
+  L2: per adapter + shared flag
+       │
+       │ subscriber: one config batch per compartment
+       ▼
+  POST /events ──────▶ EventGate ──▶ ServerConfigRegistry   capacity
+                                                    │           │
+l1.* / l2.* on the bus                              │           │
+       │                                            │           │
+       ▼                                            │           │
+  POST /events ──────▶ EventGate ──▶ CacheUsageManager     usage │
+                                                    │           │
+                                                    ▼           ▼
+                                          GET /instances/usage
+```
+
+## Why capacity rides the same stream
+
+One path. Registration used to carry it too, and two sources for one fact
+could disagree — worse, registration and event reporting are separately
+configurable, so a server with reporting off used to declare capacity whose
+usage never arrived, making every compartment read a confident `0.0`.
+
+Registration still *triggers* a declaration, through `keep_registered`'s
+`on_registered` hook. The coordinator holds declarations in memory only, so a
+restarted one has forgotten them, and re-registration (via the heartbeat
+`404`) is the only signal a server gets that its declaration may be gone.
+
+`config` is its own event type because capacity is configuration: it changes
+at boot and at reconfiguration, not per operation. It carries no `ObjectKey`,
+so `entries` is required empty — which is exactly what makes it a no-op for
+the other consumers, all of which are entries-driven and need no change.
+
+## Declarations, not deltas
+
+A declaration is always the whole topology. That is what makes a lossy
+channel acceptable: a dropped batch is repaired by the next declaration,
+where a dropped byte delta would be permanent. The emitter also holds an
+unsent declaration across a publish failure.
+
+`(incarnation, capacity_revision)` groups batches: a newer stamp starts a
+fresh set, an equal one extends it, an older one is dropped. **This is what
+retires a compartment** — a declaration that omits it never re-adds it, so a
+deleted L2 adapter stops being reported. Incarnation fencing and seq dedup
+come from the gate; nothing here duplicates them.
+
+The revision is assigned by the subscriber, beside `seq` and for the same
+reason: the bus drains on one thread, so neither counter needs a lock and a
+number cannot come apart from the topology it labels.
+
+Two gotchas:
+
+- `config` batches share the seq space with placements, so one counter covers
+  both and a reused seq is dropped as a duplicate.
+- The registry never sees a whole list, so it cannot reject a compartment
+  declared twice in one declaration. It upserts; the last batch wins.
+  `_build_capacities` emits one entry per medium and adapter, so a correct
+  producer cannot do it.
 
 ## Capacity is the configured size, not the live heap
-
-`get_configured_capacity_bytes()` is the denominator rather than
-`get_memory_usage()[1]`. On the default lazy allocator that total is the
-**currently grown heap**: it starts small and grows on demand, so a freshly
-booted server would report itself nearly full and then appear to drain as the
-pool warms. The configured size is stable from boot and is the only sound
-denominator.
 
 | Manager | `get_memory_usage()[1]` | `get_configured_capacity_bytes()` |
 | --- | --- | --- |
 | `L1MemoryManager` (default, lazy) | grown heap | `{dram: size_in_bytes}` |
 | `GDSL1MemoryManager` | configured slab | `{gds: size_in_bytes}` |
-| `DevDaxL1MemoryManager` | live active arenas | `{devdax: …}` + `{dram: …}` when hybrid |
+| `DevDaxL1MemoryManager` | live arenas | `{devdax: …}` + `{dram: …}` if hybrid |
 
-`L1Manager.report_status()` exposes the same value as
-`memory_configured_bytes` so the status dict and the capacity API cannot
-drift. `memory_total_bytes` keeps its existing meaning for existing consumers.
+The lazy allocator's total is the heap it has grown so far, so a freshly
+booted server would report itself nearly full and appear to drain as the pool
+warms. The configured size is stable from boot.
+
+L1 is declared **per medium** because one tier can span two: a hybrid
+Device-DAX tier backs objects with both `devdax` and `dram`, and each
+placement is tagged accordingly. One total would leave two compartments of
+usage sharing one denominator.
+
+`report_status()` exposes the same number as `memory_configured_bytes`, so
+the status dict and this API cannot drift.
+
+## Unknown is a value
+
+`capacity_bytes == 0` means no declared limit, and this is the **common**
+case: `fs`, `mooncake`, `p2p`, and `sagemaker` have no capacity knob at all.
+
+So `usage_ratio` is `null` — not `0.0`, not `-1.0`. A number there reads as
+real occupancy, and a fleet view that treats capacity-less backends as empty
+reports "healthy" regardless of what is happening.
+
+Ratios above `1.0` are **not clamped**: a tier holding more than its declared
+cap means the declaration is wrong, and hiding that hides a misconfiguration.
 
 ## Shared pools are counted once
 
 An adapter with `shared=True` is storage several instances mount — one S3
-bucket, one CXL region. Its bytes and its capacity are fleet-scoped. Summing
-them across the N servers that report them would overstate both by N, and the
-result looks plausible, which is worse than an obvious error.
+bucket, one CXL region. Summing across the N servers that report it would
+overstate by N, and the result looks plausible, which is worse than an
+obvious error.
 
-The usage tracker follows the same convention the key directory and the
-per-salt view use: shared placements are keyed under an empty owner
-(`SHARED_OWNER`), so they are counted once and attributed to no instance.
-`GET /instances/usage` reports them under `shared_modules`, never inside an
-instance.
-
-Capacity for a shared pool is resolved across every server that declares it.
-Declarations should agree; when they do not, the pool is reported as
-undeclared rather than picking one, since preferring a value would make the
-reading depend on registration order.
-
-## Unknown is a value
-
-`capacity_bytes == 0` means the server declares no limit. This is the
-**common** case, not an edge case: `fs`, `mooncake`, `p2p`, and `sagemaker`
-return `0` unconditionally with no configuration knob at all.
-
-So `usage_ratio` is `null` — not `0.0`, not `-1.0` — whenever there is no
-capacity to divide by. A number there would be read as a real occupancy, and
-a fleet view that treats capacity-less backends as empty reports "healthy"
-regardless of what is happening.
-
-Ratios above `1.0` are **not clamped**. A tier holding more than its declared
-cap means the declaration disagrees with what the tier admitted, and hiding
-that would hide a misconfiguration.
+Shared placements are keyed under an empty owner, the same convention the key
+directory uses, and surface under `shared_modules` rather than inside any
+instance. Capacity is resolved across every declaring server; when they
+disagree the pool reads as undeclared, since preferring one value would make
+the answer depend on registration order.
 
 ## Lifecycle
 
-- **Registration** records membership only. Capacity follows on the event
-  stream, so a just-registered server reads as `declared_capacity: false`
-  until its first report lands. A report replaces the set wholesale: a
-  server that dropped an adapter must not keep the old compartment's
-  capacity.
-- **Fencing** discards the instance's **L1** bytes. L1 lives in the reporting
-  process and dies with it; L2 bytes outlive the reporter and leave only
-  through `DELETE`. Three paths reach it: a higher incarnation arriving on
+- **Registration** records membership. Capacity follows on the stream, so a
+  just-registered server reads `declared_capacity: false` until its first
+  declaration lands.
+- **Fencing** discards the instance's **L1** bytes — L1 lives in the
+  reporting process and dies with it, while L2 outlives its reporter and
+  leaves only through `DELETE`. Three paths reach it: a higher incarnation on
   the stream (restart), the stale-eviction loop (heartbeat timeout), and
-  `DELETE /instances/{id}` (clean shutdown). That last one used to be
-  missing, so a server that left cleanly kept reporting L1 bytes forever —
-  the eviction loop could never reach it, having already been removed from
-  the registry.
-- **Deregistration** also drops the capacity declaration. A departed server's
-  caps describe a process that no longer exists, and keeping them would grow
-  without bound across a churning fleet. Its surviving L2 bytes are still
+  `DELETE /instances/{id}` (clean shutdown).
+- **Deregistration** also drops the declaration, which would otherwise grow
+  without bound across a churning fleet. Surviving L2 bytes are still
   reported, without a ratio.
 
-The registry is also a `DurableComponent`, like every other event consumer.
-Its section is `server_config` and its type is `CHECKPOINT`: declarations are
-derived from the event stream, and every server redeclares on registration,
-so they are rebuildable. A capture carries each declaration's
-`(incarnation, revision)` stamp with it -- without that, a restored registry
-would start from scratch and accept a straggler from before the capture,
-regressing the topology it had just loaded.
+An instance appears in the fleet view when it is registered, holds bytes, *or*
+has declared capacity — so a departed server whose L2 placements survive is
+not silently dropped.
 
-An instance appears in `GET /instances/usage` when it is registered, when it
-holds bytes, or when it has declared capacity — so a deregistered server whose
-L2 placements survive is not silently dropped.
+The registry is a `DurableComponent` (section `server_config`, type
+`CHECKPOINT`) like every other event consumer. A capture carries each
+declaration's stamp with its modules; without it a restored registry would
+accept a straggler from before the capture and regress what it just loaded.
 
 ## Scope
 
-Read-only. This never evicts, throttles, or pushes. There is no derived
-pressure level, no smoothing, no trend, and no ranking: while most L2
-backends have no declared capacity, a normalized `LOW`/`HIGH`/`CRITICAL`
-score would be confidently wrong on the majority of deployments. Bytes,
-capacity-where-known, and an explicit unknown are what the data supports
-today.
+Read-only: never evicts, throttles, or pushes. No derived pressure level, no
+smoothing, no ranking — while most L2 backends declare no capacity, a
+normalized `LOW`/`HIGH`/`CRITICAL` score would be confidently wrong on the
+majority of deployments. Bytes, capacity where known, and an explicit unknown
+are what the data supports.
 
-Named follow-ups: `lmcache describe` should prefer `memory_configured_bytes`
-over `memory_total_bytes` (it currently prints the grown heap as "L1
-capacity"); forwarding `L1_ALLOCATION_FAILED` to the coordinator would give a
-directly-measured pressure signal rather than an inferred ratio; a derived
-level becomes reasonable once capacity declaration is widespread.
+Follow-ups: `lmcache describe` should prefer `memory_configured_bytes` over
+`memory_total_bytes` (it prints the grown heap as "L1 capacity" today);
+forwarding `L1_ALLOCATION_FAILED` would give a measured pressure signal
+rather than an inferred ratio; a derived level becomes reasonable once
+capacity declaration is widespread.

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -194,6 +194,9 @@ The coordinator's HTTP surface (base URL ``http://localhost:9300``) groups into:
   eviction.
 - **Cache control** -- the ``/cache`` group: cache operations dispatched to a
   named server (warm prefetch, pin/unpin, and delete, with more to come).
+- **Fleet memory** -- the ``/instances/usage`` endpoints: how full each
+  server's memory compartments are, joining event-derived usage against the
+  capacity each server declares on the same event stream. Read-only.
 - **CacheBlend fragment lookup** -- ``POST /directory/blend-lookup``: finds
   cached chunk content anywhere inside a query sequence, using the blend index
   derived from the key directory's token bindings. Server-to-coordinator only;
@@ -247,7 +250,6 @@ startup.
      - int
      - Optional (default ``0``). ZMQ message-queue port P2P peers send
        lookup/unlock RPCs to; ``0`` when P2P is disabled.
-
 **Response** (``200 OK``):
 
 .. code-block:: json
@@ -1147,6 +1149,118 @@ sequence returns ``status`` ``"noop"``.
             "force": false
         }'
     # -> {"instance_id": "server-1", "requested": 12, "affected": 24, "skipped": 0, "status": "deleted"}
+
+Fleet memory
+------------
+
+The ``/instances/usage`` endpoints report how full each MP server's memory
+compartments are. A **compartment** is one thing that owns bytes: the L1 pool
+of a backing medium, or one L2 adapter. It is identified by
+``(tier, backend)`` -- the same pair cache events tag placements with.
+
+Two inputs are joined, and both ride the cache-event stream. **Usage** is
+derived from the events the servers already publish. **Capacity** arrives as
+a capacity report on the same stream -- once at startup, then whenever an
+adapter is added, removed, or reconfigured. Both are automatic; there is
+nothing to configure beyond pointing servers at a coordinator and leaving
+event reporting enabled.
+
+.. note::
+
+   Capacity travels on the event stream, so disabling event reporting
+   disables both halves together: every ``usage_ratio`` reads ``null``
+   (*unknown*) rather than a ratio against a stale declaration.
+
+These endpoints are read-only. The coordinator never evicts or throttles based
+on them.
+
+.. note::
+
+   ``usage_ratio`` is ``null`` whenever the server declared no capacity for a
+   compartment, and this is common: the ``fs``, ``mooncake``, ``p2p``, and
+   ``sagemaker`` adapters expose no capacity setting at all, and ``s3`` /
+   ``raw_block`` report one only when you set ``max_capacity_gb`` /
+   ``capacity_bytes``. A ``null`` means *unknown*, never *empty* -- do not
+   treat it as ``0``.
+
+   Ratios above ``1.0`` are reported as-is rather than capped. A compartment
+   holding more than its declared capacity means the declaration is wrong, and
+   that is worth seeing.
+
+``GET /instances/usage``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The whole fleet: every server's compartments, plus the shared pools.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "instances": [
+        {
+          "instance_id": "server-1",
+          "registered": true,
+          "declared_capacity": true,
+          "modules": [
+            {"tier": "l1", "backend": "dram", "shared": false,
+             "used_bytes": 10737418240, "capacity_bytes": 42949672960,
+             "usage_ratio": 0.25},
+            {"tier": "l2", "backend": "fs", "shared": false,
+             "used_bytes": 7516192768, "capacity_bytes": 0,
+             "usage_ratio": null}
+          ]
+        }
+      ],
+      "shared_modules": [
+        {"tier": "l2", "backend": "s3", "shared": true,
+         "used_bytes": 4398046511104, "capacity_bytes": 17592186044416,
+         "usage_ratio": 0.25}
+      ]
+    }
+
+``shared_modules`` holds storage several servers mount -- one S3 bucket, one
+CXL region. These are counted **once for the fleet** and appear in no
+instance's ``modules``. Summing them per mounting server would multiply both
+the bytes and the capacity by the number of mounts.
+
+A server appears when it is registered, when it still holds bytes, or when it
+declared capacity. ``registered: false`` therefore means a departed server
+whose L2 data outlived it; its L1 bytes are dropped when it goes.
+
+**Example:**
+
+.. code-block:: bash
+
+    # Which servers are most heavily loaded?
+    curl -s http://localhost:9300/instances/usage | jq -r '
+      .instances[] | .instance_id as $i | .modules[]
+      | select(.usage_ratio != null)
+      | "\($i) \(.tier)/\(.backend) \((.usage_ratio*100|floor))%"'
+    # -> server-1 l1/dram 25%
+    # -> server-2 l1/dram 81%
+
+``GET /instances/{instance_id}/usage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One server's compartments, in the same shape as an entry of ``instances``
+above.
+
+**HTTP status codes:**
+
+- ``200``: found.
+- ``404``: the coordinator knows nothing about this id -- it is not
+  registered, holds no bytes, and declared no capacity.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:9300/instances/server-1/usage
+
+A server whose L1 pool uses the default lazy allocator grows its heap on
+demand. Capacity here is the **configured** size, not the grown heap, so a
+freshly started server correctly reads near ``0``\% rather than near full.
 
 CacheBlend fragment lookup
 --------------------------

--- a/lmcache/usage_telemetry/messages.py
+++ b/lmcache/usage_telemetry/messages.py
@@ -215,19 +215,19 @@ class MPServerMessage(UsageMessage):
         # load it).
         # First Party
         from lmcache import __version__
+        from lmcache.v1.distributed.config import get_configured_capacity_bytes
         from lmcache.v1.distributed.l2_adapters.config import (
             get_type_name_for_config,
         )
 
         l1_config = storage_manager_config.l1_manager_config
         memory_config = l1_config.memory_config
+        # Shared derivation, so this and the fleet memory view agree. The
+        # medium label stays here: its exact strings are wire format.
+        l1_size_bytes = sum(get_configured_capacity_bytes(l1_config).values())
         if l1_config.gds_l1_config is not None:
-            l1_size_bytes = l1_config.gds_l1_config.size_in_bytes
             l1_medium = "gds"
         else:
-            l1_size_bytes = (
-                memory_config.size_in_bytes + memory_config.devdax_size_in_bytes
-            )
             l1_medium = "dram+devdax" if memory_config.devdax_path else "dram"
         adapter_configs = storage_manager_config.l2_adapter_config.adapters
         l2_adapter_types = ",".join(

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -251,6 +251,43 @@ class EncodedObjectKey:
 
 
 @dataclass(frozen=True)
+class ModuleMemoryCapacity:
+    """One compartment's configured capacity: an L1 medium or an L2 adapter.
+
+    Keyed on the same ``(tier, backend)`` axis cache events use.
+
+    Attributes:
+        tier: ``Tier.L1`` or ``Tier.L2``.
+        backend: Medium within the tier (``"dram"``, ``"devdax"``,
+            ``"gds"``, or an L2 adapter type such as ``"s3"``).
+        capacity_bytes: Configured capacity. ``0`` means undeclared --
+            reported as unknown, not as full.
+        shared: Set when instances mount this pool, so its capacity must
+            not be summed across them.
+    """
+
+    tier: "Tier"
+    backend: str
+    capacity_bytes: int
+    shared: bool = False
+
+
+@dataclass(frozen=True)
+class CapacitySnapshot:
+    """This server's memory capacities at one point in time.
+
+    Carries no revision: the cache-event subscriber numbers declarations as
+    it emits them, on the single event-bus drain thread, so the number and
+    the topology it labels cannot come apart.
+
+    Attributes:
+        modules: One entry per memory compartment.
+    """
+
+    modules: tuple["ModuleMemoryCapacity", ...]
+
+
+@dataclass(frozen=True)
 class KeyEntry:
     """One entry in a :class:`KeyListPage` including the encoded object
     key and its object size."""

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -12,6 +12,7 @@ import os
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import L1BackendType
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
     L2AdaptersConfig,
@@ -209,6 +210,52 @@ class L1ManagerConfig:
 
     read_ttl_seconds: int = field(default=300)
     """ Time to live for each object's read lock. Default is 300s (5 minutes). """
+
+
+def get_configured_capacity_bytes(
+    config: L1ManagerConfig,
+) -> dict[L1BackendType, int]:
+    """Return the configured L1 capacity of each backing medium.
+
+    The single source for "how large is L1". Unlike
+    ``L1Manager.get_memory_usage()``, whose total is the grown heap on the
+    lazy tier, this is stable from boot. Keyed per medium because a hybrid
+    Device-DAX tier spans two, matching how L1 events tag placements.
+    Reports the *configured* topology, so devices added later via
+    ``add_device`` are not counted.
+
+    Expects a **normalized** config: ``normalize_storage_manager_config``
+    back-fills ``devdax_size_in_bytes`` from a matching DAX L2 adapter,
+    without which a hybrid deployment reads as pure Device-DAX. A config
+    from a constructed ``StorageManagerConfig`` satisfies this already.
+
+    Args:
+        config: The L1 manager configuration.
+
+    Returns:
+        Configured bytes per medium, omitting any sized zero.
+    """
+    if config.gds_l1_config is not None:
+        size = config.gds_l1_config.size_in_bytes
+        return {L1BackendType.GDS: size} if size > 0 else {}
+
+    memory_config = config.memory_config
+    if memory_config.devdax_path:
+        # Mirrors DevDaxL1MemoryManager.__init__: an unset devdax size means
+        # the whole tier is Device-DAX, else size_in_bytes is the DRAM half.
+        devdax_size = memory_config.devdax_size_in_bytes or memory_config.size_in_bytes
+        local_size = (
+            memory_config.size_in_bytes if memory_config.devdax_size_in_bytes else 0
+        )
+        capacities: dict[L1BackendType, int] = {}
+        if devdax_size > 0:
+            capacities[L1BackendType.DEVDAX] = devdax_size
+        if local_size > 0:
+            capacities[L1BackendType.DRAM] = local_size
+        return capacities
+
+    size = memory_config.size_in_bytes
+    return {L1BackendType.DRAM: size} if size > 0 else {}
 
 
 @dataclass

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -12,7 +12,7 @@ import threading
 from lmcache.lmcache_native import TTLLock
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.config import L1ManagerConfig
+from lmcache.v1.distributed.config import L1ManagerConfig, get_configured_capacity_bytes
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.internal_api import L1ManagerListener, L1ObjectMeta
 from lmcache.v1.distributed.memory_manager import (
@@ -203,6 +203,11 @@ class L1Manager:
         else:
             self._memory_manager = L1MemoryManager(config.memory_config)
 
+        # Precomputed: it derives from config alone and never changes, and
+        # report_status runs under the global L1 lock on a hot polling path.
+        self._configured_capacity_bytes = sum(
+            get_configured_capacity_bytes(config).values()
+        )
         self._write_ttl_seconds = config.write_ttl_seconds
         self._read_ttl_seconds = config.read_ttl_seconds
 
@@ -867,6 +872,9 @@ class L1Manager:
             if entry.is_temporary:
                 temporary += 1
         used, total = self._memory_manager.get_memory_usage()
+        # ``memory_total_bytes`` is what the allocator currently backs (the
+        # grown heap on the lazy tier); this is the declared size. Summed to
+        # fit this dict's flat shape; ``0`` means undeclared.
         return {
             "is_healthy": self._memory_manager.memcheck(),
             "total_object_count": len(self._objects),
@@ -875,6 +883,7 @@ class L1Manager:
             "temporary_count": temporary,
             "memory_used_bytes": used,
             "memory_total_bytes": total,
+            "memory_configured_bytes": self._configured_capacity_bytes,
             "memory_usage_ratio": used / total if total > 0 else 0.0,
             "write_ttl_seconds": self._write_ttl_seconds,
             "read_ttl_seconds": self._read_ttl_seconds,

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -14,15 +14,22 @@ import time
 from lmcache.lmcache_native import Bitmap, PeriodicEventNotifier
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import (
+    CapacitySnapshot,
     MemoryLayoutDesc,
+    ModuleMemoryCapacity,
     ObjectKey,
     PrefetchHandle,
     PrefetchMode,
     PrefetchRequestSpec,
+    Tier,
     TrimPolicy,
 )
 from lmcache.v1.distributed.bitmap_ops import fold_unfold_ranked
-from lmcache.v1.distributed.config import EvictionConfig, StorageManagerConfig
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    StorageManagerConfig,
+    get_configured_capacity_bytes,
+)
 from lmcache.v1.distributed.error import L1Error, strerror
 from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 from lmcache.v1.distributed.l1_manager import L1Manager
@@ -68,6 +75,9 @@ logger = init_logger(__name__)
 class StorageManager:
     def __init__(self, config: StorageManagerConfig):
         self._l1_manager = L1Manager(config.l1_manager_config)
+        # Retained for the L1 half of the capacity report; L1's configured
+        # size is a pure function of it.
+        self._l1_config = config.l1_manager_config
         self._event_bus = get_event_bus()
 
         # L1 eviction controller
@@ -832,6 +842,52 @@ class StorageManager:
             out_by_type.setdefault(desc.type_name, []).append(usage)
         return out_by_type
 
+    def publish_capacity(self) -> None:
+        """Announce the current capacity topology on the event bus.
+
+        Called after every coordinator registration, so a restarted
+        coordinator relearns this server's capacities even if nothing is
+        ever reconfigured. Later changes announce themselves.
+        """
+        self._publish_capacity_changed()
+
+    def _build_capacities(self) -> list[ModuleMemoryCapacity]:
+        """Assemble one capacity entry per memory compartment.
+
+        Returns:
+            L1 per backing medium, then one entry per L2 adapter.
+        """
+        capacities = [
+            ModuleMemoryCapacity(
+                tier=Tier.L1,
+                backend=backend.value,
+                capacity_bytes=configured,
+                shared=False,
+            )
+            for backend, configured in get_configured_capacity_bytes(
+                self._l1_config
+            ).items()
+        ]
+        for _adapter_id, desc, adapter in self._snapshot_adapters():
+            try:
+                usage = adapter.get_usage()
+            except Exception:
+                logger.exception(
+                    "L2 adapter %s get_usage() failed; omitting from the "
+                    "capacity report",
+                    desc.type_name,
+                )
+                continue
+            capacities.append(
+                ModuleMemoryCapacity(
+                    tier=Tier.L2,
+                    backend=desc.type_name,
+                    capacity_bytes=int(usage.total_capacity_bytes),
+                    shared=bool(desc.config.shared),
+                )
+            )
+        return capacities
+
     def get_l1_usage(self) -> tuple[int, int]:
         """Current occupancy of the L1 memory pool.
 
@@ -902,6 +958,33 @@ class StorageManager:
             if self._unwrap_reconfigurable_l2_adapter(adapter) is not None
         }
 
+    def _publish_capacity_changed(self) -> None:
+        """Announce the current capacity topology on the event bus.
+
+        Lock-free. ``_build_capacities`` guards its own reads
+        (``_snapshot_adapters`` takes ``_adapters_lock``), and ordering is
+        not this class's problem: the cache-event subscriber numbers
+        declarations as it emits them, on the one bus drain thread, so a
+        number cannot come apart from the topology it labels. Callers here
+        are concurrent -- registration publishes from the event loop while a
+        worker may be adding an adapter -- which is exactly why the counter
+        does not live here.
+
+        The event carries the whole topology, not a delta, so a dropped one
+        is repaired by the next rather than leaving the coordinator
+        permanently wrong.
+        """
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.SM_CAPACITY_CHANGED,
+                metadata={
+                    "snapshot": CapacitySnapshot(
+                        modules=tuple(self._build_capacities())
+                    )
+                },
+            )
+        )
+
     def reconfigure_l2_adapter(
         self,
         adapter_index: int,
@@ -921,6 +1004,9 @@ class StorageManager:
         adapter = self._get_reconfigurable_l2_adapter(adapter_index)
         result = adapter.reconfigure(operation, payload)
         result["adapter_index"] = adapter_index
+        # Lock-free: reconfigure did not serialize against adapter
+        # add/delete before, and publishing is no reason to start.
+        self._publish_capacity_changed()
         return result
 
     def add_l2_adapter(self, config: L2AdapterConfigBase) -> int:
@@ -951,6 +1037,7 @@ class StorageManager:
                     )
                 )
             logger.info("Added L2 adapter %d (%s)", adapter_id, descriptor.type_name)
+            self._publish_capacity_changed()
             return adapter_id
 
     def delete_l2_adapter(self, adapter_id: int, timeout: float = 30.0) -> None:
@@ -993,6 +1080,7 @@ class StorageManager:
                 self._adapter_descriptors.pop(adapter_id, None)
             adapter.close()
             logger.info("Deleted L2 adapter %d", adapter_id)
+            self._publish_capacity_changed()
 
     def l2_adapters(self) -> list[tuple[AdapterDescriptor, L2AdapterInterface]]:
         """Return all active L2 adapters paired with descriptors, in

--- a/lmcache/v1/mp_coordinator/api.py
+++ b/lmcache/v1/mp_coordinator/api.py
@@ -30,12 +30,15 @@ class CacheEventType(str, Enum):
 
     ``STORE`` commits placements; ``DELETE`` removes them (owners report
     evictions as deletes); ``ACCESS`` refreshes recency without changing
-    placement state.
+    placement state. ``CONFIG`` carries no placement at all: it declares
+    one compartment's configured capacity, so the fleet view has a
+    denominator for the bytes the other three report.
     """
 
     STORE = "store"
     DELETE = "delete"
     ACCESS = "access"
+    CONFIG = "config"
 
 
 @dataclass(frozen=True)
@@ -114,11 +117,19 @@ class CacheEventBatch:
             for ``store``/``delete`` (it is part of the placement
             identity); empty for ``access``, which only refreshes
             key-level recency and carries no placement identity.
-        entries: The affected keys.
+        entries: The affected keys. Always empty for ``config``, which
+            declares a compartment rather than reporting placements.
         shared: ``True`` when the backend is a storage domain mounted by
             several instances (e.g. one S3 bucket or CXL pool). ``False``
             (default) marks the storage private to this instance.
         ts: Emitter wall-clock seconds for the batch (``0.0`` if unknown).
+        capacity_bytes: ``config`` only. The compartment's configured
+            capacity; ``0`` declares no limit.
+        capacity_revision: ``config`` only. Which declaration this batch
+            belongs to. One declaration spans one batch per compartment,
+            all sharing a revision, so the consumer can tell a fresh
+            declaration from a continuation and drop compartments the new
+            one omits.
     """
 
     instance_id: str
@@ -130,21 +141,33 @@ class CacheEventBatch:
     entries: list[CacheEventEntry] = field(default_factory=list)
     shared: bool = False
     ts: float = 0.0
+    capacity_bytes: int = 0
+    capacity_revision: int = 0
 
     def __post_init__(self) -> None:
         """Enforce intrinsic invariants.
 
         Raises:
             ValueError: If ``instance_id`` is empty, ``backend`` is empty
-                on a placement-bearing batch (``store``/``delete``),
-                ``incarnation`` or ``ts`` is negative, ``seq`` < 1, or
-                ``tier`` is not a concrete tier (``l1``/``l2``).
+                on a placement-bearing batch (``store``/``delete``) or on
+                ``config``, ``incarnation``, ``ts``, ``capacity_bytes`` or
+                ``capacity_revision`` is negative, ``seq`` < 1, ``tier`` is
+                not a concrete tier (``l1``/``l2``), or a ``config`` batch
+                carries entries.
         """
         if not self.instance_id:
             raise ValueError("instance_id must be non-empty")
         if not self.backend and self.event_type != CacheEventType.ACCESS:
             raise ValueError(
                 f"backend must be non-empty for {self.event_type.value} batches"
+            )
+        if self.event_type == CacheEventType.CONFIG and self.entries:
+            raise ValueError("config batches declare capacity and carry no entries")
+        if self.capacity_bytes < 0:
+            raise ValueError(f"capacity_bytes must be >= 0 (got {self.capacity_bytes})")
+        if self.capacity_revision < 0:
+            raise ValueError(
+                f"capacity_revision must be >= 0 (got {self.capacity_revision})"
             )
         if self.incarnation < 0:
             raise ValueError(f"incarnation must be >= 0 (got {self.incarnation})")

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -57,6 +57,7 @@ from lmcache.v1.mp_coordinator.persistence.store import (
     NullArtifactStore,
 )
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
+from lmcache.v1.mp_coordinator.server_config import ServerConfigRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.utils.router_discovery import discover_api_routers
 
@@ -107,6 +108,9 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         trigger_watermark=config.trigger_watermark,
     )
     prefetch_manager = PrefetchManager()
+    # Pressure's denominator; the numerator is usage_manager's per-instance
+    # rollup.
+    server_config = ServerConfigRegistry()
     # Resolves pin requests' token_ids to object keys; must match the fleet's
     # chunk size and hash algorithm (see MPCoordinatorConfig).
     token_hasher = TokenHasher(
@@ -120,6 +124,8 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     # usage view for the same batch, so the usage view must consume first.
     event_broadcaster.register_consumer(usage_manager)
     event_broadcaster.register_consumer(eviction_controller)
+    # Consumes ``config`` batches only, so its position is free.
+    event_broadcaster.register_consumer(server_config)
     # Held by the ingest path; whoever captures durable state takes it
     # to read across the consumers consistently.
     quiesce = QuiesceLock()
@@ -131,6 +137,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         key_directory,
         usage_manager,
         event_gate,
+        server_config,
         *eviction_controller.get_durable_components(),
     ]
     checkpoint_components = [
@@ -154,6 +161,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         key_directory=key_directory,
         event_gate=event_gate,
         metadata_persister=metadata_persister,
+        server_config=server_config,
     )
 
     async def _checkpoint_loop() -> None:

--- a/lmcache/v1/mp_coordinator/cache_events.py
+++ b/lmcache/v1/mp_coordinator/cache_events.py
@@ -22,7 +22,7 @@ import httpx
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.api import L1BackendType, ObjectKey, Tier
+from lmcache.v1.distributed.api import CapacitySnapshot, L1BackendType, ObjectKey, Tier
 from lmcache.v1.distributed.internal_api import L1ObjectMeta
 from lmcache.v1.mp_coordinator.api import (
     UNKNOWN_TOKEN_OFFSET,
@@ -60,7 +60,7 @@ class CacheEventSink(ABC):
         """Deliver ``batches`` to the directory, in list order.
 
         Args:
-            batches: The batches to deliver; never empty.
+            batches: The batches to deliver.
 
         Raises:
             CacheEventPublishError: If delivery failed. Retrying and
@@ -93,7 +93,7 @@ class HttpCacheEventSink(CacheEventSink):
         """Deliver ``batches`` via one ``POST /events`` request.
 
         Args:
-            batches: The batches to deliver; never empty.
+            batches: The batches to deliver.
 
         Raises:
             CacheEventPublishError: If the request failed or returned
@@ -186,6 +186,14 @@ class CacheEventSubscriber(EventSubscriber):
         # Consecutive same-identity entries append to the last pending
         # batch; an identity change starts a new one (order-preserving).
         self._pending_batches: list[_PendingBatch] = []
+        # At most one pending declaration: each is the whole topology, so
+        # a newer one supersedes rather than queues behind an older.
+        self._pending_capacity: CapacitySnapshot | None = None
+        # Numbered here, beside _seq, and for the same reason: the bus
+        # drains on one thread, so neither counter needs a lock, and the
+        # number cannot come apart from the topology it labels. Coalesced
+        # publishes therefore share one revision instead of burning several.
+        self._capacity_revision = 0
         # Chunk hash → token content from token-binding events (published
         # ahead of the write-finished events), used to stamp STORE
         # entries. LRU-bounded; a miss stamps nothing.
@@ -202,6 +210,7 @@ class CacheEventSubscriber(EventSubscriber):
             EventType.L2_KEYS_DELETED: self._on_l2_delete,
             EventType.L2_KEYS_ACCESSED: self._on_l2_access,
             EventType.MP_TOKENS: self._on_tokens,
+            EventType.SM_CAPACITY_CHANGED: self._on_capacity_changed,
             # TODO: decouple the flush tick from the eviction loop (e.g. a
             # bus-owned periodic hook) so cache-event freshness does not
             # silently depend on the eviction loop's cadence.
@@ -213,16 +222,21 @@ class CacheEventSubscriber(EventSubscriber):
 
         Publish failures are logged and the drained list is dropped.
         """
-        if not self._pending_batches:
+        if not self._pending_batches and self._pending_capacity is None:
             return
         pending_batches = self._pending_batches
         self._pending_batches = []
+        capacity = self._pending_capacity
+        self._pending_capacity = None
         ts = time.time()
-        batches = [
+        # Declaration first, so a flush that also carries placements gives
+        # the coordinator its denominator before the bytes it divides.
+        batches = self._capacity_batches(capacity, ts)
+        batches += [
             CacheEventBatch(
                 instance_id=self._instance_id,
                 incarnation=self._incarnation,
-                seq=self._seq + offset + 1,
+                seq=self._seq + len(batches) + offset + 1,
                 event_type=pending.event_type,
                 tier=pending.tier,
                 backend=pending.backend,
@@ -232,16 +246,58 @@ class CacheEventSubscriber(EventSubscriber):
             )
             for offset, pending in enumerate(pending_batches)
         ]
-        self._seq += len(pending_batches)
+        self._seq += len(batches)
         try:
             self._sink.publish(batches)
         except CacheEventPublishError as e:
+            # Placement batches are lost for good, but a declaration is the
+            # whole topology, so restore it for the next flush. A newer one
+            # arriving first just supersedes it.
+            if capacity is not None and self._pending_capacity is None:
+                self._pending_capacity = capacity
             logger.warning(
                 "Dropping %d cache-event batches (instance %s): %s",
                 len(batches),
                 self._instance_id,
                 e,
             )
+
+    def _capacity_batches(
+        self, capacity: "CapacitySnapshot | None", ts: float
+    ) -> list[CacheEventBatch]:
+        """Expand one declaration into a ``config`` batch per compartment.
+
+        Bumps the revision once and stamps every batch of the declaration
+        with it, which is what lets the coordinator tell a fresh declaration
+        from a continuation and retire compartments the new one omits.
+
+        Args:
+            capacity: The declaration to expand, or ``None`` for no
+                declaration this flush.
+            ts: Emitter wall-clock seconds to stamp the batches with.
+
+        Returns:
+            One batch per compartment, seq-numbered from the current
+            cursor; empty when there is nothing to declare.
+        """
+        if capacity is None:
+            return []
+        self._capacity_revision += 1
+        return [
+            CacheEventBatch(
+                instance_id=self._instance_id,
+                incarnation=self._incarnation,
+                seq=self._seq + offset + 1,
+                event_type=CacheEventType.CONFIG,
+                tier=module.tier,
+                backend=module.backend,
+                shared=module.shared,
+                ts=ts,
+                capacity_bytes=module.capacity_bytes,
+                capacity_revision=self._capacity_revision,
+            )
+            for offset, module in enumerate(capacity.modules)
+        ]
 
     def shutdown(self) -> None:
         """Flush buffered events and close the sink. Called by
@@ -250,6 +306,12 @@ class CacheEventSubscriber(EventSubscriber):
         self._sink.close()
 
     # -- Event handlers (bus drain thread) ------------------------------------
+
+    def _on_capacity_changed(self, event: Event) -> None:
+        """Hold the new declaration for the next flush."""
+        snapshot: CapacitySnapshot = event.metadata["snapshot"]
+        self._pending_capacity = snapshot
+        self._flush_if_due()
 
     def _on_tick(self, event: Event) -> None:
         self._flush_if_due()

--- a/lmcache/v1/mp_coordinator/http_apis/dependencies.py
+++ b/lmcache/v1/mp_coordinator/http_apis/dependencies.py
@@ -26,6 +26,7 @@ from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
+from lmcache.v1.mp_coordinator.server_config import ServerConfigRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
 
@@ -50,6 +51,9 @@ class CoordinatorContext:
         metadata_persister: Durable store for operator intent. Every
             handler that changes a pin or a quota must ``save`` so the
             change survives a restart.
+        server_config: Declared module capacities per MP server; the
+            denominator for a usage ratio. Populated by ``config`` cache
+            events.
     """
 
     registry: InstanceRegistry
@@ -60,6 +64,7 @@ class CoordinatorContext:
     key_directory: KeyDirectory
     event_gate: EventGate
     metadata_persister: MetadataPersister
+    server_config: ServerConfigRegistry
 
 
 def get_context(request: Request) -> CoordinatorContext:

--- a/lmcache/v1/mp_coordinator/http_apis/events_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/events_api.py
@@ -28,6 +28,9 @@ async def report_cache_events(
     emission order. Duplicates and stale incarnations are dropped and
     counted, not errors.
 
+    ``config`` batches ride the same path and reach the server-config
+    registry as a consumer, so they inherit the gate's fencing and ordering.
+
     Args:
         body: The event batches to ingest.
 

--- a/lmcache/v1/mp_coordinator/http_apis/instances_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/instances_api.py
@@ -45,11 +45,14 @@ async def register_instance(
         A :class:`RegisterResponse` carrying the (possibly generated) id.
     """
     instance_id = body.instance_id or f"mp-{uuid.uuid4().hex}"
+    ctx = get_context(request)
+    # Capacity is not taken here: it arrives as a report on the cache-event
+    # stream, fenced by (incarnation, revision).
     # Wall-clock registration_time for display; monotonic last_heartbeat_time for
     # NTP-safe stale detection (see registry.stale). register() does the
     # exists-check and write under one lock, so the re_registered flag is correct
     # even under concurrent registrations of the same id.
-    re_registered = get_context(request).registry.register(
+    re_registered = ctx.registry.register(
         MPInstance(
             instance_id=instance_id,
             ip=body.ip,
@@ -91,10 +94,19 @@ async def deregister_instance(instance_id: str, request: Request) -> Response:
     Returns:
         An empty 204 response.
     """
-    if get_context(request).registry.deregister(instance_id) is not None:
+    ctx = get_context(request)
+    if ctx.registry.deregister(instance_id) is not None:
         logger.info("Deregistered instance %s", instance_id)
     else:
         logger.info("Instance %s not registered, skipping deregistration", instance_id)
+    # A departing process takes its L1 pool with it, so its reported L1
+    # bytes are void. Only the stale-eviction loop fenced them before, and
+    # it never sees an instance that left cleanly -- deregistration already
+    # removed it from the registry, so its bytes lingered for good.
+    ctx.event_gate.drop_instance(instance_id)
+    # Dropped with the membership, or declarations grow without bound
+    # across a churning fleet. Surviving L2 bytes lose their ratio.
+    ctx.server_config.forget(instance_id)
     return Response(status_code=204)
 
 

--- a/lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Memory-usage endpoints for the ``/instances`` collection.
+
+Joins bytes used (``CacheUsageManager``) against capacity declared
+(``ServerConfigRegistry``). Read-only: never evicts, throttles, or pushes.
+A ``null`` ratio means capacity is undeclared, not that the compartment is
+empty.
+
+``GET /instances/usage`` is a literal path under a collection that also
+takes ``{instance_id}`` segments. Routers are discovered alphabetically, so
+``instances_api`` registers first -- harmless while it declares no
+``GET /instances/{instance_id}``, and guarded by a test that would fail if
+one ever shadowed this route.
+"""
+
+# Third Party
+from fastapi import APIRouter, HTTPException, Request, status
+
+# First Party
+from lmcache.v1.distributed.api import Tier
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
+from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
+from lmcache.v1.mp_coordinator.schemas import (
+    FleetMemoryResponse,
+    InstanceMemoryStatus,
+    ModuleMemoryStatus,
+)
+from lmcache.v1.mp_coordinator.server_config import UNDECLARED_CAPACITY, ModuleCapacity
+
+router = APIRouter()
+
+# ``CacheUsageManager`` keys fleet-shared pools under this instance id.
+# Their bytes belong to the fleet: counted once, never per mount.
+_SHARED_OWNER = ""
+
+_TIERS = (Tier.L1, Tier.L2)
+
+
+def _usage_by_owner(
+    usage_manager: CacheUsageManager,
+) -> dict[str, dict[tuple[Tier, str], int]]:
+    """Collect used bytes per owner across both tiers.
+
+    Returns:
+        ``instance_id`` -> ``(tier, backend)`` -> bytes. Shared pools appear
+        under :data:`_SHARED_OWNER`.
+    """
+    by_owner: dict[str, dict[tuple[Tier, str], int]] = {}
+    for tier in _TIERS:
+        for owner, backends in usage_manager.get_bytes_by_instance(tier).items():
+            for backend, used in backends.items():
+                by_owner.setdefault(owner, {})[(tier, backend)] = used
+    return by_owner
+
+
+def _to_status(
+    tier: Tier, backend: str, used_bytes: int, capacity_bytes: int, shared: bool
+) -> ModuleMemoryStatus:
+    """Join one compartment's usage to its declared capacity.
+
+    Returns:
+        The joined status. ``usage_ratio`` is ``None`` when there is no
+        capacity to divide by.
+    """
+    return ModuleMemoryStatus(
+        tier=tier,
+        backend=backend,
+        shared=shared,
+        used_bytes=used_bytes,
+        capacity_bytes=capacity_bytes,
+        usage_ratio=(
+            used_bytes / capacity_bytes
+            if capacity_bytes > UNDECLARED_CAPACITY
+            else None
+        ),
+    )
+
+
+def _instance_status(
+    instance_id: str,
+    used: dict[tuple[Tier, str], int],
+    declared: tuple[ModuleCapacity, ...],
+    registered: bool,
+) -> InstanceMemoryStatus:
+    """Build one server's status from its usage and its declaration.
+
+    Declared-but-empty compartments report ``used_bytes=0``, so a freshly
+    started server does not look unmonitored.
+
+    Returns:
+        The assembled status, compartments sorted by ``(tier, backend)``.
+    """
+    capacities = {(m.tier, m.backend): m.capacity_bytes for m in declared}
+    statuses = [
+        _to_status(
+            tier,
+            backend,
+            used_bytes,
+            capacities.get((tier, backend), UNDECLARED_CAPACITY),
+            shared=False,
+        )
+        for (tier, backend), used_bytes in used.items()
+    ]
+    for module in declared:
+        if module.shared or (module.tier, module.backend) in used:
+            continue
+        statuses.append(
+            _to_status(
+                module.tier, module.backend, 0, module.capacity_bytes, shared=False
+            )
+        )
+    statuses.sort(key=lambda m: (m.tier.value, m.backend))
+    return InstanceMemoryStatus(
+        instance_id=instance_id,
+        registered=registered,
+        declared_capacity=bool(declared),
+        modules=statuses,
+    )
+
+
+def _shared_capacities(
+    declarations: dict[str, tuple[ModuleCapacity, ...]],
+) -> dict[tuple[Tier, str], int]:
+    """Resolve each shared pool's capacity across its declaring servers.
+
+    One pool is one store, so declarations should agree. Disagreement reads
+    as undeclared -- picking one would make the answer depend on
+    registration order.
+
+    Returns:
+        ``(tier, backend)`` -> agreed capacity, else
+        :data:`UNDECLARED_CAPACITY`.
+    """
+    claims: dict[tuple[Tier, str], set[int]] = {}
+    for modules in declarations.values():
+        for module in modules:
+            if module.shared:
+                claims.setdefault((module.tier, module.backend), set()).add(
+                    module.capacity_bytes
+                )
+    return {
+        identity: values.pop() if len(values) == 1 else UNDECLARED_CAPACITY
+        for identity, values in claims.items()
+    }
+
+
+@router.get("/instances/usage")
+async def fleet_usage(request: Request) -> FleetMemoryResponse:
+    """Return the memory status of every MP server and shared pool.
+
+    Args:
+        request: Carries the coordinator context.
+
+    Returns:
+        A :class:`FleetMemoryResponse`. A server appears if it is
+        registered, still holds bytes, or declared capacity -- so one that
+        deregistered with L2 placements surviving is not dropped.
+    """
+    ctx = get_context(request)
+    declarations = ctx.server_config.get_all()
+    registered = {instance.instance_id for instance in ctx.registry.all_instances()}
+    by_owner = _usage_by_owner(ctx.usage_manager)
+    owned = {owner for owner in by_owner if owner != _SHARED_OWNER}
+
+    instances = [
+        _instance_status(
+            instance_id=instance_id,
+            used=by_owner.get(instance_id, {}),
+            declared=declarations.get(instance_id, ()),
+            registered=instance_id in registered,
+        )
+        for instance_id in sorted(registered | owned | set(declarations))
+    ]
+
+    shared_caps = _shared_capacities(declarations)
+    shared = sorted(
+        (
+            _to_status(
+                tier,
+                backend,
+                used_bytes,
+                shared_caps.get((tier, backend), UNDECLARED_CAPACITY),
+                shared=True,
+            )
+            for (tier, backend), used_bytes in by_owner.get(_SHARED_OWNER, {}).items()
+        ),
+        key=lambda m: (m.tier.value, m.backend),
+    )
+    return FleetMemoryResponse(instances=instances, shared_modules=shared)
+
+
+@router.get("/instances/{instance_id}/usage")
+async def instance_usage(instance_id: str, request: Request) -> InstanceMemoryStatus:
+    """Return one MP server's memory status.
+
+    Args:
+        instance_id: The server to report on.
+        request: Carries the coordinator context.
+
+    Returns:
+        That server's :class:`InstanceMemoryStatus`.
+
+    Raises:
+        HTTPException: 404 when the id is unknown -- not registered, holding
+            no bytes, and having declared nothing.
+    """
+    ctx = get_context(request)
+    declared = ctx.server_config.get(instance_id)
+    used = _usage_by_owner(ctx.usage_manager).get(instance_id, {})
+    registered = ctx.registry.contains(instance_id)
+    if not registered and not declared and not used:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"unknown instance {instance_id!r}",
+        )
+    return _instance_status(
+        instance_id=instance_id,
+        used=used,
+        declared=declared,
+        registered=registered,
+    )

--- a/lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py
@@ -17,7 +17,7 @@ one ever shadowed this route.
 from fastapi import APIRouter, HTTPException, Request, status
 
 # First Party
-from lmcache.v1.distributed.api import Tier
+from lmcache.v1.distributed.api import ModuleMemoryCapacity, Tier
 from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
 from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
 from lmcache.v1.mp_coordinator.schemas import (
@@ -25,7 +25,7 @@ from lmcache.v1.mp_coordinator.schemas import (
     InstanceMemoryStatus,
     ModuleMemoryStatus,
 )
-from lmcache.v1.mp_coordinator.server_config import UNDECLARED_CAPACITY, ModuleCapacity
+from lmcache.v1.mp_coordinator.server_config import UNDECLARED_CAPACITY
 
 router = APIRouter()
 
@@ -79,7 +79,7 @@ def _to_status(
 def _instance_status(
     instance_id: str,
     used: dict[tuple[Tier, str], int],
-    declared: tuple[ModuleCapacity, ...],
+    declared: tuple[ModuleMemoryCapacity, ...],
     registered: bool,
 ) -> InstanceMemoryStatus:
     """Build one server's status from its usage and its declaration.
@@ -119,7 +119,7 @@ def _instance_status(
 
 
 def _shared_capacities(
-    declarations: dict[str, tuple[ModuleCapacity, ...]],
+    declarations: dict[str, tuple[ModuleMemoryCapacity, ...]],
 ) -> dict[tuple[Tier, str], int]:
     """Resolve each shared pool's capacity across its declaring servers.
 

--- a/lmcache/v1/mp_coordinator/registrar.py
+++ b/lmcache/v1/mp_coordinator/registrar.py
@@ -29,10 +29,6 @@ from lmcache.v1.rpc_utils import get_ip
 logger = init_logger(__name__)
 
 
-def _do_nothing() -> None:
-    """Default :func:`keep_registered` post-registration hook."""
-
-
 _DEFAULT_HEARTBEAT_INTERVAL = 5.0
 
 
@@ -90,7 +86,7 @@ async def keep_registered(
     heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL,
     p2p_advertised_url: str = "",
     mq_port: int = 0,
-    on_registered: Callable[[], None] = _do_nothing,
+    on_registered: Callable[[], None],
 ) -> None:
     """Register, heartbeat on a timer, and deregister on cancellation.
 
@@ -115,10 +111,10 @@ async def keep_registered(
         mq_port: Port of this server's ZMQ message-queue server for P2P lookup
             RPCs. 0 when P2P is disabled.
         on_registered: Called after every successful registration, including
-            a re-registration. Republishes anything the coordinator keeps
-            only in memory -- capacity declarations above all, which a
-            restarted coordinator has forgotten and no topology change would
-            otherwise resend.
+            a re-registration. Required, not defaulted: the coordinator keeps
+            some state only in memory -- capacity declarations above all --
+            and a caller that republishes nothing has to say so. Pass
+            ``lambda: None`` to mean it.
     """
     base_url = coordinator_url.rstrip("/")
     ip = advertise_ip or get_ip()

--- a/lmcache/v1/mp_coordinator/registrar.py
+++ b/lmcache/v1/mp_coordinator/registrar.py
@@ -13,6 +13,7 @@ logged and retried, and it never takes the MP server down.
 """
 
 # Standard
+from collections.abc import Callable
 import asyncio
 import contextlib
 
@@ -26,6 +27,11 @@ from lmcache.v1.mp_coordinator.schemas import RegisterRequest, RegisterResponse
 from lmcache.v1.rpc_utils import get_ip
 
 logger = init_logger(__name__)
+
+
+def _do_nothing() -> None:
+    """Default :func:`keep_registered` post-registration hook."""
+
 
 _DEFAULT_HEARTBEAT_INTERVAL = 5.0
 
@@ -67,7 +73,9 @@ async def register(
         p2p_advertised_url=p2p_advertised_url,
         mq_port=mq_port,
     )
-    response = await client.post(f"{base_url}/instances", json=body.model_dump())
+    response = await client.post(
+        f"{base_url}/instances", json=body.model_dump(mode="json")
+    )
     response.raise_for_status()
     return RegisterResponse.model_validate(response.json()).instance_id
 
@@ -82,6 +90,7 @@ async def keep_registered(
     heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL,
     p2p_advertised_url: str = "",
     mq_port: int = 0,
+    on_registered: Callable[[], None] = _do_nothing,
 ) -> None:
     """Register, heartbeat on a timer, and deregister on cancellation.
 
@@ -105,6 +114,11 @@ async def keep_registered(
             when P2P is disabled.
         mq_port: Port of this server's ZMQ message-queue server for P2P lookup
             RPCs. 0 when P2P is disabled.
+        on_registered: Called after every successful registration, including
+            a re-registration. Republishes anything the coordinator keeps
+            only in memory -- capacity declarations above all, which a
+            restarted coordinator has forgotten and no topology change would
+            otherwise resend.
     """
     base_url = coordinator_url.rstrip("/")
     ip = advertise_ip or get_ip()
@@ -123,6 +137,7 @@ async def keep_registered(
                         mq_port=mq_port,
                     )
                     logger.info("Registered with coordinator as %s", assigned_id)
+                    on_registered()
                 else:
                     response = await client.put(
                         f"{base_url}/instances/{assigned_id}/heartbeat"

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -215,6 +215,68 @@ class StatusListResponse(BaseModel):
     by_cache_salt: list[StatusResponse]
 
 
+# -- Memory pressure ---------------------------------------------------------
+
+
+class ModuleMemoryStatus(BaseModel):
+    """Usage joined to declared capacity for one memory compartment.
+
+    Attributes:
+        tier: ``l1`` or ``l2``.
+        backend: Storage backend within the tier.
+        shared: Set for a fleet-shared pool, whose bytes are counted once
+            for the fleet, not once per mounting instance.
+        used_bytes: Bytes held, from the admitted cache-event stream.
+        capacity_bytes: Declared capacity, or ``0`` if none was declared.
+        usage_ratio: ``used_bytes / capacity_bytes``, or ``None`` when no
+            capacity was declared -- ``None`` rather than a sentinel, which
+            would read as real occupancy. Values above ``1.0`` are not
+            clamped: they mean the declared cap disagrees with what the
+            tier admitted.
+    """
+
+    tier: Tier
+    backend: str
+    shared: bool
+    used_bytes: int
+    capacity_bytes: int
+    usage_ratio: float | None = None
+
+
+class InstanceMemoryStatus(BaseModel):
+    """One MP server's memory compartments.
+
+    Attributes:
+        instance_id: The server this describes.
+        registered: Whether it is currently in the instance registry. A
+            deregistered server can still hold L2 bytes, so ``False`` is
+            valid.
+        declared_capacity: Whether any capacity was declared. When
+            ``False``, every module's ``usage_ratio`` is ``None``.
+        modules: Privately-owned compartments, sorted by tier then backend.
+            Shared pools are reported at the fleet level instead.
+    """
+
+    instance_id: str
+    registered: bool
+    declared_capacity: bool
+    modules: list[ModuleMemoryStatus] = Field(default_factory=list)
+
+
+class FleetMemoryResponse(BaseModel):
+    """Fleet-wide memory view: every server plus the shared pools.
+
+    Attributes:
+        instances: Per-server status, sorted by ``instance_id``.
+        shared_modules: Fleet-shared compartments, counted once. Capacity is
+            reported only when every declaring server agrees; a disagreement
+            reads as undeclared.
+    """
+
+    instances: list[InstanceMemoryStatus] = Field(default_factory=list)
+    shared_modules: list[ModuleMemoryStatus] = Field(default_factory=list)
+
+
 # -- Key directory -----------------------------------------------------------
 
 
@@ -223,6 +285,8 @@ class CacheEventsRequest(BaseModel):
 
     Attributes:
         batches: Event batches to apply, in emission order per instance.
+            Includes ``config`` batches, which declare capacity rather than
+            report placements.
     """
 
     batches: list[CacheEventBatch] = Field(default_factory=list)

--- a/lmcache/v1/mp_coordinator/server_config.py
+++ b/lmcache/v1/mp_coordinator/server_config.py
@@ -8,6 +8,9 @@ like the key directory and the usage manager, so declarations arrive through
 the same gate -- inheriting its incarnation fencing, dedup, and ordering
 instead of carrying a second mechanism alongside.
 
+Compartments are :class:`ModuleMemoryCapacity`, the same type the MP server
+builds them as -- one shape for one concept on both sides of the wire.
+
 One declaration is one ``config`` batch per compartment, all sharing a
 ``capacity_revision``. A batch whose revision is newer than what is stored
 starts a fresh set; batches at the same revision extend it. That is what
@@ -19,13 +22,12 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Mapping
-from dataclasses import dataclass
 from typing import cast
 import threading
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.api import Tier
+from lmcache.v1.distributed.api import ModuleMemoryCapacity, Tier
 from lmcache.v1.mp_coordinator.api import CacheEventBatch, CacheEventType
 from lmcache.v1.mp_coordinator.persistence.durable_component import PersistenceType
 
@@ -34,43 +36,6 @@ logger = init_logger(__name__)
 # "No cap declared". Real caps are positive, so an unlimited adapter
 # reporting 0 would otherwise read as permanently full.
 UNDECLARED_CAPACITY = 0
-
-
-@dataclass(frozen=True)
-class ModuleCapacity:
-    """One compartment's declared capacity: the L1 pool or one L2 adapter.
-
-    Keyed on the same ``(tier, backend)`` axis cache events use.
-
-    Attributes:
-        tier: ``L1`` or ``L2``; never ``ALL``.
-        backend: Backend within the tier (``"dram"``, ``"fs"``, ...).
-            Non-empty.
-        capacity_bytes: Declared bytes, or :data:`UNDECLARED_CAPACITY`.
-        shared: Set when instances mount one storage domain (an S3 bucket,
-            a CXL pool). Count once for the fleet, never per mount.
-    """
-
-    tier: Tier
-    backend: str
-    capacity_bytes: int
-    shared: bool = False
-
-    def __post_init__(self) -> None:
-        """Validate the declaration.
-
-        Raises:
-            ValueError: If ``backend`` is empty, ``capacity_bytes`` is
-                negative, or ``tier`` is not concrete.
-        """
-        if not self.backend:
-            raise ValueError("backend must be non-empty")
-        if self.capacity_bytes < 0:
-            raise ValueError(f"capacity_bytes must be >= 0 (got {self.capacity_bytes})")
-        if self.tier not in (Tier.L1, Tier.L2):
-            raise ValueError(
-                f"capacity must target a concrete tier (got {self.tier.value!r})"
-            )
 
 
 class ServerConfigRegistry:
@@ -90,7 +55,7 @@ class ServerConfigRegistry:
         # genuinely races :meth:`consume`. Unsynchronized, it would iterate
         # ``_stamps`` while ``consume`` reassigns ``_by_instance``.
         self._lock = threading.Lock()
-        self._by_instance: dict[str, dict[tuple[Tier, str], ModuleCapacity]] = {}
+        self._by_instance: dict[str, dict[tuple[Tier, str], ModuleMemoryCapacity]] = {}
         self._stamps: dict[str, tuple[int, int]] = {}
 
     def consume(self, batch: CacheEventBatch) -> None:
@@ -106,7 +71,7 @@ class ServerConfigRegistry:
         """
         if batch.event_type != CacheEventType.CONFIG:
             return
-        module = ModuleCapacity(
+        module = ModuleMemoryCapacity(
             tier=batch.tier,
             backend=batch.backend,
             capacity_bytes=batch.capacity_bytes,
@@ -135,7 +100,7 @@ class ServerConfigRegistry:
             instance_id: The instance whose reported L1 state is void.
         """
 
-    def get(self, instance_id: str) -> tuple[ModuleCapacity, ...]:
+    def get(self, instance_id: str) -> tuple[ModuleMemoryCapacity, ...]:
         """Return ``instance_id``'s declared compartments.
 
         Args:
@@ -147,7 +112,7 @@ class ServerConfigRegistry:
         with self._lock:
             return tuple(self._by_instance.get(instance_id, {}).values())
 
-    def get_all(self) -> dict[str, tuple[ModuleCapacity, ...]]:
+    def get_all(self) -> dict[str, tuple[ModuleMemoryCapacity, ...]]:
         """Return a snapshot of every server's declarations.
 
         Returns:
@@ -238,7 +203,7 @@ class ServerConfigRegistry:
             for instance_id, incarnation, revision, modules in declarations:
                 self._stamps[instance_id] = (incarnation, revision)
                 self._by_instance[instance_id] = {
-                    (Tier(tier_value), backend): ModuleCapacity(
+                    (Tier(tier_value), backend): ModuleMemoryCapacity(
                         tier=Tier(tier_value),
                         backend=backend,
                         capacity_bytes=capacity_bytes,

--- a/lmcache/v1/mp_coordinator/server_config.py
+++ b/lmcache/v1/mp_coordinator/server_config.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-MP-server memory capacity, declared by ``config`` cache events.
+
+Cache events report bytes held, never bytes holdable, so servers declare
+capacity separately and this registry stores it. It is a
+:class:`~lmcache.v1.mp_coordinator.ingest.event_broadcaster.CacheEventConsumer`
+like the key directory and the usage manager, so declarations arrive through
+the same gate -- inheriting its incarnation fencing, dedup, and ordering
+instead of carrying a second mechanism alongside.
+
+One declaration is one ``config`` batch per compartment, all sharing a
+``capacity_revision``. A batch whose revision is newer than what is stored
+starts a fresh set; batches at the same revision extend it. That is what
+retires a compartment: a declaration that omits it simply never adds it.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import Tier
+from lmcache.v1.mp_coordinator.api import CacheEventBatch, CacheEventType
+from lmcache.v1.mp_coordinator.persistence.durable_component import PersistenceType
+
+logger = init_logger(__name__)
+
+# "No cap declared". Real caps are positive, so an unlimited adapter
+# reporting 0 would otherwise read as permanently full.
+UNDECLARED_CAPACITY = 0
+
+
+@dataclass(frozen=True)
+class ModuleCapacity:
+    """One compartment's declared capacity: the L1 pool or one L2 adapter.
+
+    Keyed on the same ``(tier, backend)`` axis cache events use.
+
+    Attributes:
+        tier: ``L1`` or ``L2``; never ``ALL``.
+        backend: Backend within the tier (``"dram"``, ``"fs"``, ...).
+            Non-empty.
+        capacity_bytes: Declared bytes, or :data:`UNDECLARED_CAPACITY`.
+        shared: Set when instances mount one storage domain (an S3 bucket,
+            a CXL pool). Count once for the fleet, never per mount.
+    """
+
+    tier: Tier
+    backend: str
+    capacity_bytes: int
+    shared: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate the declaration.
+
+        Raises:
+            ValueError: If ``backend`` is empty, ``capacity_bytes`` is
+                negative, or ``tier`` is not concrete.
+        """
+        if not self.backend:
+            raise ValueError("backend must be non-empty")
+        if self.capacity_bytes < 0:
+            raise ValueError(f"capacity_bytes must be >= 0 (got {self.capacity_bytes})")
+        if self.tier not in (Tier.L1, Tier.L2):
+            raise ValueError(
+                f"capacity must target a concrete tier (got {self.tier.value!r})"
+            )
+
+
+class ServerConfigRegistry:
+    """Thread-safe store of each MP server's declared capacities.
+
+    A :class:`CacheEventConsumer`: :meth:`consume` accumulates ``config``
+    batches into one declaration per ``(incarnation, capacity_revision)``,
+    so a compartment the newest declaration omits stops being reported.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty registry."""
+        # Every HTTP caller is an async handler on one event loop, so the
+        # lock is not for them. It is for :meth:`capture`: a quiesced
+        # capture blocks on a condition variable waiting for the in-flight
+        # batch, which only works off the ingest thread -- so a capture
+        # genuinely races :meth:`consume`. Unsynchronized, it would iterate
+        # ``_stamps`` while ``consume`` reassigns ``_by_instance``.
+        self._lock = threading.Lock()
+        self._by_instance: dict[str, dict[tuple[Tier, str], ModuleCapacity]] = {}
+        self._stamps: dict[str, tuple[int, int]] = {}
+
+    def consume(self, batch: CacheEventBatch) -> None:
+        """Apply one ``config`` batch; ignore every other event type.
+
+        The gate has already dropped stale incarnations and duplicates, so
+        the only ordering left to do is grouping batches into declarations:
+        a newer ``(incarnation, capacity_revision)`` starts a fresh set, an
+        equal one extends it, an older one is a straggler and is dropped.
+
+        Args:
+            batch: A gate-admitted batch. Non-``config`` batches no-op.
+        """
+        if batch.event_type != CacheEventType.CONFIG:
+            return
+        module = ModuleCapacity(
+            tier=batch.tier,
+            backend=batch.backend,
+            capacity_bytes=batch.capacity_bytes,
+            shared=batch.shared,
+        )
+        stamp = (batch.incarnation, batch.capacity_revision)
+        with self._lock:
+            stored = self._stamps.get(batch.instance_id, (-1, -1))
+            if stamp < stored:
+                return
+            if stamp > stored:
+                # A new declaration: drop the previous set so compartments
+                # it no longer lists stop being reported.
+                self._by_instance[batch.instance_id] = {}
+                self._stamps[batch.instance_id] = stamp
+            self._by_instance[batch.instance_id][(module.tier, module.backend)] = module
+
+    def fence_instance(self, instance_id: str) -> None:
+        """No-op: capacity is configuration, not reported L1 state.
+
+        A restarting process redeclares under a higher incarnation, which
+        :meth:`consume` supersedes on its own. A departing one has its
+        declaration dropped by :meth:`forget`.
+
+        Args:
+            instance_id: The instance whose reported L1 state is void.
+        """
+
+    def get(self, instance_id: str) -> tuple[ModuleCapacity, ...]:
+        """Return ``instance_id``'s declared compartments.
+
+        Args:
+            instance_id: The server to look up.
+
+        Returns:
+            Its declarations; empty when unknown or nothing was declared.
+        """
+        with self._lock:
+            return tuple(self._by_instance.get(instance_id, {}).values())
+
+    def get_all(self) -> dict[str, tuple[ModuleCapacity, ...]]:
+        """Return a snapshot of every server's declarations.
+
+        Returns:
+            A copy mapping ``instance_id`` to its compartments.
+        """
+        with self._lock:
+            return {
+                instance_id: tuple(modules.values())
+                for instance_id, modules in self._by_instance.items()
+            }
+
+    def forget(self, instance_id: str) -> None:
+        """Drop ``instance_id``'s declaration. Idempotent.
+
+        Args:
+            instance_id: The departed server.
+        """
+        with self._lock:
+            self._by_instance.pop(instance_id, None)
+            self._stamps.pop(instance_id, None)
+
+    @property
+    def name(self) -> str:
+        """Name of the capacity registry's section in a checkpoint."""
+        return "server_config"
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        """Declarations come off the cache-event stream and every server
+        redeclares on registration, so they are checkpoint state."""
+        return PersistenceType.CHECKPOINT
+
+    def capture(self) -> Mapping[str, object]:
+        """Return each server's declaration with the stamp that ordered it.
+
+        The stamp travels with the modules. Without it a restored registry
+        would start from scratch and accept a straggler from before the
+        capture, regressing the topology it just loaded.
+
+        Returns:
+            ``{"declarations": [(instance_id, incarnation, revision,
+            [(tier, backend, capacity_bytes, shared), ...]), ...]}``.
+        """
+        with self._lock:
+            return {
+                "declarations": [
+                    (
+                        instance_id,
+                        incarnation,
+                        revision,
+                        [
+                            (
+                                module.tier.value,
+                                module.backend,
+                                module.capacity_bytes,
+                                module.shared,
+                            )
+                            for module in self._by_instance.get(
+                                instance_id, {}
+                            ).values()
+                        ],
+                    )
+                    for instance_id, (incarnation, revision) in self._stamps.items()
+                ]
+            }
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        """Load captured declarations and the stamps that ordered them.
+
+        Call once at startup.
+
+        Args:
+            state: A :meth:`capture` value.
+
+        Raises:
+            ValueError: If any declaration is already held.
+        """
+        declarations = cast(
+            "list[tuple[str, int, int, list[tuple[str, str, int, bool]]]]",
+            state["declarations"],
+        )
+        with self._lock:
+            if self._by_instance or self._stamps:
+                raise ValueError(
+                    "restore() requires an empty registry (holds "
+                    f"{len(self._by_instance)} declarations)"
+                )
+            for instance_id, incarnation, revision, modules in declarations:
+                self._stamps[instance_id] = (incarnation, revision)
+                self._by_instance[instance_id] = {
+                    (Tier(tier_value), backend): ModuleCapacity(
+                        tier=Tier(tier_value),
+                        backend=backend,
+                        capacity_bytes=capacity_bytes,
+                        shared=shared,
+                    )
+                    for tier_value, backend, capacity_bytes, shared in modules
+                }

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -57,6 +57,9 @@ class EventType(Enum):
     L2_KEYS_EVICTED = "l2.keys.evicted"
 
     # L2 adapter key-level events.
+    # Capacity topology changed (adapter added/removed/reconfigured).
+    SM_CAPACITY_CHANGED = "sm.capacity.changed"
+
     L2_KEYS_STORED = "l2.keys.stored"
     L2_KEYS_ACCESSED = "l2.keys.accessed"
     L2_KEYS_DELETED = "l2.keys.deleted"

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -138,6 +138,13 @@ async def lifespan(app: FastAPI):
                 heartbeat_interval=coordinator_config.heartbeat_interval,
                 p2p_advertised_url=mp_config.p2p_config.advertise_url,
                 mq_port=mp_config.port if mp_config.p2p_config.enabled else 0,
+                # Declare capacity after every registration. The coordinator
+                # holds declarations in memory only, so a restarted one has
+                # forgotten ours and no topology change would resend it.
+                # Safe to run on the first registration too: the task body
+                # does not start until this lifespan awaits, by which point
+                # the subscriber below is registered to carry the event.
+                on_registered=engine.storage_manager.publish_capacity,
             )
         )
     # Optionally report cache events to the coordinator

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -138,12 +138,6 @@ async def lifespan(app: FastAPI):
                 heartbeat_interval=coordinator_config.heartbeat_interval,
                 p2p_advertised_url=mp_config.p2p_config.advertise_url,
                 mq_port=mp_config.port if mp_config.p2p_config.enabled else 0,
-                # Declare capacity after every registration. The coordinator
-                # holds declarations in memory only, so a restarted one has
-                # forgotten ours and no topology change would resend it.
-                # Safe to run on the first registration too: the task body
-                # does not start until this lifespan awaits, by which point
-                # the subscriber below is registered to carry the event.
                 on_registered=engine.storage_manager.publish_capacity,
             )
         )

--- a/tests/v1/distributed/test_dax_l2_adapter.py
+++ b/tests/v1/distributed/test_dax_l2_adapter.py
@@ -4,6 +4,7 @@ Tests for the DAX MP L2 adapter.
 """
 
 # Standard
+from types import SimpleNamespace
 from typing import cast
 import select
 import threading
@@ -28,7 +29,7 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.internal_api import L2AdapterListener
-from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.l2_adapters.base import AdapterUsage, L2AdapterInterface
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
     get_registered_l2_adapter_types,
@@ -42,12 +43,14 @@ from lmcache.v1.distributed.l2_adapters.reconfiguration import (
     L2ReconfigurableAdapter,
     L2ReconfigureError,
 )
+from lmcache.v1.distributed.storage_controllers.store_policy import AdapterDescriptor
 from lmcache.v1.distributed.storage_manager import StorageManager
 from lmcache.v1.memory_allocators.ad_hoc_memory_allocator import AdHocMemoryAllocator
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObj,
 )
+from lmcache.v1.mp_observability.event_bus import EventBus
 from lmcache.v1.platform import consume_fd
 
 _EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
@@ -433,6 +436,10 @@ class _FakeReconfigurableAdapter:
         self.calls.append((operation, payload))
         return {"status": "ok", "operation": operation, "payload": payload}
 
+    def get_usage(self) -> AdapterUsage:
+        """Declare no capacity; reconfiguring still reports the compartment."""
+        return AdapterUsage(total_bytes_used=0, total_capacity_bytes=0)
+
 
 class _SerdeLikeWrapper:
     def __init__(self, inner_adapter: _FakeReconfigurableAdapter) -> None:
@@ -440,8 +447,43 @@ class _SerdeLikeWrapper:
 
 
 class _FakeAdapterDescriptor:
-    def __init__(self, type_name: str) -> None:
+    def __init__(self, type_name: str, shared: bool = False) -> None:
         self.type_name = type_name
+        # The real AdapterDescriptor always carries its config; capacity
+        # reporting reads ``shared`` off it.
+        self.config = SimpleNamespace(shared=shared)
+
+
+class _RecordingBus:
+    """Captures capacity-change events instead of publishing them."""
+
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    def publish(self, event: object) -> None:
+        self.events.append(event)
+
+
+def _wire_capacity_publishing(sm: StorageManager) -> None:
+    """Give a bare StorageManager the state its capacity publish needs.
+
+    Reconfiguring an adapter also announces the new topology, which reads
+    the L1 config, the adapter descriptors, and the event bus.
+
+    Args:
+        sm: The partially-constructed storage manager to wire up.
+    """
+    sm._lifecycle_lock = threading.Lock()
+    sm._event_bus = cast(EventBus, _RecordingBus())
+    # Declares no L1, keeping these tests about the L2 path.
+    sm._l1_config = L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(size_in_bytes=0, use_lazy=True)
+    )
+    if not hasattr(sm, "_adapter_descriptors"):
+        sm._adapter_descriptors = {
+            adapter_id: cast(AdapterDescriptor, _FakeAdapterDescriptor("fake"))
+            for adapter_id in sm._l2_adapters
+        }
 
 
 def test_storage_manager_routes_generic_l2_reconfigure_to_adapter():
@@ -449,6 +491,9 @@ def test_storage_manager_routes_generic_l2_reconfigure_to_adapter():
     adapter = _FakeReconfigurableAdapter()
     sm._adapters_lock = threading.Lock()
     sm._l2_adapters = {0: cast(L2AdapterInterface, adapter)}
+    # Reconfiguring changes capacity, so the call also announces the new
+    # topology; that needs enough state to build a capacity snapshot.
+    _wire_capacity_publishing(sm)
 
     result = sm.reconfigure_l2_adapter(0, "flip", {"enabled": True})
 

--- a/tests/v1/distributed/test_memory_capacity.py
+++ b/tests/v1/distributed/test_memory_capacity.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MP server's memory-capacity declaration.
+
+Capacity comes from config, not from the lazily grown heap, and a tier
+spanning several mediums declares one compartment per medium.
+"""
+
+# Standard
+from typing import cast
+import threading
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import L1BackendType, ModuleMemoryCapacity, Tier
+from lmcache.v1.distributed.config import (
+    GdsL1Config,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    get_configured_capacity_bytes,
+)
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.memory_manager.l1_manager_protocol import L1ManagerProtocol
+from lmcache.v1.distributed.storage_manager import StorageManager
+from lmcache.v1.mp_observability.event import Event, EventType
+
+GIB = 1 << 30
+
+
+class _FakeAdapterConfig:
+    """Stands in for an ``L2AdapterConfigBase``."""
+
+    def __init__(self, shared: bool) -> None:
+        self.shared = shared
+
+
+class _FakeDescriptor:
+    """Stands in for an ``AdapterDescriptor``."""
+
+    def __init__(self, type_name: str, shared: bool) -> None:
+        self.type_name = type_name
+        self.config = _FakeAdapterConfig(shared)
+
+
+class _FakeUsage:
+    """Stands in for an ``AdapterUsage``."""
+
+    def __init__(self, capacity_bytes: int) -> None:
+        self.total_capacity_bytes = capacity_bytes
+
+
+class _FakeAdapter:
+    """An L2 adapter that reports a fixed capacity, or raises."""
+
+    def __init__(self, capacity_bytes: int, fail: bool = False) -> None:
+        self._capacity_bytes = capacity_bytes
+        self._fail = fail
+
+    def get_usage(self) -> _FakeUsage:
+        if self._fail:
+            raise RuntimeError("adapter unavailable")
+        return _FakeUsage(self._capacity_bytes)
+
+
+class _RecordingBus:
+    """Captures what the publish path emits."""
+
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+
+    def publish(self, event: Event) -> None:
+        self.events.append(event)
+
+
+class _StorageManagerStub:
+    """Stands in for a ``StorageManager``, minus its pinned-memory ``__init__``."""
+
+    def __init__(
+        self,
+        l1: dict[L1BackendType, int],
+        adapters: list[tuple[_FakeDescriptor, _FakeAdapter]],
+    ) -> None:
+        # A real config, so the stub exercises the actual L1 derivation.
+        self._l1_config = _config_yielding(l1)
+        self._adapters = adapters
+        self._lifecycle_lock = threading.Lock()
+        self._event_bus = _RecordingBus()
+
+    def _build_capacities(self) -> list[ModuleMemoryCapacity]:
+        return StorageManager._build_capacities(cast("StorageManager", self))
+
+    def _publish_capacity_changed(self) -> None:
+        StorageManager._publish_capacity_changed(cast("StorageManager", self))
+
+    def _snapshot_adapters(
+        self,
+    ) -> list[tuple[int, _FakeDescriptor, _FakeAdapter]]:
+        return [
+            (index, desc, adapter)
+            for index, (desc, adapter) in enumerate(self._adapters)
+        ]
+
+
+def _capacities(
+    l1: dict[L1BackendType, int],
+    adapters: list[tuple[_FakeDescriptor, _FakeAdapter]],
+) -> list[ModuleMemoryCapacity]:
+    """Run ``StorageManager._build_capacities`` against fakes.
+
+    Args:
+        l1: Configured L1 capacity per backing medium.
+        adapters: The L2 adapters to report, as ``(descriptor, adapter)``.
+
+    Returns:
+        The capacities the method assembles.
+    """
+    return _StorageManagerStub(l1, adapters)._build_capacities()
+
+
+def _config_yielding(capacities: dict[L1BackendType, int]) -> L1ManagerConfig:
+    """Build a config whose derived capacity equals ``capacities``.
+
+    Args:
+        capacities: The per-medium result the config should produce.
+
+    Returns:
+        A matching :class:`L1ManagerConfig`.
+
+    Raises:
+        ValueError: If the combination is not expressible as one tier.
+    """
+    if set(capacities) == {L1BackendType.GDS}:
+        return L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(size_in_bytes=0, use_lazy=True),
+            gds_l1_config=GdsL1Config(
+                size_in_bytes=capacities[L1BackendType.GDS],
+                file_location="/tmp/gds-slab",
+            ),
+        )
+    if L1BackendType.DEVDAX in capacities:
+        return L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=capacities.get(L1BackendType.DRAM, 0),
+                devdax_path="/dev/dax0.0",
+                devdax_size_in_bytes=capacities[L1BackendType.DEVDAX],
+                use_lazy=False,
+                shm_name="",
+            )
+        )
+    if set(capacities) <= {L1BackendType.DRAM}:
+        return L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=capacities.get(L1BackendType.DRAM, 0), use_lazy=True
+            )
+        )
+    raise ValueError(f"not expressible as one tier: {capacities}")
+
+
+class TestConfiguredL1Capacity:
+    """The single derivation of "how large is L1", from config alone."""
+
+    def _config(self, **memory: object) -> L1ManagerConfig:
+        """Build an L1ManagerConfig with the given memory-config fields."""
+        defaults: dict[str, object] = {
+            "size_in_bytes": 0,
+            "devdax_path": None,
+            "use_lazy": True,
+        }
+        defaults.update(memory)
+        return L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(**defaults)  # type: ignore[arg-type]
+        )
+
+    def test_cpu_tier_reports_configured_size_not_grown_heap(self) -> None:
+        # The lazy allocator grows, so its current heap is not the capacity.
+        config = self._config(size_in_bytes=40 * GIB)
+        assert get_configured_capacity_bytes(config) == {L1BackendType.DRAM: 40 * GIB}
+
+    def test_unconfigured_tier_reports_nothing_rather_than_zero(self) -> None:
+        assert get_configured_capacity_bytes(self._config()) == {}
+
+    def test_pure_devdax_reports_one_medium(self) -> None:
+        # An unset devdax size means the whole tier is Device-DAX.
+        config = self._config(
+            size_in_bytes=100 * GIB,
+            devdax_path="/dev/dax0.0",
+            use_lazy=False,
+            shm_name="",
+        )
+        assert get_configured_capacity_bytes(config) == {
+            L1BackendType.DEVDAX: 100 * GIB
+        }
+
+    def test_hybrid_devdax_splits_into_two_mediums(self) -> None:
+        # L1 events tag placements per medium, so capacity must too.
+        config = self._config(
+            size_in_bytes=10 * GIB,
+            devdax_path="/dev/dax0.0",
+            devdax_size_in_bytes=100 * GIB,
+            use_lazy=False,
+            shm_name="",
+        )
+        assert get_configured_capacity_bytes(config) == {
+            L1BackendType.DEVDAX: 100 * GIB,
+            L1BackendType.DRAM: 10 * GIB,
+        }
+
+    def test_gds_tier_wins_over_the_dram_config(self) -> None:
+        config = L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(size_in_bytes=40 * GIB, use_lazy=True),
+            gds_l1_config=GdsL1Config(
+                size_in_bytes=8 * GIB, file_location="/tmp/gds-slab"
+            ),
+        )
+        assert get_configured_capacity_bytes(config) == {L1BackendType.GDS: 8 * GIB}
+
+    def test_matches_the_devdax_manager_arena_split(self) -> None:
+        # Mirrors DevDaxL1MemoryManager.__init__; catches drift in that split.
+        memory_config = L1MemoryManagerConfig(
+            size_in_bytes=10 * GIB,
+            devdax_path="/dev/dax0.0",
+            devdax_size_in_bytes=100 * GIB,
+            use_lazy=False,
+            shm_name="",
+        )
+        devdax_size = memory_config.devdax_size_in_bytes or memory_config.size_in_bytes
+        local_size = (
+            memory_config.size_in_bytes if memory_config.devdax_size_in_bytes else 0
+        )
+        derived = get_configured_capacity_bytes(
+            L1ManagerConfig(memory_config=memory_config)
+        )
+        assert derived[L1BackendType.DEVDAX] == devdax_size
+        assert derived[L1BackendType.DRAM] == local_size
+
+    def test_total_matches_what_usage_telemetry_reports(self) -> None:
+        # usage_telemetry sums the same derivation; drift would split the views.
+        memory_config = L1MemoryManagerConfig(
+            size_in_bytes=10 * GIB,
+            devdax_path="/dev/dax0.0",
+            devdax_size_in_bytes=100 * GIB,
+            use_lazy=False,
+            shm_name="",
+        )
+        config = L1ManagerConfig(memory_config=memory_config)
+        assert sum(get_configured_capacity_bytes(config).values()) == (
+            memory_config.size_in_bytes + memory_config.devdax_size_in_bytes
+        )
+
+
+class TestStorageManagerCapacities:
+    def test_reports_l1_per_medium(self) -> None:
+        found = _capacities(
+            {L1BackendType.DEVDAX: 100 * GIB, L1BackendType.DRAM: 10 * GIB}, []
+        )
+        assert {(c.tier, c.backend, c.capacity_bytes) for c in found} == {
+            (Tier.L1, "devdax", 100 * GIB),
+            (Tier.L1, "dram", 10 * GIB),
+        }
+        assert all(c.shared is False for c in found)
+
+    def test_reports_each_l2_adapter_with_its_shared_flag(self) -> None:
+        found = _capacities(
+            {L1BackendType.DRAM: 40 * GIB},
+            [
+                (_FakeDescriptor("fs", shared=False), _FakeAdapter(200 * GIB)),
+                (_FakeDescriptor("s3", shared=True), _FakeAdapter(4000 * GIB)),
+            ],
+        )
+        by_backend = {c.backend: c for c in found}
+        assert by_backend["fs"].tier == Tier.L2
+        assert by_backend["fs"].shared is False
+        assert by_backend["s3"].shared is True
+        assert by_backend["s3"].capacity_bytes == 4000 * GIB
+
+    def test_adapter_without_a_configured_cap_reports_zero(self) -> None:
+        # fs / mooncake / p2p / sagemaker return 0: undeclared, never "full".
+        found = _capacities(
+            {}, [(_FakeDescriptor("fs", shared=False), _FakeAdapter(0))]
+        )
+        assert [c.capacity_bytes for c in found] == [0]
+
+    def test_failing_adapter_is_omitted_not_reported_wrong(self) -> None:
+        found = _capacities(
+            {},
+            [
+                (_FakeDescriptor("fs", shared=False), _FakeAdapter(0, fail=True)),
+                (_FakeDescriptor("s3", shared=False), _FakeAdapter(9 * GIB)),
+            ],
+        )
+        assert [c.backend for c in found] == ["s3"]
+
+    def test_server_with_nothing_configured_declares_nothing(self) -> None:
+        assert _capacities({}, []) == []
+
+
+@pytest.mark.parametrize(
+    "capacities",
+    [
+        {L1BackendType.DRAM: 40 * GIB},
+        {L1BackendType.GDS: 8 * GIB},
+        {L1BackendType.DEVDAX: 100 * GIB, L1BackendType.DRAM: 10 * GIB},
+    ],
+)
+def test_backend_names_match_the_cache_event_vocabulary(capacities: dict) -> None:
+    # Capacity joins usage on (tier, backend); these strings must match events.
+    found = _capacities(capacities, [])
+    assert {c.backend for c in found} == {b.value for b in capacities}
+
+
+class TestReportStatusSharesTheSource:
+    """``report_status`` and the capacity API must report the same size."""
+
+    def _l1_manager(self, configured: dict[L1BackendType, int]) -> L1Manager:
+        """Build an L1Manager over a fake memory manager.
+
+        Args:
+            configured: Capacity the fake reports per backing medium.
+
+        Returns:
+            A manager whose ``report_status`` is callable.
+        """
+
+        class _MemoryManager:
+            def get_memory_usage(self) -> tuple[int, int]:
+                # The grown heap, deliberately unequal to the configured total.
+                return (1 * GIB, 3 * GIB)
+
+            def memcheck(self) -> bool:
+                return True
+
+        manager = L1Manager.__new__(L1Manager)
+        manager._memory_manager = cast("L1ManagerProtocol", _MemoryManager())
+        # report_status reads the total precomputed at construction.
+        manager._configured_capacity_bytes = sum(
+            get_configured_capacity_bytes(_config_yielding(configured)).values()
+        )
+        manager._objects = {}
+        manager._write_ttl_seconds = 600
+        manager._read_ttl_seconds = 600
+        # report_status is lock-guarded; the pinned-memory __init__ is skipped.
+        manager._lock = threading.Lock()
+        return manager
+
+    def test_status_reports_configured_separately_from_grown_heap(self) -> None:
+        manager = self._l1_manager({L1BackendType.DRAM: 40 * GIB})
+        status = manager.report_status()
+        assert status["memory_configured_bytes"] == 40 * GIB
+        # The pre-existing field keeps its old meaning for old consumers.
+        assert status["memory_total_bytes"] == 3 * GIB
+
+    def test_status_sums_a_hybrid_tier(self) -> None:
+        manager = self._l1_manager(
+            {L1BackendType.DEVDAX: 100 * GIB, L1BackendType.DRAM: 10 * GIB}
+        )
+        assert manager.report_status()["memory_configured_bytes"] == 110 * GIB
+
+    def test_status_and_capacity_report_agree(self) -> None:
+        # The point of one shared derivation: the two consumers of it --
+        # report_status and the coordinator capacity report -- cannot drift.
+        configured = {L1BackendType.DEVDAX: 100 * GIB, L1BackendType.DRAM: 10 * GIB}
+        manager = self._l1_manager(configured)
+        reported = sum(
+            module.capacity_bytes
+            for module in _capacities(configured, [])
+            if module.tier == Tier.L1
+        )
+        assert manager.report_status()["memory_configured_bytes"] == reported
+
+    def test_unconfigured_tier_reports_zero_not_the_heap(self) -> None:
+        manager = self._l1_manager({})
+        assert manager.report_status()["memory_configured_bytes"] == 0
+
+
+class TestCapacityChangePublishing:
+    """Runtime reconfiguration announces the new topology on the bus.
+
+    Without this, a coordinator declaration made at registration keeps the
+    boot capacity for the life of the process.
+    """
+
+    def _stub(self) -> _StorageManagerStub:
+        """A stub wired with the bus plumbing the publish path needs."""
+        return _StorageManagerStub({L1BackendType.DRAM: 40 * GIB}, [])
+
+    def test_publish_emits_one_event_per_call(self) -> None:
+        # The snapshot carries no revision: the cache-event subscriber
+        # numbers declarations as it emits them, on the one bus thread.
+        stub = self._stub()
+        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
+        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
+        assert len(stub._event_bus.events) == 2
+        assert all(
+            not hasattr(e.metadata["snapshot"], "revision")
+            for e in stub._event_bus.events
+        )
+
+    def test_published_event_carries_the_whole_declaration(self) -> None:
+        # A delta would leave the coordinator permanently wrong if dropped.
+        stub = self._stub()
+        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
+        snapshot = stub._event_bus.events[0].metadata["snapshot"]
+        assert [(m.tier, m.backend, m.capacity_bytes) for m in snapshot.modules] == [
+            (Tier.L1, "dram", 40 * GIB)
+        ]
+
+    def test_event_type_is_the_capacity_one(self) -> None:
+        stub = self._stub()
+        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
+        assert stub._event_bus.events[0].event_type == EventType.SM_CAPACITY_CHANGED
+
+    def test_snapshot_carries_the_whole_topology(self) -> None:
+        stub = self._stub()
+        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
+        snapshot = stub._event_bus.events[0].metadata["snapshot"]
+        assert len(snapshot.modules) == 1
+
+    def test_publish_capacity_declares_without_any_reconfiguration(self) -> None:
+        # The only path by which a server that never reconfigures reaches
+        # the coordinator at all.
+        stub = self._stub()
+        StorageManager.publish_capacity(cast("StorageManager", stub))
+        assert len(stub._event_bus.events) == 1
+        snapshot = stub._event_bus.events[0].metadata["snapshot"]
+        assert [(m.tier, m.backend) for m in snapshot.modules] == [(Tier.L1, "dram")]
+
+
+class TestCapacityPublishTakesNoLock:
+    """Publishing must not queue behind adapter lifecycle work."""
+
+    def test_publish_does_not_take_the_lifecycle_lock(self) -> None:
+        # add/delete/reconfigure hold _lifecycle_lock, and delete can hold
+        # it for its full timeout. Publishing runs on every registration, so
+        # taking that lock would stall registration behind a teardown.
+        stub = _StorageManagerStub({L1BackendType.DRAM: 8 * GIB}, [])
+        stub._lifecycle_lock.acquire()
+        try:
+            StorageManager.publish_capacity(cast("StorageManager", stub))
+        finally:
+            stub._lifecycle_lock.release()
+        assert len(stub._event_bus.events) == 1

--- a/tests/v1/mp_coordinator/test_cache_events.py
+++ b/tests/v1/mp_coordinator/test_cache_events.py
@@ -15,7 +15,13 @@ import numpy as np
 import pytest
 
 # First Party
-from lmcache.v1.distributed.api import L1BackendType, ObjectKey, Tier
+from lmcache.v1.distributed.api import (
+    CapacitySnapshot,
+    L1BackendType,
+    ModuleMemoryCapacity,
+    ObjectKey,
+    Tier,
+)
 from lmcache.v1.distributed.internal_api import L1ObjectMeta
 from lmcache.v1.mp_coordinator.api import (
     UNKNOWN_TOKEN_OFFSET,
@@ -809,3 +815,113 @@ def test_http_sink_raises_publish_error_on_http_failure():
     with pytest.raises(CacheEventPublishError):
         sink.publish([batch])
     sink.close()
+
+
+# -- Capacity declarations ----------------------------------------------------
+
+
+def _snapshot(*modules: ModuleMemoryCapacity) -> CapacitySnapshot:
+    """A capacity snapshot as StorageManager publishes it."""
+    return CapacitySnapshot(modules=tuple(modules))
+
+
+def _capacity_event(snapshot: CapacitySnapshot) -> Event:
+    """The bus event StorageManager emits on a topology change."""
+    return Event(
+        event_type=EventType.SM_CAPACITY_CHANGED,
+        metadata={"snapshot": snapshot},
+    )
+
+
+def test_a_declaration_becomes_one_config_batch_per_compartment():
+    sink = _RecordingSink()
+    subscriber = _subscriber(sink)
+
+    _dispatch(
+        subscriber,
+        _capacity_event(
+            _snapshot(
+                ModuleMemoryCapacity(Tier.L1, "dram", 40 * (1 << 30), False),
+                ModuleMemoryCapacity(Tier.L2, "s3", 0, True),
+            )
+        ),
+    )
+    subscriber.flush()
+
+    batches = sink.published[0]
+    assert [b.event_type for b in batches] == [CacheEventType.CONFIG] * 2
+    assert [(b.tier, b.backend, b.capacity_bytes, b.shared) for b in batches] == [
+        (Tier.L1, "dram", 40 * (1 << 30), False),
+        (Tier.L2, "s3", 0, True),
+    ]
+    # One declaration, so one revision -- that is what lets the coordinator
+    # tell a fresh declaration from a continuation.
+    assert {b.capacity_revision for b in batches} == {1}
+    # A declaration carries no placements.
+    assert all(b.entries == [] for b in batches)
+
+
+def test_config_batches_share_the_seq_space_with_placements():
+    # They ride the same stream, so a reused seq would be dropped as a
+    # duplicate by the gate.
+    sink = _RecordingSink()
+    subscriber = _subscriber(sink)
+
+    _dispatch(
+        subscriber,
+        _capacity_event(
+            _snapshot(ModuleMemoryCapacity(Tier.L1, "dram", 8 * (1 << 30), False))
+        ),
+        Event(
+            event_type=EventType.L1_WRITE_FINISHED,
+            metadata={"keys": [_key(1)], "meta": [_meta(100)]},
+        ),
+    )
+    subscriber.flush()
+
+    batches = sink.published[0]
+    assert [b.seq for b in batches] == [1, 2]
+    # Declaration first, so the denominator lands before the bytes.
+    assert batches[0].event_type == CacheEventType.CONFIG
+    assert batches[1].event_type == CacheEventType.STORE
+
+
+def test_a_newer_declaration_supersedes_an_unflushed_one():
+    sink = _RecordingSink()
+    subscriber = _subscriber(sink)
+
+    _dispatch(
+        subscriber,
+        _capacity_event(
+            _snapshot(ModuleMemoryCapacity(Tier.L1, "dram", 8 * (1 << 30), False))
+        ),
+        _capacity_event(
+            _snapshot(ModuleMemoryCapacity(Tier.L1, "dram", 16 * (1 << 30), False))
+        ),
+    )
+    subscriber.flush()
+
+    batches = sink.published[0]
+    assert [b.capacity_bytes for b in batches] == [16 * (1 << 30)]
+    # Coalesced into one declaration, so one revision -- not two burnt.
+    assert batches[0].capacity_revision == 1
+
+
+def test_a_declaration_survives_a_publish_failure():
+    # The whole topology, so resending repairs it; a byte delta could not.
+    sink = _RecordingSink()
+    subscriber = _subscriber(sink)
+
+    _dispatch(
+        subscriber,
+        _capacity_event(
+            _snapshot(ModuleMemoryCapacity(Tier.L1, "dram", 8 * (1 << 30), False))
+        ),
+    )
+    sink.fail_next = True
+    subscriber.flush()
+    assert sink.published == []
+
+    # Re-emitted at a fresh revision; the coordinator takes the newer one.
+    subscriber.flush()
+    assert [b.capacity_revision for b in sink.published[0]] == [2]

--- a/tests/v1/mp_coordinator/test_instances_usage_api.py
+++ b/tests/v1/mp_coordinator/test_instances_usage_api.py
@@ -1,0 +1,651 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the coordinator's ``/instances/usage`` endpoints."""
+
+# Standard
+from typing import cast
+
+# Third Party
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
+from lmcache.v1.mp_coordinator.persistence.durable_component import PersistenceType
+from lmcache.v1.mp_coordinator.server_config import ModuleCapacity, ServerConfigRegistry
+
+GIB = 1 << 30
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """A coordinator with both background loops disabled.
+
+    Carries a per-instance seq allocator: ``config`` batches share the seq
+    space with placement batches, so reusing a number gets the second batch
+    dropped as a duplicate.
+    """
+    app = create_app(
+        MPCoordinatorConfig(health_check_interval=0, eviction_check_interval=0)
+    )
+    test_client = TestClient(app)
+    test_client.seqs = {}  # type: ignore[attr-defined]
+    return test_client
+
+
+def _take_seqs(client: TestClient, instance_id: str, count: int) -> int:
+    """Reserve ``count`` consecutive seq numbers and return the first."""
+    seqs: dict[str, int] = client.seqs  # type: ignore[attr-defined]
+    first = seqs.get(instance_id, 0) + 1
+    seqs[instance_id] = first + count - 1
+    return first
+
+
+def _ctx(client: TestClient) -> CoordinatorContext:
+    """Return the coordinator context behind ``client``.
+
+    ``TestClient.app`` is a bare ASGI callable, so the cast happens here once.
+
+    Args:
+        client: Test client wrapping a coordinator app.
+
+    Returns:
+        That app's :class:`CoordinatorContext`.
+    """
+    return cast("FastAPI", client.app).state.ctx
+
+
+def _config_batches(
+    instance_id: str,
+    modules: list[dict[str, object]],
+    incarnation: int,
+    revision: int,
+    first_seq: int,
+) -> list[dict[str, object]]:
+    """One ``config`` batch per compartment, all at the same revision."""
+    return [
+        {
+            "instance_id": instance_id,
+            "incarnation": incarnation,
+            "seq": first_seq + offset,
+            "event_type": "config",
+            "tier": module["tier"],
+            "backend": module["backend"],
+            "shared": module.get("shared", False),
+            "entries": [],
+            "capacity_bytes": module.get("capacity_bytes", 0),
+            "capacity_revision": revision,
+        }
+        for offset, module in enumerate(modules)
+    ]
+
+
+def _declare(
+    client: TestClient,
+    instance_id: str,
+    modules: list[dict[str, object]],
+    incarnation: int = 1,
+    revision: int = 1,
+) -> None:
+    """Declare ``modules`` as ``config`` batches on the event stream."""
+    first_seq = _take_seqs(client, instance_id, max(len(modules), 1))
+    response = client.post(
+        "/events",
+        json={
+            "batches": _config_batches(
+                instance_id, modules, incarnation, revision, first_seq
+            )
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def _register(
+    client: TestClient,
+    instance_id: str,
+    modules: list[dict[str, object]],
+) -> None:
+    """Register an instance, then declare ``modules`` as a report.
+
+    Registration carries no capacity: it arrives on the event stream, so a
+    declaring server takes both steps.
+    """
+    response = client.post(
+        "/instances",
+        json={
+            "instance_id": instance_id,
+            "ip": "10.0.0.1",
+            "http_port": 8000,
+        },
+    )
+    assert response.status_code == 200
+    if modules:
+        _declare(client, instance_id, modules)
+
+
+def _ingest(
+    client: TestClient,
+    instance_id: str,
+    tier: Tier,
+    backend: str,
+    size_bytes: int,
+    index: int,
+    shared: bool = False,
+) -> None:
+    """Push one STORE batch through the ingest gate."""
+    seq = _take_seqs(client, instance_id, 1)
+    key = ObjectKey(
+        chunk_hash=bytes([index]) * 32,
+        model_name="model",
+        kv_rank=0,
+        cache_salt="tenant",
+    )
+    _ctx(client).event_gate.ingest(
+        CacheEventBatch(
+            instance_id=instance_id,
+            incarnation=1,
+            seq=seq,
+            event_type=CacheEventType.STORE,
+            tier=tier,
+            backend=backend,
+            shared=shared,
+            ts=1.0,
+            entries=[
+                CacheEventEntry(key=key.to_encoded_object_key(), size_bytes=size_bytes)
+            ],
+        )
+    )
+
+
+def _module(body: dict, tier: str, backend: str) -> dict:
+    """Pick one module out of an instance status body."""
+    found = [
+        m for m in body["modules"] if m["tier"] == tier and m["backend"] == backend
+    ]
+    assert len(found) == 1, f"expected one {tier}/{backend}, got {found}"
+    return found[0]
+
+
+class TestInstanceMemory:
+    def test_joins_usage_to_declared_capacity(self, client: TestClient) -> None:
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB}],
+        )
+        _ingest(client, "mp-1", Tier.L1, "dram", 10 * GIB, index=1)
+
+        body = client.get("/instances/mp-1/usage").json()
+        module = _module(body, "l1", "dram")
+        assert module["used_bytes"] == 10 * GIB
+        assert module["capacity_bytes"] == 40 * GIB
+        assert module["usage_ratio"] == pytest.approx(0.25)
+        assert body["registered"] is True
+        assert body["declared_capacity"] is True
+
+    def test_undeclared_capacity_reports_no_ratio(self, client: TestClient) -> None:
+        # A null ratio means unknown, not empty.
+        _register(client, "mp-1", [])
+        _ingest(client, "mp-1", Tier.L2, "fs", 7 * GIB, index=1)
+
+        body = client.get("/instances/mp-1/usage").json()
+        module = _module(body, "l2", "fs")
+        assert module["used_bytes"] == 7 * GIB
+        assert module["capacity_bytes"] == 0
+        assert module["usage_ratio"] is None
+        assert body["declared_capacity"] is False
+
+    def test_declared_but_unused_module_is_reported_empty(
+        self, client: TestClient
+    ) -> None:
+        # Declared but idle reads as 0%, not as unknown.
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB}],
+        )
+        module = _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")
+        assert module["used_bytes"] == 0
+        assert module["usage_ratio"] == pytest.approx(0.0)
+
+    def test_ratio_above_one_is_not_clamped(self, client: TestClient) -> None:
+        # Over-full signals a misconfigured cap; clamping would hide it.
+        _register(
+            client, "mp-1", [{"tier": "l1", "backend": "dram", "capacity_bytes": GIB}]
+        )
+        _ingest(client, "mp-1", Tier.L1, "dram", 3 * GIB, index=1)
+        assert _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")[
+            "usage_ratio"
+        ] == pytest.approx(3.0)
+
+    def test_unknown_instance_is_404(self, client: TestClient) -> None:
+        assert client.get("/instances/nobody/usage").status_code == 404
+
+    def test_deregistered_instance_keeps_surviving_l2_bytes(
+        self, client: TestClient
+    ) -> None:
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l2", "backend": "fs", "capacity_bytes": 40 * GIB}],
+        )
+        _ingest(client, "mp-1", Tier.L2, "fs", 5 * GIB, index=1)
+        assert client.delete("/instances/mp-1").status_code == 204
+
+        body = client.get("/instances/mp-1/usage").json()
+        assert body["registered"] is False
+        # Capacity went with the departed process; the bytes did not.
+        assert body["declared_capacity"] is False
+        module = _module(body, "l2", "fs")
+        assert module["used_bytes"] == 5 * GIB
+        assert module["usage_ratio"] is None
+
+
+class TestFleetMemory:
+    def test_lists_every_instance(self, client: TestClient) -> None:
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB}],
+        )
+        _register(
+            client,
+            "mp-2",
+            [{"tier": "l1", "backend": "dram", "capacity_bytes": 80 * GIB}],
+        )
+        _ingest(client, "mp-1", Tier.L1, "dram", 10 * GIB, index=1)
+        _ingest(client, "mp-2", Tier.L1, "dram", 60 * GIB, index=2)
+
+        body = client.get("/instances/usage").json()
+        ratios = {
+            entry["instance_id"]: _module(entry, "l1", "dram")["usage_ratio"]
+            for entry in body["instances"]
+        }
+        assert ratios == {"mp-1": pytest.approx(0.25), "mp-2": pytest.approx(0.75)}
+
+    def test_shared_pool_is_reported_once_not_per_mount(
+        self, client: TestClient
+    ) -> None:
+        shared = {
+            "tier": "l2",
+            "backend": "s3",
+            "capacity_bytes": 100 * GIB,
+            "shared": True,
+        }
+        _register(client, "mp-1", [shared])
+        _register(client, "mp-2", [shared])
+        _ingest(client, "mp-1", Tier.L2, "s3", 25 * GIB, index=1, shared=True)
+        _ingest(client, "mp-2", Tier.L2, "s3", 25 * GIB, index=1, shared=True)
+
+        body = client.get("/instances/usage").json()
+        assert len(body["shared_modules"]) == 1
+        pool = body["shared_modules"][0]
+        assert pool["used_bytes"] == 25 * GIB
+        assert pool["usage_ratio"] == pytest.approx(0.25)
+        # Counted once, never onto the mounting instances.
+        for entry in body["instances"]:
+            assert entry["modules"] == []
+
+    def test_disagreeing_shared_capacity_reads_as_undeclared(
+        self, client: TestClient
+    ) -> None:
+        # Picking either would make the answer depend on registration order.
+        _register(
+            client,
+            "mp-1",
+            [
+                {
+                    "tier": "l2",
+                    "backend": "s3",
+                    "capacity_bytes": 100 * GIB,
+                    "shared": True,
+                }
+            ],
+        )
+        _register(
+            client,
+            "mp-2",
+            [
+                {
+                    "tier": "l2",
+                    "backend": "s3",
+                    "capacity_bytes": 999 * GIB,
+                    "shared": True,
+                }
+            ],
+        )
+        _ingest(client, "mp-1", Tier.L2, "s3", 25 * GIB, index=1, shared=True)
+
+        pool = client.get("/instances/usage").json()["shared_modules"][0]
+        assert pool["capacity_bytes"] == 0
+        assert pool["usage_ratio"] is None
+
+    def test_empty_fleet(self, client: TestClient) -> None:
+        assert client.get("/instances/usage").json() == {
+            "instances": [],
+            "shared_modules": [],
+        }
+
+
+class TestRegistration:
+    """Registration establishes membership only, never capacity."""
+
+    def test_registration_alone_declares_nothing(self, client: TestClient) -> None:
+        response = client.post(
+            "/instances",
+            json={"instance_id": "mp-1", "ip": "10.0.0.1", "http_port": 8000},
+        )
+        assert response.status_code == 200
+        assert client.get("/instances/mp-1/usage").json()["declared_capacity"] is False
+
+    def test_capacity_fields_are_not_accepted_at_registration(
+        self, client: TestClient
+    ) -> None:
+        # Guards the one-path invariant: if these are ever reintroduced on
+        # the register body, capacity has two sources again.
+        response = client.post(
+            "/instances",
+            json={
+                "instance_id": "mp-1",
+                "ip": "10.0.0.1",
+                "http_port": 8000,
+                "memory_modules": [
+                    {"tier": "l1", "backend": "dram", "capacity_bytes": GIB}
+                ],
+            },
+        )
+        assert response.status_code == 200
+        assert client.get("/instances/mp-1/usage").json()["declared_capacity"] is False
+
+    def test_tier_all_is_rejected(self, client: TestClient) -> None:
+        response = client.post(
+            "/events",
+            json={
+                "batches": _config_batches(
+                    "mp-1",
+                    [{"tier": "all", "backend": "dram", "capacity_bytes": GIB}],
+                    incarnation=1,
+                    revision=1,
+                    first_seq=1,
+                )
+            },
+        )
+        assert response.status_code == 422
+
+    def test_repeated_compartment_in_one_declaration_takes_the_last(
+        self, client: TestClient
+    ) -> None:
+        # Per-compartment batches means the registry never sees the whole
+        # list, so it cannot reject a duplicate the way a single whole-list
+        # report could. It upserts, and the last batch wins. The emitter
+        # derives one entry per medium and adapter, so this is unreachable
+        # from a correct producer.
+        _register(client, "mp-1", [])
+        _declare(
+            client,
+            "mp-1",
+            [
+                {"tier": "l1", "backend": "dram", "capacity_bytes": GIB},
+                {"tier": "l1", "backend": "dram", "capacity_bytes": 2 * GIB},
+            ],
+            revision=2,
+        )
+        module = _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")
+        assert module["capacity_bytes"] == 2 * GIB
+
+
+class TestCapacityDeclarations:
+    """``config`` batches accumulate into declarations, fenced by the gate."""
+
+    def _capacity(self, client: TestClient, instance_id: str) -> int:
+        """Read back one instance's declared L1 capacity."""
+        body = client.get(f"/instances/{instance_id}/usage").json()
+        return _module(body, "l1", "dram")["capacity_bytes"]
+
+    def _l1(self, capacity_bytes: int) -> list[dict[str, object]]:
+        """One L1/dram compartment at ``capacity_bytes``."""
+        return [{"tier": "l1", "backend": "dram", "capacity_bytes": capacity_bytes}]
+
+    def test_a_later_declaration_supersedes_the_earlier_one(
+        self, client: TestClient
+    ) -> None:
+        _register(client, "mp-1", self._l1(40 * GIB))
+        _ingest(client, "mp-1", Tier.L1, "dram", 10 * GIB, index=1)
+        assert _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")[
+            "usage_ratio"
+        ] == pytest.approx(0.25)
+
+        # A device was added at runtime: same server, bigger pool.
+        _declare(client, "mp-1", self._l1(80 * GIB), revision=2)
+        assert _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")[
+            "usage_ratio"
+        ] == pytest.approx(0.125)
+
+    def test_a_stale_revision_cannot_regress_the_topology(
+        self, client: TestClient
+    ) -> None:
+        _register(client, "mp-1", [])
+        _declare(client, "mp-1", self._l1(80 * GIB), revision=5)
+        _declare(client, "mp-1", self._l1(10 * GIB), revision=3)
+        assert self._capacity(client, "mp-1") == 80 * GIB
+
+    def test_the_same_revision_extends_the_declaration(
+        self, client: TestClient
+    ) -> None:
+        # One declaration is several batches sharing a revision, so an equal
+        # revision adds a compartment rather than being ignored. This is how
+        # a multi-compartment server declares at all.
+        _register(client, "mp-1", [])
+        _declare(client, "mp-1", self._l1(40 * GIB), revision=1)
+        _declare(
+            client,
+            "mp-1",
+            [{"tier": "l2", "backend": "fs", "capacity_bytes": 90 * GIB}],
+            revision=1,
+        )
+        backends = {
+            (m["tier"], m["backend"])
+            for m in client.get("/instances/mp-1/usage").json()["modules"]
+        }
+        assert backends == {("l1", "dram"), ("l2", "fs")}
+
+    def test_a_new_declaration_retires_compartments_it_omits(
+        self, client: TestClient
+    ) -> None:
+        # The replacement for wholesale replacement: a dropped adapter is
+        # simply absent from the next revision, so it stops being reported.
+        _register(
+            client,
+            "mp-1",
+            [
+                {"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB},
+                {"tier": "l2", "backend": "fs", "capacity_bytes": 90 * GIB},
+            ],
+        )
+        _declare(client, "mp-1", self._l1(40 * GIB), revision=2)
+        backends = {
+            (m["tier"], m["backend"])
+            for m in client.get("/instances/mp-1/usage").json()["modules"]
+        }
+        assert backends == {("l1", "dram")}
+
+    def test_a_new_incarnation_supersedes_a_higher_revision(
+        self, client: TestClient
+    ) -> None:
+        # A restarted server's revision counter goes back to 1. Without
+        # incarnation in the order, every report it ever sends would look
+        # stale and its capacity would never be learned again.
+        _register(client, "mp-1", [])
+        _declare(client, "mp-1", self._l1(80 * GIB), incarnation=1, revision=9)
+        _declare(client, "mp-1", self._l1(16 * GIB), incarnation=2, revision=1)
+        assert self._capacity(client, "mp-1") == 16 * GIB
+
+    def test_an_older_incarnation_is_dropped_by_the_gate(
+        self, client: TestClient
+    ) -> None:
+        # The reverse, and now the gate's job rather than the registry's: a
+        # straggler from the previous process is fenced before it arrives.
+        _register(client, "mp-1", [])
+        _declare(client, "mp-1", self._l1(16 * GIB), incarnation=2, revision=1)
+        _declare(client, "mp-1", self._l1(80 * GIB), incarnation=1, revision=99)
+        assert self._capacity(client, "mp-1") == 16 * GIB
+
+    def test_config_and_placement_batches_ride_the_same_request(
+        self, client: TestClient
+    ) -> None:
+        _register(client, "mp-1", self._l1(40 * GIB))
+        _ingest(client, "mp-1", Tier.L1, "dram", 20 * GIB, index=1)
+        module = _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")
+        assert module["used_bytes"] == 20 * GIB
+        assert module["usage_ratio"] == pytest.approx(0.5)
+
+
+class TestRouting:
+    """``/instances/usage`` is a literal segment on a templated collection."""
+
+    def test_usage_is_not_captured_as_an_instance_id(self, client: TestClient) -> None:
+        # Routers are discovered alphabetically, so instances_api registers
+        # first. If it ever declares GET /instances/{instance_id}, that route
+        # would swallow "usage" and this fleet read would break.
+        _register(client, "mp-1", [])
+        body = client.get("/instances/usage").json()
+        assert "instances" in body and "shared_modules" in body
+        assert [e["instance_id"] for e in body["instances"]] == ["mp-1"]
+
+    def test_an_instance_literally_named_usage_still_resolves(
+        self, client: TestClient
+    ) -> None:
+        # The per-instance route carries a distinct /usage suffix, so the
+        # collection route cannot shadow it even for this id.
+        _register(client, "usage", [])
+        assert client.get("/instances/usage/usage").json()["instance_id"] == "usage"
+
+
+class TestDeparture:
+    """A departing process takes its L1 pool with it."""
+
+    def test_deregistration_fences_l1_bytes(self, client: TestClient) -> None:
+        # Only the stale-eviction loop used to fence, and it never sees an
+        # instance that left cleanly -- so its L1 bytes lingered for good.
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB}],
+        )
+        _ingest(client, "mp-1", Tier.L1, "dram", 10 * GIB, index=1)
+        assert (
+            _module(client.get("/instances/mp-1/usage").json(), "l1", "dram")[
+                "used_bytes"
+            ]
+            == 10 * GIB
+        )
+
+        assert client.delete("/instances/mp-1").status_code == 204
+        assert client.get("/instances/mp-1/usage").status_code == 404
+
+    def test_deregistration_keeps_l2_bytes(self, client: TestClient) -> None:
+        # L2 outlives the reporter: it is storage the fleet shares, and
+        # leaves only through a DELETE event.
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l2", "backend": "fs", "capacity_bytes": 40 * GIB}],
+        )
+        _ingest(client, "mp-1", Tier.L2, "fs", 5 * GIB, index=1)
+        assert client.delete("/instances/mp-1").status_code == 204
+
+        body = client.get("/instances/mp-1/usage").json()
+        assert body["registered"] is False
+        assert body["declared_capacity"] is False
+        module = _module(body, "l2", "fs")
+        assert module["used_bytes"] == 5 * GIB
+        assert module["usage_ratio"] is None
+
+
+class TestDurableComponent:
+    """The registry persists itself like every other event consumer."""
+
+    def _registry(self) -> ServerConfigRegistry:
+        """A registry holding one two-compartment declaration."""
+        registry = ServerConfigRegistry()
+        for offset, (tier, backend, capacity, shared) in enumerate(
+            [
+                (Tier.L1, "dram", 40 * GIB, False),
+                (Tier.L2, "s3", 0, True),
+            ]
+        ):
+            registry.consume(
+                CacheEventBatch(
+                    instance_id="mp-1",
+                    incarnation=5,
+                    seq=offset + 1,
+                    event_type=CacheEventType.CONFIG,
+                    tier=tier,
+                    backend=backend,
+                    shared=shared,
+                    capacity_bytes=capacity,
+                    capacity_revision=3,
+                )
+            )
+        return registry
+
+    def test_it_names_itself_and_where_it_belongs(self) -> None:
+        registry = ServerConfigRegistry()
+        assert registry.name == "server_config"
+        assert registry.persistence_type == PersistenceType.CHECKPOINT
+
+    def test_capture_is_plain_data(self) -> None:
+        # Domain objects would make every artifact writer understand what a
+        # section means.
+        captured = self._registry().capture()
+        assert captured == {
+            "declarations": [
+                (
+                    "mp-1",
+                    5,
+                    3,
+                    [("l1", "dram", 40 * GIB, False), ("l2", "s3", 0, True)],
+                )
+            ]
+        }
+
+    def test_restore_round_trips_the_declaration(self) -> None:
+        restored = ServerConfigRegistry()
+        restored.restore(self._registry().capture())
+        assert restored.get("mp-1") == (
+            ModuleCapacity(Tier.L1, "dram", 40 * GIB, False),
+            ModuleCapacity(Tier.L2, "s3", 0, True),
+        )
+
+    def test_restore_keeps_the_stamp_so_a_straggler_cannot_win(self) -> None:
+        # Without the stamp a restored registry starts from scratch and
+        # accepts a report from before the capture, regressing the topology
+        # it just loaded.
+        restored = ServerConfigRegistry()
+        restored.restore(self._registry().capture())
+        restored.consume(
+            CacheEventBatch(
+                instance_id="mp-1",
+                incarnation=5,
+                seq=99,
+                event_type=CacheEventType.CONFIG,
+                tier=Tier.L1,
+                backend="dram",
+                capacity_bytes=1 * GIB,
+                capacity_revision=2,
+            )
+        )
+        assert restored.get("mp-1")[0].capacity_bytes == 40 * GIB
+
+    def test_restore_refuses_a_non_empty_registry(self) -> None:
+        registry = self._registry()
+        with pytest.raises(ValueError, match="requires an empty registry"):
+            registry.restore(registry.capture())

--- a/tests/v1/mp_coordinator/test_instances_usage_api.py
+++ b/tests/v1/mp_coordinator/test_instances_usage_api.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 # First Party
-from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.distributed.api import ModuleMemoryCapacity, ObjectKey, Tier
 from lmcache.v1.mp_coordinator.api import (
     CacheEventBatch,
     CacheEventEntry,
@@ -20,7 +20,7 @@ from lmcache.v1.mp_coordinator.app import create_app
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
 from lmcache.v1.mp_coordinator.persistence.durable_component import PersistenceType
-from lmcache.v1.mp_coordinator.server_config import ModuleCapacity, ServerConfigRegistry
+from lmcache.v1.mp_coordinator.server_config import ServerConfigRegistry
 
 GIB = 1 << 30
 
@@ -621,8 +621,8 @@ class TestDurableComponent:
         restored = ServerConfigRegistry()
         restored.restore(self._registry().capture())
         assert restored.get("mp-1") == (
-            ModuleCapacity(Tier.L1, "dram", 40 * GIB, False),
-            ModuleCapacity(Tier.L2, "s3", 0, True),
+            ModuleMemoryCapacity(Tier.L1, "dram", 40 * GIB, False),
+            ModuleMemoryCapacity(Tier.L2, "s3", 0, True),
         )
 
     def test_restore_keeps_the_stamp_so_a_straggler_cannot_win(self) -> None:
@@ -649,3 +649,47 @@ class TestDurableComponent:
         registry = self._registry()
         with pytest.raises(ValueError, match="requires an empty registry"):
             registry.restore(registry.capture())
+
+
+class TestCheckpointWiring:
+    """The registry must be in the coordinator's checkpoint set.
+
+    It declares itself ``CHECKPOINT``, but declaring is not wiring: the
+    component list in ``create_app`` is hand-built, so a registry left out
+    of it would advertise durability and never be captured.
+    """
+
+    def test_the_registry_is_a_checkpoint_component(self, client: TestClient) -> None:
+        # First Party
+        from lmcache.v1.mp_coordinator.persistence.durable_component import (
+            DurableComponent,
+            PersistenceType,
+        )
+
+        ctx = _ctx(client)
+        components: list[DurableComponent] = [
+            ctx.key_directory,
+            ctx.usage_manager,
+            ctx.event_gate,
+            ctx.server_config,
+            *ctx.eviction_controller.get_durable_components(),
+        ]
+        names = {
+            component.name
+            for component in components
+            if component.persistence_type is PersistenceType.CHECKPOINT
+        }
+        assert "server_config" in names
+
+    def test_a_declaration_survives_capture_and_restore(
+        self, client: TestClient
+    ) -> None:
+        _register(
+            client,
+            "mp-1",
+            [{"tier": "l1", "backend": "dram", "capacity_bytes": 64 * GIB}],
+        )
+        registry = _ctx(client).server_config
+        restored = ServerConfigRegistry()
+        restored.restore(registry.capture())
+        assert restored.get("mp-1") == registry.get("mp-1")

--- a/tests/v1/mp_coordinator/test_instances_usage_e2e.py
+++ b/tests/v1/mp_coordinator/test_instances_usage_e2e.py
@@ -1,0 +1,410 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the fleet memory-usage API.
+
+Drives a uvicorn-served coordinator over real sockets: register, declare
+capacities and publish usage to ``POST /events``, read
+``GET /instances/usage``. Bodies use the same ``CacheEventsRequest`` dump
+``HttpCacheEventSink`` sends, so the wire encoding under test is the real
+one.
+"""
+
+# Standard
+from typing import cast
+import socket as _socket
+import threading
+import time
+
+# Third Party
+import pytest
+import requests
+import uvicorn
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.schemas import CacheEventsRequest
+
+GIB = 1 << 30
+
+
+def _free_port() -> int:
+    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_until_up(base_url: str, timeout: float = 5.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if requests.get(f"{base_url}/healthz", timeout=0.5).status_code == 200:
+                return
+        except requests.RequestException:
+            time.sleep(0.05)
+    raise RuntimeError("coordinator did not come up")
+
+
+@pytest.fixture
+def coordinator():
+    """A live coordinator on a free port; yields its base URL."""
+    port = _free_port()
+    config = MPCoordinatorConfig(
+        host="127.0.0.1",
+        port=port,
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+    )
+    server = uvicorn.Server(
+        uvicorn.Config(
+            create_app(config), host=config.host, port=port, log_level="warning"
+        )
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        _wait_until_up(base)
+        yield base
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+
+
+def _declare(
+    base: str,
+    instance_id: str,
+    modules: list[dict[str, object]],
+    incarnation: int = 1,
+    revision: int = 1,
+    first_seq: int = 1,
+) -> None:
+    """Declare ``modules`` as ``config`` batches on the event stream."""
+    batches = [
+        CacheEventBatch(
+            instance_id=instance_id,
+            incarnation=incarnation,
+            seq=first_seq + offset,
+            event_type=CacheEventType.CONFIG,
+            tier=Tier(module["tier"]),
+            backend=str(module["backend"]),
+            shared=bool(module.get("shared", False)),
+            capacity_bytes=cast("int", module.get("capacity_bytes", 0)),
+            capacity_revision=revision,
+        )
+        for offset, module in enumerate(modules)
+    ]
+    body = CacheEventsRequest(batches=batches)
+    response = requests.post(
+        f"{base}/events", json=body.model_dump(mode="json"), timeout=2
+    )
+    assert response.status_code == 200, response.text
+
+
+def _register(base: str, instance_id: str, modules: list[dict[str, object]]) -> None:
+    """Register an mp server, then declare ``modules`` over the event stream.
+
+    The declaration consumes ``len(modules)`` seq numbers, so callers that
+    also publish placements start those at ``len(modules) + 1``.
+    """
+    response = requests.post(
+        f"{base}/instances",
+        json={
+            "instance_id": instance_id,
+            "ip": "127.0.0.1",
+            "http_port": 9999,
+        },
+        timeout=2,
+    )
+    assert response.status_code == 200, response.text
+    if modules:
+        _declare(base, instance_id, modules)
+
+
+def _publish(
+    base: str,
+    instance_id: str,
+    tier: Tier,
+    backend: str,
+    size_bytes: int,
+    index: int,
+    shared: bool = False,
+    seq: int = 1,
+    incarnation: int = 1,
+    event_type: CacheEventType = CacheEventType.STORE,
+) -> None:
+    """Publish one cache-event batch to ``POST /events``."""
+    key = ObjectKey(
+        chunk_hash=bytes([index]) * 32,
+        model_name="model",
+        kv_rank=0,
+        cache_salt="tenant",
+    )
+    entry = (
+        CacheEventEntry(key=key.to_encoded_object_key(), size_bytes=size_bytes)
+        if event_type is CacheEventType.STORE
+        else CacheEventEntry(key=key.to_encoded_object_key())
+    )
+    body = CacheEventsRequest(
+        batches=[
+            CacheEventBatch(
+                instance_id=instance_id,
+                incarnation=incarnation,
+                seq=seq,
+                event_type=event_type,
+                tier=tier,
+                backend=backend,
+                shared=shared,
+                ts=time.time(),
+                entries=[entry],
+            )
+        ]
+    )
+    response = requests.post(
+        f"{base}/events", json=body.model_dump(mode="json"), timeout=2
+    )
+    assert response.status_code == 200, response.text
+
+
+def _module(body: dict, tier: str, backend: str) -> dict:
+    """Pick one module out of an instance-status body."""
+    found = [
+        m for m in body["modules"] if m["tier"] == tier and m["backend"] == backend
+    ]
+    assert len(found) == 1, f"expected one {tier}/{backend}, got {body['modules']}"
+    return found[0]
+
+
+def _instance(fleet: dict, instance_id: str) -> dict:
+    """Pick one instance out of a fleet body."""
+    found = [i for i in fleet["instances"] if i["instance_id"] == instance_id]
+    assert len(found) == 1, f"expected one {instance_id}, got {fleet['instances']}"
+    return found[0]
+
+
+def test_usage_and_capacity_join_over_real_http(coordinator) -> None:
+    """Both halves arrive on the event stream and are joined on read."""
+    _register(
+        coordinator,
+        "mp-1",
+        [
+            {"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB},
+            {"tier": "l2", "backend": "fs", "capacity_bytes": 200 * GIB},
+        ],
+    )
+    _register(
+        coordinator,
+        "mp-2",
+        [{"tier": "l1", "backend": "dram", "capacity_bytes": 80 * GIB}],
+    )
+
+    # Placement seqs continue past the config batches the declaration used.
+    _publish(coordinator, "mp-1", Tier.L1, "dram", 10 * GIB, index=1, seq=3)
+    _publish(coordinator, "mp-1", Tier.L2, "fs", 50 * GIB, index=2, seq=4)
+    _publish(coordinator, "mp-2", Tier.L1, "dram", 60 * GIB, index=3, seq=2)
+
+    fleet = requests.get(f"{coordinator}/instances/usage", timeout=2).json()
+    assert [i["instance_id"] for i in fleet["instances"]] == ["mp-1", "mp-2"]
+
+    mp1 = _instance(fleet, "mp-1")
+    assert _module(mp1, "l1", "dram")["usage_ratio"] == pytest.approx(0.25)
+    assert _module(mp1, "l2", "fs")["usage_ratio"] == pytest.approx(0.25)
+    assert _module(mp2 := _instance(fleet, "mp-2"), "l1", "dram")[
+        "usage_ratio"
+    ] == pytest.approx(0.75)
+    assert mp2["registered"] is True
+
+    # The per-instance endpoint agrees with the fleet view.
+    single = requests.get(f"{coordinator}/instances/mp-1/usage", timeout=2).json()
+    assert single == mp1
+
+
+def test_undeclared_capacity_serializes_as_null_over_the_wire(coordinator) -> None:
+    """Undeclared capacity (``capacity_bytes == 0``) serializes as ``null``.
+
+    A numeric stand-in would read as real occupancy.
+    """
+    _register(coordinator, "mp-1", [])
+    _publish(coordinator, "mp-1", Tier.L2, "fs", 7 * GIB, index=1)
+
+    body = requests.get(f"{coordinator}/instances/mp-1/usage", timeout=2).json()
+    module = _module(body, "l2", "fs")
+    assert module["used_bytes"] == 7 * GIB
+    assert module["capacity_bytes"] == 0
+    assert module["usage_ratio"] is None
+    assert body["declared_capacity"] is False
+    # Raw text, so a client-side default cannot mask a missing null.
+    assert '"usage_ratio":null' in requests.get(
+        f"{coordinator}/instances/mp-1/usage", timeout=2
+    ).text.replace(" ", "")
+
+
+def test_shared_pool_counted_once_across_mounts_over_real_http(coordinator) -> None:
+    """One bucket mounted by two servers is one bucket, not two."""
+    shared = {
+        "tier": "l2",
+        "backend": "s3",
+        "capacity_bytes": 100 * GIB,
+        "shared": True,
+    }
+    _register(coordinator, "mp-1", [shared])
+    _register(coordinator, "mp-2", [shared])
+
+    # Both servers report the same shared placement, at a seq past the
+    # config batch each declaration consumed.
+    _publish(coordinator, "mp-1", Tier.L2, "s3", 25 * GIB, index=1, shared=True, seq=2)
+    _publish(coordinator, "mp-2", Tier.L2, "s3", 25 * GIB, index=1, shared=True, seq=2)
+
+    fleet = requests.get(f"{coordinator}/instances/usage", timeout=2).json()
+    assert len(fleet["shared_modules"]) == 1
+    pool = fleet["shared_modules"][0]
+    assert pool["used_bytes"] == 25 * GIB
+    assert pool["usage_ratio"] == pytest.approx(0.25)
+    # Attributed to neither mounting server.
+    for entry in fleet["instances"]:
+        assert entry["modules"] == []
+
+
+def test_restart_fences_l1_but_keeps_l2_over_real_http(coordinator) -> None:
+    """An incarnation bump voids the reporter's L1; its L2 bytes outlive it."""
+    _register(
+        coordinator,
+        "mp-1",
+        [
+            {"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB},
+            {"tier": "l2", "backend": "fs", "capacity_bytes": 200 * GIB},
+        ],
+    )
+    _publish(
+        coordinator, "mp-1", Tier.L1, "dram", 10 * GIB, index=1, seq=3, incarnation=1
+    )
+    _publish(
+        coordinator, "mp-1", Tier.L2, "fs", 50 * GIB, index=2, seq=4, incarnation=1
+    )
+
+    before = requests.get(f"{coordinator}/instances/mp-1/usage", timeout=2).json()
+    assert _module(before, "l1", "dram")["used_bytes"] == 10 * GIB
+
+    # Restart: same instance, higher incarnation, seq restarts at 1.
+    _publish(
+        coordinator, "mp-1", Tier.L1, "dram", 2 * GIB, index=5, seq=1, incarnation=2
+    )
+
+    after = requests.get(f"{coordinator}/instances/mp-1/usage", timeout=2).json()
+    assert _module(after, "l1", "dram")["used_bytes"] == 2 * GIB
+    assert _module(after, "l2", "fs")["used_bytes"] == 50 * GIB
+
+
+def test_delete_releases_bytes_over_real_http(coordinator) -> None:
+    """A DELETE carries no size, so the coordinator must release what it admitted."""
+    _register(
+        coordinator,
+        "mp-1",
+        [{"tier": "l1", "backend": "dram", "capacity_bytes": 40 * GIB}],
+    )
+    _publish(coordinator, "mp-1", Tier.L1, "dram", 10 * GIB, index=1, seq=2)
+    _publish(
+        coordinator,
+        "mp-1",
+        Tier.L1,
+        "dram",
+        0,
+        index=1,
+        seq=3,
+        event_type=CacheEventType.DELETE,
+    )
+
+    body = requests.get(f"{coordinator}/instances/mp-1/usage", timeout=2).json()
+    module = _module(body, "l1", "dram")
+    assert module["used_bytes"] == 0
+    assert module["usage_ratio"] == pytest.approx(0.0)
+
+
+def test_unknown_instance_is_404_over_real_http(coordinator) -> None:
+    assert (
+        requests.get(f"{coordinator}/instances/nobody/usage", timeout=2).status_code
+        == 404
+    )
+
+
+def test_producer_declaration_yields_real_ratios_over_real_http(coordinator) -> None:
+    """What an MP server declares is what the coordinator can join against.
+
+    Drives the real producer path: a ``StorageManager`` capacity snapshot
+    through ``CacheEventSubscriber``, whose ``config`` batches are POSTed
+    verbatim. Drift between the producer's compartment identity and the
+    event stream's ``(tier, backend)`` surfaces here as a missing ratio.
+    """
+    # First Party
+    from lmcache.v1.distributed.api import CapacitySnapshot, ModuleMemoryCapacity
+    from lmcache.v1.mp_coordinator.cache_events import (
+        CacheEventSink,
+        CacheEventSubscriber,
+    )
+    from lmcache.v1.mp_observability.event import Event, EventType
+
+    # Shape _build_capacities() returns for a hybrid Device-DAX server.
+    produced = (
+        ModuleMemoryCapacity(Tier.L1, "devdax", 100 * GIB, False),
+        ModuleMemoryCapacity(Tier.L1, "dram", 10 * GIB, False),
+        ModuleMemoryCapacity(Tier.L2, "fs", 200 * GIB, False),
+        ModuleMemoryCapacity(Tier.L2, "s3", 0, True),
+    )
+    _register(coordinator, "mp-1", [])
+
+    captured: list[CacheEventBatch] = []
+
+    class _CapturingSink(CacheEventSink):
+        def publish(self, batches: list[CacheEventBatch]) -> None:
+            captured.extend(batches)
+
+    subscriber = CacheEventSubscriber(
+        sink=_CapturingSink(),
+        instance_id="mp-1",
+        incarnation=1,
+        flush_interval=0.0,
+    )
+    subscriber.get_subscriptions()[EventType.SM_CAPACITY_CHANGED](
+        Event(
+            event_type=EventType.SM_CAPACITY_CHANGED,
+            metadata={"snapshot": CapacitySnapshot(modules=produced)},
+        )
+    )
+    subscriber.flush()
+    assert len(captured) == len(produced), captured
+
+    response = requests.post(
+        f"{coordinator}/events",
+        json=CacheEventsRequest(batches=captured).model_dump(mode="json"),
+        timeout=2,
+    )
+    assert response.status_code == 200, response.text
+
+    # Usage arrives on the event stream.
+    _publish(coordinator, "mp-1", Tier.L1, "devdax", 25 * GIB, index=1, seq=5)
+    _publish(coordinator, "mp-1", Tier.L1, "dram", 5 * GIB, index=2, seq=6)
+    _publish(coordinator, "mp-1", Tier.L2, "fs", 50 * GIB, index=3, seq=7)
+    _publish(coordinator, "mp-1", Tier.L2, "s3", 9 * GIB, index=4, seq=8, shared=True)
+
+    status = requests.get(f"{coordinator}/instances/mp-1/usage", timeout=2).json()
+    assert status["declared_capacity"] is True
+
+    # Every declared compartment joins, including both hybrid L1 mediums.
+    assert _module(status, "l1", "devdax")["usage_ratio"] == pytest.approx(0.25)
+    assert _module(status, "l1", "dram")["usage_ratio"] == pytest.approx(0.5)
+    assert _module(status, "l2", "fs")["usage_ratio"] == pytest.approx(0.25)
+
+    # The uncapped shared bucket is fleet-scoped and has no denominator.
+    pool = requests.get(f"{coordinator}/instances/usage", timeout=2).json()[
+        "shared_modules"
+    ]
+    assert [(p["backend"], p["used_bytes"], p["usage_ratio"]) for p in pool] == [
+        ("s3", 9 * GIB, None)
+    ]

--- a/tests/v1/mp_coordinator/test_registrar.py
+++ b/tests/v1/mp_coordinator/test_registrar.py
@@ -224,3 +224,52 @@ def test_keep_registered_survives_unreachable_coordinator():
                 await task
 
     asyncio.run(run())
+
+
+def test_on_registered_fires_for_every_registration():
+    """The hook must fire on re-registration, not just the first one.
+
+    A restarted coordinator keeps declarations in memory only, so without
+    this the fleet view loses every capacity denominator until some
+    unrelated topology change happens to resend one.
+    """
+    calls = {"register": 0, "hook": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            calls["register"] += 1
+            return httpx.Response(
+                200, json={"instance_id": "i1", "re_registered": False}
+            )
+        if request.method == "PUT":
+            # Coordinator forgot us: forces a re-registration next tick.
+            return httpx.Response(404, json={"error": "unknown"})
+        return httpx.Response(204)
+
+    def hook() -> None:
+        calls["hook"] += 1
+
+    async def run():
+        async with _client(handler) as client:
+            await _run_loop_briefly(client, instance_id="i1", on_registered=hook)
+
+    asyncio.run(run())
+    assert calls["register"] >= 2, "expected a re-registration after the 404"
+    assert calls["hook"] == calls["register"]
+
+
+def test_on_registered_defaults_to_a_noop():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(
+                200, json={"instance_id": "i1", "re_registered": False}
+            )
+        if request.method == "PUT":
+            return httpx.Response(200, json={"instance_id": "i1"})
+        return httpx.Response(204)
+
+    async def run():
+        async with _client(handler) as client:
+            await _run_loop_briefly(client, instance_id="i1")
+
+    asyncio.run(run())  # no hook passed; must not raise

--- a/tests/v1/mp_coordinator/test_registrar.py
+++ b/tests/v1/mp_coordinator/test_registrar.py
@@ -91,7 +91,12 @@ def test_register_omits_mq_port_when_p2p_disabled():
 
 
 async def _run_loop_briefly(client: httpx.AsyncClient, **kwargs) -> None:
-    """Run keep_registered for a few ticks, then cancel it."""
+    """Run keep_registered for a few ticks, then cancel it.
+
+    Supplies a no-op ``on_registered`` unless the case under test overrides
+    it; the parameter is required, so only tests need the no-op.
+    """
+    kwargs.setdefault("on_registered", lambda: None)
     task = asyncio.create_task(
         keep_registered(
             client,
@@ -191,6 +196,7 @@ def test_keep_registered_survives_malformed_response():
                     http_port=8080,
                     advertise_ip="127.0.0.1",
                     heartbeat_interval=0.03,
+                    on_registered=lambda: None,
                 )
             )
             await asyncio.sleep(0.1)
@@ -215,6 +221,7 @@ def test_keep_registered_survives_unreachable_coordinator():
                     http_port=8080,
                     advertise_ip="127.0.0.1",
                     heartbeat_interval=0.03,
+                    on_registered=lambda: None,
                 )
             )
             await asyncio.sleep(0.1)
@@ -258,18 +265,11 @@ def test_on_registered_fires_for_every_registration():
     assert calls["hook"] == calls["register"]
 
 
-def test_on_registered_defaults_to_a_noop():
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.method == "POST":
-            return httpx.Response(
-                200, json={"instance_id": "i1", "re_registered": False}
-            )
-        if request.method == "PUT":
-            return httpx.Response(200, json={"instance_id": "i1"})
-        return httpx.Response(204)
+def test_on_registered_is_required():
+    """No default hook: a caller that republishes nothing says so."""
+    # Standard
+    import inspect
 
-    async def run():
-        async with _client(handler) as client:
-            await _run_loop_briefly(client, instance_id="i1")
-
-    asyncio.run(run())  # no hook passed; must not raise
+    parameter = inspect.signature(keep_registered).parameters["on_registered"]
+    assert parameter.default is inspect.Parameter.empty
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY


### PR DESCRIPTION
**What this PR does / why we need it**:

The coordinator knows how many bytes each MP server holds, but not how many it *can* hold. This adds the missing denominator and serves the join over HTTP.

Each MP server declares per-compartment capacity (L1 pool per backing medium, one entry per L2 adapter) on the cache-event stream it already publishes — once at startup, then on every topology change. The coordinator joins those against the per-instance totals `CacheUsageManager` already tracks from the same stream. A compartment is keyed `(tier, backend)`, the same axis cache events tag placements with.

**HTTP API**

`GET /instances/usage` — whole fleet. `GET /instances/{instance_id}/usage` — one server, same shape; `404` if the coordinator knows nothing about the id.

```
{
  "instances": [
    {"instance_id": "mp-1", "registered": true, "declared_capacity": true,
     "modules": [
       {"tier": "l1", "backend": "dram", "shared": false,
        "used_bytes": 32212254720, "capacity_bytes": 42949672960, "usage_ratio": 0.75},
       {"tier": "l2", "backend": "fs", "shared": false,
        "used_bytes": 12884901888, "capacity_bytes": 0, "usage_ratio": null}
     ]}
  ],
  "shared_modules": [
    {"tier": "l2", "backend": "s3", "shared": true,
     "used_bytes": 9663676416, "capacity_bytes": 0, "usage_ratio": null}
  ]
}
```

Conventions:

- `usage_ratio` is `null`, never a number, when no capacity was declared — the common case (`fs`, `mooncake`, `p2p`, `sagemaker` expose no capacity setting). `null` means *unknown*, not *empty*.
- Ratios above `1.0` are not clamped; over-cap means the declaration is wrong, and hiding it hides a misconfiguration.
- Shared pools (one S3 bucket, N mounts) are counted once under `shared_modules`. Capacity is reported only when every declaring server agrees; disagreement reads as undeclared.

Read-only. No eviction, no throttling, no derived LOW/HIGH/CRITICAL — with most L2 backends declaring nothing, a normalized level would be confidently wrong on most deployments.

**Why capacity rides the event stream**

Capacity is configuration: it changes at boot and reconfiguration, not per operation, and carries no `ObjectKey` for the ingest gate to dedup on. Reports are whole declarations, never deltas — which is what makes a lossy channel acceptable, since a dropped report is repaired by the next one. Unsent reports are held across publish failures. Fencing is on `(incarnation, revision)`; revision alone restarts with the process, so a restarted server's first report would look stale forever.

Registration deliberately carries no capacity. Registration and event reporting are separately configurable, so a server registering without event reporting would declare capacity whose usage never arrives — every compartment reading a confident `0.0`, indistinguishable from empty.

**Special notes for your reviewers**:

- Addresses all three review comments: endpoints under `/instances/usage`, `L1Manager.get_configured_capacity_bytes()` removed, capacity event-driven only.
- One correction: nothing was polling periodically. `memory_capacities` was a probe called once per registration. The real problem was two paths for one fact.
- `CacheEventSink.publish()` gains `capacity_reports` — breaking signature change for out-of-tree implementers.
- `configured_l1_capacity_bytes()` in `distributed/config.py` is now the single derivation of L1 size, replacing a duplicate in `usage_telemetry/messages.py`. L1 only — L2 isn't uniformly derivable from config (four field names, two units, 21 adapters; `raw_block`/`nixl_store` discover theirs at runtime), so L2 goes through each adapter's `get_usage().total_capacity_bytes`.
- Open question: `shared_modules` is fleet-scoped but served from `/instances`. A separate route is cleaner REST; one round trip is what a fleet view wants. Happy either way.
- Early commit subjects describe capacity at registration; later commits replace that. Final state is event-only.

**If applicable**:

- [x] user facing changes — docs added (`docs/source/mp/coordinator.rst`, `docs/design/v1/mp_coordinator/memory_pressure.md`)
- [x] unit tests

Cut the `jq` ranking example and the standalone `curl` invocations — reviewers can infer both from the schema. If you want it shorter still, the "Why capacity rides the event stream" section could collapse to two sentences, but it's the part most likely to preempt a review round.