### PR TITLE
[Fix] Drain the context stream before unmapping its IPC segments

### DIFF
--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -467,15 +467,18 @@ class GPUCacheContext(BaseCacheContext):
         )
 
     def close(self) -> None:
-        """Deregister the GDS staging buffer and release the imported KV
-        mappings (reverse of __init__).
+        """Drain the context stream, deregister the GDS staging buffer and
+        release the imported KV mappings (reverse of __init__).
 
-        The wrapper close unmaps raw CUDA IPC imports; without it a dead
-        worker's KV pool stays resident on this process's GPUs for the
-        process lifetime. The tensors built over those mappings must not
-        be dereferenced afterwards -- the caller (``_release_entries``)
-        drops the context right after this call.
+        The stream is synchronized first so no in-flight kernel still
+        touches the mappings when they are unmapped. The wrapper close
+        unmaps raw CUDA IPC imports; without it a dead worker's KV pool
+        stays resident on this process's GPUs for the process lifetime.
+        The tensors built over those mappings must not be dereferenced
+        afterwards -- the caller (``_release_entries``) drops the context
+        right after this call.
         """
+        self.cuda_stream_.synchronize()
         with torch_dev.stream(self.cuda_stream_):
             get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
         self._close_kv_wrappers()


### PR DESCRIPTION
**What this PR does / why we need it**:

Partial fix for https://github.com/LMCache/LMCache/issues/4676

Only the GIL hang issue.

sync stream is only called if gds is enabled right now, add an extra call as well.

Sync released gil when calling, so shall avoid the gil hang issue .

(Howevr, it will not release the vram if there are hang events

Pytorch code reference:

https://github.com/pytorch/pytorch/blob/73961011bf64f1c04b3291bf90ac1dbbe197c2ca/torch/csrc/cuda/Stream.cpp#L134

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
