### PR TITLE
docs: daily drift check — multi-process mode (2026-08-20)

### DIFF
--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -79,6 +79,13 @@ Commonly used flags include:
        and eviction, and the blend index behind fleet CacheBlend matching.
    * - ``--coordinator-event-flush-interval SECONDS``
      - Seconds between cache-event batch flushes (``> 0``, default ``1``).
+   * - ``--coordinator-blend-timeout SECONDS``
+     - Seconds a fleet CacheBlend lookup to the coordinator may take, used as
+       both the per-request HTTP timeout and the per-lookup match budget
+       (``> 0``, default ``1``).
+   * - ``--coordinator-blend-match-concurrency N``
+     - Max fleet CacheBlend match round-trips the blend client keeps in flight
+       at once (``>= 1``, default ``8``).
    * - ``--p2p-advertise-url HOST:PORT``
      - Enable P2P KV cache sharing and advertise this server's
        transfer-channel endpoint to peers (e.g. ``10.0.0.1:8500``). Setting it

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -160,6 +160,15 @@ Kubernetes downward API); an explicit flag wins over the env var.
      - ``LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL``
      - Seconds between cache-event batch flushes (must be ``> 0``, default
        ``1``).
+   * - ``--coordinator-blend-timeout``
+     - *(none)*
+     - Seconds a fleet CacheBlend lookup to the coordinator may take, used as
+       both the per-request HTTP timeout and the per-lookup match budget (must
+       be ``> 0``, default ``1``).
+   * - ``--coordinator-blend-match-concurrency``
+     - *(none)*
+     - Max fleet CacheBlend match round-trips the blend client keeps in flight
+       at once (must be ``>= 1``, default ``8``).
 
 The server registers under its stable identity (``--instance-id`` / OTel
 ``service.instance.id``); if the flag is not passed, the server mints a


### PR DESCRIPTION
## Summary

Daily docs drift check found two undocumented MP-server flags added by
[#4619](https://github.com/LMCache/LMCache/pull/4619) (merged 2026-08-17):
`--coordinator-blend-timeout` and `--coordinator-blend-match-concurrency`. Both
are advertised by `add_coordinator_args` and validated by
`parse_args_to_coordinator_config`, but neither was added to the two
user-facing tables that enumerate the `--coordinator-*` MP server flags.

### `docs/source/`

- `docs/source/cli/server.rst` — the "Commonly used flags" table lists every
  other `--coordinator-*` MP server flag (`--coordinator-url`,
  `--coordinator-advertise-ip`, `--coordinator-heartbeat-interval`,
  `--coordinator-event-reporting`, `--coordinator-event-flush-interval`) but
  is missing the two new blend flags.
- `docs/source/mp/coordinator.rst` — the "Connecting MP servers" table
  documents the same five `--coordinator-*` flags with their
  `LMCACHE_COORDINATOR_*` env fallbacks and defaults, and is likewise missing
  the two new blend flags. Per the code, the blend flags have **no**
  `LMCACHE_COORDINATOR_*` env fallback, unlike the registration flags — the
  new rows say so.

### `docs/design/`

No design-doc drift for the new flags. `docs/design/v1/mp_coordinator/blend_lookup.md`
already references `--coordinator-blend-timeout` (via `match_budget_s`) and
was updated in the same PR.

## Evidence

Flags and defaults, current `dev` HEAD 9997afbca307fb08915d13e1767b7e40262c9ce7:

- Config fields with defaults, `lmcache/v1/multiprocess/config.py:232` and
  `:236`:
  https://github.com/LMCache/LMCache/blob/9997afbca307fb08915d13e1767b7e40262c9ce7/lmcache/v1/multiprocess/config.py#L229-L237
- Argparse definitions, `add_coordinator_args`,
  `lmcache/v1/multiprocess/config.py:632` and `:640`:
  https://github.com/LMCache/LMCache/blob/9997afbca307fb08915d13e1767b7e40262c9ce7/lmcache/v1/multiprocess/config.py#L628-L645
- Validation and read-back, `parse_args_to_coordinator_config`,
  `lmcache/v1/multiprocess/config.py:766-786`:
  https://github.com/LMCache/LMCache/blob/9997afbca307fb08915d13e1767b7e40262c9ce7/lmcache/v1/multiprocess/config.py#L766-L787

Stale doc locations:

- `docs/source/cli/server.rst` "Commonly used flags" table (ends the
  `--coordinator-*` block at `--coordinator-event-flush-interval`):
  https://github.com/LMCache/LMCache/blob/9997afbca307fb08915d13e1767b7e40262c9ce7/docs/source/cli/server.rst#L66-L81
- `docs/source/mp/coordinator.rst` "Connecting MP servers" table (same
  omission):
  https://github.com/LMCache/LMCache/blob/9997afbca307fb08915d13e1767b7e40262c9ce7/docs/source/mp/coordinator.rst#L140-L163

## Proposed fix

Applied in this PR. Two new rows added to each table, in the same style as
the surrounding `--coordinator-*` entries. Both entries mirror the wording of
each flag's `help=` string and its validator (`> 0` for the timeout, `>= 1`
for the concurrency).

## Notes

- Auto-generated by the daily docs drift-check routine. Human review
  required before merge.
- Doc-only change; no code touched.
- The `LMCACHE_MP_COORDINATOR_*` references still present under
  `docs/source/locale/zh_CN/LC_MESSAGES/` are stale Chinese translations of
  the pre-#4619 English rst pages. They'll be regenerated by the translation
  toolchain on the next sync and are intentionally left out of this drift
  fix (translation refresh, not documentation drift).

---
_Generated by [Claude Code](https://claude.ai/code/session_0184hnfYNv5UFztgxs21ribr)_