### PR TITLE
docs: daily drift check — multi-process mode (2026-08-23)

### DIFF
--- a/docs/source/cli/server.rst
+++ b/docs/source/cli/server.rst
@@ -79,6 +79,14 @@ Commonly used flags include:
        and eviction, and the blend index behind fleet CacheBlend matching.
    * - ``--coordinator-event-flush-interval SECONDS``
      - Seconds between cache-event batch flushes (``> 0``, default ``1``).
+   * - ``--coordinator-blend-timeout SECONDS``
+     - Fleet CacheBlend lookup timeout, also used as the per-lookup match
+       budget (``> 0``, default ``1``). Only relevant for
+       ``--engine-type blend`` when a coordinator URL is set.
+   * - ``--coordinator-blend-match-concurrency N``
+     - Max fleet CacheBlend match round-trips in flight at once
+       (``>= 1``, default ``8``). Only relevant for ``--engine-type blend``
+       when a coordinator URL is set.
    * - ``--p2p-advertise-url HOST:PORT``
      - Enable P2P KV cache sharing and advertise this server's
        transfer-channel endpoint to peers (e.g. ``10.0.0.1:8500``). Setting it

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -173,6 +173,17 @@ Kubernetes downward API); an explicit flag wins over the env var.
      - ``LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL``
      - Seconds between cache-event batch flushes (must be ``> 0``, default
        ``1``).
+   * - ``--coordinator-blend-timeout``
+     - *(none)*
+     - Seconds a fleet CacheBlend lookup to the coordinator may take, used
+       as both the HTTP timeout and the per-lookup match budget (must be
+       ``> 0``, default ``1``). Only consulted by ``--engine-type blend``
+       when a coordinator URL is set.
+   * - ``--coordinator-blend-match-concurrency``
+     - *(none)*
+     - Max fleet CacheBlend match round-trips the blend coordinator client
+       keeps in flight at once (must be ``>= 1``, default ``8``). Only
+       consulted by ``--engine-type blend`` when a coordinator URL is set.
 
 The server registers under its stable identity (``--instance-id`` / OTel
 ``service.instance.id``); if the flag is not passed, the server mints a


### PR DESCRIPTION
## Summary

Daily automated drift check of `docs/source/` and `docs/design/` against
current `dev` (`f9addd2`), focused on the multi-process mode. One drift
found this run — two MP server CLI flags exist in code but are missing
from the user-facing coordinator docs.

### `docs/source/`

- **`docs/source/mp/coordinator.rst`** — the "Connecting MP servers"
  table lists five `--coordinator-*` flags but omits the two
  blend-client flags added in
  [#4619](https://github.com/LMCache/LMCache/pull/4619). Added rows for
  both.
- **`docs/source/cli/server.rst`** — the "Commonly used flags" table
  already lists the other `--coordinator-*` flags (URL,
  advertise-ip, heartbeat-interval, event-reporting,
  event-flush-interval) but is missing these two. Added rows for both.

### `docs/design/`

No drift found this run. The one design-doc reference to the new flags
([`blend_lookup.md#L88`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/docs/design/v1/mp_coordinator/blend_lookup.md#L88))
already names `--coordinator-blend-timeout`.

## Evidence

The `CoordinatorConfig` fields and `add_coordinator_args()` in
`lmcache/v1/multiprocess/config.py` on current `dev`:

- `blend_timeout` (default `1.0`), field defined at
  [`config.py:232-234`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/lmcache/v1/multiprocess/config.py#L232-L234);
  CLI flag `--coordinator-blend-timeout` registered at
  [`config.py:631-638`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/lmcache/v1/multiprocess/config.py#L631-L638).
- `blend_match_concurrency` (default `8`), field defined at
  [`config.py:236-238`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/lmcache/v1/multiprocess/config.py#L236-L238);
  CLI flag `--coordinator-blend-match-concurrency` registered at
  [`config.py:639-645`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/lmcache/v1/multiprocess/config.py#L639-L645).

The stale doc locations that don't mention them:

- [`docs/source/mp/coordinator.rst:148-176`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/docs/source/mp/coordinator.rst#L148-L176)
  — the "Connecting MP servers" flag table.
- [`docs/source/cli/server.rst:66-81`](https://github.com/LMCache/LMCache/blob/f9addd2e4e074f21f26cbda84c3abd932d32ef33/docs/source/cli/server.rst#L66-L81)
  — the "Commonly used flags" table (the `--coordinator-*` rows).

Both flags landed in the same commit that removed the coordinator's
env-var config, [#4619 (`bbab139`)](https://github.com/LMCache/LMCache/commit/bbab139f4f79f44f2f843f6b22d9d45d12685af6);
that PR updated the coordinator-side docs but did not update the
MP-server-side flag tables where the new server-side flags belong.

## Proposed fix (applied)

Docs-only. Add one row per flag to each of the two tables, keeping the
column shape the tables already use (`Flag` / `Env fallback` /
`Description` in `mp/coordinator.rst`, `Flag` / `Description` in
`cli/server.rst`). No env fallback for either flag; that's marked
`*(none)*` in `mp/coordinator.rst`, matching the docstring on
`add_coordinator_args()` which says "the blend client flags have no env
fallback." Both rows also flag the effective scope (only consulted by
`--engine-type blend` with a coordinator URL set), so a reader on the
`default` engine knows they don't apply.

## Notes

- No code drift found — this run only surfaces a doc gap.
- Only doc files touched (`docs/source/mp/coordinator.rst`,
  `docs/source/cli/server.rst`).
- Auto-generated by the daily drift-check routine; **human review
  required before merge**. Do not "Ready for review" or merge without
  a maintainer signing off on the wording.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQP8Wth9t97RQ5aXtZFm8v)_