### PR TITLE
fix(mp): recover expired L1 read leases

### DIFF
--- a/lmcache/cli/commands/trace/_dispatch.py
+++ b/lmcache/cli/commands/trace/_dispatch.py
@@ -174,7 +174,11 @@ def _enter_read_prefetched(ctx: ReplayContext, args: dict[str, Any]) -> None:
         args: Decoded record arguments.  Must contain ``"keys"``.
     """
     keys = args["keys"]
-    cm = ctx.sm.read_prefetched_results(keys)
+    cm = ctx.sm.read_prefetched_results(
+        keys,
+        recover_expired=bool(args.get("recover_expired", False)),
+        extra_count=int(args.get("extra_count", 0)),
+    )
     cm.__enter__()
     key_tuple = tuple(keys)
     ctx.open_read_contexts.setdefault(key_tuple, deque()).append(cm)

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -301,15 +301,24 @@ class L1Manager:
     def unsafe_read(
         self,
         keys: list[ObjectKey],
+        recover_expired: bool = False,
+        extra_count: int = 0,
     ) -> dict[ObjectKey, L1OperationResult]:
-        """Unsafe read the read-locked objects without adding new read locks.
+        """Read objects whose read locks were reserved beforehand.
 
-        This method does not acquire read locks. Therefore, the caller need
-        to make sure the `unsafe_read` is called between `reserve_read` and
-        `finish_read` calls.
+        Normally this method does not acquire read locks, so the caller must
+        call it between matching ``reserve_read`` and ``finish_read`` calls.
+        When ``recover_expired`` is enabled, an object that is still readable
+        after its read-lock TTL elapsed has its reservation restored atomically.
+        The first concurrent reader restores all ``1 + extra_count`` claims;
+        later readers observe the restored lock and do not increment it.
 
         Args:
             keys: The list of object keys to read.
+            recover_expired: Restore an expired read reservation when the
+                object still exists and is not write-locked.
+            extra_count: Extra reader claims to restore on top of the default
+                one. Must match the value used by ``reserve_read``.
 
         Returns:
             A dictionary mapping each object key to a tuple of
@@ -317,9 +326,13 @@ class L1Manager:
 
         Errors:
             KEY_NOT_EXIST: The key does not exist.
-            KEY_NOT_READABLE: The key is not readable (in this case, not read-locked).
+            KEY_NOT_READABLE: The key is not read-locked and recovery is
+                disabled, or the object is write-locked during recovery.
         """
+        extra_count = _validate_extra_count(extra_count)
+        total = 1 + extra_count
         ret: dict[ObjectKey, L1OperationResult] = {}
+        recovered_keys: list[ObjectKey] = []
 
         for key in keys:
             entry = self._objects.get(key, None)
@@ -328,10 +341,36 @@ class L1Manager:
                 continue
 
             if not entry.read_lock.is_locked():
-                ret[key] = (L1Error.KEY_NOT_READABLE, None)
-                continue
+                if not recover_expired or not entry.available_for_read():
+                    ret[key] = (L1Error.KEY_NOT_READABLE, None)
+                    continue
+
+                # The manager lock makes this check-and-restore atomic across
+                # concurrent TP workers. Only the first worker restores the
+                # full multi-reader reservation.
+                for _ in range(total):
+                    entry.read_lock.lock()
+                recovered_keys.append(key)
 
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
+
+        if recovered_keys:
+            logger.warning(
+                "Recovered expired L1 read leases for %d keys (readers per key=%d)",
+                len(recovered_keys),
+                total,
+            )
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_reserved_read(recovered_keys)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_READ_RESERVED,
+                    metadata={
+                        "keys": recovered_keys,
+                        "reason": "expired_lease_recovery",
+                    },
+                )
+            )
 
         return ret
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -255,6 +255,8 @@ class StorageManager:
     def read_prefetched_results(
         self,
         keys: list[ObjectKey],
+        recover_expired: bool = False,
+        extra_count: int = 0,
     ) -> Iterator[list[MemoryObj] | None]:
         """
         Read the memory objects from L1 storage that has been prefetched beforehand.
@@ -263,6 +265,10 @@ class StorageManager:
 
         Args:
             keys (list[ObjectKey]): List of object keys to reserve for reading.
+            recover_expired: Restore an expired read reservation for each
+                object that is still present and not write-locked.
+            extra_count: Extra reader claims to restore per key. Must match
+                the value used for the original prefetch reservation.
 
         Returns:
             Iterator[list[MemoryObj] | None]: An iterator yielding an optional list of
@@ -286,9 +292,17 @@ class StorageManager:
             publish_call_event(
                 "lmcache.v1.distributed.storage_manager."
                 "StorageManager.read_prefetched_results.__enter__",
-                {"keys": keys},
+                {
+                    "keys": keys,
+                    "recover_expired": recover_expired,
+                    "extra_count": extra_count,
+                },
             )
-        read_results = self._l1_manager.unsafe_read(keys)
+        read_results = self._l1_manager.unsafe_read(
+            keys,
+            recover_expired=recover_expired,
+            extra_count=extra_count,
+        )
         good_keys: list[ObjectKey] = []
         good_objs: list[MemoryObj] = []
         bad_keys: list[ObjectKey] = []
@@ -367,7 +381,11 @@ class StorageManager:
                 publish_call_event(
                     "lmcache.v1.distributed.storage_manager."
                     "StorageManager.read_prefetched_results.__exit__",
-                    {"keys": keys},
+                    {
+                        "keys": keys,
+                        "recover_expired": recover_expired,
+                        "extra_count": extra_count,
+                    },
                 )
 
     @enable_tracing()

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -103,17 +103,22 @@ class MPServerConfig:
     sent a PING (model warmup, or death before its first request). Must be
     >= worker_reap_timeout_seconds."""
 
+    session_ttl_seconds: float = 600.0
+    """Retention window for per-request lookup state. This must cover the
+    longest expected delay between LOOKUP and RETRIEVE. Default is 600."""
+
     enable: list[str] = field(default_factory=list)
     """List of experimental transfer modules to enable. Options: transfer_query
     (see lmcache.v1.multiprocess.modules.experimental.__init___.py)."""
 
     def __post_init__(self) -> None:
-        """Validate the worker-reaping timeouts.
+        """Validate the worker-reaping and session timeouts.
 
         Raises:
             ValueError: If a timeout is non-finite, the reap timeout is
                 negative or a non-zero value below the 30 s floor, or the
-                registration grace is below the reap timeout.
+                registration grace is below the reap timeout, or the session
+                TTL is not a finite positive value.
         """
         reap = self.worker_reap_timeout_seconds
         grace = self.worker_registration_grace_seconds
@@ -127,6 +132,11 @@ class MPServerConfig:
             raise ValueError(
                 "worker registration grace must be >= the worker reap timeout "
                 f"({reap}s); got {grace}"
+            )
+        session_ttl = self.session_ttl_seconds
+        if not math.isfinite(session_ttl) or session_ttl <= 0:
+            raise ValueError(
+                f"session TTL must be a finite number > 0; got {session_ttl}"
             )
 
 
@@ -391,6 +401,14 @@ def add_mp_server_args(
         "timeout. Default is 3600.",
     )
     mp_group.add_argument(
+        "--session-ttl-seconds",
+        type=float,
+        default=600.0,
+        help="Retention window (s) for per-request lookup state. Keep this "
+        "above the longest expected delay between LOOKUP and RETRIEVE. "
+        "Default is 600.",
+    )
+    mp_group.add_argument(
         "--enable-segmented-prefix",
         action="store_true",
         help="CacheBlend (--engine-type blend) only: on a mid-prefix L2 "
@@ -450,6 +468,7 @@ def parse_args_to_mp_server_config(
         script_allowed_imports=args.script_allowed_imports or [],
         worker_reap_timeout_seconds=args.worker_reap_timeout_seconds,
         worker_registration_grace_seconds=args.worker_registration_grace_seconds,
+        session_ttl_seconds=args.session_ttl_seconds,
         enable=args.enable or [],
     )
 

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -197,6 +197,7 @@ class MPCacheServerContext:
         separate_object_groups: Whether to split kernel groups into one object
             group per sliding-window size at KV-cache registration. Default
             False.
+        session_ttl_seconds: Retention window for per-request lookup state.
     """
 
     def __init__(
@@ -206,6 +207,7 @@ class MPCacheServerContext:
         hash_algorithm: str = "blake3",
         separate_object_groups: bool = False,
         full_sw_kv: bool = False,
+        session_ttl_seconds: float = SessionManager.DEFAULT_SESSION_TTL,
     ) -> None:
         self._chunk_size = chunk_size
         self._separate_object_groups = separate_object_groups
