### PR TITLE
[MP][Observability] L1/L2 hit attribution and early-exit reason on lookup END (revival of #4281)

### DIFF
--- a/docs/design/observability/request-event-span.md
+++ b/docs/design/observability/request-event-span.md
@@ -58,17 +58,29 @@ closes the root span before the retrieve child span ends.
 
 ## Root Span Attributes
 
-In addition to `session_id`, the root `"request"` span carries three hit rate
-attributes that are set when `MP_LOOKUP_PREFETCH_END` is processed:
+In addition to `session_id`, the root `"request"` span carries eight hit rate
+and outcome attributes that are set when `MP_LOOKUP_PREFETCH_END` is processed:
 
 | Attribute | OTel type | Value |
 |-----------|-----------|-------|
 | `hit_tokens` | `int` | tokens found in L1+L2 (numerator) |
 | `requested_tokens` | `int` | chunk-aligned tokens submitted for lookup (denominator) |
 | `hit_rate` | `float` | `hit_tokens / requested_tokens`; `0.0` when denominator is zero |
+| `l1_hit_tokens` | `int` | tokens in the prefix L1 alone could serve |
+| `l2_hit_tokens` | `int` | tokens by which L2 extended that prefix |
+| `l1_hit_rate` | `float` | `l1_hit_tokens / requested_tokens`; `0.0` when denominator is zero |
+| `l2_hit_rate` | `float` | `l2_hit_tokens / requested_tokens`; `0.0` when denominator is zero |
+| `early_exit_reason` | `str` | branch of `lookup()` that returned before submitting a prefetch; `""` on the normal path |
 
 `hit_rate` is stored as a precomputed float because trace UIs (Tempo, Jaeger)
-cannot derive it from two integer attributes at query time.
+cannot derive it from two integer attributes at query time; the same reasoning
+applies to `l1_hit_rate` and `l2_hit_rate`.
+
+`l1_hit_tokens + l2_hit_tokens == hit_tokens` exactly — `l2` is the remainder
+of `found_count` after the L1-servable prefix, not an independent count.  The
+two rates therefore sum to `hit_rate` up to float rounding, not bit-for-bit.
+See [EVENTS.md](../v1/mp_observability/EVENTS.md) for the derivation and for
+the `early_exit_reason` vocabulary.
 
 **Invariant:** these attributes are set at `MP_LOOKUP_PREFETCH_END` time, while
 the root span is still open.  `LP_END` always precedes `MP_REQUEST_END` in the
@@ -80,8 +92,10 @@ attributes are written.
 
 ### CB path — `cb.request` span
 
-The same attributes appear on the `"cb.request"` root span and are set when
-`CB_LOOKUP_END` is processed by `BlendTracingSubscriber`.
+The `hit_tokens` / `requested_tokens` / `hit_rate` trio also appears on the
+`"cb.request"` root span, set when `CB_LOOKUP_END` is processed by
+`BlendTracingSubscriber`.  The per-tier split and `early_exit_reason` are
+specific to the MP path and are not set on `"cb.request"`.
 
 `CB_LOOKUP_END` carries the hit accounting in its metadata, computed at the
 emit site in `lmcache/v1/multiprocess/modules/blend.py`

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -189,7 +189,7 @@ to correlate START/END pairs.
 | `MP_RETRIEVE_START` | `device`, `engine_id`, `model_name` | `str`, `int`, `str` |
 | `MP_RETRIEVE_END` | `device`, `retrieved_count`, `engine_id`, `model_name`, `cache_salt`, `total_bytes`, `num_tokens` | `str`, `int`, `int`, `str`, `str`, `int`, `int` |
 | `MP_LOOKUP_PREFETCH_START` | *(none)* | — |
-| `MP_LOOKUP_PREFETCH_END` | `found_count`, `requested_tokens`, `hit_tokens`, `model_name`, `cache_salt` | `int`, `int`, `int`, `str`, `str` |
+| `MP_LOOKUP_PREFETCH_END` | `found_count`, `requested_tokens`, `hit_tokens`, `l1_hit_tokens`, `l2_hit_tokens`, `early_exit_reason`, `model_name`, `cache_salt` | `int`, `int`, `int`, `int`, `int`, `str`, `str`, `str` |
 | `MP_LOOKUP` | `request_id`, `chunk_hashes`, `model_name`, `chunk_size`, `seq_len`, `dtypes`, `shapes` | `str`, `list[str]`, `str`, `int`, `int`, `list[str]`, `list[list[int]]` |
 | `MP_VLLM_BLOCK_ALLOCATION` | `instance_id`, `model_name`, `records` | `int`, `str`, `list[BlockAllocationRecord]` (each has `req_id: str`, `new_block_ids: list[int]`, `new_token_ids: list[int]`) |
 | `MP_VLLM_END_SESSION` | `request_id` | `str` |
@@ -213,6 +213,29 @@ know `chunk_size`:
   empty `chunk_hashes`).  Sub-chunk trailing tokens are excluded — they
   cannot hit at chunk granularity.
 - `hit_tokens = found_count * chunk_size`.
