### PR TITLE
ci: validate AMD pipeline jobs

### DIFF
--- a/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/amd/BK_WEB_SETUP.md
@@ -29,6 +29,12 @@ The path filter treats the following as trivial for the AMD lane:
 If you need the AMD pipeline to run for a docs/asset-only PR, add the
 `force-ci` label.
 
+### Parallel validation
+
+A documentation-only change under `.buildkite/` intentionally forces this
+lane to run. Verify that the resulting build schedules the serialized AMD unit
+tests and both serialized and unserialized vLLM benchmark matrix jobs.
+
 ## Buildkite UI snippet
 
 If you want to create or update the pipeline manually, paste this into the


### PR DESCRIPTION
## Validation

- change one `.buildkite/` documentation file so the shared path filter must upload the AMD lane
- verify that the updated AMD pipeline schedules one serialized unit-test job plus serialized and unserialized vLLM benchmark matrix jobs

Local path-filter result: `RUN` (`.buildkite/k3_tests/amd/BK_WEB_SETUP.md` is an always-trigger path).