### PR TITLE
[good-first-issue] telemetry: use lazy logging in FastAPI reporter (#4644)

### DIFF
--- a/lmcache/integration/request_telemetry/fastapi.py
+++ b/lmcache/integration/request_telemetry/fastapi.py
@@ -90,13 +90,13 @@ class FastAPIRequestTelemetry(RequestTelemetry):
             with urlopen(request, timeout=self._timeout) as response:
                 if response.status >= 400:
                     logger.warning(
-                        f"FastAPI telemetry request failed with"
-                        f" status {response.status}"
+                        "FastAPI telemetry request failed with status %s",
+                        response.status,
                     )
         except URLError as e:
-            logger.warning(f"FastAPI telemetry request failed: {e}")
+            logger.warning("FastAPI telemetry request failed: %s", e)
         except Exception as e:
-            logger.warning(f"FastAPI telemetry request failed unexpectedly: {e}")
+            logger.warning("FastAPI telemetry request failed unexpectedly: %s", e)
 
     def close(self) -> None:
         """Shutdown the thread pool executor."""


### PR DESCRIPTION
Closes #4644
Refs #3372

Convert the three f-string `logger.warning` calls in `lmcache/integration/request_telemetry/fastapi.py` to lazy `%`-style logging. Rendered messages and exception behaviour are unchanged.

## Validation

- `ruff check --select G004 lmcache/integration/request_telemetry/fastapi.py`
- `ruff format --check lmcache/integration/request_telemetry/fastapi.py`
- `pre-commit run --files lmcache/integration/request_telemetry/fastapi.py`