+- `l1_hit_tokens` and `l2_hit_tokens` split `hit_tokens` by the tier that
+  served it.  `l1_hit_tokens` comes from `PrefetchHandle.l1_hit_chunks` —
+  the prefix L1 alone could serve under each object group's attention
+  window rule — so a chunk whose out-of-window keys were never fetched is
+  still an L1 hit.  `l2_hit_tokens` is the remainder: how much further
+  `found_count` reached once L2 completed.  **Invariant:
+  `l1_hit_tokens + l2_hit_tokens == hit_tokens`, exactly, on every path**,
+  so a dashboard summing the two can never exceed 100%.
+- `early_exit_reason` names the branch of `lookup()` that returned before a
+  prefetch task was submitted.  Always present; `""` on the normal path.
+  Vocabulary:
+
+  | Value | Meaning | Operator action |
+  |---|---|---|
+  | `""` | Normal path (including a genuine cold miss) | None — inspect the hit rate |
+  | `no_gpu_context` | No layout registered for this model / world size | Configuration or registration bug; also logged at `error` |
+  | `empty_chunk_hashes` | Prompt shorter than one chunk | None — a workload property, not a cache failure |
+  | `no_group_layout_descs` | No per-object-group layouts registered for this model / world size | Configuration or registration bug; also logged at `error` |
+
+  Without it `found_count == 0` conflates a cold miss with every early
+  exit.  Extensions are additive: a new value may be added without a
+  dashboard migration, as with the `L2_PREFETCH_FAILED` `reason`
+  vocabulary.
 - `model_name` and `cache_salt` are captured at lookup time from
   `IPCCacheServerKey` and surface as OTel attributes on the
   `lmcache_mp.lookup_*_tokens` counters so the hit rate can be sliced

--- a/docs/source/mp/observability/traces.rst
+++ b/docs/source/mp/observability/traces.rst
@@ -39,7 +39,10 @@ Each session is wrapped in a per-request root span — ``request`` for the
 standard MP path and ``cb.request`` for the CacheBlend path — that nests
 all child spans (``mp.store``, ``mp.retrieve``, ``mp.lookup_prefetch``)
 beneath it.  When the lookup phase ends, the root span is annotated with
-three OTel attributes that summarise the request-level cache hit rate:
+OTel attributes that summarise the request-level cache hit rate.  Both
+root spans carry the first three below; the rest are specific to the
+``request`` span, and ``cb.request`` instead carries its own CacheBlend
+breakdown of ``hit_tokens`` (prefix / segmented-prefix / non-prefix).
 
 .. list-table::
    :header-rows: 1
@@ -59,6 +62,31 @@ three OTel attributes that summarise the request-level cache hit rate:
      - ``hit_tokens / requested_tokens``; ``0.0`` when the denominator is
        zero.  Stored as a precomputed float because trace UIs (Tempo,
        Jaeger) cannot derive it from two integer attributes at query time.
+   * - ``l1_hit_tokens``
+     - ``int``
+     - Tokens in the prefix L1 alone could serve, under each object
+       group's attention window rule.  ``request`` span only.
+   * - ``l2_hit_tokens``
+     - ``int``
+     - Tokens by which L2 extended that prefix.  Together with
+       ``l1_hit_tokens`` this is an exact integer partition of
+       ``hit_tokens``.  ``request`` span only.
+   * - ``l1_hit_rate``
+     - ``float``
+     - ``l1_hit_tokens / requested_tokens``; ``0.0`` when the denominator
+       is zero.  ``request`` span only.
+   * - ``l2_hit_rate``
+     - ``float``
+     - ``l2_hit_tokens / requested_tokens``; ``0.0`` when the denominator
+       is zero.  Sums with ``l1_hit_rate`` to ``hit_rate`` up to float
+       rounding.  ``request`` span only.
+   * - ``early_exit_reason``
+     - ``str``
+     - Which branch of the lookup returned before a prefetch was
+       submitted: ``no_gpu_context`` or ``no_group_layout_descs`` (nothing
+       registered for this model / world size), or ``empty_chunk_hashes``
+       (prompt shorter than one chunk).  ``""`` on the normal path,
+       including a genuine cold miss.  ``request`` span only.
 
 The attributes are written when ``MP_LOOKUP_PREFETCH_END`` (standard MP
 path) or ``CB_LOOKUP_END`` (CacheBlend path) is processed — while the
@@ -78,6 +106,12 @@ Example TraceQL queries (Grafana Tempo):
 
     # Complete misses (lookup ran but nothing was cached)
     { name = "request" && span.requested_tokens > 0 && span.hit_tokens = 0 }
+
+    # Requests that had to go to L2 for most of their hit
+    { name = "request" && span.l2_hit_rate > 0.5 }
+
+    # Lookups that exited early rather than genuinely missing
+    { name = "request" && span.early_exit_reason != "" }
 
 For the full event-to-span mapping and the registry pattern that links
 child spans back to the root see

--- a/lmcache/v1/mp_observability/subscribers/tracing/mp_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/mp_server.py
@@ -274,9 +274,22 @@ class MPServerTracingSubscriber(EventSubscriber):
                 hit_rate = (
                     hit_tokens / requested_tokens if requested_tokens > 0 else 0.0
                 )
+                l1_hit_tokens = int(event.metadata["l1_hit_tokens"])
+                l2_hit_tokens = int(event.metadata["l2_hit_tokens"])
+                denom = requested_tokens or 1  # 0.0 rates when nothing requested
                 root_span.set_attribute("hit_tokens", hit_tokens)
                 root_span.set_attribute("requested_tokens", requested_tokens)
                 root_span.set_attribute("hit_rate", hit_rate)
+                # Typed root-span attributes: the child-span loop above
+                # stringifies every metadata value, so these cannot be
+                # aggregated numerically from there.
+                root_span.set_attribute("l1_hit_tokens", l1_hit_tokens)
+                root_span.set_attribute("l2_hit_tokens", l2_hit_tokens)
+                root_span.set_attribute("l1_hit_rate", l1_hit_tokens / denom)
+                root_span.set_attribute("l2_hit_rate", l2_hit_tokens / denom)
+                root_span.set_attribute(
+                    "early_exit_reason", str(event.metadata["early_exit_reason"])
+                )
 
         if event.event_type == EventType.MP_STORE_END:
             if (count := self._pending_store_count.get(sid, 0)) > 0:

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -88,8 +88,8 @@ class _PrefetchJob:
     request_id: str
     # Number of tokens submitted for lookup (denominator for the L1+L2
     # token-level hit-rate metric).  Equals ``len(chunk_hashes) * chunk_size``
-    # on the happy path; 0 for early-exit paths (no GPU context matches
-    # or chunk_hashes is empty).  Consumed at ``MP_LOOKUP_PREFETCH_END``
+    # on the happy path; 0 on the early-exit paths (see
+    # ``early_exit_reason``).  Consumed at ``MP_LOOKUP_PREFETCH_END``
     # emission time in ``query_prefetch_status``.
     requested_tokens: int
     num_object_groups: int = 1
@@ -100,6 +100,9 @@ class _PrefetchJob:
     # tenant / isolation domain (an empty string means no salt set).
     model_name: str = ""
     cache_salt: str = ""
