### PR TITLE
chore(storage): use lazy logging in lightweight adapters

### DIFF
--- a/lmcache/v1/storage_backend/connector/lm_adapter.py
+++ b/lmcache/v1/storage_backend/connector/lm_adapter.py
@@ -21,7 +21,7 @@ class LMServerConnectorAdapter(ConnectorAdapter):
         # Local
         from .lm_connector import LMCServerConnector
 
-        logger.info(f"Creating LM Server connector for URL: {context.url}")
+        logger.info("Creating LM Server connector for URL: %s", context.url)
         parse_url = parse_remote_url(context.url)
         return LMCServerConnector(
             host=parse_url.host,

--- a/lmcache/v1/storage_backend/connector/mock_adapter.py
+++ b/lmcache/v1/storage_backend/connector/mock_adapter.py
@@ -24,7 +24,7 @@ class MockConnectorAdapter(ConnectorAdapter):
         # Local
         from .mock_connector import MockConnector
 
-        logger.info(f"Creating Mock connector for URL: {context.url}")
+        logger.info("Creating Mock connector for URL: %s", context.url)
 
         parsed = urlparse(context.url)
         # capacity is provided as the netloc in URLs like: mock://100/?...


### PR DESCRIPTION
## Summary

- use lazy `%s` logging in the mock connector adapter
- use lazy `%s` logging in the LM server connector adapter
- preserve the rendered messages and connector behavior

## Validation

- `python -m compileall -q lmcache/v1/storage_backend/connector/mock_adapter.py lmcache/v1/storage_backend/connector/lm_adapter.py`
- `uvx ruff check --select G004 lmcache/v1/storage_backend/connector/mock_adapter.py lmcache/v1/storage_backend/connector/lm_adapter.py`
- `uvx ruff format --check lmcache/v1/storage_backend/connector/mock_adapter.py lmcache/v1/storage_backend/connector/lm_adapter.py`

Closes #4685
Refs #3372