### PR TITLE
fix(vllm/mp): separate heartbeat liveness from transfer readiness

### DIFF
--- a/docs/design/v1/multiprocess/worker_liveness.md
+++ b/docs/design/v1/multiprocess/worker_liveness.md
@@ -18,49 +18,45 @@ silently binds it to the stale context — wrong IPC handles, corrupted transfer
 
 ## 2. Design Overview
 
-The server already receives a periodic signal from every actively serving worker:
-the heartbeat PING. The design adds the worker's `instance_id` to that message,
-stamps `last_seen` on the per-instance entries that already exist, and runs one
-periodic scan that reaps entries silent longer than a timeout via the same cleanup
-as a client unregister. The heartbeat keeps its lazy start (first store/retrieve)
-and starts healthy; a live worker pings every interval, refreshing its `last_seen`,
-so it is never reaped while alive. Entries that never produced a liveness signal
-fall under a generous registration grace. Recovery reuses existing client
-machinery: on a genuine outage the heartbeat's pings fail, clearing `health_event`;
-when the server returns the unhealthy-to-healthy edge fires the recover callback,
-which re-registers — a noop when the entry survived.
+The server tracks two independent observations on each registered transfer
+context: PING proves heartbeat participation, while the first real transfer
+through that context proves its request-serving path has been exercised. The
+heartbeat starts after KV cache registration and refreshes `last_seen`, but the
+normal reap timeout applies to a context only after both signals have arrived.
+Until then, the larger registration grace protects model warmup and CUDA Graph
+capture without letting a context whose worker dies during startup leak forever.
+The worker heartbeat uses a registration-aware request: the server both proves
+availability and reports any expected Context that no longer exists. Missing
+registrations trigger the existing idempotent re-registration callback even
+when the server itself never became unhealthy.
 
-```
-engine worker adapter                            MP server
-+---------------------------+                   +--------------------------------------+
-| HeartbeatThread           |   PING [id]       | ManagementModule                     |
-|  (instance_id, 10s)  -----+------------------>|  ping(id) -> touch_instance(id)      |
-|  lazy start on first req, |   (NORMAL pool)   |  reaper thread (scan = timeout/4)    |
-|   (starts healthy)        |                   |   -> reap_stale_instances(           |
-|  unhealthy->healthy edge  |                   |        timeout, registration_grace)  |
-|   -> re-register callback |   REGISTER        |   -> drop_instance_state(id) fan-out |
-|                           +------------------>|        |                |            |
-| register_kv_caches        |   STORE/RETRIEVE  |        v                v            |
-|  (no pings until traffic) |   (refresh too)   | LMCacheDriven/          Blend        |
-|                           |                   |  EngineDriven           (CB rope     |
-|                           |                   |  TransferModule          dropped)    |
-|                           |                   |  Entry{.., last_seen,               |
-|                           |                   |   has_liveness_signal}               |
-+---------------------------+                   |  _lock (leaf); pop -> cleanup        |
-                                                +--------------------------------------+
+```text
+Worker REGISTER -> start heartbeat
+       |
+       +-- PING_REGISTERED(id, primary type) --> Server checks primary Context
+       |                                      |
+       |<------------- present? ---------------+
+       |
+       +-- missing -> idempotent re-registration
+       +-- STORE/RETRIEVE -> latch transfer activity
+
+Server Reaper: use normal timeout only after PING + transfer; otherwise grace.
 ```
 
 ## 3. Protocol Change
 
-The PING payload changes in place from `[]` to `[int | None]`; the response stays
-`bool`, always `True` (`None` marks an untracked prober such as the scheduler
-adapter, which registers nothing and is never reapable). PING keeps its BLOCKING
-dispatch on the NORMAL thread pool. SYNC dispatch was considered but rejected:
-SYNC runs on the MQ main loop, where a slow `REGISTER_KV_CACHE` (also SYNC) would
-block PING and make a live worker look dead. Sharing the NORMAL pool is in fact
-desirable — if the pool cannot answer PING within the heartbeat timeout, the
-worker *should* enter degraded mode (the same back-pressure signal). The payload
-change is wire-visible, so both sides upgrade together (Section 7).
+The existing `PING([int | None]) -> bool` operation is unchanged. It reports
+server availability and refreshes matching Contexts; `None` marks an untracked
+prober such as the scheduler adapter. It remains BLOCKING on the NORMAL pool so
+a slow SYNC registration cannot stall heartbeat dispatch on the MQ main loop.
+
+`PING_REGISTERED(instance_id, primary_registration_type)` is an internal vLLM
+worker operation. It atomically checks and refreshes the Worker's LMCache-driven
+or engine-driven primary KV Context. `True` means it exists, `False` means the
+server is reachable but it is missing, and a transport timeout means the server
+is unreachable. Optional experimental Contexts are refreshed when present but
+are not part of registration recovery. The separate request keeps existing PING
+callers wire-compatible.
 
 ## 4. Instance ID Generation
 
@@ -72,16 +68,38 @@ Every id-carrying request reads the same field, so no other payloads change.
 
 ## 5. Server Side
 
-### 5.1 Liveness state and two-tier windows
+### 5.1 Liveness state and two-signal activation
 
-`ContextEntry` (LMCache-driven) and `EngineDrivenContextEntry` gain
-`last_seen: float` (`time.monotonic()`) and `has_liveness_signal: bool`, latched
-only by PING. The flag selects the staleness window: an entry that has pinged
-provably runs the heartbeat protocol and is judged on the reap timeout; one that
-never pinged (e.g. still warming under lazy start) is judged on the generous
-registration grace. `last_seen` is refreshed by PING (`touch_instance`: refresh
-if present, never insert), register (create and NOOP paths), and every transfer
-path, so a worker mid-transfer is never reaped; traffic never latches the flag.
+`ContextEntry` (LMCache-driven and QStore) and `EngineDrivenContextEntry` hold
+`last_seen`, `has_liveness_signal` (latched by PING), and
+`has_transfer_activity` (latched by a real store/retrieve or prepare/commit).
+The normal reap timeout applies only when both booleans are true; every other
+state uses registration grace. PING, registration, and transfer all refresh
+`last_seen`.
+
+Activation is scoped to each registered transfer context, not shared globally
+by `instance_id`. PING is fanned out to every context registered for that
+worker, while a transfer activates only the context that serves it. For example,
+a GPU KV retrieve activates the GPU KV context but not an optional QStore
+context; the QStore context retains registration grace until its own first
+`STORE_Q`. This prevents one transfer path from shortening another context's
+startup protection. A context that is never used is still cleaned up after a
+silent registration-grace interval.
+
+Mirrored state retains the same ownership boundary. Blend rope state is owned
+by the GPU KV context, so only reaping that context drops the mirror. Reaping an
+independently activated QStore context with the same `instance_id` does not
+invalidate a still-protected GPU/Blend context.
+
+| PING seen | Transfer seen | Reap window |
+|---|---|---|
+| No | No | Registration grace |
+| Yes | No | Registration grace (startup or request-idle) |
+| No | Yes | Registration grace (legacy client without heartbeat) |
+| Yes | Yes | Normal reap timeout |
+
+Metadata-only Blend operations do not mark transfer activity. The actual
+`CB_RETRIEVE_PRE_COMPUTED` scatter does.
 
 ### 5.2 Locking
 
@@ -99,23 +117,17 @@ readers use the locked accessors `get_and_touch_context_entry` (get-and-refresh)
 ### 5.3 Reaper
 
 `ManagementModule` (the PING owner) owns the reaper thread, scanning every
-`reap_timeout / 4`. Each scan calls `reap_stale_instances` on every target: under
-the module lock, collect ids whose staleness exceeds their window and pop them;
-outside the lock, run the same cleanup as a client unregister and log a WARNING
-per instance (repeated reaps of one id signal a too-small timeout). Reaped ids are
-then passed to `drop_instance_state(id)` on every target; `BlendModule` drops
-the reaped instance's per-instance CB state (e.g. rope state) there. (It no longer
-mirrors the GPU cache context — that mirror was removed upstream, so reaping the
-GPU entry now frees the context directly.) Collect+pop shares the module lock with
-register's refresh, serializing every register-vs-reap race; on close, the reaper
-is stopped and joined before any module clears state.
+`reap_timeout / 4`. Each target atomically selects and pops stale ids under its
+module lock, then performs unregister-equivalent cleanup outside the lock. Only
+a GPU KV reap invalidates GPU-owned Blend mirror state. On close, the reaper is
+stopped before modules clear their state.
 
 ### 5.4 Public protocol and config
 
 ```python
 class InstanceLivenessTarget(Protocol):
     # All methods default to a no-op; an implementer overrides only its role.
-    def touch_instance(self, instance_id: int) -> None: ...
+    def touch_instance(self, instance_id: int) -> bool: ...
     def reap_stale_instances(
         self, reap_timeout_s: float, registration_grace_s: float
     ) -> list[int]: ...
@@ -126,43 +138,45 @@ class InstanceLivenessTarget(Protocol):
 One protocol covers both reaper-driven roles. The transfer modules override the
 liveness methods (`touch`/`reap`/`count`); `BlendModule` overrides only
 `drop_instance_state` to drop its mirrored CB state. `ManagementModule` receives
-all targets in a single injected list. (Earlier a separate one-method
+all targets in a single injected list and the GPU KV target as the owner whose
+reaps invalidate that mirror. Reaps from QStore or other contexts do not fan out
+mirror cleanup. (Earlier a separate one-method
 `InstanceReapListener` held `drop_instance_state`; it was folded in since only
 `BlendModule` ever implemented it.)
 
 Config: `worker_reap_timeout_seconds` (default `120.0`; `0` disables, otherwise
 `>= 30.0`) and `worker_registration_grace_seconds` (default `3600.0`; `>=` the
-reap timeout — a tighter grace would reap warming workers faster than crashed
-ones), with matching CLI flags. Keep the timeout `>= 3 x` the client's
+reap timeout), with matching CLI flags. Grace applies until both activation
+signals exist. Keep the timeout `>= 3 x` the client's
 `lmcache.mp.heartbeat_interval` so a few missed pings never reap a live worker;
 the worker adapter warns at startup when `3 x interval` exceeds the 30 s floor.
 
 ## 6. Adapter Side
 
-### 6.1 Lazy start
+### 6.1 Registration-time start
 
-The heartbeat keeps its lazy start on first store/retrieve — no pings during
-warmup; the registration grace covers that window. It starts healthy (the event
-is set at construction), so the first store/retrieve is not gated. A live worker
-then pings every interval, refreshing its server-side `last_seen`, so it is never
-reaped while alive — no re-registration is needed at start. The recover callback
-re-registers only on a genuine recovery edge (Section 6.2). A retrieve dropped
-while the server is unhealthy is still reported via `get_finished` so async loads
-cannot hang.
+The heartbeat starts after successful KV registration, before the first
+store/retrieve. It starts healthy, refreshes `last_seen`, and verifies the actual
+LMCache-driven or engine-driven primary Context type. PING alone does not claim
+request readiness: the first real transfer latches the second signal. A missing
+primary Context clears health and invokes the existing idempotent recovery
+callback; failure stays unhealthy and retries next heartbeat. Request paths keep
+their defensive idempotent start call. A retrieve dropped while unhealthy is
+still reported via `get_finished` so async loads cannot hang.
 
 ### 6.2 Recovery after a reap
 
 ```
-T0        outage begins; pings time out -> health_event cleared, traffic stops
+T0        heartbeat is starved while the server remains available
 T0+120s   server: entry stale -> reap pops it, frees GPUCacheContext/IPC,
           layout-desc refcount; blend rope state dropped via listener <- leak fixed
-T1        connectivity back; next ping succeeds -> unhealthy->healthy edge
-T1        recover callback re-registers (id absent -> fresh context) before
-          health_event is set; traffic resumes             <- exactly one context
+T1        worker resumes; PING_REGISTERED reports the primary Context absent
+T1        health_event is cleared; recover callback re-registers the same
+          instance_id before health_event is set; traffic resumes
 ```
 
