### PR TITLE
[MP][Coordinator] Add Kafka cache-event sink

### DIFF
--- a/docs/design/v1/mp_coordinator/cache_events.md
+++ b/docs/design/v1/mp_coordinator/cache_events.md
@@ -33,12 +33,18 @@ storage layer ──► EventBus ──► CacheEventSubscriber ──► CacheE
   `POST /events` per flush, batches in list order. Failures
   raise `CacheEventPublishError`; the caller decides retry vs drop
   (both are safe, see above).
-- A future **Kafka sink** produces to a topic with the message key set
-  to `instance_id`, so one partition carries one instance's stream —
-  partition FIFO is exactly the per-instance FIFO the directory needs.
-  The coordinator side gains a consumer that feeds
-  the coordinator's `EventGate`; the subscriber and producers are
-  untouched.
+- **`KafkaCacheEventSink`** produces one JSON record per batch with the
+  message key set to `instance_id`, so Kafka assigns one instance's
+  records to one partition. The producer enables idempotence, requires
+  `acks=all`, and waits for every delivery report before `publish`
+  succeeds. The JSON value uses the existing `CacheEventsRequest`
+  envelope with exactly one batch, keeping the HTTP and Kafka wire
+  vocabulary identical.
+
+The Kafka sink is producer-side only in this milestone. Until
+coordinator-side Kafka consumption lands, retained records are not
+consumed by the coordinator; direct HTTP remains the default end-to-end
+transport.
 
 ## Batching and sequencing (inside the subscriber)
 
@@ -170,11 +176,20 @@ semantics need no change.
 
 ## Wiring and configuration
 
-Enabled in the MP HTTP server lifespan when a coordinator URL is set
-and `--coordinator-event-reporting` (or
-`LMCACHE_COORDINATOR_EVENT_REPORTING`) is on;
-`--coordinator-event-flush-interval` paces the subscriber's
-event-driven flushes (default 1s).
+Enabled in the MP HTTP server lifespan when
+`--coordinator-event-reporting` (or
+`LMCACHE_COORDINATOR_EVENT_REPORTING`) is on. HTTP delivery additionally
+requires a coordinator URL. Kafka publication is independent of HTTP
+coordinator registration and does not require that URL.
+`--coordinator-event-flush-interval` paces the subscriber's event-driven
+flushes (default 1s).
+
+`--coordinator-event-transport kafka` selects Kafka instead of HTTP and
+requires `--coordinator-kafka-bootstrap-servers`. The topic defaults to
+`lmcache-cache-events`; `--coordinator-kafka-delivery-timeout` bounds how
+long one flush waits for broker acknowledgement. Matching
+`LMCACHE_COORDINATOR_KAFKA_*` environment variables are available for
+deployments that configure the server through its environment.
 
 ## Known limitations (follow-ups)
 

--- a/docs/design/v1/mp_coordinator/usage_and_eviction.md
+++ b/docs/design/v1/mp_coordinator/usage_and_eviction.md
@@ -283,9 +283,12 @@ directory.
 | --- | --- | --- | --- |
 | ``event_reporting`` | ``False`` | ``LMCACHE_COORDINATOR_EVENT_REPORTING`` | Enable event reporting (also gates the key-directory stream) |
 | ``event_flush_interval`` | ``1.0`` | ``LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL`` | Seconds between flushes |
+| ``event_sink_config`` | HTTP | ``LMCACHE_COORDINATOR_EVENT_TRANSPORT`` | Direct HTTP or Kafka producer configuration |
 
 Both also accept CLI flags (``--coordinator-event-reporting``,
-``--coordinator-event-flush-interval``).
+``--coordinator-event-flush-interval``). Kafka delivery additionally uses
+``--coordinator-kafka-bootstrap-servers``, ``--coordinator-kafka-topic``, and
+``--coordinator-kafka-delivery-timeout``.
 
 ## Failure modes
 

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -257,6 +257,25 @@ Kubernetes downward API); an explicit flag wins over the env var.
      - ``LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL``
      - Seconds between cache-event batch flushes (must be ``> 0``, default
        ``1``).
+   * - ``--coordinator-event-transport``
+     - ``LMCACHE_COORDINATOR_EVENT_TRANSPORT``
+     - Event delivery transport: ``http`` (default) or ``kafka``.
+   * - ``--coordinator-kafka-bootstrap-servers``
+     - ``LMCACHE_COORDINATOR_KAFKA_BOOTSTRAP_SERVERS``
+     - Comma-separated Kafka bootstrap servers. Required for the ``kafka``
+       event transport.
+   * - ``--coordinator-kafka-topic``
+     - ``LMCACHE_COORDINATOR_KAFKA_TOPIC``
+     - Kafka event topic (default ``lmcache-cache-events``).
+   * - ``--coordinator-kafka-delivery-timeout``
+     - ``LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT``
+     - Seconds to wait for Kafka broker acknowledgement (default ``10``).
+
+The Kafka transport currently implements MP-server publication only. A
+coordinator Kafka source with checkpointed offsets, seeking, and replay is a
+follow-up; use the default HTTP transport for an end-to-end deployment today.
+Kafka publication does not require ``--coordinator-url``; that URL controls
+the separate HTTP registration and heartbeat flow.
 
 The server registers under its stable identity (``--instance-id`` / OTel
 ``service.instance.id``); if the flag is not passed, the server mints a

--- a/lmcache/v1/mp_coordinator/cache_events.py
+++ b/lmcache/v1/mp_coordinator/cache_events.py
@@ -5,7 +5,7 @@ A :class:`CacheEventSubscriber` on the observability event bus turns the
 storage layer's L1/L2 key events (plus the store path's token-binding
 events) into ordered :class:`CacheEventBatch`
 lists and delivers them through a :class:`CacheEventSink` — the
-transport seam (HTTP today, a message queue later). Mapping, batching,
+transport seam (direct HTTP or Kafka). Mapping, batching,
 and delivery all run on the bus's drain thread; there is no dedicated
 emission thread or task. See
 ``docs/design/v1/mp_coordinator/cache_events.md``.
@@ -15,9 +15,11 @@ emission thread or task. See
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
+import math
 import time
 
 # Third Party
+from confluent_kafka import KafkaError, KafkaException, Message, Producer
 import httpx
 
 # First Party
@@ -33,6 +35,11 @@ from lmcache.v1.mp_coordinator.api import (
 from lmcache.v1.mp_coordinator.schemas import CacheEventsRequest
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+from lmcache.v1.multiprocess.config import (
+    CoordinatorConfig,
+    HttpCacheEventSinkConfig,
+    KafkaCacheEventSinkConfig,
+)
 
 logger = init_logger(__name__)
 
@@ -41,6 +48,35 @@ _DEFAULT_FLUSH_INTERVAL = 1.0
 # Token-binding cache bound: covers the window between a chunk's
 # token-binding event and its last (async L2) store event.
 _TOKEN_BINDING_CACHE_SIZE = 65536
+
+
+def create_cache_event_sink(config: CoordinatorConfig) -> "CacheEventSink":
+    """Create the configured MP-server cache-event transport.
+
+    Args:
+        config: Coordinator connection and event-sink configuration.
+
+    Returns:
+        The configured HTTP or Kafka sink.
+
+    Raises:
+        ValueError: If HTTP delivery is selected without a coordinator URL.
+        TypeError: If the sink configuration type is unsupported.
+    """
+    sink_config = config.event_sink_config
+    if isinstance(sink_config, HttpCacheEventSinkConfig):
+        if not config.url:
+            raise ValueError("HTTP cache-event reporting requires a coordinator URL")
+        return HttpCacheEventSink(config.url)
+    if isinstance(sink_config, KafkaCacheEventSinkConfig):
+        return KafkaCacheEventSink(
+            bootstrap_servers=sink_config.bootstrap_servers,
+            topic=sink_config.topic,
+            delivery_timeout=sink_config.delivery_timeout,
+        )
+    raise TypeError(
+        f"unsupported cache-event sink config: {type(sink_config).__name__}"
+    )
 
 
 class CacheEventPublishError(Exception):
@@ -115,6 +151,109 @@ class HttpCacheEventSink(CacheEventSink):
     def close(self) -> None:
         """Close the HTTP client."""
         self._client.close()
+
+
+class KafkaCacheEventSink(CacheEventSink):
+    """Sink that publishes cache-event batches as keyed Kafka records.
+
+    Each :class:`CacheEventBatch` becomes one JSON record keyed by
+    ``instance_id``. Kafka therefore assigns every batch from one emitter to
+    the same partition, preserving the per-instance order required by the
+    coordinator. Publishing blocks until the broker acknowledges every record.
+
+    Args:
+        bootstrap_servers: Comma-separated Kafka bootstrap servers.
+        topic: Topic receiving cache-event records.
+        delivery_timeout: Seconds to wait for delivery acknowledgement.
+
+    Raises:
+        ValueError: If the Kafka sink configuration is invalid.
+    """
+
+    def __init__(
+        self,
+        bootstrap_servers: str,
+        topic: str,
+        delivery_timeout: float,
+    ) -> None:
+        sink_config = KafkaCacheEventSinkConfig(
+            bootstrap_servers=bootstrap_servers,
+            topic=topic,
+            delivery_timeout=delivery_timeout,
+        )
+        self._topic = sink_config.topic
+        self._delivery_timeout = sink_config.delivery_timeout
+        self._producer = Producer(
+            {
+                "bootstrap.servers": sink_config.bootstrap_servers,
+                "client.id": "lmcache-cache-events",
+                "enable.idempotence": True,
+                "acks": "all",
+                "message.timeout.ms": math.ceil(sink_config.delivery_timeout * 1000),
+            }
+        )
+
+    def publish(self, batches: list[CacheEventBatch]) -> None:
+        """Publish batches in list order and wait for broker acknowledgement.
+
+        Args:
+            batches: Batches to publish. Each becomes one keyed Kafka record.
+
+        Raises:
+            CacheEventPublishError: If enqueueing, flushing, or delivery fails.
+        """
+        delivery_errors: list[KafkaError] = []
+
+        def _on_delivery(error: KafkaError | None, message: Message) -> None:
+            del message
+            if error is not None:
+                delivery_errors.append(error)
+
+        try:
+            for batch in batches:
+                payload = CacheEventsRequest(batches=[batch]).model_dump_json().encode()
+                self._producer.produce(
+                    topic=self._topic,
+                    key=batch.instance_id.encode(),
+                    value=payload,
+                    on_delivery=_on_delivery,
+                )
+            remaining = self._producer.flush(self._delivery_timeout)
+        except (BufferError, KafkaException) as e:
+            raise CacheEventPublishError(
+                f"failed to publish {len(batches)} cache-event batches to "
+                f"Kafka topic {self._topic!r}: {e}"
+            ) from e
+
+        if remaining:
+            raise CacheEventPublishError(
+                f"{remaining} of {len(batches)} cache-event batches were not "
+                f"acknowledged by Kafka topic {self._topic!r} within "
+                f"{self._delivery_timeout}s"
+            )
+        if delivery_errors:
+            errors = "; ".join(str(error) for error in delivery_errors)
+            raise CacheEventPublishError(
+                f"Kafka topic {self._topic!r} rejected "
+                f"{len(delivery_errors)} of {len(batches)} cache-event "
+                f"batches: {errors}"
+            )
+
+    def close(self) -> None:
+        """Flush any records still queued during shutdown."""
+        try:
+            remaining = self._producer.flush(self._delivery_timeout)
+        except KafkaException as e:
+            logger.warning(
+                "Failed to flush Kafka cache-event producer during shutdown: %s",
+                e,
+            )
+            return
+        if remaining:
+            logger.warning(
+                "%d Kafka cache-event record(s) remained queued at shutdown",
+                remaining,
+            )
 
 
 @dataclass(frozen=True)

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -208,14 +208,54 @@ class HTTPFrontendConfig:
 
 DEFAULT_HTTP_FRONTEND_CONFIG = HTTPFrontendConfig()
 
+DEFAULT_KAFKA_CACHE_EVENT_TOPIC = "lmcache-cache-events"
+DEFAULT_KAFKA_DELIVERY_TIMEOUT = 10.0
+
+
+@dataclass(frozen=True)
+class HttpCacheEventSinkConfig:
+    """Configuration for direct HTTP cache-event delivery."""
+
+
+@dataclass(frozen=True)
+class KafkaCacheEventSinkConfig:
+    """Configuration for publishing cache events to Kafka.
+
+    Attributes:
+        bootstrap_servers: Comma-separated Kafka bootstrap servers.
+        topic: Topic receiving cache-event records.
+        delivery_timeout: Seconds to wait for broker acknowledgement.
+    """
+
+    bootstrap_servers: str
+    topic: str = DEFAULT_KAFKA_CACHE_EVENT_TOPIC
+    delivery_timeout: float = DEFAULT_KAFKA_DELIVERY_TIMEOUT
+
+    def __post_init__(self) -> None:
+        """Validate Kafka connectivity and delivery settings.
+
+        Raises:
+            ValueError: If bootstrap servers or the topic are empty, or the
+                delivery timeout is not a positive finite number.
+        """
+        if not self.bootstrap_servers.strip():
+            raise ValueError("Kafka bootstrap servers must be non-empty")
+        if not self.topic.strip():
+            raise ValueError("Kafka cache-event topic must be non-empty")
+        if not math.isfinite(self.delivery_timeout) or self.delivery_timeout <= 0:
+            raise ValueError(
+                "Kafka delivery timeout must be a finite number > 0, "
+                f"got {self.delivery_timeout}"
+            )
+
 
 @dataclass
 class CoordinatorConfig:
     """Configuration for joining an MP coordinator (registrant side).
 
-    Consumed by the HTTP server's lifespan to start the registration task.
-    When :attr:`url` is empty, the server registers with no coordinator and
-    runs exactly as before.
+    Consumed by the HTTP server's lifespan to start registration and cache-event
+    reporting. When :attr:`url` is empty, coordinator registration is disabled;
+    Kafka cache-event reporting can still be enabled independently.
     """
 
     url: str = ""
@@ -237,6 +277,11 @@ class CoordinatorConfig:
 
     event_flush_interval: float = 1.0
     """Seconds between cache-event flush attempts to the coordinator."""
+
+    event_sink_config: HttpCacheEventSinkConfig | KafkaCacheEventSinkConfig = field(
+        default_factory=HttpCacheEventSinkConfig
+    )
+    """Transport-specific cache-event delivery configuration."""
 
     blend_timeout: float = 1.0
     """Seconds a fleet CacheBlend lookup may take: both the per-request HTTP
@@ -607,7 +652,8 @@ def add_coordinator_args(
     The registration flags fall back to their ``LMCACHE_COORDINATOR_*``
     environment variables so the server can be configured either way (the env
     var is convenient for the Kubernetes downward API); an explicit flag wins
-    over the env var. The blend client flags have no env fallback.
+    over the env var. The event transport defaults to direct HTTP. The blend
+    client flags have no env fallback.
 
     Args:
         parser: The argument parser to add arguments to.
@@ -655,6 +701,37 @@ def add_coordinator_args(
         default=None,
         help="Seconds between cache-event flush attempts (must be > 0). "
         "Defaults to LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL, then 1.0.",
+    )
+    group.add_argument(
+        "--coordinator-event-transport",
+        choices=("http", "kafka"),
+        default=None,
+        help="Cache-event transport. Defaults to "
+        "LMCACHE_COORDINATOR_EVENT_TRANSPORT, then http.",
+    )
+    group.add_argument(
+        "--coordinator-kafka-bootstrap-servers",
+        type=str,
+        default=None,
+        help="Comma-separated Kafka bootstrap servers. Required when the "
+        "cache-event transport is kafka. Defaults to "
+        "LMCACHE_COORDINATOR_KAFKA_BOOTSTRAP_SERVERS.",
+    )
+    group.add_argument(
+        "--coordinator-kafka-topic",
+        type=str,
+        default=None,
+        help="Kafka topic receiving cache events. Defaults to "
+        "LMCACHE_COORDINATOR_KAFKA_TOPIC, then "
+        f"{DEFAULT_KAFKA_CACHE_EVENT_TOPIC}.",
+    )
+    group.add_argument(
+        "--coordinator-kafka-delivery-timeout",
+        type=float,
+        default=None,
+        help="Seconds to wait for Kafka broker acknowledgement. Defaults to "
+        "LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT, then "
+        f"{DEFAULT_KAFKA_DELIVERY_TIMEOUT}.",
     )
     group.add_argument(
         "--coordinator-blend-timeout",
@@ -715,9 +792,9 @@ def parse_args_to_coordinator_config(
         The configuration object.
 
     Raises:
-        ValueError: If the heartbeat interval, the event flush interval or the
-            blend timeout is not a positive finite number, or if the blend
-            match concurrency is less than 1.
+        ValueError: If a timing value is invalid, the selected event transport
+            is unknown, Kafka settings are incomplete, or the blend match
+            concurrency is less than 1.
     """
     url = (
         args.coordinator_url
@@ -791,6 +868,54 @@ def parse_args_to_coordinator_config(
             "got %s" % event_flush_interval
         )
 
+    event_transport = (
+        args.coordinator_event_transport
+        if args.coordinator_event_transport is not None
+        else os.getenv("LMCACHE_COORDINATOR_EVENT_TRANSPORT", "http")
+    ).lower()
+    if event_transport == "http":
+        event_sink_config: HttpCacheEventSinkConfig | KafkaCacheEventSinkConfig = (
+            HttpCacheEventSinkConfig()
+        )
+    elif event_transport == "kafka":
+        bootstrap_servers = (
+            args.coordinator_kafka_bootstrap_servers
+            if args.coordinator_kafka_bootstrap_servers is not None
+            else os.getenv("LMCACHE_COORDINATOR_KAFKA_BOOTSTRAP_SERVERS", "")
+        )
+        topic = (
+            args.coordinator_kafka_topic
+            if args.coordinator_kafka_topic is not None
+            else os.getenv(
+                "LMCACHE_COORDINATOR_KAFKA_TOPIC",
+                DEFAULT_KAFKA_CACHE_EVENT_TOPIC,
+            )
+        )
+        if args.coordinator_kafka_delivery_timeout is not None:
+            delivery_timeout = args.coordinator_kafka_delivery_timeout
+        else:
+            raw = os.getenv("LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT")
+            if raw:
+                try:
+                    delivery_timeout = float(raw)
+                except ValueError as exc:
+                    raise ValueError(
+                        "LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT is not "
+                        f"a number: {raw!r}"
+                    ) from exc
+            else:
+                delivery_timeout = DEFAULT_KAFKA_DELIVERY_TIMEOUT
+        event_sink_config = KafkaCacheEventSinkConfig(
+            bootstrap_servers=bootstrap_servers,
+            topic=topic,
+            delivery_timeout=delivery_timeout,
+        )
+    else:
+        raise ValueError(
+            "coordinator event transport must be 'http' or 'kafka', "
+            f"got {event_transport!r}"
+        )
+
     blend_timeout = args.coordinator_blend_timeout
     if not math.isfinite(blend_timeout) or blend_timeout <= 0:
         raise ValueError(
@@ -810,6 +935,7 @@ def parse_args_to_coordinator_config(
         heartbeat_interval=heartbeat_interval,
         event_reporting=event_reporting,
         event_flush_interval=event_flush_interval,
+        event_sink_config=event_sink_config,
         blend_timeout=blend_timeout,
         blend_match_concurrency=blend_match_concurrency,
     )

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -22,7 +22,7 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.mp_coordinator.cache_events import (
     CacheEventSubscriber,
-    HttpCacheEventSink,
+    create_cache_event_sink,
 )
 from lmcache.v1.mp_coordinator.registrar import keep_registered
 from lmcache.v1.mp_observability.config import (
@@ -35,6 +35,7 @@ from lmcache.v1.multiprocess.config import (
     DEFAULT_COORDINATOR_CONFIG,
     CoordinatorConfig,
     HTTPFrontendConfig,
+    KafkaCacheEventSinkConfig,
     MPServerConfig,
     add_coordinator_args,
     add_http_frontend_args,
@@ -142,14 +143,16 @@ async def lifespan(app: FastAPI):
             )
         )
     # Optionally report cache events to the coordinator
-    if (
+    if coordinator_config.event_reporting and (
         coordinator_client is not None
-        and coordinator_config.url
-        and coordinator_config.event_reporting
+        or isinstance(
+            coordinator_config.event_sink_config,
+            KafkaCacheEventSinkConfig,
+        )
     ):
         get_event_bus().register_subscriber(
             CacheEventSubscriber(
-                sink=HttpCacheEventSink(coordinator_config.url),
+                sink=create_cache_event_sink(coordinator_config),
                 instance_id=mp_config.instance_id,
                 # Server start time: fences out placements this instance
                 # reported before a restart (its pools restarted empty).

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,6 +5,7 @@ aiohttp
 awscrt
 cryptography
 cufile-python
+confluent-kafka>=2.3.0
 fastapi
 httpx
 huggingface_hub>=1.5.0

--- a/tests/v1/mp_coordinator/fake_kafka.py
+++ b/tests/v1/mp_coordinator/fake_kafka.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small in-memory Kafka test double for cache-event transport tests.
+
+This models only the producer/consumer surface LMCache uses. It is not a Kafka
+protocol implementation and deliberately omits consumer groups, retention,
+rebalance, seeking, and replay; those can be added when the coordinator source
+needs them.
+"""
+
+# Standard
+from collections.abc import Callable
+from dataclasses import dataclass
+
+KafkaDeliveryCallback = Callable[[object | None, "FakeKafkaMessage"], None]
+
+
+@dataclass(frozen=True)
+class FakeKafkaMessage:
+    """One retained record or failed delivery-report message.
+
+    Attributes:
+        topic_name: Topic containing the record.
+        message_key: Record key.
+        message_value: Record value.
+        partition_id: Logical partition number.
+        message_offset: Monotonic partition offset, or ``-1`` when delivery
+            failed before retention.
+    """
+
+    topic_name: str
+    message_key: bytes | None
+    message_value: bytes | None
+    partition_id: int
+    message_offset: int
+
+    def topic(self) -> str:
+        """Return the record topic."""
+        return self.topic_name
+
+    def key(self) -> bytes | None:
+        """Return the record key."""
+        return self.message_key
+
+    def value(self) -> bytes | None:
+        """Return the record value."""
+        return self.message_value
+
+    def partition(self) -> int:
+        """Return the logical partition."""
+        return self.partition_id
+
+    def offset(self) -> int:
+        """Return the partition offset."""
+        return self.message_offset
+
+
+class FakeKafkaBroker:
+    """In-memory append-only topic store shared by fake clients."""
+
+    def __init__(self) -> None:
+        self._messages: dict[str, list[FakeKafkaMessage]] = {}
+
+    def append(
+        self,
+        topic: str,
+        key: bytes | None,
+        value: bytes | None,
+    ) -> FakeKafkaMessage:
+        """Append a record to the topic's single logical partition.
+
+        Args:
+            topic: Destination topic.
+            key: Record key.
+            value: Record value.
+
+        Returns:
+            The retained record with its assigned offset.
+        """
+        messages = self._messages.setdefault(topic, [])
+        message = FakeKafkaMessage(
+            topic_name=topic,
+            message_key=key,
+            message_value=value,
+            partition_id=0,
+            message_offset=len(messages),
+        )
+        messages.append(message)
+        return message
+
+    def messages(self, topic: str) -> tuple[FakeKafkaMessage, ...]:
+        """Return an immutable snapshot of one topic's records.
+
+        Args:
+            topic: Topic to inspect.
+
+        Returns:
+            Records in offset order.
+        """
+        return tuple(self._messages.get(topic, ()))
+
+
+class FakeKafkaProducer:
+    """Synchronous producer double backed by :class:`FakeKafkaBroker`.
+
+    Args:
+        broker: Broker retaining produced records.
+        config: Producer configuration to expose to assertions.
+        delivery_error: Error passed to every delivery callback.
+        remaining_after_flush: Undelivered count returned by :meth:`flush`.
+        produce_error: Error raised instead of queueing a record.
+    """
+
+    def __init__(
+        self,
+        broker: FakeKafkaBroker,
+        config: dict[str, str | int | bool],
+        delivery_error: object | None = None,
+        remaining_after_flush: int = 0,
+        produce_error: Exception | None = None,
+    ) -> None:
+        self._broker = broker
+        self._config = dict(config)
+        self._delivery_error = delivery_error
+        self._remaining_after_flush = remaining_after_flush
+        self._produce_error = produce_error
+        self._pending_records: list[
+            tuple[
+                str,
+                bytes | None,
+                bytes | None,
+                KafkaDeliveryCallback | None,
+            ]
+        ] = []
+
+    @property
+    def config(self) -> dict[str, str | int | bool]:
+        """Return a copy of the producer configuration."""
+        return dict(self._config)
+
+    def produce(
+        self,
+        topic: str,
+        value: bytes | None = None,
+        key: bytes | None = None,
+        on_delivery: KafkaDeliveryCallback | None = None,
+    ) -> None:
+        """Queue a record for delivery during ``flush``.
+
+        Args:
+            topic: Destination topic.
+            value: Record value.
+            key: Record key.
+            on_delivery: Callback notified during :meth:`flush`.
+
+        Raises:
+            Exception: The configured producer failure, when present.
+        """
+        if self._produce_error is not None:
+            raise self._produce_error
+        self._pending_records.append((topic, key, value, on_delivery))
+
+    def flush(self, timeout: float | None = None) -> int:
+        """Complete every queued delivery.
+
+        Args:
+            timeout: Accepted for producer API compatibility.
+
+        Returns:
+            The configured undelivered count, or zero after completing all
+            queued records.
+        """
+        del timeout
+        if self._remaining_after_flush:
+            return self._remaining_after_flush
+        records = self._pending_records
+        self._pending_records = []
+        for topic, key, value, callback in records:
+            if self._delivery_error is None:
+                message = self._broker.append(topic=topic, key=key, value=value)
+            else:
+                message = FakeKafkaMessage(
+                    topic_name=topic,
+                    message_key=key,
+                    message_value=value,
+                    partition_id=0,
+                    message_offset=-1,
+                )
+            if callback is not None:
+                callback(self._delivery_error, message)
+        return 0
+
+
+class FakeKafkaConsumer:
+    """Single-consumer reader for records retained by the fake broker."""
+
+    def __init__(self, broker: FakeKafkaBroker) -> None:
+        self._broker = broker
+        self._topics: list[str] = []
+        self._positions: dict[str, int] = {}
+
+    def subscribe(self, topics: list[str]) -> None:
+        """Subscribe to topics in deterministic polling order.
+
+        Args:
+            topics: Topics to read.
+        """
+        self._topics = list(topics)
+        for topic in topics:
+            self._positions.setdefault(topic, 0)
+
+    def poll(self, timeout: float | None = None) -> FakeKafkaMessage | None:
+        """Return the next retained record, or ``None`` when exhausted.
+
+        Args:
+            timeout: Accepted for consumer API compatibility.
+
+        Returns:
+            The next message in subscription order, or ``None``.
+        """
+        del timeout
+        for topic in self._topics:
+            position = self._positions[topic]
+            messages = self._broker.messages(topic)
+            if position >= len(messages):
+                continue
+            self._positions[topic] = position + 1
+            return messages[position]
+        return None

--- a/tests/v1/mp_coordinator/test_kafka_event_sink.py
+++ b/tests/v1/mp_coordinator/test_kafka_event_sink.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MP-server cache-event publication to Kafka."""
+
+# Standard
+from unittest.mock import patch
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, Tier
+from lmcache.v1.mp_coordinator.api import (
+    CacheEventBatch,
+    CacheEventEntry,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.cache_events import (
+    CacheEventPublishError,
+    HttpCacheEventSink,
+    KafkaCacheEventSink,
+    create_cache_event_sink,
+)
+from lmcache.v1.mp_coordinator.schemas import CacheEventsRequest
+from lmcache.v1.multiprocess.config import (
+    CoordinatorConfig,
+    KafkaCacheEventSinkConfig,
+)
+
+# Local
+from .fake_kafka import FakeKafkaBroker, FakeKafkaConsumer, FakeKafkaProducer
+
+_TOPIC = "cache-events"
+
+
+def _batch(instance_id: str, seq: int) -> CacheEventBatch:
+    """Build one placement batch for transport tests.
+
+    Args:
+        instance_id: Emitter identity.
+        seq: Emitter sequence number.
+
+    Returns:
+        One valid cache-event batch.
+    """
+    key = ObjectKey(
+        chunk_hash=seq.to_bytes(4, "big"),
+        model_name="model",
+        kv_rank=0,
+    )
+    return CacheEventBatch(
+        instance_id=instance_id,
+        incarnation=1,
+        seq=seq,
+        event_type=CacheEventType.STORE,
+        tier=Tier.L1,
+        backend="dram",
+        entries=[
+            CacheEventEntry(
+                key=key.to_encoded_object_key(),
+                size_bytes=1024,
+            )
+        ],
+    )
+
+
+def _sink(
+    broker: FakeKafkaBroker,
+) -> tuple[KafkaCacheEventSink, FakeKafkaProducer]:
+    """Build a Kafka sink backed by the in-memory producer.
+
+    Args:
+        broker: Shared fake broker.
+
+    Returns:
+        The sink and its fake producer.
+    """
+    producer: FakeKafkaProducer | None = None
+
+    def _producer_factory(
+        config: dict[str, str | int | bool],
+    ) -> FakeKafkaProducer:
+        nonlocal producer
+        producer = FakeKafkaProducer(broker, config)
+        return producer
+
+    with patch(
+        "lmcache.v1.mp_coordinator.cache_events.Producer",
+        side_effect=_producer_factory,
+    ):
+        sink = KafkaCacheEventSink(
+            bootstrap_servers="broker-a:9092,broker-b:9092",
+            topic=_TOPIC,
+            delivery_timeout=3.0,
+        )
+    if producer is None:
+        raise RuntimeError("Kafka producer factory was not called")
+    return sink, producer
+
+
+def test_kafka_sink_round_trips_ordered_keyed_records() -> None:
+    broker = FakeKafkaBroker()
+    sink, _ = _sink(broker)
+    batches = [
+        _batch("node-a", 1),
+        _batch("node-a", 2),
+    ]
+
+    sink.publish(batches)
+
+    consumer = FakeKafkaConsumer(broker)
+    consumer.subscribe([_TOPIC])
+    messages = [consumer.poll(), consumer.poll()]
+    assert consumer.poll() is None
+    for offset, (message, expected) in enumerate(zip(messages, batches, strict=True)):
+        assert message is not None
+        assert message.key() == expected.instance_id.encode()
+        assert message.partition() == 0
+        assert message.offset() == offset
+        value = message.value()
+        assert value is not None
+        envelope = CacheEventsRequest.model_validate_json(value)
+        assert envelope.batches == [expected]
+
+
+def test_kafka_sink_configures_durable_ordered_producer() -> None:
+    sink, producer = _sink(FakeKafkaBroker())
+
+    assert isinstance(sink, KafkaCacheEventSink)
+    assert producer.config == {
+        "bootstrap.servers": "broker-a:9092,broker-b:9092",
+        "client.id": "lmcache-cache-events",
+        "enable.idempotence": True,
+        "acks": "all",
+        "message.timeout.ms": 3000,
+    }
+
+
+def test_kafka_sink_factory_uses_kafka_config() -> None:
+    broker = FakeKafkaBroker()
+
+    with patch(
+        "lmcache.v1.mp_coordinator.cache_events.Producer",
+        side_effect=lambda config: FakeKafkaProducer(broker, config),
+    ):
+        sink = create_cache_event_sink(
+            CoordinatorConfig(
+                event_sink_config=KafkaCacheEventSinkConfig(
+                    bootstrap_servers="broker:9092",
+                    topic=_TOPIC,
+                ),
+            )
+        )
+
+    assert isinstance(sink, KafkaCacheEventSink)
+    sink.publish([_batch("node-a", 1)])
+    assert len(broker.messages(_TOPIC)) == 1
+
+
+def test_sink_factory_preserves_default_http_transport() -> None:
+    sink = create_cache_event_sink(CoordinatorConfig(url="http://coordinator:9300"))
+
+    assert isinstance(sink, HttpCacheEventSink)
+    sink.close()
+
+
+def test_http_sink_factory_requires_coordinator_url() -> None:
+    with pytest.raises(ValueError, match="requires a coordinator URL"):
+        create_cache_event_sink(CoordinatorConfig())
+
+
+def test_kafka_sink_validates_direct_configuration() -> None:
+    with pytest.raises(ValueError, match="bootstrap servers must be non-empty"):
+        KafkaCacheEventSink(
+            bootstrap_servers="",
+            topic=_TOPIC,
+            delivery_timeout=1.0,
+        )
+    with pytest.raises(ValueError, match="topic must be non-empty"):
+        KafkaCacheEventSink(
+            bootstrap_servers="broker:9092",
+            topic="",
+            delivery_timeout=1.0,
+        )
+    with pytest.raises(ValueError, match="delivery timeout must be a finite"):
+        KafkaCacheEventSink(
+            bootstrap_servers="broker:9092",
+            topic=_TOPIC,
+            delivery_timeout=0,
+        )
+
+
+def test_kafka_sink_raises_on_delivery_failure() -> None:
+    broker = FakeKafkaBroker()
+
+    with patch(
+        "lmcache.v1.mp_coordinator.cache_events.Producer",
+        side_effect=lambda config: FakeKafkaProducer(
+            broker,
+            config,
+            delivery_error=RuntimeError("delivery failed"),
+        ),
+    ):
+        sink = KafkaCacheEventSink(
+            bootstrap_servers="broker:9092",
+            topic=_TOPIC,
+            delivery_timeout=1.0,
+        )
+
+    with pytest.raises(CacheEventPublishError, match="rejected 1 of 1"):
+        sink.publish([_batch("node-a", 1)])
+    assert broker.messages(_TOPIC) == ()
+
+
+def test_kafka_sink_wraps_producer_enqueue_failure() -> None:
+    broker = FakeKafkaBroker()
+
+    with patch(
+        "lmcache.v1.mp_coordinator.cache_events.Producer",
+        side_effect=lambda config: FakeKafkaProducer(
+            broker,
+            config,
+            produce_error=BufferError("queue full"),
+        ),
+    ):
+        sink = KafkaCacheEventSink(
+            bootstrap_servers="broker:9092",
+            topic=_TOPIC,
+            delivery_timeout=1.0,
+        )
+
+    with pytest.raises(CacheEventPublishError, match="queue full"):
+        sink.publish([_batch("node-a", 1)])
+    assert broker.messages(_TOPIC) == ()
+
+
+def test_kafka_sink_raises_when_flush_times_out() -> None:
+    broker = FakeKafkaBroker()
+
+    with patch(
+        "lmcache.v1.mp_coordinator.cache_events.Producer",
+        side_effect=lambda config: FakeKafkaProducer(
+            broker,
+            config,
+            remaining_after_flush=1,
+        ),
+    ):
+        sink = KafkaCacheEventSink(
+            bootstrap_servers="broker:9092",
+            topic=_TOPIC,
+            delivery_timeout=1.0,
+        )
+
+    with pytest.raises(CacheEventPublishError, match="not acknowledged"):
+        sink.publish([_batch("node-a", 1)])
+    assert broker.messages(_TOPIC) == ()

--- a/tests/v1/mp_coordinator/test_kafka_event_sink.py
+++ b/tests/v1/mp_coordinator/test_kafka_event_sink.py
@@ -3,8 +3,13 @@
 
 # Standard
 from unittest.mock import patch
+from uuid import uuid4
+import os
+import time
 
 # Third Party
+from confluent_kafka import Consumer, Message
+from confluent_kafka.admin import AdminClient, NewTopic
 import pytest
 
 # First Party
@@ -30,6 +35,7 @@ from lmcache.v1.multiprocess.config import (
 from .fake_kafka import FakeKafkaBroker, FakeKafkaConsumer, FakeKafkaProducer
 
 _TOPIC = "cache-events"
+_REAL_KAFKA_BOOTSTRAP_ENV = "LMCACHE_TEST_KAFKA_BOOTSTRAP_SERVERS"
 
 
 def _batch(instance_id: str, seq: int) -> CacheEventBatch:
@@ -120,6 +126,69 @@ def test_kafka_sink_round_trips_ordered_keyed_records() -> None:
         assert value is not None
         envelope = CacheEventsRequest.model_validate_json(value)
         assert envelope.batches == [expected]
+
+
+def test_kafka_sink_round_trips_against_real_broker() -> None:
+    bootstrap_servers = os.environ.get(_REAL_KAFKA_BOOTSTRAP_ENV)
+    if not bootstrap_servers:
+        pytest.skip(f"set {_REAL_KAFKA_BOOTSTRAP_ENV} to test against Kafka")
+        return
+
+    topic = f"lmcache-cache-events-{uuid4().hex}"
+    admin = AdminClient({"bootstrap.servers": bootstrap_servers})
+    topic_result = admin.create_topics(
+        [NewTopic(topic=topic, num_partitions=1, replication_factor=1)]
+    )[topic]
+    topic_result.result(timeout=30.0)
+
+    consumer = Consumer(
+        {
+            "bootstrap.servers": bootstrap_servers,
+            "group.id": f"lmcache-cache-events-{uuid4().hex}",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+        }
+    )
+    sink = KafkaCacheEventSink(
+        bootstrap_servers=bootstrap_servers,
+        topic=topic,
+        delivery_timeout=10.0,
+    )
+    batches = [_batch("node-a", 1), _batch("node-a", 2)]
+
+    try:
+        consumer.subscribe([topic])
+        sink.publish(batches)
+
+        messages: list[Message] = []
+        deadline = time.monotonic() + 30.0
+        while len(messages) < len(batches):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail(f"received {len(messages)} of {len(batches)} Kafka records")
+            message = consumer.poll(timeout=min(1.0, remaining))
+            if message is None:
+                continue
+            if message.error() is not None:
+                pytest.fail(f"Kafka consumer error: {message.error()}")
+            messages.append(message)
+
+        for offset, (message, expected) in enumerate(
+            zip(messages, batches, strict=True)
+        ):
+            assert message.key() == expected.instance_id.encode()
+            assert message.partition() == 0
+            assert message.offset() == offset
+            value = message.value()
+            if value is None:
+                pytest.fail("Kafka record value is missing")
+            envelope = CacheEventsRequest.model_validate_json(value)
+            assert envelope.batches == [expected]
+    finally:
+        sink.close()
+        consumer.close()
+        delete_result = admin.delete_topics([topic], operation_timeout=10.0)[topic]
+        delete_result.result(timeout=30.0)
 
 
 def test_kafka_sink_configures_durable_ordered_producer() -> None:

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -16,7 +16,11 @@ import pytest
 
 # First Party
 from lmcache.v1.multiprocess.config import (
+    DEFAULT_KAFKA_CACHE_EVENT_TOPIC,
+    DEFAULT_KAFKA_DELIVERY_TIMEOUT,
     CoordinatorConfig,
+    HttpCacheEventSinkConfig,
+    KafkaCacheEventSinkConfig,
     MPServerConfig,
     add_coordinator_args,
     add_mp_server_args,
@@ -30,6 +34,10 @@ _COORD_ENV = (
     "LMCACHE_COORDINATOR_HEARTBEAT_INTERVAL",
     "LMCACHE_COORDINATOR_EVENT_REPORTING",
     "LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL",
+    "LMCACHE_COORDINATOR_EVENT_TRANSPORT",
+    "LMCACHE_COORDINATOR_KAFKA_BOOTSTRAP_SERVERS",
+    "LMCACHE_COORDINATOR_KAFKA_TOPIC",
+    "LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT",
 )
 
 
@@ -202,6 +210,7 @@ def test_event_reporting_defaults_are_disabled():
     config = _parse([])
     assert config.event_reporting is False
     assert config.event_flush_interval == 1.0
+    assert isinstance(config.event_sink_config, HttpCacheEventSinkConfig)
 
 
 def test_event_reporting_flags_are_parsed():
@@ -227,6 +236,112 @@ def test_event_reporting_env_fallback(monkeypatch):
 def test_event_flush_interval_rejects_nonpositive():
     with pytest.raises(ValueError):
         _parse(["--coordinator-event-flush-interval", "0"])
+
+
+def test_kafka_event_transport_flags_are_parsed():
+    config = _parse(
+        [
+            "--coordinator-event-transport",
+            "kafka",
+            "--coordinator-kafka-bootstrap-servers",
+            "broker-a:9092,broker-b:9092",
+            "--coordinator-kafka-topic",
+            "events",
+            "--coordinator-kafka-delivery-timeout",
+            "2.5",
+        ]
+    )
+
+    assert config.event_sink_config == KafkaCacheEventSinkConfig(
+        bootstrap_servers="broker-a:9092,broker-b:9092",
+        topic="events",
+        delivery_timeout=2.5,
+    )
+
+
+def test_kafka_event_transport_env_fallback(monkeypatch):
+    monkeypatch.setenv("LMCACHE_COORDINATOR_EVENT_TRANSPORT", "kafka")
+    monkeypatch.setenv(
+        "LMCACHE_COORDINATOR_KAFKA_BOOTSTRAP_SERVERS",
+        "broker:9092",
+    )
+    monkeypatch.setenv("LMCACHE_COORDINATOR_KAFKA_TOPIC", "events")
+    monkeypatch.setenv("LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT", "4")
+
+    config = _parse([])
+
+    assert config.event_sink_config == KafkaCacheEventSinkConfig(
+        bootstrap_servers="broker:9092",
+        topic="events",
+        delivery_timeout=4.0,
+    )
+
+
+def test_kafka_event_transport_requires_bootstrap_servers():
+    with pytest.raises(ValueError, match="bootstrap servers must be non-empty"):
+        _parse(["--coordinator-event-transport", "kafka"])
+
+
+def test_kafka_event_transport_uses_topic_and_timeout_defaults():
+    config = _parse(
+        [
+            "--coordinator-event-transport",
+            "kafka",
+            "--coordinator-kafka-bootstrap-servers",
+            "broker:9092",
+        ]
+    )
+
+    assert config.event_sink_config == KafkaCacheEventSinkConfig(
+        bootstrap_servers="broker:9092",
+        topic=DEFAULT_KAFKA_CACHE_EVENT_TOPIC,
+        delivery_timeout=DEFAULT_KAFKA_DELIVERY_TIMEOUT,
+    )
+
+
+def test_kafka_event_transport_rejects_empty_topic():
+    with pytest.raises(ValueError, match="topic must be non-empty"):
+        _parse(
+            [
+                "--coordinator-event-transport",
+                "kafka",
+                "--coordinator-kafka-bootstrap-servers",
+                "broker:9092",
+                "--coordinator-kafka-topic",
+                "",
+            ]
+        )
+
+
+@pytest.mark.parametrize("timeout", ["0", "-1", "nan", "inf"])
+def test_kafka_delivery_timeout_rejects_invalid_value(timeout):
+    with pytest.raises(ValueError, match="delivery timeout must be a finite"):
+        _parse(
+            [
+                "--coordinator-event-transport",
+                "kafka",
+                "--coordinator-kafka-bootstrap-servers",
+                "broker:9092",
+                "--coordinator-kafka-delivery-timeout",
+                timeout,
+            ]
+        )
+
+
+def test_kafka_delivery_timeout_rejects_non_numeric_env(monkeypatch):
+    monkeypatch.setenv("LMCACHE_COORDINATOR_EVENT_TRANSPORT", "kafka")
+    monkeypatch.setenv("LMCACHE_COORDINATOR_KAFKA_BOOTSTRAP_SERVERS", "broker:9092")
+    monkeypatch.setenv("LMCACHE_COORDINATOR_KAFKA_DELIVERY_TIMEOUT", "slow")
+
+    with pytest.raises(ValueError, match="is not a number"):
+        _parse([])
+
+
+def test_event_transport_rejects_unknown_env_value(monkeypatch):
+    monkeypatch.setenv("LMCACHE_COORDINATOR_EVENT_TRANSPORT", "unknown")
+
+    with pytest.raises(ValueError, match="must be 'http' or 'kafka'"):
+        _parse([])
 
 
 # -- Deprecated pre-v0.5.3 aliases (operator <= v0.5.2 still emits these) -----

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -1,18 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the POST /cache/checksums endpoint (and other MP HTTP routes)."""
+"""Tests for MP HTTP server routes and lifespan wiring."""
 
 # Standard
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
+import asyncio
 
 # Third Party
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import pytest
 import torch
 
 # First Party
+from lmcache.v1.mp_coordinator.cache_events import CacheEventSink
+from lmcache.v1.mp_observability.config import ObservabilityConfig
+from lmcache.v1.multiprocess.config import (
+    CoordinatorConfig,
+    HTTPFrontendConfig,
+    KafkaCacheEventSinkConfig,
+    MPServerConfig,
+)
 from lmcache.v1.multiprocess.http_apis.dependencies import build_context
 from lmcache.v1.multiprocess.http_server import app
 import lmcache.lmcache_native as lmcache_native
+import lmcache.v1.multiprocess.http_server as http_server
 
 
 def _make_kv_tensors(
@@ -377,3 +388,53 @@ class TestHealthAndMiscEndpoints:
         resp = client_with_engine.get("/status")
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
+
+
+def test_kafka_event_reporting_registers_subscriber_without_coordinator_url() -> None:
+    """Kafka event reporting does not require HTTP coordinator registration."""
+    coordinator_config = CoordinatorConfig(
+        event_reporting=True,
+        event_sink_config=KafkaCacheEventSinkConfig(
+            bootstrap_servers="broker:9092",
+        ),
+    )
+    mp_config = MPServerConfig()
+    engine = MagicMock()
+    zmq_server = MagicMock()
+    event_bus = MagicMock()
+    sink = MagicMock(spec=CacheEventSink)
+    configs = {
+        "mp": mp_config,
+        "storage_manager": MagicMock(),
+        "observability": ObservabilityConfig(),
+        "http": HTTPFrontendConfig(),
+        "coordinator": coordinator_config,
+    }
+    test_app = FastAPI()
+
+    async def _exercise_lifespan(create_sink: MagicMock) -> None:
+        async with http_server.lifespan(test_app):
+            create_sink.assert_called_once_with(coordinator_config)
+            event_bus.register_subscriber.assert_called_once()
+
+    with (
+        patch.object(http_server, "_configs", configs),
+        patch.object(
+            http_server,
+            "run_cache_server",
+            return_value=(zmq_server, engine),
+        ),
+        patch.object(http_server, "build_context", return_value=MagicMock()),
+        patch.object(http_server, "get_event_bus", return_value=event_bus),
+        patch.object(
+            http_server,
+            "create_cache_event_sink",
+            return_value=sink,
+        ) as create_sink,
+        patch.object(http_server.torch_dev, "is_available", return_value=False),
+    ):
+        asyncio.run(_exercise_lifespan(create_sink))
+
+    event_bus.stop.assert_called_once()
+    zmq_server.close.assert_called_once()
+    engine.close.assert_called_once()


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the producer-side Kafka transport for MP-server cache events so deployments can retain events in a durable broker before coordinator-side replay lands.

- Publishes one existing `CacheEventsRequest` JSON envelope per batch, keyed by `instance_id` for per-emitter partition ordering.
- Enables idempotence, requires `acks=all`, and waits for delivery reports before publication succeeds.
- Adds CLI/environment configuration for transport selection, bootstrap servers, topic, and delivery timeout.
- Adds an LMCache-owned in-memory broker/producer/consumer test double for deterministic unit tests without Kafka infrastructure.
- Refs #4226 and #4522.

**Special notes for your reviewers**:

- This is producer-only. Kafka consumption, checkpointed offsets, seeking, and replay remain a follow-up; HTTP remains the default end-to-end transport.
- We should probably think about how do we add support for this in production environment

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
