### PR TITLE
ci(rocm): pin AMD unit tests to the torch build we ship

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,12 @@ steps:
         export TORCH_DONT_CHECK_COMPILER_ABI=1
         export CXX=hipcc
         export BUILD_WITH_HIP=1
-        uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.0
+        # Match the ABI of the wheel we publish (TORCH_ROCM_SPEC /
+        # TORCH_ROCM_INDEX in .github/workflows/build_rocm_artifacts.yml).
+        # The pin is load-bearing: left unpinned this index resolves to a
+        # much newer torch than the one the release wheel is built against.
+        uv pip install "torch==2.11.0+rocm7.2" torchvision \
+          --index-url https://download.pytorch.org/whl/rocm7.2
         uv pip install -r requirements/rocm_core.txt
       fi
 


### PR DESCRIPTION
## Summary

The AMD lane installs torch unpinned from the `rocm7.0` index, which resolves to
`2.10.0+rocm7.0`. The ROCm wheel we publish is built against `2.11.0+rocm7.2`
(`TORCH_ROCM_SPEC` / `TORCH_ROCM_INDEX` in `.github/workflows/build_rocm_artifacts.yml`),
so CI has been validating an ABI we don't ship.

Switching the index alone isn't enough — left unpinned, `rocm7.2` resolves to `2.13.0`.
So the version is pinned to match `TORCH_ROCM_SPEC` exactly:

```
rocm7.0 index, unpinned -> torch 2.10.0+rocm7.0   (today)
rocm7.2 index, unpinned -> torch 2.13.0+rocm7.2   (not what we ship)
rocm7.2 index, pinned   -> torch 2.11.0+rocm7.2   (matches the release wheel)
```

## Test plan

Ran the AMD unit job on an MI300X (gfx942) at dev `9997afbc`, replicating the pipeline's
AMD branch, once per toolchain:

| | torch | result |
|---|---|---|
| baseline (`rocm7.0`) | 2.10.0+rocm7.0 | 10 failed, 5878 passed, 239 skipped — 13:50 |
| this PR (`rocm7.2` pinned) | 2.11.0+rocm7.2 | 10 failed, 5879 passed, 239 skipped — 14:58 |

Nine of the ten failures are identical across both. The single difference is two different
members of the same already-flaky `TestDiscoverApiRouters` class, which also passes on other
hosts — so no regression is attributable to the toolchain change. The remaining failures are
environmental on that host (HuggingFace downloads of `facebook/opt-125m`, and a network-bound
`tests/cli/test_ping.py` case that fails on the baseline too).

Extensions build and import cleanly against the new toolchain
(`torch 2.11.0+rocm7.2`, `hip 7.2.26015`, `import lmcache.cuda_ops` OK).

`requirements/rocm_core.txt` is unchanged on purpose: `cupy-rocm-7-2` doesn't exist on PyPI,
and `cupy-rocm-7-0` works against this torch.

Scoped to this one line so it stays independent of the AMD pipeline-shape discussion in #4652.