### PR TITLE
fix(hf3fs): pass the configured io_depth to make_ioring

### DIFF
--- a/lmcache/v1/storage_backend/connector/hf3fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/hf3fs_connector.py
@@ -361,6 +361,7 @@ class Hf3fsClient:
                 self.config.mount_point,
                 self.config.ior_entries,
                 for_read=True,
+                io_depth=self.config.io_depth,
                 timeout=self.config.timeout,
                 numa=self.config.numa_id,
             )
@@ -376,6 +377,7 @@ class Hf3fsClient:
                 self.config.mount_point,
                 self.config.ior_entries,
                 for_read=False,
+                io_depth=self.config.io_depth,
                 timeout=self.config.timeout,
                 numa=self.config.numa_id,
             )


### PR DESCRIPTION
**What this PR does / why we need it**:

`hf3fs_io_depth` is a documented, user-facing knob for the 3FS backend, but it never
reaches the ioring — it is accepted, validated, logged, and then dropped.

The value travels through three layers:

1. `Hf3fsAdapter` reads it (`hf3fs_adapter.py:74`), prints it in the config dump
   (`:84`), range-checks it with a dedicated error message
   (`:170` — `"hf3fs_io_depth must in range [-128, 128]"`), and forwards it (`:101`).
2. `HF3fsConnector.__init__` takes it as a required argument and documents it
   (`hf3fs_connector.py:49`, `:62` — *"Control with I/O depth in ior"*), then stores it
   on `Hf3fsClientConfig` (`:89`).
3. `Hf3fsClient.__init__` builds the two iorings — and passes
   `self.config.ior_entries`, `self.config.timeout` and `self.config.numa_id`, but not
   `self.config.io_depth`.

`make_ioring(hf3fs_mount_point, entries, for_read=True, io_depth=0, priority=None,
timeout=None, numa=-1, flags=0)` therefore always gets the default `io_depth=0`, so the
submission strategy is always "submit every queued io", regardless of what the user
configured. `io_depth` is the only member of `Hf3fsClientConfig` that is never read.

The docs describe three distinct strategies for this setting
(`docs/source/kv_cache/storage_backends/3fs.rst:58-62`):

```yaml
# Control with I/O depth. 0, no control
# >0, only when io_depth requests are in queue, and issue them in one batch
# <0, wait for at most -io_depth requests are in queue and issue them in one batch
# range in [-128, 128], default: 0
hf3fs_io_depth: 0
```

Only the `0` case currently works, and it works by accident.

**Special notes for your reviewers**:

- Two-line change; `io_depth` is placed right after `for_read` to match the declared
  parameter order of `make_ioring`.
- Behaviour is unchanged for anyone on the default (`hf3fs_io_depth: 0`) — passing `0`
  explicitly is identical to omitting the keyword. Only configs that actually set a
  non-zero value change behaviour, which is what they were asking for.
- No test is added: `Hf3fsClient` construction requires a real mounted 3FS
  (`hf3fs_fuse.io` is imported behind `HF3FS_AVAILABLE`, and `tests/v1/storage_backend/
  test_hf3fs_connector.py` skips without it), so a unit test here would only assert that
  a mock was called with a keyword.
- No overlap with #3830, which touches this file only in the imports and in `sync_put`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
  (the setting is already documented in `docs/source/kv_cache/storage_backends/3fs.rst`;
  this PR makes the documentation true rather than changing it)
- [ ] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
