### PR TITLE
fix(cpu): support nonzero KV cache storage offsets

### DIFF
--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -255,11 +255,6 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
         _CPU_SHM_NAMES.pop(tid, None)
 
     nbytes = tensor.numel() * tensor.element_size()
-    assert tensor.storage_offset() == 0, (
-        "migrate_to_shm_and_wrap: SHM segment is sized to "
-        "numel*elem_size; a nonzero storage_offset would cause "
-        "OOB access. Got offset=%d" % tensor.storage_offset()
-    )
     if nbytes == 0:
         # No SHM segment for empty tensors: ``mmap`` with length 0
         # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an
@@ -280,7 +275,7 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
         shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
         tensor.set_(
             shm_storage,
-            normalized.storage_offset(),
+            0,
             normalized.shape,
             normalized.stride(),
         )

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -49,6 +49,21 @@ def test_migrate_to_shm_and_wrap_zero_copy_view():
         shm_unlink(wrapper.shm_name)
 
 
+def test_migrate_rebases_nonzero_storage_offset():
+    """A contiguous slice is rebased to offset zero in its dedicated SHM."""
+    src = torch.zeros(16, dtype=torch.float32)[4:12]
+    assert src.storage_offset() == 4
+
+    wrapper = migrate_to_shm_and_wrap(src)
+    try:
+        assert src.storage_offset() == 0
+        assert wrapper.storage_offset == 0
+        src.add_(7.0)
+        assert torch.equal(wrapper.to_tensor(), src)
+    finally:
+        shm_unlink(wrapper.shm_name)
+
+
 def test_migrate_normalizes_layout_in_place_on_caller_tensor():
     """Layout normalization must not detach migration from the caller's tensor.
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:
to fix the CI issue hit during(not lead by): https://github.com/LMCache/LMCache/pull/4433

suspect lead by vllm modification: https://github.com/vllm-project/vllm/pull/51718

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