-A shorter outage hits the NOOP register path, which refreshes `last_seen` and
-builds nothing — the server never asks a worker to re-register.
+The same callback still handles a full server outage. If all Contexts survived,
+the idempotent register path refreshes `last_seen` and builds nothing.
 
 ### 6.3 Shutdown
 
@@ -175,10 +189,15 @@ stop is already requested — a straggling cycle cannot re-create a ghost contex
 
 | Scenario | Behavior |
 |---|---|
-| Worker crash (SIGKILL, no UNREGISTER) after serving | Pings stop; reaped within ~`timeout + timeout/4`. Context, IPC handles, layout-desc refcount, and non-GPU strategy released via the same cleanup as a clean unregister; blend rope state dropped via the reap listener. The bug being fixed. |
-| Worker crash during warmup (registered, never pinged) | Reaped on the registration grace. Bounded leak instead of a permanent one. |
-| Worker alive but never pinged, idle past the grace | Reaped while alive only if it never pinged (heartbeat never started). Once the heartbeat is running, pings refresh `last_seen` every interval, so a live worker is never reaped regardless of traffic. |
+| Worker crash (SIGKILL, no UNREGISTER) after serving | Both signals are latched; pings stop and the entry is reaped within ~`timeout + timeout/4`, using normal unregister cleanup. |
+| Worker dies during startup | Before both signals exist, prolonged silence is reaped on registration grace. The startup leak stays bounded. |
+| Worker remains alive but receives no traffic | Registration starts heartbeat; each PING refreshes registration grace, so request-idle time alone never reaps it. |
+| Worker continues warmup after registration | PING does not end startup protection. A temporarily starved heartbeat has the larger grace; silence beyond that grace is treated as startup death. |
+| Legacy client transfers but sends no PING | Transfer activity alone retains registration grace, preserving compatibility while keeping cleanup bounded. |
+| Worker has multiple registered contexts | Each context activates on its own first real transfer. An unused optional context retains registration grace and is cleaned up if it stays silent beyond that bound. |
 | Heartbeat thread starved, worker transferring | Store/retrieve/prepare/commit refresh `last_seen`; never reaped. |
-| Partition shorter than the reap window | No reap. On heal, the recover callback re-registers; the NOOP path refreshes `last_seen`; zero context churn. |
+| Server stays healthy but the primary KV Context is reaped | The next registration-aware heartbeat reports it absent and triggers idempotent re-registration; detection takes at most one heartbeat interval. A transfer already entering the path may fall back once. |
+| Only an optional experimental Context is reaped | It is outside this PR's proactive registration-recovery scope; full QStore recovery can be added separately. |
+| Partition shorter than the reap window | No reap. On heal, the recovery path is idempotent; an existing Context is only refreshed. |
 | Worker crash + restart | The new process gets a fresh uuid-derived id and a fresh entry; the dead id is reaped independently. No PID-reuse aliasing. |
-| Mixed client/server versions | Every PING fails the payload-count check; the client sits permanently unhealthy. Loud, never silent corruption; upgrade both sides together. |
+| New worker with an old server | `PING_REGISTERED` is unsupported, so the worker becomes unhealthy rather than silently transferring without a Context. Upgrade both sides together. |

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1275,10 +1275,7 @@ class LMCacheMPWorkerAdapter:
         self._health_event = threading.Event()
         self._health_event.set()
 
-        # Heartbeat thread is created but NOT started yet.
-        # It will be lazily started on the first store or retrieve
-        # request, by which time vLLM is fully ready (model loaded,
-        # KV caches allocated, warmup & CUDA graph capture done).
+        # Start only after KV registration, before the first request.
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None
         self._heartbeat_lock = threading.Lock()
@@ -1384,6 +1381,7 @@ class LMCacheMPWorkerAdapter:
             layout_hints if layout_hints is not None else vllm_layout_hints()
         )
         self._send_register_kv_caches_request(kv_caches)
+        self._ensure_heartbeat_started()
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
         return expand_engine_block_ids(self.engine_group_infos, op.block_ids)
@@ -1432,14 +1430,15 @@ class LMCacheMPWorkerAdapter:
             ) from None
 
     def _ensure_heartbeat_started(self) -> None:
-        """Lazily start the heartbeat thread on first store/retrieve.
+        """Start the heartbeat thread once after KV cache registration.
 
         The heartbeat starts healthy (the event was set at construction). A
         live worker pings every interval, refreshing its server-side
-        ``last_seen``, so it is never reaped while alive -- no re-registration
-        is needed at startup, and the first store/retrieve is not gated. The
-        recover callback still re-registers on a genuine unhealthy->healthy
-        edge (server restart).
+        ``last_seen``, so an idle registered worker is not reaped before its
+        first request. Store/retrieve paths also call this method defensively;
+        the idempotent guard prevents duplicate threads. The recover callback
+        re-registers after a server outage or when a registration-aware
+        heartbeat reports that a Context was reaped.
         """
         if self._heartbeat is not None:
             return

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -31,6 +31,7 @@ from lmcache.v1.multiprocess.group_view import (
     expand_engine_block_ids,
 )
 from lmcache.v1.multiprocess.mq import MessagingFuture
+from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.multiprocess.transfer_context import (
     EngineDrivenTransferContext,
     TransferContext,
@@ -284,6 +285,23 @@ def send_ping(
         return False
 
 
+def send_registered_ping(
+    req_client: RequestClient,
+    timeout: float,
+    instance_id: int,
+    registration_type: RequestType,
+) -> bool | None:
+    """Return registration presence, or None when the server is unreachable."""
+    try:
+        future = req_client.ping_registered(instance_id, registration_type)
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        return None
+    except Exception:
+        logger.debug("Registration-aware ping failed with exception", exc_info=True)
+        return None
+
+
 @dataclass
 class ParallelStrategy:
     mla_only: bool
@@ -434,6 +452,7 @@ class HeartbeatThread(PeriodicThread):
         health_event: threading.Event,
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         instance_id: int | None = None,
+        registration_type: RequestType | None = None,
     ):
         """
         Args:
@@ -446,6 +465,7 @@ class HeartbeatThread(PeriodicThread):
             instance_id: The worker's instance ID sent with each PING so the
                 server can refresh its liveness, or None for an untracked
                 prober (the scheduler adapter).
+            registration_type: The worker's primary server registration.
         """
         super().__init__(
             name="lmcache-heartbeat",
@@ -456,8 +476,9 @@ class HeartbeatThread(PeriodicThread):
         self._health_event = health_event
         self._interval = interval
         self._instance_id = instance_id
+        self._registration_type = registration_type
 
-        # Optional callback invoked on the unhealthy->healthy edge,
+        # Optional callback invoked after an outage or missing registration,
         # before the health event is set. See register_recover_callback.
         def noop() -> bool:
             return True
@@ -465,10 +486,12 @@ class HeartbeatThread(PeriodicThread):
         self._recover_callback: Callable[[], bool] = noop
 
     def register_recover_callback(self, callback: Callable[[], bool]) -> None:
-        """Register a callback fired on the unhealthy->healthy transition.
+        """Register a callback fired after an outage or missing registration.
 
-        The callback runs **before** the health event is set. It must
-        return ``True`` on success (event will be set) or ``False`` on
+        It runs on an unhealthy-to-healthy transition and whenever a reachable
+        server reports an expected Context missing. The callback runs
+        **before** the health event is set. It must return ``True`` on success
+        (event will be set) or ``False`` on
         failure (event will stay cleared, and the next heartbeat will
         invoke the callback again on the next successful PING).
 
@@ -494,9 +517,22 @@ class HeartbeatThread(PeriodicThread):
         UNREGISTER must not re-register a ghost context.
         """
         was_healthy = self._health_event.is_set()
-        healthy = send_ping(
-            self._req_client, timeout=self._interval, instance_id=self._instance_id
-        )
+        if self._registration_type is not None and self._instance_id is not None:
+            ping_result = send_registered_ping(
+                self._req_client,
+                timeout=self._interval,
+                instance_id=self._instance_id,
+                registration_type=self._registration_type,
+            )
+            server_reachable = ping_result is not None
+            healthy = ping_result is True
+        else:
+            server_reachable = send_ping(
+                self._req_client,
+                timeout=self._interval,
+                instance_id=self._instance_id,
+            )
+            healthy = server_reachable
 
         if self.stop_requested:
             return ThreadRunSummary(
@@ -504,15 +540,27 @@ class HeartbeatThread(PeriodicThread):
                 message="stop requested; skipping health update",
             )
 
+        registration_missing = server_reachable and not healthy
+        if registration_missing:
+            # Make the degraded state visible before registration is rebuilt.
+            self._health_event.clear()
+            logger.warning(
+                "LMCache server is reachable but the worker's primary "
+                "registration is missing; triggering recovery"
+            )
+
         need_trigger_recover = (
-            healthy and not was_healthy and self._recover_callback is not None
+            server_reachable
+            and (registration_missing or not was_healthy)
+            and self._recover_callback is not None
         )
 
         # Try to call recover callback
         if need_trigger_recover:
-            logger.warning(
-                "LMCache server is healthy again, triggering recovery callback"
-            )
+            if not registration_missing:
+                logger.warning(
+                    "LMCache server is healthy again, triggering recovery callback"
+                )
             # If the callback fails, it should not become healthy
             healthy = self._recover_callback()
 
@@ -1279,6 +1327,8 @@ class LMCacheMPWorkerAdapter:
         self._heartbeat_interval = heartbeat_interval
         self._heartbeat: HeartbeatThread | None = None
         self._heartbeat_lock = threading.Lock()
+        self._recovery_lock = threading.Lock()
+        self._primary_registration_type: RequestType | None = None
         if 3 * heartbeat_interval > _SERVER_REAP_TIMEOUT_FLOOR_SECONDS:
             logger.warning(
                 "lmcache.mp.heartbeat_interval is %.1fs, so 3 x "
@@ -1318,10 +1368,8 @@ class LMCacheMPWorkerAdapter:
     def is_healthy(self) -> bool:
         """Whether the LMCache server is healthy.
 
-        Reflects the most recent heartbeat result. KV cache
-        re-registration on the unhealthy->healthy transition is handled
-        by the heartbeat thread itself via ``register_recover_callback``,
-        so this property only reads the shared event.
+        Re-registration after an outage or missing primary Context is handled
+        by the heartbeat thread; this property only reads the shared event.
         """
         return self._health_event.is_set()
 
@@ -1422,6 +1470,12 @@ class LMCacheMPWorkerAdapter:
                 engine_group_infos=self.engine_group_infos,
                 engine_type=EngineType.VLLM,
             )
+            primary_type = (
+                RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+                if isinstance(transfer_ctx, EngineDrivenTransferContext)
+                else RequestType.REGISTER_KV_CACHE
+            )
+            self._primary_registration_type = primary_type
         except TimeoutError:
             raise ConnectionError(
                 "LMCache server did not respond to "
@@ -1450,6 +1504,7 @@ class LMCacheMPWorkerAdapter:
                 health_event=self._health_event,
                 interval=self._heartbeat_interval,
                 instance_id=self.instance_id,
+                registration_type=self._primary_registration_type,
             )
             heartbeat.register_recover_callback(self._reregister_kv_caches_callback)
             heartbeat.start()
@@ -1465,15 +1520,20 @@ class LMCacheMPWorkerAdapter:
         return heartbeat is not None and heartbeat.stop_requested
 
     def _reregister_kv_caches_callback(self) -> bool:
-        """Heartbeat recover callback: re-register KV caches after the
-        server returns. Runs on the heartbeat thread, before the health
-        event is set.
+        """Heartbeat recovery callback: re-register KV caches after an outage
+        or a missing-registration response. Runs on the heartbeat thread,
+        before the health event is set.
 
         Returns:
             ``True`` if nothing needs re-registering or registration
             succeeds; ``False`` on failure or a requested heartbeat stop
             (event stays cleared; retried on the next successful PING).
         """
+        with self._recovery_lock:
+            return self._reregister_kv_caches_locked()
+
+    def _reregister_kv_caches_locked(self) -> bool:
+        """Re-register while serialized with shutdown."""
         if not self.kv_caches:
             # Nothing was registered yet (server flapped before the
             # very first register_kv_caches). Treat as success so the
@@ -2070,31 +2130,32 @@ class LMCacheMPWorkerAdapter:
             if self._heartbeat is not None:
                 self._heartbeat.stop()
 
-        logger.info("Unregistering kv caches")
-        try:
-            if isinstance(self.transfer_ctx, EngineDrivenTransferContext):
-                future = self.req_client.unregister_kv_cache_engine_driven_context(
-                    self.instance_id
+        with self._recovery_lock:
+            logger.info("Unregistering kv caches")
+            try:
+                if isinstance(self.transfer_ctx, EngineDrivenTransferContext):
+                    future = self.req_client.unregister_kv_cache_engine_driven_context(
+                        self.instance_id
+                    )
+                else:
+                    future = self.req_client.unregister_kv_cache(self.instance_id)
+                future.result(timeout=self._mq_timeout)
+            except TimeoutError:
+                logger.warning(
+                    "LMCache server did not respond to unregister within %ss. "
+                    "Proceeding with shutdown.",
+                    self._mq_timeout,
                 )
-            else:
-                future = self.req_client.unregister_kv_cache(self.instance_id)
-            future.result(timeout=self._mq_timeout)
-        except TimeoutError:
-            logger.warning(
-                "LMCache server did not respond to unregister within %ss. "
-                "Proceeding with shutdown.",
-                self._mq_timeout,
-            )
 
-        if self.dispatcher is not None:
-            dispatch(self.dispatcher, "shutdown")
+            if self.dispatcher is not None:
+                dispatch(self.dispatcher, "shutdown")
 
-        if self.transfer_ctx is not None:
-            self.transfer_ctx.close()
-            self.transfer_ctx = None
+            if self.transfer_ctx is not None:
+                self.transfer_ctx.close()
+                self.transfer_ctx = None
 
-        self.req_client.close()
-        self.request_telemetry.close()
+            self.req_client.close()
+            self.request_telemetry.close()
 
     # Helper functions
     def _update_and_get_finished_store(

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -102,15 +102,13 @@ class MPServerConfig:
     the same id. Set via ``--instance-id``; defaults to a random UUID v4."""
 
     worker_reap_timeout_seconds: float = 120.0
-    """Silence budget (seconds) after which a ping-proven worker's KV cache
-    registration is reaped. 0 disables worker reaping. Keep it >= 3 x the
-    engine adapter's heartbeat interval so a few missed pings never reap a live
-    worker."""
+    """Silence budget (seconds) after which a PING-and-transfer-proven worker's
+    KV registration is reaped. 0 disables worker reaping. Keep it >= 3 x the
+    engine adapter's heartbeat interval."""
 
     worker_registration_grace_seconds: float = 3600.0
-    """Silence budget (seconds) for a worker that registered but has never
-    sent a PING (model warmup, or death before its first request). Must be
-    >= worker_reap_timeout_seconds."""
+    """Silence budget (seconds) before a registration has observed both PING
+    and real transfer activity. Must be >= worker_reap_timeout_seconds."""
 
     enable: list[str] = field(default_factory=list)
     """List of experimental transfer modules to enable. Options: transfer_query
@@ -397,17 +395,15 @@ def add_mp_server_args(
         "--worker-reap-timeout-seconds",
         type=float,
         default=120.0,
-        help="Silence budget (s) before a ping-proven worker's KV cache "
-        "registration is reaped. 0 disables reaping. Must be >= 3 x the "
-        "engine adapter's heartbeat interval. Default is 120.",
+        help="Silence budget (s) before a PING-and-transfer-proven worker's "
+        "KV registration is reaped. 0 disables reaping. Default is 120.",
     )
     mp_group.add_argument(
         "--worker-registration-grace-seconds",
         type=float,
         default=3600.0,
-        help="Silence budget (s) for a worker that registered but never "
-        "pinged (model warmup or early death). Must be >= the worker reap "
-        "timeout. Default is 3600.",
+        help="Silence budget (s) before a registration has observed both PING "
+        "and real transfer activity. Default is 3600.",
     )
     mp_group.add_argument(
         "--enable-segmented-prefix",

--- a/lmcache/v1/multiprocess/engine_module.py
+++ b/lmcache/v1/multiprocess/engine_module.py
@@ -68,7 +68,7 @@ class EngineModule(Protocol):
 class InstanceLivenessTarget(Protocol):
     """A module the periodic reaper drives, in either or both of two roles.
 
-    * **Liveness owner** -- tracks per-worker registrations keyed by
+    * **Liveness owner** -- tracks per-context registrations keyed by
       ``instance_id``, refreshed on PING and scanned for staleness
       (``touch_instance`` / ``reap_stale_instances`` /
       ``tracked_instance_count``). The transfer modules fill this role.
@@ -82,7 +82,7 @@ class InstanceLivenessTarget(Protocol):
     touches a module's private state directly.
     """
 
-    def touch_instance(self, instance_id: int) -> None:
+    def touch_instance(self, instance_id: int) -> bool:
         """Refresh the worker's last-seen time and mark it ping-proven.
 
         A no-op if the instance is not tracked (already reaped or never
@@ -90,22 +90,23 @@ class InstanceLivenessTarget(Protocol):
 
         Args:
             instance_id: The worker's opaque instance ID.
+        Returns:
+            True when the registration exists and was refreshed; False when
+            it is absent or this target owns no liveness state.
         """
-        return
+        return False
 
     def reap_stale_instances(
         self, reap_timeout_s: float, registration_grace_s: float
     ) -> list[int]:
         """Evict and clean up workers that have gone silent.
 
-        An instance that has sent at least one PING is judged against
-        ``reap_timeout_s``; one that has never pinged (warming up, or dead
-        before its first request) is judged against ``registration_grace_s``.
+        An instance that has sent PING and real transfer activity is judged
+        against ``reap_timeout_s``; otherwise against ``registration_grace_s``.
 
         Args:
-            reap_timeout_s: Silence budget for ping-proven instances.
-            registration_grace_s: Silence budget for never-pinged instances;
-                must be >= ``reap_timeout_s``.
+            reap_timeout_s: Silence budget after both signals.
+            registration_grace_s: Silence budget before both signals.
 
         Returns:
             The instance IDs reaped during this scan; empty for a target

--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -2685,7 +2685,9 @@ class BlendModule(InstanceLivenessTarget):
             ValueError: If the instance has no registered KV cache or rope
                 state. MLA layouts are unsupported (raised during re-RoPE).
         """
-        entry = self._transfer_module.get_and_touch_context_entry(instance_id)
+        entry = self._transfer_module.get_and_touch_context_entry(
+            instance_id, transfer_activity=True
+        )
         if entry is None:
             raise ValueError(
                 f"Instance {instance_id} not registered for paged KV cache"

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -55,6 +55,7 @@ class EngineDrivenContextEntry:
             instance (register, PING, prepare/commit). Drives reaping.
         has_liveness_signal: True once the instance has sent at least one
             PING. Selects the reap window. Latched only by PING.
+        has_transfer_activity: True after a real prepare or commit request.
     """
 
     metadata: EngineDrivenContextMetadata
@@ -62,6 +63,7 @@ class EngineDrivenContextEntry:
     world_size: int
     last_seen: float = 0.0
     has_liveness_signal: bool = False
+    has_transfer_activity: bool = False
 
 
 class EngineDrivenTransferModule(InstanceLivenessTarget):
@@ -169,13 +171,16 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             self._engine_driven_contexts.clear()
             self._strategies.clear()
 
-    def touch_instance(self, instance_id: int) -> None:
+    def touch_instance(self, instance_id: int) -> bool:
         """Refresh the worker's last-seen time and mark it ping-proven.
 
         A no-op if the instance is not tracked.
 
         Args:
             instance_id: The worker instance ID.
+
+        Returns:
+            True if the Context exists and was refreshed; otherwise False.
         """
         now = time.monotonic()
         with self._lock:
@@ -183,6 +188,7 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             if entry is not None:
                 entry.last_seen = now
                 entry.has_liveness_signal = True
+            return entry is not None
 
     def tracked_instance_count(self) -> int:
         """Return the number of currently registered non-GPU instances."""
@@ -194,12 +200,12 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
     ) -> list[int]:
         """Reap non-GPU registrations that have gone silent.
 
-        A ping-proven instance is judged against ``reap_timeout_s``; one that
-        has never pinged against the larger ``registration_grace_s``.
+        A PING-and-transfer-proven instance uses ``reap_timeout_s``; all other
+        instances use ``registration_grace_s``.
 
         Args:
-            reap_timeout_s: Silence budget for ping-proven instances.
-            registration_grace_s: Silence budget for never-pinged instances.
+            reap_timeout_s: Silence budget for fully active instances.
+            registration_grace_s: Silence budget before both signals.
 
         Returns:
             The instance IDs reaped this scan.
@@ -213,7 +219,7 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
                 if now - entry.last_seen
                 > (
                     reap_timeout_s
-                    if entry.has_liveness_signal
+                    if (entry.has_liveness_signal and entry.has_transfer_activity)
                     else registration_grace_s
                 )
             ]
@@ -224,10 +230,12 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
         for iid, entry in reaped:
             self._release_entry(iid, entry)
             logger.warning(
-                "Reaped non-GPU instance %d: silent for %.1fs (pinged=%s)",
+                "Reaped non-GPU instance %d: silent for %.1fs "
+                "(pinged=%s, transfer_activity=%s)",
                 iid,
                 now - entry.last_seen,
                 entry.has_liveness_signal,
+                entry.has_transfer_activity,
             )
         return [iid for iid, _ in reaped]
 
@@ -237,8 +245,7 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
         """Return (entry, strategy) for a transfer, refreshing last_seen.
 
         Pair-atomicity guarantees the entry exists whenever the strategy
-        does. Refreshes last_seen (no latch) so an active worker is not
-        reaped mid-transfer.
+        does. Also records transfer activity.
 
         Args:
             instance_id: The worker instance ID.
@@ -259,6 +266,7 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
                     f"instance ID {instance_id}"
                 )
             entry.last_seen = now
+            entry.has_transfer_activity = True
             return entry, strategy
 
     def _release_entry(self, instance_id: int, entry: EngineDrivenContextEntry) -> None:

--- a/lmcache/v1/multiprocess/modules/experimental/qstore.py
+++ b/lmcache/v1/multiprocess/modules/experimental/qstore.py
@@ -70,15 +70,17 @@ class QStoreModule(InstanceLivenessTarget):
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
 
