### PR TITLE
[Bug][MP Observability] tests: anchor extra_stats throughput timestamps to wall-clock (#4566)

### DIFF
--- a/tests/v1/mp_observability/subscribers/logging/test_extra_stats.py
+++ b/tests/v1/mp_observability/subscribers/logging/test_extra_stats.py
@@ -113,14 +113,15 @@ class TestExtraStatsLoggingSubscriber:
     def test_store_window_logs_tokens_size_and_throughput(self):
         subs = ExtraStatsLoggingSubscriber(_INTERVAL).get_subscriptions()
         with _capture_logs() as handler:
+            now = time.time()
             subs[EventType.MP_STORE_START](
-                _start(EventType.MP_STORE_START, "req-1", 100.0)
+                _start(EventType.MP_STORE_START, "req-1", now)
             )
             subs[EventType.MP_STORE_END](
                 _end(
                     EventType.MP_STORE_END,
                     "req-1",
-                    100.5,
+                    now + 0.5,
                     total_bytes=5_000_000_000,
                     num_tokens=24576,
                 )
@@ -139,14 +140,15 @@ class TestExtraStatsLoggingSubscriber:
     def test_retrieve_window_logs_tokens_size_and_throughput(self):
         subs = ExtraStatsLoggingSubscriber(_INTERVAL).get_subscriptions()
         with _capture_logs() as handler:
+            now = time.time()
             subs[EventType.MP_RETRIEVE_START](
-                _start(EventType.MP_RETRIEVE_START, "req-1", 200.0)
+                _start(EventType.MP_RETRIEVE_START, "req-1", now)
             )
             subs[EventType.MP_RETRIEVE_END](
                 _end(
                     EventType.MP_RETRIEVE_END,
                     "req-1",
-                    200.25,
+                    now + 0.25,
                     total_bytes=2_000_000_000,
                     num_tokens=4096,
                 )
@@ -344,6 +346,34 @@ class TestExtraStatsLoggingSubscriber:
         window_lines = [m for m in handler.messages() if "last" in m]
         assert len(window_lines) == 1
         assert "store ops=1 tokens=1024 size=1.00GB avg_copy=n/a" in window_lines[0]
+
+    def test_recent_pending_start_survives_flush_before_end(self):
+        subs = ExtraStatsLoggingSubscriber(_INTERVAL).get_subscriptions()
+        with _capture_logs() as handler:
+            now = time.time()
+            subs[EventType.MP_STORE_START](
+                _start(EventType.MP_STORE_START, "req-1", now)
+            )
+            time.sleep(_WAIT)
+            subs[EventType.L1_EVICTION_LOOP_TICK](_tick())
+
+            subs[EventType.MP_STORE_END](
+                _end(
+                    EventType.MP_STORE_END,
+                    "req-1",
+                    now + 0.5,
+                    total_bytes=1_000_000_000,
+                    num_tokens=1024,
+                )
+            )
+            time.sleep(_WAIT)
+            subs[EventType.L1_EVICTION_LOOP_TICK](_tick())
+
+        window_lines = [m for m in handler.messages() if "last" in m]
+        assert len(window_lines) == 1
+        assert (
+            "store ops=1 tokens=1024 size=1.00GB avg_copy=2.00GB/s" in window_lines[0]
+        )
 
     def test_end_to_end_via_event_bus(self):
         bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4566

`tests/v1/mp_observability/subscribers/logging/test_extra_stats.py` built its
store/retrieve throughput events with hard-coded timestamps (`100.0`/`100.5`,
`200.0`/`200.25`). `Event.timestamp` is contractually wall-clock -- 
`EventBus.publish()` sets `event.timestamp = time.time()` -- and
`ExtraStatsLoggingSubscriber._prune_pending()` drops pending START entries older
than `time.time() - 60`. A synthetic START at `t=100.0` is therefore always past
the prune deadline.

`_on_store_start()` records the pending entry and then calls `_maybe_flush()`.
Since `_last_flush` is set in `__init__`, any machine that takes longer than the
0.05s test interval to get from constructing the subscriber to delivering the
START event flushes (and prunes) the START before its END arrives. The pair never
correlates, so the window line reports `avg_copy=n/a` instead of the asserted
`avg_copy=10.00GB/s`. This is timing-dependent: green on fast runners, red on
slow ones.

The fix is test-only: anchor the synthetic timestamps to `time.time()`, keeping
the same START/END deltas so the asserted throughput values are unchanged. This
matches what `test_window_resets_while_cumulative_persists` in the same file
already does. Production code is untouched, because production timestamps are
always real wall-clock and the subscriber behaves correctly with them.

Also adds `test_recent_pending_start_survives_flush_before_end`, the positive
counterpart to the existing `test_stale_pending_start_is_pruned`: it forces a
flush between START and END with a fresh timestamp and asserts the pair still
correlates. Previously only the "stale START is pruned" half of that boundary was
covered.

**Special notes for your reviewers**:

- I considered the alternative fix suggested in the issue (reordering
  `_maybe_flush()` before recording the pending entry in `_on_store_start()`).
  I did not take it: `EventBus.publish()` always stamps real wall-clock
  timestamps, so that reorder fixes no reachable production defect and would only
  mask a fixture that violates the documented `Event.timestamp` contract.
- I left the literal timestamps in `test_groups_by_device`,
  `test_no_flush_before_interval` and `test_failed_op_counts_zero_tokens` alone --
  none of their assertions depend on START/END correlation, so they cannot flake.
- Verified: with a stall injected between subscriber construction and the first
  event, the store test previously logged `avg_copy=n/a`; after the change it
  logs `avg_copy=10.00GB/s` even at a 10x-interval stall.
- `pytest tests/v1/mp_observability/subscribers/logging/test_extra_stats.py` --
  14 passed, run 6x consecutively with no flakes. `ruff check` / `ruff format` /
  `isort` / `codespell` all clean.

**If applicable**:
- [x] this PR contains unit tests