### PR TITLE
fix(cli): avoid retrying query endpoints after request errors (#4646)

### DIFF
--- a/lmcache/cli/commands/query/_request.py
+++ b/lmcache/cli/commands/query/_request.py
@@ -252,6 +252,12 @@ def _weak_completions_error(msg: str) -> bool:
     )
 
 
+def _missing_completions_endpoint(exc: BaseException) -> bool:
+    """Return whether *exc* indicates that completions are unsupported."""
+    msg = str(exc).lower()
+    return "(http 404)" in msg or "(http 405)" in msg
+
+
 class Request:
     """Build and send one query request against an OpenAI-compatible endpoint."""
 
@@ -330,6 +336,11 @@ class Request:
                     "chat API failed (no chat template); retrying with /v1/completions"
                 )
                 return self._query(request_data, chat=False)
+            if not (
+                _weak_completions_error(str(first_err))
+                or _missing_completions_endpoint(first_err)
+            ):
+                raise
             _info("/v1/completions failed; retrying with /v1/chat/completions")
             try:
                 return self._query(request_data, chat=True)

--- a/tests/cli/commands/test_query.py
+++ b/tests/cli/commands/test_query.py
@@ -10,6 +10,8 @@ import pytest
 
 # First Party
 from lmcache.cli.commands.query import QueryCommand
+from lmcache.cli.commands.query._request import Request
+import lmcache.cli.commands.query._request as request_module
 
 
 def _engine_metric_map(
@@ -242,3 +244,74 @@ class TestQueryCommandExecute:
         err = capsys.readouterr().err
         assert "Unknown documents" in err
         assert "unknown_corpus" in err
+
+
+class TestQueryRequestFallback:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RuntimeError("POST failed (HTTP 401): unauthorized"),
+            RuntimeError("POST failed (HTTP 500): server error"),
+            RuntimeError("POST failed: timed out"),
+        ],
+    )
+    def test_send_request_does_not_retry_noncompatibility_errors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        error: RuntimeError,
+    ) -> None:
+        """Propagate genuine completion failures without sending a chat retry."""
+        calls: list[bool] = []
+
+        def fail_stream(
+            _url: str,
+            _body: dict[str, object],
+            _timeout: float,
+            *,
+            chat: bool,
+            max_tokens: int,
+        ) -> dict[str, object]:
+            calls.append(chat)
+            raise error
+
+        monkeypatch.setattr(request_module, "_stream", fail_stream)
+        request = Request("http://engine.test", "model", 1, 1.0)
+
+        with pytest.raises(RuntimeError, match="POST failed"):
+            request.send_request("prompt")
+
+        assert calls == [False]
+
+    @pytest.mark.parametrize("status", [404, 405])
+    def test_send_request_retries_when_completions_endpoint_is_unsupported(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        status: int,
+    ) -> None:
+        """Retry via chat only when the completions endpoint is unsupported."""
+        calls: list[bool] = []
+
+        def stream(
+            _url: str,
+            _body: dict[str, object],
+            _timeout: float,
+            *,
+            chat: bool,
+            max_tokens: int,
+        ) -> dict[str, object]:
+            calls.append(chat)
+            if not chat:
+                raise RuntimeError(f"POST failed (HTTP {status}): unsupported")
+            return {
+                "answer": "response",
+                "prompt_tokens": 1,
+                "output_tokens": 1,
+            }
+
+        monkeypatch.setattr(request_module, "_stream", stream)
+        request = Request("http://engine.test", "model", 1, 1.0)
+
+        answer, _ = request.send_request("prompt")
+
+        assert answer == "response"
+        assert calls == [False, True]


### PR DESCRIPTION
Closes #4646

`lmcache query engine` previously retried `/v1/chat/completions` after every failure from `/v1/completions`. It now retries only when completions returns HTTP 404/405 or produces the existing empty-response condition.

Authentication failures, server failures, and transport errors now propagate without issuing a second request.

## Validation

- `pytest --noconftest -xvs tests/cli/commands/test_query.py` — 14 passed
- `ruff check lmcache/cli/commands/query/_request.py tests/cli/commands/test_query.py`
- `ruff format --check lmcache/cli/commands/query/_request.py tests/cli/commands/test_query.py`
- `pre-commit run --files lmcache/cli/commands/query/_request.py tests/cli/commands/test_query.py`

The normal test bootstrap requires the native LMCache extension, which is not installed in this CPU-only environment; the affected CLI tests run without it.