### PR TITLE
ci: validate AMD path filter code-change run

### DIFF
--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Path-filter validation draft PR placeholder; no behavior change intended.
 # Standard
 from collections import OrderedDict
 from copy import deepcopy


### PR DESCRIPTION
Validation-only draft PR for the AMD admission gate.

Expected Buildkite behavior:
- The `amd-mp-test` pipeline is admitted because the base branch is `mbl/amd-ci-admission-gate`.
- The shared path filter should upload the AMD lane because this PR changes `tests/v1/test_cache_engine.py`, which is a non-trivial path.

No merge intent; this PR exists only to demonstrate the non-trivial-code `RUN` branch of `path-filter.sh`.