+    # Names the ``lookup()`` branch that returned before submitting a prefetch
+    # task; empty on the normal path.
+    early_exit_reason: str = ""
 
 
 class LookupModule:
@@ -231,6 +234,7 @@ class LookupModule:
                     requested_tokens=0,
                     model_name=model_name,
                     cache_salt=key.cache_salt,
+                    early_exit_reason="no_gpu_context",
                 )
             )
             return
@@ -254,6 +258,7 @@ class LookupModule:
                     requested_tokens=0,
                     model_name=model_name,
                     cache_salt=key.cache_salt,
+                    early_exit_reason="empty_chunk_hashes",
                 )
             )
             return
@@ -320,6 +325,7 @@ class LookupModule:
                     requested_tokens=0,
                     model_name=model_name,
                     cache_salt=key.cache_salt,
+                    early_exit_reason="no_group_layout_descs",
                 )
             )
             return
@@ -424,6 +430,20 @@ class LookupModule:
             tuple(range(job.attn_desc.num_object_groups)),
         )
 
+        # ``l1_hit_chunks`` is the prefix L1 could serve on its own under each
+        # object group's window rule, so L2's contribution is however much
+        # further ``found_count`` reaches -- not a count of L1-resident keys.
+        l1_chunks = job.handle.l1_hit_chunks
+        if l1_chunks > found_count:
+            logger.error(
+                "L1 hit chunks exceed total hit chunks: l1=%d total=%d request=%s",
+                l1_chunks,
+                found_count,
+                request_id,
+            )
+            l1_chunks = found_count
+        l2_chunks = found_count - l1_chunks
+
         self._ctx.event_bus.publish(
             Event(
                 event_type=EventType.MP_LOOKUP_PREFETCH_END,
@@ -432,6 +452,9 @@ class LookupModule:
                     "found_count": found_count,
                     "requested_tokens": job.requested_tokens,
                     "hit_tokens": found_count * self._ctx.chunk_size,
+                    "l1_hit_tokens": l1_chunks * self._ctx.chunk_size,
+                    "l2_hit_tokens": l2_chunks * self._ctx.chunk_size,
+                    "early_exit_reason": job.early_exit_reason,
                     "model_name": job.model_name,
                     "cache_salt": job.cache_salt,
                 },

--- a/tests/v1/mp_observability/subscribers/tracing/test_mp_server.py
+++ b/tests/v1/mp_observability/subscribers/tracing/test_mp_server.py
@@ -42,6 +42,33 @@ def subscriber(registry, bus):
     return sub
 
 
+@pytest.fixture
+def exporter():
+    """Real OTel provider with in-memory exporter; patches the module tracer.
+
+    Span attributes are only recorded by a real ``TracerProvider``.
+    ``_HAS_OTEL`` is forced True so the handlers don't early-return.
+    """
+    exp = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    real_tracer = provider.get_tracer("lmcache_mp.server")
+    with (
+        patch.object(mp_server_module, "_tracer", real_tracer),
+        patch.object(mp_server_module, "_HAS_OTEL", True),
+    ):
+        yield exp
+    exp.shutdown()
+
+
+def _root_span(exporter: InMemorySpanExporter, sid: str):
+    """Return the finished root span for *sid*, or None."""
+    for span in exporter.get_finished_spans():
+        if span.name == "request" and span.attributes.get("session_id") == sid:
+            return span
+    return None
+
+
 class TestMPServerTracingSubscriber:
     def test_subscriptions_cover_all_mp_server_events(self, subscriber):
         subs = subscriber.get_subscriptions()
@@ -619,32 +646,9 @@ class TestMPServerTracingSubscriber:
 class TestHitRateAttributes:
     """Verify hit_tokens / requested_tokens / hit_rate are set on the root span.
 
-    Uses a real OTel TracerProvider backed by InMemorySpanExporter so that span
-    attributes are actually recorded.  The module-level ``_tracer`` is patched
-    for the duration of each test; ``_HAS_OTEL`` is forced True so that the
-    handlers don't early-return.
+    Uses the module-level ``exporter`` fixture so span attributes are actually
+    recorded by a real TracerProvider.
     """
-
-    @pytest.fixture
-    def exporter(self):
-        """Real OTel provider with in-memory exporter; patches module tracer."""
-        exp = InMemorySpanExporter()
-        provider = TracerProvider()
-        provider.add_span_processor(SimpleSpanProcessor(exp))
-        real_tracer = provider.get_tracer("lmcache_mp.server")
-        with (
-            patch.object(mp_server_module, "_tracer", real_tracer),
-            patch.object(mp_server_module, "_HAS_OTEL", True),
-        ):
-            yield exp
-        exp.shutdown()
-
-    def _root_span(self, exporter: InMemorySpanExporter, sid: str):
-        """Return the finished root span for *sid*, or None."""
-        for span in exporter.get_finished_spans():
-            if span.name == "request" and span.attributes.get("session_id") == sid:
-                return span
-        return None
 
     def test_hit_rate_attrs_set_on_root_span(self, exporter):
         """LP_END with hit_tokens=512, requested_tokens=1024 → hit_rate=0.5."""
@@ -674,6 +678,9 @@ class TestHitRateAttributes:
                     "hit_tokens": 512,
                     "requested_tokens": 1024,
                     "found_count": 2,
+                    "l1_hit_tokens": 512,
+                    "l2_hit_tokens": 0,
+                    "early_exit_reason": "",
                 },
             )
         )
@@ -687,7 +694,7 @@ class TestHitRateAttributes:
         time.sleep(0.15)
         bus.stop()
 
-        root = self._root_span(exporter, sid)
+        root = _root_span(exporter, sid)
         assert root is not None
         assert root.attributes["hit_tokens"] == 512
         assert root.attributes["requested_tokens"] == 1024
@@ -717,7 +724,14 @@ class TestHitRateAttributes:
                 event_type=EventType.MP_LOOKUP_PREFETCH_END,
                 session_id=sid,
                 timestamp=now + 0.010,
-                metadata={"hit_tokens": 0, "requested_tokens": 0, "found_count": 0},
+                metadata={
+                    "hit_tokens": 0,
+                    "requested_tokens": 0,
+                    "found_count": 0,
+                    "l1_hit_tokens": 0,
+                    "l2_hit_tokens": 0,
+                    "early_exit_reason": "",
+                },
             )
         )
         bus.publish(
@@ -730,7 +744,7 @@ class TestHitRateAttributes:
         time.sleep(0.15)
         bus.stop()
 
-        root = self._root_span(exporter, sid)
+        root = _root_span(exporter, sid)
         assert root is not None
         assert root.attributes["hit_tokens"] == 0
         assert root.attributes["requested_tokens"] == 0
@@ -776,7 +790,90 @@ class TestHitRateAttributes:
         time.sleep(0.15)
         bus.stop()
 
-        root = self._root_span(exporter, sid)
+        root = _root_span(exporter, sid)
         assert root is not None
         assert "hit_tokens" not in root.attributes
         assert "hit_rate" not in root.attributes
+
+
+class TestTierAttributionAttributes:
+    """Verify the per-tier hit split and early-exit reason on the root span."""
+
+    def _root_span_for(self, exporter, sid: str, end_metadata: dict):
+        """Run a REQUEST/LP_START/LP_END/REQUEST_END cycle for ``sid``.
+
+        Args:
+            exporter: In-memory span exporter from the ``exporter`` fixture.
+            sid: Session ID correlating the four events.
+            end_metadata: Metadata for the ``MP_LOOKUP_PREFETCH_END`` event.
+
+        Returns:
+            The finished root span for ``sid``, or None.
+        """
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        bus.register_subscriber(MPServerTracingSubscriber(SpanRegistry()))
+        bus.start()
+        now = time.time()
+        for event_type, offset, metadata in (
+            (EventType.MP_REQUEST_START, 0.0, {}),
+            (EventType.MP_LOOKUP_PREFETCH_START, 0.001, {}),
+            (EventType.MP_LOOKUP_PREFETCH_END, 0.010, end_metadata),
+            (EventType.MP_REQUEST_END, 0.020, {}),
+        ):
+            bus.publish(
+                Event(
+                    event_type=event_type,
+                    session_id=sid,
+                    timestamp=now + offset,
+                    metadata=metadata,
+                )
+            )
+        time.sleep(0.15)
+        bus.stop()
+        return _root_span(exporter, sid)
+
+    def test_tier_attributes_on_normal_path(self, exporter):
+        """768 hit tokens split 512/256 of 1024 requested."""
+        root = self._root_span_for(
+            exporter,
+            "req-tier-normal",
+            {
+                "found_count": 3,
+                "requested_tokens": 1024,
+                "hit_tokens": 768,
+                "l1_hit_tokens": 512,
+                "l2_hit_tokens": 256,
+                "early_exit_reason": "",
+            },
+        )
+
+        assert root is not None
+        assert root.attributes["l1_hit_tokens"] == 512
+        assert root.attributes["l2_hit_tokens"] == 256
+        assert root.attributes["l1_hit_rate"] == pytest.approx(0.5)
+        assert root.attributes["l2_hit_rate"] == pytest.approx(0.25)
+        assert root.attributes["early_exit_reason"] == ""
+        # Typed, unlike the generic child-span loop that stringifies metadata.
+        assert isinstance(root.attributes["l1_hit_tokens"], int)
+        assert isinstance(root.attributes["l1_hit_rate"], float)
+
+    @pytest.mark.parametrize("reason", ["no_gpu_context", "empty_chunk_hashes"])
+    def test_early_exit_reason_and_zero_rates(self, exporter, reason):
+        """An early exit names itself; a zero denominator yields 0.0 rates."""
+        root = self._root_span_for(
+            exporter,
+            f"req-early-{reason}",
+            {
+                "found_count": 0,
+                "requested_tokens": 0,
+                "hit_tokens": 0,
+                "l1_hit_tokens": 0,
+                "l2_hit_tokens": 0,
+                "early_exit_reason": reason,
+            },
+        )
+
+        assert root is not None
+        assert root.attributes["early_exit_reason"] == reason
+        assert root.attributes["l1_hit_rate"] == 0.0
+        assert root.attributes["l2_hit_rate"] == 0.0

--- a/tests/v1/multiprocess/test_lookup_outcome_attribution.py
+++ b/tests/v1/multiprocess/test_lookup_outcome_attribution.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the outcome-attribution fields on ``MP_LOOKUP_PREFETCH_END``.
+
+Covers the per-tier hit split (``l1_hit_tokens`` / ``l2_hit_tokens``) and
+``early_exit_reason``.  ``fold_unfold_ranked`` is patched out: these tests are
+about how its chunk count and ``PrefetchHandle.l1_hit_chunks`` become event
+metadata, not about the fold itself (which needs the native kernel).
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import AttnWindowDesc, PrefetchHandle
+from lmcache.v1.mp_observability.event import EventType
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.modules.lookup import LookupModule
+import lmcache.v1.multiprocess.modules.lookup as lookup_module
+
+CHUNK_SIZE = 256
+
+
+def _lookup_key(world_size: int) -> IPCCacheServerKey:
+    """A lookup-side IPC key (worker_id None -> expand over all workers)."""
+    return IPCCacheServerKey(
+        model_name="m",
+        world_size=world_size,
+        worker_id=None,
+        token_ids=(0,),
+        start=0,
+        end=0,
+        request_id="req-1",
+        cache_salt="salt",
+    )
+
+
+def _end_metadata(
+    chunk_hashes: list[bytes],
+    l1_hit_chunks: int = 0,
+    found_count: int = 0,
+    l1_found_indices: tuple[int, ...] = (),
+    num_groups: int = 1,
+    world_size: int = 1,
+    layout_found: bool = True,
+    group_layouts_found: bool = True,
+) -> dict:
+    """Drive a full lookup/poll cycle and return the END event's metadata.
+
+    Args:
+        chunk_hashes: Chunk hashes the token hasher reports; empty triggers the
+            ``empty_chunk_hashes`` early exit.
+        l1_hit_chunks: Prefix, in chunks, that L1 alone could serve.
+        found_count: Prefix, in chunks, served after L2 completed.
+        l1_found_indices: Retain mask the fold left read-locked in L1.
+        num_groups: Object groups per chunk.
+        world_size: kv_rank shards per chunk.
+        layout_found: False triggers the ``no_gpu_context`` early exit.
+        group_layouts_found: False triggers the ``no_group_layout_descs``
+            early exit.
+
+    Returns:
+        The metadata dict of the published ``MP_LOOKUP_PREFETCH_END`` event.
+    """
+    ctx = MagicMock()
+    ctx.chunk_size = CHUNK_SIZE
+    ctx.event_bus.has_subscribers.return_value = False
+    ctx.layout_desc_registry.find.return_value = MagicMock() if layout_found else None
+    ctx.layout_desc_registry.find_attn_desc.return_value = AttnWindowDesc(
+        num_chunks_in_sw=[-1] * num_groups, world_size=world_size
+    )
+    ctx.layout_desc_registry.find_group_layout_descs.return_value = (
+        {group_id: MagicMock() for group_id in range(num_groups)}
+        if group_layouts_found
+        else {}
+    )
+    ctx.token_hasher.compute_chunk_hashes.return_value = chunk_hashes
+    ctx.storage_manager.submit_prefetch_task.return_value = PrefetchHandle(
+        prefetch_request_id=0,
+        external_request_id="req-1",
+        l1_found_indices=l1_found_indices,
+        l1_hit_chunks=l1_hit_chunks,
+        total_requested_keys=len(chunk_hashes) * world_size * num_groups,
+        submit_time=time.monotonic(),
+    )
+
+    module = LookupModule(ctx)
+    with patch.object(
+        lookup_module, "fold_unfold_ranked", return_value=(found_count, MagicMock())
+    ):
+        module.lookup(_lookup_key(world_size), tp_size=1)
+        module.query_prefetch_status("req-1")
+
+    for call in ctx.event_bus.publish.call_args_list:
+        event = call.args[0]
+        if event.event_type is EventType.MP_LOOKUP_PREFETCH_END:
+            return event.metadata
+    raise AssertionError("no MP_LOOKUP_PREFETCH_END event was published")
+
+
+@pytest.mark.parametrize(
+    (
+        "num_chunks",
+        "num_groups",
+        "l1_found_indices",
+        "l1_hit_chunks",
+        "found_count",
+        "l1_chunks",
+        "l2_chunks",
+    ),
+    [
+        (4, 1, (), 4, 4, 4, 0),
+        (4, 1, (), 0, 4, 0, 4),
+        (4, 1, (), 2, 4, 2, 2),
+        (4, 1, (), 0, 0, 0, 0),
+        # Sliding window: group 1 has window=1, so the fold's retain mask keeps
+        # only group 0 for chunks 0-1.  All three chunks are still L1-served --
+        # attribution follows l1_hit_chunks, never the mask.
+        (3, 2, (0, 2, 4, 5), 3, 3, 3, 0),
+    ],
+    ids=[
+        "all_l1",
+        "all_l2",
+        "l2_extends_l1",
+        "cold_miss",
+        "sliding_window_retain_mask",
+    ],
+)
+def test_end_event_splits_hit_tokens_by_tier(
+    num_chunks,
+    num_groups,
+    l1_found_indices,
+    l1_hit_chunks,
+    found_count,
+    l1_chunks,
+    l2_chunks,
+):
+    """L2 is credited with however far it extended the L1-servable prefix."""
+    meta = _end_metadata(
+        chunk_hashes=[f"c{i}".encode() for i in range(num_chunks)],
+        l1_hit_chunks=l1_hit_chunks,
+        found_count=found_count,
+        l1_found_indices=l1_found_indices,
+        num_groups=num_groups,
+    )
+
+    assert meta["l1_hit_tokens"] == l1_chunks * CHUNK_SIZE
+    assert meta["l2_hit_tokens"] == l2_chunks * CHUNK_SIZE
+    assert meta["l1_hit_tokens"] + meta["l2_hit_tokens"] == meta["hit_tokens"]
+    assert meta["early_exit_reason"] == ""
+
+
+def test_l1_hit_chunks_above_found_count_is_clamped_and_logged():
+    """The storage manager guarantees l1 <= total; a breach must be visible."""
+    with patch.object(lookup_module.logger, "error") as log_error:
+        meta = _end_metadata(
+            chunk_hashes=[b"c0", b"c1", b"c2", b"c3"],
+            l1_hit_chunks=4,
+            found_count=2,
+        )
+
+    assert meta["l1_hit_tokens"] == 2 * CHUNK_SIZE
+    assert meta["l2_hit_tokens"] == 0
+    assert meta["l1_hit_tokens"] + meta["l2_hit_tokens"] == meta["hit_tokens"]
+    log_error.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"chunk_hashes": [b"c0"], "layout_found": False}, "no_gpu_context"),
+        ({"chunk_hashes": []}, "empty_chunk_hashes"),
+        (
+            {"chunk_hashes": [b"c0"], "group_layouts_found": False},
+            "no_group_layout_descs",
+        ),
+    ],
+    ids=["no_gpu_context", "empty_chunk_hashes", "no_group_layout_descs"],
+)
+def test_early_exit_reason(kwargs, reason):
+    """Each early-exit branch names itself on the END event."""
+    meta = _end_metadata(**kwargs)
+
+    assert meta["early_exit_reason"] == reason
+    assert meta["requested_tokens"] == 0
+    assert meta["hit_tokens"] == 0

