### PR TITLE
[CLI] Add `lmcache query coordinator`

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -58,7 +58,9 @@ Available Commands
    * - :doc:`ping`
      - Liveness check for LMCache or vLLM servers.
    * - :doc:`query`
-     - Single-shot query interface for the serving engine.
+     - Single-shot queries: one inference request to a serving engine
+       (``engine``), or a read of the MP coordinator's read-only HTTP APIs
+       (``coordinator``).
    * - :doc:`bench`
      - Run sustained benchmarks against an inference engine
        (``engine``), an LMCache MP server (``server``), or an L2 cache

--- a/docs/source/cli/query.rst
+++ b/docs/source/cli/query.rst
@@ -1,14 +1,16 @@
 lmcache query
 =============
 
-The ``lmcache query`` command sends a single OpenAI-compatible inference
-request and reports token and latency metrics. It has two targets:
+The ``lmcache query`` command runs a single, read-only query and reports the
+result as a metrics report. It has three targets:
 
 .. code-block:: bash
 
-   lmcache query {engine,kvcache} [options]
+   lmcache query {engine,coordinator,kvcache} [options]
 
-* ``engine`` — send one request to a serving engine's HTTP API.
+* ``engine`` — send one OpenAI-compatible inference request to a serving
+  engine's HTTP API and report token and latency metrics.
+* ``coordinator`` — read one of the MP coordinator's read-only HTTP APIs.
 * ``kvcache`` — query KV-cache endpoints (not implemented yet).
 
 
@@ -88,3 +90,444 @@ Options
    * - ``-q`` / ``--quiet``
      - No
      - Suppress stdout output. Exit code only.
+
+
+query coordinator
+-----------------
+
+The ``query coordinator`` subcommand reads one of the MP coordinator's
+read-only HTTP APIs and renders the reply as a metrics report — the same
+information ``curl`` returns, but aligned into columns and with byte counts
+and ratios already formatted. Pick the API with ``--api``; everything else
+is optional.
+
+.. code-block:: bash
+
+   lmcache query coordinator --api NAME [--url URL] [options]
+
+Only reads are exposed. The coordinator's mutating routes are either
+server-to-coordinator plumbing (``POST /events``, ``POST /instances``,
+heartbeats) or belong to a command that owns the action — quotas are written
+with :doc:`lmcache quota <quota>`. See :doc:`/mp/coordinator` for the HTTP
+surface itself and the meaning of each field.
+
+The default ``--url`` is ``http://127.0.0.1:9300``, matching the
+coordinator's default port. A URL without a scheme is assumed to be
+``http://``, and a trailing slash is ignored, so ``coordinator:9300`` and
+``http://coordinator:9300/`` are both accepted.
+
+APIs
+~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 30 24 30
+
+   * - ``--api``
+     - Reads
+     - Extra flags
+     - Reports
+   * - ``usage``
+     - ``/instances/usage``, or
+       ``/instances/{id}/usage`` with ``--instance``
+     - ``--instance`` (optional)
+     - Per-compartment occupancy against declared capacity, busiest first.
+   * - ``instances``
+     - ``/instances``
+     - —
+     - Registered MP servers with their addresses and P2P URLs.
+   * - ``health``
+     - ``/healthz``
+     - —
+     - Coordinator liveness.
+   * - ``directory``
+     - ``/directory/stats``
+     - —
+     - Key-directory size and blend-index counts.
+   * - ``keys``
+     - ``/directory/keys``
+     - ``--limit`` (default: 20)
+     - A page of directory keys and where each one is placed.
+   * - ``quota``
+     - ``/quota``, or ``/quota/{salt}``
+       with ``--cache-salt``
+     - ``--cache-salt`` (optional)
+     - Per-salt L2 usage against quota.
+   * - ``quota-config``
+     - ``/quota/config``
+     - —
+     - The default limit applied to salts with no explicit quota.
+   * - ``prefetch``
+     - ``/cache/prefetches/{instance}/{request_id}``
+     - ``--instance`` **and** ``--request-id`` (required)
+     - One warm-prefetch request's progress.
+   * - ``metrics``
+     - ``/metrics``
+     - —
+     - Prometheus text, passed through verbatim.
+
+Fleet memory
+~~~~~~~~~~~~
+
+``--api usage`` is the everyday view: one row per memory compartment
+(``tier/backend``) per server, sorted so the fullest compartment is first.
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api usage
+
+   ============== Coordinator: usage ==============
+   instance        compartment      used  capacity    ratio
+   --------------------------------------------------------
+   mp-gpu7         l1/dram      48.00 GB  64.00 GB    75.0%
+   mp-gpu8         l1/dram       2.00 GB  64.00 GB     3.1%
+   mp-gpu7         l2/fs        12.00 GB        --  unknown
+   (fleet-shared)  l2/s3         7.00 GB        --  unknown
+   ================================================
+
+Reading the table:
+
+* A capacity of ``--`` and a ratio of ``unknown`` mean the server never
+  declared a capacity for that compartment — an unmeasured tier, not an empty
+  one. A ``0`` would be misleading, so it is never printed there.
+* A compartment shared by the whole fleet (e.g. one S3 bucket behind every
+  server) is attributed to ``(fleet-shared)`` rather than to any one server.
+* Numeric columns are right-aligned so sizes line up on the decimal point.
+
+Add ``--instance`` to narrow the report to one server. The instance id must be
+known to the coordinator — registered, holding bytes, or having declared
+capacity — otherwise the coordinator answers ``404`` and the command exits
+``1``:
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api usage --instance mp-gpu7
+
+   ============== Coordinator: usage ==============
+   instance  compartment      used  capacity    ratio
+   --------------------------------------------------
+   mp-gpu7   l1/dram      48.00 GB  64.00 GB    75.0%
+   mp-gpu7   l2/fs        12.00 GB        --  unknown
+   ================================================
+
+Fleet membership
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api instances
+
+   ============ Coordinator: instances ============
+   instance  address        mq port  p2p url
+   -----------------------------------------------------
+   mp-gpu7   10.0.0.7:8101     8201  tcp://10.0.0.7:8301
+   mp-gpu8   10.0.0.8:8101       --  --
+   ================================================
+
+``--`` marks a value the server did not advertise (no MQ port, no P2P URL),
+kept distinct from ``0`` and from an empty string.
+
+Quota and usage
+~~~~~~~~~~~~~~~
+
+With no ``--cache-salt``, the fleet-wide listing:
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api quota
+
+   ============== Coordinator: quota ==============
+   Total usage (GiB):                         19.00
+   cache salt  usage GiB  quota GiB  quota set
+   -------------------------------------------
+   tenant-a        12.50      20.00  yes
+   (default)        6.50       0.00  no
+   ================================================
+
+``(default)`` is the un-salted (empty-string) tenant. ``quota set`` is ``no``
+when no explicit quota exists for that salt — such a salt is governed by
+``--api quota-config`` instead, so a ``0.00`` quota column there does not mean
+"zero bytes allowed".
+
+With ``--cache-salt``, one tenant:
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api quota --cache-salt tenant-a
+
+   ============== Coordinator: quota ==============
+   Cache salt:                             tenant-a
+   Quota (GiB):                               20.00
+   Quota set:                                  True
+   Usage (GiB):                               12.50
+   ================================================
+
+.. note::
+
+   To address the un-salted tenant, pass the sentinel the HTTP API uses:
+   ``--cache-salt _default``. An empty ``--cache-salt ''`` builds the path
+   ``/quota/``, which does not address the empty salt.
+
+The default limit for salts with no explicit quota:
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api quota-config
+
+   ========== Coordinator: quota-config ===========
+   Default limit (GiB):               none (exempt)
+   ================================================
+
+``none (exempt)`` means the default is unset, so unquota'd salts are exempt
+from eviction. That is distinct from a default of ``0.0``, which makes every
+byte under an unquota'd salt evictable. See :doc:`/mp/coordinator` for why a
+freshly restarted coordinator starts out exempt.
+
+Key directory
+~~~~~~~~~~~~~
+
+Directory size, and how much of it is fragment-matchable by CacheBlend:
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api directory
+
+   ============ Coordinator: directory ============
+   Keys:                                      18422
+   Placements:                                20117
+   ----------------- Blend index ------------------
+   Contents:                                     91
+   Chunks:                                     1740
+   Table size:                                 1740
+   ================================================
+
+A page of keys and their placements. ``--limit`` sets the page size (default
+20; the endpoint accepts 1–10000, and a value outside that range is rejected
+by the coordinator and exits ``1``):
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api keys --limit 2
+
+   ============== Coordinator: keys ===============
+   Matching keys:                             18422
+   chunk         model                    rank  salt       placements
+   ---------------------------------------------------------------------------------------
+   abababababab  meta-llama/Llama-3.1-8B     0  tenant-a   mp-gpu7:l1/dram, (shared):l2/s3
+   cdcdcdcdcdcd  meta-llama/Llama-3.1-8B     0  (default)  mp-gpu8:l1/dram
+   ================================================
+
+``Matching keys`` is the total in the directory, not the number of rows shown.
+The chunk hash is truncated to 12 hex characters — enough to correlate with a
+log line, without pushing the placements column off the terminal. A placement
+with no owning instance (a fleet-shared backend) reads as ``(shared)``. The
+directory is a live structure, so successive pages may skip or repeat keys.
+
+Prefetch progress
+~~~~~~~~~~~~~~~~~
+
+``--api prefetch`` polls a warm prefetch submitted earlier via
+``POST /cache/prefetches``. Both ``--instance`` and ``--request-id`` are
+required; omitting either exits ``2`` without issuing a request.
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api prefetch --instance mp-gpu7 --request-id abc123
+
+   ============ Coordinator: prefetch =============
+   Status:                                completed
+   Found keys:                                   12
+   Total keys:                                   12
+   ================================================
+
+While the load is still running, only ``Status: pending`` is reported. The
+labels come from the reply itself, so a server that adds fields will show them
+without a CLI change.
+
+.. warning::
+
+   The first poll that observes completion drops the job on the MP server.
+   Polling the same ``--request-id`` again returns ``404`` and exits ``1``.
+
+Prometheus metrics
+~~~~~~~~~~~~~~~~~~
+
+``--api metrics`` is the one API that is not a metrics report: the
+coordinator's ``/metrics`` body is written to stdout unchanged, so it can be
+piped to other tools. ``--format``, ``--output``, and ``--quiet`` do not apply
+to it.
+
+.. code-block:: bash
+
+   lmcache query coordinator --api metrics | promtool check metrics
+   lmcache query coordinator --api metrics | grep lmcache_coordinator
+
+Options
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Flag
+     - Required
+     - Description
+   * - ``--api NAME``
+     - Yes
+     - Which API to read. One of ``usage``, ``instances``, ``health``,
+       ``directory``, ``keys``, ``quota``, ``quota-config``, ``prefetch``,
+       ``metrics``.
+   * - ``--url URL``
+     - No
+     - Coordinator base URL (default: ``http://127.0.0.1:9300``). The scheme
+       may be omitted.
+   * - ``--instance ID``
+     - No
+     - Instance id. Narrows ``--api usage`` to one server; required by
+       ``--api prefetch``.
+   * - ``--cache-salt SALT``
+     - No
+     - Narrows ``--api quota`` to one tenant. Use ``_default`` for un-salted
+       traffic.
+   * - ``--request-id ID``
+     - No
+     - Prefetch request id. Required by ``--api prefetch``.
+   * - ``--limit N``
+     - No
+     - Rows to request for ``--api keys`` (default: 20).
+   * - ``--format``
+     - No
+     - Output format: ``terminal`` (default) or ``json``. Ignored by
+       ``--api metrics``.
+   * - ``--output PATH``
+     - No
+     - Save the report to a file (format follows ``--format``). Ignored by
+       ``--api metrics``.
+   * - ``-q`` / ``--quiet``
+     - No
+     - Suppress stdout output. Exit code only. Ignored by ``--api metrics``.
+
+JSON output
+~~~~~~~~~~~
+
+``--format json`` renders the same report as a JSON object. Table APIs become
+a list of row objects under the table's key:
+
+.. code-block:: bash
+
+   $ lmcache query coordinator --api usage --format json
+   {
+     "title": "Coordinator: usage",
+     "metrics": {
+       "usage": [
+         {
+           "instance": "mp-gpu7",
+           "compartment": "l1/dram",
+           "used": "48.00 GB",
+           "capacity": "64.00 GB",
+           "ratio": "75.0%"
+         },
+         {
+           "instance": "mp-gpu8",
+           "compartment": "l1/dram",
+           "used": "2.00 GB",
+           "capacity": "64.00 GB",
+           "ratio": "3.1%"
+         },
+         {
+           "instance": "mp-gpu7",
+           "compartment": "l2/fs",
+           "used": "12.00 GB",
+           "capacity": "--",
+           "ratio": "unknown"
+         },
+         {
+           "instance": "(fleet-shared)",
+           "compartment": "l2/s3",
+           "used": "7.00 GB",
+           "capacity": "--",
+           "ratio": "unknown"
+         }
+       ]
+     }
+   }
+
+.. warning::
+
+   Table rows carry **display strings**, not raw numbers: ``"48.00 GB"``,
+   ``"75.0%"``, ``"12.50"``, ``"yes"``, and the placeholders ``"--"`` /
+   ``"unknown"``. They are meant for reading and for grepping, not for
+   arithmetic. For machine-readable values, ``curl`` the endpoint directly:
+
+   .. code-block:: bash
+
+      curl -s http://127.0.0.1:9300/instances/usage | jq \
+        '.instances[].modules[] | {tier, backend, used_bytes, usage_ratio}'
+
+Exit codes
+~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Code
+     - Meaning
+   * - ``0``
+     - Success.
+   * - ``1``
+     - The coordinator was unreachable, returned a non-2xx status (e.g. an
+       unknown instance id or prefetch request), or replied with something
+       that was not JSON.
+   * - ``2``
+     - Usage error: a required flag for the chosen ``--api`` is missing (e.g.
+       ``--api prefetch`` without ``--request-id``). No request is sent.
+
+This makes the command usable as a readiness check:
+
+.. code-block:: bash
+
+   until lmcache query coordinator --api health -q; do sleep 1; done
+
+Common patterns
+~~~~~~~~~~~~~~~
+
+**Find the fullest server before pinning work to it:**
+
+.. code-block:: bash
+
+   lmcache query coordinator --api usage | head -5
+
+**Watch a fleet fill up:**
+
+.. code-block:: bash
+
+   watch -n 5 'lmcache query coordinator --api usage'
+
+**Check one tenant against its budget:**
+
+.. code-block:: bash
+
+   lmcache query coordinator --api quota --cache-salt tenant-a
+   lmcache query coordinator --api quota-config   # what un-quota'd salts get
+
+**Point at a coordinator in Kubernetes:**
+
+.. code-block:: bash
+
+   lmcache query coordinator --api instances \
+     --url http://coordinator.default.svc:9300
+
+Limitations
+~~~~~~~~~~~
+
+* Reports are a formatted subset of each reply, not the whole thing. ``--api
+  usage`` does not surface the ``registered`` flag, so a server that
+  deregistered while its L2 bytes survive appears in the table like any other;
+  cross-check with ``--api instances``. ``--api directory`` omits the
+  per-instance L1 key counts, and ``--api keys`` omits each key's token count.
+* ``--api keys`` requests a page size only. The endpoint's ``tier``,
+  ``instance_id``, ``backend``, and ``offset`` filters are not exposed —
+  ``curl`` ``/directory/keys`` for those.
+* ``--api quota`` reports the L2 tier, which is the tier quotas are enforced
+  on. The endpoint's ``tier`` parameter is not exposed.

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -206,6 +206,15 @@ Each endpoint is documented below. Success is ``200`` unless noted, and
 ``{cache_salt}`` uses the ``_default`` sentinel for the empty salt. The wire
 types live in ``lmcache/v1/mp_coordinator/schemas.py``.
 
+.. tip::
+
+   The read-only endpoints below can be read without ``curl`` and ``jq``.
+   ``lmcache query coordinator --api NAME`` fetches one of them — ``usage``,
+   ``instances``, ``health``, ``directory``, ``keys``, ``quota``,
+   ``quota-config``, ``prefetch``, or ``metrics`` — and prints it as an
+   aligned table with byte counts and ratios already formatted. See
+   :doc:`/cli/query`.
+
 Fleet membership and health
 ---------------------------
 

--- a/lmcache/cli/commands/query/_coordinator.py
+++ b/lmcache/cli/commands/query/_coordinator.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Read-only coordinator queries behind ``lmcache query coordinator``.
+
+One entry per queryable coordinator endpoint. Each knows its path, which
+extra arguments it needs, and how to shape the reply into a
+:class:`~lmcache.cli.metrics.Metrics` report -- so the terminal gets an
+aligned table and ``--format json`` gets the same data structurally.
+
+Only reads live here. The coordinator's mutating routes (``POST /events``,
+``POST /instances``, the ``/cache`` actions) are either server-to-coordinator
+plumbing or belong to commands that own the action.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+import json
+import sys
+import urllib.error
+import urllib.request
+
+# First Party
+from lmcache.cli.commands.describe import fmt_bytes
+from lmcache.cli.metrics import Metrics
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+_TIMEOUT = 10
+
+
+def normalize_url(url: str) -> str:
+    """Ensure *url* has a scheme and no trailing slash."""
+    if not url.startswith(("http://", "https://")):
+        url = f"http://{url}"
+    return url.rstrip("/")
+
+
+def _fetch(url: str, timeout: int = _TIMEOUT) -> str:
+    """GET *url* and return the body as text.
+
+    Args:
+        url: Full URL to request.
+        timeout: Seconds to wait.
+
+    Returns:
+        The response body.
+
+    Raises:
+        SystemExit: On a connection failure or a non-2xx status, reported as
+            a CLI error rather than a traceback.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return response.read().decode()
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        try:
+            detail = json.loads(detail).get("detail", detail)
+        except (json.JSONDecodeError, AttributeError, ValueError):
+            pass
+        logger.error("Coordinator returned %s: %s", e.code, detail)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        logger.error(
+            "Cannot reach %s -- is the coordinator running? (%s)", url, e.reason
+        )
+        sys.exit(1)
+
+
+def get_text(url: str) -> str:
+    """GET *url* and return the body unparsed.
+
+    For endpoints that are not JSON -- ``/metrics`` is Prometheus text.
+
+    Args:
+        url: Full URL to request.
+
+    Returns:
+        The response body.
+    """
+    return _fetch(url)
+
+
+def get_json(url: str) -> Any:
+    """GET *url* and parse the reply as JSON.
+
+    Args:
+        url: Full URL to request.
+
+    Returns:
+        The parsed body.
+
+    Raises:
+        SystemExit: If the reply is not JSON.
+    """
+    body = _fetch(url)
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        logger.error("Coordinator reply was not JSON: %s", body[:200])
+        sys.exit(1)
+
+
+def _ratio(value: float | None) -> str:
+    """Render a usage ratio, keeping ``null`` distinct from zero."""
+    return "unknown" if value is None else f"{value * 100:.1f}%"
+
+
+def _capacity(value: int) -> str:
+    """Render a declared capacity, keeping "undeclared" distinct from zero."""
+    return fmt_bytes(value) if value else "--"
+
+
+# -- Renderers ---------------------------------------------------------------
+# Each takes the parsed reply and fills a Metrics report.
+
+
+def _render_usage(body: Any, metrics: Metrics) -> None:
+    """Per-compartment occupancy, busiest first."""
+    table = metrics.add_table(
+        "usage",
+        "Usage",
+        ("instance", "instance"),
+        ("compartment", "compartment"),
+        ("used", "used"),
+        ("capacity", "capacity"),
+        ("ratio", "ratio"),
+    )
+    # A single-instance reply has no "instances" key; treat it as a fleet of one.
+    instances = body.get("instances", [body]) if "instances" in body else [body]
+    rows = [(i["instance_id"], m) for i in instances for m in i["modules"]]
+    rows += [("(fleet-shared)", m) for m in body.get("shared_modules", [])]
+    rows.sort(key=lambda row: -(row[1]["usage_ratio"] or 0))
+    for name, module in rows:
+        table.add_row(
+            instance=name,
+            compartment=f"{module['tier']}/{module['backend']}",
+            used=fmt_bytes(module["used_bytes"]),
+            capacity=_capacity(module["capacity_bytes"]),
+            ratio=_ratio(module["usage_ratio"]),
+        )
+
+
+def _render_instances(body: Any, metrics: Metrics) -> None:
+    """Fleet membership."""
+    table = metrics.add_table(
+        "instances",
+        "Instances",
+        ("instance", "instance"),
+        ("address", "address"),
+        ("mq_port", "mq port"),
+        ("p2p", "p2p url"),
+    )
+    for instance in body.get("instances", []):
+        table.add_row(
+            instance=instance["instance_id"],
+            address=f"{instance['ip']}:{instance['http_port']}",
+            mq_port=instance.get("mq_port") or "--",
+            p2p=instance.get("p2p_advertised_url") or "--",
+        )
+
+
+def _render_health(body: Any, metrics: Metrics) -> None:
+    """Liveness."""
+    metrics.add("status", "Status", body.get("status", "unknown"))
+
+
+def _render_directory_stats(body: Any, metrics: Metrics) -> None:
+    """Key-directory size, and how much of it is fragment-matchable."""
+    metrics.add("num_keys", "Keys", body.get("num_keys"))
+    metrics.add("num_placements", "Placements", body.get("num_placements"))
+    blend = body.get("blend") or {}
+    section = metrics.add_section("blend", "Blend index")
+    for key, label in (
+        ("num_contents", "Contents"),
+        ("num_chunks", "Chunks"),
+        ("table_size", "Table size"),
+    ):
+        section.add(key, label, blend.get(key))
+
+
+def _render_keys(body: Any, metrics: Metrics) -> None:
+    """A page of directory keys and where each one lives.
+
+    The chunk hash is truncated: 64 hex characters per row would push the
+    placements column off the terminal, and a 12-character prefix is enough
+    to correlate with a log line.
+    """
+    metrics.add("total", "Matching keys", body.get("total", 0))
+    table = metrics.add_table(
+        "keys",
+        "Keys",
+        ("chunk", "chunk"),
+        ("model", "model"),
+        ("kv_rank", "rank"),
+        ("cache_salt", "salt"),
+        ("placements", "placements"),
+    )
+    for info in body.get("keys", []):
+        key = info.get("key") or {}
+        placements = ", ".join(
+            f"{p.get('instance_id') or '(shared)'}:{p.get('tier')}/{p.get('backend')}"
+            for p in info.get("placements", [])
+        )
+        table.add_row(
+            chunk=str(key.get("chunk_hash_hex", ""))[:12],
+            model=key.get("model_name") or "--",
+            kv_rank=key.get("kv_rank"),
+            cache_salt=key.get("cache_salt") or "(default)",
+            placements=placements or "--",
+        )
+
+
+def _render_quota(body: Any, metrics: Metrics) -> None:
+    """Per-salt usage against quota. Accepts the list or single-salt reply."""
+    if "by_cache_salt" not in body:  # single-salt reply
+        for key, label in (
+            ("cache_salt", "Cache salt"),
+            ("quota_limit_gb", "Quota (GiB)"),
+            ("quota_exists", "Quota set"),
+            ("usage_gb", "Usage (GiB)"),
+        ):
+            metrics.add(key, label, body.get(key))
+        return
+    metrics.add("total_gb", "Total usage (GiB)", body.get("total_gb"))
+    table = metrics.add_table(
+        "by_cache_salt",
+        "By cache salt",
+        ("cache_salt", "cache salt"),
+        ("usage_gb", "usage GiB"),
+        ("quota_limit_gb", "quota GiB"),
+        ("quota_exists", "quota set"),
+    )
+    for row in body.get("by_cache_salt", []):
+        table.add_row(
+            cache_salt=row.get("cache_salt") or "(default)",
+            usage_gb=f"{row.get('usage_gb', 0.0):.2f}",
+            quota_limit_gb=f"{row.get('quota_limit_gb', 0.0):.2f}",
+            quota_exists="yes" if row.get("quota_exists") else "no",
+        )
+
+
+def _render_quota_config(body: Any, metrics: Metrics) -> None:
+    """The default quota applied to salts with no explicit entry."""
+    limit = body.get("default_limit_gb")
+    metrics.add(
+        "default_limit_gb",
+        "Default limit (GiB)",
+        "none (exempt)" if limit is None else limit,
+    )
+
+
+def _render_prefetch(body: Any, metrics: Metrics) -> None:
+    """One prefetch request's progress."""
+    for key, value in body.items():
+        metrics.add(key, key.replace("_", " ").capitalize(), value)
+
+
+@dataclass(frozen=True)
+class CoordinatorApi:
+    """One queryable coordinator endpoint.
+
+    Attributes:
+        summary: One-line description, shown in ``--api`` help.
+        path: Callable building the request path from parsed arguments.
+        render: Fills a report from the parsed reply.
+        requires: Argument names this endpoint needs, e.g. ``("instance",)``.
+        raw: True when the reply is not JSON and is printed verbatim
+            (``/metrics`` is Prometheus text).
+    """
+
+    summary: str
+    path: Callable[[Any], str]
+    render: Callable[[Any, Metrics], None] = field(default=_render_health)
+    requires: tuple[str, ...] = ()
+    raw: bool = False
+
+
+APIS: dict[str, CoordinatorApi] = {
+    "usage": CoordinatorApi(
+        summary="per-instance memory usage against declared capacity",
+        path=lambda a: (
+            f"/instances/{a.instance}/usage" if a.instance else "/instances/usage"
+        ),
+        render=_render_usage,
+    ),
+    "instances": CoordinatorApi(
+        summary="registered MP servers",
+        path=lambda a: "/instances",
+        render=_render_instances,
+    ),
+    "health": CoordinatorApi(
+        summary="coordinator liveness",
+        path=lambda a: "/healthz",
+        render=_render_health,
+    ),
+    "directory": CoordinatorApi(
+        summary="key-directory size and blend-index stats",
+        path=lambda a: "/directory/stats",
+        render=_render_directory_stats,
+    ),
+    "keys": CoordinatorApi(
+        summary="a page of directory keys and their placements",
+        path=lambda a: f"/directory/keys?limit={a.limit}",
+        render=_render_keys,
+    ),
+    "quota": CoordinatorApi(
+        summary="per-salt usage against quota",
+        path=lambda a: (
+            f"/quota/{a.cache_salt}" if a.cache_salt is not None else "/quota"
+        ),
+        render=_render_quota,
+    ),
+    "quota-config": CoordinatorApi(
+        summary="default quota for salts with no explicit entry",
+        path=lambda a: "/quota/config",
+        render=_render_quota_config,
+    ),
+    "prefetch": CoordinatorApi(
+        summary="status of one prefetch request",
+        path=lambda a: f"/cache/prefetches/{a.instance}/{a.request_id}",
+        render=_render_prefetch,
+        requires=("instance", "request_id"),
+    ),
+    "metrics": CoordinatorApi(
+        summary="Prometheus metrics, verbatim",
+        path=lambda a: "/metrics",
+        raw=True,
+    ),
+}

--- a/lmcache/cli/commands/query/coordinator_command.py
+++ b/lmcache/cli/commands/query/coordinator_command.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache query coordinator`` — read the MP coordinator's HTTP APIs."""
+
+# Standard
+import argparse
+import sys
+
+# First Party
+from lmcache.cli.commands.base import BaseCommand
+from lmcache.cli.commands.query._coordinator import (
+    APIS,
+    get_json,
+    get_text,
+    normalize_url,
+)
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+_DEFAULT_URL = "http://127.0.0.1:9300"
+
+
+class CoordinatorQueryCommand(BaseCommand):
+    """Query one of the coordinator's read-only HTTP APIs."""
+
+    def name(self) -> str:
+        return "coordinator"
+
+    def help(self) -> str:
+        return "Query the MP coordinator's read-only HTTP APIs."
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--api",
+            required=True,
+            choices=sorted(APIS),
+            metavar="NAME",
+            help="Which API to read. "
+            + "; ".join(f"{name}: {api.summary}" for name, api in sorted(APIS.items())),
+        )
+        parser.add_argument(
+            "--url",
+            default=_DEFAULT_URL,
+            help=f"Coordinator base URL (default: {_DEFAULT_URL}).",
+        )
+        parser.add_argument(
+            "--instance",
+            default=None,
+            help="Instance id. Narrows --api usage to one server; required "
+            "by --api prefetch.",
+        )
+        parser.add_argument(
+            "--cache-salt",
+            default=None,
+            help="Cache salt. Narrows --api quota to one tenant; pass an "
+            "empty string for un-salted traffic.",
+        )
+        parser.add_argument(
+            "--request-id",
+            default=None,
+            help="Prefetch request id, required by --api prefetch.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=20,
+            help="Rows to request for --api keys (default: 20).",
+        )
+
+    def execute(self, args: argparse.Namespace) -> None:
+        """Fetch the selected API and emit it.
+
+        Args:
+            args: Parsed CLI arguments.
+        """
+        api = APIS[args.api]
+
+        missing = [
+            f"--{name.replace('_', '-')}"
+            for name in api.requires
+            if getattr(args, name, None) is None
+        ]
+        if missing:
+            logger.error("--api %s requires %s", args.api, " and ".join(missing))
+            sys.exit(2)
+
+        url = normalize_url(args.url) + api.path(args)
+
+        if api.raw:
+            # Prometheus text, not JSON: pass it through untouched so it can
+            # be piped to promtool or grep without the report wrapper.
+            sys.stdout.write(get_text(url))
+            return
+
+        metrics = self.create_metrics(f"Coordinator: {args.api}", args)
+        api.render(get_json(url), metrics)
+        metrics.emit()

--- a/lmcache/cli/metrics/formatter.py
+++ b/lmcache/cli/metrics/formatter.py
@@ -92,6 +92,72 @@ def _format_value(value: Any) -> str:
     return str(value)
 
 
+_PLACEHOLDERS = frozenset({"", "--", "N/A", "unknown", "none"})
+
+
+def _format_table(section: "Section") -> list[str]:
+    """Render a table section as aligned columns.
+
+    Column widths come from the content, so the table is as narrow as its
+    data allows rather than padded to a fixed report width. Numeric-looking
+    cells are right-aligned, text left-aligned, which is what makes a
+    column of sizes or percentages scannable.
+
+    Args:
+        section: A section with columns set.
+
+    Returns:
+        Header, rule, and one line per row.
+    """
+    headers = [header for _key, header in section.columns]
+    cells = [
+        [
+            _format_value(row.get(key)) if key in row else ""
+            for key, _h in section.columns
+        ]
+        for row in section.rows
+    ]
+    widths = [
+        max(len(headers[i]), *(len(row[i]) for row in cells))
+        if cells
+        else len(headers[i])
+        for i in range(len(headers))
+    ]
+
+    # Right-align a column of numbers so sizes and percentages line up on
+    # the decimal point. The whole cell must parse as a number once a unit
+    # suffix is removed -- "starts with a digit" would also catch an address
+    # like "10.0.0.1:8000", which is text and belongs on the left.
+    # Placeholders get no vote; a column is numeric if every cell that
+    # carries a value is, and at least one does.
+    def _is_number(cell: str) -> bool:
+        head = cell.rstrip("%").rsplit(" ", 1)[0] if " " in cell else cell.rstrip("%")
+        try:
+            float(head)
+        except ValueError:
+            return False
+        return True
+
+    def _numeric(column: int) -> bool:
+        values = [row[column] for row in cells if row[column] not in _PLACEHOLDERS]
+        return bool(values) and all(_is_number(v) for v in values)
+
+    right = [_numeric(i) for i in range(len(headers))]
+
+    def line(values: list[str]) -> str:
+        parts = [
+            values[i].rjust(widths[i]) if right[i] else values[i].ljust(widths[i])
+            for i in range(len(values))
+        ]
+        return "  ".join(parts).rstrip()
+
+    out = [line(headers), "-" * (sum(widths) + 2 * (len(widths) - 1))]
+    out.extend(line(row) for row in cells)
+    if not cells:
+        out.append("(none)")
+    return out
+
+
 @register_formatter("terminal")
 class TerminalFormatter(MetricsFormatter):
     """Plain ASCII table formatter for terminal output.
@@ -125,6 +191,10 @@ class TerminalFormatter(MetricsFormatter):
         lines.append(title_text.center(width, "="))
 
         for section in sections:
+            if section.columns:
+                lines.extend(_format_table(section))
+                continue
+
             # Section header (skip for unnamed section)
             if section.label is not None:
                 header_text = f" {section.label} "

--- a/lmcache/cli/metrics/metrics.py
+++ b/lmcache/cli/metrics/metrics.py
@@ -110,6 +110,25 @@ class Metrics:
         self._section_map[key] = section
         return section
 
+    def add_table(self, key: str, label: str, *columns: tuple[str, str]) -> Section:
+        """Add a table section: uniform rows instead of key-value entries.
+
+        Args:
+            key: Machine-readable section key; the JSON list is keyed by it.
+            label: Human-readable label. Unused by the table renderer, which
+                lets the column headers speak for themselves.
+            columns: ``(key, header)`` pairs in display order.
+
+        Returns:
+            The section, ready for :meth:`Section.add_row`.
+
+        Raises:
+            ValueError: If a section with the same *key* already exists.
+        """
+        section = self.add_section(key, label)
+        section.set_columns(*columns)
+        return section
+
     def __getitem__(self, key: str) -> Section:
         """Return the section registered under *key*.
 

--- a/lmcache/cli/metrics/section.py
+++ b/lmcache/cli/metrics/section.py
@@ -14,6 +14,12 @@ class Section:
     Sections with the same :attr:`list_group` are collected into a
     JSON list under that key (e.g., ``"models": [{...}, {...}]``).
     In terminal output they render as normal independent sections.
+
+    A section is a **table** instead once :meth:`set_columns` is called:
+    it then holds uniform rows rather than key-value entries, renders as
+    aligned columns on a terminal, and serializes as a JSON list. Use it
+    when the interesting comparison is across rows -- one line per
+    instance -- rather than down a single object's fields.
     """
 
     def __init__(
@@ -26,6 +32,8 @@ class Section:
         self.label = label
         self.list_group = list_group
         self.entries: list[tuple[str, str, Any]] = []
+        self.columns: list[tuple[str, str]] = []
+        self.rows: list[dict[str, Any]] = []
 
     def add(self, key: str, label: str, value: Any) -> None:
         """Record a metric in this section.
@@ -37,6 +45,34 @@ class Section:
                 places on terminal output; strings are printed as-is.
         """
         self.entries.append((key, label, value))
+
+    def set_columns(self, *columns: tuple[str, str]) -> None:
+        """Make this section a table with the given ``(key, header)`` columns.
+
+        Args:
+            columns: Column definitions in display order. ``key`` names the
+                field in :meth:`add_row` and in JSON; ``header`` is the
+                terminal column heading.
+        """
+        self.columns = list(columns)
+
+    def add_row(self, **values: Any) -> None:
+        """Append one table row.
+
+        Args:
+            values: One entry per column key. A column with no value for
+                this row renders empty.
+
+        Raises:
+            ValueError: If :meth:`set_columns` has not been called, or a
+                key does not name a column.
+        """
+        if not self.columns:
+            raise ValueError("call set_columns() before add_row()")
+        unknown = set(values) - {key for key, _header in self.columns}
+        if unknown:
+            raise ValueError(f"not columns of this table: {sorted(unknown)}")
+        self.rows.append(values)
 
 
 def sections_to_dict(
@@ -62,6 +98,11 @@ def sections_to_dict(
         if section.key is None:
             for key, _label, value in section.entries:
                 metrics[key] = value
+        elif section.columns:
+            metrics[section.key] = [
+                {key: row.get(key) for key, _header in section.columns}
+                for row in section.rows
+            ]
         elif section.list_group is not None:
             section_dict: dict[str, Any] = {}
             for key, _label, value in section.entries:

--- a/tests/v1/cli/test_query_coordinator.py
+++ b/tests/v1/cli/test_query_coordinator.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache query coordinator``.
+
+The renderers are pure functions of a parsed reply, so they are tested
+against reply shapes directly. The table rendering itself is tested through
+the formatter, since that is what "formalized output" means here: one report
+object, two renderings.
+"""
+
+# Standard
+import argparse
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.query._coordinator import APIS, normalize_url
+from lmcache.cli.commands.query.coordinator_command import CoordinatorQueryCommand
+from lmcache.cli.metrics import Metrics, get_formatter
+from lmcache.cli.metrics.section import sections_to_dict
+
+GIB = 1 << 30
+
+
+def _render(api: str, body: object) -> Metrics:
+    """Run one API's renderer over ``body``."""
+    metrics = Metrics(f"Coordinator: {api}")
+    APIS[api].render(body, metrics)
+    return metrics
+
+
+def _terminal(metrics: Metrics) -> str:
+    return get_formatter("terminal").format(metrics._title, metrics._sections)
+
+
+def _json(metrics: Metrics) -> dict:
+    return sections_to_dict(metrics._title, metrics._sections)
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    """Parsed arguments with every option defaulted."""
+    defaults: dict[str, object] = {
+        "api": "usage",
+        "url": "http://127.0.0.1:9300",
+        "instance": None,
+        "cache_salt": None,
+        "request_id": None,
+        "limit": 20,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+_FLEET = {
+    "instances": [
+        {
+            "instance_id": "mp-1",
+            "registered": True,
+            "declared_capacity": True,
+            "modules": [
+                {
+                    "tier": "l1",
+                    "backend": "dram",
+                    "shared": False,
+                    "used_bytes": 48 * GIB,
+                    "capacity_bytes": 64 * GIB,
+                    "usage_ratio": 0.75,
+                },
+                {
+                    "tier": "l2",
+                    "backend": "fs",
+                    "shared": False,
+                    "used_bytes": 12 * GIB,
+                    "capacity_bytes": 0,
+                    "usage_ratio": None,
+                },
+            ],
+        },
+        {
+            "instance_id": "mp-2",
+            "registered": True,
+            "declared_capacity": True,
+            "modules": [
+                {
+                    "tier": "l1",
+                    "backend": "dram",
+                    "shared": False,
+                    "used_bytes": 2 * GIB,
+                    "capacity_bytes": 64 * GIB,
+                    "usage_ratio": 0.03125,
+                }
+            ],
+        },
+    ],
+    "shared_modules": [
+        {
+            "tier": "l2",
+            "backend": "s3",
+            "shared": True,
+            "used_bytes": 7 * GIB,
+            "capacity_bytes": 0,
+            "usage_ratio": None,
+        }
+    ],
+}
+
+
+class TestUsage:
+    def test_rows_are_ordered_busiest_first(self) -> None:
+        # The point of the table: which server to avoid, at a glance.
+        rendered = _json(_render("usage", _FLEET))["metrics"]["usage"]
+        assert [row["ratio"] for row in rendered] == [
+            "75.0%",
+            "3.1%",
+            "unknown",
+            "unknown",
+        ]
+
+    def test_undeclared_capacity_is_not_shown_as_zero(self) -> None:
+        # A "0" here would read as an empty tier rather than an unknown one.
+        rows = _json(_render("usage", _FLEET))["metrics"]["usage"]
+        fs = next(r for r in rows if r["compartment"] == "l2/fs")
+        assert fs["capacity"] == "--"
+        assert fs["ratio"] == "unknown"
+
+    def test_shared_pool_is_attributed_to_the_fleet(self) -> None:
+        rows = _json(_render("usage", _FLEET))["metrics"]["usage"]
+        shared = next(r for r in rows if r["compartment"] == "l2/s3")
+        assert shared["instance"] == "(fleet-shared)"
+
+    def test_a_single_instance_reply_renders_as_one_server(self) -> None:
+        body = _FLEET["instances"][0]
+        rows = _json(_render("usage", body))["metrics"]["usage"]
+        assert {r["instance"] for r in rows} == {"mp-1"}
+
+    def test_numeric_columns_are_right_aligned(self) -> None:
+        # Sizes must line up on the decimal point to be comparable by eye.
+        lines = _terminal(_render("usage", _FLEET)).splitlines()
+        body = [ln for ln in lines if "l1/dram" in ln]
+        assert len(body) == 2
+        assert all(line.index("GB") == body[0].index("GB") for line in body)
+
+    def test_an_empty_fleet_says_so(self) -> None:
+        out = _terminal(_render("usage", {"instances": [], "shared_modules": []}))
+        assert "(none)" in out
+
+
+class TestOtherApis:
+    def test_instances_lists_addresses(self) -> None:
+        body = {
+            "instances": [
+                {
+                    "instance_id": "mp-1",
+                    "ip": "10.0.0.1",
+                    "http_port": 8101,
+                    "mq_port": 0,
+                    "p2p_advertised_url": "",
+                }
+            ]
+        }
+        row = _json(_render("instances", body))["metrics"]["instances"][0]
+        assert row["address"] == "10.0.0.1:8101"
+        # Absent optional values read as absent, not as 0 / "".
+        assert row["mq_port"] == "--"
+        assert row["p2p"] == "--"
+
+    def test_an_address_column_is_not_treated_as_numeric(self) -> None:
+        # "10.0.0.1:8000" starts with a digit but is text; right-aligning it
+        # makes the column look broken next to a left-aligned header.
+        body = {
+            "instances": [
+                {
+                    "instance_id": "mp-1",
+                    "ip": "10.0.0.1",
+                    "http_port": 8000,
+                    "mq_port": 0,
+                    "p2p_advertised_url": "",
+                }
+            ]
+        }
+        lines = _terminal(_render("instances", body)).splitlines()
+        header = next(ln for ln in lines if ln.startswith("instance"))
+        row = next(ln for ln in lines if ln.startswith("mp-1"))
+        assert header.index("address") == row.index("10.0.0.1:8000")
+
+    def test_health(self) -> None:
+        assert (
+            _json(_render("health", {"status": "healthy"}))["metrics"]["status"]
+            == "healthy"
+        )
+
+    def test_quota_list_and_single_salt_both_render(self) -> None:
+        listing = {
+            "total_gb": 19.0,
+            "by_cache_salt": [
+                {
+                    "cache_salt": "",
+                    "usage_gb": 19.0,
+                    "quota_limit_gb": 0.0,
+                    "quota_exists": False,
+                }
+            ],
+        }
+        rows = _json(_render("quota", listing))["metrics"]["by_cache_salt"]
+        assert rows[0]["cache_salt"] == "(default)"
+        assert rows[0]["quota_exists"] == "no"
+
+        single = {
+            "cache_salt": "t",
+            "usage_gb": 1.0,
+            "quota_limit_gb": 0.0,
+            "quota_exists": False,
+        }
+        assert _json(_render("quota", single))["metrics"]["cache_salt"] == "t"
+
+    def test_quota_config_distinguishes_exempt_from_zero(self) -> None:
+        exempt = _json(_render("quota-config", {"default_limit_gb": None}))
+        assert exempt["metrics"]["default_limit_gb"] == "none (exempt)"
+        zero = _json(_render("quota-config", {"default_limit_gb": 0.0}))
+        assert zero["metrics"]["default_limit_gb"] == 0.0
+
+    def test_keys_truncates_the_chunk_hash(self) -> None:
+        # 64 hex chars per row would push the placements column off-screen.
+        body = {
+            "total": 1,
+            "keys": [
+                {
+                    "key": {
+                        "chunk_hash_hex": "ab" * 32,
+                        "model_name": "m",
+                        "kv_rank": 0,
+                        "cache_salt": "",
+                    },
+                    "placements": [
+                        {"instance_id": "mp-1", "tier": "l1", "backend": "dram"}
+                    ],
+                }
+            ],
+        }
+        row = _json(_render("keys", body))["metrics"]["keys"][0]
+        assert row["chunk"] == "ab" * 6
+        assert row["placements"] == "mp-1:l1/dram"
+        assert row["cache_salt"] == "(default)"
+
+    def test_directory_stats_nests_the_blend_index(self) -> None:
+        body = {
+            "num_keys": 3,
+            "num_placements": 4,
+            "blend": {"num_contents": 1, "num_chunks": 2, "table_size": 1024},
+        }
+        metrics = _json(_render("directory", body))["metrics"]
+        assert metrics["num_keys"] == 3
+        assert metrics["blend"]["table_size"] == 1024
+
+
+class TestPaths:
+    def test_usage_narrows_to_one_instance(self) -> None:
+        assert APIS["usage"].path(_args()) == "/instances/usage"
+        assert APIS["usage"].path(_args(instance="mp-1")) == "/instances/mp-1/usage"
+
+    def test_quota_narrows_to_one_salt(self) -> None:
+        assert APIS["quota"].path(_args()) == "/quota"
+        # An empty salt is a real tenant, not "unset".
+        assert APIS["quota"].path(_args(cache_salt="")) == "/quota/"
+
+    def test_every_api_builds_a_path(self) -> None:
+        args = _args(instance="mp-1", request_id="r1", cache_salt="s")
+        for name, api in APIS.items():
+            assert APIS[name].path(args).startswith("/"), name
+
+    @pytest.mark.parametrize("url", ["127.0.0.1:9300", "http://127.0.0.1:9300/"])
+    def test_url_is_normalized(self, url: str) -> None:
+        assert normalize_url(url) == "http://127.0.0.1:9300"
+
+
+class TestRequiredArguments:
+    def test_prefetch_needs_an_instance_and_a_request(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            CoordinatorQueryCommand().execute(_args(api="prefetch"))
+        # 2 is the conventional exit for a usage error, distinct from a
+        # failed request (1).
+        assert excinfo.value.code == 2
+
+    def test_only_prefetch_requires_extra_arguments(self) -> None:
+        assert {name for name, api in APIS.items() if api.requires} == {"prefetch"}
+
+    def test_metrics_is_the_only_non_json_api(self) -> None:
+        assert {name for name, api in APIS.items() if api.raw} == {"metrics"}


### PR DESCRIPTION
 ## Description 

Follow up PR on #4639

Reading the coordinator meant `curl` + `jq` + mental arithmetic on raw byte counts. This wires its read-only HTTP surface into the CLI:

    $ lmcache query coordinator --api usage
    ============== Coordinator: usage ==============
    instance  compartment     used  capacity  ratio
    -----------------------------------------------
    mp-gpu7   l1/dram      8.16 GB  20.00 GB  40.8%
    mp-gpu6   l1/dram      5.19 GB  16.00 GB  32.4%
    mp-gpu5   l1/dram      3.16 GB  12.00 GB  26.3%
    mp-gpu4   l1/dram      1.59 GB   8.00 GB  19.9%
    ================================================

Nine read-only APIs: `usage`, `instances`, `health`, `directory`, `keys`, `quota`, `quota-config`, `prefetch`, `metrics`. Narrow with `--instance` / `--cache-salt`; `--api metrics` passes Prometheus text through verbatim.

Mutating routes are out of scope: `POST /events`, `POST /instances` and the heartbeat are server-to-coordinator plumbing, and `/cache` actions belong to a command that owns the action, not to `query`.

## Output

`Section` gains a table mode (`set_columns()` / `add_row()`), so one report renders as aligned columns on a terminal and as a JSON list under `--format json` — no second output path to keep in sync. Existing key-value sections are untouched.

Column widths come from the content. A column right-aligns when every value-bearing cell starts with a digit; placeholders don't vote, otherwise a single `--` in a capacity column left-aligns everything and the sizes stop lining up.

Endpoint conventions are carried through, not flattened: undeclared capacity prints `--` with ratio `unknown` rather than `0` (a zero reads as an empty tier, not an unmeasured one), shared pools show as `(fleet-shared)`, and rows sort busiest first.

## Notes for reviewers

- Byte counts reuse `describe.fmt_bytes` — no second byte format.
- `--format json` carries display strings, not raw numbers. `curl` the endpoint for machine-readable values.
- The HTTP client duplicates ~30 lines of `commands/quota/_helpers.py`. A shared `commands/_http.py` is the obvious convergence; left out to keep the diff to one command.
- Exit codes: 0 success, 1 unreachable/erroring coordinator, 2 usage error (e.g. `--api prefetch` without `--request-id`).
- Pre-existing: `lmcache.logging` imports torch, so every command prints a few INFO lines first. It all goes to stderr, so piping is unaffected. `LMCACHE_DISABLE_BANNER=1 LMCACHE_LOG_LEVEL=WARNING` quiets it.

## Testing

20 unit tests over renderers, paths and required-argument handling, plus a manual run against a live coordinator (4 MP servers, 4 vLLM instances, 4 GPUs) covering a real ratio, an undeclared L2 adapter, and a shared pool.

Based on `feat/coordinotor-memory-pressure-api` (the `/instances/usage` endpoint this reads).

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests