### PR TITLE
fix(nixl): report pool status in allocation-slot units

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -122,6 +122,16 @@ class NixlObjPool:
         with self._lock:
             self.indices.extend(obj_indices)
 
+    def get_slot_counts(self) -> tuple[int, int]:
+        """Return the total and currently free storage slot counts.
+
+        Returns:
+            A tuple containing the total number of slots managed by the pool
+            and the number of slots currently available for allocation.
+        """
+        with self._lock:
+            return self._total, len(self.indices)
+
     def get_slot_usage(self) -> tuple[float, float]:
         """
         Return (current_usage, usage_after_ongoing_eviction) in [0, 1] for
@@ -668,16 +678,14 @@ class NixlStoreL2Adapter(L2AdapterInterface):
             pinned_object_count = sum(
                 1 for obj in self._memory_objects.values() if obj.pin_count > 0
             )
-        pool = self.nixl_agent.pool
-        with pool._lock:
-            pool_free_slots = len(pool.indices)
+        pool_size, pool_free_slots = self.nixl_agent.pool.get_slot_counts()
         return {
             "is_healthy": self._loop_thread.is_alive(),
             "type": "NixlStoreL2Adapter",
             "backend": self._config.backend,
             "stored_object_count": stored_object_count,
             "pinned_object_count": pinned_object_count,
-            "pool_size": self._config.pool_size,
+            "pool_size": pool_size,
             "pool_free_slots": pool_free_slots,
             "event_loop_alive": self._loop_thread.is_alive(),
         }

--- a/tests/v1/distributed/test_nixl_store_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_l2_adapter.py
@@ -7,6 +7,7 @@ Tests only use public methods and do not access private fields.
 """
 
 # Standard
+from pathlib import Path
 from unittest.mock import call, patch
 import errno
 import os
@@ -867,6 +868,68 @@ class TestReportStatus:
         status = adpt.report_status()
         assert status["stored_object_count"] == 1
         assert status["pool_free_slots"] < status["pool_size"]
+
+    def test_report_status_counts_slots_for_multi_page_files(
+        self, tmp_path: Path
+    ) -> None:
+        """Pool status should use page-slot units for multi-page files."""
+        pages_per_file = 3
+        pool_file_count = 2
+        expected_slot_count = pool_file_count * pages_per_file
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        l1_memory = L1MemoryDesc(
+            ptr=buffer.data_ptr(),
+            size=buffer.numel(),
+            align_bytes=PAGE_SIZE,
+        )
+        config = NixlStoreL2AdapterConfig(
+            backend="POSIX",
+            backend_params={
+                "file_path": str(tmp_path),
+                "file_size": str(PAGE_SIZE * pages_per_file),
+                "use_direct_io": "false",
+            },
+            pool_size=pool_file_count,
+        )
+        adpt = NixlStoreL2Adapter(config, l1_memory)
+
+        try:
+            status_before_store = adpt.report_status()
+            assert status_before_store["pool_size"] == expected_slot_count
+            assert status_before_store["pool_free_slots"] == expected_slot_count
+            assert (
+                0
+                <= status_before_store["pool_free_slots"]
+                <= status_before_store["pool_size"]
+            )
+
+            key = create_object_key(42)
+            obj = create_memory_obj(buffer, page_index=0, num_pages=2)
+            _store_and_wait(adpt, key, obj)
+
+            status_during_store = adpt.report_status()
+            assert status_during_store["pool_size"] == expected_slot_count
+            assert status_during_store["pool_free_slots"] == expected_slot_count - 2
+            assert (
+                0
+                <= status_during_store["pool_free_slots"]
+                <= status_during_store["pool_size"]
+            )
+
+            adpt.delete([key])
+
+            status_after_delete = adpt.report_status()
+            assert status_after_delete["pool_size"] == expected_slot_count
+            assert status_after_delete["pool_free_slots"] == expected_slot_count
+            assert (
+                0
+                <= status_after_delete["pool_free_slots"]
+                <= status_after_delete["pool_size"]
+            )
+        finally:
+            adpt.close()
 
     def test_report_status_after_close(self):
         """is_healthy should become False after close()."""


### PR DESCRIPTION
**What this PR does / why we need it**:

For file-backed storage, `NixlStoreL2Adapter.report_status()` reported `pool_size` as the number of backing files but reported `pool_free_slots` as the number of free allocation pages. When a backing file contained multiple pages, the two fields used different units, causing the CLI to display negative pool usage.

This PR adds a public, lock-protected API to `NixlObjPool` for reading the total and free allocation-slot counts together. `report_status()` now uses that API for both fields, which also removes its direct access to the pool's private lock.

The regression test uses POSIX backing files containing multiple aligned pages. It verifies the pool-size invariant before storing an object, while its slots are allocated, and after the object is deleted.

Object backends and one-page-per-file configurations retain their existing behavior. No CLI workaround or value clamping is needed.

Fixes #4698

**Special notes for your reviewers**:

The regression was validated on Linux using NIXL 1.4.0 with the real POSIX backend. With the production fix temporarily reverted, the new test failed as expected because `pool_size` was `2` while the allocation-slot total was `6`. With the fix restored, the regression passed and the complete focused NIXL adapter suite passed with 48 tests.

The changed-file pre-commit checks also pass, including isort, Ruff lint and formatting, codespell, and mypy.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