-    def get_and_touch_context_entry(self, instance_id: int) -> ContextEntry | None:
+    def get_and_touch_context_entry(
+        self, instance_id: int, *, transfer_activity: bool = False
+    ) -> ContextEntry | None:
         """Return the entry for ``instance_id``, refreshing its last-seen time.
 
         The refresh keeps an actively transferring worker from being reaped
-        even if its PINGs are briefly delayed. Does not latch the
-        ping-proven flag -- only PINGs do that.
+        even if its PINGs are briefly delayed. Transfer activity is optional.
 
         Args:
             instance_id: The worker instance ID.
+            transfer_activity: Whether this is a real Q transfer.
 
         Returns:
             The entry, or None if the instance is not (or no longer) tracked.
@@ -88,6 +90,8 @@ class QStoreModule(InstanceLivenessTarget):
             entry = self._q_contexts.get(instance_id)
             if entry is not None:
                 entry.last_seen = now
+                if transfer_activity:
+                    entry.has_transfer_activity = True
             return entry
 
     def context_entries_snapshot(self) -> dict[int, ContextEntry]:
@@ -100,13 +104,16 @@ class QStoreModule(InstanceLivenessTarget):
         with self._lock:
             return dict(self._q_contexts)
 
-    def touch_instance(self, instance_id: int) -> None:
+    def touch_instance(self, instance_id: int) -> bool:
         """Refresh the worker's last-seen time and mark it ping-proven.
 
         A no-op if the instance is not tracked.
 
         Args:
             instance_id: The worker instance ID.
+
+        Returns:
+            True if the Context exists and was refreshed; otherwise False.
         """
         now = time.monotonic()
         with self._lock:
@@ -114,6 +121,7 @@ class QStoreModule(InstanceLivenessTarget):
             if entry is not None:
                 entry.last_seen = now
                 entry.has_liveness_signal = True
+            return entry is not None
 
     def tracked_instance_count(self) -> int:
         """Return the number of currently registered instances."""
@@ -125,12 +133,12 @@ class QStoreModule(InstanceLivenessTarget):
     ) -> list[int]:
         """Reap Q ring registrations that have gone silent.
 
-        A ping-proven instance is judged against ``reap_timeout_s``; one
-        that has never pinged against the larger ``registration_grace_s``.
+        Both PING and Q-store activity select ``reap_timeout_s``; otherwise the
+        larger ``registration_grace_s`` applies.
 
         Args:
-            reap_timeout_s: Silence budget for ping-proven instances.
-            registration_grace_s: Silence budget for never-pinged instances.
+            reap_timeout_s: Silence budget after both signals.
+            registration_grace_s: Silence budget before both signals.
 
         Returns:
             The instance IDs reaped this scan.
@@ -144,7 +152,7 @@ class QStoreModule(InstanceLivenessTarget):
                 if now - entry.last_seen
                 > (
                     reap_timeout_s
-                    if entry.has_liveness_signal
+                    if (entry.has_liveness_signal and entry.has_transfer_activity)
                     else registration_grace_s
                 )
             ]
@@ -379,7 +387,7 @@ class QStoreModule(InstanceLivenessTarget):
         """
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
+        entry = self.get_and_touch_context_entry(instance_id, transfer_activity=True)
         if entry is None:
             raise ValueError(f"No Q ring registered for instance ID {instance_id}")
         cache_context = entry.cache_context

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -639,8 +639,8 @@ class ContextEntry:
         last_seen: ``time.monotonic()`` of the most recent activity from
             this instance (register, PING, store, or retrieve). Drives reaping.
         has_liveness_signal: True once the instance has sent at least one
-            PING. Selects the reap window (timeout vs registration grace).
-            Latched only by PING, never by traffic.
+            PING. Latched only by PING, never by traffic.
+        has_transfer_activity: True after a real store or retrieve.
         event_backend: Cached event backend selected for this context's device.
     """
 
@@ -649,6 +649,7 @@ class ContextEntry:
     world_size: int
     last_seen: float = 0.0
     has_liveness_signal: bool = False
+    has_transfer_activity: bool = False
     event_backend: EventIPCBackend | None = None
 
 
@@ -692,15 +693,18 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
 
-    def get_and_touch_context_entry(self, instance_id: int) -> ContextEntry | None:
+    def get_and_touch_context_entry(
+        self, instance_id: int, *, transfer_activity: bool = False
+    ) -> ContextEntry | None:
         """Return the entry for ``instance_id``, refreshing its last-seen time.
 
         The refresh keeps an actively transferring worker from being reaped
-        even if its PINGs are briefly delayed. Does not latch the
-        ping-proven flag -- only PINGs do that.
+        even if its PINGs are briefly delayed. ``transfer_activity`` is latched
+        only for real transfers.
 
         Args:
             instance_id: The worker instance ID.
+            transfer_activity: Whether this is a real transfer request.
 
         Returns:
             The entry, or None if the instance is not (or no longer) tracked.
@@ -710,6 +714,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             entry = self._cache_contexts.get(instance_id)
             if entry is not None:
                 entry.last_seen = now
+                if transfer_activity:
+                    entry.has_transfer_activity = True
             return entry
 
     def _release_failed_retrieve_locks(
@@ -767,13 +773,16 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         with self._lock:
             return dict(self._cache_contexts)
 
-    def touch_instance(self, instance_id: int) -> None:
+    def touch_instance(self, instance_id: int) -> bool:
         """Refresh the worker's last-seen time and mark it ping-proven.
 
         A no-op if the instance is not tracked.
 
         Args:
             instance_id: The worker instance ID.
+
+        Returns:
+            True if the Context exists and was refreshed; otherwise False.
         """
         now = time.monotonic()
         with self._lock:
@@ -781,6 +790,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             if entry is not None:
                 entry.last_seen = now
                 entry.has_liveness_signal = True
+            return entry is not None
 
     def tracked_instance_count(self) -> int:
         """Return the number of currently registered instances."""
@@ -792,12 +802,12 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
     ) -> list[int]:
         """Reap GPU registrations that have gone silent.
 
-        A ping-proven instance is judged against ``reap_timeout_s``; one
-        that has never pinged against the larger ``registration_grace_s``.
+        A PING-and-transfer-proven instance uses ``reap_timeout_s``; all other
+        instances use ``registration_grace_s``.
 
         Args:
-            reap_timeout_s: Silence budget for ping-proven instances.
-            registration_grace_s: Silence budget for never-pinged instances.
+            reap_timeout_s: Silence budget for fully active instances.
+            registration_grace_s: Silence budget before both signals.
 
         Returns:
             The instance IDs reaped this scan.
@@ -811,7 +821,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 if now - entry.last_seen
                 > (
                     reap_timeout_s
-                    if entry.has_liveness_signal
+                    if (entry.has_liveness_signal and entry.has_transfer_activity)
                     else registration_grace_s
                 )
             ]
@@ -821,10 +831,12 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         entries: list[ContextEntry] = []
         for iid, e in reaped:
             logger.warning(
-                "Reaped GPU instance %d: silent for %.1fs (pinged=%s)",
+                "Reaped GPU instance %d: silent for %.1fs "
+                "(pinged=%s, transfer_activity=%s)",
                 iid,
                 now - e.last_seen,
                 e.has_liveness_signal,
+                e.has_transfer_activity,
             )
             reaped_ids.append(iid)
             entries.append(e)
@@ -1074,7 +1086,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         """
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
+        entry = self.get_and_touch_context_entry(instance_id, transfer_activity=True)
         if entry is None:
             # The worker can reconnect to a replacement server before its next
             # registration probe. No device work was submitted in that window,
@@ -1314,7 +1326,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         """
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
+        entry = self.get_and_touch_context_entry(instance_id, transfer_activity=True)
         if entry is None:
             # See store(): there is no completion event because no device work
             # was submitted. The False result lets the caller recover or

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -2,7 +2,7 @@
 """Management and utility operations for the MPCacheServer."""
 
 # Standard
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 import threading
 
 # First Party
@@ -52,6 +52,9 @@ class ManagementModule:
         self,
         ctx: MPCacheServerContext,
         liveness_targets: Sequence[InstanceLivenessTarget] = (),
+        registration_targets: Mapping[RequestType, InstanceLivenessTarget]
+        | None = None,
+        mirror_state_owner: InstanceLivenessTarget | None = None,
         worker_reap_timeout_seconds: float = 0.0,
         worker_registration_grace_seconds: float = 0.0,
         experimental_transfer: Sequence[str] = (),
@@ -59,6 +62,8 @@ class ManagementModule:
         self._ctx = ctx
         self._clear_lock = threading.Lock()
         self._liveness_targets = tuple(liveness_targets)
+        self._registration_targets = dict(registration_targets or {})
+        self._mirror_state_owner = mirror_state_owner
         self._reap_timeout = worker_reap_timeout_seconds
         self._reap_grace = worker_registration_grace_seconds
         self._experimental_transfer = tuple(experimental_transfer)
@@ -153,18 +158,22 @@ class ManagementModule:
     def _reap_cycle(self) -> ThreadRunSummary:
         """Run one reaper scan: reap stale workers, drop mirrored state.
 
-        Each reaped instance id is passed to ``drop_instance_state`` on every
-        target; it is a no-op for targets that mirror nothing for that id.
+    def _reap_cycle(self) -> ThreadRunSummary:
+        """Run one reaper scan and drop mirrors owned by reaped Contexts.
 
         Returns:
             A summary recording how many instances were reaped this scan.
         """
         reaped: list[int] = []
+        mirror_reaped: list[int] = []
         for target in self._liveness_targets:
-            reaped.extend(
-                target.reap_stale_instances(self._reap_timeout, self._reap_grace)
+            target_reaped = target.reap_stale_instances(
+                self._reap_timeout, self._reap_grace
             )
-        for instance_id in reaped:
+            reaped.extend(target_reaped)
+            if target is self._mirror_state_owner:
+                mirror_reaped.extend(target_reaped)
+        for instance_id in mirror_reaped:
             for target in self._liveness_targets:
                 target.drop_instance_state(instance_id)
         return ThreadRunSummary(success=True, message=f"reaped={len(reaped)}")

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -40,10 +40,14 @@ class ManagementModule:
             whose per-instance registrations are refreshed on PING and scanned
             for staleness, plus any state mirror (e.g. ``BlendModule``)
             notified via ``drop_instance_state`` when an instance is reaped.
-        worker_reap_timeout_seconds: Silence budget for a ping-proven worker;
-            0 disables reaping (no thread is started).
-        worker_registration_grace_seconds: Silence budget for a worker that
-            registered but never pinged.
+        registration_targets: Registration request types mapped to the owning
+            liveness target for registration-aware worker heartbeats.
+        mirror_state_owner: The liveness target whose reaps invalidate mirrored
+            per-instance state. Reaps from other contexts with the same
+            ``instance_id`` do not notify mirrors.
+        worker_reap_timeout_seconds: Silence budget after both liveness signals;
+            0 disables reaping.
+        worker_registration_grace_seconds: Silence budget before both signals.
         experimental_transfer: Types of experimental intermediate tensor
             transfer built in the server.
     """
@@ -107,6 +111,11 @@ class ManagementModule:
                 ThreadPoolType.SYNC,
             ),
             HandlerSpec(RequestType.PING, self.ping, ThreadPoolType.NORMAL),
+            HandlerSpec(
+                RequestType.PING_REGISTERED,
+                self.ping_registered,
+                ThreadPoolType.NORMAL,
+            ),
             HandlerSpec(RequestType.NOOP, self.debug, ThreadPoolType.SYNC),
             HandlerSpec(
                 RequestType.REPORT_BLOCK_ALLOCATION,
@@ -155,8 +164,20 @@ class ManagementModule:
                 target.touch_instance(instance_id)
         return True
 
-    def _reap_cycle(self) -> ThreadRunSummary:
-        """Run one reaper scan: reap stale workers, drop mirrored state.
+    def ping_registered(
+        self,
+        instance_id: int,
+        registration_type: RequestType,
+    ) -> bool:
+        """Refresh liveness and report whether the primary Context exists."""
+        target = self._registration_targets.get(registration_type)
+        registered = target is not None and target.touch_instance(instance_id)
+        # Preserve PING's refresh for optional Contexts without making them
+        # part of primary-registration recovery.
+        for other in self._liveness_targets:
+            if other is not target:
+                other.touch_instance(instance_id)
+        return registered
 
     def _reap_cycle(self) -> ThreadRunSummary:
         """Run one reaper scan and drop mirrors owned by reaped Contexts.

--- a/lmcache/v1/multiprocess/protocols/README.md
+++ b/lmcache/v1/multiprocess/protocols/README.md
@@ -10,7 +10,7 @@ protocols/
 ├── __init__.py         # Protocol initialization and registration
 ├── base.py             # Common types (HandlerType, ProtocolDefinition, RequestType)
 ├── engine.py           # Engine operations (REGISTER/UNREGISTER, STORE, RETRIEVE, LOOKUP, PREPARE/COMMIT, ...)
-├── controller.py       # Controller operations (CLEAR, GET_CHUNK_SIZE, PING)
+├── controller.py       # Controller operations (CLEAR, GET_CHUNK_SIZE, PING, PING_REGISTERED)
 ├── debug.py            # Debug operations (NOOP)
 ├── blend.py            # CacheBlend rope + unified lookup + retrieve (CB_REGISTER_ROPE, CB_UNREGISTER_ROPE, CB_RETRIEVE_PRE_COMPUTED, CB_UNIFIED_LOOKUP)
 ├── observability.py    # Observability events (REPORT_BLOCK_ALLOCATION)
@@ -212,6 +212,7 @@ Cache management and configuration:
 - `CLEAR`: Clear all caches in the server
 - `GET_CHUNK_SIZE`: Get the chunk size configuration
 - `PING`: Liveness / worker probe (payload: sender's worker instance id or `None`)
+- `PING_REGISTERED`: Internal worker probe that checks the primary KV registration
 
 ### Debug Operations (`debug.py`)
 Testing and monitoring:

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -86,6 +86,9 @@ class RequestType(enum.Enum):
     # Experimental transfer intermediate tensor
     GET_EXPERIMENTAL = enum.auto()
 
+    # Internal vLLM registration-aware heartbeat; append to preserve values.
+    PING_REGISTERED = enum.auto()
+
     # Deprecated aliases must follow every auto-valued member. On Python 3.10,
     # placing aliases before auto() can reuse the preceding member's value.
     CB_REGISTER_ROPE_V3 = CB_REGISTER_ROPE

--- a/lmcache/v1/multiprocess/protocols/controller.py
+++ b/lmcache/v1/multiprocess/protocols/controller.py
@@ -9,7 +9,11 @@ This module defines the protocol for:
 """
 
 # First Party
-from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
+from lmcache.v1.multiprocess.protocols.base import (
+    HandlerType,
+    ProtocolDefinition,
+    RequestType,
+)
 
 # Define request names for this protocol group
 REQUEST_NAMES = [
@@ -17,6 +21,7 @@ REQUEST_NAMES = [
     "GET_CHUNK_SIZE",
     "GET_EXPERIMENTAL",
     "PING",
+    "PING_REGISTERED",
 ]
 
 
@@ -53,6 +58,12 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # surface as worker degraded mode.
         "PING": ProtocolDefinition(
             payload_classes=[int | None],
+            response_class=bool,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Registration-aware worker ping.
+        "PING_REGISTERED": ProtocolDefinition(
+            payload_classes=[int, RequestType],
             response_class=bool,
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -219,15 +219,24 @@ def _build_modules(
 
     logger.info("Supported transfer mode: %s", mp_config.supported_transfer_mode)
 
-    # Targets the reaper scans (and reap-notifies). The transfer modules own
-    # per-instance liveness; BlendModule is appended below as a state mirror.
+    # Targets the reaper scans. The transfer modules own per-context liveness;
+    # BlendModule is appended below as a state mirror of the GPU KV context.
     liveness_targets: list[InstanceLivenessTarget] = [
         m
         for m in transfer_modules
         if isinstance(m, (LMCacheDrivenTransferModule, EngineDrivenTransferModule))
     ]
+    registration_targets: dict[RequestType, InstanceLivenessTarget] = {}
+    for module in liveness_targets:
+        if isinstance(module, LMCacheDrivenTransferModule):
+            registration_targets[RequestType.REGISTER_KV_CACHE] = module
+        elif isinstance(module, EngineDrivenTransferModule):
+            registration_targets[
+                RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+            ] = module
 
     blend_module: EngineModule | None = None
+    mirror_state_owner: InstanceLivenessTarget | None = None
     if mp_config.engine_type == "blend":
         if mp_config.supported_transfer_mode == "engine_driven":
             raise ValueError(
@@ -271,8 +280,9 @@ def _build_modules(
             enable_dedup_content=mp_config.enable_dedup_content,
         )
         blend_module = blend
-        # The blend module mirrors per-instance CB rope state, so the reaper
-        # must notify it via drop_instance_state when an instance is reaped.
+        # Blend mirrors the GPU KV context's CB rope state. QStore and other
+        # contexts sharing the instance ID must not invalidate that mirror.
+        mirror_state_owner = transfer_module
         liveness_targets.append(blend)
 
     # Experimental intermediate tensor transfer modules
@@ -301,6 +311,8 @@ def _build_modules(
     management = ManagementModule(
         ctx,
         liveness_targets=liveness_targets,
+        registration_targets=registration_targets,
+        mirror_state_owner=mirror_state_owner,
         worker_reap_timeout_seconds=mp_config.worker_reap_timeout_seconds,
         worker_registration_grace_seconds=mp_config.worker_registration_grace_seconds,
         experimental_transfer=experimental_transfer,

--- a/lmcache/v1/multiprocess/transport/base.py
+++ b/lmcache/v1/multiprocess/transport/base.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 # First Party
 from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.protocols.base import RequestType
 
 
 class RequestClient(Protocol):
@@ -99,6 +100,10 @@ class RequestClient(Protocol):
     def get_chunk_size(self) -> MessagingFuture[Any]: ...
 
     def ping(self, instance_id: int | None) -> MessagingFuture[Any]: ...
+
+    def ping_registered(
+        self, instance_id: int, registration_type: RequestType
+    ) -> MessagingFuture[Any]: ...
 
     def report_block_allocation(
         self,

--- a/lmcache/v1/multiprocess/transport/zmq_impl/client.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/client.py
@@ -192,6 +192,16 @@ class ZmqMultiprocessClient(RequestClient):
         """Check server health and refresh worker liveness."""
         return self._call(RequestType.PING, instance_id)
 
+    def ping_registered(
+        self, instance_id: int, registration_type: RequestType
+    ) -> MessagingFuture[Any]:
+        """Check server health and the worker's primary registration."""
+        return self._call(
+            RequestType.PING_REGISTERED,
+            instance_id,
+            registration_type,
+        )
+
     def report_block_allocation(
         self,
         instance_id: int,

--- a/tests/v1/multiprocess/test_blend_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_load_store_opts.py
@@ -911,6 +911,25 @@ def test_register_rope_dual_cache_round_trip():
     assert len(state.cos_sin_caches) == 2
     assert state.group_to_cache == [0, 1]
     assert state.cache_for_group(1) is state.cos_sin_caches[1]
+    eng._transfer_module.get_and_touch_context_entry.assert_called_with(7)
+
+
+def test_retrieve_precomputed_marks_real_transfer_activity():
+    """Blend metadata setup is not readiness; the real scatter request is."""
+    # First Party
+    from lmcache.v1.multiprocess.modules import blend as blend_mod
+
+    eng = MagicMock(spec=blend_mod.BlendModule)
+    eng._transfer_module = MagicMock()
+    eng._transfer_module.get_and_touch_context_entry.return_value = None
+    retrieve = blend_mod.BlendModule.cb_retrieve_pre_computed.__get__(eng)
+
+    with pytest.raises(ValueError, match="not registered"):
+        retrieve(MagicMock(), [], [], 7, b"")
+
+    eng._transfer_module.get_and_touch_context_entry.assert_called_once_with(
+        7, transfer_activity=True
+    )
 
 
 def test_register_rope_rejects_invalid_group_to_cache():

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -119,6 +119,23 @@ def test_named_rpc_method_delegates_to_zmq_request_envelope() -> None:
     ]
 
 
+def test_registration_aware_ping_delegates_to_zmq_request_envelope() -> None:
+    transport = _RecordingMessageQueueClient()
+    client = ZmqMultiprocessClient(transport)
+    request_type = RequestType.PING_REGISTERED
+
+    future = client.ping_registered(7, RequestType.REGISTER_KV_CACHE)
+
+    assert future.result(timeout=0) is request_type
+    assert transport.calls == [
+        (
+            request_type,
+            [7, RequestType.REGISTER_KV_CACHE],
+            get_response_class(request_type),
+        )
+    ]
+
+
 def test_compatibility_alias_delegates_to_same_zmq_request_type() -> None:
     transport = _RecordingMessageQueueClient()
     client = ZmqMultiprocessClient(transport)

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -259,7 +259,7 @@ def test_server_store_and_retrieve_delegate_event_ordering(
     monkeypatch.setattr(
         module,
         "get_and_touch_context_entry",
-        lambda instance_id: entry,
+        lambda instance_id, **kwargs: entry,
     )
     key = SimpleNamespace(request_id="request", cache_salt="", worker_id=0)
 

--- a/tests/v1/multiprocess/test_lmcache_driven_missing_registration.py
+++ b/tests/v1/multiprocess/test_lmcache_driven_missing_registration.py
@@ -105,7 +105,9 @@ def test_missing_registration_returns_terminal_false(method_name: str) -> None:
     )
 
     assert result == (b"", False)
-    module.get_and_touch_context_entry.assert_called_once_with(42)
+    module.get_and_touch_context_entry.assert_called_once_with(
+        42, transfer_activity=True
+    )
 
 
 @pytest.mark.parametrize("mla", [False, True], ids=["sharded-kv", "mla-shared-kv"])

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -326,6 +326,24 @@ def test_mq_noop_request():
     )
 
 
+def test_mq_registration_aware_ping_round_trip() -> None:
+    """Registration types survive a real client/server ZMQ round trip."""
+    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:16556")
+    helper.register_handler(
+        RequestType.PING_REGISTERED,
+        test_mq_handler_helpers.ping_registered_handler,
+    )
+
+    helper.run_test(
+        request_type=RequestType.PING_REGISTERED,
+        payloads=[
+            7,
+            RequestType.REGISTER_KV_CACHE,
+        ],
+        expected_response=True,
+    )
+
+
 def test_mq_noop_multiple_requests():
     """
     Test MessageQueue with multiple NOOP requests.

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -15,6 +15,7 @@ from lmcache.v1.multiprocess.custom_types import (
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocol import KeyType
+from lmcache.v1.multiprocess.protocols.base import RequestType
 
 # ==============================================================================
 # NOOP Request Handlers
@@ -27,6 +28,13 @@ def noop_handler() -> str:
     Takes no arguments and returns a simple string response.
     """
     return "NOOP_OK"
+
+
+def ping_registered_handler(instance_id: int, registration_type: RequestType) -> bool:
+    """Exercise enum payload encoding for a registration-aware PING."""
+    assert instance_id == 7
+    assert registration_type is RequestType.REGISTER_KV_CACHE
+    return True
 
 
 # ==============================================================================

--- a/tests/v1/multiprocess/test_protocols.py
+++ b/tests/v1/multiprocess/test_protocols.py
@@ -5,6 +5,7 @@
 import pytest
 
 # First Party
+from lmcache.v1.multiprocess.mq import msgspec_decode, msgspec_encode
 from lmcache.v1.multiprocess.protocols import initialize_protocols
 from lmcache.v1.multiprocess.protocols.base import RequestType
 
@@ -25,6 +26,21 @@ DEPRECATED_CB_ALIASES = {
 def test_every_request_type_has_a_definition() -> None:
     definitions = initialize_protocols()
     assert set(definitions) == set(RequestType)
+
+
+def test_registration_aware_ping_protocol_is_registered() -> None:
+    definitions = initialize_protocols()
+    request_type = RequestType.PING_REGISTERED
+
+    definition = definitions[request_type]
+    assert definition.payload_classes == [int, RequestType]
+    assert definition.response_class is bool
+
+
+def test_registration_type_round_trips_on_the_wire() -> None:
+    registration_type = RequestType.REGISTER_KV_CACHE
+    encoded = msgspec_encode(registration_type, cls=RequestType)
+    assert msgspec_decode(encoded, cls=RequestType) is registration_type
 
 
 def test_blend_requests_are_registered() -> None:
@@ -57,6 +73,7 @@ def test_deprecated_cb_aliases_are_not_separate_members() -> None:
         "P2P_QUERY_LOOKUP_RESULTS",
         "P2P_UNLOCK_OBJECTS",
         "GET_EXPERIMENTAL",
+        "PING_REGISTERED",
     ],
 )
 def test_compatibility_aliases_do_not_reuse_later_auto_values(name: str) -> None:

--- a/tests/v1/multiprocess/test_qstore.py
+++ b/tests/v1/multiprocess/test_qstore.py
@@ -17,10 +17,12 @@ import pytest
 # First Party
 from lmcache.v1.multiprocess import server as server_mod
 from lmcache.v1.multiprocess.config import MPServerConfig
+from lmcache.v1.multiprocess.modules import blend as blend_mod
 from lmcache.v1.multiprocess.modules.experimental import TRANSFER_QUERY
 from lmcache.v1.multiprocess.modules.experimental import qstore as qstore_mod
 from lmcache.v1.multiprocess.modules.experimental.qstore import QStoreModule
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import ContextEntry
+from lmcache.v1.multiprocess.protocols.base import RequestType
 
 REGISTER_ARGS = ("model##query", 2)
 
@@ -67,6 +69,8 @@ def test_register_inserts_unlatched_entry(monkeypatch) -> None:
     assert module.tracked_instance_count() == 1
     entry = module.get_and_touch_context_entry(1)
     assert entry is not None
+    assert entry.has_liveness_signal is False
+    assert entry.has_transfer_activity is False
 
 
 def test_duplicate_register_refreshes_without_rebuilding(monkeypatch) -> None:
@@ -87,15 +91,26 @@ def test_duplicate_register_refreshes_without_rebuilding(monkeypatch) -> None:
 
 
 def test_reap_uses_two_tier_windows() -> None:
-    """Check that the reaper uses two time windows to decide which entries to drop.
-    This is a verbatim copy from tests/v1/multiprocess/test_worker_liveness.py"""
+    """Normal timeout requires PING and Q transfer; PING alone keeps grace."""
     module = _module()
     old = time.monotonic() - 1000.0
     module._q_contexts.update(
         {
-            1: ContextEntry(MagicMock(), *REGISTER_ARGS, old, True),
-            2: ContextEntry(MagicMock(), *REGISTER_ARGS, old, False),
-            3: ContextEntry(MagicMock(), *REGISTER_ARGS, time.monotonic(), True),
+            1: ContextEntry(
+                MagicMock(),
+                *REGISTER_ARGS,
+                old,
+                has_liveness_signal=True,
+                has_transfer_activity=True,
+            ),
+            2: ContextEntry(MagicMock(), *REGISTER_ARGS, old, has_liveness_signal=True),
+            3: ContextEntry(
+                MagicMock(),
+                *REGISTER_ARGS,
+                time.monotonic(),
+                has_liveness_signal=True,
+                has_transfer_activity=True,
+            ),
         }
     )
 
@@ -215,6 +230,7 @@ def test_store_q_block_id_underflow_fails_closed(stub_device) -> None:
 
     assert ok is False
     assert handle == b"event-handle"
+    assert module._q_contexts[1].has_transfer_activity is True
     assert stub_device[0].records == 1
     cast(MagicMock, ctx.storage_manager.reserve_write).assert_not_called()
     cast(MagicMock, ctx.event_bus.publish).assert_not_called()
@@ -235,6 +251,12 @@ class _FakeQStore:
         self.ctx = ctx
 
 
+class _FakeBlend:
+    def __init__(self, ctx, transfer_module, **kwargs) -> None:
+        self.ctx = ctx
+        self.transfer_module = transfer_module
+
+
 @pytest.fixture
 def stub_server_modules(monkeypatch):
     """Stub the server's module constructors. Returns the ManagementModule mock.
@@ -245,6 +267,7 @@ def stub_server_modules(monkeypatch):
     monkeypatch.setattr(server_mod, "LMCacheDrivenTransferModule", _FakeLMCacheDriven)
     monkeypatch.setattr(server_mod, "EngineDrivenTransferModule", _FakeEngineDriven)
     monkeypatch.setattr(server_mod, "QStoreModule", _FakeQStore)
+    monkeypatch.setattr(blend_mod, "BlendModule", _FakeBlend)
     management = MagicMock(name="ManagementModule")
     monkeypatch.setattr(server_mod, "ManagementModule", management)
     return management
@@ -287,6 +310,42 @@ def test_server_builds_q_store_module(stub_server_modules) -> None:
     kwargs = stub_server_modules.call_args.kwargs
     assert kwargs["experimental_transfer"] == [TRANSFER_QUERY]
     assert any(isinstance(t, _FakeQStore) for t in kwargs["liveness_targets"])
+    assert isinstance(
+        kwargs["registration_targets"][RequestType.REGISTER_KV_CACHE],
+        _FakeLMCacheDriven,
+    )
+
+
+def test_server_auto_mode_maps_both_primary_registration_types(
+    stub_server_modules,
+) -> None:
+    _build(stub_server_modules, supported_transfer_mode="auto")
+
+    targets = stub_server_modules.call_args.kwargs["registration_targets"]
+    assert isinstance(targets[RequestType.REGISTER_KV_CACHE], _FakeLMCacheDriven)
+    assert isinstance(
+        targets[RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT],
+        _FakeEngineDriven,
+    )
+
+
+def test_server_wires_gpu_context_as_blend_mirror_owner(
+    stub_server_modules,
+) -> None:
+    """QStore reaps must not invalidate Blend's GPU-owned mirror."""
+    _build(
+        stub_server_modules,
+        engine_type="blend",
+        enable=[TRANSFER_QUERY],
+        supported_transfer_mode="lmcache_driven",
+    )
+
+    kwargs = stub_server_modules.call_args.kwargs
+    owner = kwargs["mirror_state_owner"]
+    assert isinstance(owner, _FakeLMCacheDriven)
+    assert owner in kwargs["liveness_targets"]
+    assert any(isinstance(t, _FakeQStore) for t in kwargs["liveness_targets"])
+    assert any(isinstance(t, _FakeBlend) for t in kwargs["liveness_targets"])
 
 
 def test_server_builds_nothing_when_no_feature_is_enabled(

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -348,6 +348,30 @@ def test_management_ping_touches_targets() -> None:
     assert target.touched == [42]
 
 
+@pytest.mark.parametrize("primary_present", [True, False])
+def test_registration_aware_ping_checks_primary_and_touches_optional_contexts(
+    primary_present: bool,
+) -> None:
+    gpu = _FakeTarget()
+    qstore = _FakeTarget()
+    if primary_present:
+        gpu.registered.add(42)
+    qstore.registered.add(42)
+    mgmt = ManagementModule(
+        MagicMock(),
+        liveness_targets=[gpu, qstore],
+        registration_targets={
+            RequestType.REGISTER_KV_CACHE: gpu,
+        },
+    )
+
+    assert mgmt.ping_registered(42, RequestType.REGISTER_KV_CACHE) is primary_present
+    assert gpu.touched == [42]
+    assert qstore.touched == [42]
+    # Compatibility PING still reports server availability for an absent ID.
+    assert mgmt.ping(999) is True
+
+
 def test_management_reaper_reaps_and_drops() -> None:
     """The reaper scans targets and calls drop_instance_state for reaped ids."""
     target = _FakeTarget()

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -23,11 +23,13 @@ from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as gpu_mod
 from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
     EngineDrivenTransferModule,
 )
+from lmcache.v1.multiprocess.modules.experimental.qstore import QStoreModule
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     ContextEntry,
     LMCacheDrivenTransferModule,
 )
 from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.periodic_thread import PeriodicThreadRegistry
 
 
@@ -57,6 +59,15 @@ def _bare_non_gpu_module() -> EngineDrivenTransferModule:
     return module
 
 
+def _bare_q_module() -> QStoreModule:
+    """A QStoreModule with only its per-registration liveness state."""
+    module = QStoreModule.__new__(QStoreModule)
+    module._ctx = MagicMock(name="q_ctx")
+    module._q_contexts = {}
+    module._lock = threading.Lock()
+    return module
+
+
 def _stub_gpu_registration_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub Event IPC lookup for liveness tests unrelated to event handling."""
     monkeypatch.setattr(
@@ -67,7 +78,7 @@ def _stub_gpu_registration_backend(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_gpu_register_inserts_unlatched_entry(monkeypatch) -> None:
-    """register_kv_cache inserts an entry that is not yet ping-proven."""
+    """Registration starts with neither activation signal latched."""
     _stub_gpu_registration_backend(monkeypatch)
     monkeypatch.setattr(
         gpu_mod,
@@ -84,11 +95,11 @@ def test_gpu_register_inserts_unlatched_entry(monkeypatch) -> None:
     assert module.tracked_instance_count() == 1
     entry = module.get_and_touch_context_entry(1)
     assert entry is not None and entry.has_liveness_signal is False
+    assert entry.has_transfer_activity is False
 
 
 def test_gpu_noop_register_refreshes_without_latching(monkeypatch) -> None:
-    """Re-registering a known instance refreshes last_seen but does not
-    rebuild the context or latch the ping-proven flag."""
+    """Re-registering refreshes last_seen without latching either signal."""
     _stub_gpu_registration_backend(monkeypatch)
     create = MagicMock(
         return_value=MagicMock(
@@ -106,40 +117,129 @@ def test_gpu_noop_register_refreshes_without_latching(monkeypatch) -> None:
     assert create.call_count == 1  # not rebuilt
     assert module._cache_contexts[1].last_seen > 0.0  # refreshed
     assert module._cache_contexts[1].has_liveness_signal is False
+    assert module._cache_contexts[1].has_transfer_activity is False
 
 
-def test_gpu_touch_latches_get_does_not() -> None:
-    """touch_instance marks ping-proven; get_and_touch_context_entry only refreshes."""
+def test_gpu_ping_and_transfer_latch_independently() -> None:
+    """PING and a real transfer latch separate activation signals."""
     module = _bare_gpu_module()
     module._cache_contexts[1] = ContextEntry(MagicMock(), "m", 1, last_seen=0.0)
 
     module.get_and_touch_context_entry(1)
     assert module._cache_contexts[1].last_seen > 0.0
     assert module._cache_contexts[1].has_liveness_signal is False
+    assert module._cache_contexts[1].has_transfer_activity is False
 
-    module.touch_instance(1)
+    assert module.touch_instance(1) is True
     assert module._cache_contexts[1].has_liveness_signal is True
-    module.touch_instance(999)  # absent -> no error
+    assert module._cache_contexts[1].has_transfer_activity is False
+
+    module.get_and_touch_context_entry(1, transfer_activity=True)
+    assert module._cache_contexts[1].has_transfer_activity is True
+    assert module.touch_instance(999) is False
 
 
-def test_gpu_reap_two_tier_windows() -> None:
-    """Ping-proven entries reap at the timeout; never-pinged ones survive
-    until the larger registration grace."""
+def test_other_context_types_report_registration_presence() -> None:
+    non_gpu = _bare_non_gpu_module()
+    non_gpu._engine_driven_contexts[1] = non_gpu_mod.EngineDrivenContextEntry(
+        MagicMock(), "m", 1, 0.0
+    )
+    qstore = _bare_q_module()
+    qstore._q_contexts[1] = ContextEntry(MagicMock(), "q", 1, last_seen=0.0)
+
+    assert non_gpu.touch_instance(1) is True
+    assert non_gpu.touch_instance(999) is False
+    assert qstore.touch_instance(1) is True
+    assert qstore.touch_instance(999) is False
+
+
+@pytest.mark.parametrize(
+    ("age", "pinged", "transferred", "expected"),
+    [
+        (1000.0, False, False, []),
+        (1000.0, True, False, []),
+        (1000.0, False, True, []),
+        (1000.0, True, True, [1]),
+        (4000.0, True, False, [1]),
+    ],
+)
+def test_gpu_reap_requires_ping_and_transfer(
+    age: float, pinged: bool, transferred: bool, expected: list[int]
+) -> None:
+    """Only both signals select normal timeout; startup grace stays bounded."""
     module = _bare_gpu_module()
-    old = time.monotonic() - 1000.0
-    module._cache_contexts[1] = ContextEntry(MagicMock(), "m", 1, old, True)
-    module._cache_contexts[2] = ContextEntry(MagicMock(), "m", 1, old, False)
-    module._cache_contexts[3] = ContextEntry(
-        MagicMock(), "m", 1, time.monotonic(), True
+    module._cache_contexts[1] = ContextEntry(
+        MagicMock(),
+        "m",
+        1,
+        time.monotonic() - age,
+        has_liveness_signal=pinged,
+        has_transfer_activity=transferred,
     )
 
     reaped = module.reap_stale_instances(120.0, 3600.0)
 
-    assert reaped == [1]  # only the ping-proven stale entry
-    assert module.tracked_instance_count() == 2
-    cast(
-        MagicMock, module._ctx.layout_desc_registry.unregister
-    ).assert_called_once_with("m", 1)
+    assert reaped == expected
+    assert module.tracked_instance_count() == (0 if expected else 1)
+
+
+@pytest.mark.parametrize("active_context", ["gpu", "qstore"])
+def test_multi_context_reap_preserves_mirror_ownership(
+    active_context: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GPU and Q registrations activate and clean up independently."""
+    # First Party
+    from lmcache.v1.multiprocess.modules.blend import BlendModule
+
+    gpu = _bare_gpu_module()
+    qstore = _bare_q_module()
+    gpu._cache_contexts[7] = ContextEntry(MagicMock(), "kv", 1)
+    qstore._q_contexts[7] = ContextEntry(MagicMock(), "q", 1)
+    blend = BlendModule.__new__(BlendModule)
+    blend._cb_rope_state = {7: MagicMock()}
+
+    reaper = MagicMock()
+    monkeypatch.setattr(
+        "lmcache.v1.multiprocess.modules.management.create_periodic_thread",
+        MagicMock(return_value=reaper),
+    )
+    mgmt = ManagementModule(
+        MagicMock(),
+        liveness_targets=[gpu, qstore, blend],
+        mirror_state_owner=gpu,
+        worker_reap_timeout_seconds=120.0,
+        worker_registration_grace_seconds=3600.0,
+    )
+
+    try:
+        mgmt.ping(7)
+        if active_context == "gpu":
+            gpu.get_and_touch_context_entry(7, transfer_activity=True)
+        else:
+            qstore.get_and_touch_context_entry(7, transfer_activity=True)
+
+        normal_stale = time.monotonic() - 200.0
+        gpu._cache_contexts[7].last_seen = normal_stale
+        qstore._q_contexts[7].last_seen = normal_stale
+        mgmt._reap_cycle()
+
+        if active_context == "gpu":
+            assert gpu.tracked_instance_count() == 0
+            assert qstore.tracked_instance_count() == 1
+            assert 7 not in blend._cb_rope_state
+            qstore._q_contexts[7].last_seen = time.monotonic() - 4000.0
+        else:
+            assert qstore.tracked_instance_count() == 0
+            assert gpu.tracked_instance_count() == 1
+            assert 7 in blend._cb_rope_state
+            gpu._cache_contexts[7].last_seen = time.monotonic() - 4000.0
+
+        mgmt._reap_cycle()
+        assert gpu.tracked_instance_count() == 0
+        assert qstore.tracked_instance_count() == 0
+        assert 7 not in blend._cb_rope_state
+    finally:
+        mgmt.close()
 
 
 def test_gpu_unregister_cleans_up() -> None:
@@ -162,11 +262,16 @@ def test_non_gpu_reap_pops_strategy_as_pair() -> None:
     module = _bare_non_gpu_module()
     old = time.monotonic() - 1000.0
     module._engine_driven_contexts[1] = non_gpu_mod.EngineDrivenContextEntry(
-        MagicMock(), "m", 1, old, True
+        MagicMock(),
+        "m",
+        1,
+        old,
+        has_liveness_signal=True,
+        has_transfer_activity=True,
     )
     module._strategies[1] = MagicMock()
     module._engine_driven_contexts[2] = non_gpu_mod.EngineDrivenContextEntry(
-        MagicMock(), "m", 1, old, False
+        MagicMock(), "m", 1, old, has_liveness_signal=True
     )
     module._strategies[2] = MagicMock()
 
@@ -174,7 +279,7 @@ def test_non_gpu_reap_pops_strategy_as_pair() -> None:
 
     assert reaped == [1]
     assert 1 not in module._strategies  # strategy popped with the entry
-    assert 2 in module._strategies  # never-pinged survives on grace
+    assert 2 in module._strategies  # PING-only startup survives on grace
 
 
 def test_non_gpu_resolve_for_transfer_refreshes_and_raises() -> None:
@@ -190,7 +295,8 @@ def test_non_gpu_resolve_for_transfer_refreshes_and_raises() -> None:
     entry, resolved = module._resolve_for_transfer(1)
     assert resolved is strategy
     assert entry.last_seen > 0.0
-    assert entry.has_liveness_signal is False  # traffic does not latch
+    assert entry.has_liveness_signal is False
+    assert entry.has_transfer_activity is True
 
     with pytest.raises(ValueError, match="not registered"):
         module._resolve_for_transfer(999)
@@ -201,12 +307,14 @@ class _FakeTarget:
 
     def __init__(self) -> None:
         self.touched: list[int] = []
+        self.registered: set[int] = set()
         self.to_reap: list[int] = []
         self.dropped: list[int] = []
         self.count = 0
 
-    def touch_instance(self, instance_id: int) -> None:
+    def touch_instance(self, instance_id: int) -> bool:
         self.touched.append(instance_id)
+        return instance_id in self.registered
 
     def reap_stale_instances(
         self, reap_timeout_s: float, registration_grace_s: float
@@ -246,6 +354,7 @@ def test_management_reaper_reaps_and_drops() -> None:
     mgmt = ManagementModule(
         MagicMock(),
         liveness_targets=[target],
+        mirror_state_owner=target,
         worker_reap_timeout_seconds=0.4,
         worker_registration_grace_seconds=0.8,
     )

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -26,6 +26,7 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
     ParallelStrategy,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.platform.isolated_ipc import is_isolated_ipc, set_isolated_ipc
 
@@ -49,6 +50,7 @@ class FakeHeartbeatThread:
         health_event: threading.Event | None = None,
         interval: float = 0.0,
         instance_id: int | None = None,
+        registration_type: RequestType | None = None,
     ) -> None:
         self.req_client = req_client
         self.health_event = (
@@ -56,6 +58,7 @@ class FakeHeartbeatThread:
         )
         self.interval = interval
         self.instance_id = instance_id
+        self.registration_type = registration_type
         # Snapshot of the health event at construction time: lets tests
         # assert the adapter starts the heartbeat healthy (event still set).
         self.health_event_set_at_init = self.health_event.is_set()
@@ -214,6 +217,7 @@ def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
 
     assert adapter.kv_caches is new_caches
     req_client.register_kv_cache.assert_called_once()
+    assert adapter._primary_registration_type is RequestType.REGISTER_KV_CACHE
 
 
 def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
@@ -225,6 +229,23 @@ def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
         fake_tensor = MagicMock()
         fake_tensor.device.type = "cuda"
         adapter.register_kv_caches({"layer.0": fake_tensor})
+
+    assert FakeHeartbeatThread.instances == []
+    assert adapter._primary_registration_type is None
+
+
+def test_repeated_registration_starts_only_one_heartbeat(fake_adapter) -> None:
+    """Repeated successful registration keeps one worker heartbeat."""
+    adapter, req_client, _ = fake_adapter
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    kv_caches = {"layer.0": fake_tensor}
+
+    adapter.register_kv_caches(kv_caches)
+    adapter.register_kv_caches(kv_caches)
+
+    assert req_client.register_kv_cache.call_count == 2
+    assert len(FakeHeartbeatThread.instances) == 1
 
 
 def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
@@ -248,6 +269,10 @@ def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     assert adapter.kv_caches is cpu_kv
     req_client.register_kv_cache_engine_driven_context.assert_called_once()
     assert len(req_client.register_kv_cache_engine_driven_context.call_args.args) == 1
+    assert (
+        adapter._primary_registration_type
+        is RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+    )
     assert adapter.create_recorded_event() is None
 
 
@@ -663,15 +688,18 @@ def test_instance_id_logged_at_info_on_construction(fake_adapter, monkeypatch) -
     assert any(str(adapter.instance_id) in msg for msg in messages)
 
 
-def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
-    """The lazy create path starts the heartbeat healthy (no pessimistic
-    clear) and wires the recover callback before ``start()``; the first
-    store is not gated. Idempotent on re-entry (no second thread)."""
+def test_registration_starts_heartbeat_before_first_request(
+    fake_adapter, monkeypatch
+) -> None:
+    """Successful registration starts the heartbeat healthy and wires the
+    recover callback before ``start()``. Later requests are idempotent."""
     adapter, _send_mock, _ = fake_adapter
-    adapter.transfer_ctx = MagicMock()
+    contexts = _patch_transfer_context_factory(monkeypatch)
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
     assert adapter.is_healthy  # the constructor leaves the event set
 
-    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    adapter.register_kv_caches({"layer.0": fake_tensor})
 
     assert len(FakeHeartbeatThread.instances) == 1
     heartbeat = FakeHeartbeatThread.instances[0]
@@ -680,13 +708,15 @@ def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
     assert heartbeat.health_event_set_at_init is True
     # The recover callback is wired before start() (for genuine recovery).
     assert heartbeat.calls == ["register_recover_callback", "start"]
+    assert heartbeat.registration_type is RequestType.REGISTER_KV_CACHE
     assert adapter.is_healthy
-    assert adapter.transfer_ctx.submit_store.call_count == 1
 
-    # Re-entry is idempotent: no new thread.
-    adapter.submit_store_request("req-2", _op([[1]]), MagicMock())
+    # Store and retrieve keep the registration-started heartbeat idempotent.
+    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    adapter.submit_retrieve_request("req-2", _op([[1]]), MagicMock())
     assert len(FakeHeartbeatThread.instances) == 1
