### PR TITLE
fix(vllm): support packed subpaged attention caches

### DIFF
--- a/docs/design/integration/vllm/kv_cache_group_edits.md
+++ b/docs/design/integration/vllm/kv_cache_group_edits.md
@@ -67,6 +67,19 @@ page space. The edit re-views the tensor as
 `view()`, valid because `k` kernel pages tile each logical page's bytes
 exactly (enforced; see Invariants).
 
+vLLM >= 0.26 registers non-MLA attention K/V-*packed* instead: K and V share
+the trailing content axis (`CS == 2 * head_size`) and the tensor is rank-4,
+`[#pages, kernel_block_size, #heads, CS]` (NHD) or `[#pages, #heads,
+kernel_block_size, CS]` (HND) — the only rank-4 vLLM layouts (see
+`kv_format/detectors/vllm.py`). Same problem, same fix, one extra rule
+(`subpaged-packed-attention-view`): a rank-4 attention tensor whose page is
+smaller than `spec.page_size_bytes` was re-paged by the backend, and is
+re-viewed to `(#pages / k, block_size, 1, CS')` (NHD) or `(#pages / k, 1,
+block_size, CS')` (HND). The result stays K/V-packed, so the same rank-4
+format spec describes it at logical-block granularity. Which middle axis
+carries tokens is not derivable from the shape, so `apply` reads the
+`kv_layout` hint (as `mamba-unified-view` does) and refuses an absent one.
+
 ## Startup validation
 
 `validate_kv_cache_groups` (called at connector init and again at
@@ -144,7 +157,11 @@ bijective block-id → bytes mapping. Consequences:
 | vLLM kernel-page split + block-table expansion | `vllm/v1/worker/utils.py`, `vllm/v1/worker/block_table.py` |
 | End-to-end test | `.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh` (`hma_lm_eval_qwen3_5`) |
 
-Testing is end-to-end only (the `hma_lm_eval_qwen3_5` store-vs-retrieve gsm8k
-check): the edit internals are expected to change as more group kinds are
-covered, so tests pin the observable contract — faithful retrieve — rather
-than view shapes.
+Testing is primarily end-to-end (the `hma_lm_eval_qwen3_5` store-vs-retrieve
+gsm8k check): the edit internals are expected to change as more group kinds
+are covered, so tests pin the observable contract — faithful retrieve —
+rather than view shapes. `tests/v1/test_vllm_kv_cache_group_edits.py` adds a
+GPU-free guard for the one property the e2e test cannot localize: that a
+sub-paged attention group is matched and re-viewed at block-id granularity in
+every registered layout, since an unmatched group is silently mis-transferred
+rather than failing.

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -4,8 +4,8 @@
 This is needed to mask out attention-specific details while making sure that
 LMCache can still store / load KV cache correctly.
 
-Currently there are three edits, one per :class:`KVCacheGroupEdit` subclass
-below. All are for Mamba-hybrid models; the registry is only consulted when
+There is one edit per :class:`KVCacheGroupEdit` subclass below, registered in
+``_EDITS``. All are for Mamba-hybrid models; the registry is only consulted when
 ``kv_cache_config.has_mamba_layers``. :func:`validate_kv_cache_groups`
 additionally rejects, at startup, group specs the transfer path cannot serve
 correctly yet (see its docstring).
@@ -162,6 +162,87 @@ def _synthetic_attention_shape(elems_per_page: int, block_size: int) -> tuple[in
             f"(2, block_size={block_size}, num_heads={_SYNTHETIC_NUM_HEADS}, head_size)"
         )
     return _SYNTHETIC_NUM_HEADS, elems_per_page // denom
+
+
+def _synthetic_packed_content_size(elems_per_page: int, block_size: int) -> int:
+    """Factor a K/V-packed page's element count into its content size.
+
+    The K/V-packed layouts keep both planes in the trailing content axis
+    (``CS == 2 * head_size``) instead of a separate ``2`` axis, so unlike
+    :func:`_synthetic_attention_shape` there is no factor of two to divide out.
+
+    Args:
+        elems_per_page: Total elements in one page (one logical block).
+        block_size: Logical block size (tokens per page).
+
+    Returns:
+        ``content_size`` such that
+        ``block_size * num_heads * content_size == elems_per_page`` for the
+        synthetic head count.
+
+    Raises:
+        ValueError: If the page size does not factor into the target shape.
+    """
+    denom = block_size * _SYNTHETIC_NUM_HEADS
+    if elems_per_page % denom != 0:
+        raise ValueError(
+            f"page ({elems_per_page} elems) does not factor into "
+            f"(block_size={block_size}, num_heads={_SYNTHETIC_NUM_HEADS}, "
+            f"content_size)"
+        )
+    return elems_per_page // denom
+
+
+def _logical_block_ratio(
+    spec: KVCacheSpec, kv_cache: torch.Tensor, kernel_block_size: int
+) -> int:
+    """Return how many kernel pages tile one logical block, validating the fit.
+
+    Shared by every sub-paged rule: the tensor's leading dim counts kernel
+    pages, and everything after it is one kernel page's payload.
+
+    Args:
+        spec: The layer's vLLM KV cache spec (for the logical block size and
+            page size).
+        kv_cache: The kernel-paged tensor.
+        kernel_block_size: Tokens per kernel page, read from the axis the
+            caller's layout puts them on.
+
+    Returns:
+        ``spec.block_size // kernel_block_size``.
+
+    Raises:
+        ValueError: If the sizes do not divide evenly, the kernel pages of one
+            logical block do not tile its page bytes exactly (which would
+            indicate an undeclared packed layout that must not be edited), or
+            the tensor is not contiguous.
+    """
+    logical_block_size = spec.block_size
+    if logical_block_size % kernel_block_size != 0:
+        raise ValueError(
+            f"logical block size {logical_block_size} is not a multiple of "
+            f"kernel block size {kernel_block_size}"
+        )
+    ratio = logical_block_size // kernel_block_size
+
+    num_kernel_pages = kv_cache.shape[0]
+    if num_kernel_pages % ratio != 0:
+        raise ValueError(
+            f"kernel page count {num_kernel_pages} is not a multiple of "
+            f"the logical/kernel block ratio {ratio}"
+        )
+    kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
+    if kernel_page_bytes * ratio != spec.page_size_bytes:
+        raise ValueError(
+            f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
+            f"not tile the logical page ({spec.page_size_bytes} bytes)"
+        )
+    if not kv_cache.is_contiguous():
+        raise ValueError(
+            "kernel-paged attention KV tensor must be contiguous to "
+            "re-view as logical pages"
+        )
+    return ratio
 
 
 class KVCacheGroupEdit(ABC):
@@ -334,33 +415,9 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
                 f"attention KV tensor, got {got}"
             )
         logical_block_size = spec.block_size
