### PR TITLE
ci: run nightly build at 22:00 KST

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -2,7 +2,8 @@ name: Build nightly container image of latest code
 
 on:
   schedule:
-    - cron: '30 7 * * *'
+    # 22:00 KST (UTC+9)
+    - cron: '0 13 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:

Shifts the nightly build workflow's schedule from `30 7 * * *` UTC (16:30 KST) to `0 13 * * *` UTC, which is 22:00 KST.

**Special notes for your reviewers**:

GitHub Actions `schedule` cron is always evaluated in UTC, so the change is a straight UTC-offset conversion (KST = UTC+9); no other workflow behavior changes.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests