### PR TITLE
[fix] fix nigtly vllm cpu kv layout shift imcompatible

### DIFF
--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -64,10 +64,6 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
     map the **same** physical pages for the KV cache, mirroring the
     GPU-mode CUDA-IPC zero-copy semantics.
 
-    ``nbytes`` is the ``mmap`` length of the SHM segment (which may
-    exceed the view's own span when views share one storage); ``shape``
-    / ``stride`` / ``storage_offset`` locate the view inside it.
-
     Subclassing :class:`DeviceIPCWrapper` is load-bearing for the same
     reason :class:`RawCudaIPCWrapper` does it: msgspec does not
     support unions of custom ext-encoded types, so all wire-level
@@ -91,8 +87,8 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
         :func:`~lmcache.v1.platform.resolve_kv_wrapper_factory`.
 
         Delegates to :func:`migrate_to_shm_and_wrap`, which migrates the
-        tensor's backing storage to a POSIX SHM segment so the LMCache
-        mp server can map the same physical pages.
+        tensor's storage to a POSIX SHM segment so the LMCache mp server
+        can map the same physical pages.
 
         Args:
             tensor: A contiguous CPU tensor to migrate and wrap.

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -5,6 +5,11 @@ Mirrors the GPU-mode CUDA-IPC zero-copy semantics for hosts without an
 accelerator: client and LMCache mp server map the **same** physical
 pages so transfers are pointer-shuffles rather than memcpys.
 
+Migration granularity is one SHM segment per *backing storage*, not
+per tensor: views sharing one storage share one segment and keep their
+``storage_offset`` / stride, so they stay aliased to the same bytes. A
+tensor owning its whole storage is simply the one-view case.
+
 Bound to ``device_type="cpu"`` via
 :attr:`~lmcache.v1.platform.cpu.CpuDeviceSpec.ipc_wrapper_cls`, so the
 multiprocess adapter can dispatch by ``tensor.device.type`` without
@@ -17,6 +22,7 @@ from __future__ import annotations
 # Standard
 from typing import ClassVar
 import ctypes
+import dataclasses
 import itertools
 import os
 import threading
@@ -63,6 +69,10 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
     map the **same** physical pages for the KV cache, mirroring the
     GPU-mode CUDA-IPC zero-copy semantics.
 
+    ``nbytes`` is the ``mmap`` length of the SHM segment (which may
+    exceed the view's own span when views share one storage); ``shape``
+    / ``stride`` / ``storage_offset`` locate the view inside it.
+
     Subclassing :class:`DeviceIPCWrapper` is load-bearing for the same
     reason :class:`RawCudaIPCWrapper` does it: msgspec does not
     support unions of custom ext-encoded types, so all wire-level
@@ -86,8 +96,8 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
         :func:`~lmcache.v1.platform.resolve_kv_wrapper_factory`.
 
         Delegates to :func:`migrate_to_shm_and_wrap`, which migrates the
-        tensor's storage to a POSIX SHM segment so the LMCache mp server
-        can map the same physical pages.
+        tensor's backing storage to a POSIX SHM segment so the LMCache
+        mp server can map the same physical pages.
 
         Args:
             tensor: A contiguous CPU tensor to migrate and wrap.
@@ -98,7 +108,26 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
         """
         return migrate_to_shm_and_wrap(tensor)
 
-    def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:
+    def __init__(
+        self,
+        tensor: torch.Tensor,
+        shm_name: str,
+        segment_nbytes: int | None = None,
+    ) -> None:
+        """Describe ``tensor``'s view of the SHM segment ``shm_name``.
+
+        Args:
+            tensor: The (already SHM-backed) CPU tensor to describe.
+            shm_name: POSIX SHM name of the backing segment, or ``""``
+                for empty tensors that carry no segment.
+            segment_nbytes: Byte length of the SHM segment. Defaults to
+                the tensor's own span (``numel * element_size``); pass
+                the storage's byte size when views share one segment.
+
+        Raises:
+            ValueError: If the tensor is not a contiguous CPU tensor,
+                or its view does not fit inside the segment.
+        """
         if tensor.device.type != "cpu":
             raise ValueError(
                 "CpuShmTensorWrapper requires a CPU tensor, got %s" % tensor.device
@@ -107,9 +136,9 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
             raise ValueError("CpuShmTensorWrapper requires a contiguous tensor")
 
         self.shm_name = shm_name
-        # ``numel * element_size`` is the correct logical byte size; the
-        # underlying storage may be larger when the tensor is a view.
-        self.nbytes = tensor.numel() * tensor.element_size()
+        # ``nbytes`` is the mmap length on the receiving side.
+        view_nbytes = tensor.numel() * tensor.element_size()
+        self.nbytes = view_nbytes if segment_nbytes is None else segment_nbytes
 
         # DeviceIPCWrapper interface fields. ``handle`` / ``device_uuid``
         # are unused on the CPU path but kept to satisfy the base
@@ -121,13 +150,25 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
         self.storage_offset = int(tensor.storage_offset())
         self.device_uuid = "cpu"
 
+        # The view must land inside the segment, or ``to_tensor`` on
+        # the receiving side would read past the mapping.
+        view_end = (self.storage_offset * tensor.element_size()) + view_nbytes
+        if self.shm_name and view_end > self.nbytes:
+            raise ValueError(
+                "CpuShmTensorWrapper: view ends at byte %d but the SHM "
+                "segment is only %d bytes; a nonzero storage_offset "
+                "requires a segment covering the whole backing storage"
+                % (view_end, self.nbytes)
+            )
+
     def to_tensor(self) -> torch.Tensor:
         """Reconstruct the tensor by mapping the same SHM segment.
 
         The returned tensor owns the mmap: a ``weakref.finalize`` hook
         runs ``munmap`` once the tensor (and any views derived from it)
         is garbage-collected, so the per-process virtual address space
-        does not leak across repeated ``to_tensor`` calls.
+        does not leak across repeated ``to_tensor`` calls. Wrappers
+        sharing one segment map it independently (pages are shared).
 
         We rebuild the view through ``as_strided`` so the original
         memory layout (stride / storage_offset / memory_format) is
@@ -145,7 +186,11 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
         buf_type = ctypes.c_uint8 * self.nbytes
         buf = buf_type.from_address(addr)
         flat = torch.frombuffer(buf, dtype=torch.uint8)
-        typed = flat.view(self.dtype)
+        # Truncate to a multiple of the element size before the typed
+        # view: a whole-storage segment is not guaranteed to divide
+        # evenly by this view's dtype width.
+        itemsize = self.dtype.itemsize
+        typed = flat[: self.nbytes - (self.nbytes % itemsize)].view(self.dtype)
         out = torch.as_strided(typed, self.shape, self.stride, self.storage_offset)
         # Pin the mmap to the *storage*, not the outer tensor: views
         # (reshape / slicing) create new tensor objects that share the
@@ -164,21 +209,31 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
 # Migrate-and-wrap factory (used by the multiprocess adapter)              #
 # ---------------------------------------------------------------------------
 
-# Per-process registry of SHM segments we have created, so the same
-# tensor object is only migrated to SHM once even if the factory is
-# called multiple times.
-#
-# Keyed by ``id(tensor)`` for cheap O(1) lookup, but each entry also
-# holds a ``weakref.ref`` to the original tensor and we *verify the
-# referent is still that exact object* before reusing the cached SHM
-# name. CPython recycles object IDs, so a fresh tensor allocated at
-# the same address as a previously migrated (now garbage-collected)
-# one would otherwise inherit a stale name -- and because
-# :func:`shm_create_readwrite` uses ``O_EXCL``, the next migration
-# would crash with ``EEXIST`` ("File exists"). The weakref-validated
-# lookup below makes that race impossible: a stale entry can only
-# point at a dead referent, which we treat as a miss.
-_CPU_SHM_NAMES: dict[int, tuple["weakref.ReferenceType[torch.Tensor]", str]] = {}
+
+@dataclasses.dataclass
+class _ShmSegmentRecord:
+    """Registry entry describing one migrated backing storage.
+
+    ``origin_ref`` weak-references the storage the entry was keyed for
+    (a CPython id-recycling collision reads as a miss); ``shm_storage_ref``
+    weak-references the SHM-backed storage so a hit can re-point sibling
+    views without the registry keeping the segment alive.
+    """
+
+    origin_ref: "weakref.ReferenceType[object]"
+    shm_storage_ref: "weakref.ReferenceType[object]"
+    shm_name: str
+    segment_nbytes: int
+
+
+# Per-process registry of SHM segments we have created, so each backing
+# storage is migrated only once no matter how many of its views are
+# wrapped. Keyed by ``id(untyped_storage)``; PyTorch preserves the
+# ``UntypedStorage`` PyObject for the lifetime of its C++ impl, so the
+# id is stable while any view is alive. Each record is inserted under
+# two keys -- the original storage and the SHM-backed one -- so both
+# "wrap a sibling view" and "re-wrap a migrated tensor" hit.
+_CPU_SHM_SEGMENTS: dict[int, _ShmSegmentRecord] = {}
 _CPU_SHM_LOCK = threading.Lock()
 _CPU_SHM_COUNTER = itertools.count()
 
@@ -202,16 +257,32 @@ def _release_shm_segment(storage_id: int, addr: int, nbytes: int) -> None:
     shm_munmap(addr, nbytes)
 
 
-def _cleanup_shm_segment(tid: int, shm_name: str, addr: int, nbytes: int) -> None:
-    """Release the mmap, unlink, and forget the cached SHM name."""
+def _cleanup_shm_segment(
+    origin_sid: int,
+    shm_sid: int,
+    shm_name: str,
+    addr: int,
+    nbytes: int,
+) -> None:
+    """Release the mmap, unlink, and forget both registry keys.
+
+    Registered via ``weakref.finalize`` on the SHM-backed storage, so it
+    fires only once the *last* view sharing the segment is gone.
+    """
     with _CPU_SHM_LOCK:
-        # Only drop the entry if it still points at *this* segment;
-        # a future tensor reusing ``tid`` may already have replaced it.
-        cached = _CPU_SHM_NAMES.get(tid)
-        if cached is not None and cached[1] == shm_name:
-            _CPU_SHM_NAMES.pop(tid, None)
+        for sid in (origin_sid, shm_sid):
+            # Only drop an entry still pointing at *this* segment; a
+            # future storage reusing the id may already have replaced it.
+            cached = _CPU_SHM_SEGMENTS.get(sid)
+            if cached is not None and cached.shm_name == shm_name:
+                _CPU_SHM_SEGMENTS.pop(sid, None)
     shm_munmap(addr, nbytes)
-    shm_unlink(shm_name)
+    try:
+        shm_unlink(shm_name)
+    except OSError:
+        # Already unlinked, e.g. by wrap_kv_caches' partial-batch
+        # rollback. The mapping above is ours either way.
+        logger.debug("shm_unlink(%s) failed during cleanup", shm_name, exc_info=True)
 
 
 def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
@@ -219,10 +290,18 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
 
     Used as the registered ``"cpu"`` KV-wrapper factory: the LMCache mp
     server can mmap the same physical pages on the receiving side.
-    Idempotent per tensor identity (validated via a stored weakref so
-    Python's id-recycling cannot produce a stale-name hit). The SHM
-    segment is released (``munmap`` + ``shm_unlink``) automatically
-    when the migrated tensor is garbage-collected.
+
+    The unit of migration is the tensor's *backing storage*: the first
+    view of a storage to arrive copies the whole storage into a fresh
+    SHM segment; every later view is re-pointed at that segment with
+    its own ``storage_offset`` / stride preserved, so all views keep
+    aliasing the same bytes. Views must be migrated *before* the buffer
+    is written -- only the tensors handed in are re-pointed.
+
+    The segment is released (``munmap`` + ``shm_unlink``) once the last
+    migrated view of it is garbage-collected. Concurrent first-time
+    migration of views sharing one storage is not supported; the
+    register-time ``wrap_kv_caches`` loop wraps sequentially.
     """
     # First Party
     from lmcache.v1.gpu_connector.kv_format.contiguity import (
@@ -232,7 +311,11 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
     # Validate and normalise the tensor *before* touching the registry
     # or mutating storage, so a bad input never leaves things half-done.
     normalized = attempt_permute_to_contiguous_view(tensor)
-    assert isinstance(normalized, torch.Tensor)
+    if not isinstance(normalized, torch.Tensor):
+        raise TypeError(
+            "attempt_permute_to_contiguous_view returned %s, expected a tensor"
+            % type(normalized)
+        )
     if tensor.device.type != "cpu":
         raise ValueError(
             "migrate_to_shm_and_wrap requires a CPU tensor, got %s" % tensor.device
@@ -240,44 +323,69 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
     if not normalized.is_contiguous():
         raise ValueError("migrate_to_shm_and_wrap requires a contiguous tensor")
 
-    tid = id(tensor)
-
-    # Fast path: check the registry under the lock, return early if the
-    # tensor has already been migrated.
-    with _CPU_SHM_LOCK:
-        cached = _CPU_SHM_NAMES.get(tid)
-        if cached is not None:
-            ref, cached_name = cached
-            if ref() is tensor:
-                return CpuShmTensorWrapper(tensor, cached_name)
-            # Stale entry from a GC'd tensor whose id has been
-            # reused; drop it and fall through to allocate fresh.
-        _CPU_SHM_NAMES.pop(tid, None)
-
-    nbytes = tensor.numel() * tensor.element_size()
-    assert tensor.storage_offset() == 0, (
-        "migrate_to_shm_and_wrap: SHM segment is sized to "
-        "numel*elem_size; a nonzero storage_offset would cause "
-        "OOB access. Got offset=%d" % tensor.storage_offset()
-    )
-    if nbytes == 0:
+    if tensor.numel() == 0:
         # No SHM segment for empty tensors: ``mmap`` with length 0
         # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an
         # empty view directly when ``shm_name`` is empty.
         return CpuShmTensorWrapper(tensor, "")
+
+    storage = tensor.untyped_storage()
+    segment_nbytes = storage.nbytes()
+
+    # Fast path: the storage was already migrated (either this very
+    # tensor, or a sibling view of the same buffer). Validate the hit
+    # under the lock, re-point outside it.
+    shm_storage: torch.UntypedStorage | None = None
+    hit: _ShmSegmentRecord | None = None
+    with _CPU_SHM_LOCK:
+        cached = _CPU_SHM_SEGMENTS.get(id(storage))
+        if cached is not None:
+            if cached.origin_ref() is storage:
+                resolved = cached.shm_storage_ref()
+                if resolved is not None:
+                    hit = cached
+                    shm_storage = resolved
+            if hit is None:
+                # Stale entry: a recycled id, or a segment whose last
+                # view already died. Fall through to a fresh migration.
+                _CPU_SHM_SEGMENTS.pop(id(storage), None)
+
+    if hit is not None and shm_storage is not None:
+        if storage is not shm_storage:
+            # Sibling view: re-point it, keeping its offset / layout.
+            tensor.set_(
+                shm_storage,
+                normalized.storage_offset(),
+                normalized.shape,
+                normalized.stride(),
+            )
+            logger.debug(
+                "Re-pointed sibling KV view (offset=%d) onto SHM %s",
+                int(tensor.storage_offset()),
+                hit.shm_name,
+            )
+        return CpuShmTensorWrapper(
+            tensor, hit.shm_name, segment_nbytes=hit.segment_nbytes
+        )
 
     shm_name = "%s%d_%d" % (
         CpuShmTensorWrapper.SHM_NAME_PREFIX,
         os.getpid(),
         next(_CPU_SHM_COUNTER),
     )
-    # Perform the heavy work (syscall + tensor mutation) outside the lock
-    # to keep the critical section small.
-    addr = shm_create_readwrite(shm_name, nbytes)
+    # Perform the heavy work (syscall + copy + tensor mutation) outside
+    # the lock to keep the critical section small.
+    addr = shm_create_readwrite(shm_name, segment_nbytes)
     try:
-        buf_type = ctypes.c_uint8 * nbytes
+        buf_type = ctypes.c_uint8 * segment_nbytes
         buf = buf_type.from_address(addr)
-        shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
+        shm_flat = torch.frombuffer(buf, dtype=torch.uint8)
+        # Copy the whole origin storage so sibling views keep their
+        # bytes and their offsets stay valid.
+        src_flat = torch.empty(0, dtype=torch.uint8)
+        src_flat.set_(storage)
+        shm_flat.copy_(src_flat)
+        shm_storage = shm_flat.untyped_storage()
         tensor.set_(
             shm_storage,
             normalized.storage_offset(),
@@ -287,33 +395,58 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
     except Exception:
         # Make sure the SHM resources don't leak if migration fails
         # part-way (e.g. ``set_`` rejects an unusual stride).
-        shm_munmap(addr, nbytes)
+        shm_munmap(addr, segment_nbytes)
         shm_unlink(shm_name)
         raise
 
+    record = _ShmSegmentRecord(
+        origin_ref=weakref.ref(storage),
+        shm_storage_ref=weakref.ref(shm_storage),
+        shm_name=shm_name,
+        segment_nbytes=segment_nbytes,
+    )
     with _CPU_SHM_LOCK:
-        _CPU_SHM_NAMES[tid] = (weakref.ref(tensor), shm_name)
-    weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
+        _CPU_SHM_SEGMENTS[id(storage)] = record
+        _CPU_SHM_SEGMENTS[id(shm_storage)] = dataclasses.replace(
+            record, origin_ref=weakref.ref(shm_storage)
+        )
+    # Unlink fires when the SHM-backed storage dies, i.e. once the last
+    # view sharing the segment is garbage-collected.
+    weakref.finalize(
+        shm_storage,
+        _cleanup_shm_segment,
+        id(storage),
+        id(shm_storage),
+        shm_name,
+        addr,
+        segment_nbytes,
+    )
     logger.info(
-        "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
-        nbytes,
+        "Migrated CPU KV backing storage (segment_nbytes=%d, view_offset=%d) to SHM %s",
+        segment_nbytes,
+        int(tensor.storage_offset()),
         shm_name,
     )
-    return CpuShmTensorWrapper(tensor, shm_name)
+    return CpuShmTensorWrapper(tensor, shm_name, segment_nbytes=segment_nbytes)
 
 
 def inject_stale_cache_entry_for_test(
     tensor: torch.Tensor,
-    dead_ref: "weakref.ReferenceType[torch.Tensor]",
+    dead_ref: "weakref.ReferenceType[object]",
     stale_shm_name: str,
 ) -> None:
     """Test-only hook: pre-seed the registry with a stale entry.
 
     Lets unit tests reproduce the CPython id-reuse race -- where a
-    fresh tensor lands on the same id as a previously migrated and
+    fresh storage lands on the same id as a previously migrated and
     garbage-collected one -- without the per-test global-state
     surgery that would otherwise have to reach into the module's
     private dict / lock.
     """
     with _CPU_SHM_LOCK:
-        _CPU_SHM_NAMES[id(tensor)] = (dead_ref, stale_shm_name)
+        _CPU_SHM_SEGMENTS[id(tensor.untyped_storage())] = _ShmSegmentRecord(
+            origin_ref=dead_ref,
+            shm_storage_ref=dead_ref,
+            shm_name=stale_shm_name,
+            segment_nbytes=0,
+        )

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -265,12 +265,7 @@ def _cleanup_shm_segment(
             if cached is not None and cached[2] == shm_name:
                 _CPU_SHM_SEGMENTS.pop(sid, None)
     shm_munmap(addr, nbytes)
-    try:
-        shm_unlink(shm_name)
-    except OSError:
-        # Already unlinked, e.g. by wrap_kv_caches' partial-batch
-        # rollback. The mapping above is ours either way.
-        logger.debug("shm_unlink(%s) failed during cleanup", shm_name, exc_info=True)
+    shm_unlink(shm_name)
 
 
 def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 # Standard
 from typing import ClassVar
 import ctypes
-import dataclasses
 import itertools
 import os
 import threading
@@ -201,20 +200,18 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
 # ---------------------------------------------------------------------------
 
 
-@dataclasses.dataclass
-class _ShmSegmentRecord:
-    """Registry entry describing one migrated backing storage.
-
-    ``origin_ref`` weak-references the storage the entry was keyed for
-    (a CPython id-recycling collision reads as a miss); ``shm_storage_ref``
-    weak-references the SHM-backed storage so a hit can re-point sibling
-    views without the registry keeping the segment alive.
-    """
-
-    origin_ref: "weakref.ReferenceType[object]"
-    shm_storage_ref: "weakref.ReferenceType[object]"
-    shm_name: str
-    segment_nbytes: int
+# Registry record for one migrated backing storage:
+# ``(origin_ref, shm_storage_ref, shm_name, segment_nbytes)``.
+# ``origin_ref`` weak-references the storage the entry was keyed for (a
+# CPython id-recycling collision reads as a miss); ``shm_storage_ref``
+# weak-references the SHM-backed storage so a hit can re-point sibling
+# views without the registry keeping the segment alive.
+_ShmSegmentRecord = tuple[
+    "weakref.ReferenceType[object]",
+    "weakref.ReferenceType[object]",
+    str,
+    int,
+]
 
 
 # Per-process registry of SHM segments we have created, so each backing
@@ -265,7 +262,7 @@ def _cleanup_shm_segment(
             # Only drop an entry still pointing at *this* segment; a
             # future storage reusing the id may already have replaced it.
             cached = _CPU_SHM_SEGMENTS.get(sid)
-            if cached is not None and cached.shm_name == shm_name:
+            if cached is not None and cached[2] == shm_name:
                 _CPU_SHM_SEGMENTS.pop(sid, None)
     shm_munmap(addr, nbytes)
     try:
@@ -327,21 +324,24 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
     # tensor, or a sibling view of the same buffer). Validate the hit
     # under the lock, re-point outside it.
     shm_storage: torch.UntypedStorage | None = None
-    hit: _ShmSegmentRecord | None = None
+    hit_name = ""
+    hit_nbytes = 0
     with _CPU_SHM_LOCK:
         cached = _CPU_SHM_SEGMENTS.get(id(storage))
         if cached is not None:
-            if cached.origin_ref() is storage:
-                resolved = cached.shm_storage_ref()
+            origin_ref, shm_storage_ref, cached_name, cached_nbytes = cached
+            if origin_ref() is storage:
+                resolved = shm_storage_ref()
                 if resolved is not None:
-                    hit = cached
                     shm_storage = resolved
-            if hit is None:
+                    hit_name = cached_name
+                    hit_nbytes = cached_nbytes
+            if shm_storage is None:
                 # Stale entry: a recycled id, or a segment whose last
                 # view already died. Fall through to a fresh migration.
                 _CPU_SHM_SEGMENTS.pop(id(storage), None)
 
-    if hit is not None and shm_storage is not None:
+    if shm_storage is not None:
         if storage is not shm_storage:
             # Sibling view: re-point it, keeping its offset / layout.
             tensor.set_(
@@ -353,11 +353,9 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
             logger.debug(
                 "Re-pointed sibling KV view (offset=%d) onto SHM %s",
                 int(tensor.storage_offset()),
-                hit.shm_name,
+                hit_name,
             )
-        return CpuShmTensorWrapper(
-            tensor, hit.shm_name, segment_nbytes=hit.segment_nbytes
-        )
+        return CpuShmTensorWrapper(tensor, hit_name, segment_nbytes=hit_nbytes)
 
     shm_name = "%s%d_%d" % (
         CpuShmTensorWrapper.SHM_NAME_PREFIX,
@@ -390,16 +388,19 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
         shm_unlink(shm_name)
         raise
 
-    record = _ShmSegmentRecord(
-        origin_ref=weakref.ref(storage),
-        shm_storage_ref=weakref.ref(shm_storage),
-        shm_name=shm_name,
-        segment_nbytes=segment_nbytes,
-    )
+    shm_storage_ref = weakref.ref(shm_storage)
     with _CPU_SHM_LOCK:
-        _CPU_SHM_SEGMENTS[id(storage)] = record
-        _CPU_SHM_SEGMENTS[id(shm_storage)] = dataclasses.replace(
-            record, origin_ref=weakref.ref(shm_storage)
+        _CPU_SHM_SEGMENTS[id(storage)] = (
+            weakref.ref(storage),
+            shm_storage_ref,
+            shm_name,
+            segment_nbytes,
+        )
+        _CPU_SHM_SEGMENTS[id(shm_storage)] = (
+            shm_storage_ref,
+            shm_storage_ref,
+            shm_name,
+            segment_nbytes,
         )
     # Unlink fires when the SHM-backed storage dies, i.e. once the last
     # view sharing the segment is garbage-collected.
@@ -435,9 +436,9 @@ def inject_stale_cache_entry_for_test(
     private dict / lock.
     """
     with _CPU_SHM_LOCK:
-        _CPU_SHM_SEGMENTS[id(tensor.untyped_storage())] = _ShmSegmentRecord(
-            origin_ref=dead_ref,
-            shm_storage_ref=dead_ref,
-            shm_name=stale_shm_name,
-            segment_nbytes=0,
+        _CPU_SHM_SEGMENTS[id(tensor.untyped_storage())] = (
+            dead_ref,
+            dead_ref,
+            stale_shm_name,
+            0,
         )

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -5,11 +5,6 @@ Mirrors the GPU-mode CUDA-IPC zero-copy semantics for hosts without an
 accelerator: client and LMCache mp server map the **same** physical
 pages so transfers are pointer-shuffles rather than memcpys.
 
-Migration granularity is one SHM segment per *backing storage*, not
-per tensor: views sharing one storage share one segment and keep their
-``storage_offset`` / stride, so they stay aliased to the same bytes. A
-tensor owning its whole storage is simply the one-view case.
-
 Bound to ``device_type="cpu"`` via
 :attr:`~lmcache.v1.platform.cpu.CpuDeviceSpec.ipc_wrapper_cls`, so the
 multiprocess adapter can dispatch by ``tensor.device.type`` without

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -263,6 +263,110 @@ def test_wrap_kv_caches_unlinks_partial_batch_on_failure(monkeypatch):
         shm_map_readwrite(state["first_name"], nbytes)
 
 
+def test_migrate_shares_one_segment_across_views_of_one_storage():
+    """Views of one backing buffer share a single SHM segment.
+
+    Engines may register every KV layer as a strided view into one
+    shared allocation (nonzero ``storage_offset``): migration must key
+    on the backing storage so every view lands in one segment, keeps
+    its own offset, and stays aliased to the same bytes. Regression
+    for the storage_offset assert crash in ``cpu_e2e_validation
+    (server_copy)``.
+    """
+    layers, layer_numel = 4, 1024
+    base = torch.zeros(layers * layer_numel, dtype=torch.bfloat16)
+    views = [
+        base[i * layer_numel : (i + 1) * layer_numel].view(4, 16, 16)
+        for i in range(layers)
+    ]
+
+    wrappers = [migrate_to_shm_and_wrap(v) for v in views]
+    try:
+        # One segment for all views, each keeping its own offset.
+        names = {w.shm_name for w in wrappers}
+        assert len(names) == 1
+        segment_nbytes = layers * layer_numel * base.element_size()
+        for i, w in enumerate(wrappers):
+            assert w.storage_offset == i * layer_numel
+            assert w.nbytes == segment_nbytes
+
+        # All migrated views share the SHM-backed storage.
+        storages = {id(v.untyped_storage()) for v in views}
+        assert len(storages) == 1
+
+        # Aliasing survives the round-trip in both directions.
+        views[2].fill_(3.0)
+        rebuilt = wrappers[2].to_tensor()
+        assert torch.equal(rebuilt, views[2])
+        rebuilt.add_(1.0)
+        assert views[2].float().max().item() == 4.0
+        # Sibling views are untouched (offsets do not overlap).
+        assert views[1].float().abs().sum().item() == 0.0
+    finally:
+        shm_unlink(wrappers[0].shm_name)
+
+
+def test_migrate_preserves_nonzero_storage_offset_roundtrip():
+    """A lone offset view wraps, ships its offset, and round-trips data."""
+    base = torch.arange(300, dtype=torch.float32)
+    view = base[100:200]
+    w = migrate_to_shm_and_wrap(view)
+    try:
+        assert w.storage_offset == 100
+        assert w.nbytes == 300 * 4  # whole backing storage
+        rebuilt = w.to_tensor()
+        assert torch.equal(rebuilt, torch.arange(100, 200, dtype=torch.float32))
+    finally:
+        shm_unlink(w.shm_name)
+
+
+def test_migrate_is_idempotent_across_sibling_views():
+    """Wrapping sibling views (or re-wrapping one) reuses the segment."""
+    base = torch.zeros(2 * 64, dtype=torch.float32)
+    v1, v2 = base[:64], base[64:]
+    w1 = migrate_to_shm_and_wrap(v1)
+    try:
+        w2 = migrate_to_shm_and_wrap(v2)
+        w1_again = migrate_to_shm_and_wrap(v1)
+        assert w1.shm_name == w2.shm_name == w1_again.shm_name
+    finally:
+        shm_unlink(w1.shm_name)
+
+
+def test_migrate_segment_unlinks_only_after_last_view_dies():
+    """The shared segment must outlive every view, not just the first."""
+    # Standard
+    import gc
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite, shm_munmap
+
+    base = torch.zeros(2 * 64, dtype=torch.float32)
+    v1, v2 = base[:64], base[64:]
+    w1 = migrate_to_shm_and_wrap(v1)
+    w2 = migrate_to_shm_and_wrap(v2)
+    name, nbytes = w1.shm_name, w1.nbytes
+
+    del base, v1, w1, w2
+    gc.collect()
+    # v2 still holds the SHM-backed storage: the segment must survive.
+    addr = shm_map_readwrite(name, nbytes)
+    shm_munmap(addr, nbytes)
+
+    del v2
+    gc.collect()
+    with pytest.raises(OSError):
+        shm_map_readwrite(name, nbytes)
+
+
+def test_wrapper_rejects_view_larger_than_segment():
+    """A view whose end lies past the declared segment must be refused."""
+    base = torch.zeros(200, dtype=torch.float32)
+    view = base[100:200]
+    with pytest.raises(ValueError, match="segment"):
+        CpuShmTensorWrapper(view, "/lmcache_test_never_created", segment_nbytes=100 * 4)
+
+
 def test_migrate_ignores_stale_entry_from_id_reuse():
     """A cached entry whose weakref is dead must not be reused.
 


### PR DESCRIPTION
## Summary

All `cpu_e2e_validation (server_copy)` legs fail with:

    AssertionError: migrate_to_shm_and_wrap: SHM segment is sized to numel*elem_size;
    a nonzero storage_offset would cause OOB access. Got offset=44630016

vLLM now allocates all KV-cache layers in one backing buffer (vllm-project/vllm#51718, in nightlies since 2026-08-22), so each layer tensor is a strided view with a nonzero `storage_offset`. LMCache's CPU `lmcache_driven` path created one SHM segment per tensor sized `numel * elem_size` and required `storage_offset == 0`, crashing the worker in `register_kv_caches`.

## Fix

Migrate per backing storage instead of per tensor (`lmcache/v1/platform/cpu/shm.py`):

- The first view copies the whole storage into one segment (`storage.nbytes()`); sibling views are re-pointed onto it with `tensor.set_`, keeping their own offset/stride.
- Registry keyed by `id(untyped_storage)` instead of `id(tensor)` (weakref-validated against id recycling, dual-keyed for sibling-view and re-wrap hits).
- Unlink moves to a `weakref.finalize` on the SHM-backed storage, firing only after the last view is collected.
- `CpuShmTensorWrapper` gains an optional `segment_nbytes`; the `offset == 0` assert becomes a "view must fit in segment" `ValueError`. `to_tensor()` already replays offset/stride via `as_strided`, so it is unchanged.

A tensor owning its whole storage (pre-#51718 layout, bench path) is the one-view degenerate case and is unaffected. Total `/dev/shm` usage is unchanged — N per-layer segments become one N-layer segment.

## Validation

- New unit tests: sibling-view aliasing, nonzero-offset round-trip, cross-view idempotence, unlink-only-after-last-view, oversized-view rejection. Pre-existing tests pass unchanged (17 passed, 1 skipped).
- E2E on the failing nightly (`vllm-cpu-nightly==0.27.2.dev202608230642`, opt-125m, `lmcache_driven`): server ready, L1 store (3 chunks), same-instance hit, cross-instance hit after restart, all three outputs bit-identical.
- `engine_driven` leg unaffected — it never wraps KV tensors.