-    assert adapter.transfer_ctx.submit_store.call_count == 2
+    assert contexts[0].submit_store.call_count == 1
+    assert contexts[0].submit_retrieve.call_count == 1
 
 
 def test_heartbeat_first_ping_runs_callback_before_setting_event(
@@ -718,6 +748,77 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
         heartbeat.stop(timeout=10.0)
 
     assert event_state_during_callback == [False]
+
+
+@pytest.mark.parametrize(
+    ("ping_result", "expected_health", "expected_recovery_calls"),
+    [
+        pytest.param(False, True, 1, id="missing-registration"),
+        pytest.param(None, False, 0, id="server-unreachable"),
+        pytest.param(True, True, 0, id="registration-complete"),
+    ],
+)
+def test_registered_ping_drives_health_and_recovery(
+    monkeypatch,
+    ping_result: bool | None,
+    expected_health: bool,
+    expected_recovery_calls: int,
+) -> None:
+    """Distinguish a missing Context from server failure and a complete ACK."""
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_registered_ping",
+        lambda req_client, timeout, instance_id, registration_type: ping_result,
+    )
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(
+        req_client=MagicMock(name="req_client"),
+        health_event=health_event,
+        interval=60.0,
+        instance_id=7,
+        registration_type=RequestType.REGISTER_KV_CACHE,
+    )
+    event_state_during_callback: list[bool] = []
+
+    def recover() -> bool:
+        event_state_during_callback.append(health_event.is_set())
+        return True
+
+    heartbeat.register_recover_callback(recover)
+
+    assert heartbeat._execute().message == (
+        "healthy" if expected_health else "unhealthy"
+    )
+    assert health_event.is_set() is expected_health
+    assert len(event_state_during_callback) == expected_recovery_calls
+    if expected_recovery_calls:
+        assert event_state_during_callback == [False]
+
+
+def test_missing_registration_retries_after_recovery_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_registered_ping",
+        lambda req_client, timeout, instance_id, registration_type: False,
+    )
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(
+        req_client=MagicMock(name="req_client"),
+        health_event=health_event,
+        interval=60.0,
+        instance_id=7,
+        registration_type=RequestType.REGISTER_KV_CACHE,
+    )
+    recover = MagicMock(side_effect=[False, True])
+    heartbeat.register_recover_callback(recover)
+
+    assert heartbeat._execute().message == "unhealthy"
+    assert not health_event.is_set()
+    assert heartbeat._execute().message == "healthy"
+    assert health_event.is_set()
+    assert recover.call_count == 2
 
 
 def test_dropped_retrieve_reported_once_via_unhealthy_get_finished(
@@ -777,8 +878,9 @@ def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     """shutdown() stops the heartbeat before sending UNREGISTER, so no
     stray heartbeat ping can race the closing req_client."""
     adapter, req_client, future = fake_adapter
-    adapter.transfer_ctx = MagicMock()
-    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    adapter.register_kv_caches({"layer.0": fake_tensor})
     heartbeat = FakeHeartbeatThread.instances[0]
 
     stop_state_at_unregister: list[bool] = []
@@ -795,10 +897,56 @@ def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     assert stop_state_at_unregister == [True]
 
 
+def test_shutdown_waits_for_inflight_recovery_before_unregister(
+    fake_adapter, monkeypatch
+) -> None:
+    """An in-flight recovery must finish before shutdown unregisters, so a
+    delayed REGISTER cannot recreate a Context after UNREGISTER."""
+    adapter, req_client, future = fake_adapter
+    contexts = _patch_transfer_context_factory(monkeypatch)
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    adapter.register_kv_caches({"layer.0": fake_tensor})
+    heartbeat = FakeHeartbeatThread.instances[0]
+    assert heartbeat.recover_callback is not None
+
+    recovery_entered = threading.Event()
+    release_recovery = threading.Event()
+    call_order: list[str] = []
+
+    def blocked_register(_kv_caches) -> None:
+        recovery_entered.set()
+        assert release_recovery.wait(timeout=10.0)
+        call_order.append("register")
+
+    monkeypatch.setattr(adapter, "_send_register_kv_caches_request", blocked_register)
+
+    def unregister(_instance_id: int):
+        call_order.append("unregister")
+        return future
+
+    req_client.unregister_kv_cache.side_effect = unregister
+    recovery_thread = threading.Thread(target=heartbeat.recover_callback)
+    shutdown_thread = threading.Thread(target=adapter.shutdown)
+
+    recovery_thread.start()
+    assert recovery_entered.wait(timeout=10.0)
+    shutdown_thread.start()
+    time.sleep(0.05)
+    assert call_order == []
+    release_recovery.set()
+    recovery_thread.join(timeout=10.0)
+    shutdown_thread.join(timeout=10.0)
+
+    assert not recovery_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert call_order == ["register", "unregister"]
+    contexts[0].close.assert_called_once_with()
+
+
 def test_shutdown_without_heartbeat_sends_unregister(fake_adapter) -> None:
-    """shutdown() on an adapter whose heartbeat was never lazily started
-    (cold shutdown before any traffic) still sends UNREGISTER and does
-    not raise."""
+    """Shutdown before KV cache registration still sends UNREGISTER and
+    does not raise."""
     adapter, req_client, _future = fake_adapter
 
     adapter.shutdown()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR starts the MP worker heartbeat immediately after
`register_kv_caches()` succeeds, instead of waiting for the first store or
retrieve request.

Registration creates a server-side GPU context that is managed by the worker
reaper. With the current first-request lazy start, a healthy worker that has
registered but receives no traffic sends no PINGs. It can therefore be reaped
after `worker_registration_grace_seconds`. When traffic eventually reaches that
worker, the server no longer has its GPU context, and the retrieve request can
hang after the HTTP response headers have already been sent.

### Before-fix reproduction

I reproduced the complete failure chain from #4715 on a clean, unmodified
`f9addd2e4e074f21f26cbda84c3abd932d32ef33` baseline.

The deterministic test used:

- 2 x RTX 3090 24 GB;
- LMCache MP mode with an external server;
- vLLM 0.27.1 and Qwen2.5-1.5B-Instruct;
- worker A on GPU 0 and worker B on GPU 1;
- a 1981-token shared prompt, producing 7 chunk-aligned L1 keys / 1792 stored
  tokens; and
- a 30-second worker reap timeout, 30-second registration grace, and an observed
  7.5-second reaper scan interval.

Worker A received traffic and stored the shared prefix. Worker B registered
successfully but received no request. The resulting timeline was:

1. B registered normally but did not start `lmcache-heartbeat`.
2. After 36.2 seconds, the server logged that B was reaped with `pinged=False`.
3. B's first request then found all 7/7 shared-prefix keys in L1.
4. B started its heartbeat only after that request arrived, which was too late.
5. The server raised `No GPU context registered for instance ID ...` in the
   blocking retrieve handler.
6. The client received `HTTP/1.1 200 OK` and SSE response headers, but received
   zero response-body bytes. curl timed out after 30 seconds with exit code 28.

Both vLLM health endpoints remained HTTP 200 before and after the failure, and
worker A completed a follow-up request successfully. This shows that B was alive
from vLLM's perspective when LMCache removed its registered GPU context.

The reproduction therefore confirms the full causal chain:

```text
successful registration
  -> no heartbeat while idle
  -> live worker reaped with pinged=False
  -> first request starts heartbeat too late
  -> shared-prefix cache hit
  -> missing GPU context
  -> HTTP 200 headers with zero SSE bytes
  -> client timeout
```

### Fix

After `_send_register_kv_caches_request()` returns successfully,
`register_kv_caches()` now calls the existing idempotent
`_ensure_heartbeat_started()` helper.

This creates the intended lifecycle boundary:

- Adapter construction still does not start a heartbeat or send premature PINGs.
- A failed or timed-out registration does not start a heartbeat.
- A successfully registered worker starts sending PINGs before its first request.
- Existing store/retrieve calls retain the idempotent defensive start guard.
- Repeated registration and later transfers do not create duplicate heartbeat
  threads.
- Shutdown stops the heartbeat before sending UNREGISTER.

Historically, #2798 delayed constructor-time heartbeat startup to avoid reporting
a worker unhealthy during large-model warmup. #2943 later moved startup from
registration to the first request to avoid warmup and CUDA Graph interactions.
After the worker reaper was introduced, that first-request behavior left a
registered but idle worker indistinguishable from a dead worker. This change
restores the successful-registration lifecycle boundary and explicitly validates
the CUDA Graph startup path.

This PR does not change the PING protocol, worker reaper behavior, timeout
defaults, scheduler adapter, or retrieve error fallback.

### After-fix validation

I repeated the issue scenario with the same two-worker topology, model, shared
prefix, and 30-second grace/reap settings on the patched `dev` baseline:

1. Worker A stored the same shared prefix.
2. Worker B registered, and its heartbeat entered the main loop immediately,
   before B received any request.
3. B then remained request-idle for at least 75 seconds, crossing the registration
   grace, reap timeout, and multiple reaper scans.
4. The server did not reap B.
5. B's first request found all 7/7 L1 keys and returned HTTP 200 with a non-empty
   SSE body: 3987 bytes, curl exit code 0, in approximately 0.38 seconds.
6. No `No GPU context registered`, blocking-handler error, or unexpected reaping
   occurred. Both workers' follow-up requests and health checks returned HTTP 200.

The after-fix evidence verifier reported 21/21 assertions passing. This is a
controlled before/after result: the pre-fix run reproduced the exact idle-worker
reap and request hang, while the patched run kept the same idle worker registered
and completed the same shared-prefix request successfully.

### CUDA Graph startup regression validation

Because the first-request lazy start was introduced to avoid model warmup and CUDA
Graph interactions, I also ran a separate vLLM instance without `--enforce-eager`:

- normal `torch.compile` and CUDA Graph capture completed after the
  registration-started heartbeat was already running;
- the API became ready normally;
- the registered worker remained request-idle for another 45 seconds, beyond the
  reaper timeout;
- its first request and subsequent health check returned HTTP 200;
- no warmup failure, reaping, missing-context error, or unhealthy/recovery loop was
  observed; and
- shutdown stopped the heartbeat before UNREGISTER.

The CUDA Graph evidence verifier reported 15/15 assertions passing.

Fixes #4715

**Special notes for your reviewers**:

PR #4730 was opened while this patch was being developed and validated
independently. It implements the same core lifecycle change. This version
additionally:

- documents the complete before-fix and after-fix GPU experiments;
- updates the worker-liveness design documentation and failure-mode table;
- tests repeated registration, store/retrieve idempotency, recover-callback
  ordering, registration failure, shutdown ordering, and cold shutdown before
  registration; and
- explicitly validates normal CUDA Graph startup without `--enforce-eager`.

I am calling out this overlap so maintainers can choose the preferred patch shape.
I am happy to rebase or consolidate the work based on review.

The heartbeat is created only after `_send_register_kv_caches_request()` returns
successfully. `_ensure_heartbeat_started()` remains lock-protected and idempotent,
so retaining its calls in the store/retrieve paths is intentional defensive
behavior. The recovery callback invokes the internal registration helper and
therefore does not recursively create heartbeat threads.

Additional validation:

- Public-interface tests were added before the implementation; the 3 focused tests
  failed on the affected code as expected and passed after the fix.
- `pytest -q tests/v1/test_vllm_mp_adapter.py tests/v1/multiprocess/test_worker_liveness.py`
  — 41 passed.
- Modified-file pre-commit checks passed: SPDX, device rules, TimeoutError rule,
  isort, Ruff, Ruff format, codespell, and mypy. Unrelated Rust hooks were skipped.
- Sphinx documentation build succeeded with 30 pre-existing warnings.
- The broader pytest run reached 3863 passed, 144 skipped, and 1 xpassed. The only
  failure was `tests/v1/test_mem_kernels.py::test_extract_and_load_back[256]`
  because the optional `lmcache.cuda_ops` extension was not built in the editable
  development environment. An isolated rerun failed for the same environmental
  reason.

This local validation used RTX 3090 GPUs and Qwen2.5-1.5B. It does not claim
production validation on the reporter's B300/DeepSeek-V4-Flash deployment;
testing the patch in that environment would still be valuable.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests