### PR TITLE
raw_block: fix effective QD~1 on the io_uring_cmd (NVMe passthrough) load path

### DIFF
--- a/benchmarks/raw_block/README.md
+++ b/benchmarks/raw_block/README.md
@@ -1,0 +1,87 @@
+# raw_block io_uring_cmd load — end-to-end A/B
+
+A reproducible serving A/B for the `raw_block` io_uring_cmd load-path changes,
+measured on a real vLLM + LMCache MP stack (raw_block L2 on an NVMe passthrough
+char device, `/dev/ng*`) rather than a storage microbenchmark — so the numbers
+reflect user-facing **TTFT** and **throughput**, not just device bandwidth.
+
+## Result
+
+Llama-3.1-8B, 1× H100, Gen5 NVMe passthrough. Baseline arm = per-chunk
+`read_uring()` (QD~1); fixed arm = `batched_read()` + one `wait_iouring()` per
+object. KV genuinely resident on the device (guards below prove it).
+
+### Realistic default (`mq_timeout=10s`, recompute fallback on)
+What a deployed user sees — vLLM abandons a load that misses the window and
+recomputes on the GPU instead.
+
+| metric              | baseline (QD~1) | batched (QD256) | speedup |
+|---------------------|----------------:|----------------:|--------:|
+| C=1 TTFT p50        |        3154 ms  |         779 ms  |  4.0×   |
+| C=1 TTFT p99        |        3960 ms  |         813 ms  |  4.9×   |
+| C=4 TTFT p50        |        7008 ms  |        1476 ms  |  4.7×   |
+| C=4 throughput      |      0.52 req/s |      2.60 req/s |  5.0×   |
+| external hit rate   |         47–56 % |         73–83 % |    —    |
+
+### Isolated storage load (`mq_timeout=90s`, no recompute rescue)
+Loads *wait* for storage, so baseline TTFT is the full QD~1 restore time.
+
+| metric              | baseline (QD~1) | batched (QD256) | speedup |
+|---------------------|----------------:|----------------:|--------:|
+| C=1 TTFT p50        |       11885 ms  |         763 ms  | 15.6×   |
+| C=4 TTFT p50        |       20248 ms  |        1375 ms  | 14.7×   |
+| C=4 throughput      |      0.19 req/s |      2.76 req/s | 14.5×   |
+
+Batched TTFT is stable across both configs (779→763 ms) — it loads fast enough
+to never hit the timeout. Baseline swings 3154→11885 ms with the timeout,
+proving its slowness *is* the QD~1 storage load. The slow path also loses the
+cache: its loads time out into recompute, so the external-cache hit rate falls
+to 47–56 % vs 73–83 %.
+
+## Running it
+
+```bash
+# prepare two core.py variants to compare (see ab_arm.sh header), then:
+DEVICE=/dev/ng1n1 NVME_CTRL=/dev/nvme1 MODEL=meta-llama/Llama-3.1-8B-Instruct \
+  MQ_TIMEOUT=10 ./ab_arm.sh stock
+MQ_TIMEOUT=10 ./ab_arm.sh batched
+# repeat with MQ_TIMEOUT=90 to isolate the storage load from recompute.
+```
+
+`ab_arm.sh` brings up one arm end to end and emits the validity guards.
+`ab_drive.py` is the TTFT driver: it warms N distinct long prefixes to L2, then
+measures by cycling them round-robin. **Paths and geometry are host-specific and
+exposed as overridable environment variables** — adapt them to your setup.
+
+## Why a naive serving A/B is invalid — the four confounds
+
+Each of these silently collapses the two arms to *equal* (or produces garbage),
+and each is instrumented out here. If you skip the guards you will "measure" no
+difference and wrongly conclude the change does nothing.
+
+1. **L1 DRAM-cache dilution.** The first load promotes KV into the L1 memory
+   tier; repeat requests hit L1, not raw_block. A single repeated prefix always
+   caches. → Use *N distinct* prefixes with a working set ≫ L1 and cycle them
+   round-robin so every revisit misses L1. *Guard:* tier split shows `0 L1`.
+
+2. **Staging-pool starvation.** `--eviction-policy noop` with a small L1 fills
+   the shared DRAM pool and never evicts, so store/load allocations fail
+   (`Failed to batched allocate … no memory`) and vLLM recomputes everything
+   (external hit ~0 %). → Use `--eviction-policy LRU` and size L1 for concurrent
+   staging while keeping it ≪ working set. *Guard:* 0 alloc failures.
+
+3. **Recompute masking.** At the default `mq_timeout`, the baseline's slow loads
+   time out and fall back to GPU recompute, which *caps* baseline TTFT and hides
+   the true storage penalty. → Sweep `mq_timeout` (10 s realistic, 90 s to
+   isolate storage) and report both. *Guard:* external hit rate.
+
+4. **iostat is blind to io_uring_cmd.** Block-layer counters (`/proc/diskstats`,
+   `iostat`) do **not** count NVMe passthrough on `/dev/ng`, so they read ~0
+   even under a heavy load. → Use the controller's own `Data Units Read`
+   (`nvme smart-log -o json`), which counts passthrough. *Guard:* device GB read.
+
+## Metrics reported
+TTFT p50/p99 at C=1 (latency) and C≥4 (saturation); throughput (req/s);
+external prefix-cache hit rate (loads served from LMCache vs recompute);
+tier split (no L1 dilution); alloc failures (no pool starvation); device GB
+read via the NVMe controller counter (device-served, passthrough-aware).

--- a/benchmarks/raw_block/ab_arm.sh
+++ b/benchmarks/raw_block/ab_arm.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# End-to-end A/B for the raw_block io_uring_cmd load path: bring up a real
+# LMCache MP server (raw_block L2 on an NVMe passthrough char device) + vLLM,
+# drive TTFT at low and higher concurrency, and emit validity guards that prove
+# the loads were actually served from the device (not the L1 DRAM cache and not
+# GPU recompute). See README.md for the four confounds these guards defend.
+#
+# Usage:  ab_arm.sh <arm-label>
+#   The script copies "$CORE_VARIANT_DIR/core_<arm-label>.py" over the live
+#   raw_block core.py, so prepare two variants to compare, e.g.
+#     core_stock.py    -- baseline (per-chunk read_uring, QD~1)
+#     core_batched.py  -- batched_read()+wait_iouring() per object
+#   Upstream you would instead compare two builds/branches; the in-place toggle
+#   is just a convenience for a single checkout.
+#
+# All host-specific values below are overridable via the environment.
+set -u
+ARM="$1"
+
+# ---- environment-specific config (override via env) -------------------------
+: "${DEVICE:=/dev/ng1n1}"                 # NVMe passthrough char device (io_uring_cmd)
+: "${NVME_CTRL:=/dev/nvme1}"              # its controller, for smart-log counters
+: "${MODEL:=meta-llama/Llama-3.1-8B-Instruct}"
+: "${SLOT_BYTES:=33685504}"              # per-object slot (KV chunk + 128KiB header)
+: "${L1_SIZE_GB:=24}"                    # DRAM pool: >= concurrent staging, << working set
+: "${MQ_TIMEOUT:=10}"                    # connector load timeout (s); 10=realistic, 90=isolate storage
+: "${MAX_WORKERS:=4}"
+: "${MP_PORT:=6555}"; : "${HTTP_PORT:=8080}"; : "${VLLM_PORT:=8000}"
+: "${CORE_PATH:=$HOME/kvio/LMCache/lmcache/v1/storage_backend/raw_block/core.py}"
+: "${CORE_VARIANT_DIR:=$HOME/kvio}"      # holds core_<arm>.py variants
+: "${BIN:=}"                             # optional venv bin dir prefix, e.g. ~/venv/bin
+: "${OUTDIR:=$HOME/kvio-bench/ab}"
+: "${DRIVER:=$(dirname "$0")/ab_drive.py}"
+lmcache() { ${BIN:+$BIN/}lmcache "$@"; }
+vllm()    { ${BIN:+$BIN/}vllm "$@"; }
+py()      { ${BIN:+$BIN/}python3 "$@"; }
+# -----------------------------------------------------------------------------
+
+D="$OUTDIR"; mkdir -p "$D"; RES="$D/result_$ARM.txt"
+export LMCACHE_TRACK_USAGE=false
+: > "$RES"; echo "==== ARM=$ARM $(date +%T)  mq_timeout=$MQ_TIMEOUT ====" >> "$RES"
+
+# kill any prior stack (use exact patterns, never a bare 'vllm' that self-matches)
+pkill -f "bin/vllm" 2>/dev/null; pkill -f "bin/lmcache server" 2>/dev/null; sleep 6
+pkill -9 -f "bin/vllm" 2>/dev/null; sleep 2
+sudo chown "$USER" "$DEVICE" 2>/dev/null || true
+
+# select the arm's core.py variant
+cp "$CORE_VARIANT_DIR/core_$ARM.py" "$CORE_PATH"
+echo "core.py <- core_$ARM.py ($(grep -c 'batched_read(chunk_offsets' "$CORE_PATH") batched-markers)" >> "$RES"
+
+CUDA_VISIBLE_DEVICES=0 \
+nohup lmcache server --l1-size-gb "$L1_SIZE_GB" --l1-align-bytes 131072 \
+  --eviction-policy LRU --l2-store-policy skip_l1 --l2-prefetch-policy default \
+  --l2-adapter "{\"type\":\"raw_block\",\"device_path\":\"$DEVICE\",\"slot_bytes\":$SLOT_BYTES,\"block_align\":131072,\"header_bytes\":131072,\"io_engine\":\"io_uring\",\"use_uring_cmd\":true,\"load_checkpoint_on_init\":false}" \
+  --max-workers "$MAX_WORKERS" --port "$MP_PORT" --http-port "$HTTP_PORT" > "$D/mp_$ARM.log" 2>&1 &
+sleep 12
+ss -ltn | grep -q "$MP_PORT" || { echo "MP FAILED" >> "$RES"; tail -5 "$D/mp_$ARM.log" >> "$RES"; exit 1; }
+
+env -u VLLM_PORT CUDA_VISIBLE_DEVICES=0 VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+nohup vllm serve "$MODEL" \
+  --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_load_failure_policy\":\"recompute\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$MP_PORT,\"lmcache.mp.mq_timeout\":$MQ_TIMEOUT}}" \
+  --attention-backend FLASH_ATTN --no-enable-prefix-caching \
+  --port "$VLLM_PORT" --no-async-scheduling > "$D/vllm_$ARM.log" 2>&1 &
+
+UP=0
+for i in $(seq 1 96); do
+  [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$VLLM_PORT/health 2>/dev/null)" = 200 ] && { UP=1; break; }
+  sleep 5
+done
+[ "$UP" = 1 ] || { echo "VLLM FAILED" >> "$RES"; tail -8 "$D/vllm_$ARM.log" >> "$RES"; exit 1; }
+echo "stack up $(date +%T)" >> "$RES"
+
+# The authoritative device-read counter is the NVMe controller's Data Units Read
+# (512KB units). It COUNTS io_uring_cmd passthrough, which block-layer iostat /
+# /proc/diskstats do NOT -- so it is how we prove loads hit the device.
+MPLINE=$(wc -l < "$D/mp_$ARM.log"); VLINE=$(wc -l < "$D/vllm_$ARM.log")
+duread() { sudo nvme smart-log "$NVME_CTRL" -o json 2>/dev/null \
+    | py -c "import sys,json;print(json.load(sys.stdin)['data_units_read'])"; }
+: > "$D/devgb_$ARM.txt"
+drive_one() { # $1=concurrency $2=duration_s
+  u0=$(duread)
+  py "$DRIVER" --arm "$ARM" --concurrency "$1" --duration "$2" 2>&1 \
+    | grep -E "RESULT|warmed|NO_COMPLETED" >> "$RES"
+  u1=$(duread)
+  echo "  C=$1 device GB read = $(py -c "print(f'{($u1-$u0)*0.000512:.2f}')")" >> "$D/devgb_$ARM.txt"
+}
+drive_one 1 45
+drive_one 4 30
+
+# ---- validity guards (README.md explains each) ------------------------------
+echo "--- external prefix cache hit rate (LOW ~0 => GPU recompute, not cache) ---" >> "$RES"
+tail -n +"$VLINE" "$D/vllm_$ARM.log" | grep -oE "External prefix cache hit rate: [0-9.]+%" | sort -t: -k2 -n | tail -3 >> "$RES"
+echo "--- alloc failures (>0 => staging pool starved => silent recompute) ---" >> "$RES"
+echo "  $(tail -n +"$MPLINE" "$D/mp_$ARM.log" | grep -c 'Failed to batched allocate') alloc failures" >> "$RES"
+echo "--- device GB read per pass (NVMe ctrl counter; counts passthrough) ---" >> "$RES"
+cat "$D/devgb_$ARM.txt" >> "$RES"
+echo "--- tier split (want 0 L1 => no DRAM-cache dilution) ---" >> "$RES"
+tail -n +"$MPLINE" "$D/mp_$ARM.log" | grep -oE "retained keys \([0-9]+ L1, [0-9]+ L2\)" | sort | uniq -c | tail -6 >> "$RES"
+
+pkill -f "bin/vllm" 2>/dev/null; pkill -f "bin/lmcache server" 2>/dev/null; sleep 5
+pkill -9 -f "bin/vllm" 2>/dev/null
+echo "ARM_DONE $ARM $(date +%T)" >> "$RES"

--- a/benchmarks/raw_block/ab_drive.py
+++ b/benchmarks/raw_block/ab_drive.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""E8 A/B driver: force raw-block (L2) hits via WORKING-SET >> L1. Warms K distinct
+long prefixes (stored to L2), then measures TTFT by cycling them round-robin so
+each is evicted from the small L1 before revisit -> loads come from L2 (raw_block).
+Measure TTFT at concurrency 1 and a saturation point."""
+
+# Standard
+import argparse
+import json
+import os
+import random
+import threading
+import time
+
+# Third Party
+import requests
+
+URL = os.environ.get("KVIO_URL", "http://localhost:8000/v1/completions")
+MODEL = os.environ.get("KVIO_MODEL", "meta-llama/Llama-3.1-8B-Instruct")
+VOCAB = (
+    "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima "
+    "mike november oscar papa quebec romeo sierra tango"
+).split()
+
+
+def make_prefix(seed, nwords):
+    r = random.Random(seed)
+    return (
+        "Document "
+        + str(seed)
+        + ": "
+        + " ".join(r.choice(VOCAB) + str(r.randint(0, 999)) for _ in range(nwords))
+    )
+
+
+def ttft_once(prompt):
+    t0 = time.perf_counter()
+    try:
+        r = requests.post(
+            URL,
+            json={
+                "model": MODEL,
+                "prompt": prompt,
+                "max_tokens": 4,
+                "temperature": 0,
+                "stream": True,
+            },
+            stream=True,
+            timeout=300,
+        )
+    except Exception:
+        return None
+    ttft = None
+    for line in r.iter_lines():
+        if line and line.startswith(b"data:"):
+            d = line[5:].strip()
+            if d == b"[DONE]":
+                break
+            try:
+                j = json.loads(d)
+            except Exception:
+                continue
+            if j.get("choices") and j["choices"][0].get("text") and ttft is None:
+                ttft = time.perf_counter() - t0
+    r.close()
+    return ttft
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", required=True)
+    ap.add_argument("--concurrency", type=int, default=1)
+    ap.add_argument("--words", type=int, default=11000)  # ~14K tokens ~ 1.75GB KV
+    ap.add_argument("--nprefix", type=int, default=24)  # working set ~ 42GB >> L1
+    ap.add_argument("--duration", type=float, default=25.0)
+    a = ap.parse_args()
+
+    prefixes = [make_prefix(1000 + i, a.words) for i in range(a.nprefix)]
+    # WARM: store all prefixes to L2 (once each). Only done for concurrency==1 pass;
+    # the 2nd pass reuses what's already on the device.
+    if a.concurrency == 1:
+        for p in prefixes:
+            ttft_once(p)
+        print(f"[{a.arm}] warmed {a.nprefix} prefixes to L2", flush=True)
+        time.sleep(6)
+
+    # MEASURE: round-robin cycle -> each prefix maximally evicted from L1 -> L2 load
+    ttfts = []
+    idx = [0]
+    stop = time.time() + a.duration
+    lock = threading.Lock()
+
+    def worker():
+        while time.time() < stop:
+            with lock:
+                p = prefixes[idx[0] % a.nprefix]
+                idx[0] += 1
+            t = ttft_once(p)
+            if t is not None:
+                with lock:
+                    ttfts.append(t)
+
+    threads = [
+        threading.Thread(target=worker, daemon=True) for _ in range(a.concurrency)
+    ]
+    t0 = time.time()
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join(timeout=a.duration + 40)
+    elapsed = time.time() - t0
+
+    ttfts.sort()
+    n = len(ttfts)
+    if n == 0:
+        print(f"RESULT arm={a.arm} C={a.concurrency} n=0 NO_COMPLETED", flush=True)
+        return
+    p50 = ttfts[n // 2]
+    p99 = ttfts[min(n - 1, int(0.99 * n))]
+    print(
+        f"RESULT arm={a.arm} C={a.concurrency} n={n} "
+        f"TTFT_p50={p50 * 1000:.0f}ms TTFT_p99={p99 * 1000:.0f}ms "
+        f"tput={n / elapsed:.2f}req/s",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -545,6 +545,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             fdp_slot_affinity_enabled=(
                 self.fdp_slot_reuse_policy == _FDP_SLOT_REUSE_POLICY_PID_AFFINITY
             ),
+            # Reuse the existing num_load_workers knob to bound how many objects'
+            # reads load_many_into keeps in flight; serial loading pins the NVMe
+            # passthrough path at QD~1.
+            load_parallelism=self.num_load_workers,
         )
 
 

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1422,6 +1422,15 @@ class RawBlockCore:
     ) -> None:
         """Read buffers as bounded NVMe raw-command chunks.
 
+        Each object is split into ``max_data_transfer_size`` chunks; all of an
+        object's (and all objects') chunk reads are submitted together through
+        ``batched_read()`` + a single ``wait_iouring()``. The chunks are
+        independent reads into non-overlapping destination ranges, so letting
+        the ring pipeline them keeps the device queue busy. The previous
+        implementation issued one chunk per ``read_uring()`` call and blocked
+        on its completion before the next, pinning the device at QD~1 (~1.3 GB/s
+        vs ~5 GB/s single-threaded on a Gen5 drive).
+
         Args:
             offsets: Device offsets for each logical read.
             buffers: Destination buffers.
@@ -1433,7 +1442,12 @@ class RawBlockCore:
             Exception: Propagates Rust raw-device read errors.
         """
         raw_dev = self._rawdev()
-        read_uring = raw_dev.read_uring
+
+        chunk_offsets: list[int] = []
+        chunk_buffers: list[Any] = []
+        chunk_lens: list[int] = []
+        keepalive: list[Any] = []  # hold bounce targets alive until wait returns
+        copybacks: list[tuple[Any, memoryview, int]] = []
 
         for offset, buf, payload_len, total_len in zip(
             offsets, buffers, payload_lens, total_lens, strict=True
@@ -1448,25 +1462,28 @@ class RawBlockCore:
                 if len(dst) < payload_len:
                     raise ValueError("output buffer shorter than payload_len")
                 target = self._allocate_aligned_buffer(total_len)
-                copy_back = True
+                keepalive.append(target)
+                copybacks.append((dst, target, payload_len))
             else:
                 target = dst[:total_len]
-                copy_back = False
 
             cursor = 0
             while cursor < total_len:
                 chunk_len = min(self.max_data_transfer_size, total_len - cursor)
                 self._validate_uring_cmd_chunk(offset + cursor, chunk_len)
-                read_uring(
-                    offset + cursor,
-                    target[cursor : cursor + chunk_len],
-                    chunk_len,
-                    chunk_len,
-                )
+                chunk_offsets.append(offset + cursor)
+                chunk_buffers.append(target[cursor : cursor + chunk_len])
+                chunk_lens.append(chunk_len)
                 cursor += chunk_len
 
-            if copy_back:
-                dst[:payload_len] = target[:payload_len]
+        if not chunk_offsets:
+            return
+
+        batch_id = raw_dev.batched_read(chunk_offsets, chunk_buffers, chunk_lens)
+        raw_dev.wait_iouring(batch_id)
+
+        for dst, target, payload_len in copybacks:
+            dst[:payload_len] = target[:payload_len]
 
     def _write_buffers(
         self,

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Optional
 import ctypes
@@ -198,6 +199,14 @@ class RawBlockCoreConfig:
     use_uring_cmd: bool = False
     meta_checkpoint_placement_id: PlacementId = None
     fdp_slot_affinity_enabled: bool = False
+    # Number of KV objects whose reads may be in flight concurrently in
+    # load_many_into (1 = serial, the default). Each object is a
+    # large transfer that WE split into max_data_transfer_size-sized commands
+    # (this engine is NVMe passthrough: no block layer, so userspace owns the
+    # split, bounded above by the device's MDTS); issuing several objects'
+    # reads at once keeps the device queue busy instead of submitting one
+    # command and waiting for it (QD~1). See load_many_into.
+    load_parallelism: int = 1
 
 
 @dataclass
@@ -270,6 +279,7 @@ class RawBlockCore:
         self.meta_verify_on_load = bool(config.meta_verify_on_load)
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
+        self.load_parallelism = max(1, int(getattr(config, "load_parallelism", 1)))
         self.use_uring_cmd = bool(config.use_uring_cmd)
         self.fdp_slot_affinity_enabled = bool(config.fdp_slot_affinity_enabled)
         self.meta_checkpoint_placement_id = normalize_raw_block_placement_ids(
@@ -381,6 +391,19 @@ class RawBlockCore:
 
         self._raw = None
         self._closed = False
+
+        # Optional pool used by load_many_into to issue several objects' reads
+        # concurrently against the shared device (the per-object read releases
+        # self._lock before doing I/O, and the Rust io_uring binding drops the
+        # GIL during the wait, so this is real concurrency).
+        self._load_pool: Optional[ThreadPoolExecutor] = (
+            ThreadPoolExecutor(
+                max_workers=self.load_parallelism,
+                thread_name_prefix="raw-block-load",
+            )
+            if self.load_parallelism > 1
+            else None
+        )
 
         self._meta_seq: int = 0
         self._meta_dirty_total: int = 0
@@ -877,59 +900,98 @@ class RawBlockCore:
             self._inflight_io_count += 1
 
         results = [False] * len(encoded_keys)
+        pending = [
+            (i, encoded_key, entry)
+            for i, (encoded_key, entry) in enumerate(items)
+            if entry is not None
+        ]
         try:
-            for i, (encoded_key, entry) in enumerate(items):
-                if entry is None:
-                    continue
-                try:
-                    payload_len = int(entry.size)
-                    total_len = (
-                        round_up(payload_len, self.block_align)
-                        if self._requires_transfer_alignment
-                        else payload_len
+            if self._load_pool is not None and len(pending) > 1:
+                # Issue the objects' reads concurrently; each _load_one_into
+                # does its own device I/O with no shared mutable state beyond
+                # the distinct results[i] / objs[i] slots. Propagate the first
+                # exception only when raise_on_error was requested (matching the
+                # serial path, which otherwise logs and continues).
+                futures = [
+                    self._load_pool.submit(
+                        self._load_one_into,
+                        i,
+                        encoded_key,
+                        entry,
+                        objs,
+                        results,
+                        raise_on_error,
                     )
-                    buf = memoryview(objs[i].byte_array)
-                    try:
-                        buf = buf.cast("B")
-                    except Exception:
-                        pass
-
-                    direct_view = self._build_direct_odirect_view(
-                        memory_obj=objs[i],
-                        payload_len=payload_len,
-                        total_len=total_len,
-                        buffer_len=len(buf),
-                        zero_tail=False,
+                    for (i, encoded_key, entry) in pending
+                ]
+                for fut in futures:
+                    fut.result()
+            else:
+                for i, encoded_key, entry in pending:
+                    self._load_one_into(
+                        i, encoded_key, entry, objs, results, raise_on_error
                     )
-                    if direct_view is not None:
-                        self._read_buffers(
-                            [entry.offset + self.header_bytes],
-                            [direct_view],
-                            [
-                                total_len
-                                if len(direct_view) >= total_len
-                                else payload_len
-                            ],
-                            [total_len],
-                        )
-                    else:
-                        self._read_buffers(
-                            [entry.offset + self.header_bytes],
-                            [buf],
-                            [payload_len],
-                            [total_len],
-                        )
-                    objs[i].metadata.cached_positions = entry.meta.cached_positions
-                    results[i] = True
-                except Exception as e:
-                    if raise_on_error:
-                        raise
-                    logger.error("RawBlockCore load failed for %s: %s", encoded_key, e)
         finally:
             with self._lock:
                 self._inflight_io_count -= 1
                 self._last_io_ts = time.monotonic()
         return results
+
+    def _load_one_into(
+        self,
+        i: int,
+        encoded_key: str,
+        entry: "_Entry",
+        objs: Sequence[MemoryObj],
+        results: list[bool],
+        raise_on_error: bool,
+    ) -> None:
+        """Read one indexed object into ``objs[i]``; set ``results[i]``.
+
+        Extracted from load_many_into so the object loop can run either serially
+        or across the load pool. Touches only the caller-provided ``objs[i]`` and
+        ``results[i]``, so concurrent invocations for distinct ``i`` are safe.
+        """
+        try:
+            payload_len = int(entry.size)
+            total_len = (
+                round_up(payload_len, self.block_align)
+                if self._requires_transfer_alignment
+                else payload_len
+            )
+            buf = memoryview(objs[i].byte_array)
+            try:
+                buf = buf.cast("B")
+            except Exception:
+                pass
+
+            direct_view = self._build_direct_odirect_view(
+                memory_obj=objs[i],
+                payload_len=payload_len,
+                total_len=total_len,
+                buffer_len=len(buf),
+                zero_tail=False,
+            )
+            if direct_view is not None:
+                self._read_buffers(
+                    [entry.offset + self.header_bytes],
+                    [direct_view],
+                    [total_len if len(direct_view) >= total_len else payload_len],
+                    [total_len],
+                )
+            else:
+                self._read_buffers(
+                    [entry.offset + self.header_bytes],
+                    [buf],
+                    [payload_len],
+                    [total_len],
+                )
+            objs[i].metadata.cached_positions = entry.meta.cached_positions
+            results[i] = True
+        except Exception as e:
+            if raise_on_error:
+                raise
+            logger.error("RawBlockCore load failed for %s: %s", encoded_key, e)
 
     def unlock_many(self, encoded_keys: Sequence[str]) -> None:
         """Release L2 lock references for encoded keys.
@@ -1065,6 +1127,10 @@ class RawBlockCore:
             self._meta_thread.join(timeout=5)
             self._meta_thread = None
 
+        if self._load_pool is not None:
+            self._load_pool.shutdown(wait=True)
+            self._load_pool = None
+
         try:
             self._checkpoint_once(force=True)
         except Exception as e:
@@ -1086,6 +1152,9 @@ class RawBlockCore:
         if self._meta_thread is not None:
             self._meta_thread.join(timeout=5)
             self._meta_thread = None
+        if self._load_pool is not None:
+            self._load_pool.shutdown(wait=False)
+            self._load_pool = None
         if self._raw is not None:
             try:
                 self._raw.close()

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -1426,9 +1426,9 @@ impl RawBlockDevice {
                         IoUringWrapper::Big(ring) => {
                             let mut ring = ring.lock().unwrap();
                             unsafe {
-                                ring.submission()
-                                    .push(&sqe128)
-                                    .expect("failed to push sqe128");
+                                ring.submission().push(&sqe128).map_err(|_| {
+                                    PyRuntimeError::new_err("submission queue full")
+                                })?;
                             }
                         }
                         IoUringWrapper::Standard(_) => {
@@ -1470,13 +1470,17 @@ impl RawBlockDevice {
                             let mut ring = ring.lock().unwrap();
                             let sqe128: Entry128 = sqe.into();
                             unsafe {
-                                ring.submission().push(&sqe128).expect("failed to push sqe");
+                                ring.submission().push(&sqe128).map_err(|_| {
+                                    PyRuntimeError::new_err("submission queue full")
+                                })?;
                             }
                         }
                         IoUringWrapper::Standard(ring) => {
                             let mut ring = ring.lock().unwrap();
                             unsafe {
-                                ring.submission().push(&sqe).expect("failed to push sqe");
+                                ring.submission().push(&sqe).map_err(|_| {
+                                    PyRuntimeError::new_err("submission queue full")
+                                })?;
                             }
                         }
                     }
@@ -1712,7 +1716,18 @@ impl RawBlockDevice {
                             let batch: Vec<IoSubmission> = std::mem::take(&mut *q);
                             let batch_len = batch.len();
 
-                            let available = ring_size - ring_clone.submission_len();
+                            // Bound OUTSTANDING I/O to the ring depth, not just the number
+                            // of unsubmitted SQEs. submission_len() drops to 0 after each
+                            // submit(), so bounding on it alone lets total in-flight grow past
+                            // the completion-queue capacity; a CQ overflow silently drops
+                            // completions, so in_flight/batch counters never reach 0 and
+                            // wait_iouring() hangs forever. in_flight.len() is the live
+                            // outstanding count on this ring; capping it at ring_size keeps a
+                            // bounded window full and never overflows the CQ.
+                            ring_clone.submission_sync();
+                            let inflight_room = ring_size.saturating_sub(in_flight.len());
+                            let sq_room = ring_size.saturating_sub(ring_clone.submission_len());
+                            let available = std::cmp::min(inflight_room, sq_room);
                             let to_submit_count = std::cmp::min(available, batch_len);
 
                             if to_submit_count < batch_len {

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -84,6 +84,20 @@ class _RecordingRawDevice:
         target[:total_len] = self.read_data[self.read_cursor : end]
         self.read_cursor = end
 
+    def batched_read(
+        self,
+        offsets: list[int],
+        buffers: list[memoryview],
+        lengths: list[int],
+    ) -> int:
+        del offsets
+        for buf, length in zip(buffers, lengths, strict=True):
+            self.read_buffers.append(buf)
+            end = self.read_cursor + length
+            buf[:length] = self.read_data[self.read_cursor : end]
+            self.read_cursor = end
+        return 17
+
 
 def _buffer_address(buf: memoryview) -> int:
     return ctypes.addressof((ctypes.c_byte * 1).from_buffer(buf))


### PR DESCRIPTION
# raw_block: fix effective QD~1 on the io_uring_cmd (NVMe passthrough) load path

- **Branch:** `2026-08-10-fix-raw-block-qd1-load` (on `github.com/mcgrof/LMCache`)
- **Target:** `LMCache/LMCache` `dev` (based on `1a430626`, 2026-08-11)
- **Commits:** 3

The `raw_block` L2 backend restored KV objects one at a time, and within each
object issued one 128 KiB `io_uring_cmd` at a time, blocking on each completion.
On Gen5 NVMe passthrough that pins the load at **QD~1**: eBPF shows ~83 µs between
consecutive 128 KiB submissions against ~16 µs device latency — ~1.2 GB/s, **~11%
of an 11.3 GB/s drive**. `iouring_queue_depth` had no effect, because nothing was
ever in flight to fill the queue.

Two independent serializations — one across objects, one within an object — and a
repro harness.

## The fixes

1. **Across objects — parallelize `load_many_into`.** Factor per-object work into
   `_load_one_into`, dispatch over a `ThreadPoolExecutor` sized by a new
   `RawBlockCoreConfig.load_parallelism` (default `1` = serial, unchanged). The MP
   adapter passes its existing `num_load_workers` (4) through. Safe: the read holds
   `self._lock` only for the index lookup, releases before the I/O, each read
   touches its own slot, and the Rust binding drops the GIL during the wait.
   *128× 20 MiB, `/dev/ng1n1`: 1.9 → 5.3 GB/s (2.8×) at 8 workers.*

2. **Within an object — batch the chunk reads.** The passthrough path split each
   object into 128 KiB chunks and issued them one `read_uring()` at a time. Wire it
   to the `batched_read()` + single `wait_iouring()` primitive the block path
   already uses, so an object's chunks pipeline into non-overlapping ranges. A full
   batch is larger than the ring, so the same commit makes the single io_uring
   worker survive it (see the #4294 note below). Fixes single-object latency, which
   the cross-object pool cannot.
   *Single-threaded: 1.27 → 5.24 GB/s (4.1×); eBPF gap 91.7 → 11.0 µs; QD sweep
   4..256 completes at every ring depth.*

3. **A/B harness** (`benchmarks/raw_block/`) — measured on a real vLLM + LMCache MP
   serving stack, not a microbenchmark.

## Numbers

End-to-end, Llama-3.1-8B, 1× H100, Gen5 NVMe `/dev/ng`, `raw_block` L2, KV resident
on device:

- TTFT p50 **3154 → 779 ms (~4×)** at the default connector `mq_timeout`
- throughput **0.52 → 2.60 req/s (~5×)** at concurrency 4
- isolated storage **11885 → 763 ms (~15×)** with recompute rescue disabled
- external-cache hit rate **47–56% → 73–83%** — the QD~1 path times out and falls
  back to GPU recompute, silently losing the cache

The harness README documents the four confounds that otherwise collapse both arms
to equal: L1 DRAM-cache dilution, staging-pool starvation under eviction-policy
`noop`, recompute masking at low `mq_timeout`, and `iostat` being blind to
`io_uring_cmd` passthrough (use the controller's *Data Units Read*).

## Worker survival under a full batch (commit 2's Rust hunks) and #4294

A batch is larger than the ring, so the single submission worker must survive both
queues filling. Commit 2's `rust/raw_block/src/lib.rs` hunks do two things:

- **Submission queue full.** `build_and_submit_sqe()` pushed SQEs with `.expect()`,
  so a full SQ panicked the worker; a dead worker posts no completions and every
  outstanding load blocks forever. Return the push error instead. Upstream #4294
  ("[Fix][RawBlock] handle uring_cmd SQE build errors") already made the submit
  loop `match` on that `Result` — but left the `.expect()` inside
  `build_and_submit_sqe` on dev, so the error #4294 handles was still a panic in
  practice. This makes it reachable; the two are complementary, not overlapping.
- **Completion queue overflow.** `available = ring_size - submission_len()` bounds
  only *unsubmitted* SQEs, which drop to 0 after each `submit()`, so outstanding
  I/O grew past CQ capacity, completions were silently dropped, and
  `wait_iouring()` hung (a ring ≥ the batch never hung; small rings always did).
  Bound outstanding by the live `in_flight.len()`.

These ride in the batching commit, not a follow-up: `batched_read()` is what first
drives a batch past the ring, so the batching is born able to survive it (bisect
lands on a working commit, never a hang).

## Testing

Based on current `dev` `1a430626` (the bounce-buffer read adopts dev's aligned
allocation); `cargo check` clean on `rust/raw_block`; touched Python compiles.
Numbers above on real Gen5 NVMe passthrough.

All commits carry `Signed-off-by: Luis Chamberlain <mcgrof@do-not-panic.com>`.
