### PR TITLE
fix(observability): make the shared observability lock reentrant

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -682,7 +682,13 @@ def _lmcache_nvtx_annotate(func, domain="lmcache"):
 
 
 ##### Observability Threading related #####
-_shared_observability_lock = threading.Lock()
+# Reentrant on purpose. ``MemoryObj.__del__`` calls ``allocator.free()``, which
+# updates ``LMCStatsMonitor`` counters -- also guarded by this lock. The garbage
+# collector can run ``__del__`` at any allocation point, so that update can land
+# on a thread already holding this lock (e.g. inside
+# ``PrometheusLogger.GetOrCreate``, which allocates via ``prometheus_client``).
+# With a plain Lock that is an unrecoverable self-deadlock.
+_shared_observability_lock = threading.RLock()
 
 
 def thread_safe(func):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -464,3 +464,44 @@ def test_prometheus_logger_reset_reinitializes_all_label_views(
         )
         == 0
     )
+
+
+def test_thread_safe_is_reentrant():
+    """A ``@thread_safe`` callable must be able to call another one.
+
+    ``MemoryObj.__del__`` calls ``allocator.free()``, which updates
+    ``LMCStatsMonitor`` counters -- both guarded by the shared observability
+    lock. The garbage collector can run ``__del__`` at any allocation point, so
+    that update can land on a thread already holding the lock. A non-reentrant
+    lock turns that into an unrecoverable self-deadlock.
+
+    Runs in a worker thread so a regression fails this test instead of hanging
+    the whole suite.
+    """
+    # Standard
+    import threading
+
+    # First Party
+    from lmcache.utils import thread_safe
+
+    @thread_safe
+    def inner() -> int:
+        return 1
+
+    @thread_safe
+    def outer() -> int:
+        return inner()
+
+    result: list[int] = []
+    done = threading.Event()
+
+    def run() -> None:
+        result.append(outer())
+        done.set()
+
+    threading.Thread(target=run, daemon=True).start()
+    assert done.wait(timeout=30), (
+        "nested @thread_safe call deadlocked: _shared_observability_lock is "
+        "not reentrant"
+    )
+    assert result == [1]


### PR DESCRIPTION
## Summary

`lmcache/utils.py` defines one module-global, non-reentrant lock shared by all 30
`@thread_safe` methods in `observability.py`:

```python
_shared_observability_lock = threading.Lock()

def thread_safe(func):
    def wrapper(*args, **kwargs):
        with _shared_observability_lock:      # acquire
            result = func(*args, **kwargs)    # inside
```

`MemoryObj.__del__` (`memory_management.py:672`) calls `parent_allocator.free(self)`, and the
paged allocator's `free()` calls two `@thread_safe` methods —
`update_local_cache_usage` and `update_active_memory_objs_count`
(`paged_tensor_memory_allocator.py:257-258`).

Because the garbage collector can run `__del__` at any allocation point, that update can land
on a thread **already holding** the lock, which hangs permanently. It is reachable in normal
operation through `PrometheusLogger.GetOrCreate` (itself `@thread_safe`), which allocates via
`prometheus_client` while binding label views. Stack captured with py-spy on a hung run:

```
GetOrCreate (observability.py:1863)          <- holds the lock (utils.py:700)
  _create_label_view (observability.py:1920)
  _bind_dynamic_metric_children (observability.py:1493)
  labels (prometheus_client/metrics.py:176)
  <genexpr> (prometheus_client/metrics.py:176)
  __del__ (memory_management.py:688)         <- collector runs here
  free (mixed_memory_allocator.py:201)
  free (paged_tensor_memory_allocator.py:257)
  wrapper (utils.py:699)                     <- re-acquires. Deadlock.
```

Both the holding frame and the acquiring frame are in the **same thread's** stack, so this is
same-thread re-entry, not lock ordering across threads.

**Re-entry is safe here.** The two methods reached through `free()` each assign a single
`LMCStatsMonitor` attribute. They touch no `PrometheusLogger` state and do not iterate the
collector dict that `_bind_dynamic_metric_children` is walking, so allowing re-entry breaks no
invariant.

## Reproducers

Minimal — needs no GPU, hangs with `CUDA_VISIBLE_DEVICES=""`:

```python
from lmcache.utils import thread_safe

@thread_safe
def inner(): return 1

@thread_safe
def outer(): return inner()

outer()   # hangs forever on dev
```

The real path, public APIs only:

```python
import torch
from lmcache.utils import thread_safe
from lmcache.v1.memory_allocators.mixed_memory_allocator import MixedMemoryAllocator
from lmcache.v1.memory_management import MemoryFormat

shape = torch.Size([2, 16, 8, 64])
alloc = MixedMemoryAllocator(size=256 * 1024 * 1024, use_paging=True,
                             shapes=[shape], dtypes=[torch.float16],
                             fmt=MemoryFormat.KV_2TD)
holder = {"obj": alloc.allocate(shape, torch.float16, fmt=MemoryFormat.KV_2TD)}

@thread_safe
def locked_region():
    holder["obj"] = None   # __del__ -> free -> update_local_cache_usage

locked_region()   # hangs forever on dev
```

## How it surfaced

The unit suite hangs at `tests/v1/test_remote_mla_worker_id_as0.py:91` (a `LocalCPUBackend`
constructor) with an identical stack each time. It hit **3 of the 5 runs in which that test
executed** — found while running the suite 8 times to validate an unrelated CI change.

Seen on MI300X/gfx942 with torch 2.10.0+rocm7.0 and MI350X/gfx950 with torch 2.11.0+rocm7.2 —
two architectures, two toolchains, two hosts. I have not reproduced it on NVIDIA, but nothing
in this path is vendor-specific: it is pure Python, and the minimal reproducer needs no GPU.

It is a permanent hang, not a slow test, and there is no per-test timeout
(`pytest-timeout` is not in `requirements/test.txt`), so a job burns its full
`timeout_in_minutes: 60` and reports a timeout naming no test — which reads as an agent
problem and invites a retry rather than an investigation.

## Test plan

The regression test runs the nested call in a worker thread, so a future regression **fails
the test instead of hanging the suite**:

- with this fix: passes in 2.6s
- with the fix reverted to `threading.Lock()`: fails in 32.6s (the 30s wait)

Also on an MI300X:

- 434 passed across `tests/test_observability.py`, `tests/v1/mp_observability`,
  `tests/v1/mp_coordinator/test_observability.py`, `tests/v1/distributed/test_l1_l2_state_metrics.py`
- full unit suite: 9 failed / 5881 passed / 239 skipped vs 10 failed / 5879 passed / 239 skipped
  without the fix, on the same workspace and toolchain. The failure sets differ by one entry, the
  already-flaky `TestDiscoverApiRouters` member that oscillates run to run. Runtime 15:06 vs 14:58.
- `test_remote_mla_worker_id_as0` **passes** in that run

## Note on scope

This is the stop-gap, not the design fix. Keeping `__del__` out of observability entirely
(deferring the stats update rather than taking a lock under the collector), or splitting the
lock so `PrometheusLogger` registration and `LMCStatsMonitor` counters don't share one global,
would remove the hazard rather than tolerate it. Those are judgement calls for the owners of
this area rather than something to decide here.

Adding `pytest-timeout` with a per-test cap is worth doing separately, so a hang surfaces as a
named test rather than an opaque job timeout.

cc @sammshen @ApostaC — you own `memory_management.py`, the other half of this path, though
this diff doesn't touch it.