### PR TITLE
docs: daily drift check — multi-process mode (2026-08-22)

### DIFF
--- a/docs/source/kv_cache_optimizations/cacheblend.rst
+++ b/docs/source/kv_cache_optimizations/cacheblend.rst
@@ -15,9 +15,13 @@ Start the LMCache server with the blend engine:
 
    lmcache server --l1-size-gb 20 --eviction-policy LRU --engine-type blend
 
-The ``blend`` engine composes a ``BlendModule`` into the server and requires
-``--supported-transfer-mode`` to be ``lmcache_driven`` (the default) or ``auto``. See
-:doc:`/mp/configuration` for the related server flags.
+The ``blend`` engine composes a ``BlendV3Module`` — the current paged-aware
+CacheBlend V3 implementation — into the server and requires
+``--supported-transfer-mode`` to be ``lmcache_driven`` (the default) or ``auto``.
+To select the original CacheBlend implementation instead, pass
+``--engine-type blend_legacy``, which composes a ``BlendModule``. See
+:doc:`/mp/configuration` for the related server flags and
+:doc:`/mp/index` for the engine composition and CacheBlend module layout.
 
 .. note::
 


### PR DESCRIPTION
## Summary

Daily docs drift check against `upstream/dev` at
[`f9addd2`](https://github.com/LMCache/LMCache/commit/f9addd212a11b6c15e2f24d59baef31816e19f30),
focused on multi-process mode. One user-facing inconsistency found today,
in `docs/source/kv_cache_optimizations/cacheblend.rst` (the CacheBlend
MP-mode enablement page).

### `docs/source/`

- `docs/source/kv_cache_optimizations/cacheblend.rst` — the *Enabling
  CacheBlend (MP mode)* section still names the module the `blend`
  engine composes as `BlendModule`. Since the CacheBlend V3 rewrite,
  `--engine-type blend` composes a `BlendV3Module` (the paged-aware V3
  implementation); `--engine-type blend_legacy` is what composes the
  original `BlendModule`. This is the only user-facing page that names
  the wrong module for the `blend` engine — both `docs/source/mp/index.rst`
  and `docs/source/mp/configuration.rst` already document the
  `blend` → `BlendV3Module` / `blend_legacy` → `BlendModule` mapping
  correctly.

### `docs/design/`

- No new design-doc drift found today for MP mode. The MP-adjacent
  design docs under `docs/design/v1/multiprocess/`,
  `docs/design/v1/mp_coordinator/`, and `docs/design/v1/mp_observability/`
  describe the current code; the pre-existing
  `docs/design/integration/vllm/lazy_offload.md` staleness (threshold /
  drain-ratio semantics) is already tracked by open PR
  [#4570](https://github.com/LMCache/LMCache/pull/4570), not re-touched
  here.

## Recent MP-touching upstream commits reviewed against docs

Since the previous drift-check base at
[`9997afb`](https://github.com/LMCache/LMCache/commit/9997afbca307fb08915d13e1767b7e40262c9ce7),
these commits landed on `dev`; the docs impact each carries is listed
below:

| Commit | Docs impact reviewed |
| --- | --- |
| [`eea57e1`](https://github.com/LMCache/LMCache/commit/eea57e14be953347d8ab96424e3e86c864d59304) — `[feat][CB] linear hybrid model support (#4468)` | Adds `GroupKind` / `AttnWindowDesc.group_kinds` and reworks `BlendV3Module` so a blend server also serves recurrent-state hybrid clients. No new user-facing flag or connector key. The `BlendModule` / `BlendV3Module` naming drift on `cacheblend.rst` pre-dates this commit (the V3 rewrite already shipped) but this PR's landing made it easy to spot; **addressed in this PR.** The `docs/source/mp/hybrid_models.rst` "Caveats" claim that "content-aware features (CacheGen compression, CacheBlend) do not apply" to Mamba/GDN hybrid pages is worth a follow-up review: after this commit CacheBlend applies to the *attention* groups of a linear-hybrid model (recurrent groups still cache at block boundaries). Flagging but not rewriting here — that's an editorial call about what to promise users, not a routine drift fix. |
| [`c152256`](https://github.com/LMCache/LMCache/commit/c1522561600cb98d6b49699beab97d2316fa24b9) — `[feat] coordinator memory pressure api (#4639)` | The PR added a *Fleet memory* section to `docs/source/mp/coordinator.rst` and a `memory_pressure.md` under `docs/design/v1/mp_coordinator/`. The `/instances/usage` and `/instances/{id}/usage` endpoints, capacity-on-event-stream contract, and `usage_ratio` null semantics all match the shipped `instances_usage_api.py`. No drift. |
| [`96c9e05`](https://github.com/LMCache/LMCache/commit/96c9e05eff7cf796a287939143f96d4bf947736c) — `[MP][Coordinator] Persist the coordinator's durable state to disk (#4678)` | The PR added `--checkpoint-path` / `--checkpoint-interval` / `--metadata-path` rows to `docs/source/cli/coordinator.rst` and `docs/source/mp/coordinator.rst`, and a `persistence/README.md` under `docs/design/v1/mp_coordinator/`. All three flags and their defaults match `MPCoordinatorConfig`. No drift. |
| [`32042ea`](https://github.com/LMCache/LMCache/commit/32042ea26ba23e4b67d956e5a0375028901cd9a0) — `[MP][Coordinator] Add durable-component contract with consistent capture (#4653)` | Design-doc addition (`persistence/README.md`) matching the shipped `DurableComponent` protocol / `quiesce.py`. No user-facing surface. |
| [`d79c537`](https://github.com/LMCache/LMCache/commit/d79c537c6058651f5d42fca05c0c012f81125e3b) — `[MP][Platform]: add timeline-semaphore event IPC backend (#4551)` | Adds a new device-IPC backend under `lmcache/v1/platform/cuda/`, documented in `docs/design/v1/platform/cuda/timeline_semaphore_event_ipc.md`. No user-facing CLI/env surface; no drift. |
| [`b1531bd`](https://github.com/LMCache/LMCache/commit/b1531bd0d6c7ae4a10a1af57ea50d3a5a0dda1b6) — `[Platform][MUSA] Add lazy pinned memory support (#4632)` | Platform-internal change; not user-facing. |
| [`4f96acf`](https://github.com/LMCache/LMCache/commit/4f96acf) / [`1a43062`](https://github.com/LMCache/LMCache/commit/1a43062) / [`6698fbd`](https://github.com/LMCache/LMCache/commit/6698fbd) — ROCm / CI packaging | No user-facing docs implicated. |
| [`f9addd2`](https://github.com/LMCache/LMCache/commit/f9addd212a11b6c15e2f24d59baef31816e19f30) — `tests: refine gpu_connector tests (#4513)` | Test-only. |

## Evidence

### Stale doc (before this PR)

`docs/source/kv_cache_optimizations/cacheblend.rst` line 18 @
`dev@f9addd2`:
https://github.com/LMCache/LMCache/blob/f9addd212a11b6c15e2f24d59baef31816e19f30/docs/source/kv_cache_optimizations/cacheblend.rst#L18

> The ``blend`` engine composes a ``BlendModule`` into the server and requires
> ``--supported-transfer-mode`` to be ``lmcache_driven`` (the default) or ``auto``.

### Actual code

- `lmcache/v1/multiprocess/server.py:245` composes `BlendV3Module` for
  `engine_type == "blend"`:
  https://github.com/LMCache/LMCache/blob/f9addd212a11b6c15e2f24d59baef31816e19f30/lmcache/v1/multiprocess/server.py#L245-L286
- `lmcache/v1/multiprocess/server.py:232` composes `BlendModule` for
  `engine_type == "blend_legacy"`:
  https://github.com/LMCache/LMCache/blob/f9addd212a11b6c15e2f24d59baef31816e19f30/lmcache/v1/multiprocess/server.py#L229-L243

### Matching user-facing docs

Both other pages document the correct mapping:

- `docs/source/mp/index.rst` @ `dev@f9addd2` — the *Engine and Modules*
  block reads "``blend`` appends ``BlendV3Module`` (the current
  paged-aware implementation), and ``blend_legacy`` appends
  ``BlendModule`` (the original)":
  https://github.com/LMCache/LMCache/blob/f9addd212a11b6c15e2f24d59baef31816e19f30/docs/source/mp/index.rst#L100-L130
- `docs/source/mp/configuration.rst` @ `dev@f9addd2` — the
  `--engine-type` row reads "``blend`` selects the current CacheBlend V3
  implementation (composes a ``BlendV3Module`` into the engine);
  ``blend_legacy`` selects the original CacheBlend (composes a
  ``BlendModule``)":
  https://github.com/LMCache/LMCache/blob/f9addd212a11b6c15e2f24d59baef31816e19f30/docs/source/mp/configuration.rst#L57-L67

## Proposed fix

Applied in this PR's diff:

- `docs/source/kv_cache_optimizations/cacheblend.rst` — rewrite the
  *Enabling CacheBlend (MP mode)* prose so the module the `blend`
  engine composes is named as `BlendV3Module` (the paged-aware V3
  implementation), and note that `--engine-type blend_legacy` is what
  now composes the original `BlendModule`. Adds a cross-link to
  `docs/source/mp/index.rst` for the module layout so the two
  descriptions stay in sync.

No code changes; docs only.

## Not fixed in this PR

- The `docs/source/mp/hybrid_models.rst` *Caveats* claim under
  *Mamba / GDN hybrids* that "content-aware features (CacheGen
  compression, CacheBlend) do not apply" is arguably stale after
  #4468's linear-hybrid CacheBlend support, but the actual scope of
  CacheBlend on a linear hybrid (attention groups only, recurrent
  groups still cache at block boundaries) is an editorial promise
  about a just-landed feature, not a routine drift fix — leaving that
  rewrite for a follow-up once a user-facing recipe exists.
- The pre-existing user-facing `lmcache.mp.lazy_offload*` connector
  coverage gap in `docs/source/mp/configuration.rst` is already
  handled by open PR
  [#4596](https://github.com/LMCache/LMCache/pull/4596); not
  duplicated here.
- The pre-existing `docs/design/integration/vllm/lazy_offload.md`
  design-doc staleness (threshold / drain-ratio semantics) is
  already tracked by open PR
  [#4570](https://github.com/LMCache/LMCache/pull/4570); not
  re-touched here.
- The `--enable` (bare) experimental-transfer flag row still missing
  from `docs/source/mp/configuration.rst` is already covered by open
  PR [#4462](https://github.com/LMCache/LMCache/pull/4462); not
  duplicated here.
- The `--coordinator-blend-timeout` / `--coordinator-blend-match-concurrency`
  MP-server-side flags still missing from
  `docs/source/cli/server.rst` and `docs/source/mp/coordinator.rst`
  are already covered by open PR
  [#4669](https://github.com/LMCache/LMCache/pull/4669); not
  duplicated here.

## Notes

Auto-generated by the daily docs drift-check routine. **Human review
required before merge.** Kept as **draft**; not marked "Ready for
review." No code files touched. Deduplicated against prior open
drift-check PRs (#4669, #4633, #4596, #4570, #4519, #4480, #4462,
#4455); today's finding is the CacheBlend enablement page's stale
`BlendModule` mention for the `--engine-type blend` case, which none
of them touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF4YB9MqRv9t34eK3veVrf)_