### PR TITLE
fix(mp): start worker heartbeat after KV registration

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1164,10 +1164,9 @@ class LMCacheMPWorkerAdapter:
         self._health_event = threading.Event()
         self._health_event.set()
 
-        # Heartbeat thread is created but NOT started yet.
-        # It will be lazily started on the first store or retrieve
-        # request, by which time vLLM is fully ready (model loaded,
-        # KV caches allocated, warmup & CUDA graph capture done).
+        # Heartbeat thread is created after KV-cache registration succeeds.
+        # Starting it at registration keeps live but idle workers from being
+        # reaped before their first store or retrieve request.
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None
         self._heartbeat_lock = threading.Lock()
@@ -1266,6 +1265,7 @@ class LMCacheMPWorkerAdapter:
         self.kv_caches = kv_caches
         self.engine_group_infos = list(engine_group_infos)
         self._send_register_kv_caches_request(kv_caches)
+        self._ensure_heartbeat_started()
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
         return expand_engine_block_ids(self.engine_group_infos, op.block_ids)
@@ -1315,14 +1315,13 @@ class LMCacheMPWorkerAdapter:
             ) from None
 
     def _ensure_heartbeat_started(self) -> None:
-        """Lazily start the heartbeat thread on first store/retrieve.
+        """Start the heartbeat thread after KV-cache registration.
 
         The heartbeat starts healthy (the event was set at construction). A
         live worker pings every interval, refreshing its server-side
-        ``last_seen``, so it is never reaped while alive -- no re-registration
-        is needed at startup, and the first store/retrieve is not gated. The
-        recover callback still re-registers on a genuine unhealthy->healthy
-        edge (server restart).
+        ``last_seen``, so it is never reaped while alive, including while idle
+        before its first store/retrieve. The recover callback re-registers on
+        a genuine unhealthy->healthy edge (server restart).
         """
         if self._heartbeat is not None:
             return

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -188,7 +188,7 @@ def fake_adapter(monkeypatch):
 
 
 def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
-    """Public register_kv_caches stores the dict and submits one request."""
+    """Registration stores the caches, submits, and starts heartbeats."""
     adapter, send_mock, _ = fake_adapter
     fake_tensor = MagicMock()
     fake_tensor.device.type = "cuda"
@@ -200,6 +200,10 @@ def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
     assert send_mock.call_count == 1
     args, _kwargs = send_mock.call_args
     assert args[1] == RequestType.REGISTER_KV_CACHE
+    assert len(FakeHeartbeatThread.instances) == 1
+    heartbeat = FakeHeartbeatThread.instances[0]
+    assert heartbeat.health_event_set_at_init is True
+    assert heartbeat.calls == ["register_recover_callback", "start"]
 
 
 def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
@@ -211,6 +215,8 @@ def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
         fake_tensor = MagicMock()
         fake_tensor.device.type = "cuda"
         adapter.register_kv_caches({"layer.0": fake_tensor})
+
+    assert FakeHeartbeatThread.instances == []
 
 
 def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
@@ -415,23 +421,27 @@ def test_instance_id_logged_at_info_on_construction(fake_adapter, monkeypatch) -
     assert any(str(adapter.instance_id) in msg for msg in messages)
 
 
-def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
-    """The lazy create path starts the heartbeat healthy (no pessimistic
-    clear) and wires the recover callback before ``start()``; the first
-    store is not gated. Idempotent on re-entry (no second thread)."""
+def test_registration_starts_heartbeat_before_first_store(
+    fake_adapter, monkeypatch
+) -> None:
+    """A registered idle worker heartbeats before its first store request."""
     adapter, _send_mock, _ = fake_adapter
-    adapter.transfer_ctx = MagicMock()
+    contexts = _patch_transfer_context_factory(monkeypatch)
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
     assert adapter.is_healthy  # the constructor leaves the event set
+
+    adapter.register_kv_caches({"layer.0": fake_tensor})
+
+    assert len(contexts) == 1
+    assert len(FakeHeartbeatThread.instances) == 1
+    heartbeat = FakeHeartbeatThread.instances[0]
+    assert heartbeat.health_event_set_at_init is True
+    assert heartbeat.calls == ["register_recover_callback", "start"]
 
     adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
 
     assert len(FakeHeartbeatThread.instances) == 1
-    heartbeat = FakeHeartbeatThread.instances[0]
-    # Started healthy: the event was NOT cleared before construction, so
-    # the first store is not dropped.
-    assert heartbeat.health_event_set_at_init is True
-    # The recover callback is wired before start() (for genuine recovery).
-    assert heartbeat.calls == ["register_recover_callback", "start"]
     assert adapter.is_healthy
     assert adapter.transfer_ctx.submit_store.call_count == 1
 
@@ -551,9 +561,7 @@ def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
 
 
 def test_shutdown_without_heartbeat_sends_unregister(fake_adapter) -> None:
-    """shutdown() on an adapter whose heartbeat was never lazily started
-    (cold shutdown before any traffic) still sends UNREGISTER and does
-    not raise."""
+    """Shutdown before KV registration still sends UNREGISTER and does not raise."""
     adapter, send_mock, _future = fake_adapter
 
     adapter.shutdown()


### PR DESCRIPTION
## What this PR does / why we need it

Starts the MP worker heartbeat immediately after `register_kv_caches()` succeeds instead of waiting for the first store or retrieve request.

A registered but idle worker currently sends no heartbeat. The server can therefore reap a healthy worker after `worker_registration_grace_seconds`; when traffic eventually reaches that worker, its KV context is gone and retrieve requests can hang.

The heartbeat start remains idempotent, and failed registrations do not start a heartbeat. Recovery continues to use the internal registration helper, so heartbeat-triggered re-registration does not recursively create another heartbeat thread.

Fixes #4715

## Validation

- `NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `.venv/bin/pytest -q tests/v1/multiprocess/test_worker_liveness.py tests/v1/multiprocess/test_free_locks.py tests/v1/test_vllm_mp_adapter.py` — 55 passed
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files` — passed
- `.venv/bin/python -m py_compile lmcache/integration/vllm/vllm_multi_process_adapter.py tests/v1/test_vllm_mp_adapter.py` — passed

## Tests added/updated

- Verifies successful KV registration starts the heartbeat before any store request.
- Verifies registration timeout does not start a heartbeat.
- Verifies later store calls do not create duplicate heartbeat threads.

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
