### PR TITLE
[Bugfix] storage: skip duplicate puts for resident disk keys

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -328,8 +328,15 @@ class LocalDiskBackend(StorageBackendInterface):
         :param on_complete_callback: Optional callback invoked once per key
             after the disk write completes. Callback exceptions are caught
             and logged.
+        :returns: Always ``None``. The task is skipped when a write for this
+            key is already in flight or when the key is already on disk.
         """
         assert memory_obj.tensor is not None
+
+        with self.disk_lock:
+            if key in self.dict:
+                self.cache_policy.update_on_hit(key, self.dict)
+                return None
 
         # skip repeated save
         if self.exists_in_put_tasks(key):

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -198,6 +198,7 @@ class TestLocalDiskBackend:
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
+
 class TestMultiPathDiskBackend:
     """Test cases for multi-path (multi-device) LocalDiskBackend."""
 
@@ -596,6 +597,7 @@ class TestBatchedGetBlocking:
             local_disk_backend, "read_file", side_effect=tracking_read_file
         ):
             results = local_disk_backend.batched_get_blocking(keys)
+
         assert all(r is not None for r in results)
         # With 4 keys and 4 threads, we should see more than 1 unique thread.
         assert len(set(thread_ids)) > 1, (

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -610,3 +610,47 @@ class TestBatchedGetBlocking:
         results = local_disk_backend.batched_get_blocking([])
         assert results == []
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestSubmitPutTask:
+    """Tests for LocalDiskBackend.submit_put_task()."""
+
+    @pytest.mark.parametrize(
+        "put_in_progress",
+        [False, True],
+        ids=["resident_only", "resident_and_inflight"],
+    )
+    def test_already_stored_key_is_not_rewritten(
+        self, put_in_progress: bool
+    ) -> None:
+        key = create_test_key(1)
+        resident_metadata = MagicMock()
+        backend = object.__new__(LocalDiskBackend)
+        backend.disk_lock = threading.Lock()
+        backend.dict = {key: resident_metadata}
+        backend.cache_policy = MagicMock()
+        backend.disk_worker = MagicMock()
+        backend.exists_in_put_tasks = MagicMock(return_value=put_in_progress)
+        backend.current_cache_size = 4096
+        backend.usage = 4096
+
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.tensor = torch.empty(1, dtype=torch.bfloat16)
+        callback = MagicMock()
+
+        result = backend.submit_put_task(
+            key,
+            memory_obj,
+            on_complete_callback=callback,
+        )
+
+        assert result is None
+        assert backend.current_cache_size == 4096
+        assert backend.usage == 4096
+        backend.cache_policy.update_on_hit.assert_called_once_with(key, backend.dict)
+        backend.exists_in_put_tasks.assert_not_called()
+        backend.disk_worker.insert_put_task.assert_not_called()
+        backend.disk_worker.submit_task.assert_not_called()
+        memory_obj.get_physical_size.assert_not_called()
+        memory_obj.ref_count_up.assert_not_called()
+        callback.assert_not_called()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -198,7 +198,6 @@ class TestLocalDiskBackend:
 
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
-
 class TestMultiPathDiskBackend:
     """Test cases for multi-path (multi-device) LocalDiskBackend."""
 
@@ -597,7 +596,6 @@ class TestBatchedGetBlocking:
             local_disk_backend, "read_file", side_effect=tracking_read_file
         ):
             results = local_disk_backend.batched_get_blocking(keys)
-
         assert all(r is not None for r in results)
         # With 4 keys and 4 threads, we should see more than 1 unique thread.
         assert len(set(thread_ids)) > 1, (
@@ -620,9 +618,7 @@ class TestSubmitPutTask:
         [False, True],
         ids=["resident_only", "resident_and_inflight"],
     )
-    def test_already_stored_key_is_not_rewritten(
-        self, put_in_progress: bool
-    ) -> None:
+    def test_already_stored_key_is_not_rewritten(self, put_in_progress: bool) -> None:
         key = create_test_key(1)
         resident_metadata = MagicMock()
         backend = object.__new__(LocalDiskBackend)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -630,7 +630,6 @@ class TestSubmitPutTask:
         backend.dict = {key: resident_metadata}
         backend.cache_policy = MagicMock()
         backend.disk_worker = MagicMock()
-        backend.exists_in_put_tasks = MagicMock(return_value=put_in_progress)
         backend.current_cache_size = 4096
         backend.usage = 4096
 
@@ -638,17 +637,20 @@ class TestSubmitPutTask:
         memory_obj.tensor = torch.empty(1, dtype=torch.bfloat16)
         callback = MagicMock()
 
-        result = backend.submit_put_task(
-            key,
-            memory_obj,
-            on_complete_callback=callback,
-        )
+        with patch.object(
+            backend, "exists_in_put_tasks", return_value=put_in_progress
+        ) as mock_exists_in_put_tasks:
+            result = backend.submit_put_task(
+                key,
+                memory_obj,
+                on_complete_callback=callback,
+            )
 
         assert result is None
         assert backend.current_cache_size == 4096
         assert backend.usage == 4096
         backend.cache_policy.update_on_hit.assert_called_once_with(key, backend.dict)
-        backend.exists_in_put_tasks.assert_not_called()
+        mock_exists_in_put_tasks.assert_not_called()
         backend.disk_worker.insert_put_task.assert_not_called()
         backend.disk_worker.submit_task.assert_not_called()
         memory_obj.get_physical_size.assert_not_called()


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #4655.

`LocalDiskBackend` already suppresses duplicate writes while the first write is in progress, but it did not suppress a repeated put after the key became resident. The repeated put reserved the same bytes again and rewrote the same file; `insert_key()` then kept only one metadata entry. Repeating this caused `current_cache_size` and `usage` to drift above the actual on-disk footprint and could evict or reject unrelated cache entries while space was still available.

This change treats a resident-key put as idempotent, matching `LocalCPUBackend`: it refreshes eviction recency and returns before registering work, reserving capacity, changing reference counts, or scheduling disk I/O.

## Regression coverage

Focused CPU coverage lives in `tests/v1/storage_backend/test_local_disk_backend.py` under `TestSubmitPutTask` and covers both resident states:

- a key that is resident and no longer in the in-flight task set;
- the short interval after `insert_key()` publishes the resident entry but before the original task removes its in-flight marker.

Both cases verify that a repeated put:

- leaves `current_cache_size` and `usage` unchanged;
- calls `update_on_hit()` exactly once;
- returns before consulting the in-flight task set once residency is established;
- does not register or submit a disk task;
- does not query the new object's physical size;
- does not increment its reference count;
- does not invoke the completion callback.

The tests intentionally avoid starting the asynchronous disk worker, event loop, or session allocator because none of those components participate in this early-return contract.

## Verification

Current head: `e2485c6e3e30`.

All four branch commits are signed off. GitHub reports the PR mergeable. The reviewer-requested mypy fix replaces the direct assignment to `exists_in_put_tasks()` with `patch.object(...)`, retaining the not-called assertion without a `method-assign` violation. A subsequent Code Quality run confirmed mypy and every other static check passed; its only failure was `ruff-format` rewriting the test signature onto one line, which is applied on the current head.

The equivalent two-file implementation and regression were previously verified with:

- Focused and `LocalDiskBackend` tests: 35 passed locally.
- Ruff check and format check: passed.
- `python -m py_compile`: passed.
- `git diff --check`: passed.
- `buildkite/k3-unit-tests`: passed.
- `buildkite/unit-tests-amd`: passed.

The automated review's resident-plus-in-flight ordering concern is covered: resident membership is checked before the in-flight short circuit, and the regression covers that exact interval. The reviewer-requested return documentation and test colocation are also included.

## Scope

This is independent of #4546. That issue repairs accounting when entries are removed; this change prevents accounting drift when an existing entry is put again without any removal.

It is also complementary to #4660: this PR handles already-resident keys, while #4660 handles atomic in-flight registration and rollback-safe capacity admission.

## If applicable

- [ ] this PR contains user-facing changes — docs added
- [x] this PR contains unit tests