### PR TITLE
[MP][Coordinator] Persist the coordinator's durable state to disk

### DIFF
--- a/docs/design/v1/mp_coordinator/persistence/README.md
+++ b/docs/design/v1/mp_coordinator/persistence/README.md
@@ -134,3 +134,34 @@ The one real consequence is for whoever writes the artifact: the
 directory's capture holds numpy token arrays, which must be written
 outside the msgpack document rather than inlined, or peak write memory
 tracks the whole token corpus instead of the metadata.
+
+## The two artifacts
+
+| | Checkpoint | Metadata document |
+|---|---|---|
+| Holds | `CHECKPOINT` sections | `METADATA` sections |
+| Format | msgpack, 12-byte header | JSON, indented |
+| Written | every `--checkpoint-interval` and on a clean stop | synchronously, by whatever changed a pin or a quota |
+| Losing it costs | hit rate until the fleet re-stores | an operator noticing and re-applying |
+| Enabled by | `--checkpoint-path` | `--metadata-path` |
+
+Both go through `ArtifactStore`: one whole object, replaced atomically,
+at one location. The local backend writes beside the target and renames,
+so a reader sees the previous artifact or the new one and never a torn
+one; an unconfigured path gets a store that discards writes, so
+persistence being off is not a case every caller tests for.
+
+**The codec knows nothing about any section.** That is the payoff from
+the plain-data contract: `write_checkpoint` is one `msgspec.msgpack`
+encode of every section together, and adding a component changes no code
+here. The cost is that a checkpoint is encoded whole before it is
+written -- peak memory runs about 1.3x the file, so roughly 1.6 GB for a
+fleet holding a million chunks, of which 84% is token content. Encoding
+section by section is the escape hatch if that ever bites.
+
+**Every failure is survivable.** A missing, corrupt, or future-version
+artifact logs and leaves the coordinator cold rather than refusing to
+boot; one unreadable section does not cost the others; a failed write is
+logged and retried on the next tick. A checkpoint is an optimization, and
+a coordinator that dies because it could not write one is strictly worse
+than one that keeps serving.

--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -68,6 +68,17 @@ Options
    * - ``--blend-probe-stride N``
      - Positions between CacheBlend match probes; ``1`` probes every offset
        for full recall (default: ``1``). Ignored unless blend lookup is on.
+   * - ``--checkpoint-path FILE``
+     - Checkpoint the coordinator's directory, usage view and stream cursors
+       to this file, so a restart resumes instead of starting cold. Unset
+       disables checkpointing.
+   * - ``--checkpoint-interval SECS``
+     - Seconds between checkpoint writes; ``0`` writes only on a clean stop
+       (default: ``60``). Ignored unless ``--checkpoint-path`` is set.
+   * - ``--metadata-path FILE``
+     - Store operator-set state -- L2 pins and per-``cache_salt`` quotas -- in
+       this file, written whenever it changes. Unset means that state is lost
+       on restart.
    * - ``--timeout-keep-alive SECS``
      - Seconds the HTTP server keeps idle connections open before closing
        them. Must be greater than the MP servers' heartbeat interval

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -88,6 +88,19 @@ keeps the default below.
      - ``1``
      - Positions between CacheBlend match probes. ``1`` probes every offset
        for full recall. Ignored unless blend lookup is on.
+   * - ``--checkpoint-path``
+     - (empty)
+     - File the coordinator's derived state is checkpointed to. Empty
+       disables it and the coordinator starts cold after every restart.
+   * - ``--checkpoint-interval``
+     - ``60``
+     - Seconds between checkpoint writes; ``0`` writes only on a clean stop.
+       Ignored without a path. Does not affect the metadata file, which is
+       written whenever pins or quotas change.
+   * - ``--metadata-path``
+     - (empty)
+     - File the operator-set state (L2 pins and per-``cache_salt`` quotas)
+       is stored in. Empty means that state is lost on restart.
    * - ``--timeout-keep-alive``
      - ``10``
      - Seconds the HTTP server keeps idle connections open before closing

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -142,6 +142,33 @@ class CoordinatorCommand(BaseCommand):
             ),
         )
         parser.add_argument(
+            "--checkpoint-path",
+            type=str,
+            default=None,
+            help=(
+                "File to checkpoint the coordinator's derived state to, so a "
+                "restart resumes instead of starting cold. Unset disables it."
+            ),
+        )
+        parser.add_argument(
+            "--checkpoint-interval",
+            type=float,
+            default=None,
+            help=(
+                "Seconds between checkpoint writes; 0 writes only on a clean "
+                "stop (default: 60). Ignored without --checkpoint-path."
+            ),
+        )
+        parser.add_argument(
+            "--metadata-path",
+            type=str,
+            default=None,
+            help=(
+                "File to store operator-set state (L2 pins and per-cache_salt "
+                "quotas) in. Unset means that state is lost on restart."
+            ),
+        )
+        parser.add_argument(
             "--timeout-keep-alive",
             type=int,
             default=None,
@@ -213,6 +240,9 @@ class CoordinatorCommand(BaseCommand):
                 ("hash_algorithm", args.hash_algorithm),
                 ("enable_blend_lookup", args.enable_blend_lookup),
                 ("blend_probe_stride", args.blend_probe_stride),
+                ("checkpoint_path", args.checkpoint_path),
+                ("checkpoint_interval", args.checkpoint_interval),
+                ("metadata_path", args.metadata_path),
                 ("timeout_keep_alive", args.timeout_keep_alive),
                 ("otlp_endpoint", args.otlp_endpoint),
             )

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -41,7 +41,21 @@ from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
 from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.checkpoint import (
+    load_checkpoint,
+    save_checkpoint,
+)
+from lmcache.v1.mp_coordinator.persistence.durable_component import (
+    DurableComponent,
+    PersistenceType,
+)
+from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
 from lmcache.v1.mp_coordinator.persistence.quiesce import QuiesceLock
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactStore,
+    LocalArtifactStore,
+    NullArtifactStore,
+)
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.utils.router_discovery import discover_api_routers
@@ -111,6 +125,26 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     quiesce = QuiesceLock()
     event_gate = EventGate(event_broadcaster, quiesce)
 
+    # Durable state, split by where each component says it belongs. PR 3
+    # replaces this hand-built list with controller discovery.
+    durable: list[DurableComponent] = [
+        key_directory,
+        usage_manager,
+        event_gate,
+        *eviction_controller.get_durable_components(),
+    ]
+    checkpoint_components = [
+        c for c in durable if c.persistence_type is PersistenceType.CHECKPOINT
+    ]
+    checkpoint_store = _artifact_store(config.checkpoint_path)
+    metadata_persister = MetadataPersister(_artifact_store(config.metadata_path))
+    for component in durable:
+        if component.persistence_type is PersistenceType.METADATA:
+            metadata_persister.register(component)
+    # Before the checkpoint, so a restored key arrives already pinned.
+    metadata_persister.load()
+    load_checkpoint(checkpoint_store, checkpoint_components)
+
     ctx = CoordinatorContext(
         registry=registry,
         usage_manager=usage_manager,
@@ -119,7 +153,24 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         token_hasher=token_hasher,
         key_directory=key_directory,
         event_gate=event_gate,
+        metadata_persister=metadata_persister,
     )
+
+    async def _checkpoint_loop() -> None:
+        """Checkpoint on a timer until cancelled.
+
+        Only derived state runs on a timer: it changes continuously, so a
+        cadence is the only sensible cost. Operator intent is written when
+        it changes instead (see ``MetadataPersister``).
+        """
+        while True:
+            await asyncio.sleep(config.checkpoint_interval)
+            await asyncio.to_thread(
+                save_checkpoint,
+                checkpoint_store,
+                quiesce,
+                checkpoint_components,
+            )
 
     async def _health_loop() -> None:
         """Evict stale instances on a timer until cancelled.
@@ -144,6 +195,9 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         app.state.outbound_client = outbound_client
         health_task = None
         eviction_task = None
+        checkpoint_task = None
+        if config.checkpoint_path and config.checkpoint_interval > 0:
+            checkpoint_task = asyncio.create_task(_checkpoint_loop())
         if config.health_check_interval > 0:
             health_task = asyncio.create_task(_health_loop())
         if config.eviction_check_interval > 0:
@@ -158,11 +212,20 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         try:
             yield
         finally:
-            for task in (health_task, eviction_task):
+            for task in (health_task, eviction_task, checkpoint_task):
                 if task is not None:
                     task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await task
+            if config.checkpoint_path:
+                # One last write, so a clean restart resumes where this
+                # process stopped rather than an interval-old copy.
+                await asyncio.to_thread(
+                    save_checkpoint,
+                    checkpoint_store,
+                    quiesce,
+                    checkpoint_components,
+                )
             await eviction_controller.wait_for_in_flight_dispatches()
             await outbound_client.aclose()
 
@@ -177,3 +240,12 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         app.include_router(router)
 
     return app
+
+
+def _artifact_store(path: str) -> ArtifactStore:
+    """Return the store for ``path``, or one that discards if unset.
+
+    Args:
+        path: Configured location, empty when the operator wants none.
+    """
+    return LocalArtifactStore(Path(path)) if path else NullArtifactStore()

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -42,6 +42,14 @@ class MPCoordinatorConfig:
             no content.
         blend_probe_stride: Positions between match probes; ``1`` gives full
             recall. Ignored unless ``enable_blend_lookup`` is set.
+        checkpoint_path: File the coordinator's derived state is
+            checkpointed to. Empty disables checkpointing, and the
+            coordinator starts cold after every restart.
+        checkpoint_interval: Seconds between checkpoint writes; ``0``
+            writes only on a clean stop. Ignored without a path.
+        metadata_path: File the operator-set state (L2 pins and
+            per-``cache_salt`` quotas) is stored in. Empty disables it,
+            and that state is lost on restart.
         timeout_keep_alive: Seconds the HTTP server keeps idle connections
             open before closing them. Must be greater than the heartbeat
             interval of MP servers to avoid race-condition disconnects.
@@ -61,6 +69,9 @@ class MPCoordinatorConfig:
     hash_algorithm: str = "blake3"
     enable_blend_lookup: bool = False
     blend_probe_stride: int = 1
+    checkpoint_path: str = ""
+    checkpoint_interval: float = 60.0
+    metadata_path: str = ""
     timeout_keep_alive: int = 10
     metrics_enabled: bool = True
     otlp_endpoint: str | None = None
@@ -89,5 +100,7 @@ class MPCoordinatorConfig:
             raise ValueError("hash_algorithm must be a non-empty string")
         if self.blend_probe_stride < 1:
             raise ValueError("blend_probe_stride must be positive")
+        if self.checkpoint_interval < 0:
+            raise ValueError("checkpoint_interval must be non-negative")
         if self.timeout_keep_alive <= 0:
             raise ValueError("timeout_keep_alive must be positive")

--- a/lmcache/v1/mp_coordinator/http_apis/cache_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/cache_api.py
@@ -170,6 +170,7 @@ async def request_pin(body: PinRequest, request: Request) -> PinResponse:
         raise HTTPException(status_code=400, detail=str(exc)) from None
 
     ctx.eviction_controller.pin(resolved)
+    ctx.metadata_persister.save()
     return PinResponse(
         requested=chunks,
         affected=len(resolved),
@@ -206,6 +207,7 @@ async def request_unpin(body: PinRequest, request: Request) -> PinResponse:
         raise HTTPException(status_code=400, detail=str(exc)) from None
 
     ctx.eviction_controller.unpin(resolved)
+    ctx.metadata_persister.save()
     return PinResponse(
         requested=chunks,
         affected=len(resolved),
@@ -297,6 +299,7 @@ async def request_delete(body: DeleteRequest, request: Request) -> DeleteRespons
 
     if touches_l2 and body.force:
         ctx.eviction_controller.drop_pins(resolved)
+        ctx.metadata_persister.save()
 
     # ``skipped`` = L1 keys the node refused (locks) + L2 keys the coordinator
     # held back for a pin.

--- a/lmcache/v1/mp_coordinator/http_apis/dependencies.py
+++ b/lmcache/v1/mp_coordinator/http_apis/dependencies.py
@@ -24,6 +24,7 @@ from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManag
 from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
@@ -46,6 +47,9 @@ class CoordinatorContext:
             MP-server cache events (eventually consistent).
         event_gate: Ingest entry point for the fleet cache-event stream
             (``POST /events``).
+        metadata_persister: Durable store for operator intent. Every
+            handler that changes a pin or a quota must ``save`` so the
+            change survives a restart.
     """
 
     registry: InstanceRegistry
@@ -55,6 +59,7 @@ class CoordinatorContext:
     token_hasher: TokenHasher
     key_directory: KeyDirectory
     event_gate: EventGate
+    metadata_persister: MetadataPersister
 
 
 def get_context(request: Request) -> CoordinatorContext:

--- a/lmcache/v1/mp_coordinator/http_apis/quota_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/quota_api.py
@@ -112,8 +112,9 @@ async def set_quota_config(
     default_limit_bytes = (
         None if body.default_limit_gb is None else int(body.default_limit_gb * _GB)
     )
-    quota = get_context(request).eviction_controller.quota
-    quota.set_default_limit_bytes(default_limit_bytes)
+    ctx = get_context(request)
+    ctx.eviction_controller.quota.set_default_limit_bytes(default_limit_bytes)
+    ctx.metadata_persister.save()
     return QuotaConfigResponse(default_limit_gb=body.default_limit_gb)
 
 
@@ -157,12 +158,12 @@ async def set_quota(
     _require_quota_tier(body.tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
     limit_bytes = int(body.limit_gb * _GB)
+    ctx = get_context(request)
     try:
-        get_context(request).eviction_controller.quota.set_quota(
-            cache_salt, limit_bytes
-        )
+        ctx.eviction_controller.quota.set_quota(cache_salt, limit_bytes)
     except ValueError:
         return JSONResponse(status_code=400, content={"error": "invalid quota limit"})
+    ctx.metadata_persister.save()
     return QuotaResponse(cache_salt=cache_salt, limit_gb=body.limit_gb, status="ok")
 
 
@@ -181,8 +182,9 @@ async def delete_quota(
     """
     _require_quota_tier(tier)
     cache_salt = _resolve_salt_from_api_path(cache_salt)
-    quota = get_context(request).eviction_controller.quota
-    removed = quota.delete_quota(cache_salt)
+    ctx = get_context(request)
+    removed = ctx.eviction_controller.quota.delete_quota(cache_salt)
+    ctx.metadata_persister.save()
     return QuotaResponse(
         cache_salt=cache_salt,
         limit_gb=0.0,

--- a/lmcache/v1/mp_coordinator/persistence/checkpoint.py
+++ b/lmcache/v1/mp_coordinator/persistence/checkpoint.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The coordinator's checkpoint: derived state that outlives the process.
+
+Written on a timer and on a clean stop, read once at startup. A restart
+that finds one comes back knowing what the fleet has cached; one that
+does not starts blind and relearns only what gets stored again.
+
+The format is a short header and one msgpack document holding every
+section. Because a capture is plain data, the codec never learns what a
+section means -- adding a component changes nothing here.
+"""
+
+# Standard
+from collections.abc import Mapping, Sequence
+from typing import BinaryIO, cast
+import struct
+
+# Third Party
+import msgspec
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.persistence.durable_component import DurableComponent
+from lmcache.v1.mp_coordinator.persistence.quiesce import (
+    DEFAULT_QUIESCE_TIMEOUT,
+    QuiesceLock,
+)
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactNotFoundError,
+    ArtifactStore,
+)
+
+logger = init_logger(__name__)
+
+_MAGIC = b"LMCKPT\0\0"
+_FORMAT_VERSION = 1
+_HEADER = struct.Struct("<8sI")
+
+
+class CheckpointFormatError(Exception):
+    """A checkpoint is malformed, truncated, or of an unknown version."""
+
+
+def save_checkpoint(
+    store: ArtifactStore,
+    quiesce: QuiesceLock,
+    components: Sequence[DurableComponent],
+    timeout: float = DEFAULT_QUIESCE_TIMEOUT,
+) -> None:
+    """Capture ``components`` and replace the stored checkpoint.
+
+    Ingest is quiesced while the components are read, which is the only
+    way the sections agree with each other -- one batch is applied by
+    several of them. It is released before the write: a disk write under
+    the quiesce would park the fleet's event stream for its duration.
+
+    Failures are logged rather than raised: a checkpoint is an
+    optimization, and a coordinator that dies because it could not write
+    one is strictly worse than one that keeps serving.
+
+    Args:
+        store: Where the checkpoint lives.
+        quiesce: The lock the ingest path holds while applying.
+        components: The state to persist.
+        timeout: Seconds to wait for an in-flight batch.
+    """
+    try:
+        sections: dict[str, Mapping[str, object]] = {}
+        with quiesce.quiesced(timeout):
+            for component in components:
+                if component.name in sections:
+                    raise ValueError(f"two components named {component.name!r}")
+                sections[component.name] = component.capture()
+        with store.open_write() as stream:
+            _write_checkpoint(sections, stream)
+    except (OSError, TimeoutError, ValueError) as e:
+        logger.warning("Failed to write checkpoint %s: %s", store.location(), e)
+        return
+    logger.debug("Checkpointed %d section(s) to %s", len(sections), store.location())
+
+
+def load_checkpoint(
+    store: ArtifactStore, components: Sequence[DurableComponent]
+) -> None:
+    """Restore ``components`` from the stored checkpoint, if there is one.
+
+    Call once at startup, before the gate admits anything. Each component
+    loads its own section, so the order here does not matter and a
+    component whose section is absent keeps whatever it started with.
+
+    Every failure is survivable: a missing, corrupt, or future-version
+    checkpoint logs and leaves the coordinator cold rather than refusing
+    to boot.
+
+    Args:
+        store: Where the checkpoint lives.
+        components: The state to restore.
+    """
+    try:
+        with store.open_read() as stream:
+            sections = _read_checkpoint(stream)
+    except ArtifactNotFoundError:
+        logger.info("No checkpoint at %s; starting cold", store.location())
+        return
+    except (OSError, CheckpointFormatError) as e:
+        logger.warning("Ignoring checkpoint %s: %s", store.location(), e)
+        return
+
+    restored = []
+    for component in components:
+        section = sections.get(component.name)
+        if section is None:
+            continue
+        try:
+            component.restore(section)
+        except (ValueError, TypeError, KeyError) as e:
+            # One unreadable section must not cost the others.
+            logger.warning("Ignoring %r section: %s", component.name, e)
+            continue
+        restored.append(component.name)
+    logger.info(
+        "Restored %s from checkpoint %s",
+        ", ".join(restored) or "nothing",
+        store.location(),
+    )
+
+
+# -- Internals ----------------------------------------------------------------
+
+
+def _write_checkpoint(
+    sections: Mapping[str, Mapping[str, object]], stream: BinaryIO
+) -> None:
+    """Encode ``sections`` and write them to ``stream``.
+
+    Args:
+        sections: Captures keyed by component name.
+        stream: Where to write; positioned at the end on return.
+
+    Raises:
+        OSError: If the stream rejects a write.
+    """
+    payload = msgspec.msgpack.encode(sections)
+    stream.write(_HEADER.pack(_MAGIC, _FORMAT_VERSION))
+    stream.write(payload)
+
+
+def _read_checkpoint(stream: BinaryIO) -> dict[str, Mapping[str, object]]:
+    """Decode a checkpoint written by :func:`_write_checkpoint`.
+
+    Args:
+        stream: Positioned at the start of the checkpoint.
+
+    Returns:
+        Sections keyed by component name.
+
+    Raises:
+        CheckpointFormatError: If the stream is not a checkpoint, carries
+            an unsupported version, or is malformed.
+    """
+    header = stream.read(_HEADER.size)
+    if len(header) != _HEADER.size:
+        raise CheckpointFormatError(f"truncated header ({len(header)} bytes)")
+    magic, version = _HEADER.unpack(header)
+    if magic != _MAGIC:
+        raise CheckpointFormatError(f"not a checkpoint (magic {magic!r})")
+    if version != _FORMAT_VERSION:
+        raise CheckpointFormatError(
+            f"unsupported checkpoint version {version} "
+            f"(this build reads {_FORMAT_VERSION})"
+        )
+    try:
+        decoded = msgspec.msgpack.decode(stream.read())
+    except msgspec.MsgspecError as e:
+        raise CheckpointFormatError(f"malformed checkpoint: {e}") from e
+    if not isinstance(decoded, dict):
+        raise CheckpointFormatError(f"checkpoint holds a {type(decoded).__name__}")
+    return cast("dict[str, Mapping[str, object]]", decoded)

--- a/lmcache/v1/mp_coordinator/persistence/checkpoint.py
+++ b/lmcache/v1/mp_coordinator/persistence/checkpoint.py
@@ -53,6 +53,8 @@ def save_checkpoint(
     way the sections agree with each other -- one batch is applied by
     several of them. It is released before the write: a disk write under
     the quiesce would park the fleet's event stream for its duration.
+    That is why ``capture`` must return copies -- by the time the
+    sections are encoded, the components they came from are moving again.
 
     Failures are logged rather than raised: a checkpoint is an
     optimization, and a coordinator that dies because it could not write

--- a/lmcache/v1/mp_coordinator/persistence/durable_component.py
+++ b/lmcache/v1/mp_coordinator/persistence/durable_component.py
@@ -52,6 +52,12 @@ class DurableComponent(Protocol):
         strings and bytes. Domain objects would make every artifact
         writer know what a section means, and a section's shape is the
         component's business alone.
+
+        Copies, never references into live state. Ingest is quiesced for
+        the capture but released before the artifact is encoded, so a
+        returned reference would be serialized while the component is
+        being mutated -- a torn section, or an iteration error, long
+        after this returns.
         """
         ...
 

--- a/lmcache/v1/mp_coordinator/persistence/metadata.py
+++ b/lmcache/v1/mp_coordinator/persistence/metadata.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The coordinator's metadata document: what an operator set by hand.
+
+Pins and quotas are small, change rarely, and nothing can reconstruct
+them -- so they are written the moment they change rather than on a
+timer, and in JSON rather than msgpack, because the one person likely to
+read this file by hand is the operator who wrote its contents.
+"""
+
+# Standard
+from collections.abc import Mapping
+from typing import cast
+import json
+import time
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.persistence.durable_component import (
+    DurableComponent,
+    PersistenceType,
+)
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactNotFoundError,
+    ArtifactStore,
+)
+
+logger = init_logger(__name__)
+
+_FORMAT_VERSION = 1
+
+
+class MetadataFormatError(Exception):
+    """A metadata document is malformed or of an unknown version."""
+
+
+class MetadataPersister:
+    """Keeps the metadata document in step with its components.
+
+    The document is the coordinator's own: its shape is checked, but the
+    values inside a section are taken as written, and the component that
+    owns a section is the only thing that understands it.
+    """
+
+    def __init__(self, store: ArtifactStore) -> None:
+        """Args:
+        store: Where the document lives.
+        """
+        self._store = store
+        self._components: list[DurableComponent] = []
+
+    def register(self, component: DurableComponent) -> None:
+        """Add ``component`` to the document; call before :meth:`load`.
+
+        Args:
+            component: The state to persist. Its ``persistence_type``
+                must be ``METADATA``.
+
+        Raises:
+            ValueError: If the component belongs in the checkpoint --
+                derived state here would be rewritten on every operator
+                change and reloaded ahead of the checkpoint that owns it.
+        """
+        if component.persistence_type is not PersistenceType.METADATA:
+            raise ValueError(
+                f"{component.name!r} is {component.persistence_type.value} state; "
+                f"the metadata document takes only metadata components"
+            )
+        self._components.append(component)
+
+    def load(self) -> None:
+        """Restore every registered component from the document.
+
+        Call once at startup. A missing or unreadable document leaves the
+        components as they are: an operator can re-apply their intent,
+        which is better than refusing to boot.
+        """
+        try:
+            with self._store.open_read() as stream:
+                document = self._decode(stream.read())
+        except ArtifactNotFoundError:
+            logger.info("Starting with no metadata: %s", self._store.location())
+            return
+        except (OSError, MetadataFormatError) as e:
+            logger.warning("Ignoring metadata %s: %s", self._store.location(), e)
+            return
+
+        sections = cast("Mapping[str, Mapping[str, object]]", document["components"])
+        restored = []
+        for component in self._components:
+            section = sections.get(component.name)
+            if section is None:
+                continue
+            try:
+                component.restore(section)
+            except (ValueError, TypeError, KeyError) as e:
+                logger.warning("Ignoring %r section: %s", component.name, e)
+                continue
+            restored.append(component.name)
+        logger.info(
+            "Restored %s from %s, captured %.0fs ago",
+            ", ".join(restored) or "nothing",
+            self._store.location(),
+            max(0.0, time.time() - cast("float", document["saved_at"])),
+        )
+
+    def save(self) -> None:
+        """Replace the document with the components' current state.
+
+        Called by whatever changed one of them, so a ``200`` from an API
+        that sets a pin or a quota means the change survives a restart.
+        Failures are logged rather than raised.
+        """
+        document = {
+            "version": _FORMAT_VERSION,
+            "saved_at": time.time(),
+            "components": {c.name: c.capture() for c in self._components},
+        }
+        try:
+            with self._store.open_write() as stream:
+                stream.write(json.dumps(document, indent=2).encode())
+        except (OSError, TypeError, ValueError) as e:
+            logger.warning("Failed to write metadata %s: %s", self._store.location(), e)
+
+    # -- Internals ----------------------------------------------------------------
+
+    def _decode(self, raw: bytes) -> Mapping[str, object]:
+        """Parse a document and check its shape.
+
+        Args:
+            raw: The stored bytes.
+
+        Returns:
+            The document.
+
+        Raises:
+            MetadataFormatError: If it is not JSON, is not an object, or
+                carries an unsupported version.
+        """
+        try:
+            document = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise MetadataFormatError(f"not JSON: {e}") from e
+        if not isinstance(document, dict):
+            raise MetadataFormatError(f"holds a {type(document).__name__}")
+        if document.get("version") != _FORMAT_VERSION:
+            raise MetadataFormatError(
+                f"unsupported version {document.get('version')!r} "
+                f"(this build reads {_FORMAT_VERSION})"
+            )
+        if not isinstance(document.get("components"), dict):
+            raise MetadataFormatError("no components object")
+        if not isinstance(document.get("saved_at"), (int, float)):
+            raise MetadataFormatError("no saved_at timestamp")
+        return cast("Mapping[str, object]", document)

--- a/lmcache/v1/mp_coordinator/persistence/store.py
+++ b/lmcache/v1/mp_coordinator/persistence/store.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Where a durable artifact's bytes live.
+
+One contract serves both artifacts: each is a single whole object,
+replaced atomically, at one location. The seam is a byte stream rather
+than a value, because a checkpoint runs to gigabytes and neither side
+should hold two copies of it.
+"""
+
+# Standard
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from pathlib import Path
+from typing import BinaryIO
+import io
+import os
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+_TMP_SUFFIX = ".tmp"
+
+
+class ArtifactNotFoundError(Exception):
+    """Nothing is stored at the artifact's location."""
+
+
+class ArtifactStore(ABC):
+    """A single named artifact, read and replaced whole."""
+
+    @abstractmethod
+    def open_read(self) -> AbstractContextManager[BinaryIO]:
+        """Open the stored artifact for reading.
+
+        Returns:
+            A context manager yielding the artifact's bytes.
+
+        Raises:
+            ArtifactNotFoundError: If nothing is stored yet.
+            OSError: If the artifact cannot be opened.
+        """
+
+    @abstractmethod
+    def open_write(self) -> AbstractContextManager[BinaryIO]:
+        """Open a stream that replaces the artifact on clean exit.
+
+        A reader sees either the previous artifact or the new one, never
+        a partial write, and an exception inside the block leaves the
+        previous one in place.
+
+        Returns:
+            A context manager yielding the stream to write.
+
+        Raises:
+            OSError: If the artifact cannot be written.
+        """
+
+    @abstractmethod
+    def location(self) -> str:
+        """Where this artifact lives, for logs and errors."""
+
+
+class LocalArtifactStore(ArtifactStore):
+    """An artifact in a local file.
+
+    Writes land beside the target and are renamed over it, so a crash
+    mid-write leaves at most a stale temporary file. On Kubernetes the
+    path is typically a PersistentVolumeClaim.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Args:
+        path: The file to read and replace.
+        """
+        self._path = path
+
+    @contextmanager
+    def open_read(self) -> Iterator[BinaryIO]:
+        """See :meth:`ArtifactStore.open_read`."""
+        try:
+            with self._path.open("rb") as stream:
+                yield stream
+        except FileNotFoundError as e:
+            raise ArtifactNotFoundError(str(self._path)) from e
+
+    @contextmanager
+    def open_write(self) -> Iterator[BinaryIO]:
+        """See :meth:`ArtifactStore.open_write`."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_name(self._path.name + _TMP_SUFFIX)
+        try:
+            with tmp.open("wb") as stream:
+                yield stream
+                stream.flush()
+                # Durable before the rename, or a crash can publish a
+                # name pointing at unwritten blocks.
+                os.fsync(stream.fileno())
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+        os.replace(tmp, self._path)
+
+    def location(self) -> str:
+        """See :meth:`ArtifactStore.location`."""
+        return str(self._path)
+
+
+class NullArtifactStore(ArtifactStore):
+    """The store for an artifact nobody configured.
+
+    Reads report nothing stored and writes are discarded, so persistence
+    being off is not a special case every caller has to test for.
+    """
+
+    @contextmanager
+    def open_read(self) -> Iterator[BinaryIO]:
+        """See :meth:`ArtifactStore.open_read`; always raises."""
+        raise ArtifactNotFoundError(self.location())
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    @contextmanager
+    def open_write(self) -> Iterator[BinaryIO]:
+        """See :meth:`ArtifactStore.open_write`; discards what is written."""
+        with io.BytesIO() as sink:
+            yield sink
+
+    def location(self) -> str:
+        """See :meth:`ArtifactStore.location`."""
+        return "<not configured>"

--- a/tests/cli/commands/test_coordinator.py
+++ b/tests/cli/commands/test_coordinator.py
@@ -60,6 +60,12 @@ class TestCoordinatorCommandArguments:
                 "sha256",
                 "--blend-probe-stride",
                 "2",
+                "--checkpoint-path",
+                "/tmp/checkpoint",
+                "--checkpoint-interval",
+                "30",
+                "--metadata-path",
+                "/tmp/metadata.json",
                 "--timeout-keep-alive",
                 "15",
                 "--disable-metrics",
@@ -72,6 +78,9 @@ class TestCoordinatorCommandArguments:
         assert args.chunk_size == 512
         assert args.hash_algorithm == "sha256"
         assert args.blend_probe_stride == 2
+        assert args.checkpoint_path == "/tmp/checkpoint"
+        assert args.checkpoint_interval == 30.0
+        assert args.metadata_path == "/tmp/metadata.json"
         assert args.timeout_keep_alive == 15
         assert args.disable_metrics is True
         assert args.otlp_endpoint == "http://collector:4317"
@@ -88,6 +97,9 @@ class TestCoordinatorCommandArguments:
         assert args.hash_algorithm is None
         assert args.enable_blend_lookup is None
         assert args.blend_probe_stride is None
+        assert args.checkpoint_path is None
+        assert args.checkpoint_interval is None
+        assert args.metadata_path is None
         assert args.timeout_keep_alive is None
         assert args.disable_metrics is None
         assert args.otlp_endpoint is None
@@ -111,6 +123,9 @@ class TestCoordinatorCommandExecute:
             hash_algorithm="sha256",
             enable_blend_lookup=True,
             blend_probe_stride=2,
+            checkpoint_path="/var/lib/lmcache/checkpoint",
+            checkpoint_interval=30.0,
+            metadata_path="/var/lib/lmcache/metadata.json",
             timeout_keep_alive=None,
             disable_metrics=True,
             otlp_endpoint="http://collector:4317",
@@ -138,6 +153,9 @@ class TestCoordinatorCommandExecute:
         assert captured["config"].hash_algorithm == "sha256"
         assert captured["config"].enable_blend_lookup is True
         assert captured["config"].blend_probe_stride == 2
+        assert captured["config"].checkpoint_path == "/var/lib/lmcache/checkpoint"
+        assert captured["config"].checkpoint_interval == 30.0
+        assert captured["config"].metadata_path == "/var/lib/lmcache/metadata.json"
         assert captured["config"].metrics_enabled is False
         assert captured["config"].otlp_endpoint == "http://collector:4317"
         # Unset flags keep the config defaults.
@@ -166,6 +184,9 @@ class TestCoordinatorCommandExecute:
             hash_algorithm=None,
             enable_blend_lookup=None,
             blend_probe_stride=None,
+            checkpoint_path=None,
+            checkpoint_interval=None,
+            metadata_path=None,
             timeout_keep_alive=None,
             disable_metrics=None,
             otlp_endpoint=None,

--- a/tests/v1/mp_coordinator/persistence/test_app_persistence.py
+++ b/tests/v1/mp_coordinator/persistence/test_app_persistence.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Persistence as the coordinator actually wires it: through the app."""
+
+# Standard
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+import json
+
+# Third Party
+from fastapi.testclient import TestClient
+
+# First Party
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+
+@contextmanager
+def _coordinator(checkpoint: Path, metadata: Path) -> Iterator[TestClient]:
+    """Run a coordinator over the given artifacts, stopping it cleanly."""
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        # Writes happen on the clean stop, so the tests need no timer.
+        checkpoint_interval=0.0,
+        checkpoint_path=str(checkpoint),
+        metadata_path=str(metadata),
+    )
+    with TestClient(create_app(config)) as client:
+        yield client
+
+
+def _store_one_key(client: TestClient) -> None:
+    """Report one L2 store, as an MP server would."""
+    response = client.post(
+        "/events",
+        json={
+            "batches": [
+                {
+                    "instance_id": "node-a",
+                    "incarnation": 1,
+                    "seq": 1,
+                    "event_type": "store",
+                    "tier": "l2",
+                    "backend": "fs",
+                    "entries": [
+                        {
+                            "key": {
+                                "chunk_hash_hex": "aa",
+                                "model_name": "m",
+                                "kv_rank": 0,
+                            },
+                            "size_bytes": 1024,
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+
+
+class TestBothArtifacts:
+    def test_a_restart_resumes_the_directory_and_the_operator_intent(
+        self, tmp_path: Path
+    ):
+        """The two halves are stored apart but must come back together:
+        the directory says what is cached, the metadata what may not be
+        evicted."""
+        checkpoint, metadata = tmp_path / "checkpoint", tmp_path / "metadata.json"
+
+        with _coordinator(checkpoint, metadata) as client:
+            _store_one_key(client)
+            assert (
+                client.put("/quota/config", json={"default_limit_gb": 2}).status_code
+                == 200
+            )
+
+        assert checkpoint.is_file() and metadata.is_file()
+        with _coordinator(checkpoint, metadata) as restarted:
+            assert restarted.get("/directory/stats").json()["num_keys"] == 1
+            assert restarted.get("/quota/config").json()["default_limit_gb"] == 2
+
+    def test_operator_intent_is_durable_before_the_response(self, tmp_path: Path):
+        """A 200 from a quota call has to mean the change survives, not
+        that it will at the next checkpoint tick."""
+        checkpoint, metadata = tmp_path / "checkpoint", tmp_path / "metadata.json"
+
+        with _coordinator(checkpoint, metadata) as client:
+            client.put("/quota/tenant-a", json={"limit_gb": 1})
+
+            document = json.loads(metadata.read_text())
+            assert document["components"]["quotas"]["limits"] == {
+                "tenant-a": 1073741824
+            }
+
+    def test_persistence_off_by_default(self, tmp_path: Path):
+        """Unconfigured paths must not create files or break the app."""
+        config = MPCoordinatorConfig(
+            health_check_interval=0.0, eviction_check_interval=0.0
+        )
+
+        with TestClient(create_app(config)) as client:
+            _store_one_key(client)
+            assert client.get("/directory/stats").json()["num_keys"] == 1
+
+        assert list(tmp_path.iterdir()) == []

--- a/tests/v1/mp_coordinator/persistence/test_checkpoint.py
+++ b/tests/v1/mp_coordinator/persistence/test_checkpoint.py
@@ -249,3 +249,38 @@ def _capture(coordinator: _Coordinator) -> dict[str, Mapping[str, object]]:
     """Read a coordinator's sections, as a checkpoint would."""
     with coordinator.quiesce.quiesced():
         return {c.name: c.capture() for c in coordinator.components}
+
+
+class TestCapturesAreCopies:
+    def test_mutating_a_component_does_not_change_its_capture(self):
+        """The quiesce is released before the artifact is encoded, so a
+        capture that aliased live state would be serialized mid-mutation.
+        Copies are the contract; this is what enforces it.
+        """
+        live = _Coordinator()
+        live.gate.ingest(_store(seq=1, keys=[_key(1)]))
+        live.controller.pin([_key(1)])
+        live.controller.quota.set_quota("tenant-a", 4096)
+        every_component = [
+            live.directory,
+            live.usage,
+            live.gate,
+            *live.controller.get_durable_components(),
+        ]
+
+        captured = {c.name: c.capture() for c in every_component}
+
+        # Everything a live coordinator would go on to do while the
+        # checkpoint from those captures is still being encoded.
+        live.gate.ingest(_store(seq=2, keys=[_key(2), _key(3)]))
+        live.controller.pin([_key(2)])
+        live.controller.unpin([_key(1)])
+        live.controller.quota.set_quota("tenant-b", 8192)
+        live.gate.drop_instance("node-a")
+
+        assert len(captured["key_directory"]["keys"]) == 1
+        assert len(captured["cache_usage"]["placements"]) == 1
+        assert len(captured["lru_order"]["buckets"][""]) == 1
+        assert len(captured["pins"]["entries"]) == 1
+        assert captured["quotas"]["limits"] == {"tenant-a": 4096}
+        assert set(captured["stream_cursors"]["cursors"]) == {"node-a"}

--- a/tests/v1/mp_coordinator/persistence/test_checkpoint.py
+++ b/tests/v1/mp_coordinator/persistence/test_checkpoint.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the checkpoint: what survives a restart, and what a bad
+checkpoint costs."""
+
+# Standard
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
+from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
+from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
+from lmcache.v1.mp_coordinator.key_directory import KeyDirectory
+from lmcache.v1.mp_coordinator.persistence.checkpoint import (
+    load_checkpoint,
+    save_checkpoint,
+)
+from lmcache.v1.mp_coordinator.persistence.durable_component import (
+    DurableComponent,
+    PersistenceType,
+)
+from lmcache.v1.mp_coordinator.persistence.quiesce import QuiesceLock
+from lmcache.v1.mp_coordinator.persistence.store import LocalArtifactStore
+
+
+class _Coordinator:
+    """The consumers a coordinator wires up, plus its capture."""
+
+    def __init__(self) -> None:
+        self.directory = KeyDirectory()
+        self.usage = CacheUsageManager()
+        self.controller = FleetEvictionController(usage_manager=self.usage)
+        broadcaster = CacheEventBroadcaster()
+        broadcaster.register_consumer(self.directory)
+        broadcaster.register_consumer(self.usage)
+        broadcaster.register_consumer(self.controller)
+        quiesce = QuiesceLock()
+        self.gate = EventGate(broadcaster, quiesce)
+        self.quiesce = quiesce
+        durable: list[DurableComponent] = [
+            self.directory,
+            self.usage,
+            self.gate,
+            *self.controller.get_durable_components(),
+        ]
+        self.components = [
+            c for c in durable if c.persistence_type is PersistenceType.CHECKPOINT
+        ]
+
+
+def _key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(chunk_hash=chunk_id.to_bytes(4, "big"), model_name="m", kv_rank=0)
+
+
+def _store(
+    seq: int,
+    keys: list[ObjectKey],
+    tier: Tier = Tier.L2,
+    incarnation: int = 7,
+) -> CacheEventBatch:
+    return CacheEventBatch(
+        instance_id="node-a",
+        incarnation=incarnation,
+        seq=seq,
+        event_type=CacheEventType.STORE,
+        tier=tier,
+        backend="fs" if tier is Tier.L2 else "dram",
+        entries=[
+            CacheEventEntry(
+                key=k.to_encoded_object_key(),
+                size_bytes=1024,
+                token_ids=[i, i + 1],
+                token_offset=i * 2,
+            )
+            for i, k in enumerate(keys, start=1)
+        ],
+    )
+
+
+class TestRoundTrip:
+    def test_a_restarted_coordinator_resumes(self, tmp_path: Path):
+        """The whole point: what the fleet cached survives the process
+        that learned it."""
+        store = LocalArtifactStore(tmp_path / "checkpoint")
+        live = _Coordinator()
+        live.gate.ingest(_store(seq=1, keys=[_key(1), _key(2)]))
+        live.gate.ingest(_store(seq=2, keys=[_key(3)], tier=Tier.L1))
+
+        save_checkpoint(store, live.quiesce, live.components)
+        restarted = _Coordinator()
+        load_checkpoint(store, restarted.components)
+
+        assert restarted.directory.stats().num_keys == 3
+        assert restarted.usage.get_salt_bytes(Tier.L2, "") == 2048
+        assert _capture(restarted) == _capture(live)
+
+    def test_restored_cursors_fence_a_restarted_emitter(self, tmp_path: Path):
+        """Placements are only fenceable if the cursor dating them comes
+        back with them."""
+        store = LocalArtifactStore(tmp_path / "checkpoint")
+        live = _Coordinator()
+        live.gate.ingest(_store(seq=1, keys=[_key(1)], tier=Tier.L1))
+        save_checkpoint(store, live.quiesce, live.components)
+
+        restarted = _Coordinator()
+        load_checkpoint(store, restarted.components)
+        assert restarted.directory.lookup([_key(1)])[0], "restored L1 placement"
+
+        restarted.gate.ingest(
+            _store(seq=1, keys=[_key(9)], tier=Tier.L1, incarnation=8)
+        )
+
+        assert restarted.directory.lookup([_key(1)]) == [[]]
+
+
+class TestConsistency:
+    def test_a_checkpoint_never_holds_a_half_applied_batch(self, tmp_path: Path):
+        """A batch reaches the directory and the usage view in turn. A
+        save that read them while one was in flight would write a state
+        no moment matched -- a key the ledger has no bytes for -- and it
+        would look perfectly plausible on restore.
+        """
+        store = LocalArtifactStore(tmp_path / "checkpoint")
+        live = _Coordinator()
+
+        # Widen the window between the two consumers; the real one is
+        # microseconds, which a test would clear by luck.
+        usage_consume = live.usage.consume
+
+        def slow_usage_consume(batch: CacheEventBatch) -> None:
+            time.sleep(0.3)
+            usage_consume(batch)
+
+        live.usage.consume = slow_usage_consume  # type: ignore[method-assign]
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            ingesting = pool.submit(live.gate.ingest, _store(seq=1, keys=[_key(1)]))
+            time.sleep(0.05)  # let the batch reach the slow consumer
+            saving = pool.submit(save_checkpoint, store, live.quiesce, live.components)
+            saving.result(timeout=5.0)
+            assert ingesting.result(timeout=5.0)
+
+        restarted = _Coordinator()
+        load_checkpoint(store, restarted.components)
+
+        assert restarted.directory.stats().num_keys == 1
+        assert restarted.usage.get_salt_bytes(Tier.L2, "") == 1024, (
+            "the checkpoint caught the directory without the bytes for it"
+        )
+
+
+class TestSurvivableFailures:
+    def test_no_checkpoint_starts_cold(self, tmp_path: Path):
+        """A first boot is not an error."""
+        restarted = _Coordinator()
+
+        load_checkpoint(LocalArtifactStore(tmp_path / "absent"), restarted.components)
+
+        assert restarted.directory.stats().num_keys == 0
+
+    @pytest.mark.parametrize(
+        ("payload", "reason"),
+        [
+            (b"not a checkpoint at all", "wrong magic"),
+            (b"LMCKPT\0\0\x63\0\0\0rest", "unsupported version"),
+            (b"LMCKPT\0\0", "no payload"),
+            (b"LMC", "truncated header"),
+        ],
+    )
+    def test_a_bad_checkpoint_is_ignored_not_fatal(
+        self, tmp_path: Path, payload: bytes, reason: str
+    ):
+        """A coordinator that refuses to boot over a corrupt optimization
+        is strictly worse than one that starts cold."""
+        path = tmp_path / "checkpoint"
+        path.write_bytes(payload)
+        restarted = _Coordinator()
+
+        load_checkpoint(LocalArtifactStore(path), restarted.components)
+
+        assert restarted.directory.stats().num_keys == 0, reason
+
+    def test_one_unreadable_section_does_not_cost_the_others(self, tmp_path: Path):
+        """Sections are independent, so a component that cannot read its
+        own must not take the rest of the restore with it."""
+        store = LocalArtifactStore(tmp_path / "checkpoint")
+        quiesce = QuiesceLock()
+        save_checkpoint(store, quiesce, [_Section("first"), _Section("second")])
+
+        readable, unreadable = _Section("first"), _Unreadable("second")
+        load_checkpoint(store, [unreadable, readable])
+
+        assert readable.restored == {"value": 1}, "a good section still loaded"
+
+    def test_an_unwritable_checkpoint_does_not_raise(self, tmp_path: Path):
+        """A checkpoint is an optimization; failing to write one must not
+        take the coordinator down."""
+        unwritable = tmp_path / "dir-in-the-way"
+        unwritable.mkdir()
+        live = _Coordinator()
+
+        save_checkpoint(LocalArtifactStore(unwritable), live.quiesce, live.components)
+
+
+class _Section:
+    """A component with one trivial section."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self.restored: Mapping[str, object] = {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def persistence_type(self) -> PersistenceType:
+        return PersistenceType.CHECKPOINT
+
+    def capture(self) -> Mapping[str, object]:
+        return {"value": 1}
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        self.restored = state
+
+
+class _Unreadable(_Section):
+    """A component that cannot read the section it wrote."""
+
+    def restore(self, state: Mapping[str, object]) -> None:
+        raise ValueError("cannot read my own section")
+
+
+def _capture(coordinator: _Coordinator) -> dict[str, Mapping[str, object]]:
+    """Read a coordinator's sections, as a checkpoint would."""
+    with coordinator.quiesce.quiesced():
+        return {c.name: c.capture() for c in coordinator.components}

--- a/tests/v1/mp_coordinator/persistence/test_metadata.py
+++ b/tests/v1/mp_coordinator/persistence/test_metadata.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the metadata document: operator intent, written on change."""
+
+# Standard
+from pathlib import Path
+import json
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.controllers.usage_manager import CacheUsageManager
+from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
+from lmcache.v1.mp_coordinator.persistence.store import LocalArtifactStore
+
+
+def _key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(chunk_hash=chunk_id.to_bytes(4, "big"), model_name="m", kv_rank=0)
+
+
+def _controller() -> FleetEvictionController:
+    return FleetEvictionController(usage_manager=CacheUsageManager())
+
+
+class TestRoundTrip:
+    def test_pins_and_quotas_survive_a_restart(self, tmp_path: Path):
+        """Nothing can reconstruct operator intent, so losing it means an
+        operator has to notice and re-apply it."""
+        store = LocalArtifactStore(tmp_path / "metadata.json")
+        live = _controller()
+        live.pin([_key(1)])
+        live.quota.set_quota("tenant-a", 4096)
+        live.quota.set_default_limit_bytes(8192)
+        persister = MetadataPersister(store)
+        persister.register(live)
+        persister.register(live.quota)
+
+        persister.save()
+
+        restored = _controller()
+        restarted = MetadataPersister(store)
+        restarted.register(restored)
+        restarted.register(restored.quota)
+        restarted.load()
+
+        assert restored.filter_unpinned([_key(1)]) == []
+        assert restored.quota.get_limit_bytes("tenant-a") == 4096
+        assert restored.quota.get_default_limit_bytes() == 8192
+
+    def test_the_document_is_readable_json(self, tmp_path: Path):
+        """The one person likely to open this file is the operator whose
+        intent it holds."""
+        store = LocalArtifactStore(tmp_path / "metadata.json")
+        controller = _controller()
+        controller.quota.set_quota("tenant-a", 4096)
+        persister = MetadataPersister(store)
+        persister.register(controller.quota)
+
+        persister.save()
+
+        document = json.loads((tmp_path / "metadata.json").read_text())
+        assert document["version"] == 1
+        assert document["components"]["quotas"]["limits"] == {"tenant-a": 4096}
+
+
+class TestSurvivableFailures:
+    def test_a_missing_document_leaves_the_components_alone(self, tmp_path: Path):
+        controller = _controller()
+        persister = MetadataPersister(LocalArtifactStore(tmp_path / "absent"))
+        persister.register(controller)
+
+        persister.load()
+
+        assert controller.filter_unpinned([_key(1)]) == [_key(1)]
+
+    @pytest.mark.parametrize(
+        ("payload", "reason"),
+        [
+            ("{not json", "unparsable"),
+            ("[]", "not an object"),
+            ('{"version": 99, "components": {}, "saved_at": 0}', "wrong version"),
+            ('{"version": 1, "saved_at": 0}', "no components"),
+            ('{"version": 1, "components": {}}', "no timestamp"),
+        ],
+    )
+    def test_a_bad_document_is_ignored_not_fatal(
+        self, tmp_path: Path, payload: str, reason: str
+    ):
+        """An operator can re-apply intent; a coordinator that will not
+        boot needs someone paged."""
+        path = tmp_path / "metadata.json"
+        path.write_text(payload)
+        controller = _controller()
+        persister = MetadataPersister(LocalArtifactStore(path))
+        persister.register(controller)
+
+        persister.load()
+
+        assert controller.filter_unpinned([_key(1)]) == [_key(1)], reason
+
+
+class TestRegistration:
+    def test_checkpoint_state_is_refused(self, tmp_path: Path):
+        """Derived state here would be rewritten on every operator change
+        and reloaded ahead of the checkpoint that owns it."""
+        persister = MetadataPersister(LocalArtifactStore(tmp_path / "metadata.json"))
+
+        with pytest.raises(ValueError, match="checkpoint state"):
+            persister.register(_controller().policy)
+
+    def test_a_quota_manager_alone_is_enough(self, tmp_path: Path):
+        """Components are independent: registering one does not require
+        the others."""
+        store = LocalArtifactStore(tmp_path / "metadata.json")
+        quota = QuotaManager()
+        quota.set_quota("t", 1024)
+        persister = MetadataPersister(store)
+        persister.register(quota)
+        persister.save()
+
+        restored = QuotaManager()
+        reader = MetadataPersister(store)
+        reader.register(restored)
+        reader.load()
+
+        assert restored.get_limit_bytes("t") == 1024

--- a/tests/v1/mp_coordinator/persistence/test_restore_without_replay.py
+++ b/tests/v1/mp_coordinator/persistence/test_restore_without_replay.py
@@ -64,10 +64,15 @@ def _key(chunk_id: int, cache_salt: str = "") -> ObjectKey:
     )
 
 
-def _store(seq: int, keys: list[ObjectKey], tier: Tier = Tier.L2) -> CacheEventBatch:
+def _store(
+    seq: int,
+    keys: list[ObjectKey],
+    tier: Tier = Tier.L2,
+    incarnation: int = 7,
+) -> CacheEventBatch:
     return CacheEventBatch(
         instance_id="node-a",
-        incarnation=7,
+        incarnation=incarnation,
         seq=seq,
         event_type=CacheEventType.STORE,
         tier=tier,
@@ -125,9 +130,9 @@ class TestRestoreWithoutReplay:
         assert restarted.directory.lookup([_key(1)])[0], "restored L1 placement"
 
         # The emitter comes back with a higher incarnation.
-        batch = _store(seq=1, keys=[_key(9)], tier=Tier.L1)
-        object.__setattr__(batch, "incarnation", 8)
-        restarted.gate.ingest(batch)
+        restarted.gate.ingest(
+            _store(seq=1, keys=[_key(9)], tier=Tier.L1, incarnation=8)
+        )
 
         assert restarted.directory.lookup([_key(1)]) == [[]], (
             "incarnation 8 should have fenced incarnation 7's L1 slice"

--- a/tests/v1/mp_coordinator/persistence/test_store.py
+++ b/tests/v1/mp_coordinator/persistence/test_store.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the artifact store: atomicity, absence, and the null case."""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_coordinator.persistence.store import (
+    ArtifactNotFoundError,
+    LocalArtifactStore,
+    NullArtifactStore,
+)
+
+
+class TestLocalArtifactStore:
+    def test_a_written_artifact_reads_back(self, tmp_path: Path):
+        store = LocalArtifactStore(tmp_path / "nested" / "artifact")
+
+        with store.open_write() as stream:
+            stream.write(b"payload")
+        with store.open_read() as stream:
+            assert stream.read() == b"payload"
+
+    def test_reading_nothing_says_so(self, tmp_path: Path):
+        """Absence is normal on a first boot, so it is its own error
+        rather than an OSError the caller has to classify."""
+        with pytest.raises(ArtifactNotFoundError):
+            with LocalArtifactStore(tmp_path / "absent").open_read() as _:
+                pass
+
+    def test_a_failed_write_leaves_the_previous_artifact(self, tmp_path: Path):
+        """The point of writing beside and renaming: a half-written
+        checkpoint must never replace a good one."""
+        path = tmp_path / "artifact"
+        store = LocalArtifactStore(path)
+        with store.open_write() as stream:
+            stream.write(b"first")
+
+        with pytest.raises(RuntimeError):
+            with store.open_write() as stream:
+                stream.write(b"second, interrupted")
+                raise RuntimeError("boom")
+
+        assert path.read_bytes() == b"first"
+        assert list(tmp_path.iterdir()) == [path], "left a temporary file behind"
+
+
+class TestNullArtifactStore:
+    def test_writes_are_discarded_and_reads_find_nothing(self):
+        """Persistence being unconfigured is not a special case every
+        caller has to test for."""
+        store = NullArtifactStore()
+
+        with store.open_write() as stream:
+            stream.write(b"ignored")
+        with pytest.raises(ArtifactNotFoundError):
+            with store.open_read() as _:
+                pass


### PR DESCRIPTION
**What this PR does / why we need it**:

Second of three PRs giving the coordinator state that survives a restart.
#4653 defined the contract -- what is durable, who owns it, and how a
consistent copy is taken. This one adds the I/O: where those captures go and
when they are written. Controller discovery follows in PR 3.

Two artifacts, because the two kinds of state want opposite things. Derived
state -- the key directory, the usage view, stream cursors, the LRU order --
is large and changes constantly, so it goes to a msgpack **checkpoint** on a
timer and on a clean stop; losing it costs hit rate. Operator intent -- L2
pins and per-`cache_salt` quotas -- is small, changes rarely, and nothing can
reconstruct it, so it goes to a JSON **metadata document** written
synchronously by whatever changed it. A `200` from `POST /cache/pins` now
means the pin survives a restart.

Both sit behind one `ArtifactStore`: a single object replaced atomically, so a
reader sees the old artifact or the new one and never a torn one. Every
failure is survivable -- a missing, corrupt, or future-version artifact logs
and starts cold rather than refusing to boot, and one unreadable section does
not cost the others.

The checkpoint codec knows nothing about any section. That falls out of the
plain-data contract from #4653: adding a durable component changes no code
here.

**Special notes for your reviewers**:

A checkpoint is encoded whole before it is written -- peak memory runs about
1.3x the file, roughly 1.6 GB for a fleet holding a million chunks. Encoding
section by section is the escape hatch if that ever bites.

Restore is a flat loop over sections: no synthesized event replay, and no
ordering between components.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