-        kernel_block_size = kv_cache.shape[2]
-        if logical_block_size % kernel_block_size != 0:
-            raise ValueError(
-                f"logical block size {logical_block_size} is not a multiple of "
-                f"kernel block size {kernel_block_size}"
-            )
-        ratio = logical_block_size // kernel_block_size
+        ratio = _logical_block_ratio(spec, kv_cache, kv_cache.shape[2])
 
-        num_kernel_pages = kv_cache.shape[0]
-        if num_kernel_pages % ratio != 0:
-            raise ValueError(
-                f"kernel page count {num_kernel_pages} is not a multiple of "
-                f"the logical/kernel block ratio {ratio}"
-            )
-        kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
-        if kernel_page_bytes * ratio != spec.page_size_bytes:
-            raise ValueError(
-                f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
-                f"not tile the logical page ({spec.page_size_bytes} bytes)"
-            )
-        if not kv_cache.is_contiguous():
-            raise ValueError(
-                "kernel-paged attention KV tensor must be contiguous to "
-                "re-view as logical pages"
-            )
-
-        num_blocks = num_kernel_pages // ratio
+        num_blocks = kv_cache.shape[0] // ratio
         elems_per_page = spec.page_size_bytes // kv_cache.element_size()
         num_heads, head_size = _synthetic_attention_shape(
             elems_per_page, logical_block_size
@@ -465,34 +522,100 @@ class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
                 indicate an undeclared packed layout that must not be edited).
         """
         assert isinstance(kv_cache, torch.Tensor)
+        ratio = _logical_block_ratio(spec, kv_cache, kv_cache.shape[1])
+        return kv_cache.view(kv_cache.shape[0] // ratio, spec.block_size, -1)
+
+
+class _SubpagedPackedAttentionViewEdit(KVCacheGroupEdit):
+    """Re-view a kernel-paged, K/V-packed attention tensor as logical pages.
+
+    Same problem and same fix as :class:`_SubpagedAttentionViewEdit`, for the
+    rank-4 layout vLLM >= 0.26 registers for non-MLA attention: K and V share
+    the trailing content axis (``CS == 2 * head_size``) instead of getting
+    their own ``2`` axis, so the tensor is paged as
+
+        ``[#pages, kernel_block_size, #heads, CS]``  (NHD), or
+        ``[#pages, #heads, kernel_block_size, CS]``  (HND)
+
+    -- the only rank-4 vLLM layouts (see
+    ``lmcache.v1.gpu_connector.kv_format.detectors.vllm``). Without this rule
+    the rank-4 tensors of a hybrid model never match any edit, LMCache
+    discovers ``block_size == kernel_block_size < spec.block_size``, and
+    ``lmcache.v1.kv_layer_groups`` misclassifies the group as slot-compressed:
+    only one of the ``ratio`` kernel pages per logical block is transferred.
+
+    The result keeps the K/V-packed convention -- ``[#pages / ratio,
+    block_size, 1, CS']`` (NHD) or ``[#pages / ratio, 1, block_size, CS']``
+    (HND) -- so the same rank-4 format spec still describes it, now at
+    logical-block granularity.
+
+    The opaque-page contract of :class:`_SubpagedAttentionViewEdit` applies
+    here too: the dims are addressing metadata, the bytes of one logical page
+    interleave K and V at kernel-page granularity, so content-aware processing
+    does not apply.
+    """
+
+    name = "subpaged-packed-attention-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        return (
+            # Standard-paged attention only; MLA layouts and declared slot
+            # compression (DeepSeek) belong to other transfer paths.
+            get_kv_cache_spec_kind(spec) in _SUBPAGEABLE_ATTENTION_KINDS
+            and not _declares_slot_compression(spec)
+            # Rank-4 is blocks-first K/V-packed attention. Which middle axis
+            # carries the tokens depends on the kv_layout hint, which
+            # ``matches`` does not get -- but the byte accounting settles it
+            # either way: a page registered at block-id granularity holds
+            # exactly ``page_size_bytes``, so anything smaller means the
+            # backend re-paged the tensor at its kernel block size.
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 4
+            and kv_cache.shape[1:].numel() * kv_cache.element_size()
+            != spec.page_size_bytes
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """Re-view ``kv_cache`` at logical-block granularity.
+
+        The token axis is axis 1 for NHD and axis 2 for HND, so the layout
+        hint decides which axis carries the kernel block size and where the
+        synthetic head axis goes.
+
+        Raises:
+            ValueError: If the layout hint is missing or unsupported, or the
+                kernel pages of one logical block do not tile its page bytes
+                exactly (see :func:`_logical_block_ratio`).
+        """
+        assert isinstance(kv_cache, torch.Tensor), (
+            "single-layer KV cache must be a torch.Tensor"
+        )
+        kv_layout = layout_hints.get("kv_layout", "none")
+        if kv_layout not in ("NHD", "HND"):
+            raise ValueError(
+                f"Unsupported kv_layout: {kv_layout}. Only NHD and HND are supported."
+            )
+        token_axis = 1 if kv_layout == "NHD" else 2
         logical_block_size = spec.block_size
-        kernel_block_size = kv_cache.shape[1]
-        if logical_block_size % kernel_block_size != 0:
-            raise ValueError(
-                f"logical block size {logical_block_size} is not a multiple of "
-                f"kernel block size {kernel_block_size}"
-            )
-        ratio = logical_block_size // kernel_block_size
+        ratio = _logical_block_ratio(spec, kv_cache, kv_cache.shape[token_axis])
 
-        num_kernel_pages = kv_cache.shape[0]
-        if num_kernel_pages % ratio != 0:
-            raise ValueError(
-                f"kernel page count {num_kernel_pages} is not a multiple of "
-                f"the logical/kernel block ratio {ratio}"
+        num_blocks = kv_cache.shape[0] // ratio
+        elems_per_page = spec.page_size_bytes // kv_cache.element_size()
+        content_size = _synthetic_packed_content_size(
+            elems_per_page, logical_block_size
+        )
+        if kv_layout == "NHD":
+            return kv_cache.view(
+                num_blocks, logical_block_size, _SYNTHETIC_NUM_HEADS, content_size
             )
-        kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
-        if kernel_page_bytes * ratio != spec.page_size_bytes:
-            raise ValueError(
-                f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
-                f"not tile the logical page ({spec.page_size_bytes} bytes)"
-            )
-        if not kv_cache.is_contiguous():
-            raise ValueError(
-                "kernel-paged attention KV tensor must be contiguous to "
-                "re-view as logical pages"
-            )
-
-        return kv_cache.view(num_kernel_pages // ratio, logical_block_size, -1)
+        return kv_cache.view(
+            num_blocks, _SYNTHETIC_NUM_HEADS, logical_block_size, content_size
+        )
 
 
 # Rule registry, in match priority order.
@@ -501,6 +624,7 @@ _EDITS: tuple[KVCacheGroupEdit, ...] = (
     _MambaPageViewEdit(),
     _SubpagedMLAAttentionViewEdit(),
     _SubpagedAttentionViewEdit(),
+    _SubpagedPackedAttentionViewEdit(),
 )
 
 

--- a/tests/v1/test_vllm_kv_cache_group_edits.py
+++ b/tests/v1/test_vllm_kv_cache_group_edits.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the sub-paged attention edits (GPU-free).
+
+The rules decide purely from a vLLM spec and a registered tensor, so real
+specs plus plain CPU tensors cover them; only the ``KVCacheConfig`` is a
+duck-typed double, since the edits read just two of its attributes.
+"""
+
+# Standard
+from dataclasses import dataclass
+from typing import Any, cast
+
+# Third Party
+import pytest
+import torch
+
+kv_iface = pytest.importorskip(
+    "vllm.v1.kv_cache_interface",
+    reason="kv_cache_group_edits imports vLLM at module top",
+)
+
+# First Party
+# First Party (after importorskip)
+from lmcache.integration.vllm.kv_cache_group_edits import (  # noqa: E402
+    apply_kv_cache_group_edits,
+)
+from lmcache.v1.gpu_connector.utils import LayoutHints  # noqa: E402
+
+
+@dataclass
+class MockKVCacheGroup:
+    layer_names: list[str]
+    kv_cache_spec: object
+
+
+@dataclass
+class MockKVCacheConfig:
+    kv_cache_groups: list[MockKVCacheGroup]
+    has_mamba_layers: bool = True
+
+
+# One observed hybrid configuration (Qwen3.5 GDN on vLLM 0.27.1): the
+# scheduler inflates the attention block to 1600 tokens to align with the
+# Mamba page while the backend pages the tensor at 64, so one logical block
+# spans 25 kernel pages.
+_LOGICAL_BLOCK_SIZE = 1600
+_KERNEL_BLOCK_SIZE = 64
+_RATIO = _LOGICAL_BLOCK_SIZE // _KERNEL_BLOCK_SIZE
+_NUM_LOGICAL_BLOCKS = 3
+_NUM_KERNEL_PAGES = _NUM_LOGICAL_BLOCKS * _RATIO
+_NUM_HEADS = 4
+_HEAD_SIZE = 128
+_DTYPE = torch.bfloat16
+
+
+def _fa_spec(page_size_padded: int | None = None) -> Any:
+    """A full-attention spec whose page holds one whole logical block.
+
+    ``page_size_bytes`` is derived by vLLM as ``num_kv_heads * block_size *
+    2 * head_size * itemsize``; ``page_size_padded`` overrides it, which the
+    byte-accounting tests use to simulate a page the kernel pages cannot tile.
+    """
+    return kv_iface.FullAttentionSpec(
+        block_size=_LOGICAL_BLOCK_SIZE,
+        num_kv_heads=_NUM_HEADS,
+        head_size=_HEAD_SIZE,
+        dtype=_DTYPE,
+        page_size_padded=page_size_padded,
+    )
+
+
+def _split_kv_cache() -> torch.Tensor:
+    """The rank-5 layout of vLLM < 0.26: K and V get their own axis."""
+    return torch.zeros(
+        _NUM_KERNEL_PAGES,
+        2,
+        _KERNEL_BLOCK_SIZE,
+        _NUM_HEADS,
+        _HEAD_SIZE,
+        dtype=_DTYPE,
+    )
+
+
+def _packed_kv_cache(kv_layout: str = "NHD") -> torch.Tensor:
+    """The rank-4 layout of vLLM >= 0.26: K/V packed in the content axis."""
+    heads_first = kv_layout == "HND"
+    return torch.zeros(
+        _NUM_KERNEL_PAGES,
+        _NUM_HEADS if heads_first else _KERNEL_BLOCK_SIZE,
+        _KERNEL_BLOCK_SIZE if heads_first else _NUM_HEADS,
+        2 * _HEAD_SIZE,
+        dtype=_DTYPE,
+    )
+
+
+def _edit(
+    kv_cache: torch.Tensor,
+    spec: Any | None = None,
+    kv_layout: str = "NHD",
+) -> torch.Tensor:
+    """Run the registry over one layer and return its (possibly edited) view."""
+    config = MockKVCacheConfig(
+        kv_cache_groups=[
+            MockKVCacheGroup(layer_names=["layer.0"], kv_cache_spec=spec or _fa_spec())
+        ]
+    )
+    edited = apply_kv_cache_group_edits(
+        config, {"layer.0": kv_cache}, cast(LayoutHints, {"kv_layout": kv_layout})
+    )
+    return edited["layer.0"]
+
+
+def test_page_size_bytes_matches_one_logical_block() -> None:
+    """Pin the premise the other tests build on."""
+    expected = 2 * _LOGICAL_BLOCK_SIZE * _NUM_HEADS * _HEAD_SIZE * _DTYPE.itemsize
+    assert _fa_spec().page_size_bytes == expected
+
+
+def test_subpaged_split_layout_is_reviewed_at_logical_block_size() -> None:
+    """The rank-5 layout re-views to one page per scheduler block."""
+    kv_cache = _split_kv_cache()
+
+    edited = _edit(kv_cache)
+
+    assert edited.shape[0] == _NUM_LOGICAL_BLOCKS
+    assert edited.shape[2] == _LOGICAL_BLOCK_SIZE
+    assert edited.data_ptr() == kv_cache.data_ptr()
+    assert edited.numel() == kv_cache.numel()
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+def test_subpaged_packed_layout_is_reviewed_at_logical_block_size(
+    kv_layout: str,
+) -> None:
+    """The rank-4 K/V-packed layout re-views the same way, on both layouts.
+
+    Regression test for the sub-paged full-attention group being left
+    unedited on vLLM >= 0.26: the raw kernel geometry then reaches
+    ``lmcache.v1.kv_layer_groups``, which reads it as slot compression and
+    transfers one of every ``ratio`` kernel pages.
+    """
+    kv_cache = _packed_kv_cache(kv_layout)
+
+    edited = _edit(kv_cache, kv_layout=kv_layout)
+
+    token_axis = 1 if kv_layout == "NHD" else 2
+    head_axis = 2 if kv_layout == "NHD" else 1
+    assert edited.ndim == 4
+    assert edited.shape[0] == _NUM_LOGICAL_BLOCKS
+    assert edited.shape[token_axis] == _LOGICAL_BLOCK_SIZE
+    assert edited.shape[head_axis] == 1
+    # A whole logical page per block: nothing dropped, same storage.
+    page_bytes = edited.shape[1:].numel() * edited.element_size()
+    assert page_bytes == _fa_spec().page_size_bytes
+    assert edited.data_ptr() == kv_cache.data_ptr()
+    assert edited.numel() == kv_cache.numel()
+
+
+def test_packed_layout_already_at_block_size_is_untouched() -> None:
+    """A layer the backend did not re-page must not be edited."""
+    kv_cache = torch.zeros(
+        _NUM_LOGICAL_BLOCKS,
+        _LOGICAL_BLOCK_SIZE,
+        _NUM_HEADS,
+        2 * _HEAD_SIZE,
+        dtype=_DTYPE,
+    )
+
+    assert _edit(kv_cache) is kv_cache
+
+
+def test_packed_layout_that_does_not_tile_the_page_raises() -> None:
+    """An undeclared packed layout must fail loudly, not transfer wrongly."""
+    padded = _fa_spec().page_size_bytes + _DTYPE.itemsize
+    with pytest.raises(ValueError, match="do not tile the logical page"):
+        _edit(_packed_kv_cache(), spec=_fa_spec(page_size_padded=padded))
+
+
+def test_packed_layout_without_a_layout_hint_raises() -> None:
+    """The token axis is unknowable without the hint, so refuse to guess."""
+    with pytest.raises(ValueError, match="Unsupported kv_layout"):
+        _edit(_packed_kv_cache(), kv_layout="none")
+
+
+def test_non_mamba_config_is_returned_unedited() -> None:
+    """The registry is only consulted for Mamba-hybrid models."""
+    kv_cache = _packed_kv_cache()
+    config = MockKVCacheConfig(
+        kv_cache_groups=[
+            MockKVCacheGroup(layer_names=["layer.0"], kv_cache_spec=_fa_spec())
+        ],
+        has_mamba_layers=False,
+    )
+
+    edited = apply_kv_cache_group_edits(
+        config, {"layer.0": kv_cache}, {"kv_layout": "NHD"}
+    )
+
+    assert edited["layer.0"] is kv_cache
+
+
+def test_mamba_layer_is_not_claimed_by_the_packed_rule() -> None:
+    """Rank-4 Mamba state keeps matching ``mamba-unified-view`` first."""
+    kv_cache = torch.zeros(
+        _NUM_LOGICAL_BLOCKS, 1, 1, _LOGICAL_BLOCK_SIZE * _HEAD_SIZE, dtype=_DTYPE
+    )
+    spec = kv_iface.MambaSpec(
+        block_size=_LOGICAL_BLOCK_SIZE,
+        shapes=((_LOGICAL_BLOCK_SIZE, _HEAD_SIZE),),
+        dtypes=(_DTYPE,),
+        mamba_cache_mode="align",
+    )
+
+    edited = _edit(kv_cache, spec=spec)
+
+    assert edited.shape == (_NUM_LOGICAL_BLOCKS, _LOGICAL_BLOCK_SIZE, 1, _HEAD_SIZE)


### PR DESCRIPTION
## Summary

- recognize vLLM >= 0.26 rank-4 K/V-packed attention caches when a hybrid backend splits one logical block across kernel pages
- re-view NHD and HND layouts at scheduler block granularity without copying or dropping bytes
- share sub-page tiling and contiguity validation across split-K/V, packed-K/V, and MLA layouts
- add CPU regression coverage for both packed layouts, unchanged layouts, invalid page geometry, and Mamba rule priority
- document the packed sub-page layout and why the edit is required

Closes #4701.

Thanks to @dl4rce for the reproducer, root-cause analysis, and reference patch attached to the issue.

## Validation

- `NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `PYTHONPATH=/tmp/lmcache-vllm-stub .venv/bin/pytest -xvs tests/v1/test_vllm_kv_cache_group_edits.py tests/v1/test_vllm_kv_cache_groups.py` — 25 passed
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files` — passed
- `cd docs && make clean && make html` — built successfully; repository currently emits 30 pre-existing warnings

The standard full pytest command cannot collect in this CPU-only environment because `vllm` is not installed (`tests/v1/test_pos_kernels.py` imports it unconditionally). The new regression tests were forced to execute locally with a minimal API-compatible KV spec stub rather than being skipped.
