### PR TITLE
[CI] Auto-size nvcc --threads so MAX_JOBS x NVCC_THREADS fits the build host

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ ARG max_jobs=2
 ENV MAX_JOBS=${max_jobs}
 
 # Number of threads used by nvcc
-ARG nvcc_threads=8
+ARG nvcc_threads=auto
 ENV NVCC_THREADS=$nvcc_threads
 
 ARG CUDA_VERSION

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -98,7 +98,7 @@ ARG max_jobs=2
 ENV MAX_JOBS=${max_jobs}
 
 # Number of threads used by nvcc
-ARG nvcc_threads=8
+ARG nvcc_threads=auto
 ENV NVCC_THREADS=$nvcc_threads
 
 # --index-url (singular) keeps PyPI out of torch resolution so uv can't

--- a/docker/README.md
+++ b/docker/README.md
@@ -180,7 +180,7 @@ docker run --runtime nvidia --gpus all \
 | `UBUNTU_VERSION` | `24.04` | Ubuntu base version |
 | `PYTHON_VERSION` | `3.12` | Python version |
 | `max_jobs` | `2` | Max parallel jobs for build |
-| `nvcc_threads` | `8` | Number of nvcc threads |
+| `nvcc_threads` | `auto` | nvcc `--threads`; `auto` sizes it so `max_jobs` × `nvcc_threads` fits the host's CPUs and RAM (~3 GiB per compile). A number forces it |
 | `torch_cuda_arch_list` | `7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX` | CUDA architectures |
 
 `Dockerfile.lightweight` does not define build arguments. ROCm images use ROCm-specific arguments such as `ROCM_VERSION` and `PYTORCH_ROCM_ARCH`.
@@ -191,7 +191,6 @@ docker run --runtime nvidia --gpus all \
 docker build \
   --build-arg CUDA_VERSION=12.4 \
   --build-arg max_jobs=4 \
-  --build-arg nvcc_threads=16 \
   --target image-build \
   --tag lmcache/vllm-openai:cuda12.4 \
   --file docker/Dockerfile .

--- a/setup_extensions/build_profiles/cuda.py
+++ b/setup_extensions/build_profiles/cuda.py
@@ -21,7 +21,78 @@ from setup_extensions.build_profiles import BuildProfile
 ENABLE_CXX11_ABI = os.environ.get("ENABLE_CXX11_ABI", "1") == "1"
 CSRC_DIR = str(Path(__file__).resolve().parents[2] / "csrc")
 
-NVCC_THREADS = int(os.environ.get("NVCC_THREADS", "2"))
+# Peak memory of one nvcc compile (heaviest .cu, CUDA 13.0: 2.7--3.0 GiB).
+# Concurrent compiles = MAX_JOBS x NVCC_THREADS, so a fixed 2 x 8 needed ~48 GiB
+# and got the 16 GB GitHub runner SIGTERMed (nightly #500).
+NVCC_SLOT_GIB = 3.0
+# Reserved for the OS, docker and the CI runner agent.
+BUILD_MEM_HEADROOM_GIB = 3.0
+# Ninja's default job count when MAX_JOBS is unset is cpu_count + 2.
+NINJA_DEFAULT_EXTRA_JOBS = 2
+
+
+def _cpu_count() -> int:
+    """Return the number of CPUs this process may run on (>= 1)."""
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        return max(1, os.cpu_count() or 1)
+
+
+def _memory_budget_gib() -> float | None:
+    """Return min(physical RAM, cgroup v2 limit) in GiB, or None if unknown."""
+    candidates: list[int] = []
+    try:
+        raw = Path("/sys/fs/cgroup/memory.max").read_text().strip()
+        if raw.isdigit():
+            candidates.append(int(raw))
+    except OSError:
+        pass
+    try:
+        candidates.append(os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE"))
+    except (AttributeError, OSError, ValueError):
+        pass
+    if not candidates:
+        return None
+    return min(candidates) / 2**30
+
+
+def resolve_build_parallelism() -> tuple[int, int, bool]:
+    """Resolve ``MAX_JOBS`` and nvcc ``--threads`` for this host.
+
+    Concurrent compiles (``jobs x threads``) are capped at
+    ``min(cpus, (memory - headroom) / NVCC_SLOT_GIB)``. Explicit
+    ``MAX_JOBS=<n>`` / ``NVCC_THREADS=<n>`` are used as-is; unset, empty,
+    ``0`` or ``auto`` ``NVCC_THREADS`` is sized to fill the remaining cap.
+
+    Returns:
+        ``(max_jobs, nvcc_threads, export_max_jobs)``; the last is True when
+        ``MAX_JOBS`` was derived here and must be exported for ninja.
+
+    Raises:
+        ValueError: If ``NVCC_THREADS`` is neither an integer nor ``auto``.
+    """
+    cpus = _cpu_count()
+    slots = cpus
+    budget = _memory_budget_gib()
+    if budget is not None:
+        slots = min(slots, int((budget - BUILD_MEM_HEADROOM_GIB) // NVCC_SLOT_GIB))
+    slots = max(1, slots)
+
+    raw_jobs = os.environ.get("MAX_JOBS")
+    if raw_jobs is not None and raw_jobs.isdigit():
+        jobs = max(1, int(raw_jobs))
+        export_jobs = False
+    else:
+        jobs = min(cpus + NINJA_DEFAULT_EXTRA_JOBS, slots)
+        export_jobs = True
+
+    raw_threads = os.environ.get("NVCC_THREADS", "").strip().lower()
+    if raw_threads in ("", "0", "auto"):
+        threads = max(1, slots // jobs)
+    else:
+        threads = max(1, int(raw_threads))
+    return jobs, threads, export_jobs
 
 
 class CudaProfile(BuildProfile):
@@ -65,6 +136,18 @@ class CudaProfile(BuildProfile):
             "csrc/cuda/event_recorder.cpp",
             "csrc/cuda/completion_recorder.cpp",
         ]
+        max_jobs, nvcc_threads, export_jobs = resolve_build_parallelism()
+        if export_jobs:
+            # torch's BuildExtension reads MAX_JOBS from os.environ at ninja time.
+            os.environ["MAX_JOBS"] = str(max_jobs)
+        print(
+            "CUDA build parallelism: MAX_JOBS=%d NVCC_THREADS=%d"
+            % (max_jobs, nvcc_threads)
+        )
+        nvcc_flags = [flag_cxx_abi]
+        # --threads=1 is a no-op; omit it to keep the historical command line.
+        if nvcc_threads > 1:
+            nvcc_flags.append(f"--threads={nvcc_threads}")
         ext_modules = [
             cpp_extension.CUDAExtension(
                 "lmcache.cuda_ops",
@@ -72,7 +155,7 @@ class CudaProfile(BuildProfile):
                 include_dirs=[CSRC_DIR],
                 extra_compile_args={
                     "cxx": [flag_cxx_abi, "-std=c++17"],
-                    "nvcc": [flag_cxx_abi, f"--threads={NVCC_THREADS}"],
+                    "nvcc": nvcc_flags,
                 },
             ),
         ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Nightly [[#500](https://github.com/LMCache/LMCache/actions/runs/32822991575)](https://github.com/LMCache/LMCache/actions/runs/32822991575) died with `exit code 143` in the cu13 image build (and lost the wheel runner) — the runner agent was starved. #4621 started honouring `NVCC_THREADS`, and the Dockerfile had long set `NVCC_THREADS=8` with `MAX_JOBS=2`; since each concurrent nvcc compile of our heaviest `.cu` files peaks at ~3 GiB (CUDA 13.0), `2 x 8` asked the 4-vCPU / 16 GB `ubuntu-latest` runner for ~48 GiB.

`cuda.py` now sizes `nvcc --threads` (and `MAX_JOBS` when unset) so that `MAX_JOBS x NVCC_THREADS <= min(cpus, (RAM - 3 GiB) / 3 GiB)`, honouring a cgroup memory limit. On the GitHub runner that resolves to `2 x 2` (~1.7x faster device compile than `--threads=1`, ~12 GiB peak); large build boxes are unchanged. Explicit `MAX_JOBS` / `NVCC_THREADS` are still used as-is. The Dockerfiles' `nvcc_threads` default becomes `auto`.

**Special notes for your reviewers**:

Measured peaks for `mem_kernels.cu` across the 7 nightly archs: `--threads=1` 2.7 GiB / 153 s, `--threads=2` 5.4 GiB / 91 s, `--threads=8` 18 GiB / 45 s. `--threads=1` is omitted from the command line, so the default build stays byte-identical to pre-#4621.

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests