### PR TITLE
fix(xpu): preserve cached prefixes in V2/V3 H2D transfers

### DIFF
--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -195,15 +195,15 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         device_ops.multi_layer_kv_transfer(
-            memory_obj.tensor,
-            kv_cache_pointers,
-            slot_mapping[start:end],
-            self.device,
-            self.page_buffer_size,
-            lmcache_native.TransferDirection.H2D,
-            self.engine_kv_format,
-            self.block_size,
-            skip_prefix_n_tokens,
+            key_value=memory_obj.tensor,
+            key_value_ptrs=kv_cache_pointers,
+            slot_mapping=slot_mapping[start:end],
+            paged_memory_device=self.device,
+            page_buffer_size=self.page_buffer_size,
+            direction=lmcache_native.TransferDirection.H2D,
+            engine_kv_format=self.engine_kv_format,
+            block_size=self.block_size,
+            skip_prefix_n_tokens=skip_prefix_n_tokens,
         )
 
     @_lmcache_nvtx_annotate
@@ -242,28 +242,28 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         with torch.xpu.stream(self.store_stream):
             if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
                 device_ops.multi_layer_kv_transfer(
-                    memory_obj.tensor,
-                    kv_cache_pointers,
-                    slot_mapping[start:end],
-                    self.kvcaches[0].device,
-                    self.page_buffer_size,
-                    lmcache_native.TransferDirection.D2H,
-                    self.engine_kv_format,
-                    self.block_size,
+                    key_value=memory_obj.tensor,
+                    key_value_ptrs=kv_cache_pointers,
+                    slot_mapping=slot_mapping[start:end],
+                    paged_memory_device=self.kvcaches[0].device,
+                    page_buffer_size=self.page_buffer_size,
+                    direction=lmcache_native.TransferDirection.D2H,
+                    engine_kv_format=self.engine_kv_format,
+                    block_size=self.block_size,
                 )
             else:
                 # kvcaches -> gpu_buffer -> memobj
                 assert self.gpu_buffer.device == self.kvcaches[0].device
                 tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
                 device_ops.multi_layer_kv_transfer(
-                    tmp_gpu_buffer,
-                    kv_cache_pointers,
-                    slot_mapping[start:end],
-                    self.kvcaches[0].device,
-                    self.page_buffer_size,
-                    lmcache_native.TransferDirection.D2H,
-                    self.engine_kv_format,
-                    self.block_size,
+                    key_value=tmp_gpu_buffer,
+                    key_value_ptrs=kv_cache_pointers,
+                    slot_mapping=slot_mapping[start:end],
+                    paged_memory_device=self.kvcaches[0].device,
+                    page_buffer_size=self.page_buffer_size,
+                    direction=lmcache_native.TransferDirection.D2H,
+                    engine_kv_format=self.engine_kv_format,
+                    block_size=self.block_size,
                 )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
@@ -395,15 +395,15 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
             memory_obj_tensor = memory_obj.get_tensor(i)
             assert memory_obj_tensor is not None
             device_ops.multi_layer_kv_transfer(
-                memory_obj_tensor,
-                kv_cache_pointer,
-                slot_mapping[start:end],
-                self.device,
-                self.page_buffer_size,
-                lmcache_native.TransferDirection.H2D,
-                self.engine_kv_format,
-                self.block_size,
-                skip_prefix_n_tokens,
+                key_value=memory_obj_tensor,
+                key_value_ptrs=kv_cache_pointer,
+                slot_mapping=slot_mapping[start:end],
+                paged_memory_device=self.device,
+                page_buffer_size=self.page_buffer_size,
+                direction=lmcache_native.TransferDirection.H2D,
+                engine_kv_format=self.engine_kv_format,
+                block_size=self.block_size,
+                skip_prefix_n_tokens=skip_prefix_n_tokens,
             )
 
     @_lmcache_nvtx_annotate
@@ -425,14 +425,14 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                     memory_obj_tensor = memory_obj.get_tensor(i)
                     assert memory_obj_tensor is not None
                     device_ops.multi_layer_kv_transfer(
-                        memory_obj_tensor,
-                        kv_cache_pointer,
-                        slot_mapping[start:end],
-                        self.device,
-                        self.page_buffer_size,
-                        lmcache_native.TransferDirection.D2H,
-                        self.engine_kv_format,
-                        self.block_size,
+                        key_value=memory_obj_tensor,
+                        key_value_ptrs=kv_cache_pointer,
+                        slot_mapping=slot_mapping[start:end],
+                        paged_memory_device=self.device,
+                        page_buffer_size=self.page_buffer_size,
+                        direction=lmcache_native.TransferDirection.D2H,
+                        engine_kv_format=self.engine_kv_format,
+                        block_size=self.block_size,
                     )
             else:
                 # kvcaches -> gpu_buffer -> memobj
@@ -442,14 +442,14 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                 ):
                     tmp_gpu_buffer = self.group_tmp_buffer[i][:, :, : end - start, :]
                     device_ops.multi_layer_kv_transfer(
-                        tmp_gpu_buffer,
-                        kv_cache_pointer,
-                        slot_mapping[start:end],
-                        self.device,
-                        self.page_buffer_size,
-                        lmcache_native.TransferDirection.D2H,
-                        self.engine_kv_format,
-                        self.block_size,
+                        key_value=tmp_gpu_buffer,
+                        key_value_ptrs=kv_cache_pointer,
+                        slot_mapping=slot_mapping[start:end],
+                        paged_memory_device=self.device,
+                        page_buffer_size=self.page_buffer_size,
+                        direction=lmcache_native.TransferDirection.D2H,
+                        engine_kv_format=self.engine_kv_format,
+                        block_size=self.block_size,
                     )
                     memory_obj_tensor = memory_obj.get_tensor(i)
                     assert memory_obj_tensor is not None

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -135,6 +135,9 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, engine_kv_format):
     slot_mapping = torch.tensor(
         slot_mapping, device=torch_device_type, dtype=torch.int64
     )
+    num_cached_tokens = 3
+    cached_slot_mapping = slot_mapping[:num_cached_tokens]
+    uncached_slot_mapping = slot_mapping[num_cached_tokens:]
 
     # Check the gpu_kv is not the same before copying
     with pytest.raises(AssertionError):
@@ -151,6 +154,24 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, engine_kv_format):
                 head_size,
                 engine_kv_format,
             )
+
+    # The cached prefix must already differ so the preservation check below
+    # cannot pass if H2D mistakenly overwrites it.
+    with pytest.raises(AssertionError):
+        if use_mla:
+            check_paged_kv_cache_equal_with_mla(
+                gpu_kv_src, gpu_kv_dst, cached_slot_mapping, head_size
+            )
+        else:
+            check_paged_kv_cache_equal(
+                gpu_kv_src,
+                gpu_kv_dst,
+                cached_slot_mapping,
+                num_heads,
+                head_size,
+                engine_kv_format,
+            )
+    gpu_kv_dst_before = [tensor.clone() for tensor in gpu_kv_dst]
 
     connector = VLLMPagedMemXPUConnectorV2(
         hidden_dim,
@@ -196,17 +217,34 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, engine_kv_format):
             kvcaches=gpu_kv_dst,
             slot_mapping=slot_mapping,
             offset=0,
+            vllm_cached_tokens=num_cached_tokens,
         )
         allocator.free(memory_obj)
         assert allocator.memcheck()
 
     if use_mla:
         check_paged_kv_cache_equal_with_mla(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, head_size
+            gpu_kv_dst_before, gpu_kv_dst, cached_slot_mapping, head_size
+        )
+        check_paged_kv_cache_equal_with_mla(
+            gpu_kv_src, gpu_kv_dst, uncached_slot_mapping, head_size
         )
     else:
         check_paged_kv_cache_equal(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
+            gpu_kv_dst_before,
+            gpu_kv_dst,
+            cached_slot_mapping,
+            num_heads,
+            head_size,
+            engine_kv_format,
+        )
+        check_paged_kv_cache_equal(
+            gpu_kv_src,
+            gpu_kv_dst,
+            uncached_slot_mapping,
+            num_heads,
+            head_size,
+            engine_kv_format,
         )
     allocator.close()
 
@@ -264,6 +302,9 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(
     slot_mapping = torch.tensor(
         slot_mapping, device=torch_device_type, dtype=torch.int64
     )
+    num_cached_tokens = 3
+    cached_slot_mapping = slot_mapping[:num_cached_tokens]
+    uncached_slot_mapping = slot_mapping[num_cached_tokens:]
 
     # Check the kv group is not the same before copying
     with pytest.raises(AssertionError):
@@ -281,6 +322,31 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(
                     head_sizes[i],
                     engine_kv_format,
                 )
+
+    for i in range(num_groups):
+        with pytest.raises(AssertionError):
+            if use_mla:
+                check_paged_kv_cache_equal_with_mla(
+                    src_kv_groups[i],
+                    dst_kv_groups[i],
+                    cached_slot_mapping,
+                    head_sizes[i],
+                )
+            else:
+                check_paged_kv_cache_equal(
+                    src_kv_groups[i],
+                    dst_kv_groups[i],
+                    cached_slot_mapping,
+                    num_heads,
+                    head_sizes[i],
+                    engine_kv_format,
+                )
+
+    # Preserve the original destination so the prefix oracle is independent
+    # of the source values copied into the uncached suffix.
+    dst_kv_groups_before = [
+        [tensor.clone() for tensor in group] for group in dst_kv_groups
+    ]
 
     # create metadata and init kv layer groups
     metadata = _create_metadata(use_mla, src_kv_caches, engine_kv_format)
@@ -327,21 +393,39 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(
             kvcaches=list(dst_kv_caches.values()),
             slot_mapping=slot_mapping,
             offset=0,
+            vllm_cached_tokens=num_cached_tokens,
         )
         allocator.free(memory_obj)
         assert allocator.memcheck()
 
-    # Check the kv group is same after copying
+    # The cached prefix stays untouched; only the uncached suffix is loaded.
     for i in range(num_groups):
         if use_mla:
             check_paged_kv_cache_equal_with_mla(
-                src_kv_groups[i], dst_kv_groups[i], slot_mapping, head_sizes[i]
+                dst_kv_groups_before[i],
+                dst_kv_groups[i],
+                cached_slot_mapping,
+                head_sizes[i],
+            )
+            check_paged_kv_cache_equal_with_mla(
+                src_kv_groups[i],
+                dst_kv_groups[i],
+                uncached_slot_mapping,
+                head_sizes[i],
             )
         else:
             check_paged_kv_cache_equal(
+                dst_kv_groups_before[i],
+                dst_kv_groups[i],
+                cached_slot_mapping,
+                num_heads,
+                head_sizes[i],
+                engine_kv_format,
+            )
+            check_paged_kv_cache_equal(
                 src_kv_groups[i],
                 dst_kv_groups[i],
-                slot_mapping,
+                uncached_slot_mapping,
                 num_heads,
                 head_sizes[i],
                 engine_kv_format,


### PR DESCRIPTION
## Summary

- bind all six V2/V3 XPU `multi_layer_kv_transfer` call sites with explicit
  keyword arguments
- pass the computed nonzero prefix through
  `skip_prefix_n_tokens=skip_prefix_n_tokens`
- extend the existing XPU connector tests to verify that cached destination
  slots remain untouched while the uncached suffix is restored

## Root cause

Both V2 and V3 compute the intended prefix skip correctly, but their H2D calls
passed it as positional argument 9. The XPU pybind signature places
`head_size` at position 9 and `skip_prefix_n_tokens` at position 10, so the
value bound to the currently unused `head_size` parameter while the actual
skip retained its default of zero.

This is a pre-existing XPU caller bug and was not introduced by #4467. Using
keywords at every call site also prevents future optional-parameter insertions
from silently changing the caller contract.

## Validation

- `ruff check` passed for both changed files
- `ruff format --check` passed for both changed files
- `git diff --check` passed
- source-level binding probe confirmed six keyword-only calls and, for V2/V3,
  `head_size=0` with `skip_prefix_n_tokens=3`

I do not have Intel XPU hardware, so the updated hardware regression has not
been run locally. Please add the `xpu` label to trigger the repository's
dedicated Intel XPU Buildkite pipeline. This PR remains a draft until that
runtime result is available.
