### PR TITLE
ci: validate AMD path filter docs-only skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 </div>
 
 ## Updates
+- [validation] Path-filter docs-only draft PR placeholder for the AMD admission gate.
 - [2026/05] 🔥 Agentic workload benchmark on AMD MI300X ([blog](https://blog.lmcache.ai/en/2026/05/12/benchmarking-lmcache-for-multi-turn-agentic-workloads-on-amd-mi300x/)).
 - [2026/04] 🔥 LMCache's new multiprocess (MP) architecture release ([blog](https://blog.lmcache.ai/en/2026/04/03/lmcaches-new-architecture-boosts-moe-inference-performance-by-10x/)).
 - [2026/03] LMCache at GTC 2026 ([post](https://www.linkedin.com/posts/lmcache-lab_llm-opensource-nvidiagtc-activity-7442721875664826369-pMAu?utm_source=share&utm_medium=member_desktop&rcm=ACoAADkIIvQBTyG53kXXX70OZdE5rhpllYQqmIA)).


### PR DESCRIPTION
Validation-only draft PR for the AMD admission gate.

Expected Buildkite behavior:
- The `amd-mp-test` pipeline is admitted because the base branch is `mbl/amd-ci-admission-gate`.
- The shared path filter should skip uploading the AMD lane because this PR only changes `README.md`.

No merge intent; this PR exists only to demonstrate the `SKIP` branch of `path-filter.sh`.