@@ -222,7 +224,9 @@ class MPCacheServerContext:
         self._token_hasher = TokenHasher(
             chunk_size=chunk_size, hash_algorithm=hash_algorithm
         )
-        self._session_manager = SessionManager(self._token_hasher)
+        self._session_manager = SessionManager(
+            self._token_hasher, ttl=session_ttl_seconds
+        )
         self._event_bus = get_event_bus()
         self._layout_desc_registry = LayoutDescRegistry()
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -1272,6 +1272,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
             key, list(range(num_object_groups))
         )
+        prefetch_extra_count = self._ctx.session_manager.get_or_create(
+            key.request_id
+        ).prefetch_extra_count
         num_chunks = len(obj_keys_per_obj_group[0])
 
         # CPU-synchronous sentinel: a GPU retrieve is about to be enqueued.
@@ -1360,7 +1363,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     skip = group_skips[obj_group_id]
                     in_window_keys = obj_keys_per_obj_group[obj_group_id][skip:]
                     with self._ctx.storage_manager.read_prefetched_results(
-                        in_window_keys
+                        in_window_keys,
+                        recover_expired=True,
+                        extra_count=prefetch_extra_count,
                     ) as window_objs:
                         if not window_objs or len(window_objs) != len(in_window_keys):
                             logger.error("Some keys not found during retrieve!")

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -279,6 +279,7 @@ class LookupModule:
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
+        session.prefetch_extra_count = extra_count
 
         # Lay keys out chunk-major across object groups (see
         # _chunk_major_object_keys); pass the windows to the prefetch policy.

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -411,6 +411,7 @@ def run_cache_server(
         hash_algorithm=mp_config.hash_algorithm,
         separate_object_groups=mp_config.separate_object_groups,
         full_sw_kv=is_blend,
+        session_ttl_seconds=mp_config.session_ttl_seconds,
     )
 
     modules = _build_modules(ctx, mp_config, coordinator_config)

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -42,6 +42,7 @@ class Session:
     created_at: float = field(default_factory=time.time)
     lookup_ipc_key: Optional[IPCCacheServerKey] = None
     prefetch_hit_chunks: int = -1
+    prefetch_extra_count: int = 0
     extras: dict[str, Any] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/tests/cli/commands/trace/test_dispatch.py
+++ b/tests/cli/commands/trace/test_dispatch.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 # Standard
-from typing import Any
+from typing import Any, cast
 
 # Third Party
 import pytest
@@ -18,6 +18,7 @@ from lmcache.cli.commands.trace._dispatch import (
     build_default_dispatcher,
 )
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.storage_manager import StorageManager
 
 _SM_PREFIX = "lmcache.v1.distributed.storage_manager.StorageManager"
 
@@ -48,7 +49,22 @@ class _FakeSM:
     def finish_read_prefetched(self, **kw: Any) -> None:
         self.calls.append(("finish_read_prefetched", kw))
 
-    def read_prefetched_results(self, keys: list[ObjectKey]) -> "_FakeCM":
+    def read_prefetched_results(
+        self,
+        keys: list[ObjectKey],
+        recover_expired: bool = False,
+        extra_count: int = 0,
+    ) -> "_FakeCM":
+        self.calls.append(
+            (
+                "read_prefetched_results",
+                {
+                    "keys": keys,
+                    "recover_expired": recover_expired,
+                    "extra_count": extra_count,
+                },
+            )
+        )
         return _FakeCM(self, keys)
 
 
@@ -109,7 +125,7 @@ class TestDefaultDispatcher:
 
     def test_simple_method_forwarded_with_kwargs(self):
         sm = _FakeSM()
