### PR TITLE
[good-first-issue] storage: use lazy logging in mock and LM server adapters

### DIFF
--- a/lmcache/v1/storage_backend/connector/lm_adapter.py
+++ b/lmcache/v1/storage_backend/connector/lm_adapter.py
@@ -21,7 +21,7 @@ class LMServerConnectorAdapter(ConnectorAdapter):
         # Local
         from .lm_connector import LMCServerConnector
 
-        logger.info(f"Creating LM Server connector for URL: {context.url}")
+        logger.info("Creating LM Server connector for URL: %s", context.url)
         parse_url = parse_remote_url(context.url)
         return LMCServerConnector(
             host=parse_url.host,

--- a/lmcache/v1/storage_backend/connector/mock_adapter.py
+++ b/lmcache/v1/storage_backend/connector/mock_adapter.py
@@ -24,7 +24,7 @@ class MockConnectorAdapter(ConnectorAdapter):
         # Local
         from .mock_connector import MockConnector
 
-        logger.info(f"Creating Mock connector for URL: {context.url}")
+        logger.info("Creating Mock connector for URL: %s", context.url)
 
         parsed = urlparse(context.url)
         # capacity is provided as the netloc in URLs like: mock://100/?...


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4685.
Refs #3372.

This PR converts the two connector adapter `logger.info` f-strings to Python logging's lazy `%s` parameterization. This avoids constructing the rendered message when INFO logging is disabled while preserving the exact emitted text and connector behavior.

Changed files:

- `lmcache/v1/storage_backend/connector/mock_adapter.py`
- `lmcache/v1/storage_backend/connector/lm_adapter.py`

**Special notes for your reviewers**:

Validation completed:

- `ruff check --select G004` on both files: passed
- full `ruff check` on both files: passed
- `ruff format --check` on both files: passed
- targeted pre-commit hooks for SPDX, isort, Ruff, Ruff format, codespell, and mypy: passed

The repository-local Bash policy hooks could not run on this Windows host because WSL is unavailable. No business logic, interfaces, exception handling, return values, or unrelated files were changed.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