--- a/tests/v1/multiprocess/test_lookup_outcome_attribution.py
+++ b/tests/v1/multiprocess/test_lookup_outcome_attribution.py
@@ -35,6 +35,7 @@ def _lookup_key(world_size: int) -> IPCCacheServerKey:
         end=0,
         request_id="req-1",
         cache_salt="salt",
+        num_kv_readers=1,
     )
 
 


### PR DESCRIPTION
Revives #4281 by @thegoldenflow, authorship preserved (single cherry-picked commit), rebased onto current `dev`. Scope is unchanged from the original — no logic edits.

## What it does

Adds `l1_hit_tokens`, `l2_hit_tokens` and `early_exit_reason` to `MP_LOOKUP_PREFETCH_END`, and promotes them plus the derived hit rates onto the request root span as typed attributes. Attribution comes from `PrefetchHandle.l1_hit_chunks` (computed by `fold_unfold_ranked` from each object group's window rule), preserving `l1_hit_tokens + l2_hit_tokens == hit_tokens`, with a defensive clamp if the storage-manager invariant `l1_hit_chunks <= found_count` is ever violated. Refs #3659.

## Rebase notes

One conflict, in `modules/lookup.py`: `dev` now records session bookkeeping at the same point this PR computes the attribution split (`prefetch_hit_chunks` / `prefetch_locked_gids`, from #4468 "linear hybrid model support"). The two are independent — one feeds `free_lookup_locks`, the other feeds the event — so both hunks are kept in sequence, bookkeeping first. Nothing else in the original commit was modified; the diffstat is unchanged from the original (7 files, +431/−38).

## Testing

- `ruff format --check` and `ruff check` clean on all touched files.
- `tests/v1/mp_observability/subscribers/tracing/test_mp_server.py`: 23 passed locally.
- `tests/v1/multiprocess/test_lookup_outcome_attribution.py`: skipped in our environment — `tests/v1/multiprocess/__init__.py` guards the package on the compiled `lmcache_native` extension, which our dev box lacks. Relying on CI for this file.

## Scope

Unchanged from the original: this establishes the request-level attribution and tracing fields only. Prometheus aggregation and dashboard panels stay out of scope until the event semantics are settled.

Context for why we care, in case it's useful to reviewers: on an interleaved sliding-window model (sliding-window layers plus full-attention layers, i.e. two object groups) the combined lookup-hit metric runs several times higher than what `vllm:prompt_tokens_by_source{source="external_kv_transfer"}` reports as actually delivered, and L2 reads run a multiple of the delivered keys. Without a per-tier split those numbers can't be reconciled, which is what led us here.
