### PR TITLE
ci: validate AMD path filter buildkite trigger (rerun)

### DIFF
--- a/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
@@ -1,0 +1,50 @@
+# Buildkite Web UI Setup: AMD Unit Tests
+
+**Steps editor**: paste the contents of `buildkite-pipeline.yml`.
+
+**GitHub trigger settings**:
+- Filter: `build.pull_request.labels includes "amd" || build.pull_request.labels includes "full" || build.branch == 'dev'`
+- Rebuild on PR label change: Yes
+- Skip queued / cancel running branch builds: Yes
+
+This pipeline runs the bare-metal ROCm unit-test flow while making PR admission
+opt-in so AMD capacity is only consumed when requested.
+
+### Trigger strategy
+
+| Condition | Result |
+|-----------|--------|
+| PR label includes `amd` | upload the AMD pipeline |
+| PR label includes `full` | upload the AMD pipeline |
+| branch is `dev` | upload the AMD pipeline |
+| any docs/asset-only change | path filter skips upload |
+| any change under `.buildkite/` | path filter forces upload |
+
+The path filter treats the following as trivial for the AMD lane:
+
+- `*.md`, `LICENSE*`, `NOTICE*`
+- `.gitignore`, `.gitattributes`, `.editorconfig`, `.mailmap`, `CODEOWNERS`
+- anything under `docs/`, `asset/`, or `.github/`
+
+If you need the AMD pipeline to run for a docs/asset-only PR, add the
+`force-ci` label.
+
+## Buildkite UI snippet
+
+If you want to create or update the pipeline manually, paste this into the
+Steps editor:
+
+```yaml
+steps:
+  - label: ":pipeline: Upload pipeline"
+    command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/amd/pipeline.yml
+```
+
+Keep the existing AMD runner / queue assignment in the Buildkite pipeline
+configuration; this repository change does not alter host provisioning.
+
+## What this pipeline does
+
+- Runs the AMD bare-metal unit-test workflow in `.buildkite/k3_tests/amd/pipeline.yml`
+- Admits PRs carrying the `amd` or `full` label
+- Reuses the shared path filter so docs-only PRs skip the AMD lane cleanly

--- a/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
@@ -7,6 +7,9 @@
 - Rebuild on PR label change: Yes
 - Skip queued / cancel running branch builds: Yes
 
+This file is also a convenient `.buildkite/`-path validation target when
+checking that the shared path filter forces AMD lane uploads.
+
 This pipeline runs the bare-metal ROCm unit-test flow while making PR admission
 opt-in so AMD capacity is only consumed when requested.
 

--- a/.buildkite/k3_tests/amd/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/amd/buildkite-pipeline.yml
@@ -1,0 +1,7 @@
+# Paste this into the Buildkite pipeline's "Steps" editor.
+# It uploads the real pipeline definition from the repo. Keep the existing
+# AMD runner / queue selection in the Buildkite pipeline configuration.
+
+steps:
+  - label: ":pipeline: Upload pipeline"
+    command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/amd/pipeline.yml

--- a/.buildkite/k3_tests/amd/pipeline.yml
+++ b/.buildkite/k3_tests/amd/pipeline.yml
@@ -1,0 +1,54 @@
+# AMD bare-metal unit tests.
+
+env:
+  PATH: "$HOME/.local/bin:$PATH"
+
+steps:
+  - label: "AMD Unit Tests"
+    key: "amd_unit_tests"
+    timeout_in_minutes: 60
+    command: |
+      echo $PWD # for debugging
+
+      uv venv --python 3.12 .venv-$BUILDKITE_BUILD_ID
+      source .venv-$BUILDKITE_BUILD_ID/bin/activate
+      uv pip install --upgrade pip setuptools wheel
+
+      source .buildkite/scripts/pick-free-gpu-amd.sh 18000
+      export AMD_SERIALIZE_KERNEL=1
+      export PYTORCH_ROCM_ARCH="gfx942"
+      export TORCH_DONT_CHECK_COMPILER_ABI=1
+      export CXX=hipcc
+      export BUILD_WITH_HIP=1
+      uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.0
+      uv pip install -r requirements/rocm_core.txt
+
+      uv pip install -r requirements/common.txt
+      uv pip install -r requirements/test.txt
+      uv pip install -e . --no-build-isolation
+      uv pip freeze
+
+      LMCACHE_TRACK_USAGE="false" \
+      pytest --maxfail=1 --cov=lmcache \
+        --cov-report term --cov-report=html:coverage-test \
+        --cov-report=xml:coverage-test.xml --html=durations/test.html \
+        --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
+        --ignore=tests/v1/test_nixl_batched_contains.py \
+        --ignore=tests/v1/test_device_id_race.py \
+        --ignore=tests/v1/test_nixl_multipath.py \
+        --ignore=tests/skipped \
+        --ignore=tests/v1/storage_backend/test_eic.py
+
+      cat << EOF | buildkite-agent annotate --style "info"
+        Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>
+      EOF
+
+      export TARGET="$PWD"
+      echo "Deleting current workspace $TARGET"
+      cd /
+      sudo rm -rf "$TARGET"
+
+    artifact_paths:
+      - "durations/test.html"
+      - "coverage-test.xml"
+      - "coverage-test/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,21 +12,16 @@ steps:
       source .venv-$BUILDKITE_BUILD_ID/bin/activate
       uv pip install --upgrade pip setuptools wheel
 
