### PR TITLE
ci: validate AMD path filter buildkite trigger

### DIFF
--- a/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
@@ -7,6 +7,9 @@
 - Rebuild on PR label change: Yes
 - Skip queued / cancel running branch builds: Yes
 
+This file is also a convenient `.buildkite/`-path validation target when
+checking that the shared path filter forces AMD lane uploads.
+
 This pipeline runs the bare-metal ROCm unit-test flow while making PR admission
 opt-in so AMD capacity is only consumed when requested.
 


### PR DESCRIPTION
Validation-only draft PR for the AMD admission gate.

Expected Buildkite behavior:
- The `amd-mp-test` pipeline is admitted because the base branch is `mbl/amd-ci-admission-gate`.
- The shared path filter should upload the AMD lane because this PR changes `.buildkite/k3_tests/amd/BK_WEB_SETUP.md`, and any `.buildkite/` path is a force-trigger.

No merge intent; this PR exists only to demonstrate the `.buildkite/* -> RUN` branch of `path-filter.sh`.