-        ctx = ReplayContext(sm=sm)
+        ctx = ReplayContext(sm=cast(StorageManager, sm))
         d = build_default_dispatcher()
         d.dispatch(
             f"{_SM_PREFIX}.reserve_write",
@@ -146,6 +162,29 @@ class TestDefaultDispatcher:
         assert sm.events == ["enter-2", "enter-2", "exit-2", "exit-2"]
         # Fully drained → dict cleaned up.
         assert ctx.open_read_contexts == {}
+
+    def test_read_prefetched_recovery_args_are_forwarded(self) -> None:
+        sm = _FakeSM()
+        ctx = ReplayContext(sm=cast(StorageManager, sm))
+        d = build_default_dispatcher()
+        keys = [_key(1)]
+
+        d.dispatch(
+            f"{_SM_PREFIX}.read_prefetched_results.__enter__",
+            ctx,
+            {"keys": keys, "recover_expired": True, "extra_count": 3},
+        )
+
+        assert sm.calls == [
+            (
+                "read_prefetched_results",
+                {
+                    "keys": keys,
+                    "recover_expired": True,
+                    "extra_count": 3,
+                },
+            )
+        ]
 
     def test_exit_without_matching_enter_is_warning_only(self, caplog):
         sm = _FakeSM()

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -927,6 +927,43 @@ def _events_of_type(events: list, event_type: EventType) -> list:
     return [e for e in events if e.event_type == event_type]
 
 
+def test_read_prefetched_results_recovers_expired_tp4_lease(
+    basic_storage_manager_config, basic_layout
+):
+    """A resident object remains retrievable after its TP4 lease expires."""
+    sm = StorageManager(basic_storage_manager_config)
+    key = make_object_key(4242)
+    try:
+        reserved = sm.reserve_write([key], basic_layout, mode="new")
+        sm.finish_write(list(reserved))
+        handle = sm.submit_prefetch_task(
+            PrefetchRequestSpec([key], {0: basic_layout}, extra_count=3)
+        )
+        assert wait_for_prefetch_status(sm, handle) == 1
+
+        # Releasing all claims models the same resident-but-unlocked state
+        # produced by TTLLock expiry, without a wall-clock sleep.
+        sm.finish_read_prefetched([key], extra_count=3)
+        with sm.read_prefetched_results([key]) as objs:
+            assert objs is None
+
+        # Two ranks may race into retrieve. The first restores all four
+        # claims atomically; the second observes them without incrementing.
+        for _ in range(2):
+            with sm.read_prefetched_results(
+                [key], recover_expired=True, extra_count=3
+            ) as objs:
+                assert objs is not None
+                assert len(objs) == 1
+
+        for _ in range(4):
+            sm.finish_read_prefetched([key])
+        with sm.read_prefetched_results([key]) as objs:
+            assert objs is None
+    finally:
+        sm.close()
+
+
 class TestFailureEventProduction:
     """Verifies LM-291 health-monitoring events are published at the
     right producer call sites with the expected metadata."""

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -484,6 +484,35 @@ class TestUnsafeRead:
 
         manager.close()
 
+    def test_unsafe_read_recovers_multi_reader_reservation_once(
+        self, basic_l1_config, basic_layout
+    ):
+        """Concurrent TP readers restore one expired four-reader lease."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12346)
+
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+        manager.reserve_read([key], extra_count=3)
+
+        # Return the persistent object to the ready state, which is the state
+        # observed after its TTL lease expires without evicting the object.
+        manager.finish_read([key], extra_count=3)
+        assert manager.unsafe_read([key])[key][0] == L1Error.KEY_NOT_READABLE
+
+        first = manager.unsafe_read([key], recover_expired=True, extra_count=3)
+        second = manager.unsafe_read([key], recover_expired=True, extra_count=3)
+        assert first[key][0] == L1Error.SUCCESS
+        assert second[key][0] == L1Error.SUCCESS
+
+        # The second TP reader must not add another four claims. Exactly four
+        # worker completions return the object to the ready state.
+        for _ in range(4):
+            assert manager.finish_read([key])[key] == L1Error.SUCCESS
+        assert manager.unsafe_read([key])[key][0] == L1Error.KEY_NOT_READABLE
+
+        manager.close()
+
     def test_unsafe_read_multiple_keys(self, basic_l1_config, basic_layout):
         """Test unsafe_read with multiple keys in a single call."""
         manager = L1Manager(basic_l1_config)

--- a/tests/v1/distributed/test_l1_read_lease_recovery.py
+++ b/tests/v1/distributed/test_l1_read_lease_recovery.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only regression tests for expired L1 read-lease recovery."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l1_manager import L1Manager
+
+
+def test_tp4_expired_read_lease_is_recovered_exactly_once() -> None:
+    """Two TP readers restore one four-reader reservation, not two."""
+    memory_obj = MagicMock(name="memory_obj")
+    config = L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(size_in_bytes=4096, use_lazy=False),
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+    layout = MemoryLayoutDesc(
+        shapes=[torch.Size([1])],
+        dtypes=[torch.bfloat16],
+    )
+    key = ObjectKey(
+        chunk_hash=b"lease-recovery",
+        model_name="test-model",
+        kv_rank=0,
+    )
+
+    with patch(
+        "lmcache.v1.distributed.l1_manager.L1MemoryManager"
+    ) as memory_manager_cls:
+        memory_manager_cls.return_value.allocate.return_value = (
+            L1Error.SUCCESS,
+            [memory_obj],
+        )
+        manager = L1Manager(config)
+
+        manager.reserve_write([key], [False], layout)
+        manager.finish_write([key])
+        manager.reserve_read([key], extra_count=3)
+
+        # Releasing the reservation produces the same persistent, readable,
+        # unlocked state that remains after TTLLock's read TTL expires.
+        manager.finish_read([key], extra_count=3)
+        assert manager.unsafe_read([key])[key][0] == L1Error.KEY_NOT_READABLE
+
+        first = manager.unsafe_read([key], recover_expired=True, extra_count=3)
+        second = manager.unsafe_read([key], recover_expired=True, extra_count=3)
+        assert first[key] == (L1Error.SUCCESS, memory_obj)
+        assert second[key] == (L1Error.SUCCESS, memory_obj)
+
+        # Four TP completions exhaust the recovered lease. If the second read
+        # had restored it again, another four claims would still be held.
+        for _ in range(4):
+            assert manager.finish_read([key])[key] == L1Error.SUCCESS
+        assert manager.unsafe_read([key])[key][0] == L1Error.KEY_NOT_READABLE
+
+        manager.close()

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -168,6 +168,17 @@ def test_instance_id_dataclass_default_is_distinct():
     assert MPServerConfig().instance_id != MPServerConfig().instance_id
 
 
+def test_session_ttl_flag_is_parsed() -> None:
+    config = _parse_mp(["--session-ttl-seconds", "5400"])
+    assert config.session_ttl_seconds == 5400.0
+
+
+@pytest.mark.parametrize("ttl", ["0", "-1", "nan", "inf"])
+def test_invalid_session_ttl_rejected(ttl: str) -> None:
+    with pytest.raises(ValueError, match="session TTL must be a finite number > 0"):
+        _parse_mp(["--session-ttl-seconds", ttl])
+
+
 # -- Event reporting ----------------------------------------------------------
 
 

--- a/tests/v1/multiprocess/test_lmcache_driven_transfer_skip.py
+++ b/tests/v1/multiprocess/test_lmcache_driven_transfer_skip.py
@@ -130,11 +130,12 @@ def _make_module(monkeypatch, num_chunks, num_chunks_in_sw):
     read_calls: list[list[str]] = []
 
     @contextmanager
-    def fake_read(keys):
+    def fake_read(keys, **_kwargs):
         read_calls.append(list(keys))
         yield [MagicMock(get_size=MagicMock(return_value=10)) for _ in keys]
 
     ctx.storage_manager.read_prefetched_results = MagicMock(side_effect=fake_read)
+    ctx.session_manager.get_or_create.return_value.prefetch_extra_count = 3
     module._ctx = ctx
 
     transfer_calls: list[tuple[int, list]] = []
@@ -180,6 +181,8 @@ def test_retrieve_reads_and_transfers_only_in_window(monkeypatch):
     # Full-attention group reads all 5 keys; mamba group reads only the last.
     assert read_calls[0] == [f"g0c{c}" for c in range(5)]
     assert read_calls[1] == ["g1c4"]
+    for call in module.context.storage_manager.read_prefetched_results.call_args_list:
+        assert call.kwargs == {"recover_expired": True, "extra_count": 3}
 
     # memory_objs handed to the transfer stay full-length; the mamba group's
     # skipped prefix is None-padded (skip = num_chunks - window = 4).

--- a/tests/v1/multiprocess/test_query_lookup_hits.py
+++ b/tests/v1/multiprocess/test_query_lookup_hits.py
@@ -249,8 +249,11 @@ def _lookup_key(world_size: int) -> IPCCacheServerKey:
 
 
 def _captured_lookup_object_keys(
-    world_size: int, num_groups: int, chunk_hashes: list[bytes]
-) -> list[ObjectKey]:
+    world_size: int,
+    num_groups: int,
+    chunk_hashes: list[bytes],
+    tp_size: int = 1,
+) -> tuple[list[ObjectKey], MagicMock]:
     """Drive the public ``lookup()`` and return the object keys it submits.
 
     The engine context is mocked so ``lookup()`` runs end-to-end; the
@@ -272,17 +275,20 @@ def _captured_lookup_object_keys(
     ctx.token_hasher.compute_chunk_hashes.return_value = chunk_hashes
 
     module = LookupModule(ctx)
-    module.lookup(_lookup_key(world_size=world_size), tp_size=1)
+    module.lookup(_lookup_key(world_size=world_size), tp_size=tp_size)
 
     ctx.storage_manager.submit_prefetch_task.assert_called_once()
-    return ctx.storage_manager.submit_prefetch_task.call_args.args[0].keys
+    return (
+        ctx.storage_manager.submit_prefetch_task.call_args.args[0].keys,
+        ctx.session_manager.get_or_create.return_value,
+    )
 
 
 def test_lookup_lays_keys_out_chunk_then_group_then_rank():
     """lookup() submits keys laid out chunk -> object group -> kv_rank, so each
     chunk's keys are contiguous (the property that makes a leading-ones prefix
     equal to the full-attention model-wide hit)."""
-    keys = _captured_lookup_object_keys(
+    keys, _session = _captured_lookup_object_keys(
         world_size=2, num_groups=2, chunk_hashes=[b"c0", b"c1"]
     )
 
@@ -303,9 +309,21 @@ def test_lookup_single_group_matches_single_group_layout():
     single-group layout (the object-group-separation-disabled / non-hybrid
     case)."""
     chunk_hashes = [b"c0", b"c1"]
-    keys = _captured_lookup_object_keys(
+    keys, _session = _captured_lookup_object_keys(
         world_size=2, num_groups=1, chunk_hashes=chunk_hashes
     )
 
     expected = ipc_key_to_object_keys(_lookup_key(world_size=2), chunk_hashes, [0])[0]
     assert keys == expected
+
+
+def test_lookup_records_tp4_reader_count_for_lease_recovery():
+    """The retrieve session retains the count used by the TP4 prefetch."""
+    _keys, session = _captured_lookup_object_keys(
+        world_size=1,
+        num_groups=1,
+        chunk_hashes=[b"c0"],
+        tp_size=4,
+    )
+
+    assert session.prefetch_extra_count == 3


### PR DESCRIPTION
### Summary

- recover an expired prefetched L1 read reservation when the object is still resident and not write-locked
- restore the original multi-reader count exactly once under the existing L1 manager lock, including TP-shared MLA objects
- retain the prefetch reader count in request-session state and add `--session-ttl-seconds` for deep request queues
- keep existing callers and old trace recordings backward compatible

### Problem

The MP LOOKUP/PREFETCH path reserves L1 read locks before RETRIEVE. If queueing delays RETRIEVE beyond `read_ttl_seconds`, `unsafe_read()` currently reports the still-resident objects as `KEY_NOT_READABLE`. The cache hit then becomes a failed retrieve even though no writer owns the object.

A TP-shared object also needs the original `1 + extra_count` reservation restored once. Restoring per arriving rank can over-count; restoring one claim can under-count completion.

### Implementation

The LMCache-driven retrieve path opts into recovery. `L1Manager.unsafe_read()` performs the availability check and full-count restoration while holding its existing manager lock, so only the first TP reader rebuilds the lease. Later readers observe the active lease without incrementing it.

Lookup records the prefetch reader count in the request session. The new `--session-ttl-seconds` setting allows deployments to retain that metadata for their maximum LOOKUP-to-RETRIEVE queueing delay; the default remains 600 seconds.

Trace replay forwards the new fields while defaulting absent fields to false/zero for old recordings.

### Validation

- CPU regression: two TP readers recover one four-reader lease, followed by exactly four successful completions
- StorageManager context regression for resident-but-unlocked objects
- lookup/retrieve propagation tests for TP4 `extra_count=3`
- CLI parsing and invalid-value tests for `--session-ttl-seconds`
- trace replay compatibility and argument-forwarding tests
- 97 relevant functional tests passed; two loopback tests that cannot bind inside the sandbox also passed when rerun with local socket permission
- touched-file pre-commit checks passed: SPDX, isort, Ruff, Ruff format, codespell, and mypy

GPU/live validation is intentionally deferred to the next authorized maintenance window.

Related defense-in-depth timeout/failure handling: #4516, #4517, #4600.