-      if command -v nvidia-smi >/dev/null 2>&1; then
-        source .buildkite/scripts/pick-free-gpu.sh 18000
-        export CUDA_LAUNCH_BLOCKING=1
-        # Pin torch to a version compatible with the CI machine's CUDA 12.x driver
-        uv pip install "torch>=2.6.0,<2.11.0"
-      else
-        source .buildkite/scripts/pick-free-gpu-amd.sh 18000
-        export AMD_SERIALIZE_KERNEL=1
-        export PYTORCH_ROCM_ARCH="gfx942"
-        export TORCH_DONT_CHECK_COMPILER_ABI=1
-        export CXX=hipcc
-        export BUILD_WITH_HIP=1
-        uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.0
-        uv pip install -r requirements/rocm_core.txt
+      if ! command -v nvidia-smi >/dev/null 2>&1; then
+        echo "This pipeline expects an NVIDIA runner." >&2
+        echo "Use .buildkite/k3_tests/amd/pipeline.yml for AMD unit tests." >&2
+        exit 1
       fi
+
+      source .buildkite/scripts/pick-free-gpu.sh 18000
+      export CUDA_LAUNCH_BLOCKING=1
+      # Pin torch to a version compatible with the CI machine's CUDA 12.x driver
+      uv pip install "torch>=2.6.0,<2.11.0"
 
       uv pip install -r requirements/common.txt
       uv pip install -r requirements/test.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ Test dependencies: `uv pip install -r requirements/test.txt`
 
 Pytest marker: `@pytest.mark.no_shared_allocator` disables the shared-allocator monkeypatch for a test.
 
+### Buildkite Lane Boundaries
+
+- Keep the shared root `.buildkite/pipeline.yml` NVIDIA-only. AMD/ROCm unit tests belong in `.buildkite/k3_tests/amd/`; if a dedicated AMD lane exists, remove any AMD fallback from the root pipeline to avoid running the same AMD UT flow twice.
+- The shared path filter is a post-admission upload gate, not the PR admission gate itself. The call chain is `.buildkite/k3_tests/<lane>/buildkite-pipeline.yml` -> `.buildkite/k3_tests/common_scripts/upload-pipeline.sh` -> `.buildkite/k3_tests/common_scripts/path-filter.sh`. Use the Buildkite pipeline's GitHub trigger condition to control which PRs create AMD builds at all.
+
 ### Testing Practices
 
 - Write tests against the **public interface and docstring contract**, not the implementation. Test as if you don't know the internals — verify that behavior matches what the docstring describes.


### PR DESCRIPTION
Validation-only draft PR for the AMD admission gate after updating the amd-mp-test Steps configuration.

Expected Buildkite behavior:
- The `amd-mp-test` pipeline is admitted because the base branch is `mbl/amd-ci-admission-gate`.
- The shared path filter should upload the AMD lane because this PR changes `.buildkite/k3_tests/amd/BK_WEB_SETUP.md`, and any `.buildkite/` path is a force-trigger.
- Therefore the build should include an `AMD Unit Tests` job.

No merge intent; this PR exists only to demonstrate the `.buildkite/* -> RUN` branch of `path-filter.sh` under the current Buildkite settings.