### PR TITLE
docs: update NIXL HF3FS examples

### DIFF
--- a/docs/source/mp/l2_storage/nixl.rst
+++ b/docs/source/mp/l2_storage/nixl.rst
@@ -74,8 +74,8 @@ The ``OBJ`` and ``AZURE_BLOB`` backends (object stores) do not require ``file_pa
     # GDS_MT backend
     --l2-adapter '{"type": "nixl_store", "backend": "GDS_MT", "backend_params": {"file_path": "/data/nvme/lmcache", "use_direct_io": "true"}, "pool_size": 128}'
 
-    # HF3FS backend
-    --l2-adapter '{"type": "nixl_store", "backend": "HF3FS", "backend_params": {"file_path": "/mnt/hf3fs/lmcache", "use_direct_io": "false"}, "pool_size": 64}'
+    # HF3FS backend using NIXL's default /mnt/3fs mount point
+    --l2-adapter '{"type": "nixl_store", "backend": "HF3FS", "backend_params": {"file_path": "/mnt/3fs/lmcache", "use_direct_io": "false"}, "pool_size": 64}'
 
     # OBJ backend
     --l2-adapter '{"type": "nixl_store", "backend": "OBJ", "backend_params": {}, "pool_size": 32}'
@@ -147,6 +147,9 @@ populates the in-memory index when a file is found.
 
     # Basic dynamic POSIX backend (persist enabled by default)
     --l2-adapter '{"type": "nixl_store_dynamic", "backend": "POSIX", "backend_params": {"file_path": "/data/lmcache/l2", "use_direct_io": "false", "max_capacity_gb": "10"}}'
+
+    # Dynamic HF3FS backend with a custom mount point
+    --l2-adapter '{"type": "nixl_store_dynamic", "backend": "HF3FS", "backend_params": {"file_path": "/mnt/hf3fs/lmcache", "mount_point": "/mnt/hf3fs", "use_direct_io": "false", "max_capacity_gb": "100"}}'
 
     # Explicitly disable persist
     --l2-adapter '{"type": "nixl_store_dynamic", "backend": "POSIX", "backend_params": {"file_path": "/data/lmcache/l2", "use_direct_io": "false", "max_capacity_gb": "10"}, "persist_enabled": false}'


### PR DESCRIPTION
**What this PR does / why we need it**:

The static HF3FS example uses `/mnt/hf3fs/lmcache` without specifying a
`mount_point`. However, the NIXL HF3FS backend defaults `mount_point` to
`/mnt/3fs/`, so the example does not match the default NIXL configuration.

This was reproduced with 3FS mounted at `/mnt/hf3fs` and
`file_path=/mnt/hf3fs/lmcache`. Omitting `mount_point` still made NIXL resolve
its `/mnt/3fs/` default during backend creation, which failed before the
configured `file_path` could be used:

```text
Failed to create engine: boost::filesystem::canonical: No such file or directory [generic:2]: "/mnt/3fs/"
createBackend: backend creation failed for 'HF3FS'
nixl_cu12._bindings.nixlBackendError: NIXL_ERR_BACKEND
```

This PR:

- updates the static `nixl_store` example to use `/mnt/3fs/lmcache`; and
- adds a `nixl_store_dynamic` example that shows how to provide a custom
  `mount_point` together with its corresponding `file_path`.

NIXL defines the default in its
[HF3FS backend implementation](https://github.com/ai-dynamo/nixl/blob/main/src/plugins/hf3fs/hf3fs_backend.cpp#L50-L57):

```cpp
std::string mount_point = "/mnt/3fs/"; // default
```

The LMCache example uses the equivalent path `/mnt/3fs` without a trailing
slash.

**Special notes for your reviewers**:

- This is a documentation-only change; runtime behavior is unchanged.
- Validation:
  - `pre-commit run --all-files`
  - `make -C docs clean`
  - `make -C docs html`

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests