### PR TITLE
Make event IPC backends explicitly implement EventIPCBackend

### DIFF
--- a/lmcache/v1/platform/base/event_ipc.py
+++ b/lmcache/v1/platform/base/event_ipc.py
@@ -160,7 +160,7 @@ class EventIPCBackend(Protocol):
         ...
 
 
-class DefaultEventIPCBackend:
+class DefaultEventIPCBackend(EventIPCBackend):
     """CUDA-style event IPC backend over an injectable event module.
 
     Works for any backend whose ``Event`` class supports interprocess handles,

--- a/lmcache/v1/platform/musa/event_ipc.py
+++ b/lmcache/v1/platform/musa/event_ipc.py
@@ -16,7 +16,7 @@ from lmcache.v1.platform.base.event_ipc import (
 )
 
 
-class MusaEventIPCBackend:
+class MusaEventIPCBackend(EventIPCBackend):
     """Event IPC backend backed by TorchMUSA interprocess events."""
 
     device_type: str = "musa"
@@ -116,6 +116,3 @@ class MusaEventIPCBackend:
     def synchronize_event(self, event: object, device: object) -> None:
         """Block the host until a TorchMUSA event completes."""
         self._default_backend().synchronize_event(event, device)
-
-
-assert isinstance(MusaEventIPCBackend(), EventIPCBackend)

--- a/tests/v1/platform/test_event_ipc.py
+++ b/tests/v1/platform/test_event_ipc.py
@@ -106,6 +106,13 @@ def test_default_backend_record_wait_query_synchronize_delegate():
     assert ("synchronize",) in event.calls
 
 
+def test_default_backend_is_event_ipc_backend() -> None:
+    backend = DefaultEventIPCBackend(
+        event_module=_FakeEventModule(), device_type="fake"
+    )
+    assert isinstance(backend, EventIPCBackend)
+
+
 def test_check_event_support_raises_with_device_name_when_no_interprocess():
     backend = DefaultEventIPCBackend(
         event_module=_NoInterprocessModule(), device_type="weirddev"
@@ -221,6 +228,10 @@ def test_cpu_device_spec_exposes_cached_default_event_backend() -> None:
 
 
 @pytest.mark.cuda
+@pytest.mark.skipif(
+    torch_device_type != "cuda",
+    reason="CUDA device spec test requires the CUDA platform to be active",
+)
 def test_cuda_device_spec_exposes_cached_default_event_backend() -> None:
     spec = CudaDeviceSpec()
     assert isinstance(spec.event_ipc_backend, DefaultEventIPCBackend)

--- a/tests/v1/platform/test_event_ipc.py
+++ b/tests/v1/platform/test_event_ipc.py
@@ -105,6 +105,7 @@ def test_default_backend_record_wait_query_synchronize_delegate():
     assert ("wait", "STREAM") in event.calls
     assert ("synchronize",) in event.calls
 
+
 def test_check_event_support_raises_with_device_name_when_no_interprocess():
     backend = DefaultEventIPCBackend(
         event_module=_NoInterprocessModule(), device_type="weirddev"
@@ -217,6 +218,7 @@ def test_cpu_device_spec_exposes_cached_default_event_backend() -> None:
     spec = CpuDeviceSpec()
     assert isinstance(spec.event_ipc_backend, DefaultEventIPCBackend)
     assert spec.event_ipc_backend is spec.event_ipc_backend
+
 
 @pytest.mark.cuda
 def test_cuda_device_spec_exposes_cached_default_event_backend() -> None:

--- a/tests/v1/platform/test_event_ipc.py
+++ b/tests/v1/platform/test_event_ipc.py
@@ -105,14 +105,6 @@ def test_default_backend_record_wait_query_synchronize_delegate():
     assert ("wait", "STREAM") in event.calls
     assert ("synchronize",) in event.calls
 
-
-def test_default_backend_is_event_ipc_backend() -> None:
-    backend = DefaultEventIPCBackend(
-        event_module=_FakeEventModule(), device_type="fake"
-    )
-    assert isinstance(backend, EventIPCBackend)
-
-
 def test_check_event_support_raises_with_device_name_when_no_interprocess():
     backend = DefaultEventIPCBackend(
         event_module=_NoInterprocessModule(), device_type="weirddev"
@@ -226,12 +218,7 @@ def test_cpu_device_spec_exposes_cached_default_event_backend() -> None:
     assert isinstance(spec.event_ipc_backend, DefaultEventIPCBackend)
     assert spec.event_ipc_backend is spec.event_ipc_backend
 
-
 @pytest.mark.cuda
-@pytest.mark.skipif(
-    torch_device_type != "cuda",
-    reason="CUDA device spec test requires the CUDA platform to be active",
-)
 def test_cuda_device_spec_exposes_cached_default_event_backend() -> None:
     spec = CudaDeviceSpec()
     assert isinstance(spec.event_ipc_backend, DefaultEventIPCBackend)


### PR DESCRIPTION
## Summary
- Make `DefaultEventIPCBackend` explicitly implement `EventIPCBackend`.
- Make `MusaEventIPCBackend` explicitly implement `EventIPCBackend`.
- Remove redundant runtime protocol assertions now that the relationship is declared directly.

## Validation
- `python3 -m pre_commit run --all-files` on macOS: non-Rust hooks passed; `rust-clippy` is blocked by the repo-documented `io-uring` Linux-only dependency.
- `SKIP=rust-fmt,rust-clippy python3 -m pre_commit run --files lmcache/v1/platform/base/event_ipc.py lmcache/v1/platform/musa/event_ipc.py tests/v1/platform/test_event_ipc.py`