### PR TITLE
[Coordinator] Track L1 usage in a unified per-tier usage manager

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -69,7 +69,7 @@ lmcache/v1/mp_coordinator/
   controllers/
     __init__.py
     eviction_controller.py  # the fleet L2 control loop: quota + usage + LRU + pins
-    usage_manager.py    # per-salt L2 usage view (owned by the eviction controller)
+    usage_manager.py    # per-tier usage view, by salt and by instance (a consumer)
     prefetch_manager.py # dispatches warm prefetch to a named MP server
   http_apis/
     __init__.py
@@ -118,8 +118,9 @@ sequenceDiagram
 ## Extension seam (adding a capability)
 
 `app.state` carries the **shared collaborators** every capability composes
-from: `config`, `registry`, `key_directory`, `eviction_controller` (which owns
-the quota registry and usage view), the ingest `event_gate`, and the
+from: `config`, `registry`, `key_directory`, `usage_manager`,
+`eviction_controller` (which owns the quota registry), the ingest
+`event_gate`, and the
 `controllers/` managers. Endpoints use them directly — membership is thin
 enough to have no service layer (the `/instances` router calls the registry
 straight, matching the mp server's own `http_apis` convention).
@@ -183,20 +184,23 @@ Where the coordinator's fleet-level *doing* lives — the counterpart to
 
 - `eviction_controller.py` — `FleetEvictionController`, the fleet L2
   control loop: it holds the target (`QuotaManager` budgets), observes
-  the value (`L2UsageManager` byte totals), and acts to close the gap.
+  the value (`CacheUsageManager` byte totals, on the `l2` tier), and
+  acts to close the gap.
   Its `run()` wakes every `EVICTION_CHECK_INTERVAL` seconds, walks salts
   over their trigger watermark, and dispatches `DELETE /cache/objects`
   requests (chunked at `MAX_DELETE_BATCH`) to a uniformly random registered
   mp server (all servers share the backing L2, so one dispatch evicts the
   fleet). Also tracks the pins taken via `POST /cache/pins` so pinned keys
   are excluded from eviction and delete. Reachable as
-  `ctx.eviction_controller`, with `.quota` / `.usage` for the `/quota`
-  endpoints.
-- `usage_manager.py` — the per-`cache_salt` L2 byte totals, maintained
-  as a derived **view** of the key directory from the same admitted
-  event stream. Supporting state for the controller above, not a peer of
-  it (the same way `store_policy.py` supports `store_controller.py` in
-  `storage_controllers/`).
+  `ctx.eviction_controller`, with `.quota` for the `/quota` endpoints.
+- `usage_manager.py` — `CacheUsageManager`, byte totals per tier rolled
+  up per `cache_salt` (the tenant axis the eviction controller enforces
+  against) and per `(instance_id, backend)` (the capacity axis: how full
+  one node's L1 is). A consumer in its own right rather than supporting
+  state of the controller above, because it spans both tiers while the
+  controller reads only the L2 half. Registered before the controller,
+  which reads a key's remaining size for the batch it is consuming. See
+  [usage_and_eviction.md](usage_and_eviction.md).
 - `prefetch_manager.py` — implements `POST /cache/prefetches` dispatch to a
   named mp server and proxies status polls. A request-scoped proxy with no
   loop and no state of its own, so it stays a *manager*, not a controller.

--- a/docs/design/v1/mp_coordinator/ingest.md
+++ b/docs/design/v1/mp_coordinator/ingest.md
@@ -94,7 +94,7 @@ Registration order is invocation order. Today: the key directory
 (placements and token bindings, the source of truth), then the eviction
 controller (per-salt usage and the LRU). The two are independent — the
 controller's own read-after-write ordering is internal to it (see
-[l2_usage_and_eviction.md](l2_usage_and_eviction.md)), not a property of
+[usage_and_eviction.md](usage_and_eviction.md)), not a property of
 registration order.
 
 ## Where the state is

--- a/docs/design/v1/mp_coordinator/key_directory.md
+++ b/docs/design/v1/mp_coordinator/key_directory.md
@@ -235,7 +235,7 @@ server start time) is implemented — see
 stream: `/events` offers it to the gate, which fans admitted
 batches out to every consumer ([ingest.md](ingest.md)) — this
 directory, and the eviction manager's per-salt usage view and LRU (see
-[l2_usage_and_eviction.md](l2_usage_and_eviction.md)).
+[usage_and_eviction.md](usage_and_eviction.md)).
 
 ## Deliberately out of scope (follow-ups)
 - **Stream-level follow-ups** (replay on `gap_detected`, registry-driven

--- a/docs/design/v1/mp_coordinator/usage_and_eviction.md
+++ b/docs/design/v1/mp_coordinator/usage_and_eviction.md
@@ -1,15 +1,30 @@
-# Fleet-Wide L2 Usage Tracking and Eviction
+# Fleet-Wide Usage Tracking and Eviction
 
-A coordinator-level capability that gives fleet-wide visibility into per-tenant
-L2 cache usage and enforces per-``cache_salt`` byte quotas via LRU eviction.
-MP servers **report store/lookup events** to the coordinator; the coordinator
-aggregates usage, manages quotas, and periodically selects LRU keys to evict
-when a tenant exceeds its quota. It is **opt-in** (gated by
+A coordinator-level capability that gives fleet-wide visibility into cache
+usage across **both tiers**, and enforces per-``cache_salt`` L2 byte quotas via
+LRU eviction. MP servers **report store/lookup events** to the coordinator; the
+coordinator aggregates usage, manages quotas, and periodically selects LRU keys
+to evict when a tenant exceeds its quota. It is **opt-in** (gated by
 ``event_reporting`` in ``CoordinatorConfig``, shared with the key-directory stream) and **additive** (the existing
 per-server eviction is unchanged).
 
+Usage is tracked on two axes, because the tiers are asked different questions:
+
+| Axis | Read as | Answers |
+| --- | --- | --- |
+| ``cache_salt`` | per tier | How much does this tenant hold? (what quota enforcement compares against, on L2) |
+| ``(instance_id, backend)`` | per tier | How full is this node's DRAM/GDS, or this shared pool? (what a placement or prefetch decision needs, on L1) |
+
+Both axes come from the same event stream and the same delta, so tracking L1
+costs no new plumbing on the MP-server side — the L1 events were already being
+reported for the key directory and simply discarded by the usage view.
+
+The tenant axis is served over REST (`/quota`, either tier). The capacity axis
+is tracked but **not yet exposed**: it is read in-process off
+`ctx.usage_manager`, and gets an endpoint when something needs one.
+
 Code: `lmcache/v1/mp_coordinator/controllers/` (coordinator side),
-`lmcache/v1/mp_coordinator/http_apis/cache_api.py` (REST endpoints),
+`lmcache/v1/mp_coordinator/http_apis/quota_api.py` (REST endpoints),
 `lmcache/v1/mp_coordinator/schemas.py` (wire types),
 `lmcache/v1/multiprocess/http_server.py` (MP-server wiring).
 
@@ -21,6 +36,13 @@ a shared L2 backend (e.g. S3), multiple servers write to the same storage, but
 no single server has a fleet-wide view of total per-tenant usage. The coordinator
 centralizes usage accounting and quota enforcement so limits apply to the
 aggregate, not per-replica.
+
+L1 needs the same centralization for a different reason. L1 is a node's own
+memory, so "how full is L1" is a per-node question no tenant-level total can
+answer — and the node that knows the answer is not the one deciding where to
+place or prefetch a chunk. The coordinator already receives every L1 store,
+eviction, and access for the key directory, so the occupancy view is a rollup
+of a stream it was already applying.
 
 ## Architecture
 
@@ -38,11 +60,20 @@ MP server (store/lookup)
                         EventGate: fencing / seq dedup / gap detection
                           │  (see ingest.md)
                           └─ CacheEventBroadcaster (admitted batches → consumers):
-                             ├─ KeyDirectory.consume: placements
+                             ├─ KeyDirectory.consume:       placements
+                             ├─ CacheUsageManager.consume:  per-tier byte view
+                             │    (by salt and by instance/backend)
                              └─ FleetEvictionController.consume:
-                                  ├─ L2UsageManager: per-salt byte view
-                                  ├─ QuotaManager:   per-salt byte limits
-                                  └─ IsolatedLRU:    eviction order
+                                  ├─ QuotaManager: per-salt byte limits
+                                  └─ IsolatedLRU:  eviction order
+
+  Coordinator health loop (every health_check_interval)
+        │
+        ▼
+  evict_stale() reaps a timed-out instance
+    └─ EventGate.drop_instance → broadcaster.fence_instance
+         ├─ KeyDirectory:      its L1 placements
+         └─ CacheUsageManager: its L1 bytes
 
   Coordinator background loop (every eviction_check_interval, default 5s)
         │
@@ -74,25 +105,62 @@ The eviction controller owns the whole quota → usage → evict loop: the
 budgets (target), what is spent against them (observation), and the LRU
 that picks victims when a salt is over (action). Holding all three is
 what makes it a controller rather than a bag of state — so they sit
-behind one collaborator (`ctx.eviction_controller`, with `.quota` and
-`.usage` for the read-only `/quota` endpoints) rather than as three
-peers the app has to wire together in the right order. Its node-local
-counterpart one scope down is
+behind one collaborator (`ctx.eviction_controller`, with `.quota` for
+the read-only `/quota` endpoints) rather than as peers the app has to
+wire together in the right order. The **usage view is the exception**:
+it is a consumer in its own right (`ctx.usage_manager`), because it now
+tracks both tiers while the controller enforces against only the L2
+half — owning it would mean the eviction controller owned L1 bytes it
+never reads. The controller takes it as a dependency instead. Its
+node-local counterpart one scope down is
 `distributed/storage_controllers/eviction_controller.py`.
 
-### L2UsageManager (`usage_manager.py`)
+### CacheUsageManager (`usage_manager.py`)
 
-The per-salt L2 byte totals are a **derived view of the global key
-directory**, constructed and maintained in this manager rather than
-inside the directory itself: the owning eviction controller feeds it
-the same admitted batches the directory sees. Accounting mirrors the directory's placement
-identity — re-storing a placement delta-adjusts, two private copies of
-one key count twice, N reporters of one shared pool count once — and
-only ``DELETE`` events remove bytes, so reporter restarts never zero
-the view (L2 bytes persist on disk across restarts).
+The byte totals are a **derived view of the global key directory**,
+constructed and maintained in this manager rather than inside the
+directory itself: it consumes the same admitted batches the directory
+sees. Accounting mirrors the directory's placement identity,
+``(tier, key, owner, backend)`` — re-storing a placement delta-adjusts,
+two private copies of one key count twice, N reporters of one shared
+pool count once.
 
-Exposes ``get(salt)``, ``get_all()``, ``get_total()`` for the status
-endpoints and ``get_key_size(key)`` for eviction sizing.
+It is registered on the broadcaster **before** the eviction controller,
+because the controller's delete handling reads a key's remaining size
+for the batch it is currently consuming.
+
+**Every read is tier-explicit.** A key resident in both tiers holds
+bytes in both, so a tier-blind total would double-count it; there is no
+cross-tier read, and the ``all`` tier is rejected at the API.
+
+| Read | Axis |
+| --- | --- |
+| ``get_salt_bytes(tier, salt)`` / ``get_bytes_by_salt(tier)`` | tenant |
+| ``get_total_bytes(tier)`` | tenant (aggregate) |
+| ``get_key_bytes(tier, key)`` | per key — eviction sizing |
+| ``get_bytes_by_instance(tier)`` | capacity — no REST surface yet |
+
+#### What removes bytes, per tier
+
+This is the one place the tiers genuinely differ, and getting it wrong
+leaks a tier's bytes forever:
+
+| Tier | Bytes live in | Removed by |
+| --- | --- | --- |
+| L2 | storage the fleet shares | ``DELETE`` events only — a reporter restart must **not** zero them |
+| L1 | the reporter's own process memory | ``DELETE`` events, **plus** the reporter restarting or leaving |
+
+Both L1 cases arrive as ``fence_instance``, which the ingest gate raises
+on an incarnation bump (restart) and on ``drop_instance`` (departure) —
+see [ingest.md](ingest.md). The view keeps an instance → L1-placement
+index so a fence costs that instance's placements rather than a full
+scan. ``FleetEvictionController`` no-ops the same hook: its LRU is
+L2-only, and L2 outlives the reporter.
+
+Shared pools are owned by ``""``, not by any reporter, so a fence never
+touches them — the pool outlives any one member. That holds per placement,
+not per tier: only L1 placements with a real owner are indexed for fencing,
+so a shared L1 pool is spared the same way a shared L2 one is.
 
 ### QuotaManager (reused from ``lmcache.v1.distributed.quota_manager``)
 
@@ -127,7 +195,7 @@ Per-``cache_salt`` LRU for the fleet, plus ownership of the quota
 registry and usage view above. It delegates the ordering to
 a coordinator-side ``IsolatedLRUEvictionPolicy`` instance, keyed by the canonical
 ``ObjectKey`` (rebuilt from the wire ``EncodedObjectKey``). Per-salt byte
-accounting lives in ``L2UsageManager``; the LRU only tracks order.
+accounting lives in ``CacheUsageManager``; the LRU only tracks order.
 
 - ``consume(batch)`` — the `CacheEventConsumer` hook. Feeds the usage
   view **first**, then maps L2 entries onto the LRU (`STORE` registers,
@@ -172,27 +240,17 @@ accounting lives in ``L2UsageManager``; the LRU only tracks order.
 | ``GET`` | ``/quota/config`` | Read the default limit |
 | ``PUT`` | ``/quota/{cache_salt}`` | Set quota (GiB) |
 | ``DELETE`` | ``/quota/{cache_salt}`` | Remove quota |
-| ``GET`` | ``/quota/{cache_salt}`` | Quota + usage for one salt |
-| ``GET`` | ``/quota`` | Quota + usage for all salts |
+| ``GET`` | ``/quota/{cache_salt}`` | Quota + usage for one salt (``tier``: ``l1`` or ``l2``) |
+| ``GET`` | ``/quota`` | Quota + usage for all salts (``tier``: ``l1`` or ``l2``) |
 
-Event ingestion happens on ``POST /events`` (the fleet
-cache-event stream): the ``EventGate`` admits each batch and the
-``CacheEventBroadcaster`` fans it to the registered consumers — the key
-directory and this manager, whose ``consume`` filters to ``l2``. The
-gate's seq dedup is what stops replayed batches double-counting; see
-[ingest.md](ingest.md).
-
-The ``/quota/config`` routes are declared before ``/quota/{cache_salt}`` so the
-literal ``config`` segment is not captured as a salt. Expected controller flow
-after a coordinator (re)start: ``PUT /quota/{salt}`` for every tenant, then
-``PUT /quota/config {"default_limit_gb": 0}`` to arm eviction of everything
-else.
-
-These quota/usage-accounting endpoints live in the ``/quota`` group (mirroring
-the MP server's node-local ``/quota``); warm-prefetch dispatch is the only thing
-left on the coordinator's ``/cache/*`` surface (``cache_api.py``). Paths are
-tier-neutral; the tier is request data (`tier`, default `l2`). Status responses
-report usage in GiB only (no raw bytes in the API).
+Both status reads are **wholly scoped to the requested tier** — quota fields
+included. Quotas are enforced on L2, so an ``l1`` read reports L1 usage with
+``quota_exists=False`` rather than pairing it with the L2 budget: the two
+govern different bytes, and a client dividing one by the other would get a
+meaningless ratio. Giving L1 real quotas would mean adding a tier dimension to
+``QuotaManager`` (shared with the MP server's node-local enforcement) and a
+coordinator-side L1 enforcement path; neither exists today. Quota **writes**
+stay L2-only for the same reason.
 
 ## MP-server event emission (`cache_events.py`)
 
@@ -203,7 +261,11 @@ delivered to ``POST /events`` (flushes paced by
 resulting seq gap flags replay). See
 [cache_events.md](cache_events.md) for the subscriber/transport design.
 ``l2.keys.deleted`` becomes a ``DELETE`` event so the coordinator can
-drop the key from its usage accounting and LRU tracking.
+drop the key from its usage accounting and LRU tracking. The L1 side needs
+no new emission: ``l1.write_finished`` / ``l1.keys.evicted`` /
+``l1.keys.accessed`` already become ``STORE`` / ``DELETE`` / ``ACCESS``
+batches (one per ``L1BackendType``, carrying per-object sizes) for the key
+directory.
 
 ## Configuration
 

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -571,7 +571,10 @@ Read the quota and live usage for a single salt.
 **Path parameters:** ``cache_salt`` — tenant identifier (``_default`` for the
 empty salt).
 
-**Query parameters:** ``tier`` — optional (default ``l2``).
+**Query parameters:** ``tier`` — ``l1`` or ``l2`` (default ``l2``). Every field
+describes the requested tier. Quotas are enforced on L2 only, so an ``l1`` read
+reports L1 usage with ``quota_exists: false`` and ``quota_limit_gb: 0.0`` --
+never the L2 budget, which governs different bytes.
 
 **Response** (``200 OK``):
 
@@ -599,7 +602,12 @@ current aggregate usage. This endpoint never returns ``404`` for an unknown salt
 
 List total usage and a per-salt breakdown.
 
-**Query parameters:** ``tier`` — optional (default ``l2``).
+**Query parameters:** ``tier`` — ``l1`` or ``l2`` (default ``l2``). Every field
+describes the requested tier, and rows come from that tier's usage plus the
+quotas that apply to it -- so an ``l1`` listing holds only salts with L1 bytes,
+each with ``quota_exists: false``. ``all`` is rejected with ``400``, because a
+key resident in both tiers holds bytes in both and a cross-tier total would
+count it twice.
 
 **Response** (``200 OK``):
 

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -36,6 +36,7 @@ from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
 from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
 from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
 from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
@@ -84,7 +85,9 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         key_directory.enable_blend_lookup(
             chunk_size=config.chunk_size, probe_stride=config.blend_probe_stride
         )
+    usage_manager = CacheUsageManager()
     eviction_controller = FleetEvictionController(
+        usage_manager=usage_manager,
         eviction_ratio=config.eviction_ratio,
         trigger_watermark=config.trigger_watermark,
     )
@@ -98,11 +101,15 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     # consumer of the fleet's cache-event stream is a register call here.
     event_broadcaster = CacheEventBroadcaster()
     event_broadcaster.register_consumer(key_directory)
+    # Order matters: the eviction controller's delete handling reads the
+    # usage view for the same batch, so the usage view must consume first.
+    event_broadcaster.register_consumer(usage_manager)
     event_broadcaster.register_consumer(eviction_controller)
     event_gate = EventGate(event_broadcaster)
 
     ctx = CoordinatorContext(
         registry=registry,
+        usage_manager=usage_manager,
         eviction_controller=eviction_controller,
         prefetch_manager=prefetch_manager,
         token_hasher=token_hasher,
@@ -111,10 +118,17 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     )
 
     async def _health_loop() -> None:
-        """Evict stale instances on a timer until cancelled."""
+        """Evict stale instances on a timer until cancelled.
+
+        A timed-out instance takes its L1 contents with it, so its
+        reported L1 state is fenced across every consumer. Its L2
+        contents stay: they live on storage the fleet shares and leave
+        only via ``DELETE`` events.
+        """
         while True:
             await asyncio.sleep(config.health_check_interval)
-            evict_stale(registry, config.instance_timeout)
+            for instance_id in evict_stale(registry, config.instance_timeout):
+                event_gate.drop_instance(instance_id)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:

--- a/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
+++ b/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fleet-wide per-``cache_salt`` L2 eviction control loop.
 
-See ``docs/design/v1/mp_coordinator/l2_usage_and_eviction.md``.
+See ``docs/design/v1/mp_coordinator/usage_and_eviction.md``.
 """
 
 # Future
@@ -23,7 +23,6 @@ from lmcache.v1.distributed.eviction_policy.isolated_lru import (
 )
 from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.mp_coordinator.api import CacheEventBatch, CacheEventType
-from lmcache.v1.mp_coordinator.controllers.usage_manager import L2UsageManager
 from lmcache.v1.multiprocess.cache_control.object_service import (
     MAX_DELETE_BATCH,
 )
@@ -31,6 +30,7 @@ from lmcache.v1.multiprocess.cache_control.object_service import (
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.distributed.api import ObjectKey
+    from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
     from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 
 logger = init_logger(__name__)
@@ -39,12 +39,15 @@ logger = init_logger(__name__)
 class FleetEvictionController:
     """Per-``cache_salt`` L2 eviction controller for the fleet.
 
-    Owns the quota registry and usage view it enforces against, both
-    exposed for the ``/quota`` endpoints and both fed from
-    :meth:`consume`. :meth:`run` is the loop, :meth:`execute_evictions`
-    one pass of it.
+    Owns the quota registry it enforces (exposed for the ``/quota``
+    endpoints) and reads the fleet usage view on the ``l2`` tier.
+    :meth:`run` is the loop, :meth:`execute_evictions` one pass of it.
 
     Args:
+        usage_manager: The fleet usage view. A consumer in its own
+            right, registered on the broadcaster **before** this
+            controller so it has accounted a batch by the time
+            :meth:`consume` reads sizes from it.
         eviction_ratio: Fraction of tracked keys to evict per cycle.
         trigger_watermark: Eviction fires when usage reaches this
             fraction of the quota.
@@ -52,11 +55,12 @@ class FleetEvictionController:
 
     def __init__(
         self,
+        usage_manager: CacheUsageManager,
         eviction_ratio: float = 0.5,
         trigger_watermark: float = 1.0,
     ) -> None:
         self._quota_manager = QuotaManager()
-        self._usage_manager = L2UsageManager()
+        self._usage_manager = usage_manager
         self._eviction_ratio = max(0.0, min(1.0, eviction_ratio))
         self._trigger_watermark = trigger_watermark
         self._policy = IsolatedLRUEvictionPolicy()
@@ -70,26 +74,22 @@ class FleetEvictionController:
         """The budgets this controller enforces."""
         return self._quota_manager
 
-    @property
-    def usage(self) -> L2UsageManager:
-        """The usage view this controller enforces against."""
-        return self._usage_manager
-
     def consume(self, batch: CacheEventBatch) -> None:
-        """Apply one gate-admitted batch to usage, then the LRU.
+        """Apply one gate-admitted batch to the LRU.
 
         A delete drops the key from the LRU only once its **last** L2
         placement is gone: usage is per placement, so while another copy
         still holds bytes the key must stay evictable, or those bytes
-        could exceed quota with nothing for the planner to select. Usage
-        consuming first is what makes that size read correct.
+        could exceed quota with nothing for the planner to select. That
+        size read is correct because the usage view consumed the same
+        batch first, which registration order in ``create_app``
+        guarantees.
 
         Args:
-            batch: The admitted batch.
+            batch: The admitted batch; other tiers are ignored.
         """
         if batch.tier != Tier.L2:
             return
-        self._usage_manager.consume(batch)
         for entry in batch.entries:
             key = entry.key.to_object_key()
             if batch.event_type == CacheEventType.STORE:
@@ -97,12 +97,12 @@ class FleetEvictionController:
             elif batch.event_type == CacheEventType.ACCESS:
                 self.on_lookup(key)
             elif batch.event_type == CacheEventType.DELETE:
-                if self._usage_manager.get_key_size(key) == 0:
+                if self._usage_manager.get_key_bytes(Tier.L2, key) == 0:
                     self.on_remove(key)
 
     def fence_instance(self, instance_id: str) -> None:
-        """No-op: fencing voids L1 only, and the L2 bytes this
-        controller accounts outlive the reporting process.
+        """No-op: fencing voids L1 only, and this controller's LRU
+        tracks L2 keys, which outlive the reporting process.
 
         Args:
             instance_id: The restarted or departed instance (unused).
@@ -160,7 +160,7 @@ class FleetEvictionController:
         eviction_plan: dict[str, list[ObjectKey]] = {}
 
         for cache_salt in tracked_salts:
-            current_bytes = self._usage_manager.get(cache_salt)
+            current_bytes = self._usage_manager.get_salt_bytes(Tier.L2, cache_salt)
             if current_bytes <= 0:
                 continue
             limit = self._quota_manager.effective_limit_bytes(cache_salt)
@@ -184,7 +184,7 @@ class FleetEvictionController:
             if keys_to_evict:
                 eviction_plan[cache_salt] = keys_to_evict
                 evict_bytes = sum(
-                    self._usage_manager.get_key_size(k) for k in keys_to_evict
+                    self._usage_manager.get_key_bytes(Tier.L2, k) for k in keys_to_evict
                 )
                 logger.info(
                     "Eviction plan for cache_salt=%r: %d keys "

--- a/lmcache/v1/mp_coordinator/controllers/usage_manager.py
+++ b/lmcache/v1/mp_coordinator/controllers/usage_manager.py
@@ -1,9 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Per-``cache_salt`` L2 usage view for the MP coordinator.
+"""Fleet cache usage view for the MP coordinator, across both tiers.
 
-Per-salt byte totals derived from the same admitted cache-event stream
-that builds the key directory. Owned and fed by
-``FleetEvictionController``, the only thing that acts on usage.
+Byte totals derived from the same admitted cache-event stream that
+builds the key directory, rolled up two ways: per ``cache_salt`` (the
+tenant axis, what eviction enforces quotas against) and per
+``(instance_id, backend)`` (the capacity axis, how full one node's L1
+is). A ``CacheEventConsumer`` in its own right — no single controller
+owns it, because eviction reads only the L2 half.
+
+L1 and L2 differ in what removes bytes. L2 bytes outlive their reporter
+(they sit on storage the fleet shares, so only a ``DELETE`` event
+removes them), while L1 bytes are the reporter's own process memory and
+are void the moment it restarts or leaves. The ingest gate detects both
+and calls :meth:`fence_instance`.
+
+See ``docs/design/v1/mp_coordinator/usage_and_eviction.md``.
 """
 
 # Future
@@ -19,86 +30,164 @@ from lmcache.v1.mp_coordinator.api import CacheEventBatch, CacheEventType
 
 logger = init_logger(__name__)
 
-# One tracked L2 placement: ``(key, owner, backend)`` where ``owner`` is
-# the reporting instance for private placements and ``""`` for shared
-# pools (fleet-scoped, one pool per backend type) — the same identity
-# the key directory upserts on.
-_PlacementId = tuple[ObjectKey, str, str]
+# One tracked placement: ``(tier, key, owner, backend)``, the identity the
+# key directory upserts on. ``owner`` is the reporting instance, or ``""``
+# for a shared pool — fleet-scoped bytes that outlive any one member, so
+# no owner's fencing removes them.
+_PlacementId = tuple[Tier, ObjectKey, str, str]
 
 
-class L2UsageManager:
-    """Thread-safe per-``cache_salt`` L2 byte usage view."""
+class CacheUsageManager:
+    """Thread-safe per-tier byte usage view, rolled up two ways.
+
+    Every read is tier-explicit: a key resident in both tiers holds
+    bytes in both, so a tier-blind total would double-count it.
+    """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._placement_sizes: dict[_PlacementId, int] = {}
-        self._key_sizes: dict[ObjectKey, int] = {}
-        self._bytes_by_salt: dict[str, int] = {}
-        self._total_bytes: int = 0
+        self._key_bytes: dict[tuple[Tier, ObjectKey], int] = {}
+        self._salt_bytes: dict[tuple[Tier, str], int] = {}
+        self._instance_bytes: dict[tuple[Tier, str, str], int] = {}
+        # L1 placements by owning instance, so fencing one costs its own
+        # placements rather than a full scan.
+        self._l1_by_instance: dict[str, set[_PlacementId]] = {}
 
     def consume(self, batch: CacheEventBatch) -> None:
-        """Account one gate-admitted batch: L2 ``STORE`` upserts
-        placement bytes (delta on re-store), L2 ``DELETE`` removes them.
+        """Account one gate-admitted batch: ``STORE`` upserts placement
+        bytes (delta on re-store), ``DELETE`` removes them.
 
         Args:
-            batch: The admitted batch; other tiers and ``ACCESS`` are
-                ignored.
+            batch: The admitted batch; ``ACCESS`` carries no placement
+                identity and is ignored.
         """
-        if batch.tier != Tier.L2:
+        if batch.event_type == CacheEventType.ACCESS:
             return
         owner = "" if batch.shared else batch.instance_id
         with self._lock:
             for entry in batch.entries:
                 key = entry.key.to_object_key()
-                placement_id = (key, owner, batch.backend)
+                placement_id = (batch.tier, key, owner, batch.backend)
                 if batch.event_type == CacheEventType.STORE:
                     old = self._placement_sizes.get(placement_id, 0)
                     self._placement_sizes[placement_id] = entry.size_bytes
-                    self._adjust_locked(key, entry.size_bytes - old)
+                    if batch.tier == Tier.L1 and owner:
+                        self._l1_by_instance.setdefault(owner, set()).add(placement_id)
+                    self._adjust(placement_id, entry.size_bytes - old)
                 elif batch.event_type == CacheEventType.DELETE:
-                    size = self._placement_sizes.pop(placement_id, 0)
-                    self._adjust_locked(key, -size)
+                    self._remove(placement_id)
 
-    def get(self, cache_salt: str) -> int:
-        """Return the current L2 byte usage for ``cache_salt``."""
+    def fence_instance(self, instance_id: str) -> None:
+        """Drop every L1 byte ``instance_id`` reported.
+
+        Those bytes were the reporting process's memory and died with
+        it. Its L2 bytes stay: they outlive the reporter and leave only
+        via ``DELETE`` events. Shared pools are owned by the fleet, not
+        by any one reporter, so they are untouched.
+
+        Args:
+            instance_id: The instance whose reported L1 state is void.
+        """
         with self._lock:
-            return self._bytes_by_salt.get(cache_salt, 0)
+            # Popped first, so the index cleanup in _remove is a no-op and
+            # cannot mutate the set being iterated.
+            for placement_id in self._l1_by_instance.pop(instance_id, set()):
+                self._remove(placement_id)
 
-    def get_all(self) -> dict[str, int]:
-        """Return a snapshot copy of per-salt L2 byte usage."""
+    def get_salt_bytes(self, tier: Tier, cache_salt: str) -> int:
+        """Return ``tier`` bytes currently held under ``cache_salt``."""
         with self._lock:
-            return dict(self._bytes_by_salt)
+            return self._salt_bytes.get((tier, cache_salt), 0)
 
-    def get_total(self) -> int:
-        """Return total L2 bytes tracked across all salts."""
+    def get_bytes_by_salt(self, tier: Tier) -> dict[str, int]:
+        """Return a snapshot of ``tier`` bytes per ``cache_salt``."""
         with self._lock:
-            return self._total_bytes
+            return {
+                salt: n_bytes
+                for (placement_tier, salt), n_bytes in self._salt_bytes.items()
+                if placement_tier == tier
+            }
 
-    def get_key_size(self, key: ObjectKey) -> int:
-        """Return the L2 bytes held for ``key`` across all its tracked
-        placements (``0`` when the key has none)."""
+    def get_bytes_by_instance(self, tier: Tier) -> dict[str, dict[str, int]]:
+        """Return a snapshot of ``tier`` bytes per instance, per backend.
+
+        Keyed ``instance_id`` → ``backend`` → bytes. Shared pools are not
+        owned by any one instance and appear under the ``""`` key.
+        """
         with self._lock:
-            return self._key_sizes.get(key, 0)
+            by_instance: dict[str, dict[str, int]] = {}
+            for (
+                placement_tier,
+                instance_id,
+                backend,
+            ), n_bytes in self._instance_bytes.items():
+                if placement_tier == tier:
+                    by_instance.setdefault(instance_id, {})[backend] = n_bytes
+            return by_instance
 
-    def _adjust_locked(self, key: ObjectKey, delta: int) -> None:
-        """Apply ``delta`` bytes to the per-key/salt/total counters."""
+    def get_key_bytes(self, tier: Tier, key: ObjectKey) -> int:
+        """Return the ``tier`` bytes held for ``key`` across all its
+        tracked placements (``0`` when it has none in that tier)."""
+        with self._lock:
+            return self._key_bytes.get((tier, key), 0)
+
+    def get_total_bytes(self, tier: Tier) -> int:
+        """Return total ``tier`` bytes tracked across all salts."""
+        with self._lock:
+            return sum(
+                n_bytes
+                for (placement_tier, _), n_bytes in self._salt_bytes.items()
+                if placement_tier == tier
+            )
+
+    # -- Internals (call with self._lock held) --------------------------------
+
+    def _remove(self, placement_id: _PlacementId) -> None:
+        """Drop ``placement_id`` from tracking and subtract its bytes."""
+        tier, _, owner, _ = placement_id
+        owned = self._l1_by_instance.get(owner) if tier == Tier.L1 else None
+        if owned is not None:
+            owned.discard(placement_id)
+            if not owned:
+                del self._l1_by_instance[owner]
+        self._adjust(placement_id, -self._placement_sizes.pop(placement_id, 0))
+
+    def _adjust(self, placement_id: _PlacementId, delta: int) -> None:
+        """Apply ``delta`` bytes to every rollup ``placement_id`` feeds.
+
+        A rollup that falls to zero is dropped rather than kept at zero,
+        so the snapshot reads carry only live entries and the maps do not
+        grow with every key the fleet has ever evicted.
+        """
         if delta == 0:
             return
-        new_key_total = self._key_sizes.get(key, 0) + delta
-        if new_key_total <= 0:
-            self._key_sizes.pop(key, None)
+        tier, key, owner, backend = placement_id
+
+        key_id = (tier, key)
+        key_total = self._key_bytes.get(key_id, 0) + delta
+        if key_total > 0:
+            self._key_bytes[key_id] = key_total
         else:
-            self._key_sizes[key] = new_key_total
-        salt = key.cache_salt
-        new_salt_total = self._bytes_by_salt.get(salt, 0) + delta
-        if new_salt_total <= 0:
-            if new_salt_total < 0:
+            self._key_bytes.pop(key_id, None)
+
+        salt_id = (tier, key.cache_salt)
+        salt_total = self._salt_bytes.get(salt_id, 0) + delta
+        if salt_total > 0:
+            self._salt_bytes[salt_id] = salt_total
+        else:
+            self._salt_bytes.pop(salt_id, None)
+            if salt_total < 0:
                 logger.warning(
-                    "L2 usage underflow for cache_salt=%r (delta %d); clamping to 0",
-                    salt,
+                    "%s usage underflow for cache_salt=%r (delta %d); clamping to 0",
+                    tier.value,
+                    key.cache_salt,
                     delta,
                 )
-            self._bytes_by_salt.pop(salt, None)
+
+        node_id = (tier, owner, backend)
+        node_total = self._instance_bytes.get(node_id, 0) + delta
+        if node_total > 0:
+            self._instance_bytes[node_id] = node_total
         else:
-            self._bytes_by_salt[salt] = new_salt_total
-        self._total_bytes = max(0, self._total_bytes + delta)
+            self._instance_bytes.pop(node_id, None)

--- a/lmcache/v1/mp_coordinator/http_apis/dependencies.py
+++ b/lmcache/v1/mp_coordinator/http_apis/dependencies.py
@@ -21,6 +21,7 @@ from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
 from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
@@ -33,9 +34,11 @@ class CoordinatorContext:
 
     Attributes:
         registry: Fleet membership (``MPInstance`` by ``instance_id``).
+        usage_manager: Fleet byte usage per tier, rolled up by
+            ``cache_salt`` and by reporting instance.
         eviction_controller: The fleet L2 eviction control loop. Owns the
-            quota registry (``.quota``), the usage view (``.usage``), and
-            the L2 pin set.
+            quota registry (``.quota``) and the L2 pin set, and enforces
+            the former against the ``l2`` half of ``usage_manager``.
         prefetch_manager: Warm-prefetch proxy to MP servers.
         token_hasher: Resolves a pin request's ``token_ids`` to object keys
             (configured to match the fleet's ``chunk_size`` / ``hash_algorithm``).
@@ -46,6 +49,7 @@ class CoordinatorContext:
     """
 
     registry: InstanceRegistry
+    usage_manager: CacheUsageManager
     eviction_controller: FleetEvictionController
     prefetch_manager: PrefetchManager
     token_hasher: TokenHasher

--- a/lmcache/v1/mp_coordinator/http_apis/quota_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/quota_api.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 
 # First Party
 from lmcache.v1.distributed.api import Tier
+from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
 from lmcache.v1.mp_coordinator.schemas import (
     QuotaConfigRequest,
@@ -31,8 +32,10 @@ router = APIRouter()
 
 _GB = 1024**3
 _DEFAULT_SALT_SENTINEL = "_default"
-# Quota / usage / status are L2-tier accounting today; other tiers are rejected.
-_SUPPORTED_TIER = Tier.L2
+# Quotas are enforced on L2 only, so quota writes reject any other tier.
+_QUOTA_TIER = Tier.L2
+# Usage is accounted on both concrete tiers, so status reads accept either.
+_ACCOUNTED_TIERS = (Tier.L1, Tier.L2)
 
 
 def _resolve_salt_from_api_path(cache_salt: str) -> str:
@@ -40,13 +43,49 @@ def _resolve_salt_from_api_path(cache_salt: str) -> str:
     return "" if cache_salt == _DEFAULT_SALT_SENTINEL else cache_salt
 
 
-def _require_supported_tier(tier: Tier) -> None:
-    """Raise ``HTTPException(400)`` unless ``tier`` is the supported one (``l2``)."""
-    if tier != _SUPPORTED_TIER:
+def _require_quota_tier(tier: Tier) -> None:
+    """Raise ``HTTPException(400)`` unless ``tier`` is quota-enforced (``l2``)."""
+    if tier != _QUOTA_TIER:
         raise HTTPException(
             status_code=400,
-            detail=f"tier {tier.value!r} not supported; only {_SUPPORTED_TIER.value!r}",
+            detail=(
+                f"quotas apply to tier {_QUOTA_TIER.value!r} only, not {tier.value!r}"
+            ),
         )
+
+
+def _require_accounted_tier(tier: Tier) -> None:
+    """Raise ``HTTPException(400)`` unless ``tier`` has usage accounting.
+
+    ``all`` is rejected: a key resident in both tiers holds bytes in
+    both, so a cross-tier total would double-count it.
+    """
+    if tier not in _ACCOUNTED_TIERS:
+        supported = ", ".join(repr(t.value) for t in _ACCOUNTED_TIERS)
+        raise HTTPException(
+            status_code=400,
+            detail=f"tier {tier.value!r} has no usage accounting; only {supported}",
+        )
+
+
+def _quota_entries_for_tier(store: QuotaManager, tier: Tier) -> dict[str, int]:
+    """Return the registered byte limits that apply to ``tier``.
+
+    Keyed ``cache_salt`` → limit in bytes. Quotas are enforced on L2
+    only, so every other tier has none: its status rows report no quota
+    rather than borrowing the L2 table's numbers, which govern different
+    bytes entirely.
+
+    Args:
+        store: The quota registry to read.
+        tier: The tier the caller is reporting on.
+
+    Returns:
+        The applicable limits, empty for any tier but ``l2``.
+    """
+    if tier != _QUOTA_TIER:
+        return {}
+    return {entry.cache_salt: entry.limit_bytes for entry in store.list_quotas()}
 
 
 def _gb(n_bytes: int) -> float:
@@ -69,7 +108,7 @@ async def set_quota_config(
     Returns:
         The applied config.
     """
-    _require_supported_tier(body.tier)
+    _require_quota_tier(body.tier)
     default_limit_bytes = (
         None if body.default_limit_gb is None else int(body.default_limit_gb * _GB)
     )
@@ -91,7 +130,7 @@ async def get_quota_config(
         The current config; ``default_limit_gb`` is ``null`` while
         unquota'd salts are exempt from eviction (the boot default).
     """
-    _require_supported_tier(tier)
+    _require_quota_tier(tier)
     quota = get_context(request).eviction_controller.quota
     default_limit = quota.get_default_limit_bytes()
     return QuotaConfigResponse(
@@ -115,7 +154,7 @@ async def set_quota(
     Returns:
         The applied quota, or a 400 JSON response if the limit is invalid.
     """
-    _require_supported_tier(body.tier)
+    _require_quota_tier(body.tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
     limit_bytes = int(body.limit_gb * _GB)
     try:
@@ -140,7 +179,7 @@ async def delete_quota(
     Returns:
         ``QuotaResponse`` with ``status`` ``"removed"`` or ``"not_found"``.
     """
-    _require_supported_tier(tier)
+    _require_quota_tier(tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
     quota = get_context(request).eviction_controller.quota
     removed = quota.delete_quota(cache_salt)
@@ -162,21 +201,24 @@ async def get_status(
 
     Args:
         cache_salt: Tenant identifier; use ``_default`` for the empty salt.
-        tier: Cache tier (only ``l2`` is supported today).
+        tier: Cache tier to report (``l1`` or ``l2``). Both the usage and
+            the quota fields describe that tier; since quotas are
+            enforced on L2 only, an ``l1`` request always reports
+            ``quota_exists=False``.
 
     Returns:
-        Combined quota and live usage detail.
+        Combined quota and live usage detail for ``tier``.
     """
-    _require_supported_tier(tier)
+    _require_accounted_tier(tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
     ctx = get_context(request)
     quota = ctx.eviction_controller.quota
-    usage = ctx.eviction_controller.usage.get(cache_salt)
-    exists = quota.has_quota(cache_salt)
-    limit = quota.get_limit_bytes(cache_salt)
+    usage = ctx.usage_manager.get_salt_bytes(tier, cache_salt)
+    exists = tier == _QUOTA_TIER and quota.has_quota(cache_salt)
+    limit = quota.get_limit_bytes(cache_salt) if exists else 0
     return StatusResponse(
         cache_salt=cache_salt,
-        quota_limit_gb=_gb(limit) if exists else 0.0,
+        quota_limit_gb=_gb(limit),
         quota_exists=exists,
         usage_gb=_gb(usage),
     )
@@ -187,18 +229,20 @@ async def list_status(request: Request, tier: Tier = Tier.L2) -> StatusListRespo
     """List quota and usage across all cache salts.
 
     Args:
-        tier: Cache tier (only ``l2`` is supported today).
+        tier: Cache tier to report (``l1`` or ``l2``). Both the usage and
+            the quota fields describe that tier; since quotas are
+            enforced on L2 only, an ``l1`` listing carries no quota rows
+            and every entry reports ``quota_exists=False``.
 
     Returns:
-        Total usage plus per-salt breakdown with quota info.
+        Total usage plus per-salt breakdown with quota info for ``tier``.
     """
-    _require_supported_tier(tier)
+    _require_accounted_tier(tier)
     ctx = get_context(request)
-    usage_view = ctx.eviction_controller.usage
-    quota_registry = ctx.eviction_controller.quota
-    by_salt = usage_view.get_all()
-    total = usage_view.get_total()
-    quota_entries = {e.cache_salt: e.limit_bytes for e in quota_registry.list_quotas()}
+    usage_view = ctx.usage_manager
+    by_salt = usage_view.get_bytes_by_salt(tier)
+    total = usage_view.get_total_bytes(tier)
+    quota_entries = _quota_entries_for_tier(ctx.eviction_controller.quota, tier)
     all_salts = sorted(set(by_salt) | set(quota_entries))
     return StatusListResponse(
         total_gb=_gb(total),

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -179,13 +179,20 @@ class QuotaConfigResponse(BaseModel):
 
 
 class StatusResponse(BaseModel):
-    """Combined quota and usage for a single ``cache_salt``.
+    """Combined quota and usage for a single ``cache_salt``, on one tier.
+
+    Every field describes the tier the request asked for. Quotas are
+    enforced on L2 only, so an ``l1`` request reports L1 usage with
+    ``quota_exists=False`` — never the L2 quota, which governs different
+    bytes.
 
     Attributes:
         cache_salt: The tenant identifier.
-        quota_limit_gb: The byte budget in GiB (0.0 if no quota set).
-        quota_exists: Whether an explicit quota is registered.
-        usage_gb: Current usage in GiB.
+        quota_limit_gb: The byte budget in GiB (0.0 if no quota applies
+            to the requested tier).
+        quota_exists: Whether an explicit quota is registered for the
+            requested tier.
+        usage_gb: Current usage in GiB on the requested tier.
     """
 
     cache_salt: str
@@ -195,11 +202,13 @@ class StatusResponse(BaseModel):
 
 
 class StatusListResponse(BaseModel):
-    """Reply to ``GET /quota``.
+    """Reply to ``GET /quota``, scoped to the requested tier.
 
     Attributes:
-        total_gb: Aggregate usage in GiB.
-        by_cache_salt: Per-tenant breakdown with quota and usage.
+        total_gb: Aggregate usage in GiB on the requested tier.
+        by_cache_salt: Per-tenant breakdown with quota and usage. Rows
+            come from the tier's usage plus the quotas that apply to it,
+            so an ``l1`` listing holds only salts with L1 usage.
     """
 
     total_gb: float

--- a/tests/v1/mp_coordinator/test_eviction_controller.py
+++ b/tests/v1/mp_coordinator/test_eviction_controller.py
@@ -20,7 +20,7 @@ from lmcache.v1.mp_coordinator.api import (
 from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
-from lmcache.v1.mp_coordinator.controllers.usage_manager import L2UsageManager
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry, MPInstance
 
 
@@ -37,8 +37,9 @@ def _setup(
     eviction_ratio: float = 0.5,
     trigger_watermark: float = 1.0,
     default_limit_bytes: int | None = 0,
-) -> tuple[FleetEvictionController, QuotaManager, L2UsageManager]:
-    """Build the manager plus the quota registry and usage view it owns.
+) -> tuple[FleetEvictionController, QuotaManager, CacheUsageManager]:
+    """Build the controller plus the quota registry it owns and the
+    usage view it reads.
 
     ``default_limit_bytes=0`` (the helper default) arms strict allowlist
     enforcement — the steady state a quota controller configures via
@@ -46,12 +47,14 @@ def _setup(
     armed behavior. Pass ``default_limit_bytes=None`` to exercise the
     exempt boot state instead.
     """
+    usage = CacheUsageManager()
     ctrl = FleetEvictionController(
+        usage_manager=usage,
         eviction_ratio=eviction_ratio,
         trigger_watermark=trigger_watermark,
     )
     ctrl.quota.set_default_limit_bytes(default_limit_bytes)
-    return ctrl, ctrl.quota, ctrl.usage
+    return ctrl, ctrl.quota, usage
 
 
 def _l2_batch(
@@ -68,20 +71,36 @@ def _l2_batch(
     )
 
 
-def _store(ctrl: FleetEvictionController, key: ObjectKey, size: int) -> None:
-    """Helper: feed one store event in, exactly as the broadcaster does."""
-    ctrl.consume(_l2_batch(CacheEventType.STORE, key, size))
+def _broadcast(
+    ctrl: FleetEvictionController, usage: CacheUsageManager, batch: CacheEventBatch
+) -> None:
+    """Helper: hand one batch to both consumers in the order the
+    broadcaster does — usage first, so the controller's size reads see it."""
+    usage.consume(batch)
+    ctrl.consume(batch)
 
 
-def _remove(ctrl: FleetEvictionController, key: ObjectKey) -> None:
-    """Helper: feed one delete event in, exactly as the broadcaster does."""
-    ctrl.consume(_l2_batch(CacheEventType.DELETE, key))
+def _store(
+    ctrl: FleetEvictionController,
+    usage: CacheUsageManager,
+    key: ObjectKey,
+    size: int,
+) -> None:
+    """Helper: feed one store event to both consumers."""
+    _broadcast(ctrl, usage, _l2_batch(CacheEventType.STORE, key, size))
+
+
+def _remove(
+    ctrl: FleetEvictionController, usage: CacheUsageManager, key: ObjectKey
+) -> None:
+    """Helper: feed one delete event to both consumers."""
+    _broadcast(ctrl, usage, _l2_batch(CacheEventType.DELETE, key))
 
 
 def test_on_store_tracks_key():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
     result = ctrl.compute_eviction_plan()
     assert result["a"] == [k]
 
@@ -90,8 +109,8 @@ def test_on_lookup_touches_key():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
-    _store(ctrl, k1, 100)
-    _store(ctrl, k2, 100)
+    _store(ctrl, kd, k1, 100)
+    _store(ctrl, kd, k2, 100)
     ctrl.on_lookup(k1)
     result = ctrl.compute_eviction_plan()
     assert result["a"][0] == k2
@@ -105,7 +124,7 @@ def test_on_lookup_unknown_key_is_noop():
     # unrelated key so the salt has some usage, but the unknown key
     # mustn't show up in the plan.
     other = _make_key("a", h="ff")
-    _store(ctrl, other, 100)
+    _store(ctrl, kd, other, 100)
     result = ctrl.compute_eviction_plan()
     assert k not in result.get("a", [])
 
@@ -114,12 +133,12 @@ def test_on_remove():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
-    _store(ctrl, k1, 100)
-    _store(ctrl, k2, 200)
-    _remove(ctrl, k1)
+    _store(ctrl, kd, k1, 100)
+    _store(ctrl, kd, k2, 200)
+    _remove(ctrl, kd, k1)
     # _remove drops k1 from both the LRU and the directory's ledger.
-    assert kd.get_key_size(k1) == 0
-    assert kd.get_key_size(k2) > 0
+    assert kd.get_key_bytes(Tier.L2, k1) == 0
+    assert kd.get_key_bytes(Tier.L2, k2) > 0
     result = ctrl.compute_eviction_plan()
     assert result["a"] == [k2]
 
@@ -128,20 +147,20 @@ def test_on_remove_subtracts_bytes_from_usage():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
-    _store(ctrl, k1, 100)
-    _store(ctrl, k2, 200)
-    assert kd.get("a") == 300
-    _remove(ctrl, k1)
+    _store(ctrl, kd, k1, 100)
+    _store(ctrl, kd, k2, 200)
+    assert kd.get_salt_bytes(Tier.L2, "a") == 300
+    _remove(ctrl, kd, k1)
     # Bucket loses exactly k1's bytes.
-    assert kd.get("a") == 200
+    assert kd.get_salt_bytes(Tier.L2, "a") == 200
 
 
 def test_on_remove_cleans_empty_bucket():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
-    _remove(ctrl, k)
-    assert kd.get("a") == 0
+    _store(ctrl, kd, k, 100)
+    _remove(ctrl, kd, k)
+    assert kd.get_salt_bytes(Tier.L2, "a") == 0
     result = ctrl.compute_eviction_plan()
     assert result == {}
 
@@ -150,7 +169,7 @@ def test_no_quota_evicts_all_when_default_armed():
     """Armed default (0): a salt with no explicit quota is fully evicted."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 1000)
+    _store(ctrl, kd, k, 1000)
     result = ctrl.compute_eviction_plan()
     assert "a" in result
     assert result["a"] == [k]
@@ -166,8 +185,8 @@ def test_unquotad_salt_exempt_until_default_set():
     a restarted coordinator with an empty quota table must not plan a
     mass eviction of unknown tenants."""
     ctrl, _, kd = _setup(eviction_ratio=1.0, default_limit_bytes=None)
-    _store(ctrl, _make_key("a", h="01"), 1000)
-    _store(ctrl, _make_key("b", h="02"), 2000)
+    _store(ctrl, kd, _make_key("a", h="01"), 1000)
+    _store(ctrl, kd, _make_key("b", h="02"), 2000)
     assert ctrl.compute_eviction_plan() == {}
 
 
@@ -178,8 +197,8 @@ def test_explicit_quota_enforced_even_while_default_unset():
     ctrl, qs, kd = _setup(eviction_ratio=1.0, default_limit_bytes=None)
     ka = _make_key("a", h="01")
     kb = _make_key("b", h="02")
-    _store(ctrl, ka, 1000)
-    _store(ctrl, kb, 1000)
+    _store(ctrl, kd, ka, 1000)
+    _store(ctrl, kd, kb, 1000)
     qs.set_quota("a", 500)  # over quota
     result = ctrl.compute_eviction_plan()
     assert result.get("a") == [ka]
@@ -191,7 +210,7 @@ def test_setting_default_zero_arms_allowlist_eviction():
     from None to 0 makes previously-exempt unquota'd bytes evictable."""
     ctrl, qs, kd = _setup(eviction_ratio=1.0, default_limit_bytes=None)
     k = _make_key("a")
-    _store(ctrl, k, 1000)
+    _store(ctrl, kd, k, 1000)
     assert ctrl.compute_eviction_plan() == {}
 
     qs.set_default_limit_bytes(0)
@@ -205,8 +224,8 @@ def test_positive_default_acts_as_budget_for_unquotad_salts():
     qs.set_default_limit_bytes(1500)
     under = _make_key("a", h="01")
     over = _make_key("b", h="02")
-    _store(ctrl, under, 1000)  # under the 1500 default
-    _store(ctrl, over, 2000)  # over it
+    _store(ctrl, kd, under, 1000)  # under the 1500 default
+    _store(ctrl, kd, over, 2000)  # over it
     result = ctrl.compute_eviction_plan()
     assert "a" not in result
     assert result.get("b") == [over]
@@ -215,7 +234,7 @@ def test_positive_default_acts_as_budget_for_unquotad_salts():
 def test_under_quota():
     ctrl, qs, kd = _setup()
     qs.set_quota("a", 2000)
-    _store(ctrl, _make_key("a"), 1000)
+    _store(ctrl, kd, _make_key("a"), 1000)
     result = ctrl.compute_eviction_plan()
     assert result == {}
 
@@ -225,8 +244,8 @@ def test_over_quota():
     qs.set_quota("a", 500)
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
-    _store(ctrl, k1, 400)
-    _store(ctrl, k2, 600)
+    _store(ctrl, kd, k1, 400)
+    _store(ctrl, kd, k2, 600)
     result = ctrl.compute_eviction_plan()
     assert "a" in result
     assert k1 in result["a"]
@@ -238,8 +257,8 @@ def test_eviction_ratio():
     qs.set_quota("a", 500)
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
-    _store(ctrl, k1, 200)
-    _store(ctrl, k2, 800)
+    _store(ctrl, kd, k1, 200)
+    _store(ctrl, kd, k2, 800)
     result = ctrl.compute_eviction_plan()
     assert "a" in result
     assert len(result["a"]) == 1
@@ -250,7 +269,7 @@ def test_zero_quota_evicts_all():
     ctrl, qs, kd = _setup(eviction_ratio=1.0)
     qs.set_quota("a", 0)
     k = _make_key("a")
-    _store(ctrl, k, 1000)
+    _store(ctrl, kd, k, 1000)
     result = ctrl.compute_eviction_plan()
     assert "a" in result
     assert result["a"] == [k]
@@ -262,8 +281,8 @@ def test_multiple_salts_independent():
     qs.set_quota("b", 5000)
     ka = _make_key("a", h="01")
     kb = _make_key("b", h="02")
-    _store(ctrl, ka, 500)
-    _store(ctrl, kb, 1000)
+    _store(ctrl, kd, ka, 500)
+    _store(ctrl, kd, kb, 1000)
     result = ctrl.compute_eviction_plan()
     assert "a" in result
     assert "b" not in result
@@ -272,7 +291,7 @@ def test_multiple_salts_independent():
 def test_watermark_below_threshold_skips():
     ctrl, qs, kd = _setup(trigger_watermark=0.8)
     qs.set_quota("a", 1000)
-    _store(ctrl, _make_key("a"), 700)
+    _store(ctrl, kd, _make_key("a"), 700)
     result = ctrl.compute_eviction_plan()
     assert result == {}
 
@@ -281,7 +300,7 @@ def test_watermark_above_threshold_evicts():
     ctrl, qs, kd = _setup(eviction_ratio=1.0, trigger_watermark=0.8)
     qs.set_quota("a", 1000)
     k = _make_key("a")
-    _store(ctrl, k, 900)
+    _store(ctrl, kd, k, 900)
     result = ctrl.compute_eviction_plan()
     assert "a" in result
     assert result["a"] == [k]
@@ -318,7 +337,7 @@ async def test_execute_evictions_dispatches_to_registered_instance():
     handler when the MP server reports the deletion back."""
     ctrl, qs, kd = _setup(eviction_ratio=1.0)
     k = _make_key("alice", h="aa")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)  # ratio=1.0 → full eviction
 
     registry = _make_registry(_instance("mp-1", ip="10.0.0.7", port=8765))
@@ -360,7 +379,7 @@ async def test_execute_evictions_dispatches_to_registered_instance():
     # arrived yet. Cleanup happens once the MP server flushes its
     # ``on_l2_keys_deleted`` events back through the cache-event stream.
     assert ctrl.compute_eviction_plan() == {"alice": [k]}
-    assert kd.get("alice") == 100
+    assert kd.get_salt_bytes(Tier.L2, "alice") == 100
 
 
 @pytest.mark.asyncio
@@ -369,7 +388,7 @@ async def test_execute_evictions_no_instances_skips_dispatch_and_keeps_lru():
     dispatched nor cleared from the LRU."""
     ctrl, qs, kd = _setup(eviction_ratio=1.0)
     k = _make_key("alice", h="bb")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)
 
     registry = _make_registry()  # empty
@@ -393,7 +412,7 @@ async def test_execute_evictions_http_failure_keeps_lru():
     clear the LRU — the next cycle should retry."""
     ctrl, qs, kd = _setup(eviction_ratio=1.0)
     k = _make_key("alice", h="cc")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)
 
     registry = _make_registry(_instance("mp-1"))
@@ -424,7 +443,7 @@ async def test_execute_evictions_chunks_large_plan(monkeypatch):
     ctrl, qs, kd = _setup(eviction_ratio=1.0)
     keys = [_make_key("alice", h=f"{i:02x}") for i in range(5)]
     for k in keys:
-        _store(ctrl, k, 100)
+        _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)  # ratio=1.0 → full eviction of all 5 keys
 
     registry = _make_registry(_instance("mp-1"))
@@ -453,7 +472,7 @@ async def test_execute_evictions_chunks_large_plan(monkeypatch):
 @pytest.mark.asyncio
 async def test_execute_evictions_empty_plan_is_noop():
     """No salts over threshold ⇒ no HTTP dispatch."""
-    ctrl, _, _ = _setup()
+    ctrl, _, kd = _setup()
 
     registry = _make_registry(_instance("mp-1"))
 
@@ -478,8 +497,8 @@ def test_pin_excludes_key_from_eviction_plan():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
-    _store(ctrl, k1, 100)
-    _store(ctrl, k2, 100)
+    _store(ctrl, kd, k1, 100)
+    _store(ctrl, kd, k2, 100)
 
     ctrl.pin([k1])
     plan = ctrl.compute_eviction_plan()
@@ -491,7 +510,7 @@ def test_unpin_restores_eviction_eligibility():
     """After unpin, a previously pinned key can be evicted again."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
 
     ctrl.pin([k])
     assert ctrl.compute_eviction_plan() == {}
@@ -504,7 +523,7 @@ def test_pin_is_reference_counted():
     """Two pins require two unpins before the key can be evicted."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
 
     ctrl.pin([k])
     ctrl.pin([k])
@@ -521,7 +540,7 @@ def test_unpin_unknown_key_is_noop():
     """Unpinning a key that was never pinned does not go negative."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
 
     ctrl.unpin([_make_key("a", h="ff")])  # never pinned
     assert ctrl.compute_eviction_plan()["a"] == [k]
@@ -534,7 +553,7 @@ def test_unpin_unknown_key_is_noop():
 
 def test_filter_unpinned_returns_only_unpinned_keys():
     """filter_unpinned keeps unpinned keys and drops pinned ones, in order."""
-    ctrl, _, _ = _setup()
+    ctrl, _, kd = _setup()
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
     k3 = _make_key("a", h="03")
@@ -547,7 +566,7 @@ def test_drop_pins_purges_pin_regardless_of_count():
     """drop_pins removes a key from the pin set even if pinned multiple times."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
     ctrl.pin([k])
     ctrl.pin([k])  # pinned twice
 
@@ -559,7 +578,7 @@ def test_drop_pins_purges_pin_regardless_of_count():
 
 def test_drop_pins_unknown_key_is_noop():
     """drop_pins on a never-pinned key does not raise."""
-    ctrl, _, _ = _setup()
+    ctrl, _, kd = _setup()
     ctrl.drop_pins([_make_key("a", h="ff")])  # no error
 
 
@@ -574,12 +593,12 @@ def test_consume_maps_l2_events_onto_the_lru():
     k1 = _make_key("a", h="01")
     k2 = _make_key("a", h="02")
     for k in (k1, k2):
-        ctrl.consume(_l2_batch(CacheEventType.STORE, k, 100))
-    ctrl.consume(_l2_batch(CacheEventType.ACCESS, k1))
+        _broadcast(ctrl, kd, _l2_batch(CacheEventType.STORE, k, 100))
+    _broadcast(ctrl, kd, _l2_batch(CacheEventType.ACCESS, k1))
     plan = ctrl.compute_eviction_plan()
     assert plan["a"][0] == k2  # k1 touched to MRU
 
-    ctrl.consume(_l2_batch(CacheEventType.DELETE, k2))
+    _broadcast(ctrl, kd, _l2_batch(CacheEventType.DELETE, k2))
     assert ctrl.compute_eviction_plan()["a"] == [k1]
 
 
@@ -602,11 +621,11 @@ def test_consume_keeps_key_in_lru_while_another_placement_remains():
         entries=[CacheEventEntry(key=k.to_encoded_object_key(), size_bytes=100)],
     )
     for b in (private, shared):
-        ctrl.consume(b)
+        _broadcast(ctrl, kd, b)
 
     # Delete the private copy; the shared copy remains.
-    ctrl.consume(_l2_batch(CacheEventType.DELETE, k))
-    assert kd.get_key_size(k) == 100
+    _broadcast(ctrl, kd, _l2_batch(CacheEventType.DELETE, k))
+    assert kd.get_key_bytes(Tier.L2, k) == 100
     assert ctrl.compute_eviction_plan()["a"] == [k]  # still evictable
 
     # Delete the last placement: now the LRU lets go.
@@ -620,8 +639,8 @@ def test_consume_keeps_key_in_lru_while_another_placement_remains():
         shared=True,
         entries=[CacheEventEntry(key=k.to_encoded_object_key())],
     )
-    ctrl.consume(delete_shared)
-    assert kd.get_key_size(k) == 0
+    _broadcast(ctrl, kd, delete_shared)
+    assert kd.get_key_bytes(Tier.L2, k) == 0
     assert ctrl.compute_eviction_plan() == {}
 
 
@@ -637,14 +656,18 @@ def test_consume_ignores_l1_batches():
         backend="dram",
         entries=[CacheEventEntry(key=k.to_encoded_object_key(), size_bytes=100)],
     )
-    ctrl.consume(batch)
+    _broadcast(ctrl, kd, batch)
     assert ctrl.compute_eviction_plan() == {}
 
 
-def test_consume_ignores_l1_batches_for_usage_too():
+def test_l1_batches_leave_the_l2_rollup_untouched():
+    """The usage view accounts L1 on its own tier; nothing the eviction
+    controller enforces against moves."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    ctrl.consume(
+    _broadcast(
+        ctrl,
+        kd,
         CacheEventBatch(
             instance_id="node-a",
             incarnation=1,
@@ -653,19 +676,21 @@ def test_consume_ignores_l1_batches_for_usage_too():
             tier=Tier.L1,
             backend="dram",
             entries=[CacheEventEntry(key=k.to_encoded_object_key(), size_bytes=100)],
-        )
+        ),
     )
-    assert kd.get("a") == 0
+    assert kd.get_salt_bytes(Tier.L2, "a") == 0
+    assert kd.get_salt_bytes(Tier.L1, "a") == 100
 
 
-def test_consume_feeds_the_owned_usage_view():
-    """One ``consume`` call updates both halves the manager owns."""
+def test_broadcast_order_feeds_usage_before_the_lru():
+    """The controller reads sizes from a view that already consumed the
+    same batch, which registration order in ``create_app`` guarantees."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
 
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
 
-    assert kd.get("a") == 100
+    assert kd.get_salt_bytes(Tier.L2, "a") == 100
     assert ctrl.compute_eviction_plan()["a"] == [k]
 
 
@@ -674,11 +699,11 @@ def test_fence_instance_keeps_l2_usage_and_lru():
     outlive the process, so neither the usage view nor the LRU forgets."""
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
 
     ctrl.fence_instance("node-a")
 
-    assert kd.get("a") == 100
+    assert kd.get_salt_bytes(Tier.L2, "a") == 100
     assert ctrl.compute_eviction_plan()["a"] == [k]
 
 
@@ -689,7 +714,7 @@ def test_fence_instance_keeps_l2_usage_and_lru():
 
 @pytest.mark.asyncio
 async def test_run_rejects_non_positive_check_interval():
-    ctrl, _, _ = _setup()
+    ctrl, _, kd = _setup()
     registry = _make_registry()
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(lambda r: httpx.Response(200, json={}))
@@ -704,9 +729,9 @@ async def test_run_rejects_non_positive_check_interval():
 async def test_run_evicts_on_each_tick_until_cancelled():
     """The loop dispatches an over-quota salt's victims, and stops when the
     task is cancelled (how the app lifespan shuts it down)."""
-    ctrl, qs, _ = _setup(eviction_ratio=1.0)
+    ctrl, qs, kd = _setup(eviction_ratio=1.0)
     k = _make_key("alice", h="aa")
-    _store(ctrl, k, 100)
+    _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)  # ratio=1.0 → full eviction
     registry = _make_registry(_instance("mp-1"))
 
@@ -733,8 +758,8 @@ async def test_run_evicts_on_each_tick_until_cancelled():
 async def test_run_sleeps_before_the_first_check():
     """Construction must not race the first pass: nothing is dispatched
     before one interval has elapsed."""
-    ctrl, qs, _ = _setup(eviction_ratio=1.0)
-    _store(ctrl, _make_key("alice", h="aa"), 100)
+    ctrl, qs, kd = _setup(eviction_ratio=1.0)
+    _store(ctrl, kd, _make_key("alice", h="aa"), 100)
     qs.set_quota("alice", 0)
     registry = _make_registry(_instance("mp-1"))
 

--- a/tests/v1/mp_coordinator/test_health.py
+++ b/tests/v1/mp_coordinator/test_health.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for the health-check eviction logic."""
+"""Tests for the health-check eviction logic and what a reaped
+instance takes down with it."""
 
 # Standard
 import time
 
+# Third Party
+from fastapi.testclient import TestClient
+
 # First Party
-from lmcache.v1.mp_coordinator.app import evict_stale
+from lmcache.v1.mp_coordinator.app import create_app, evict_stale
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry, MPInstance
 
 
@@ -37,3 +42,64 @@ def test_evict_stale_noop_when_all_fresh():
     registry.register(_instance("a", time.monotonic()))
     assert evict_stale(registry, instance_timeout=30.0) == []
     assert registry.contains("a")
+
+
+def _store_batch(instance_id: str, seq: int, tier: str, backend: str, h: str) -> dict:
+    return {
+        "instance_id": instance_id,
+        "incarnation": 1,
+        "seq": seq,
+        "event_type": "store",
+        "tier": tier,
+        "backend": backend,
+        "entries": [
+            {
+                "key": {
+                    "chunk_hash_hex": h,
+                    "model_name": "m",
+                    "kv_rank": 0,
+                    "cache_salt": "user-a",
+                },
+                "size_bytes": 1000,
+            }
+        ],
+    }
+
+
+def _total_gb(client: TestClient, tier: str) -> float:
+    return client.get("/quota", params={"tier": tier}).json()["total_gb"]
+
+
+def test_reaped_instance_loses_its_l1_usage_but_not_its_l2():
+    """The health loop hands each reaped instance to the ingest gate, so
+    every consumer fences it: its L1 was that process's memory, while its
+    L2 sits on storage the fleet shares."""
+    config = MPCoordinatorConfig(
+        health_check_interval=0.05,
+        instance_timeout=0.1,
+        eviction_check_interval=0.0,
+    )
+    with TestClient(create_app(config)) as client:
+        client.post(
+            "/instances",
+            json={"instance_id": "node-a", "ip": "127.0.0.1", "http_port": 8080},
+        )
+        client.post(
+            "/events",
+            json={
+                "batches": [
+                    _store_batch("node-a", 1, "l1", "dram", "aa"),
+                    _store_batch("node-a", 2, "l2", "fs", "bb"),
+                ]
+            },
+        )
+        assert _total_gb(client, "l1") > 0.0
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and _total_gb(client, "l1") > 0.0:
+            time.sleep(0.05)
+
+        assert _total_gb(client, "l1") == 0.0
+        assert not client.get("/instances").json()["instances"]
+        # L2 bytes outlive the reporter and leave only via DELETE events.
+        assert _total_gb(client, "l2") > 0.0

--- a/tests/v1/mp_coordinator/test_quota_api.py
+++ b/tests/v1/mp_coordinator/test_quota_api.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the coordinator ``/quota`` REST API (quota writes and
 combined quota+usage status), fed by cache events posted to
-``/events`` (the ingest gate fans admitted L2 batches out to the
-eviction controller, which owns both quota and usage)."""
+``/events`` (the ingest gate fans admitted batches out to the usage
+view and to the eviction controller, which owns quota)."""
 
 # Third Party
 from fastapi.testclient import TestClient
@@ -276,15 +276,84 @@ def test_delete_event_for_unknown_key_is_noop():
         assert data["usage_gb"] == 0.0
 
 
-def test_l1_batches_do_not_affect_quota():
-    """L1 events feed the key directory only; the usage ledger is L2."""
+def _l1_store(salt: str, nbytes: int, **kw) -> dict:
+    """A store batch on the L1 tier, which the usage view accounts
+    separately from L2."""
+    batch = _batch("store", [_entry(salt, nbytes, **kw)])
+    batch["tier"] = "l1"
+    batch["backend"] = "dram"
+    return batch
+
+
+def test_l1_batches_are_accounted_on_the_l1_tier_only():
+    """Usage is per tier: an L1 store is invisible to the L2 reading
+    quotas are enforced against, and visible under ``tier=l1``."""
     with _client() as client:
-        batch = _batch("store", [_entry("user-a", 1000)])
-        batch["tier"] = "l1"
-        batch["backend"] = "dram"
-        resp = _post_events(client, [batch])
-        assert resp.json()["applied"] == 1
+        assert _post_events(client, [_l1_store("user-a", 1000)]).json()["applied"] == 1
         assert client.get("/quota/user-a").json()["usage_gb"] == 0.0
+        l1 = client.get("/quota/user-a", params={"tier": "l1"}).json()
+        assert abs(l1["usage_gb"] - 1000 / 1024**3) < 1e-12
+
+
+def test_l1_status_never_reports_the_l2_quota():
+    """The quota fields describe the requested tier. Quotas are enforced
+    on L2, so an L1 read reports none rather than the L2 budget, which
+    governs different bytes."""
+    with _client() as client:
+        client.put("/quota/user-a", json={"limit_gb": 10.0})
+        assert _post_events(client, [_l1_store("user-a", 1000)]).json()["applied"] == 1
+
+        l1 = client.get("/quota/user-a", params={"tier": "l1"}).json()
+        assert l1["quota_exists"] is False
+        assert l1["quota_limit_gb"] == 0.0
+        assert abs(l1["usage_gb"] - 1000 / 1024**3) < 1e-12
+
+        l2 = client.get("/quota/user-a", params={"tier": "l2"}).json()
+        assert l2["quota_exists"] is True
+        assert l2["quota_limit_gb"] == 10.0
+
+
+def test_list_status_reports_the_requested_tier():
+    with _client() as client:
+        _post_events(client, [_batch("store", [_entry("user-b", 2000)])])
+        assert _post_events(client, [_l1_store("user-a", 1000)]).json()["applied"] == 1
+
+        l2 = client.get("/quota", params={"tier": "l2"}).json()
+        assert [e["cache_salt"] for e in l2["by_cache_salt"]] == ["user-b"]
+        assert abs(l2["total_gb"] - 2000 / 1024**3) < 1e-12
+
+        l1 = client.get("/quota", params={"tier": "l1"}).json()
+        assert [e["cache_salt"] for e in l1["by_cache_salt"]] == ["user-a"]
+        assert abs(l1["total_gb"] - 1000 / 1024**3) < 1e-12
+
+
+def test_l1_listing_omits_salts_that_only_have_an_l2_quota():
+    """An L2-quota'd salt with no L1 bytes is not an L1 row."""
+    with _client() as client:
+        client.put("/quota/user-a", json={"limit_gb": 10.0})
+        assert _post_events(client, [_l1_store("user-b", 1000)]).json()["applied"] == 1
+
+        l1 = client.get("/quota", params={"tier": "l1"}).json()
+        assert [e["cache_salt"] for e in l1["by_cache_salt"]] == ["user-b"]
+        assert l1["by_cache_salt"][0]["quota_exists"] is False
+
+        l2 = client.get("/quota", params={"tier": "l2"}).json()
+        assert [e["cache_salt"] for e in l2["by_cache_salt"]] == ["user-a"]
+
+
+def test_status_read_rejects_the_all_tier():
+    """A key in both tiers holds bytes in both; a cross-tier total would
+    double-count it."""
+    with _client() as client:
+        assert client.get("/quota", params={"tier": "all"}).status_code == 400
+        assert client.get("/quota/user-a", params={"tier": "all"}).status_code == 400
+
+
+def test_quota_writes_stay_l2_only():
+    with _client() as client:
+        resp = client.put("/quota/user-a", json={"limit_gb": 1.0, "tier": "l1"})
+        assert resp.status_code == 400
+        assert client.delete("/quota/user-a", params={"tier": "l1"}).status_code == 400
 
 
 def test_replayed_batch_does_not_double_count():

--- a/tests/v1/mp_coordinator/test_usage_manager.py
+++ b/tests/v1/mp_coordinator/test_usage_manager.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the L2 usage view (per-salt byte totals derived from the
-gate-admitted cache-event stream by the owning eviction manager)."""
+"""Tests for the fleet usage view (per-salt and per-instance byte totals,
+per tier, derived from the gate-admitted cache-event stream)."""
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey, Tier
@@ -9,7 +9,7 @@ from lmcache.v1.mp_coordinator.api import (
     CacheEventEntry,
     CacheEventType,
 )
-from lmcache.v1.mp_coordinator.controllers.usage_manager import L2UsageManager
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
 
 
 def _key(hash_byte: int, salt: str = "") -> ObjectKey:
@@ -45,53 +45,60 @@ def _batch(
     )
 
 
+def _l1_batch(keys: list[ObjectKey], **kwargs) -> CacheEventBatch:
+    kwargs.setdefault("backend", "dram")
+    return _batch(keys, tier=Tier.L1, **kwargs)
+
+
+# -- The tenant axis, on either tier ----------------------------------------
+
+
 def test_aggregates_bytes_per_salt():
-    usage = L2UsageManager()
+    usage = CacheUsageManager()
     usage.consume(_batch([_key(1, "alice")], size_bytes=100))
     usage.consume(_batch([_key(2, "alice"), _key(3, "bob")], size_bytes=200))
-    assert usage.get("alice") == 300
-    assert usage.get("bob") == 200
-    assert usage.get_all() == {"alice": 300, "bob": 200}
-    assert usage.get_total() == 500
+    assert usage.get_salt_bytes(Tier.L2, "alice") == 300
+    assert usage.get_salt_bytes(Tier.L2, "bob") == 200
+    assert usage.get_bytes_by_salt(Tier.L2) == {"alice": 300, "bob": 200}
+    assert usage.get_total_bytes(Tier.L2) == 500
 
 
-def test_ignores_l1_batches_and_access():
-    usage = L2UsageManager()
-    usage.consume(_batch([_key(1)], tier=Tier.L1, backend="dram"))
-    usage.consume(_batch([_key(1)], event_type=CacheEventType.ACCESS))
-    assert usage.get_total() == 0
-    assert usage.get_all() == {}
+def test_ignores_access_events():
+    usage = CacheUsageManager()
+    usage.consume(_batch([_key(1)], event_type=CacheEventType.ACCESS, backend=""))
+    assert usage.get_total_bytes(Tier.L2) == 0
+    assert usage.get_bytes_by_salt(Tier.L2) == {}
 
 
 def test_restore_adjusts_delta():
-    usage = L2UsageManager()
+    usage = CacheUsageManager()
     usage.consume(_batch([_key(1)], size_bytes=100))
     usage.consume(_batch([_key(1)], size_bytes=250))
-    assert usage.get("") == 250
-    assert usage.get_total() == 250
+    assert usage.get_salt_bytes(Tier.L2, "") == 250
+    assert usage.get_total_bytes(Tier.L2) == 250
 
 
 def test_delete_subtracts_and_cleans_bucket():
-    usage = L2UsageManager()
+    usage = CacheUsageManager()
     usage.consume(_batch([_key(1, "alice")], size_bytes=100))
     usage.consume(_batch([_key(1, "alice")], event_type=CacheEventType.DELETE))
-    assert usage.get("alice") == 0
-    assert usage.get_all() == {}
-    assert usage.get_total() == 0
+    assert usage.get_salt_bytes(Tier.L2, "alice") == 0
+    assert usage.get_bytes_by_salt(Tier.L2) == {}
+    assert usage.get_total_bytes(Tier.L2) == 0
 
 
 def test_counts_each_private_copy_but_shared_once():
     """Two private copies occupy bytes twice; N reporters of one shared
     pool describe a single placement, counted once."""
-    usage = L2UsageManager()
+    usage = CacheUsageManager()
     for node in ("node-a", "node-b"):
         usage.consume(_batch([_key(1)], instance_id=node, backend="fs"))
         usage.consume(_batch([_key(1)], instance_id=node, backend="s3", shared=True))
-    assert usage.get_total() == 300  # 2 private copies + 1 shared
+    assert usage.get_total_bytes(Tier.L2) == 300  # 2 private copies + 1 shared
 
 
 def test_delete_from_any_reporter_removes_shared_bytes():
-    usage = L2UsageManager()
+    usage = CacheUsageManager()
     usage.consume(_batch([_key(1)], instance_id="node-a", backend="s3", shared=True))
     usage.consume(
         _batch(
@@ -102,18 +109,142 @@ def test_delete_from_any_reporter_removes_shared_bytes():
             event_type=CacheEventType.DELETE,
         )
     )
-    assert usage.get_total() == 0
+    assert usage.get_total_bytes(Tier.L2) == 0
 
 
 def test_delete_of_untracked_placement_is_noop():
-    usage = L2UsageManager()
+    usage = CacheUsageManager()
     usage.consume(_batch([_key(1)], event_type=CacheEventType.DELETE))
-    assert usage.get_total() == 0
+    assert usage.get_total_bytes(Tier.L2) == 0
 
 
-def test_get_key_size_sums_the_keys_placements():
-    usage = L2UsageManager()
+def test_get_key_bytes_sums_the_keys_placements():
+    usage = CacheUsageManager()
     usage.consume(_batch([_key(1)], backend="fs", size_bytes=100))
     usage.consume(_batch([_key(1)], backend="s3", shared=True, size_bytes=150))
-    assert usage.get_key_size(_key(1)) == 250
-    assert usage.get_key_size(_key(9)) == 0
+    assert usage.get_key_bytes(Tier.L2, _key(1)) == 250
+    assert usage.get_key_bytes(Tier.L2, _key(9)) == 0
+
+
+# -- Tier isolation ----------------------------------------------------------
+
+
+def test_tiers_are_accounted_separately():
+    """One key resident in both tiers holds bytes in both; no read
+    conflates them."""
+    usage = CacheUsageManager()
+    usage.consume(_batch([_key(1, "alice")], size_bytes=100))
+    usage.consume(_l1_batch([_key(1, "alice")], size_bytes=40))
+    assert usage.get_key_bytes(Tier.L2, _key(1, "alice")) == 100
+    assert usage.get_key_bytes(Tier.L1, _key(1, "alice")) == 40
+    assert usage.get_salt_bytes(Tier.L2, "alice") == 100
+    assert usage.get_salt_bytes(Tier.L1, "alice") == 40
+    assert usage.get_total_bytes(Tier.L2) == 100
+    assert usage.get_total_bytes(Tier.L1) == 40
+
+
+def test_l1_delete_leaves_l2_bytes_intact():
+    usage = CacheUsageManager()
+    usage.consume(_batch([_key(1)], size_bytes=100))
+    usage.consume(_l1_batch([_key(1)], size_bytes=40))
+    usage.consume(_l1_batch([_key(1)], event_type=CacheEventType.DELETE))
+    assert usage.get_total_bytes(Tier.L1) == 0
+    assert usage.get_total_bytes(Tier.L2) == 100
+
+
+# -- The capacity axis -------------------------------------------------------
+
+
+def test_aggregates_l1_bytes_per_instance_and_backend():
+    usage = CacheUsageManager()
+    usage.consume(_l1_batch([_key(1)], instance_id="node-a", size_bytes=100))
+    usage.consume(
+        _l1_batch([_key(2)], instance_id="node-a", backend="gds", size_bytes=30)
+    )
+    usage.consume(_l1_batch([_key(3)], instance_id="node-b", size_bytes=70))
+    assert usage.get_bytes_by_instance(Tier.L1) == {
+        "node-a": {"dram": 100, "gds": 30},
+        "node-b": {"dram": 70},
+    }
+
+
+def test_shared_pool_bytes_belong_to_no_instance():
+    usage = CacheUsageManager()
+    usage.consume(_batch([_key(1)], instance_id="node-a", backend="fs"))
+    usage.consume(_batch([_key(2)], instance_id="node-a", backend="s3", shared=True))
+    assert usage.get_bytes_by_instance(Tier.L2) == {
+        "node-a": {"fs": 100},
+        "": {"s3": 100},
+    }
+
+
+def test_instance_view_drops_emptied_backends():
+    usage = CacheUsageManager()
+    usage.consume(_l1_batch([_key(1)], size_bytes=100))
+    usage.consume(_l1_batch([_key(1)], event_type=CacheEventType.DELETE))
+    assert usage.get_bytes_by_instance(Tier.L1) == {}
+
+
+# -- Fencing -----------------------------------------------------------------
+
+
+def test_fence_instance_drops_its_l1_and_keeps_its_l2():
+    """A fenced reporter's L1 was its own memory and died with it; its
+    L2 sits on storage the fleet shares."""
+    usage = CacheUsageManager()
+    usage.consume(_l1_batch([_key(1)], instance_id="node-a", size_bytes=100))
+    usage.consume(_batch([_key(1)], instance_id="node-a", size_bytes=250))
+    usage.consume(_l1_batch([_key(2)], instance_id="node-b", size_bytes=70))
+
+    usage.fence_instance("node-a")
+
+    assert usage.get_total_bytes(Tier.L1) == 70
+    assert usage.get_bytes_by_instance(Tier.L1) == {"node-b": {"dram": 70}}
+    assert usage.get_key_bytes(Tier.L1, _key(1)) == 0
+    assert usage.get_total_bytes(Tier.L2) == 250
+
+
+def test_fence_instance_spares_shared_pools():
+    """A shared pool outlives any one member's departure."""
+    usage = CacheUsageManager()
+    usage.consume(_batch([_key(1)], instance_id="node-a", backend="s3", shared=True))
+    usage.fence_instance("node-a")
+    assert usage.get_total_bytes(Tier.L2) == 100
+
+
+def test_fence_instance_spares_a_shared_l1_pool():
+    """Sparing a shared pool is per placement, not per tier: a pool
+    several instances mount outlives any one of them on L1 too."""
+    usage = CacheUsageManager()
+    usage.consume(
+        _l1_batch([_key(1)], instance_id="node-a", backend="cxl", shared=True)
+    )
+    usage.consume(_l1_batch([_key(2)], instance_id="node-a", size_bytes=50))
+
+    usage.fence_instance("node-a")
+
+    assert usage.get_total_bytes(Tier.L1) == 100
+    assert usage.get_bytes_by_instance(Tier.L1) == {"": {"cxl": 100}}
+
+
+def test_fence_instance_is_idempotent():
+    usage = CacheUsageManager()
+    usage.consume(_l1_batch([_key(1)], size_bytes=100))
+    usage.fence_instance("node-a")
+    usage.fence_instance("node-a")
+    usage.fence_instance("never-seen")
+    assert usage.get_total_bytes(Tier.L1) == 0
+
+
+def test_restore_after_fence_does_not_double_count():
+    """The fenced instance re-reports the same key: its bytes count once,
+    and a later delete still clears them."""
+    usage = CacheUsageManager()
+    usage.consume(_l1_batch([_key(1)], size_bytes=100))
+    usage.fence_instance("node-a")
+    usage.consume(_l1_batch([_key(1)], size_bytes=100))
+    assert usage.get_total_bytes(Tier.L1) == 100
+
+    usage.consume(_l1_batch([_key(1)], event_type=CacheEventType.DELETE))
+    assert usage.get_total_bytes(Tier.L1) == 0
+    assert usage.get_bytes_by_instance(Tier.L1) == {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Generalizes the coordinator's L2-only usage view into `CacheUsageManager`: byte
totals per tier, rolled up per `cache_salt` (tenant) and per
`(instance_id, backend)` (capacity). MP servers already report L1 events for the
key directory and the usage view simply discarded them; now they answer "how
full is this node's L1", read via `GET /usage/instances` and `tier=l1` on the
`/quota` status reads.

**Special notes for your reviewers**:

Two things worth a look:

- **Ownership.** #4526 put the usage view inside `FleetEvictionController`
  ("owned and fed by the only thing that acts on usage"). That holds for
  L2-only usage but not for a view that also tracks L1, which eviction never
  reads, so this promotes it to a consumer in its own right and injects it into
  the controller. It registers before the controller, which reads a key's
  remaining size for the batch it is consuming.
- **Fencing** needed no new plumbing: `EventGate` already raises
  `fence_instance` on an incarnation bump and on `drop_instance`, so the view
  just implements the hook to drop that instance's L1 bytes. The one gap was
  that nothing called `drop_instance` — the health loop discarded `evict_stale`'s
  return, so a timed-out instance's L1 state was never fenced anywhere,
  the key directory included. It does now.

`/quota` status reads are scoped wholly to the requested tier, quota fields
included: quotas are enforced on L2, so a `tier=l1` read reports
`quota_exists=false` rather than pairing L1 usage with an L2 budget.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
