### PR TITLE
chore: add andyluo7 to CODEOWNERS for the ROCm surface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,9 +26,14 @@
 
 # GPU connector
 /lmcache/v1/gpu_connector/             @sammshen @ApostaC @hlin99
+/lmcache/v1/gpu_connector/_gds_async.py   @sammshen @ApostaC @hlin99 @andyluo7
+/lmcache/v1/gpu_connector/gds_context.py  @sammshen @ApostaC @hlin99 @andyluo7
+/lmcache/v1/gpu_connector/_hipfile_async.py @andyluo7
 
 # Platform
 /lmcache/v1/platform/                  @maobaolong @hlin99
+/lmcache/v1/platform/base/event_ipc.py @maobaolong @hlin99 @andyluo7
+/lmcache/v1/platform/rocm/             @maobaolong @hlin99 @andyluo7
 
 # Lookup client
 /lmcache/v1/lookup_client/             @maobaolong @YaoJiayi @sammshen
@@ -105,6 +110,14 @@
 /lmcache/v1/storage_backend/plugins/dax_backend.py     @DongDongJu
 /docs/source/kv_cache/storage_backends/maru.rst        @DongDongJu
 /docs/source/kv_cache/storage_backends/dax.rst         @DongDongJu
+
+# ROCm / AMD Instinct
+/.github/workflows/build_rocm_artifacts.yml  @andyluo7
+/.github/scripts/build_rocm_wheel.sh         @andyluo7
+/setup_extensions/build_profiles/rocm.py     @andyluo7
+/docker/Dockerfile.rocm                      @andyluo7
+/docker/Dockerfile.rocm-lightweight          @andyluo7
+/docs/design/v1/platform/base/event_ipc_abstraction.md  @maobaolong @hlin99 @andyluo7
 
 # Packaging
 pyproject.toml                         @sammshen @ApostaC @deng451e @hickeyma


### PR DESCRIPTION
Accepting the committer invitation — thank you.

Claiming the AMD/ROCm surface, since none of it currently has an owner in this file and it's the part I can actually test:

**Mine outright** — I wrote these and I'm the only one with the hardware to exercise them:
- `.github/workflows/build_rocm_artifacts.yml` and `.github/scripts/build_rocm_wheel.sh` (#4273, #4363, #4481)
- `setup_extensions/build_profiles/rocm.py`
- `docker/Dockerfile.rocm`, `docker/Dockerfile.rocm-lightweight` (#3101)
- `lmcache/v1/gpu_connector/_hipfile_async.py` (#3843)

**Added alongside the existing owners, not replacing them** — the GDS L1 tier my hipFile backend plugs into, and the event IPC contract:
- `lmcache/v1/gpu_connector/_gds_async.py`, `gds_context.py`
- `lmcache/v1/platform/base/event_ipc.py` and its design doc
- `lmcache/v1/platform/rocm/`

Two notes:

I deliberately did not take `/lmcache/v1/platform/` wholesale — that stays with @maobaolong and @hlin99. Owning the directory would put me on every XPU, MUSA, RBLN and Trainium change, and I'd mostly be noise there.

`/lmcache/v1/platform/rocm/` doesn't exist on `dev` yet; it arrives with #4561. Harmless to list early since CODEOWNERS ignores non-matching paths, but happy to split it into a follow-up if you'd rather.

What I can offer that's otherwise missing here: MI300X (gfx942), MI350X/MI355X (gfx950) and an NVIDIA B300, so ROCm changes can be checked on real hardware and against a CUDA control rather than reasoned about.
