### PR TITLE
feat: add native ATOM multiprocess integration

### DIFF
--- a/lmcache/integration/atom/__init__.py
+++ b/lmcache/integration/atom/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native ATOM integration for LMCache."""
+
+# Local
+from .multi_process_adapter import (
+    AtomMPParallelConfig,
+    AtomMPSchedulerAdapter,
+    AtomMPTransferSpec,
+    AtomMPWorkerAdapter,
+)
+
+__all__ = [
+    "AtomMPParallelConfig",
+    "AtomMPSchedulerAdapter",
+    "AtomMPTransferSpec",
+    "AtomMPWorkerAdapter",
+]

--- a/lmcache/integration/atom/multi_process_adapter.py
+++ b/lmcache/integration/atom/multi_process_adapter.py
@@ -1,0 +1,854 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native ATOM client adapters for LMCache multiprocess mode.
+
+This module contains only the transport surface ATOM needs: scheduler lookup
+and lock cleanup, plus worker registration and asynchronous store/retrieve.
+ATOM-specific cache geometry stays in the ATOM connector; engine-neutral
+transport and device-event futures stay under :mod:`lmcache.v1.multiprocess`.
+"""
+
+# Standard
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+import threading
+import uuid
+
+# Third Party
+import torch
+import zmq
+
+# First Party
+from lmcache.utils import EngineType, init_logger
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.group_view import (
+    EngineGroupInfo,
+    expand_engine_block_ids,
+)
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.multiprocess.transfer_context import (
+    TransferContext,
+    create_transfer_context,
+)
+from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
+
+logger = init_logger(__name__)
+
+DEFAULT_MQ_TIMEOUT = 300.0
+DEFAULT_HEARTBEAT_INTERVAL = 10.0
+
+
+class _IpcEvent(Protocol):
+    """Device event accepted by the multiprocess transfer context."""
+
+    def ipc_handle(self) -> Any: ...
+
+    def wait(self, stream: object | None = None) -> None: ...
+
+
+def _send_request(
+    client: MessageQueueClient,
+    request_type: RequestType,
+    payloads: list[Any],
+) -> MessagingFuture[Any]:
+    """Submit one typed request to an LMCache multiprocess server."""
+    return client.submit_request(
+        request_type,
+        payloads,
+        get_response_class(request_type),
+    )
+
+
+def _get_chunk_size(client: MessageQueueClient, timeout: float) -> int:
+    """Read the server's configured token chunk size."""
+    return int(_send_request(client, RequestType.GET_CHUNK_SIZE, []).result(timeout))
+
+
+class _HeartbeatThread(PeriodicThread):
+    """Keep track of the active LMCache server's health."""
+
+    def __init__(
+        self,
+        client: MessageQueueClient,
+        health_event: threading.Event,
+        instance_id: int,
+        interval: float,
+    ) -> None:
+        super().__init__(
+            name="lmcache-atom-heartbeat",
+            interval=interval,
+            level=ThreadLevel.CRITICAL,
+        )
+        self._client = client
+        self._health_event = health_event
+        self._instance_id = instance_id
+        self._timeout = interval
+        self._recover_callback: Callable[[], bool] = lambda: True
+        self._unhealthy_callback: Callable[[], None] = lambda: None
+        self._healthy_callback: Callable[[], bool] = self._set_health_event
+
+    def _set_health_event(self) -> bool:
+        self._health_event.set()
+        return True
+
+    def register_recover_callback(self, callback: Callable[[], bool]) -> None:
+        """Run ``callback`` before publishing recovery from an outage."""
+        self._recover_callback = callback
+
+    def register_unhealthy_callback(self, callback: Callable[[], None]) -> None:
+        """Run ``callback`` once when a healthy server becomes unhealthy."""
+        self._unhealthy_callback = callback
+
+    def register_healthy_callback(self, callback: Callable[[], bool]) -> None:
+        """Publish health through ``callback`` after any needed recovery."""
+        self._healthy_callback = callback
+
+    def _publish_unhealthy(self) -> None:
+        """Publish one healthy-to-unhealthy edge and clear the probe event."""
+        self._unhealthy_callback()
+        self._health_event.clear()
+
+    def stop_and_wait(self) -> None:
+        """Request stop and join even when one callback exceeds the soft timeout."""
+        self.stop()
+        thread = self._thread
+        if (
+            thread is not None
+            and thread is not threading.current_thread()
+            and thread.is_alive()
+        ):
+            thread.join()
+
+    def _execute(self) -> ThreadRunSummary:
+        was_healthy = self._health_event.is_set()
+        try:
+            healthy = bool(
+                _send_request(
+                    self._client,
+                    RequestType.PING,
+                    [self._instance_id],
+                ).result(timeout=self._timeout)
+            )
+        except Exception:
+            healthy = False
+        if self.stop_requested:
+            return ThreadRunSummary(success=True, message="stopping")
+
+        if healthy and not was_healthy:
+            try:
+                healthy = self._recover_callback()
+            except Exception:
+                logger.exception("ATOM LMCache recovery callback failed")
+                healthy = False
+
+        if self.stop_requested:
+            return ThreadRunSummary(success=True, message="stopping")
+        if healthy:
+            try:
+                healthy = self._healthy_callback()
+            except Exception:
+                logger.exception("ATOM LMCache healthy callback failed")
+                healthy = False
+        if not healthy and self._health_event.is_set():
+            self._publish_unhealthy()
+        return ThreadRunSummary(
+            success=True,
+            message="healthy" if healthy else "unhealthy",
+        )
+
+
+@dataclass(frozen=True)
+class AtomMPParallelConfig:
+    """ATOM rank information used to construct LMCache keys."""
+
+    world_size: int
+    worker_id: int
+    tp_size: int
+
+
+@dataclass
+class AtomMPTransferSpec:
+    """One ATOM token range and its engine-side block IDs."""
+
+    token_ids: list[int]
+    block_ids: list[list[int]]
+    start: int = 0
+    end: int = 0
+
+
+class AtomMPSchedulerAdapter:
+    """Scheduler-side lookup client for an ATOM deployment."""
+
+    def __init__(
+        self,
+        server_url: str,
+        context: zmq.Context,
+        model_name: str,
+        block_size: int,
+        parallel_config: AtomMPParallelConfig,
+        *,
+        mq_timeout: float = DEFAULT_MQ_TIMEOUT,
+    ) -> None:
+        client = MessageQueueClient(server_url, context)
+        self._model_name = model_name
+        self._parallel = parallel_config
+        self._mq_timeout = mq_timeout
+        try:
+            self.lmcache_tokens_per_chunk = _get_chunk_size(client, mq_timeout)
+            if self.lmcache_tokens_per_chunk % block_size:
+                raise ValueError(
+                    "LMCache chunk size must be divisible by ATOM block size, got "
+                    f"{self.lmcache_tokens_per_chunk} and {block_size}"
+                )
+        except Exception:
+            try:
+                client.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close ATOM scheduler MQ client after init failure",
+                    exc_info=True,
+                )
+            raise
+        self._client = client
+        self._closed = False
+        self._pending_lookups: set[str] = set()
+        self._lookup_results: dict[str, int] = {}
+
+    def maybe_submit_lookup_request(
+        self,
+        request_id: str,
+        token_ids: list[int],
+    ) -> None:
+        """Submit a lookup once for ``request_id``.
+
+        Args:
+            request_id: ATOM request identifier.
+            token_ids: Full prompt token sequence.
+        """
+        if request_id in self._pending_lookups:
+            return
+        aligned_end = (
+            len(token_ids) // self.lmcache_tokens_per_chunk
+        ) * self.lmcache_tokens_per_chunk
+        if aligned_end == 0:
+            self._lookup_results[request_id] = 0
+            return
+        key = self._create_key(
+            token_ids,
+            start=0,
+            end=aligned_end,
+            request_id=request_id,
+            worker_id=None,
+        )
+        _send_request(
+            self._client,
+            RequestType.LOOKUP,
+            [key, self._parallel.tp_size],
+        ).result(timeout=self._mq_timeout)
+        self._pending_lookups.add(request_id)
+
+    def check_lookup_result(self, request_id: str) -> int | None:
+        """Return matched tokens, ``None`` while prefetch is still pending."""
+        if request_id in self._lookup_results:
+            return self._lookup_results[request_id]
+        if request_id not in self._pending_lookups:
+            return 0
+        result = _send_request(
+            self._client,
+            RequestType.QUERY_PREFETCH_STATUS,
+            [request_id],
+        ).result(timeout=self._mq_timeout)
+        if result is None:
+            return None
+        matched_tokens = int(result) * self.lmcache_tokens_per_chunk
+        self._lookup_results[request_id] = matched_tokens
+        return matched_tokens
+
+    def free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+    ) -> None:
+        """Release lookup locks for an ATOM token range."""
+        if start >= end:
+            return
+        key = self._create_key(
+            token_ids,
+            start=start,
+            end=end,
+            request_id=request_id,
+            worker_id=None,
+        )
+        _send_request(
+            self._client,
+            RequestType.FREE_LOOKUP_LOCKS,
+            [key, self._parallel.tp_size],
+        )
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        """Discard client-side lookup state after handoff or cleanup."""
+        self._pending_lookups.discard(request_id)
+        self._lookup_results.pop(request_id, None)
+
+    def end_session(self, request_id: str) -> None:
+        """Ask the LMCache server to release request-scoped state."""
+        _send_request(self._client, RequestType.END_SESSION, [request_id])
+
+    def shutdown(self) -> None:
+        """Close the scheduler-side message queue client."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._client.close()
+        except Exception:
+            logger.warning("Failed to close ATOM scheduler MQ client", exc_info=True)
+
+    def _create_key(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        worker_id: int | None,
+    ) -> IPCCacheServerKey:
+        return IPCCacheServerKey(
+            model_name=self._model_name,
+            world_size=self._parallel.world_size,
+            worker_id=worker_id,
+            token_ids=tuple(token_ids),
+            start=start,
+            end=end,
+            request_id=request_id,
+        )
+
+
+class AtomMPWorkerAdapter:
+    """Worker-side ATOM registration and asynchronous transfer client."""
+
+    def __init__(
+        self,
+        server_url: str,
+        context: zmq.Context,
+        model_name: str,
+        block_size: int,
+        parallel_config: AtomMPParallelConfig,
+        *,
+        mq_timeout: float = DEFAULT_MQ_TIMEOUT,
+        heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        transfer_mode: str | None = None,
+    ) -> None:
+        client = MessageQueueClient(server_url, context)
+        self._model_name = model_name
+        self._block_size = block_size
+        self._parallel = parallel_config
+        self._mq_timeout = mq_timeout
+        self._heartbeat_interval = heartbeat_interval
+        self._transfer_mode = transfer_mode
+        self.instance_id = uuid.uuid4().int & ((1 << 63) - 1)
+        try:
+            self.lmcache_tokens_per_chunk = _get_chunk_size(client, mq_timeout)
+            if self.lmcache_tokens_per_chunk % block_size:
+                raise ValueError(
+                    "LMCache chunk size must be divisible by ATOM block size, got "
+                    f"{self.lmcache_tokens_per_chunk} and {block_size}"
+                )
+        except Exception:
+            try:
+                client.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close ATOM worker MQ client after init failure",
+                    exc_info=True,
+                )
+            raise
+        self._client = client
+        self.blocks_in_chunk = self.lmcache_tokens_per_chunk // block_size
+        self._kv_caches: dict[str, torch.Tensor] = {}
+        self._engine_group_infos: list[EngineGroupInfo] = []
+        self._transfer_context: TransferContext | None = None
+        self._registered = False
+        self._state_lock = threading.RLock()
+        self._state_changed = threading.Condition(self._state_lock)
+        self._closed = False
+        self._lifecycle_generation = 0
+        self._registrations_inflight = 0
+        self._context_submission_leases: dict[TransferContext, int] = {}
+        self._context_operation_futures: dict[
+            TransferContext, set[MessagingFuture[bool]]
+        ] = {}
+        self._public_registration_started = False
+        self._shutdown_complete = threading.Event()
+        self._health_event = threading.Event()
+        self._heartbeat: _HeartbeatThread | None = None
+
+    @property
+    def is_healthy(self) -> bool:
+        """Whether the server is reachable and this worker is registered."""
+        with self._state_lock:
+            return not self._closed and self._health_event.is_set()
+
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        *,
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
+    ) -> None:
+        """Register ATOM cache views with the LMCache server."""
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("ATOM LMCache worker adapter is shut down")
+            if self._public_registration_started:
+                raise RuntimeError(
+                    "ATOM KV caches are already being or were registered"
+                )
+            self._public_registration_started = True
+            self._kv_caches = kv_caches
+            self._engine_group_infos = list(engine_group_infos)
+            generation = self._lifecycle_generation
+        try:
+            if not self._register_kv_caches(generation):
+                raise RuntimeError("ATOM LMCache registration was cancelled")
+            if not self._mark_healthy():
+                raise RuntimeError("ATOM LMCache worker adapter is shutting down")
+
+            with self._state_lock:
+                if self._closed or generation != self._lifecycle_generation:
+                    raise RuntimeError("ATOM LMCache worker adapter is shutting down")
+                heartbeat = _HeartbeatThread(
+                    self._client,
+                    self._health_event,
+                    self.instance_id,
+                    self._heartbeat_interval,
+                )
+                heartbeat.register_recover_callback(self._reregister_kv_caches)
+                heartbeat.register_unhealthy_callback(self._mark_unhealthy)
+                heartbeat.register_healthy_callback(self._mark_healthy)
+                self._heartbeat = heartbeat
+                # Publish and start under the same lifecycle critical section
+                # so shutdown cannot detach an unstarted heartbeat. If start
+                # raises, keep it published so shutdown can stop/join even an
+                # implementation that launched a thread before raising.
+                heartbeat.start()
+        except Exception:
+            self.shutdown()
+            raise
+
+    def submit_store_request(
+        self,
+        request_id: str,
+        spec: AtomMPTransferSpec,
+        event: _IpcEvent,
+    ) -> MessagingFuture[bool] | None:
+        """Submit an asynchronous ATOM store.
+
+        ``None`` means the request was dropped before submission because the
+        server was unhealthy. The ATOM connector treats that as a completed
+        save opportunity, matching vLLM's degraded-mode behavior.
+        """
+        with self._state_lock:
+            if self._closed or not self._health_event.is_set():
+                return None
+            context = self._require_transfer_context_locked()
+            kv_caches = self._kv_caches
+            block_ids = expand_engine_block_ids(
+                self._engine_group_infos,
+                spec.block_ids,
+            )
+            self._context_submission_leases[context] = (
+                self._context_submission_leases.get(context, 0) + 1
+            )
+        try:
+            future = context.submit_store(
+                request_id,
+                self._create_key(request_id, spec),
+                self.instance_id,
+                kv_caches,
+                block_ids,
+                event,
+                self.blocks_in_chunk,
+            )
+            future.retain_reference(event)
+            self._track_operation_future(context, future)
+        finally:
+            self._release_submission_lease(context)
+        return future
+
+    def submit_retrieve_request(
+        self,
+        request_id: str,
+        spec: AtomMPTransferSpec,
+        event: _IpcEvent,
+    ) -> MessagingFuture[bool] | None:
+        """Submit an asynchronous ATOM retrieve.
+
+        ``None`` means no transfer was submitted. The ATOM connector reports
+        that load as failed so the scheduler recomputes into its existing
+        allocated blocks, as vLLM does for failed asynchronous loads.
+        """
+        with self._state_lock:
+            if self._closed or not self._health_event.is_set():
+                return None
+            context = self._require_transfer_context_locked()
+            kv_caches = self._kv_caches
+            block_ids = expand_engine_block_ids(
+                self._engine_group_infos,
+                spec.block_ids,
+            )
+            self._context_submission_leases[context] = (
+                self._context_submission_leases.get(context, 0) + 1
+            )
+        try:
+            future = context.submit_retrieve(
+                request_id,
+                self._create_key(request_id, spec),
+                self.instance_id,
+                kv_caches,
+                block_ids,
+                event,
+                self.blocks_in_chunk,
+            )
+            future.retain_reference(event)
+            self._track_operation_future(context, future)
+        finally:
+            self._release_submission_lease(context)
+        return future
+
+    def shutdown(self) -> None:
+        """Stop heartbeat, unregister ATOM cache views, and close the client."""
+        with self._state_lock:
+            if self._closed:
+                wait_for_shutdown = True
+                heartbeat = None
+            else:
+                wait_for_shutdown = False
+                self._closed = True
+                self._lifecycle_generation += 1
+                self._health_event.clear()
+                heartbeat = self._heartbeat
+                self._heartbeat = None
+        if wait_for_shutdown:
+            self._shutdown_complete.wait()
+            return
+
+        transfer_context: TransferContext | None = None
+        registered = False
+        try:
+            if heartbeat is not None:
+                try:
+                    heartbeat.stop_and_wait()
+                except Exception:
+                    logger.warning(
+                        "Failed while joining ATOM heartbeat during shutdown",
+                        exc_info=True,
+                    )
+
+            with self._state_changed:
+                while self._registrations_inflight or self._context_submission_leases:
+                    self._state_changed.wait()
+
+            self._drain_operation_futures()
+
+            with self._state_changed:
+                registered = self._registered
+                transfer_context = self._transfer_context
+                self._transfer_context = None
+                self._registered = False
+
+            if registered and transfer_context is not None:
+                try:
+                    _send_request(
+                        self._client,
+                        RequestType.UNREGISTER_KV_CACHE,
+                        [self.instance_id],
+                    ).result(timeout=self._mq_timeout)
+                except Exception:
+                    logger.warning(
+                        "ATOM LMCache unregister failed during shutdown",
+                        exc_info=True,
+                    )
+        finally:
+            if transfer_context is not None:
+                try:
+                    transfer_context.close()
+                except Exception:
+                    logger.warning(
+                        "Failed to close ATOM transfer context during shutdown",
+                        exc_info=True,
+                    )
+            try:
+                self._client.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close ATOM worker MQ client during shutdown",
+                    exc_info=True,
+                )
+            finally:
+                self._shutdown_complete.set()
+
+    def _register_kv_caches(self, expected_generation: int) -> bool:
+        """Build and publish a context if its lifecycle generation stays live."""
+        with self._state_lock:
+            if self._closed or expected_generation != self._lifecycle_generation:
+                return False
+            kv_caches = self._kv_caches
+            engine_group_infos = list(self._engine_group_infos)
+            self._registrations_inflight += 1
+
+        transfer_context: TransferContext | None = None
+        try:
+            transfer_context = create_transfer_context(
+                kv_caches,
+                mode=self._transfer_mode,
+            )
+            transfer_context.register(
+                self.instance_id,
+                kv_caches,
+                self._model_name,
+                self._parallel.world_size,
+                self.blocks_in_chunk,
+                self._client,
+                self._mq_timeout,
+                _send_request,
+                layout_hints={},
+                engine_group_infos=engine_group_infos,
+                engine_type=EngineType.ATOM,
+            )
+        except Exception:
+            try:
+                if transfer_context is not None:
+                    # REGISTER completion is ambiguous on timeout. Roll back
+                    # the candidate's wire registration before releasing local
+                    # resources. During recovery the old local context remains
+                    # published (but unhealthy), so a later heartbeat can
+                    # register it again if this removes a pre-existing entry.
+                    self._rollback_candidate_registration(transfer_context)
+                    transfer_context.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close rejected ATOM transfer context",
+                    exc_info=True,
+                )
+            finally:
+                self._finish_registration_attempt()
+            raise
+
+        assert transfer_context is not None
+        with self._state_lock:
+            accepted = (
+                not self._closed and expected_generation == self._lifecycle_generation
+            )
+            if accepted:
+                previous_context = self._transfer_context
+                if (
+                    previous_context is not None
+                    and previous_context is not transfer_context
+                    and self._health_event.is_set()
+                ):
+                    # A context swap must stop new submissions to the old
+                    # context before waiting for its existing leases.
+                    self._health_event.clear()
+                self._transfer_context = transfer_context
+                self._registered = True
+            else:
+                previous_context = None
+
+        if accepted:
+            try:
+                if (
+                    previous_context is not None
+                    and previous_context is not transfer_context
+                ):
+                    self._wait_for_context_leases(previous_context)
+                    try:
+                        previous_context.close()
+                    except Exception:
+                        logger.warning(
+                            "Failed to close superseded ATOM transfer context",
+                            exc_info=True,
+                        )
+                return True
+            finally:
+                self._finish_registration_attempt()
+
+        # shutdown may finish before a blocking REGISTER returns. Remove the
+        # late server registration and never publish its local context.
+        try:
+            try:
+                _send_request(
+                    self._client,
+                    RequestType.UNREGISTER_KV_CACHE,
+                    [self.instance_id],
+                ).result(timeout=self._mq_timeout)
+            except Exception:
+                logger.warning(
+                    "Failed to remove late ATOM LMCache registration",
+                    exc_info=True,
+                )
+        finally:
+            try:
+                transfer_context.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close late ATOM transfer context",
+                    exc_info=True,
+                )
+            finally:
+                self._finish_registration_attempt()
+        return False
+
+    def _reregister_kv_caches(self) -> bool:
+        """Re-register saved cache views before a recovered server is usable."""
+        with self._state_lock:
+            heartbeat = self._heartbeat
+            has_caches = bool(self._kv_caches)
+            generation = self._lifecycle_generation
+            closed = self._closed
+        if not has_caches:
+            return not closed
+        if closed or heartbeat is None or heartbeat.stop_requested:
+            return False
+        try:
+            registered = self._register_kv_caches(generation)
+        except Exception:
+            logger.exception(
+                "Failed to re-register ATOM KV caches after LMCache recovery"
+            )
+            return False
+        if not registered:
+            return False
+        logger.warning("Re-registered ATOM KV caches after LMCache recovery")
+        return True
+
+    def _mark_unhealthy(self) -> None:
+        """Clear worker health so new transfer submissions are dropped."""
+        with self._state_lock:
+            self._health_event.clear()
+
+    def _mark_healthy(self) -> bool:
+        """Publish health only for a live generation with a registered context."""
+        with self._state_lock:
+            if self._closed or not self._registered or self._transfer_context is None:
+                return False
+            self._health_event.set()
+            return True
+
+    def _finish_registration_attempt(self) -> None:
+        """Release one registration barrier slot and wake shutdown."""
+        with self._state_changed:
+            self._registrations_inflight -= 1
+            self._state_changed.notify_all()
+
+    def _wait_for_context_leases(self, transfer_context: TransferContext) -> None:
+        """Wait until no synchronous submission is using ``transfer_context``."""
+        with self._state_changed:
+            while self._context_submission_leases.get(transfer_context, 0):
+                self._state_changed.wait()
+
+    def _track_operation_future(
+        self,
+        transfer_context: TransferContext,
+        future: MessagingFuture[bool],
+    ) -> None:
+        """Track an operation so shutdown can drain it before unregistering."""
+        with self._state_changed:
+            tracked = list(self._context_operation_futures.get(transfer_context, set()))
+
+        completed: list[MessagingFuture[bool]] = []
+        for pending in tracked:
+            try:
+                if pending.query():
+                    completed.append(pending)
+            except Exception:
+                # Keep failures tracked so shutdown observes them via result().
+                continue
+
+        with self._state_changed:
+            futures = self._context_operation_futures.setdefault(
+                transfer_context, set()
+            )
+            futures.difference_update(completed)
+            futures.add(future)
+
+    def _drain_operation_futures(self) -> None:
+        """Wait for every submitted operation to reach a terminal state."""
+        with self._state_changed:
+            futures = [
+                future
+                for context_futures in self._context_operation_futures.values()
+                for future in context_futures
+            ]
+
+        for future in futures:
+            try:
+                # DeviceMessagingFuture.result() also synchronizes the exported
+                # completion event, so the server no longer uses this worker's
+                # GPUCacheContext when unregister is sent below.
+                future.result()
+            except Exception:
+                logger.warning(
+                    "ATOM transfer ended with an error during shutdown",
+                    exc_info=True,
+                )
+
+        with self._state_changed:
+            self._context_operation_futures.clear()
+            self._state_changed.notify_all()
+
+    def _rollback_candidate_registration(
+        self,
+        transfer_context: TransferContext,
+    ) -> None:
+        """Best-effort removal of an ambiguously registered candidate."""
+        try:
+            _send_request(
+                self._client,
+                RequestType.UNREGISTER_KV_CACHE,
+                [self.instance_id],
+            ).result(timeout=self._mq_timeout)
+        except Exception:
+            logger.warning(
+                "Failed to roll back rejected ATOM LMCache registration",
+                exc_info=True,
+            )
+
+    def _release_submission_lease(
+        self,
+        transfer_context: TransferContext,
+    ) -> None:
+        """Release one context-specific submission lease and wake waiters."""
+        with self._state_changed:
+            remaining = self._context_submission_leases[transfer_context] - 1
+            if remaining:
+                self._context_submission_leases[transfer_context] = remaining
+            else:
+                del self._context_submission_leases[transfer_context]
+            self._state_changed.notify_all()
+
+    def _require_transfer_context_locked(self) -> TransferContext:
+        """Return the active context while the caller holds ``_state_lock``."""
+        transfer_context = self._transfer_context
+        if transfer_context is None:
+            raise RuntimeError(
+                "ATOM KV caches are not registered; call register_kv_caches() first"
+            )
+        return transfer_context
+
+    def _create_key(
+        self,
+        request_id: str,
+        spec: AtomMPTransferSpec,
+    ) -> IPCCacheServerKey:
+        return IPCCacheServerKey(
+            model_name=self._model_name,
+            world_size=self._parallel.world_size,
+            worker_id=self._parallel.worker_id,
+            token_ids=tuple(spec.token_ids),
+            start=spec.start,
+            end=spec.end,
+            request_id=request_id,
+        )

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -655,6 +655,7 @@ class CacheStoreEvent:
 
 class EngineType(Enum):
     VLLM = "vllm"
+    ATOM = "atom"
     SGLANG = "sglang"
     TRTLLM = "trtllm"
     MOCK = "mock"

--- a/lmcache/v1/gpu_connector/kv_format/detectors/atom.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/atom.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ATOM KV-cache format discovery."""
+
+# Standard
+from typing import Optional
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.kv_format.detectors.base import (
+    EngineDetector,
+    measure_list_depth_until_tensor,
+)
+from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache, LayoutHints
+import lmcache.lmcache_native as lmcache_native
+
+
+class AtomDetector(EngineDetector):
+    """Detect ATOM's per-layer paged latent and index cache views."""
+
+    engine_type = EngineType.ATOM
+
+    def discover(
+        self, kv_caches: DiscoverableKVCache, layout_hints: LayoutHints
+    ) -> "tuple[Optional[lmcache_native.EngineKVFormat], DiscoverableKVCache]":
+        """Recognize ATOM's ``[num_blocks, block_size, width]`` tensors.
+
+        Args:
+            kv_caches: Per-layer latent or index cache tensors.
+            layout_hints: Reserved for future ATOM layouts.
+
+        Returns:
+            The paged single-vector format and original tensor views, or
+            ``None`` when the structure is not an ATOM paged cache.
+        """
+        del layout_hints
+        list_depth, tensor_ndim, _first_tensor = measure_list_depth_until_tensor(
+            kv_caches
+        )
+        if list_depth == 1 and tensor_ndim == 3:
+            return lmcache_native.EngineKVFormat.NL_X_NB_BS_HS, kv_caches
+        return None, kv_caches

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -1,0 +1,960 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the native ATOM multiprocess integration."""
+
+# Standard
+from typing import Any, cast
+from unittest.mock import MagicMock
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.integration.atom import multi_process_adapter as atom_adapter
+from lmcache.integration.atom.multi_process_adapter import (
+    AtomMPParallelConfig,
+    AtomMPSchedulerAdapter,
+    AtomMPTransferSpec,
+    AtomMPWorkerAdapter,
+)
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.kv_format import detect_format
+from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.protocol import RequestType
+import lmcache.lmcache_native as lmcache_native
+
+
+class _FakeHeartbeatThread:
+    """No-thread heartbeat double used by worker adapter tests."""
+
+    instances: list["_FakeHeartbeatThread"] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.health_event = args[1]
+        self.started = False
+        self.stop_requested = False
+        self.recover_callback = lambda: True
+        self.unhealthy_callback = lambda: None
+        self.healthy_callback = self._set_healthy
+        self.instances.append(self)
+
+    def _set_healthy(self) -> bool:
+        self.health_event.set()
+        return True
+
+    def register_recover_callback(self, callback: Any) -> None:
+        self.recover_callback = callback
+
+    def register_unhealthy_callback(self, callback: Any) -> None:
+        self.unhealthy_callback = callback
+
+    def register_healthy_callback(self, callback: Any) -> None:
+        self.healthy_callback = callback
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stop_requested = True
+        self.started = False
+
+    def stop_and_wait(self) -> None:
+        self.stop()
+
+    def mark_unhealthy(self) -> None:
+        self.unhealthy_callback()
+        self.health_event.clear()
+
+    def recover(self) -> bool:
+        recovered = self.recover_callback()
+        if recovered:
+            recovered = self.healthy_callback()
+        return recovered
+
+
+class _FakeEvent:
+    """Minimal event accepted by the transfer-context protocol."""
+
+    def ipc_handle(self) -> bytes:
+        return b"atom-event"
+
+    def wait(self, stream: object | None = None) -> None:
+        del stream
+
+
+@pytest.fixture
+def worker_with_transfer_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]]:
+    """Construct a worker with its MQ and transfer boundaries stubbed."""
+    client = MagicMock(name="mq_client")
+    transfer_context = MagicMock(name="transfer_context")
+    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
+    monkeypatch.setattr(
+        atom_adapter,
+        "create_transfer_context",
+        lambda *args, **kwargs: transfer_context,
+    )
+    monkeypatch.setattr(atom_adapter, "_HeartbeatThread", _FakeHeartbeatThread)
+    _FakeHeartbeatThread.instances.clear()
+
+    worker = AtomMPWorkerAdapter(
+        server_url="tcp://127.0.0.1:5555",
+        context=MagicMock(name="zmq_context"),
+        model_name="atom-test-model",
+        block_size=64,
+        parallel_config=AtomMPParallelConfig(
+            world_size=2,
+            worker_id=1,
+            tp_size=2,
+        ),
+        transfer_mode="lmcache_driven",
+    )
+    caches = {
+        "layer.0.latent": torch.empty(4, 64, 576),
+        "layer.0.index": torch.empty(4, 64, 144),
+    }
+    return worker, transfer_context, caches
+
+
+def _atom_groups() -> list[EngineGroupInfo]:
+    """Return ATOM latent/index kernel groups sharing one block namespace."""
+    return [
+        EngineGroupInfo(
+            engine_group_id=0,
+            layer_indices=(0,),
+            tokens_per_block=64,
+        ),
+        EngineGroupInfo(
+            engine_group_id=0,
+            layer_indices=(1,),
+            tokens_per_block=64,
+        ),
+    ]
+
+
+def _make_adapter(
+    adapter_kind: str,
+) -> AtomMPSchedulerAdapter | AtomMPWorkerAdapter:
+    """Construct the requested ATOM adapter with shared test parameters."""
+    if adapter_kind == "scheduler":
+        return AtomMPSchedulerAdapter(
+            server_url="tcp://127.0.0.1:5555",
+            context=MagicMock(name="zmq_context"),
+            model_name="atom-test-model",
+            block_size=64,
+            parallel_config=AtomMPParallelConfig(2, 1, 2),
+        )
+    return AtomMPWorkerAdapter(
+        server_url="tcp://127.0.0.1:5555",
+        context=MagicMock(name="zmq_context"),
+        model_name="atom-test-model",
+        block_size=64,
+        parallel_config=AtomMPParallelConfig(2, 1, 2),
+    )
+
+
+def _mock_client(worker: AtomMPWorkerAdapter) -> MagicMock:
+    """Expose the fixture-provided MQ mock with its assertion helpers."""
+    return cast(MagicMock, worker._client)
+
+
+def test_atom_worker_registers_native_engine_type(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """Registration identifies ATOM and forwards its physical cache groups."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    groups = _atom_groups()
+
+    worker.register_kv_caches(caches, engine_group_infos=groups)
+
+    register_call = transfer_context.register.call_args
+    assert register_call.kwargs["engine_type"] is EngineType.ATOM
+    assert register_call.kwargs["layout_hints"] == {}
+    assert register_call.kwargs["engine_group_infos"] == groups
+
+
+@pytest.mark.parametrize(
+    ("method_name", "submit_name"),
+    [
+        ("submit_store_request", "submit_store"),
+        ("submit_retrieve_request", "submit_retrieve"),
+    ],
+)
+def test_atom_submit_returns_future_and_expands_physical_groups(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    method_name: str,
+    submit_name: str,
+) -> None:
+    """One ATOM block list fans out to latent/index and returns its future."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    future: MessagingFuture[bool] = MessagingFuture()
+    getattr(transfer_context, submit_name).return_value = future
+    spec = AtomMPTransferSpec(
+        token_ids=list(range(256)),
+        block_ids=[[7, 8, 9, 10]],
+        start=0,
+        end=256,
+    )
+    event = _FakeEvent()
+
+    returned = getattr(worker, method_name)(
+        "request-1",
+        spec,
+        event,
+    )
+
+    assert returned is future
+    assert event in returned._retained_references
+    submit_call = getattr(transfer_context, submit_name).call_args
+    assert submit_call.args[4] == [[7, 8, 9, 10], [7, 8, 9, 10]]
+
+    future.set_result(True)
+    assert returned.result(timeout=0) is True
+
+
+def test_atom_worker_reregisters_without_wrapping_inflight_future(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recovery republishes cache registration before health becomes visible."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    future: MessagingFuture[bool] = MessagingFuture()
+    transfer_context.submit_store.return_value = future
+    returned = worker.submit_store_request(
+        "request-1",
+        AtomMPTransferSpec(
+            token_ids=list(range(256)),
+            block_ids=[[0, 1, 2, 3]],
+            end=256,
+        ),
+        _FakeEvent(),
+    )
+    heartbeat = _FakeHeartbeatThread.instances[0]
+    recovery_context = MagicMock(name="recovery_transfer_context")
+    monkeypatch.setattr(
+        atom_adapter,
+        "create_transfer_context",
+        lambda *args, **kwargs: recovery_context,
+    )
+
+    heartbeat.mark_unhealthy()
+
+    assert worker.is_healthy is False
+    assert returned is future
+    assert returned.query() is False
+    assert heartbeat.recover() is True
+    assert worker.is_healthy is True
+    recovery_context.register.assert_called_once()
+    transfer_context.close.assert_called_once_with()
+    assert worker._transfer_context is recovery_context
+
+    future.set_result(True)
+    assert returned.result(timeout=0) is True
+
+
+def test_atom_heartbeat_runs_recovery_before_publishing_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful ping only restores health after re-registration succeeds."""
+    ping_results = iter([False, True])
+
+    def send_request(
+        _client: Any,
+        request_type: RequestType,
+        _payloads: list[Any],
+    ) -> MessagingFuture[Any]:
+        future: MessagingFuture[Any] = MessagingFuture()
+        result = next(ping_results) if request_type is RequestType.PING else True
+        future.set_result(result)
+        return future
+
+    monkeypatch.setattr(atom_adapter, "_send_request", send_request)
+    health_event = threading.Event()
+    health_event.set()
+    recover = MagicMock(return_value=True)
+    unhealthy = MagicMock()
+    heartbeat = atom_adapter._HeartbeatThread(
+        MagicMock(),
+        health_event,
+        instance_id=7,
+        interval=1.0,
+    )
+    heartbeat.register_recover_callback(recover)
+    heartbeat.register_unhealthy_callback(unhealthy)
+
+    heartbeat._execute()
+    assert health_event.is_set() is False
+    unhealthy.assert_called_once_with()
+
+    heartbeat._execute()
+    assert health_event.is_set() is True
+    recover.assert_called_once_with()
+
+
+@pytest.mark.parametrize("adapter_kind", ["scheduler", "worker"])
+@pytest.mark.parametrize("failure_kind", ["chunk_query", "misaligned_chunk"])
+def test_atom_adapter_constructor_closes_client_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter_kind: str,
+    failure_kind: str,
+) -> None:
+    """GET_CHUNK_SIZE and validation failures do not leak the MQ client."""
+    client = MagicMock(name="mq_client")
+    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    if failure_kind == "chunk_query":
+        monkeypatch.setattr(
+            atom_adapter,
+            "_get_chunk_size",
+            MagicMock(side_effect=RuntimeError("chunk query failed")),
+        )
+        error: type[Exception] = RuntimeError
+    else:
+        monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 255)
+        error = ValueError
+
+    with pytest.raises(error):
+        _make_adapter(adapter_kind)
+
+    client.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("adapter_kind", ["scheduler", "worker"])
+def test_atom_constructor_preserves_error_when_client_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter_kind: str,
+) -> None:
+    """Cleanup errors cannot replace the constructor's original failure."""
+    client = MagicMock(name="mq_client")
+    client.close.side_effect = RuntimeError("close failed")
+    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(
+        atom_adapter,
+        "_get_chunk_size",
+        MagicMock(side_effect=ValueError("original init failure")),
+    )
+    with pytest.raises(ValueError, match="original init failure"):
+        _make_adapter(adapter_kind)
+
+
+def test_atom_initial_registration_failure_rolls_back_candidate(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """An ambiguous registration failure removes the GPU candidate."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    register_error = TimeoutError("server accepted but registration response timed out")
+    transfer_context.register.side_effect = register_error
+    rollback_future: MessagingFuture[None] = MessagingFuture()
+    rollback_future.set_result(None)
+    client.submit_request.return_value = rollback_future
+
+    with pytest.raises(type(register_error)) as exc_info:
+        worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+
+    assert exc_info.value is register_error
+    rollback_call = client.submit_request.call_args
+    assert rollback_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+    assert rollback_call.args[1] == [worker.instance_id]
+    transfer_context.close.assert_called_once_with()
+    client.close.assert_called_once_with()
+    assert worker.is_healthy is False
+
+
+def test_atom_initial_registration_preserves_error_across_cleanup_failures(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """Context/client close failures cannot replace a registration error."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    transfer_context.register.side_effect = ValueError("original register failure")
+    client.submit_request.side_effect = RuntimeError("rollback failed")
+    transfer_context.close.side_effect = RuntimeError("context close failed")
+    client.close.side_effect = RuntimeError("client close failed")
+
+    with pytest.raises(ValueError, match="original register failure"):
+        worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+
+    assert worker._shutdown_complete.is_set()
+
+
+def test_atom_failed_recovery_rolls_back_candidate_and_keeps_old_context(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed recovery cleans its candidate and can retry the old registration."""
+    worker, old_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    heartbeat = _FakeHeartbeatThread.instances[0]
+    heartbeat.mark_unhealthy()
+
+    failed_candidate = MagicMock(name="failed_candidate")
+    failed_candidate.register.side_effect = TimeoutError(
+        "server accepted but recovery response timed out"
+    )
+    retry_context = MagicMock(name="retry_context")
+    candidates = iter([failed_candidate, retry_context])
+    monkeypatch.setattr(
+        atom_adapter,
+        "create_transfer_context",
+        lambda *args, **kwargs: next(candidates),
+    )
+    rollback_future: MessagingFuture[None] = MessagingFuture()
+    rollback_future.set_result(None)
+    client.submit_request.return_value = rollback_future
+
+    assert heartbeat.recover() is False
+    failed_candidate.close.assert_called_once_with()
+    old_context.close.assert_not_called()
+    assert worker._transfer_context is old_context
+    assert worker._registered is True
+    assert worker.is_healthy is False
+    rollback_call = client.submit_request.call_args
+    assert rollback_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+
+    assert heartbeat.recover() is True
+    old_context.close.assert_called_once_with()
+    assert worker._transfer_context is retry_context
+    assert worker.is_healthy is True
+
+
+@pytest.mark.parametrize(
+    ("method_name", "submit_name"),
+    [
+        ("submit_store_request", "submit_store"),
+        ("submit_retrieve_request", "submit_retrieve"),
+    ],
+)
+def test_atom_submit_while_unhealthy_is_dropped_without_enqueue(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    method_name: str,
+    submit_name: str,
+) -> None:
+    """An unhealthy generation cannot enqueue new transfer work."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    _FakeHeartbeatThread.instances[0].mark_unhealthy()
+
+    returned = getattr(worker, method_name)(
+        "request-1",
+        AtomMPTransferSpec(
+            token_ids=list(range(256)),
+            block_ids=[[0, 1, 2, 3]],
+            end=256,
+        ),
+        _FakeEvent(),
+    )
+
+    assert returned is None
+    getattr(transfer_context, submit_name).assert_not_called()
+
+
+def test_atom_submit_and_health_transition_are_atomic(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """A failure transition cannot slip inside a healthy request enqueue."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+    failure_published = threading.Event()
+    future: MessagingFuture[bool] = MessagingFuture()
+
+    def delayed_submit(*args: Any, **kwargs: Any) -> MessagingFuture[bool]:
+        del args, kwargs
+        submit_entered.set()
+        assert release_submit.wait(timeout=5.0)
+        return future
+
+    transfer_context.submit_store.side_effect = delayed_submit
+    futures: list[MessagingFuture[bool] | None] = []
+    submit_thread = threading.Thread(
+        target=lambda: futures.append(
+            worker.submit_store_request(
+                "request-1",
+                AtomMPTransferSpec(
+                    token_ids=list(range(256)),
+                    block_ids=[[0, 1, 2, 3]],
+                    end=256,
+                ),
+                _FakeEvent(),
+            )
+        )
+    )
+    submit_thread.start()
+    assert submit_entered.wait(timeout=5.0)
+
+    def publish_failure() -> None:
+        worker._mark_unhealthy()
+        failure_published.set()
+
+    failure_thread = threading.Thread(target=publish_failure)
+    failure_thread.start()
+    # The submit lease keeps the context alive without holding the state lock;
+    # heartbeat failure must remain publishable while engine-driven submit blocks.
+    assert failure_published.wait(timeout=5.0)
+    release_submit.set()
+    submit_thread.join(timeout=5.0)
+    failure_thread.join(timeout=5.0)
+
+    assert not submit_thread.is_alive()
+    assert not failure_thread.is_alive()
+    assert futures == [future]
+    assert worker.is_healthy is False
+
+
+@pytest.mark.parametrize(
+    ("method_name", "submit_name"),
+    [
+        ("submit_store_request", "submit_store"),
+        ("submit_retrieve_request", "submit_retrieve"),
+    ],
+)
+def test_atom_recovery_waits_for_old_context_submission_lease(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    submit_name: str,
+) -> None:
+    """Recovery cannot close an old context during its synchronous submit."""
+    worker, old_context, caches = worker_with_transfer_context
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    heartbeat = _FakeHeartbeatThread.instances[0]
+    recovery_context = MagicMock(name="recovery_context")
+    monkeypatch.setattr(
+        atom_adapter,
+        "create_transfer_context",
+        lambda *args, **kwargs: recovery_context,
+    )
+
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+    context_submit_returning = threading.Event()
+    waiting_for_old_lease = threading.Event()
+    old_context_closed = threading.Event()
+    future: MessagingFuture[bool] = MessagingFuture()
+
+    def delayed_submit(*args: Any, **kwargs: Any) -> MessagingFuture[bool]:
+        del args, kwargs
+        submit_entered.set()
+        assert release_submit.wait(timeout=5.0)
+        context_submit_returning.set()
+        return future
+
+    def close_old_context() -> None:
+        assert context_submit_returning.is_set()
+        old_context_closed.set()
+
+    original_wait = worker._wait_for_context_leases
+
+    def observed_wait(transfer_context: Any) -> None:
+        assert transfer_context is old_context
+        waiting_for_old_lease.set()
+        original_wait(transfer_context)
+
+    getattr(old_context, submit_name).side_effect = delayed_submit
+    old_context.close.side_effect = close_old_context
+    monkeypatch.setattr(worker, "_wait_for_context_leases", observed_wait)
+
+    futures: list[MessagingFuture[bool] | None] = []
+    submit_errors: list[BaseException] = []
+
+    def submit() -> None:
+        try:
+            futures.append(
+                getattr(worker, method_name)(
+                    "request-1",
+                    AtomMPTransferSpec(
+                        token_ids=list(range(256)),
+                        block_ids=[[0, 1, 2, 3]],
+                        end=256,
+                    ),
+                    _FakeEvent(),
+                )
+            )
+        except BaseException as error:
+            submit_errors.append(error)
+
+    submit_thread = threading.Thread(target=submit)
+    submit_thread.start()
+    assert submit_entered.wait(timeout=5.0)
+
+    heartbeat.mark_unhealthy()
+    recovery_results: list[bool] = []
+    recovery_thread = threading.Thread(
+        target=lambda: recovery_results.append(heartbeat.recover())
+    )
+    recovery_thread.start()
+
+    assert waiting_for_old_lease.wait(timeout=5.0)
+    assert worker._transfer_context is recovery_context
+    assert worker.is_healthy is False
+    assert old_context_closed.is_set() is False
+    assert recovery_thread.is_alive()
+
+    release_submit.set()
+    submit_thread.join(timeout=5.0)
+    recovery_thread.join(timeout=5.0)
+
+    assert not submit_thread.is_alive()
+    assert not recovery_thread.is_alive()
+    assert submit_errors == []
+    assert futures == [future]
+    assert recovery_results == [True]
+    assert old_context_closed.is_set()
+    old_context.close.assert_called_once_with()
+    assert worker.is_healthy is True
+
+
+def test_atom_shutdown_discards_late_recovery_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A callback returning after shutdown cannot republish context or health."""
+    client = MagicMock(name="mq_client")
+    initial_context = MagicMock(name="initial_context")
+    recovery_context = MagicMock(name="recovery_context")
+    recovery_entered = threading.Event()
+    release_recovery = threading.Event()
+
+    def delayed_register(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        recovery_entered.set()
+        assert release_recovery.wait(timeout=5.0)
+
+    recovery_context.register.side_effect = delayed_register
+    contexts = iter([initial_context, recovery_context])
+    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
+    monkeypatch.setattr(
+        atom_adapter,
+        "create_transfer_context",
+        lambda *args, **kwargs: next(contexts),
+    )
+    monkeypatch.setattr(atom_adapter, "_HeartbeatThread", _FakeHeartbeatThread)
+    _FakeHeartbeatThread.instances.clear()
+    worker = AtomMPWorkerAdapter(
+        server_url="tcp://127.0.0.1:5555",
+        context=MagicMock(name="zmq_context"),
+        model_name="atom-test-model",
+        block_size=64,
+        parallel_config=AtomMPParallelConfig(2, 1, 2),
+    )
+    caches = {"layer.0": torch.empty(4, 64, 576)}
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups()[:1])
+    heartbeat = _FakeHeartbeatThread.instances[0]
+    heartbeat.mark_unhealthy()
+    recovery_results: list[bool] = []
+    recovery_thread = threading.Thread(
+        target=lambda: recovery_results.append(heartbeat.recover())
+    )
+    recovery_thread.start()
+    assert recovery_entered.wait(timeout=5.0)
+
+    shutdown_returned = threading.Event()
+
+    def shutdown() -> None:
+        worker.shutdown()
+        shutdown_returned.set()
+
+    shutdown_thread = threading.Thread(target=shutdown)
+    shutdown_thread.start()
+    assert not shutdown_returned.wait(timeout=0.05)
+    assert worker._transfer_context is initial_context
+    assert worker.is_healthy is False
+    client.close.assert_not_called()
+
+    release_recovery.set()
+    recovery_thread.join(timeout=5.0)
+    shutdown_thread.join(timeout=5.0)
+    assert not recovery_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert shutdown_returned.is_set()
+    assert recovery_results == [False]
+    recovery_context.close.assert_called_once_with()
+    initial_context.close.assert_called_once_with()
+    client.close.assert_called_once_with()
+    assert worker._transfer_context is None
+    assert worker._registered is False
+    assert worker.is_healthy is False
+
+
+def test_atom_heartbeat_publish_and_start_are_one_lifecycle_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """shutdown cannot detach a heartbeat in the publish-before-start window."""
+    start_entered = threading.Event()
+    release_start = threading.Event()
+
+    class _BlockingStartHeartbeat(_FakeHeartbeatThread):
+        def start(self) -> None:
+            start_entered.set()
+            assert release_start.wait(timeout=5.0)
+            super().start()
+
+    client = MagicMock(name="mq_client")
+    transfer_context = MagicMock(name="transfer_context")
+    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
+    monkeypatch.setattr(
+        atom_adapter,
+        "create_transfer_context",
+        lambda *args, **kwargs: transfer_context,
+    )
+    monkeypatch.setattr(atom_adapter, "_HeartbeatThread", _BlockingStartHeartbeat)
+    _BlockingStartHeartbeat.instances.clear()
+    worker = AtomMPWorkerAdapter(
+        server_url="tcp://127.0.0.1:5555",
+        context=MagicMock(name="zmq_context"),
+        model_name="atom-test-model",
+        block_size=64,
+        parallel_config=AtomMPParallelConfig(2, 1, 2),
+    )
+    caches = {"layer.0": torch.empty(4, 64, 576)}
+    register_errors: list[Exception] = []
+
+    def register() -> None:
+        try:
+            worker.register_kv_caches(caches, engine_group_infos=_atom_groups()[:1])
+        except Exception as error:
+            register_errors.append(error)
+
+    register_thread = threading.Thread(target=register)
+    register_thread.start()
+    assert start_entered.wait(timeout=5.0)
+    shutdown_returned = threading.Event()
+
+    def shutdown() -> None:
+        worker.shutdown()
+        shutdown_returned.set()
+
+    shutdown_thread = threading.Thread(target=shutdown)
+    shutdown_thread.start()
+    assert not shutdown_returned.wait(timeout=0.05)
+
+    release_start.set()
+    register_thread.join(timeout=5.0)
+    shutdown_thread.join(timeout=5.0)
+
+    assert not register_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert register_errors == []
+    heartbeat = _BlockingStartHeartbeat.instances[0]
+    assert heartbeat.stop_requested is True
+    assert heartbeat.started is False
+    client.close.assert_called_once_with()
+
+
+def test_atom_repeated_public_registration_fails_without_overwrite(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """A second public register cannot overwrite the live local context."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+
+    with pytest.raises(RuntimeError, match="already being or were registered"):
+        worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+
+    transfer_context.register.assert_called_once()
+    assert worker._transfer_context is transfer_context
+
+
+def test_atom_shutdown_unregisters_gpu_context(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """ATOM removes its LMCache-driven GPU registration during shutdown."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+
+    worker.shutdown()
+
+    request_types = [call.args[0] for call in client.submit_request.call_args_list]
+    assert request_types == [RequestType.UNREGISTER_KV_CACHE]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "submit_name"),
+    [
+        ("submit_store_request", "submit_store"),
+        ("submit_retrieve_request", "submit_retrieve"),
+    ],
+)
+def test_atom_shutdown_drains_unresolved_operation_before_unregister(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    method_name: str,
+    submit_name: str,
+) -> None:
+    """Shutdown preserves registration and context until the future finishes."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    wait_started = threading.Event()
+
+    class _ObservedFuture(MessagingFuture[bool]):
+        def wait(self, timeout: float | None = None) -> bool:
+            wait_started.set()
+            return super().wait(timeout)
+
+    future = _ObservedFuture()
+    getattr(transfer_context, submit_name).return_value = future
+    returned = getattr(worker, method_name)(
+        "request-1",
+        AtomMPTransferSpec(
+            token_ids=list(range(256)),
+            block_ids=[[0, 1, 2, 3]],
+            end=256,
+        ),
+        _FakeEvent(),
+    )
+
+    shutdown_thread = threading.Thread(target=worker.shutdown)
+    shutdown_thread.start()
+    assert wait_started.wait(timeout=5.0)
+    transfer_context.close.assert_not_called()
+    client.close.assert_not_called()
+    client.submit_request.assert_not_called()
+
+    future.set_result(True)
+    shutdown_thread.join(timeout=5.0)
+
+    assert not shutdown_thread.is_alive()
+    assert returned is future
+    assert returned.result(timeout=0) is True
+    transfer_context.close.assert_called_once_with()
+    client.close.assert_called_once_with()
+    unregister_call = client.submit_request.call_args
+    assert unregister_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+
+
+@pytest.mark.parametrize(
+    ("method_name", "submit_name"),
+    [
+        ("submit_store_request", "submit_store"),
+        ("submit_retrieve_request", "submit_retrieve"),
+    ],
+)
+def test_atom_restart_window_transfer_and_shutdown_terminate(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+    method_name: str,
+    submit_name: str,
+) -> None:
+    """A missing-registration response cannot strand an ATOM operation."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    raw_wait_started = threading.Event()
+
+    class _ObservedRawFuture(MessagingFuture[tuple[bytes, bool]]):
+        def wait(self, timeout: float | None = None) -> bool:
+            raw_wait_started.set()
+            return super().wait(timeout)
+
+    # The server has restarted since the last heartbeat, but the worker still
+    # considers its registration healthy. #4709 makes the replacement server
+    # answer the admitted request with an empty event handle and False.
+    raw_future = _ObservedRawFuture()
+    device_future = raw_future.to_device_future(device="cpu")
+    getattr(transfer_context, submit_name).return_value = device_future
+    assert worker.is_healthy is True
+
+    returned = getattr(worker, method_name)(
+        "request-1",
+        AtomMPTransferSpec(
+            token_ids=list(range(256)),
+            block_ids=[[0, 1, 2, 3]],
+            end=256,
+        ),
+        _FakeEvent(),
+    )
+    assert returned is device_future
+
+    shutdown_thread = threading.Thread(target=worker.shutdown)
+    shutdown_thread.start()
+    assert raw_wait_started.wait(timeout=5.0)
+    transfer_context.close.assert_not_called()
+    client.close.assert_not_called()
+    client.submit_request.assert_not_called()
+
+    raw_future.set_result((b"", False))
+    shutdown_thread.join(timeout=5.0)
+
+    assert not shutdown_thread.is_alive()
+    assert returned.result(timeout=0) is False
+    transfer_context.close.assert_called_once_with()
+    client.close.assert_called_once_with()
+    unregister_call = client.submit_request.call_args
+    assert unregister_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+
+
+def test_atom_shutdown_finally_closes_client_when_context_close_fails(
+    worker_with_transfer_context: tuple[
+        AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
+    ],
+) -> None:
+    """Normal shutdown completes all cleanup stages despite close failures."""
+    worker, transfer_context, caches = worker_with_transfer_context
+    client = _mock_client(worker)
+    worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
+    transfer_context.close.side_effect = RuntimeError("context close failed")
+    client.close.side_effect = RuntimeError("client close failed")
+
+    worker.shutdown()
+
+    transfer_context.close.assert_called_once_with()
+    client.close.assert_called_once_with()
+    assert worker._shutdown_complete.is_set()
+
+
+def test_atom_detector_recognizes_paged_3d_cache_views() -> None:
+    """ATOM's per-layer ``[NB, BS, width]`` views use the MLA-like format."""
+    cache_tensors = [
+        torch.empty(4, 64, 576),
+        torch.empty(4, 64, 144),
+    ]
+    caches: DiscoverableKVCache = cache_tensors
+
+    detected, normalized = detect_format(caches, EngineType.ATOM, {})
+    normalized_tensors = cast(list[torch.Tensor], normalized)
+
+    assert EngineType.ATOM.value == "atom"
+    assert detected is lmcache_native.EngineKVFormat.NL_X_NB_BS_HS
+    assert [tuple(tensor.shape) for tensor in normalized_tensors] == [
+        (4, 64, 576),
+        (4, 64, 144),
+    ]
+    assert [tensor.data_ptr() for tensor in normalized_tensors] == [
+        tensor.data_ptr() for tensor in cache_tensors
+    ]

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -47,7 +47,7 @@ class TestEngineType:
         assert EngineType.TRTLLM.value == "trtllm"
 
     def test_all_engine_types(self) -> None:
-        expected = {"vllm", "sglang", "trtllm", "mock"}
+        expected = {"vllm", "atom", "sglang", "trtllm", "mock"}
         actual = {e.value for e in EngineType}
         assert expected == actual
 


### PR DESCRIPTION
## Summary

- Add native ATOM scheduler and worker multiprocess adapters under `lmcache/integration/atom/`.
- Register `EngineType.ATOM` and detect ATOM paged latent/index KV-cache views.
- Support scheduler lookup/lock cleanup and asynchronous worker STORE/RETRIEVE with `MessagingFuture[bool] | None`.
- Re-register saved cache views after a PING-observed unhealthy-to-healthy transition before publishing healthy state.
- Harden ATOM shutdown by closing admission, waiting for submitters, draining device-aware operation futures, unregistering, and closing the transfer context and MQ client.

This PR intentionally does not add ATOM-specific registration-state probing for a complete server restart that occurs between two successful heartbeat probes. That recovery gap is shared by ATOM, vLLM, and SGLang and should be addressed by a separate generalized change.

Generic future callback/cancellation and MQ-client close hardening are isolated in #4742 and are not part of this PR.

## Failure semantics

- `None`: no operation was submitted because the adapter is unhealthy or closed.
- `False`: the submitted operation reached a terminal failure response.
- `True`: the submitted operation completed successfully.

Shutdown waits through the returned device event before unregistering, so the server cannot outlive the worker cache context for an admitted operation.

## Validation

- Current-head pre-commit checks passed, including SPDX headers, import sorting, Ruff, formatting, codespell, and full-repository mypy.
- Python bytecode compilation passed for the modified Python modules and tests.
- The author also posted an eight-rank GLM-5.2 TP8 end-to-end benchmark in the PR discussion.