### PR TITLE
fix(rocm): install patchelf from PyPI so auditwheel repair works again

### DIFF
--- a/.github/scripts/build_rocm_wheel.sh
+++ b/.github/scripts/build_rocm_wheel.sh
@@ -20,8 +20,12 @@ export MAX_JOBS="${MAX_JOBS:-$(nproc)}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -q
+# patchelf deliberately NOT installed from apt: jammy ships 0.14.3, and
+# auditwheel enforces a minimum patchelf version at repair time (6.8.1 raised
+# it to >= 0.14.5). It is installed from PyPI below so both tools come from the
+# same index and move together.
 apt-get install -y -q --no-install-recommends \
-    software-properties-common curl ca-certificates patchelf git
+    software-properties-common curl ca-certificates git
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update -q
 # Match the upstream vllm/vllm-openai-rocm interpreter (cp312).
@@ -40,8 +44,40 @@ $PY --version
 # Build against the public ROCm torch whose ABI matches the vLLM image.
 $PY -m pip install --no-cache-dir "${TORCH_ROCM_SPEC}" --index-url "${TORCH_ROCM_INDEX}"
 $PY -m pip install --no-cache-dir \
-    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm wheel pybind11 auditwheel
+    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm wheel pybind11 auditwheel \
+    "patchelf>=0.17"
 $PY -c 'import torch; print("BUILD TORCH:", torch.__version__, "hip:", torch.version.hip, "cxx11abi:", torch._C._GLIBCXX_USE_CXX11_ABI)'
+
+# Preflight the repair toolchain before the ~12-minute compile. auditwheel only
+# checks patchelf when `repair` runs, which is the very last step -- so a version
+# mismatch otherwise costs a full build before surfacing. Report versions either
+# way; they are the first thing to look at when a wheel misbehaves.
+$PY - <<'PREFLIGHT'
+from importlib.metadata import version
+import shutil
+import subprocess
+import sys
+
+patchelf = shutil.which("patchelf")
+if patchelf is None:
+    sys.exit("patchelf not found on PATH")
+reported = subprocess.run(
+    [patchelf, "--version"], capture_output=True, text=True, check=True
+).stdout.strip()
+print(f"BUILD auditwheel: {version('auditwheel')}")
+print(f"BUILD patchelf:   {version('patchelf')} ({reported}) at {patchelf}")
+
+try:
+    from auditwheel.patcher import _verify_patchelf
+except ImportError:
+    # Internal helper moved; `repair` still enforces its own requirement.
+    sys.exit(0)
+try:
+    _verify_patchelf("patchelf")
+except TypeError:
+    _verify_patchelf()  # signature before auditwheel grew patcher variants
+print("BUILD patchelf accepted by auditwheel")
+PREFLIGHT
 
 cd /work/LMCache
 rm -rf build dist dist_rocm csrc_hip


### PR DESCRIPTION
## Summary

The ROCm wheel build has been failing since **2026-08-15**, and nothing in the repo changed.

`patchelf` was installed from apt, and jammy — the base of `rocm/dev-ubuntu-22.04` — ships
**0.14.3**. `auditwheel` was installed unpinned. auditwheel **6.8.1**, published
2026-08-15 08:34 UTC, raised its floor:

```
ValueError: patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5.
```

The last successful ROCm wheel, `v0.5.4rc4-rocm`, was built at **07:40 UTC the same day** —
54 minutes before that auditwheel release.

Because `repair` is the final step, this surfaces only after the full ~12-minute compile.

## Impact

- **`v0.5.4` shipped with no ROCm wheel** (`v0.5.4-rocm` release does not exist)
- **`nightly-rocm` has never produced an artifact** — the rolling nightly from #4482 merged
  on 08-20, after the break
- Every `Build and Publish to PyPI` run since 08-15 has failed on this job

`build_cu129_artifacts.yml` and `nightly_build.yml` also call `auditwheel repair`, but they
run on manylinux images that already ship a newer patchelf, so only the ROCm lane is affected.

## Fix

Take `patchelf` from PyPI instead of apt, so it sits on the same index as `auditwheel` and the
two move together rather than one being frozen by the base image's distro. Pinning auditwheel
instead would unbreak today but re-arm the same trap.

Also preflight the repair toolchain right after the build deps are installed, so a future
mismatch fails in seconds with a clear message rather than after a full compile — and print
both versions, which are the first thing to check when a wheel misbehaves. The preflight
degrades gracefully if auditwheel moves its internal helper.

## Test plan

All in `rocm/dev-ubuntu-22.04:7.2.3-complete`, the image the workflow uses.

- **Reproduced** the failure: apt patchelf 0.14.3 + auditwheel 6.8.1 -> the exact `ValueError`
- **Fix in isolation**: pip patchelf 0.19.1 installs to `/usr/local/bin/patchelf`, which
  precedes `/usr/bin` on PATH, and auditwheel accepts it
- **Full build with the patched script succeeds**, producing
  `lmcache-0.5.5.dev0+rocm7.2-cp312-cp312-manylinux_2_35_x86_64.whl`, with the preflight
  reporting:
  ```
  BUILD auditwheel: 6.8.1
  BUILD patchelf:   0.19.1.0 (patchelf 0.19.1) at /usr/local/bin/patchelf
  BUILD patchelf accepted by auditwheel
  ```
- **No regression in wheel contents**: diffed against the last published good wheel
  (`v0.5.4rc4-rocm`) — **0 files lost**, 24 added, all of them modules that landed in dev
  since 08-15. Still only the four LMCache extensions; torch and the ROCm runtime remain
  excluded, nothing vendored.
- **Preflight negative control**: with apt patchelf only, it exits 1 with the same
  `ValueError` — before the compile rather than after it.

Not addressed here, noted for a separate change: the build log shows some translation units
compiling for `gfx906`, so `PYTORCH_ROCM_ARCH` is not reaching every hipcc invocation. That
affects build time and wheel size, not correctness.