### PR TITLE
fix(mp): detect server restarts from heartbeat tokens

### DIFF
--- a/docs/design/v1/multiprocess/worker_liveness.md
+++ b/docs/design/v1/multiprocess/worker_liveness.md
@@ -19,25 +19,27 @@ silently binds it to the stale context — wrong IPC handles, corrupted transfer
 ## 2. Design Overview
 
 The server already receives a periodic signal from every actively serving worker:
-the heartbeat PING. The design adds the worker's `instance_id` to that message,
-stamps `last_seen` on the per-instance entries that already exist, and runs one
-periodic scan that reaps entries silent longer than a timeout via the same cleanup
-as a client unregister. The heartbeat keeps its lazy start (first store/retrieve)
-and starts healthy; a live worker pings every interval, refreshing its `last_seen`,
-so it is never reaped while alive. Entries that never produced a liveness signal
-fall under a generous registration grace. Recovery reuses existing client
-machinery: on a genuine outage the heartbeat's pings fail, clearing `health_event`;
-when the server returns the unhealthy-to-healthy edge fires the recover callback,
-which re-registers — a noop when the entry survived.
+the heartbeat PING. The request carries the worker's `instance_id`, stamps
+`last_seen` on existing per-instance entries, and returns a random per-process
+boot token. A periodic server scan reaps entries silent longer than a timeout via
+the same cleanup as a client unregister.
+
+The worker captures the boot token during adapter initialization. The heartbeat
+still starts lazily on the first store/retrieve, but that operation waits for the
+first PING. A changed token therefore detects a server restart even when no PING
+failed between the old and new processes. Both an unhealthy-to-healthy transition
+and a token change run the existing re-registration callback before cache traffic
+resumes. Entries that never produced a liveness signal remain covered by the
+registration grace.
 
 ```
 engine worker adapter                            MP server
 +---------------------------+                   +--------------------------------------+
 | HeartbeatThread           |   PING [id]       | ManagementModule                     |
-|  (instance_id, 10s)  -----+------------------>|  ping(id) -> touch_instance(id)      |
+|  (instance_id, 10s)  -----+------------------>|  ping(id) -> boot token + touch      |
 |  lazy start on first req, |   (NORMAL pool)   |  reaper thread (scan = timeout/4)    |
-|   (starts healthy)        |                   |   -> reap_stale_instances(           |
-|  unhealthy->healthy edge  |                   |        timeout, registration_grace)  |
+|   first req waits         |                   |   -> reap_stale_instances(           |
+|  recovery or token change |                   |        timeout, registration_grace)  |
 |   -> re-register callback |   REGISTER        |   -> drop_instance_state(id) fan-out |
 |                           +------------------>|        |                |            |
 | register_kv_caches        |   STORE/RETRIEVE  |        v                v            |
@@ -139,30 +141,36 @@ the worker adapter warns at startup when `3 x interval` exceeds the 30 s floor.
 
 ## 6. Adapter Side
 
-### 6.1 Lazy start
+### 6.1 Lazy start and first-check barrier
 
-The heartbeat keeps its lazy start on first store/retrieve — no pings during
-warmup; the registration grace covers that window. It starts healthy (the event
-is set at construction), so the first store/retrieve is not gated. A live worker
-then pings every interval, refreshing its server-side `last_seen`, so it is never
-reaped while alive — no re-registration is needed at start. The recover callback
-re-registers only on a genuine recovery edge (Section 6.2). A retrieve dropped
-while the server is unhealthy is still reported via `get_finished` so async loads
-cannot hang.
+The adapter captures the current server boot token synchronously during
+initialization. The periodic heartbeat still starts lazily on the first
+store/retrieve, so model loading and warmup do not generate background pings. The
+first cache operation waits for the initial heartbeat check. If the token differs
+from the initialization token, the server restarted after initialization and the
+worker re-registers before the operation proceeds.
 
-### 6.2 Recovery after a reap
+After that barrier, a live worker pings every interval and refreshes its
+server-side `last_seen`. A retrieve dropped while the server is unhealthy is
+still reported via `get_finished` so async loads cannot hang.
+
+### 6.2 Recovery after an outage or restart
 
 ```
 T0        outage begins; pings time out -> health_event cleared, traffic stops
 T0+120s   server: entry stale -> reap pops it, frees GPUCacheContext/IPC,
           layout-desc refcount; blend rope state dropped via listener <- leak fixed
-T1        connectivity back; next ping succeeds -> unhealthy->healthy edge
+T1        connectivity back, or a new boot token is observed
 T1        recover callback re-registers (id absent -> fresh context) before
           health_event is set; traffic resumes             <- exactly one context
 ```
 
 A shorter outage hits the NOOP register path, which refreshes `last_seen` and
-builds nothing — the server never asks a worker to re-register.
+builds nothing. A process restart produces a new boot token and rebuilds the
+worker registration. KV entries held only in the old server process are lost and
+must be populated again; re-registration restores future cache operations, not
+the old in-memory cache contents. Detection takes at most one configured
+`lmcache.mp.heartbeat_interval` after the restart once the heartbeat is running.
 
 ### 6.3 Shutdown
 
@@ -180,5 +188,6 @@ stop is already requested — a straggling cycle cannot re-create a ghost contex
 | Worker alive but never pinged, idle past the grace | Reaped while alive only if it never pinged (heartbeat never started). Once the heartbeat is running, pings refresh `last_seen` every interval, so a live worker is never reaped regardless of traffic. |
 | Heartbeat thread starved, worker transferring | Store/retrieve/prepare/commit refresh `last_seen`; never reaped. |
 | Partition shorter than the reap window | No reap. On heal, the recover callback re-registers; the NOOP path refreshes `last_seen`; zero context churn. |
+| MP server process restart | The changed boot token triggers worker re-registration before cache traffic resumes. Old process-local L1 entries are lost and rebuild on later stores. |
 | Worker crash + restart | The new process gets a fresh uuid-derived id and a fresh entry; the dead id is reaped independently. No PID-reuse aliasing. |
-| Mixed client/server versions | Every PING fails the payload-count check; the client sits permanently unhealthy. Loud, never silent corruption; upgrade both sides together. |
+| Mixed client/server versions | Compatible during rolling upgrades: old boolean PING replies decode as reserved token `1`, while old clients treat a new positive integer token as a successful PING. Restart detection becomes available once both sides support boot tokens. |

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -660,7 +660,10 @@ All connector-level options are passed through
    * - ``lmcache.mp.heartbeat_interval``
      - ``10.0``
      - Interval (seconds) between periodic heartbeat pings sent from the
-       connector to the server.
+       connector to the server. A server restart is detected by a changed
+       boot token on the next ping, so detection can take up to this interval.
+       The worker then re-registers its KV cache handles; cache entries held
+       only by the old server process are lost and must be rebuilt.
    * - ``lmcache.mp.eager_prefetch``
      - ``false``
      - Submit the LMCache lookup when a request enters vLLM's waiting queue,

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -28,6 +28,19 @@ Key Benefits
 - **Built-in observability** -- Prometheus metrics and a telemetry event system
   out of the box.
 
+Server Restart Recovery
+-----------------------
+
+The vLLM MP worker records a per-process boot token returned by the LMCache
+server. If a later heartbeat observes a different token, the worker pauses cache
+operations, re-registers its KV cache handles, and then resumes. Detection can
+take up to one ``lmcache.mp.heartbeat_interval`` (10 seconds by default).
+
+Re-registration restores connectivity to the new server process. It does not
+restore cache entries that existed only in the old server's L1 memory; those
+entries are rebuilt by later inference requests. See
+:doc:`configuration` for the heartbeat setting.
+
 Prerequisites
 -------------
 
@@ -235,7 +248,7 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
      - Return the server's chunk size.
    * - ``PING``
      - BLOCKING
-     - Liveness ping; the handler always returns ``True``.
+     - Liveness ping; returns a per-process boot token used to detect server restarts.
    * - ``REPORT_BLOCK_ALLOCATION``
      - BLOCKING
      - Fire-and-forget channel for the vLLM scheduler to report GPU block

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -239,8 +239,8 @@ def send_ping(
     mq_client: MessageQueueClient,
     timeout: float,
     instance_id: int | None = None,
-) -> bool:
-    """Send a PING request and return the result.
+) -> int:
+    """Send a PING request and return the server boot token.
 
     Args:
         mq_client: The message queue client.
@@ -249,16 +249,17 @@ def send_ping(
             liveness, or None for an untracked prober (scheduler adapter).
 
     Returns:
-        True if server is healthy, False on timeout or error.
+        The positive server boot token, or zero on timeout or error. Legacy
+        servers return ``True``, which the protocol decodes as token ``1``.
     """
     try:
         future = send_lmcache_request(mq_client, RequestType.PING, [instance_id])
-        return future.result(timeout=timeout)
+        return int(future.result(timeout=timeout))
     except TimeoutError:
-        return False
+        return 0
     except Exception:
         logger.debug("Ping failed with exception", exc_info=True)
-        return False
+        return 0
 
 
 @dataclass
@@ -411,6 +412,7 @@ class HeartbeatThread(PeriodicThread):
         health_event: threading.Event,
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         instance_id: int | None = None,
+        initial_server_boot_token: int | None = None,
     ):
         """
         Args:
@@ -423,6 +425,9 @@ class HeartbeatThread(PeriodicThread):
             instance_id: The worker's instance ID sent with each PING so the
                 server can refresh its liveness, or None for an untracked
                 prober (the scheduler adapter).
+            initial_server_boot_token: Token captured synchronously when the
+                worker adapter connected. A different first-heartbeat token
+                means the server restarted after initialization.
         """
         super().__init__(
             name="lmcache-heartbeat",
@@ -434,15 +439,17 @@ class HeartbeatThread(PeriodicThread):
         self._interval = interval
         self._instance_id = instance_id
 
-        # Optional callback invoked on the unhealthy->healthy edge,
+        # Optional callback invoked on recovery or a boot-token change,
         # before the health event is set. See register_recover_callback.
         def noop() -> bool:
             return True
 
         self._recover_callback: Callable[[], bool] = noop
+        self._server_boot_token = initial_server_boot_token
+        self._initial_check_complete = threading.Event()
 
     def register_recover_callback(self, callback: Callable[[], bool]) -> None:
-        """Register a callback fired on the unhealthy->healthy transition.
+        """Register a callback fired on recovery or server restart.
 
         The callback runs **before** the health event is set. It must
         return ``True`` on success (event will be set) or ``False`` on
@@ -463,6 +470,17 @@ class HeartbeatThread(PeriodicThread):
         """
         self._recover_callback = callback
 
+    def wait_for_initial_check(self, timeout: float | None = None) -> bool:
+        """Wait until the first heartbeat cycle finishes.
+
+        Args:
+            timeout: Maximum seconds to wait, or ``None`` to wait indefinitely.
+
+        Returns:
+            ``True`` if the first check completed, otherwise ``False``.
+        """
+        return self._initial_check_complete.wait(timeout=timeout)
+
     def _execute(self) -> ThreadRunSummary:
         """Run one heartbeat cycle: ping, recover callback, event update.
 
@@ -471,31 +489,41 @@ class HeartbeatThread(PeriodicThread):
         UNREGISTER must not re-register a ghost context.
         """
         was_healthy = self._health_event.is_set()
-        healthy = send_ping(
+        server_boot_token = send_ping(
             self._mq_client, timeout=self._interval, instance_id=self._instance_id
+        )
+        healthy = server_boot_token > 0
+        server_restarted = (
+            healthy
+            and self._server_boot_token is not None
+            and server_boot_token != self._server_boot_token
         )
 
         if self.stop_requested:
+            self._initial_check_complete.set()
             return ThreadRunSummary(
                 success=True,
                 message="stop requested; skipping health update",
             )
 
-        need_trigger_recover = (
-            healthy and not was_healthy and self._recover_callback is not None
-        )
+        need_trigger_recover = healthy and (not was_healthy or server_restarted)
 
-        # Try to call recover callback
         if need_trigger_recover:
-            logger.warning(
-                "LMCache server is healthy again, triggering recovery callback"
-            )
-            # If the callback fails, it should not become healthy
+            self._health_event.clear()
+            if server_restarted:
+                logger.warning(
+                    "LMCache server restart detected, triggering recovery callback"
+                )
+            else:
+                logger.warning(
+                    "LMCache server is healthy again, triggering recovery callback"
+                )
             healthy = self._recover_callback()
 
         if healthy:
+            self._server_boot_token = server_boot_token
             self._health_event.set()
-            if not was_healthy:
+            if not was_healthy or server_restarted:
                 logger.warning(
                     "LMCache server is healthy again — resuming normal operation"
                 )
@@ -504,6 +532,7 @@ class HeartbeatThread(PeriodicThread):
             if was_healthy:
                 logger.warning("LMCache server is unhealthy — entering degraded mode")
 
+        self._initial_check_complete.set()
         return ThreadRunSummary(
             success=True,
             message="healthy" if healthy else "unhealthy",
@@ -1201,9 +1230,21 @@ class LMCacheMPWorkerAdapter:
         )
         self.dispatcher: "Dispatcher | None" = None
 
+        initial_server_boot_token = send_ping(
+            self.mq_client,
+            timeout=heartbeat_interval,
+            instance_id=self.instance_id,
+        )
+        self._initial_server_boot_token = initial_server_boot_token or None
+
         # Health state (shared with heartbeat thread)
         self._health_event = threading.Event()
-        self._health_event.set()
+        if self._initial_server_boot_token is not None:
+            self._health_event.set()
+        else:
+            logger.warning(
+                "Initial LMCache heartbeat failed; starting worker in degraded mode"
+            )
 
         # Heartbeat thread is created but NOT started yet.
         # It will be lazily started on the first store or retrieve
@@ -1356,29 +1397,39 @@ class LMCacheMPWorkerAdapter:
             ) from None
 
     def _ensure_heartbeat_started(self) -> None:
-        """Lazily start the heartbeat thread on first store/retrieve.
+        """Start the heartbeat and wait for its first server check.
 
-        The heartbeat starts healthy (the event was set at construction). A
-        live worker pings every interval, refreshing its server-side
-        ``last_seen``, so it is never reaped while alive -- no re-registration
-        is needed at startup, and the first store/retrieve is not gated. The
-        recover callback still re-registers on a genuine unhealthy->healthy
-        edge (server restart).
+        The heartbeat starts lazily on the first store/retrieve, after vLLM
+        initialization. The first cache operation waits for one PING so a
+        server restart between KV registration and heartbeat startup triggers
+        re-registration before that operation reaches the new server.
         """
-        if self._heartbeat is not None:
-            return
-        with self._heartbeat_lock:
-            if self._heartbeat is not None:
-                return
-            heartbeat = HeartbeatThread(
-                mq_client=self.mq_client,
-                health_event=self._health_event,
-                interval=self._heartbeat_interval,
-                instance_id=self.instance_id,
+        heartbeat = self._heartbeat
+        if heartbeat is None:
+            with self._heartbeat_lock:
+                heartbeat = self._heartbeat
+                if heartbeat is None:
+                    heartbeat = HeartbeatThread(
+                        mq_client=self.mq_client,
+                        health_event=self._health_event,
+                        interval=self._heartbeat_interval,
+                        instance_id=self.instance_id,
+                        initial_server_boot_token=self._initial_server_boot_token,
+                    )
+                    heartbeat.register_recover_callback(
+                        self._reregister_kv_caches_callback
+                    )
+                    self._heartbeat = heartbeat
+                    heartbeat.start()
+
+        initial_check_timeout = self._heartbeat_interval + 1.0
+        if not heartbeat.wait_for_initial_check(timeout=initial_check_timeout):
+            self._health_event.clear()
+            logger.warning(
+                "Initial LMCache heartbeat did not finish within %.1fs; "
+                "entering degraded mode",
+                initial_check_timeout,
             )
-            heartbeat.register_recover_callback(self._reregister_kv_caches_callback)
-            heartbeat.start()
-            self._heartbeat = heartbeat
 
     def _heartbeat_stop_requested(self) -> bool:
         """Whether a created heartbeat thread has a stop requested.

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -3,6 +3,7 @@
 
 # Standard
 from collections.abc import Sequence
+import secrets
 import threading
 
 # First Party
@@ -62,6 +63,7 @@ class ManagementModule:
         self._reap_timeout = worker_reap_timeout_seconds
         self._reap_grace = worker_registration_grace_seconds
         self._experimental_transfer = tuple(experimental_transfer)
+        self._server_boot_token = secrets.randbelow(2**63 - 2) + 2
 
         # Periodic reaper, started only when reaping is enabled and there is
         # something to scan. Scans every reap_timeout/4, so an instance is
@@ -134,7 +136,7 @@ class ManagementModule:
         if self._reaper is not None:
             self._reaper.stop()
 
-    def ping(self, instance_id: int | None) -> bool:
+    def ping(self, instance_id: int | None) -> int:
         """Respond to a ping and refresh the sender's liveness.
 
         Args:
@@ -143,12 +145,13 @@ class ManagementModule:
                 worker's last-seen time is refreshed on every liveness target.
 
         Returns:
-            Always True.
+            A process-unique boot token greater than one. Clients use token
+            changes to detect a server restart even when no ping is missed.
         """
         if instance_id is not None:
             for target in self._liveness_targets:
                 target.touch_instance(instance_id)
-        return True
+        return self._server_boot_token
 
     def _reap_cycle(self) -> ThreadRunSummary:
         """Run one reaper scan: reap stale workers, drop mirrored state.

--- a/lmcache/v1/multiprocess/protocols/README.md
+++ b/lmcache/v1/multiprocess/protocols/README.md
@@ -215,7 +215,7 @@ Core KV cache operations and their split-phase variants:
 Cache management and configuration:
 - `CLEAR`: Clear all caches in the server
 - `GET_CHUNK_SIZE`: Get the chunk size configuration
-- `PING`: Liveness / worker probe (payload: sender's worker instance id or `None`)
+- `PING`: Liveness / worker probe returning a per-process boot token (payload: sender's worker instance id or `None`)
 
 ### Debug Operations (`debug.py`)
 Testing and monitoring:

--- a/lmcache/v1/multiprocess/protocols/controller.py
+++ b/lmcache/v1/multiprocess/protocols/controller.py
@@ -47,13 +47,13 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Ping
         # Payload: [instance_id] -- the sender's worker instance ID, or None
         #   for an untracked prober (the scheduler adapter).
-        # Returns: bool - Always True
+        # Returns: int - Server boot token (>1); legacy servers return True (1)
         # BLOCKING on the NORMAL pool: keeps PING off the MQ main loop (where a
         # slow SYNC REGISTER_KV_CACHE would stall it) and lets pool saturation
         # surface as worker degraded mode.
         "PING": ProtocolDefinition(
             payload_classes=[int | None],
-            response_class=bool,
+            response_class=int,
             handler_type=HandlerType.BLOCKING,
         ),
         # Get the enabled experimental intermediate tensor transfer types

--- a/tests/v1/multiprocess/test_ping_protocol.py
+++ b/tests/v1/multiprocess/test_ping_protocol.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility tests for the MP PING boot-token protocol."""
+
+# First Party
+from lmcache.v1.multiprocess.mq import msgspec_decode, msgspec_encode
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+
+
+def test_ping_response_uses_integer_boot_token() -> None:
+    """PING responses declare the integer token used for restart detection."""
+    assert get_response_class(RequestType.PING) is int
+
+
+def test_ping_boot_token_is_compatible_with_legacy_boolean_response() -> None:
+    """Boolean and integer PING responses interoperate during rolling upgrades."""
+    legacy_response = msgspec_encode(True, cls=bool)
+    assert msgspec_decode(legacy_response, cls=int) == 1
+
+    boot_token_response = msgspec_encode(42, cls=int)
+    assert msgspec_decode(boot_token_response, cls=bool) is True

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -235,8 +235,9 @@ def test_management_ping_touches_targets() -> None:
     target = _FakeTarget()
     mgmt = ManagementModule(MagicMock(), liveness_targets=[target])
 
-    assert mgmt.ping(42) is True
-    assert mgmt.ping(None) is True
+    boot_token = mgmt.ping(42)
+    assert boot_token > 1
+    assert mgmt.ping(None) == boot_token
     assert target.touched == [42]
 
 
@@ -267,7 +268,7 @@ def test_management_reaper_disabled_when_timeout_zero() -> None:
         worker_reap_timeout_seconds=0.0,
     )
     assert mgmt._reaper is None
-    assert mgmt.ping(1) is True
+    assert mgmt.ping(1) > 1
 
 
 def test_management_report_status_summarizes_liveness() -> None:

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -48,6 +48,7 @@ class FakeHeartbeatThread:
         health_event: threading.Event | None = None,
         interval: float = 0.0,
         instance_id: int | None = None,
+        initial_server_boot_token: int | None = None,
     ) -> None:
         self.mq_client = mq_client
         self.health_event = (
@@ -55,6 +56,9 @@ class FakeHeartbeatThread:
         )
         self.interval = interval
         self.instance_id = instance_id
+        self.server_boot_token = initial_server_boot_token
+        self.initial_check_complete = threading.Event()
+        self.wait_started = threading.Event()
         # Snapshot of the health event at construction time: lets tests
         # assert the adapter starts the heartbeat healthy (event still set).
         self.health_event_set_at_init = self.health_event.is_set()
@@ -80,17 +84,33 @@ class FakeHeartbeatThread:
     def stop(self, timeout: float = 5.0) -> None:
         self.calls.append("stop")
         self.stop_requested = True
+        self.initial_check_complete.set()
 
-    def simulate_successful_ping(self) -> None:
-        """Mimic one successful heartbeat cycle: on the unhealthy->healthy
-        edge the recover callback runs first, and the event is set only
-        when the callback returns ``True``."""
+    def wait_for_initial_check(self, timeout: float | None = None) -> bool:
+        self.calls.append("wait_for_initial_check")
+        self.wait_started.set()
+        return self.initial_check_complete.wait(timeout=timeout)
+
+    def simulate_failed_ping(self) -> None:
+        """Mimic one failed heartbeat cycle and complete the first check."""
+        self.health_event.clear()
+        self.initial_check_complete.set()
+
+    def simulate_successful_ping(self, server_boot_token: int | None = None) -> None:
+        """Mimic one successful heartbeat cycle and restart detection."""
+        token = server_boot_token or self.server_boot_token or 1
         was_healthy = self.health_event.is_set()
+        server_restarted = (
+            self.server_boot_token is not None and token != self.server_boot_token
+        )
         ok = True
-        if not was_healthy and self.recover_callback is not None:
+        if (not was_healthy or server_restarted) and self.recover_callback is not None:
+            self.health_event.clear()
             ok = self.recover_callback()
         if ok:
+            self.server_boot_token = token
             self.health_event.set()
+        self.initial_check_complete.set()
 
 
 def _make_worker_adapter(
@@ -154,6 +174,7 @@ def fake_adapter(monkeypatch):
     monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
+    monkeypatch.setattr(adapter_mod, "send_ping", lambda *a, **kw: 101)
 
     future = MagicMock(name="future")
     future.result.return_value = None
@@ -518,7 +539,11 @@ def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
     # the first store is not dropped.
     assert heartbeat.health_event_set_at_init is True
     # The recover callback is wired before start() (for genuine recovery).
-    assert heartbeat.calls == ["register_recover_callback", "start"]
+    assert heartbeat.calls == [
+        "register_recover_callback",
+        "start",
+        "wait_for_initial_check",
+    ]
     assert adapter.is_healthy
     assert adapter.transfer_ctx.submit_store.call_count == 1
 
@@ -526,6 +551,59 @@ def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
     adapter.submit_store_request("req-2", _op([[1]]), MagicMock())
     assert len(FakeHeartbeatThread.instances) == 1
     assert adapter.transfer_ctx.submit_store.call_count == 2
+
+
+def test_first_store_recovers_restart_before_heartbeat(
+    fake_adapter, monkeypatch
+) -> None:
+    """A restart after registration is repaired before the first store."""
+    adapter, send_mock, _ = fake_adapter
+    contexts = _patch_transfer_context_factory(monkeypatch)
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    adapter.register_kv_caches({"layer.0": fake_tensor})
+
+    FakeHeartbeatThread.start_hook = lambda heartbeat: (
+        heartbeat.simulate_successful_ping(202)
+    )
+    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+
+    assert send_mock.call_args_list == []
+    assert len(contexts) == 2
+    contexts[0].register.assert_called_once()
+    contexts[1].register.assert_called_once()
+    contexts[-1].submit_store.assert_called_once()
+
+
+def test_first_store_waits_for_initial_heartbeat(fake_adapter) -> None:
+    """The first cache operation waits until the initial PING completes."""
+    adapter, _send_mock, _ = fake_adapter
+    transfer_ctx = MagicMock()
+    adapter.transfer_ctx = transfer_ctx
+    FakeHeartbeatThread.start_hook = lambda heartbeat: None
+    errors: list[BaseException] = []
+
+    def submit_store() -> None:
+        try:
+            adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+        except BaseException as error:
+            errors.append(error)
+
+    submit_thread = threading.Thread(target=submit_store)
+    submit_thread.start()
+    deadline = time.time() + 10.0
+    while not FakeHeartbeatThread.instances and time.time() < deadline:
+        time.sleep(0.01)
+    heartbeat = FakeHeartbeatThread.instances[0]
+    assert heartbeat.wait_started.wait(timeout=10.0)
+    transfer_ctx.submit_store.assert_not_called()
+
+    heartbeat.simulate_successful_ping(101)
+    submit_thread.join(timeout=10.0)
+
+    assert not submit_thread.is_alive()
+    assert errors == []
+    transfer_ctx.submit_store.assert_called_once()
 
 
 def test_heartbeat_first_ping_runs_callback_before_setting_event(
@@ -559,6 +637,79 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
     assert event_state_during_callback == [False]
 
 
+def test_heartbeat_detects_server_restart_without_failed_ping(
+    monkeypatch,
+) -> None:
+    """A changed boot token triggers recovery even when both pings succeed."""
+    boot_tokens = iter([202])
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_ping",
+        lambda mq_client, timeout, instance_id=None: next(boot_tokens),
+    )
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(
+        mq_client=MagicMock(name="mq_client"),
+        health_event=health_event,
+        interval=60.0,
+        initial_server_boot_token=101,
+    )
+    event_state_during_callback: list[bool] = []
+
+    def recover() -> bool:
+        event_state_during_callback.append(health_event.is_set())
+        return True
+
+    heartbeat.register_recover_callback(recover)
+    try:
+        heartbeat.start()
+        assert heartbeat.wait_for_initial_check(timeout=10.0)
+    finally:
+        heartbeat.stop(timeout=10.0)
+
+    assert event_state_during_callback == [False]
+    assert health_event.is_set()
+
+
+def test_heartbeat_retries_restart_recovery_until_success(
+    monkeypatch,
+) -> None:
+    """A failed restart recovery keeps the worker unhealthy and retries."""
+    boot_tokens = iter([202, 202])
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_ping",
+        lambda mq_client, timeout, instance_id=None: next(boot_tokens),
+    )
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(
+        mq_client=MagicMock(name="mq_client"),
+        health_event=health_event,
+        interval=60.0,
+        initial_server_boot_token=101,
+    )
+    recover = MagicMock(side_effect=[False, True])
+    heartbeat.register_recover_callback(recover)
+    try:
+        heartbeat.start()
+        assert heartbeat.wait_for_initial_check(timeout=10.0)
+        assert not health_event.is_set()
+        assert recover.call_count == 1
+
+        heartbeat.wake()
+        deadline = time.time() + 10.0
+        while heartbeat.total_runs < 2 and time.time() < deadline:
+            time.sleep(0.01)
+        assert heartbeat.total_runs == 2
+    finally:
+        heartbeat.stop(timeout=10.0)
+
+    assert recover.call_count == 2
+    assert health_event.is_set()
+
+
 def test_dropped_retrieve_reported_once_via_unhealthy_get_finished(
     fake_adapter,
 ) -> None:
@@ -569,7 +720,7 @@ def test_dropped_retrieve_reported_once_via_unhealthy_get_finished(
     transfer_ctx = MagicMock()
     adapter.transfer_ctx = transfer_ctx
     # Simulate a failed first ping: the heartbeat start clears the event.
-    FakeHeartbeatThread.start_hook = lambda hb: hb.health_event.clear()
+    FakeHeartbeatThread.start_hook = lambda heartbeat: heartbeat.simulate_failed_ping()
 
     adapter.submit_retrieve_request("req-1", _op([[3, 4]]), MagicMock())
 
@@ -595,7 +746,7 @@ def test_dropped_retrieve_reported_once_via_healthy_get_finished(
     adapter, _send_mock, _ = fake_adapter
     adapter.transfer_ctx = MagicMock()
     # Simulate a failed first ping: the heartbeat start clears the event.
-    FakeHeartbeatThread.start_hook = lambda hb: hb.health_event.clear()
+    FakeHeartbeatThread.start_hook = lambda heartbeat: heartbeat.simulate_failed_ping()
 
     adapter.submit_retrieve_request("req-1", _op([[5]]), MagicMock())
     assert not adapter.is_healthy


### PR DESCRIPTION
## Summary

- return a random per-process boot token from the MP server PING handler
- capture the initial token synchronously during worker-adapter initialization
- make the first STORE/RETRIEVE wait for the initial heartbeat check
- detect token changes even when consecutive heartbeats both succeed
- reuse the existing KV-cache re-registration callback after a fast server restart
- keep the worker unhealthy and retry when re-registration fails
- preserve rolling-upgrade compatibility with legacy boolean PING responses
- document restart detection latency and loss of old process-local L1 entries

The boot-token approach follows the design proposed by @rob-9 in #4642.

## Validation

- `NO_GPU_EXT=1 uv pip install -e . --no-build-isolation --reinstall`
- `pytest -q tests/v1/test_vllm_mp_adapter.py tests/v1/multiprocess/test_worker_liveness.py tests/v1/multiprocess/test_ping_protocol.py` (46 passed)
- `python -m compileall -q` on all modified Python files
- `SKIP=rust-fmt,rust-clippy pre-commit run --files ...` (all applicable hooks passed, including mypy)
- `cd docs && make clean && make html` (build succeeded; the repository still reports 29 pre-existing warnings, none from the modified documents)

Closes #4642