### PR TITLE
Route multiprocess IPC events through platform APIs

### DIFF
--- a/docs/design/integration/vllm/multimodal_cache_keying.md
+++ b/docs/design/integration/vllm/multimodal_cache_keying.md
@@ -102,7 +102,10 @@ Substitution is applied on:
 - the in-process connector (`vllm_v1_adapter.py`: save, load, lookup),
 - the main MP connector (`lmcache_mp_metadata.py`; every key-carrying call
   in `lmcache_mp_connector.py` — lookup, store, retrieve, lock management,
-  eager prefetch — goes through the tracker's `get_token_ids()`).
+  eager prefetch — goes through the tracker's `get_token_ids()`), and
+- the version-pinned MP connector copies (`lmcache_mp_connector_0180.py`,
+  `lmcache_mp_connector_0201.py`), which embed the same tracker-level
+  substitution so vendored deployments on those vLLM versions are covered.
 
 NOT yet handled (multimodal requests on these paths can still cross-hit and
 need either substitution or an MM bypass guard):

--- a/docs/design/v1/platform/base/event_ipc_abstraction.md
+++ b/docs/design/v1/platform/base/event_ipc_abstraction.md
@@ -195,25 +195,25 @@ resolution; the selection is module-level, not spec-instance state, so every
 
 ```text
 Worker adapter
-  create/record producer event using its existing device API
-  get_event_ipc_backend(device)
-  export_event(producer_event, device)
+  after mode/config selection: resolve and validate event_backend once
+  event_backend.create_event / record_event / export_event
   send event handle in STORE/RETRIEVE
 
 Server: lmcache_driven_transfer.py
-  get_event_ipc_backend(cache_context.device)
-  check_event_support(device)
-  import_event(worker_handle, device)
-  wait_event(imported_event, cache_context.stream)
+  at KV registration: resolve, validate, and cache event_backend in ContextEntry
+  event_backend.import_event / wait_event
   enqueue KV transfer
-  create_event(device), record_event(done_event, stream)
-  export_event(done_event, device)
+  event_backend.create_event / record_event / export_event
 
 Worker: futures.py
-  get_event_ipc_backend(device)
-  import_event(server_handle, device)
-  query_event / wait_event / synchronize_event
+  reuse the transfer context's cached event_backend
+  event_backend.import_event / query_event / wait_event / synchronize_event
 ```
+
+Backend lookup and capability validation belong to initialization or cache
+registration, after process-wide IPC configuration is finalized. Request hot
+paths call the cached backend directly; they do not repeat platform discovery
+or support probing for each event operation.
 
 The following generic modules use only the platform API:
 
@@ -227,7 +227,8 @@ alias for `to_device_future()`.
 
 ## Error Contract
 
-`check_event_support(device)` runs before any cross-process memory transfer.
+`event_backend.check_event_support(device)` runs once during initialization or
+registration, before any cross-process memory transfer.
 The default backend rejects missing `Event`, missing `interprocess` support, or
 missing `Event.from_ipc_handle`. The MUSA backend additionally rejects a
 disabled/unavailable MUSA event API, a missing TorchMUSA module, or an event

--- a/docs/design/v1/platform/cuda/timeline_semaphore_event_ipc.md
+++ b/docs/design/v1/platform/cuda/timeline_semaphore_event_ipc.md
@@ -151,20 +151,26 @@ when the failure is on the server).
 device event; this backend only exports its own event objects. Call sites
 that bypass the backend break under isolated IPC:
 
-- **Migrated**: the vLLM MP connector (`lmcache_mp_connector.py`) creates
-  producer events via `LMCacheMPWorkerAdapter.create_recorded_event`,
-  which routes `create_event` / `record_event` through the resolved
-  backend. The event objects satisfy the `IPCEvent` duck protocol, so
+- **Migrated**: the vLLM MP connectors (`main`, `_0180`, `_0201`) now call
+  `LMCacheMPWorkerAdapter.create_recorded_event()` after mode and config
+  selection. That delegates to `transfer_ctx.create_recorded_event()`, so
+  LMCache-driven transfers use the cached platform event backend, async
+  engine-driven transfers keep a local ordering event, and synchronous
+  engine-driven or unhealthy-drop paths can return `None`. The returned
+  event objects still satisfy the existing `IPCEvent` duck protocol, so
   `event.wait(stream)` call sites keep working. Server
   (`lmcache_driven_transfer.py`) and worker futures (`futures.py`) were
   already fully backend-routed.
-- **Not migrated** (the reason the switch defaults to off): SGLang and
-  TRT-LLM adapters create raw `torch_dev.Event(interprocess=True)`
-  producer events; CacheBlend and qstore server modules return raw
-  `event.ipc_handle()` bytes instead of `export_event(...)` (already
-  outside the event-IPC abstraction, see `event_ipc_abstraction.md`
-  non-goals). Once these remaining call sites route through the backend,
-  the default flips to on.
+- **Migrated**: SGLang and TRT-LLM adapters resolve and validate their event
+  backend during initialization or KV registration, route producer-event
+  creation through its `create_event` / `record_event` methods, and retain
+  exported events on the raw request future until the daemon replies.
+- **Migrated for event handles**: CacheBlend and qstore server modules now
+  return `export_event(...)` on the registration-cached backend instead of raw
+  `event.ipc_handle()` bytes. The switch still defaults to off because the
+  raw KV-wrapper work (already outside the event-IPC abstraction; see
+  `event_ipc_abstraction.md` non-goals) remains before hostIPC-free
+  deployment is complete.
 
 ## Status
 

--- a/lmcache/cli/commands/bench/server_bench/client.py
+++ b/lmcache/cli/commands/bench/server_bench/client.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     # First Party
     from lmcache.v1.multiprocess.transport.base import RequestClient
+    from lmcache.v1.platform.base.event_ipc import EventIPCBackend
 
 
 @dataclass(frozen=True)
@@ -161,6 +162,7 @@ class ServerBenchClient:
         self._log = log
         self._zmq_context: Any | None = None
         self._req_client: "RequestClient | None" = None
+        self._event_backend: "EventIPCBackend | None" = None
         self._workers: list[WorkerContext] = []
         self._registered_instance_ids: list[int] = []
         self._shm_names: list[str] = []
@@ -360,6 +362,7 @@ class ServerBenchClient:
                 chunk_size=self._chunk_size,
                 server_pool=worker.server_pool,
                 instance_id=worker.spec.instance_id,
+                event_backend=self._event_backend,
             )
             if worker_status == "stored":
                 successful.append(worker.spec.rank)
@@ -452,6 +455,7 @@ class ServerBenchClient:
                 client_tensors=self._data_tensors(worker),
                 server_pool=worker.server_pool,
                 instance_id=worker.spec.instance_id,
+                event_backend=self._event_backend,
             )
             if worker_status == "retrieved":
                 successful.append(worker.spec.rank)
@@ -681,6 +685,7 @@ class ServerBenchClient:
         self._registered_instance_ids.clear()
         self._workers.clear()
         self._shm_names.clear()
+        self._event_backend = None
         self._started = False
 
     def _initialize(self) -> None:
@@ -707,6 +712,7 @@ class ServerBenchClient:
         )
         from lmcache.v1.multiprocess.group_view import EngineGroupInfo
         from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
+        from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
 
         config = self._config
         use_gpu = config.is_gpu
@@ -718,6 +724,11 @@ class ServerBenchClient:
                 "  [info] --transfer-mode=lmcache_driven on cpu mode: "
                 "using REGISTER_KV_CACHE + STORE/RETRIEVE over POSIX SHM"
             )
+        if use_gpu and use_handle:
+            device = torch_dev.current_device()
+            event_backend = get_event_ipc_backend(device)
+            event_backend.check_event_support(device)
+            self._event_backend = event_backend
 
         self._log(
             "Connecting to LMCache MP Server at %s (mode=%s) ..."

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -44,10 +44,7 @@ try:
     import zmq  # noqa: F401  # availability probe; used by command.py
 
     # First Party
-    from lmcache.utils import (
-        EngineType,
-        check_interprocess_event_support,
-    )
+    from lmcache.utils import EngineType
     from lmcache.v1.kv_layer_groups import (
         DTYPE_MAP,
         KVLayerGroupInfo,
@@ -65,6 +62,7 @@ try:
     )
     from lmcache.v1.multiprocess.transfer_context.shm import ShmSlotDescriptor
     from lmcache.v1.multiprocess.transport.base import RequestClient
+    from lmcache.v1.platform.base.event_ipc import EventIPCBackend
     from lmcache.v1.platform.cpu.shm import (
         CpuShmTensorWrapper,
         shm_create_readwrite,
@@ -144,16 +142,26 @@ _TIMEOUT = object()
 def _wait_for_result(
     future: MessagingFuture[Any],
     timeout_s: float = _DEFAULT_RPC_TIMEOUT_S,
+    retain_refs: tuple[object, ...] = (),
 ) -> Any:
     """Wait for an RPC future and convert a timeout to ``_TIMEOUT``.
 
     Returns the decoded response (possibly ``None`` for void replies)
-    on success, or the sentinel ``_TIMEOUT`` on RPC timeout.
+    on success, or the sentinel ``_TIMEOUT`` on RPC timeout. Objects in
+    ``retain_refs`` stay owned by the raw future until the transport
+    finishes with the request, including timeout paths where the reply may
+    still arrive later.
     """
+    for ref in retain_refs:
+        future.retain_reference(ref)
     try:
-        return future.result(timeout=timeout_s)
+        result = future.result(timeout=timeout_s)
     except TimeoutError:
         return _TIMEOUT
+    release_references = getattr(future, "release_references", None)
+    if callable(release_references):
+        release_references()
+    return result
 
 
 # ------------------------------------------------------------------ #
@@ -567,19 +575,24 @@ def _poll_prefetch_status(
     return None
 
 
-def _make_event_handle(use_gpu: bool = True) -> bytes:
-    """Create a CUDA event IPC handle for GPU mode.
+def _make_exported_event(
+    event_backend: EventIPCBackend | None,
+    use_gpu: bool = True,
+) -> tuple[object | None, bytes]:
+    """Create and export the producer event for handle-mode bench requests.
 
     CPU mode does not need a cross-process event (SHM mappings are
     coherent without device-side sync), so an empty handle is
     returned and the server treats it as a no-op.
     """
     if not use_gpu:
-        return b""
-    check_interprocess_event_support()
-    event = torch_dev.Event(interprocess=True)
-    event.record()
-    return event.ipc_handle()
+        return None, b""
+    if event_backend is None:
+        raise RuntimeError("GPU handle mode requires an initialized event backend")
+    device = torch_dev.current_device()
+    event = event_backend.create_event(device)
+    event_backend.record_event(event, None)
+    return event, event_backend.export_event(event, device)
 
 
 def _build_server_slot_views(
@@ -790,6 +803,7 @@ def _send_store(
     chunk_size: int = 0,
     server_pool: "mmap.mmap | None" = None,
     instance_id: int = _INSTANCE_ID,
+    event_backend: EventIPCBackend | None = None,
 ) -> str:
     """Store KV cache blocks. Returns status string.
 
@@ -809,13 +823,17 @@ def _send_store(
         num_tokens = key.end - key.start
         num_blocks = num_tokens // block_size
         block_ids = list(range(block_offset, block_offset + num_blocks))
+        event, event_handle = _make_exported_event(event_backend, use_gpu)
+        future = client.store(
+            key,
+            instance_id,
+            [block_ids] * num_engine_group_infos,
+            event_handle,
+        )
+        retain_refs = (event,) if event is not None else ()
         result = _wait_for_result(
-            client.store(
-                key,
-                instance_id,
-                [block_ids] * num_engine_group_infos,
-                _make_event_handle(),
-            )
+            future,
+            retain_refs=retain_refs,
         )
         if result is _TIMEOUT:
             return "timeout"
@@ -861,6 +879,7 @@ def _send_retrieve(
     client_tensors: list["torch.Tensor"] | None = None,
     server_pool: "mmap.mmap | None" = None,
     instance_id: int = _INSTANCE_ID,
+    event_backend: EventIPCBackend | None = None,
 ) -> str:
     """Retrieve KV cache blocks. Returns status.
 
@@ -880,14 +899,18 @@ def _send_retrieve(
         hit_tokens = hit_chunks * chunk_size
         num_blocks = hit_tokens // block_size
         block_ids = list(range(block_offset, block_offset + num_blocks))
+        event, event_handle = _make_exported_event(event_backend, use_gpu)
+        future = client.retrieve(
+            key,
+            instance_id,
+            [block_ids] * num_engine_group_infos,
+            event_handle,
+            0,  # skip_first_n_tokens
+        )
+        retain_refs = (event,) if event is not None else ()
         result = _wait_for_result(
-            client.retrieve(
-                key,
-                instance_id,
-                [block_ids] * num_engine_group_infos,
-                _make_event_handle(),
-                0,  # skip_first_n_tokens
-            )
+            future,
+            retain_refs=retain_refs,
         )
         if result is _TIMEOUT:
             return "timeout"

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -36,6 +36,10 @@ from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform import get_device_spec
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
 from lmcache.v1.platform.kv_wrap import wrap_one_kv_cache
 
 if TYPE_CHECKING:
@@ -186,6 +190,8 @@ class LMCacheMPConnector:
         self.worker_id = rank
         self.page_size = page_size
         self.device = device
+        self._event_backend: EventIPCBackend = get_event_ipc_backend(device)
+        self._event_backend.check_event_support(device)
         self.model_name = sgl_config.model_path
         self.num_layers = len(k_pool)
         self.tp_group = tp_group
@@ -456,8 +462,8 @@ class LMCacheMPConnector:
         MessagingFuture[tuple[bytes, bool]],
         MessagingFuture[bool],
     ]:
-        event = torch_dev.Event(interprocess=True)
-        event.record(torch_dev.current_stream())
+        event = self._event_backend.create_event(self.device)
+        self._event_backend.record_event(event, torch_dev.current_stream())
         raw_future: MessagingFuture[tuple[bytes, bool]] = self.req_client.retrieve(
             self._create_key(
                 token_ids,
@@ -469,14 +475,17 @@ class LMCacheMPConnector:
             # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
             # non-hybrid, so wrap the flat list as a single group.
             [block_ids],
-            event.ipc_handle(),
+            self._event_backend.export_event(event, self.device),
             skip_prefix_n_blocks,
         )
-        future = raw_future.to_device_future(device=self.device)
+        raw_future.retain_reference(event)
+        future = raw_future.to_device_future(
+            device=self.device,
+            event_backend=self._event_backend,
+        )
         # The daemon imports this IPC event after the request crosses the wire.
-        # Retain the exporting event until the returned future is released so
-        # its underlying handle cannot be destroyed during that interval.
-        future.retain_reference(event)
+        # Keep ownership on the raw future so timeout callers cannot drop the
+        # exported event before the transport finishes the request.
         return raw_future, future
 
     def retrieve_kv(self, load_metadata: LoadMetadata) -> int:
@@ -609,9 +618,9 @@ class LMCacheMPConnector:
         block_ids = self._slot_mapping_to_block_ids(
             store_metadata.kv_indices[:aligned_end]
         )
-        event = torch_dev.Event(interprocess=True)
-        event.record(torch_dev.current_stream())
-        future = self.req_client.store(
+        event = self._event_backend.create_event(self.device)
+        self._event_backend.record_event(event, torch_dev.current_stream())
+        raw_future = self.req_client.store(
             self._create_key(
                 store_metadata.token_ids,
                 start=0,
@@ -622,13 +631,15 @@ class LMCacheMPConnector:
             # STORE takes per-group block IDs (list[list[int]]); SGLang is
             # non-hybrid, so wrap the flat list as a single group.
             [block_ids],
-            event.ipc_handle(),
-        ).to_device_future(device=self.device)
-        # Keep the exporting device event alive until the caller releases the
-        # future. Since we return without blocking, the local ``event`` would
-        # otherwise be garbage-collected immediately, destroying the underlying
-        # event before the daemon imports its IPC handle and waits on it.
-        future.retain_reference(event)
+            self._event_backend.export_event(event, self.device),
+        )
+        raw_future.retain_reference(event)
+        future = raw_future.to_device_future(
+            device=self.device,
+            event_backend=self._event_backend,
+        )
+        # Keep ownership on the raw future so timeout callers cannot drop the
+        # exported event before the transport finishes the request.
         return future
 
     def store_kv(self, store_metadata: StoreMetadata) -> None:
@@ -645,25 +656,30 @@ class LMCacheMPConnector:
         block_ids = self._slot_mapping_to_block_ids(
             store_metadata.kv_indices[:aligned_end]
         )
-        event = torch_dev.Event(interprocess=True)
-        event.record(torch_dev.current_stream())
-        success = (
-            self.req_client.store(
-                self._create_key(
-                    store_metadata.token_ids,
-                    start=0,
-                    end=aligned_end,
-                    request_id=request_id,
-                ),
-                self.instance_id,
-                # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
-                event.ipc_handle(),
-            )
-            .to_device_future(device=self.device)
-            .result(timeout=self._mq_timeout)
+        event = self._event_backend.create_event(self.device)
+        self._event_backend.record_event(event, torch_dev.current_stream())
+        raw_future = self.req_client.store(
+            self._create_key(
+                store_metadata.token_ids,
+                start=0,
+                end=aligned_end,
+                request_id=request_id,
+            ),
+            self.instance_id,
+            # STORE takes per-group block IDs (list[list[int]]); SGLang is
+            # non-hybrid, so wrap the flat list as a single group.
+            [block_ids],
+            self._event_backend.export_event(event, self.device),
         )
+        # The daemon imports this IPC event after the request crosses the wire.
+        # Keep ownership on the raw future so timeout callers cannot drop the
+        # exported event before the transport finishes the request.
+        raw_future.retain_reference(event)
+        future = raw_future.to_device_future(
+            device=self.device,
+            event_backend=self._event_backend,
+        )
+        success = future.result(timeout=self._mq_timeout)
         # END_SESSION is owned by ``LMCRadixCache.cache_finished_req`` so
         # it fires once per request, even when STORE early-returns or no
         # STORE was needed. See ``LMCacheMPConnector.end_session``.

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -34,12 +34,16 @@ import zmq
 # First Party
 from lmcache import torch_dev
 from lmcache.logging import init_logger
-from lmcache.utils import EngineType, check_interprocess_event_support
+from lmcache.utils import EngineType
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
 from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
 logger = init_logger(__name__)
@@ -274,6 +278,8 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
 
         self._instance_id = os.getpid()
         self._registered = False
+        self._device: torch.device | None = None
+        self._event_backend: EventIPCBackend | None = None
 
         # Third Party
         import tensorrt_llm
@@ -343,6 +349,9 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             "head_dim": head_dim,
         }
 
+        event_backend = get_event_ipc_backend(kv_cache_tensor.device)
+        event_backend.check_event_support(kv_cache_tensor.device)
+
         future = self._req_client.register_kv_cache(
             self._instance_id,
             wrapped,
@@ -352,9 +361,12 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             layout_hints,
             [],
         )
+
         try:
             future.result(timeout=self._mq_timeout)
             self._registered = True
+            self._device = kv_cache_tensor.device
+            self._event_backend = event_backend
             logger.info(
                 "LMCache MP worker: registered KV caches "
                 "(tensor_shape=%s, NH=%d, BS=%d, HS=%d)",
@@ -376,10 +388,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             return
 
         t0 = time.perf_counter()
-        # Not all backends support interprocess Events (CUDA IPC specific)
-        check_interprocess_event_support()
-        event = torch_dev.Event(interprocess=True)
-        event.record(stream)
+        event = self._create_and_record_event(stream)
 
         for req_id, spec in meta.loads.items():
             if not spec.tokens or not spec.block_ids:
@@ -387,17 +396,18 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
 
             key = self._create_key(spec.tokens, req_id)
             try:
-                success = (
-                    self._req_client.retrieve(
-                        key,
-                        self._instance_id,
-                        [spec.block_ids],
-                        event.ipc_handle(),
-                        0,  # skip_first_n_tokens
-                    )
-                    .to_device_future()
-                    .result(timeout=self._mq_timeout)
+                raw_future = self._req_client.retrieve(
+                    key,
+                    self._instance_id,
+                    [spec.block_ids],
+                    self._export_event(event),
+                    0,  # skip_first_n_tokens
                 )
+                raw_future.retain_reference(event)
+                success = raw_future.to_device_future(
+                    device=self._device,
+                    event_backend=self._event_backend,
+                ).result(timeout=self._mq_timeout)
             except Exception as e:
                 logger.error(
                     "LMCache MP worker: retrieve failed for req %d: %s",
@@ -435,10 +445,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             return
 
         t0 = time.perf_counter()
-        # Not all backends support interprocess Events (CUDA IPC specific)
-        check_interprocess_event_support()
-        event = torch_dev.Event(interprocess=True)
-        event.record(stream)
+        event = self._create_and_record_event(stream)
 
         for req_id, spec in meta.saves.items():
             if not spec.tokens or not spec.block_ids:
@@ -446,16 +453,17 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
 
             key = self._create_key(spec.tokens, req_id)
             try:
-                success = (
-                    self._req_client.store(
-                        key,
-                        self._instance_id,
-                        [spec.block_ids],
-                        event.ipc_handle(),
-                    )
-                    .to_device_future()
-                    .result(timeout=self._mq_timeout)
+                raw_future = self._req_client.store(
+                    key,
+                    self._instance_id,
+                    [spec.block_ids],
+                    self._export_event(event),
                 )
+                raw_future.retain_reference(event)
+                success = raw_future.to_device_future(
+                    device=self._device,
+                    event_backend=self._event_backend,
+                ).result(timeout=self._mq_timeout)
                 if not success:
                     logger.warning(
                         "LMCache MP worker: store returned False for req %d",
@@ -481,3 +489,23 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
     ) -> Tuple[List[int], List[int]]:
         """All operations are synchronous — nothing is ever pending."""
         return [], []
+
+    def _create_and_record_event(self, stream: object) -> object:
+        """Create and record an event for the registered KV cache device."""
+        if self._device is None or self._event_backend is None:
+            raise RuntimeError(
+                "LMCache MP worker: KV caches must be registered before "
+                "submitting transfer requests"
+            )
+        event = self._event_backend.create_event(self._device)
+        self._event_backend.record_event(event, stream)
+        return event
+
+    def _export_event(self, event: object) -> bytes:
+        """Export ``event`` with the backend selected at registration."""
+        if self._device is None or self._event_backend is None:
+            raise RuntimeError(
+                "LMCache MP worker: KV caches must be registered before "
+                "submitting transfer requests"
+            )
+        return self._event_backend.export_event(event, self._device)

--- a/lmcache/integration/vllm/experimental/dispatcher.py
+++ b/lmcache/integration/vllm/experimental/dispatcher.py
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
     )
     from lmcache.integration.vllm.vllm_multi_process_adapter import (
         LMCacheMPWorkerAdapter,
-        _IpcEvent,
     )
+    from lmcache.v1.multiprocess.transfer_context.worker_transfer import IPCEvent
 
 logger = init_logger(__name__)
 
@@ -65,7 +65,7 @@ class QTensorFeature:
     ) -> None:
         self._capture.save_q_layer(layer_name, metadata, **layer_io)
 
-    def wait_for_save(self, event: _IpcEvent | None) -> None:
+    def wait_for_save(self, event: IPCEvent | None) -> None:
         self._capture.batched_submit_qstore_requests(event=event)
 
     def reclaim(self) -> None:
@@ -188,7 +188,7 @@ class Dispatcher:
         for feature in self._features:
             feature.save_kv_layer(layer_name, metadata, **layer_io)
 
-    def wait_for_save(self, event: _IpcEvent | None) -> None:
+    def wait_for_save(self, event: IPCEvent | None) -> None:
         """Fan out ``wait_for_save`` (connector ``wait_for_save``)."""
         for feature in self._features:
             feature.wait_for_save(event)

--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -1,0 +1,1125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import enum
+import inspect
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import torch
+import zmq
+from lmcache.integration.vllm.utils import (
+    apply_mm_hashes_to_token_ids,
+    extract_mm_features,
+    extract_request_configs_from_request,
+    mla_enabled,
+)
+from lmcache.utils import init_logger as lmcache_init_logger
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import RequestStatus
+from vllm.v1.utils import ConstantList
+
+try:
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        LMCacheMPSchedulerAdapter,
+        LMCacheMPWorkerAdapter,
+        LoadStoreOp,
+    )
+except ImportError:
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (
+        LMCacheMPSchedulerAdapter,
+        LMCacheMPWorkerAdapter,
+        LoadStoreOp,
+    )
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_events import KVCacheEvent
+    from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+        KVConnectorPromMetrics,
+        KVConnectorStats,
+        PromMetric,
+        PromMetricT,
+    )
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.core.kv_cache_utils import BlockHash
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = lmcache_init_logger(__name__)
+
+
+def _adapter_accepts_tp_size() -> bool:
+    """Check if the imported adapter accepts tp_size."""
+    sig = inspect.signature(LMCacheMPSchedulerAdapter.__init__)
+    return "tp_size" in sig.parameters
+
+
+# Helper functions
+def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
+    if block_ids is None:
+        return []
+    assert isinstance(block_ids, tuple), (
+        f"Expected block_ids to be a tuple of lists, but got {type(block_ids)}"
+    )
+
+    if len(block_ids) > 1:
+        raise RuntimeError(
+            "LMCacheMPConnector only works without hybrid kv cache manager. "
+            "Please pass --disable-hybrid-kv-cache-manager when starting vllm"
+        )
+
+    return block_ids[0]
+
+
+def extract_world_size_and_kv_rank(
+    world_size: int,
+    rank: int,
+    vllm_config: VllmConfig,
+) -> tuple[int, int]:
+    """
+    Convert the rank for the MLA.
+    """
+    use_mla = mla_enabled(vllm_config.model_config)
+    if not use_mla:
+        return world_size, rank
+    else:
+        # Tensor parallel does not change the KV caches for MLA models.
+        # So we need to "exclude" the effect of TP on rank and world size
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        # vLLM constructs TP groups first, and then construct other
+        # parallel groups on top of TP groups.
+        # for example, TP=4, PP=2,
+        # TP group: [0, 1, 2, 3], [4, 5, 6, 7]
+        # PP group: [0, 4], [1, 5], [2, 6], [3, 7]
+        # So we can "exclude" the effect of TP by rank // tp_size.
+        return world_size // tp_size, rank // tp_size
+
+
+def create_scheduler_adapter(
+    server_url: str,
+    zmq_context: zmq.Context,
+    vllm_config: VllmConfig,
+    mq_timeout: float,
+    heartbeat_interval: float,
+) -> LMCacheMPSchedulerAdapter:
+    world_size, kv_rank = extract_world_size_and_kv_rank(
+        vllm_config.parallel_config.world_size,
+        vllm_config.parallel_config.rank,
+        vllm_config,
+    )
+    tp_size = vllm_config.parallel_config.tensor_parallel_size
+
+    # Pass tp_size only when the adapter accepts it so that
+    # a newer vllm can still work with an older LMCache.
+    kwargs: dict[str, Any] = {}
+    if _adapter_accepts_tp_size():
+        kwargs["tp_size"] = tp_size
+
+    return LMCacheMPSchedulerAdapter(
+        server_url,
+        zmq_context,
+        vllm_config.model_config.model,
+        world_size,
+        kv_rank,
+        vllm_config.cache_config.block_size,
+        mq_timeout=mq_timeout,
+        heartbeat_interval=heartbeat_interval,
+        **kwargs,
+    )
+
+
+def create_worker_adapter(
+    server_url: str,
+    zmq_context: zmq.Context,
+    vllm_config: VllmConfig,
+    mq_timeout: float,
+    heartbeat_interval: float,
+) -> LMCacheMPWorkerAdapter:
+    world_size, kv_rank = extract_world_size_and_kv_rank(
+        vllm_config.parallel_config.world_size,
+        vllm_config.parallel_config.rank,
+        vllm_config,
+    )
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
+    return LMCacheMPWorkerAdapter(
+        server_url,
+        zmq_context,
+        vllm_config.model_config.model,
+        world_size,
+        kv_rank,
+        vllm_config.cache_config.block_size,
+        mq_timeout=mq_timeout,
+        heartbeat_interval=heartbeat_interval,
+        extra_config=extra_config,
+    )
+
+
+class LMCacheMPRequestState(enum.Enum):
+    """
+    State machine:
+    PREFETCHING -- update_state_after_alloc --> WAITING_FOR_LOAD
+    WAITING_FOR_LOAD -- process_loading_requests --> READY
+    """
+
+    PREFETCHING = enum.auto()
+    WAITING_FOR_LOAD = enum.auto()
+    READY = enum.auto()
+
+
+@dataclass
+class LMCacheMPRequestTracker:
+    # NOTE: this class used vLLM data structures, should be part of
+    # vLLM integration code
+
+    request_id: str
+
+    # Read-only lists to track the token ids and block hashes
+    all_token_ids: ConstantList[int]
+    block_hashes: ConstantList["BlockHash"]
+
+    # Block ids and hashes will be updated at update_states_after_alloc and
+    # during the generation
+    allocated_block_ids: list[int] = field(default_factory=list)
+
+    # Number of scheduled tokens in this request. We keep tracking this to
+    # avoid saving half-full blocks.
+    num_scheduled_tokens: int = 0
+
+    # Number of blocks stored will be initialized when lookup the external
+    # hit tokens and will be updated when processing new requests and cached
+    # requests.
+    num_stored_blocks: int = 0
+
+    # Staging load operation -- save vllm and lmcache hit tokens during lookup
+    num_vllm_hit_blocks: int = 0
+    num_lmcache_hit_blocks: int = 0
+
+    # Main state
+    state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
+    request_configs: dict[str, Any] | None = None
+
+    # Prompt token ids with multimodal placeholder spans replaced by values
+    # derived from the items' content hashes. Empty for text-only requests.
+    mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
+
+    def __init__(self, request: "Request"):
+        self.request_id = request.request_id
+        self.request_configs = extract_request_configs_from_request(request)
+        self.all_token_ids = request.all_token_ids
+        self.block_hashes = ConstantList(request.block_hashes)
+        self.allocated_block_ids = []
+        self.num_stored_blocks = 0
+        self.num_vllm_hit_blocks = 0
+        self.num_lmcache_hit_blocks = 0
+        self.state = LMCacheMPRequestState.PREFETCHING
+        self.mm_adjusted_prompt_ids = []
+        mm_hashes, mm_positions = extract_mm_features(request)
+        if mm_hashes and mm_positions:
+            prompt_ids = torch.tensor(request.prompt_token_ids)
+            apply_mm_hashes_to_token_ids(prompt_ids, mm_hashes, mm_positions)
+            self.mm_adjusted_prompt_ids = prompt_ids.tolist()
+
+    ####
+    # Check the state of the request
+    ####
+    def needs_retrieve(self) -> bool:
+        """Check whether the current request needs retrieve, will be used
+        update_stage_after_alloc"""
+        return (
+            self.num_lmcache_hit_blocks > self.num_vllm_hit_blocks
+            and self.state != LMCacheMPRequestState.READY
+        )
+
+    def is_ready_for_retrieving(self) -> bool:
+        """Check whether the current request is ready for retrieving,
+        will be used in process_loading_requests"""
+        return (
+            self.state == LMCacheMPRequestState.WAITING_FOR_LOAD
+            and self.needs_retrieve()
+        )
+
+    ####
+    # Update internal states
+    ####
+    def increase_num_scheduled_tokens(self, num_new_tokens: int):
+        self.num_scheduled_tokens += num_new_tokens
+
+    def increase_num_stored_blocks(self, num_new_blocks: int):
+        """Increase the number of stored blocks for the current request
+        This function will be called when processing the cached requests.
+        """
+        self.num_stored_blocks += num_new_blocks
+
+    def append_block_ids(
+        self,
+        new_block_ids: list[int],
+    ):
+        """Update the block ids for the current request
+        This function will be called when processing the cached requests.
+        """
+        self.allocated_block_ids.extend(new_block_ids)
+
+    def get_token_ids(self) -> list[int]:
+        """Return the token ids to use for LMCache key derivation.
+
+        Multimodal placeholder spans carry no content identity, so the
+        MM-adjusted prompt tokens must be used for every LMCache key
+        operation (lookup, store, retrieve, lock management); otherwise two
+        different images with identical placeholder tokens share cache
+        entries. Generated tokens (beyond the prompt) are appended as-is.
+        """
+        if not self.mm_adjusted_prompt_ids:
+            return list(self.all_token_ids)
+        num_prompt_tokens = len(self.mm_adjusted_prompt_ids)
+        return self.mm_adjusted_prompt_ids + list(
+            self.all_token_ids[num_prompt_tokens:]
+        )
+
+    ####
+    # For debugging
+    ####
+    def __repr__(self) -> str:
+        return (
+            f"LMCacheMPRequestTracker(request_id={self.request_id}, "
+            f"num_tokens={len(self.all_token_ids)}, "
+            f"num_block_hashes={len(self.block_hashes)}, "
+            f"num_allocated_blocks={len(self.allocated_block_ids)}, "
+            f"num_stored_blocks={self.num_stored_blocks}, "
+            f"vllm_hit_blocks={self.num_vllm_hit_blocks}, "
+            f"lmcache_hit_blocks={self.num_lmcache_hit_blocks}, "
+            f"state={self.state})"
+        )
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+
+@dataclass
+class LMCacheMPRequestMetadata:
+    request_id: str
+    direction: Literal["STORE", "RETRIEVE"]
+    op: LoadStoreOp
+    request_configs: dict[str, Any] | None = None
+
+    @staticmethod
+    def GetStoreMetadata(
+        tracker: LMCacheMPRequestTracker,
+        blocks_in_chunk: int,
+        vllm_block_size: int,
+    ) -> "LMCacheMPRequestMetadata | None":
+        """
+        Generate the store metadata for the current request tracker.
+
+        Args:
+            tracker: The request tracker to generate the metadata from.
+            blocks_in_chunk: the number of blocks in a LMCache data chunk
+            vllm_block_size: the block size used in vLLM
+        """
+        # Store the blocks that has block hashes
+        # NOTE: the invariant here is that `num_stored_blocks` should
+        # always be a multiple of `blocks_in_chunk`
+        # TODO: This should be checked everytime we update the num_stored_blocks
+        #
+        # Why computed_blocks uses max(num_vllm_hit_blocks, num_lmcache_hit_blocks):
+        #
+        # Both values represent a prefix of blocks whose KV data is already
+        # available (either from vLLM APC or from LMCache), so they must NOT
+        # be summed (that would double-count the overlapping prefix).
+        #
+        # * num_lmcache_hit_blocks: LMCache-hit blocks are already counted in
+        #   num_stored_blocks (set during lookup), so they must be included
+        #   here to keep the upper bound consistent.  They are NOT re-stored.
+        # * num_vllm_hit_blocks: LMCache stores in units of chunks (N blocks),
+        #   so num_lmcache_hit_blocks is rounded DOWN to the nearest chunk
+        #   boundary.  When vLLM APC hits more blocks than that rounded value
+        #   (e.g. APC=44 blocks, LMCache=32 blocks after chunk alignment),
+        #   using only num_lmcache_hit_blocks would set the upper bound too
+        #   low and silently skip the APC-hit blocks that fall between the
+        #   two values, causing under-storing.  Taking the max ensures we
+        #   always use the tighter (larger) of the two hit counts.
+        computed_blocks = tracker.num_scheduled_tokens // vllm_block_size + max(
+            tracker.num_vllm_hit_blocks, tracker.num_lmcache_hit_blocks
+        )
+        min_available_blocks = min(
+            len(tracker.block_hashes),
+            len(tracker.allocated_block_ids),
+            computed_blocks,
+        )
+        num_staging_blocks = min_available_blocks - tracker.num_stored_blocks
+        num_chunks = num_staging_blocks // blocks_in_chunk
+
+        if num_chunks >= 1:
+            start = tracker.num_stored_blocks
+            end = start + num_chunks * blocks_in_chunk
+            block_ids = tracker.allocated_block_ids[start:end]
+            start_token_idx = start * vllm_block_size
+            end_token_idx = end * vllm_block_size
+            token_ids = tracker.get_token_ids()
+            op = LoadStoreOp(
+                token_ids=token_ids,
+                block_ids=block_ids,
+                start=start_token_idx,
+                end=end_token_idx,
+            )
+
+            ret = LMCacheMPRequestMetadata(
+                request_id=tracker.request_id,
+                direction="STORE",
+                op=op,
+                request_configs=tracker.request_configs,
+            )
+
+            # Update the request tracker
+            tracker.increase_num_stored_blocks(end - start)
+            return ret
+
+        return None
+
+    @staticmethod
+    def GetRetrieveMetadata(
+        tracker: LMCacheMPRequestTracker,
+        blocks_in_chunk: int,
+        vllm_block_size: int,
+    ) -> "LMCacheMPRequestMetadata | None":
+        """
+        Generate the retrieve metadata for the current request tracker.
+
+        Args:
+            tracker: The request tracker to generate the metadata from.
+            blocks_in_chunk: the number of blocks in a LMCache data chunk
+            vllm_block_size: the block size used in vLLM
+        """
+        if not tracker.is_ready_for_retrieving():
+            return None
+
+        # |---------------------|-----------------|----------------|
+        # | num_vllm_hit_blocks |
+        # | lmcache chunk 1   | lmcache chunk 2   |
+        #                     |  need to retrieve |
+
+        start = tracker.num_vllm_hit_blocks // blocks_in_chunk * blocks_in_chunk
+        end = tracker.num_lmcache_hit_blocks
+        assert end % blocks_in_chunk == 0, (
+            "The number of LMCache hit blocks should be a multiple of the "
+            "number of blocks in a lmcache chunk. "
+        )
+        assert len(tracker.block_hashes) >= end, (
+            "The number of block hashes should be greater than or equal to the "
+            "number of LMCache hit blocks. "
+        )
+        if end > start:
+            block_ids = tracker.allocated_block_ids[start:end]
+            start_token_idx = start * vllm_block_size
+            end_token_idx = end * vllm_block_size
+            token_ids = tracker.get_token_ids()
+
+            # Compute how many tokens at the start of the retrieve range
+            # overlap with APC-shared blocks. The server must skip writing
+            # to these positions to avoid a cross-stream data race: the
+            # retrieve writes on the LMCache CUDA stream while concurrent
+            # requests may read these APC-shared blocks on the vLLM stream.
+            apc_overlap_blocks = tracker.num_vllm_hit_blocks - start
+            skip_first_n_tokens = apc_overlap_blocks * vllm_block_size
+
+            op = LoadStoreOp(
+                token_ids=token_ids,
+                block_ids=block_ids,
+                start=start_token_idx,
+                end=end_token_idx,
+                skip_first_n_tokens=skip_first_n_tokens,
+            )
+
+            ret = LMCacheMPRequestMetadata(
+                request_id=tracker.request_id,
+                direction="RETRIEVE",
+                op=op,
+                request_configs=tracker.request_configs,
+            )
+            return ret
+
+        return None
+
+
+class LMCacheMPConnectorMetadata(KVConnectorMetadata):
+    def __init__(self):
+        super().__init__()
+        self.requests: list[LMCacheMPRequestMetadata] = []
+
+    def add_request_metadata(self, request_metadata: LMCacheMPRequestMetadata):
+        self.requests.append(request_metadata)
+
+    def __len__(self):
+        return len(self.requests)
+
+    # For debugging
+    def __str__(self):
+        request_strs = []
+        for req_meta in self.requests:
+            request_strs.append(
+                f"RequestMetadata(request_id={req_meta.request_id}, "
+                f"direction={req_meta.direction}, "
+                f"num_blocks={len(req_meta.op.flat_block_ids)}, "
+                f"block_ids={req_meta.op.block_ids})"
+            )
+        return "[" + "\n".join(request_strs) + "]"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class LMCacheMPConnector(KVConnectorBase_V1):
+    """
+    The connector for LMCache multi-process mode.
+
+    Extra configs (kv_transfer_config.extra_config):
+    - lmcache.mp.host: the host of the LMCache server.
+    - lmcache.mp.port: the port of the LMCache server.
+    - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.
+    - lmcache.mp.heartbeat_interval: interval (seconds) between server
+      heartbeat pings.
+    - lmcache.mp.mp_transfer_mode: routing mode for the worker -> server
+      transfer context. One of ``auto`` (default; CUDA -> engine_driven,
+      others -> lmcache_driven), ``engine_driven`` (force IPC / SHM
+      zero-copy), ``lmcache_driven`` (force worker-side gather/scatter
+      copy). Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig | None" = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+
+        assert vllm_config.kv_transfer_config is not None
+        server_host = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.host", "tcp://localhost"
+        )
+        server_port = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.port", 5555
+        )
+        mq_timeout = float(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.mq_timeout", 300.0
+            )
+        )
+        heartbeat_interval = float(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.heartbeat_interval", 10.0
+            )
+        )
+
+        server_url = f"{server_host}:{server_port}"
+        zmq_context = zmq.Context.instance()
+        if self.role == KVConnectorRole.SCHEDULER:
+            self.scheduler_adapter = create_scheduler_adapter(
+                server_url,
+                zmq_context,
+                vllm_config,
+                mq_timeout,
+                heartbeat_interval,
+            )
+            self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+        elif self.role == KVConnectorRole.WORKER:
+            self.worker_adapter = create_worker_adapter(
+                server_url,
+                zmq_context,
+                vllm_config,
+                mq_timeout,
+                heartbeat_interval,
+            )
+        else:
+            raise ValueError(f"Unknown KVConnectorRole: {self.role}")
+
+        self.vllm_block_size = vllm_config.cache_config.block_size
+
+    @property
+    def role(self) -> KVConnectorRole:
+        return self._role
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def _get_connector_metadata(self) -> KVConnectorMetadata:
+        """Get the connector metadata.
+
+        This function should only be called inside the connector.
+
+        Returns:
+            ConnectorMetadata: the connector metadata.
+        """
+
+        # Should only be called while set to valid metadata.
+        assert self._connector_metadata is not None
+        return self._connector_metadata
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        """
+        Initialize with the KV caches. Useful for pre-registering the
+        KV Caches in the KVConnector (e.g. for NIXL).
+
+        Args:
+            kv_caches: dictionary of layer names, kv cache
+        """
+        logger.info("Registering kv caches!")
+        self.worker_adapter.register_kv_caches(kv_caches)
+        return
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        """
+        Start loading the KV cache from the connector to vLLM's paged
+        KV buffer. This is called from the forward context before the
+        forward pass to enable async loading during model execution.
+
+        Args:
+            forward_context (ForwardContext): the forward context.
+            **kwargs: additional arguments for the load operation
+        """
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        request_ids = []
+        ops = []
+        request_configs_list = []
+
+        for meta in metadata.requests:
+            if meta.direction != "RETRIEVE":
+                continue
+            request_ids.append(meta.request_id)
+            ops.append(meta.op)
+            request_configs_list.append(meta.request_configs)
+
+        if len(request_ids) == 0:
+            return
+
+        event = self.worker_adapter.create_recorded_event()
+
+        self.worker_adapter.batched_submit_retrieve_requests(
+            request_ids,
+            ops,
+            event,
+            request_configs_list=request_configs_list,
+        )
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        """
+        Block until the KV for a specific layer is loaded into vLLM's
+        paged buffer. This is called from within attention layer to ensure
+        async copying from start_load_kv is complete.
+
+        This interface will be useful for layer-by-layer pipelining.
+
+        Args:
+            layer_name: the name of that layer
+        """
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Start saving a layer of KV cache from vLLM's paged buffer
+        to the connector. This is called from within attention layer to
+        enable async copying during execution.
+
+        Args:
+            layer_name (str): the name of the layer.
+            kv_layer (torch.Tensor): the paged KV buffer of the current
+                layer in vLLM.
+            attn_metadata (AttentionMetadata): the attention metadata.
+            **kwargs: additional arguments for the save operation.
+        """
+        return
+
+    def wait_for_save(self):
+        """
+        Block until all the save operations is done. This is called
+        as the forward context exits to ensure that the async saving
+        from save_kv_layer is complete before finishing the forward.
+
+        This prevents overwrites of paged KV buffer before saving done.
+        """
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        request_ids = []
+        ops = []
+        request_configs_list = []
+        for meta in metadata.requests:
+            if meta.direction != "STORE":
+                continue
+            request_ids.append(meta.request_id)
+            ops.append(meta.op)
+            request_configs_list.append(meta.request_configs)
+
+        if len(request_ids) == 0:
+            return
+
+        event = self.worker_adapter.create_recorded_event()
+
+        self.worker_adapter.batched_submit_store_requests(
+            request_ids,
+            ops,
+            event,
+            request_configs_list=request_configs_list,
+        )
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        """
+        Notifies worker-side connector ids of requests that have
+        finished generating tokens on the worker.
+        The scheduler process (via the Executors) will use this output
+        to track which workers are done.
+
+        Returns:
+            ids of requests that have finished asynchronous transfer
+            (requests that previously returned True from request_finished()),
+            tuple of (sending/saving ids, recving/loading ids).
+            The finished saves/sends req ids must belong to a set provided in a
+            call to this method (this call or a prior one).
+        """
+        val = self.worker_adapter.get_finished(finished_req_ids)
+        # logger.error("Finished req ids: %s, %s", val[0], val[1])
+        return val
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """
+        Get the set of block IDs that failed to load.
+
+        Returns:
+            Set of block IDs that encountered load errors.
+            Empty set if no load errors occurred.
+
+        Notes:
+            - Applies to both sync- and async-loading requests.
+            - Async loading: failed blocks may be reported in any forward pass
+              up to and including the pass where the request ID is returned by
+              `get_finished()`. Even if failures occur, the request must still
+              be reported via `get_finished()`, and the failed block IDs must
+              appear here no later than that same pass.
+            - Sync loading: failed blocks should be reported in the forward
+              pass in which they are detected.
+        """
+        return self.worker_adapter.get_block_ids_with_load_errors()
+
+    def shutdown(self):
+        """
+        Shutdown the connector. This is called when the worker process
+        is shutting down to ensure that all the async operations are
+        completed and the connector is cleaned up properly.
+        """
+        if hasattr(self, "worker_adapter"):
+            self.worker_adapter.shutdown()
+        return None
+
+    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+        """
+        Get the KV connector stats collected during the last interval.
+        """
+        return None
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        """
+        Get number of new tokens that can be loaded from the
+        external KV cache beyond the num_computed_tokens.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+
+        Returns:
+            A tuple with the following elements:
+                - An optional number of tokens that can be loaded from the
+                  external KV cache beyond what is already computed.
+                  If None, it means that the connector needs more time to
+                  determine the number of matched tokens, and the scheduler
+                  should query for this request again later.
+                - `True` if external KV cache tokens will be loaded
+                  asynchronously (between scheduler steps). Must be
+                  'False' if the first element is 0.
+
+        Notes:
+            The connector should only consider the largest prefix of prompt-
+            tokens for which KV cache is actually available at the time of the
+            call. If the cache cannot be loaded for some tokens (e.g., due to
+            connectivity issues or eviction), those tokens must not be taken
+            into account.
+        """
+        tracker = self._get_or_create_request_tracker(request)
+        # TODO: support loading KV for preempted requests in the future
+        if request.status == RequestStatus.PREEMPTED:
+            return 0, False
+
+        self.scheduler_adapter.maybe_submit_lookup_request(
+            request.request_id,
+            token_ids=tracker.get_token_ids(),
+            request_configs=tracker.request_configs,
+        )
+
+        ret = self.scheduler_adapter.check_lookup_result(request.request_id)
+        if ret is None:
+            return None, True
+
+        if ret == 0:
+            return 0, False
+
+        assert (
+            ret % (self.scheduler_adapter.num_blocks_per_chunk() * self.vllm_block_size)
+            == 0
+        )
+
+        # Update num stored blocks for the tracker
+        num_vllm_blocks = num_computed_tokens // self.vllm_block_size
+        num_lmcache_blocks = ret // self.vllm_block_size
+        tracker.increase_num_stored_blocks(num_lmcache_blocks)
+
+        # Save the vllm and lmcache hit tokens
+        tracker.num_vllm_hit_blocks = num_vllm_blocks
+        tracker.num_lmcache_hit_blocks = num_lmcache_blocks
+
+        need_to_load = max(0, ret - num_computed_tokens)
+        logger.debug(
+            "vLLM hit is: %d, Need to load is %d", num_computed_tokens, need_to_load
+        )
+        return need_to_load, need_to_load > 0
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        """
+        Update KVConnector state after block allocation.
+
+        If get_num_new_matched_tokens previously returned True for a
+        request, this function may be called twice for that same request -
+        first when blocks are allocated for the connector tokens to be
+        asynchronously loaded into, and second when any additional blocks
+        are allocated, after the load/transfer is complete.
+
+        Args:
+            request (Request): the request object.
+            blocks (KVCacheBlocks): the blocks allocated for the request.
+            num_external_tokens (int): the number of tokens that will be
+                loaded from the external KV cache.
+        """
+        # NOTE: `blocks` comes from kv_cache_manager.get_blocks(request_id),
+        # which returns ALL blocks for the request (not just newly allocated).
+        # This function may be called twice for async-load requests:
+        #   1st call: blocks = initial allocation (APC + fresh)
+        #   2nd call: blocks = all blocks
+        #  (initial + newly allocated for remaining tokens)
+        # We must only append the NEW blocks beyond what's already tracked
+        # to avoid duplication, which would corrupt the store path's block indexing.
+        tracker = self._get_request_tracker(request.request_id)
+        block_ids = reformat_block_ids(blocks.get_block_ids())
+
+        # Only append blocks beyond what's already tracked
+        existing_count = len(tracker.allocated_block_ids)
+        new_block_ids = block_ids[existing_count:]
+        if new_block_ids:
+            tracker.append_block_ids(new_block_ids)
+
+        # Update the state of the tracker
+        condition = tracker.needs_retrieve()
+        if tracker.state == LMCacheMPRequestState.PREFETCHING:
+            # If need to retrieve, change to WAITING_FOR_LOAD
+            # Otherwise, change to READY
+            tracker.state = (
+                LMCacheMPRequestState.WAITING_FOR_LOAD
+                if condition
+                else LMCacheMPRequestState.READY
+            )
+            # Clean up lookup future in scheduler adapter
+            self.scheduler_adapter.cleanup_lookup_result(request.request_id)
+
+            # Free locks on chunks that vLLM already computed and won't
+            # retrieve from LMCache.
+            if tracker.num_lmcache_hit_blocks > 0:
+                if not condition:
+                    # No retrieve needed — free ALL locked chunks
+                    free_end = tracker.num_lmcache_hit_blocks * self.vllm_block_size
+                else:
+                    # Note(Roy): Boundary misalignment between vLLM blocks and LMCache
+                    # blocks is handled in free_lookup_locks. It makes sure that if
+                    # the last vLLM computed block ends in the middle of a LMCache
+                    # block, the end LMCache block is not freed (i.e., floor division)
+                    # since it will still be needed by vLLM and such block's lock will
+                    # be freed by vLLM's retrieve.
+                    free_end = tracker.num_vllm_hit_blocks * self.vllm_block_size
+
+                if free_end > 0:
+                    self.scheduler_adapter.free_lookup_locks(
+                        token_ids=tracker.get_token_ids(),
+                        start=0,
+                        end=free_end,
+                        request_id=request.request_id,
+                        request_configs=tracker.request_configs,
+                    )
+                    logger.debug(
+                        "Free locks of tokens %d-%d since it is cached by vLLM.",
+                        0,
+                        free_end,
+                    )
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        """
+        Build the connector metadata for this step.
+
+        This function should NOT modify fields in the scheduler_output.
+        Also, calling this function will reset the state of the connector.
+
+        Args:
+            scheduler_output (SchedulerOutput): the scheduler output object.
+        """
+        metadata = LMCacheMPConnectorMetadata()
+
+        self._process_retrieve_requests(metadata)
+        self._process_new_requests(scheduler_output, metadata)
+        self._process_cached_requests(scheduler_output, metadata)
+
+        if len(metadata) > 0:
+            logger.debug("Final connector metadata: %s", metadata)
+
+        return metadata
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        """
+        Update KVConnector state from worker-side connectors output.
+
+        Args:
+            connector_output (KVConnectorOutput): the worker-side
+                connectors output.
+        """
+        return
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called exactly once when a request has finished, before its blocks are
+        freed.
+
+        The connector may assumes responsibility for freeing the blocks
+        asynchronously by returning True.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+        # Clean up request tracker to prevent memory leak
+        self._cleanup_request_tracker(request.request_id)
+        # Notify LMCache to end the session for this request
+        self.scheduler_adapter.end_session(request.request_id)
+        # Drop lookup state for a request aborted before its lookup was
+        # consumed (update_state_after_alloc never ran for it).
+        self.scheduler_adapter.cleanup_lookup_result(request.request_id)
+
+        return True, None
+
+    def take_events(self) -> Iterable["KVCacheEvent"]:
+        """
+        Take the KV cache events from the connector.
+
+        Yields:
+            New KV cache events since the last call.
+        """
+        return ()
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        """
+        Get the required KV cache layout for this connector.
+        Args:
+            vllm_config (VllmConfig): the vllm config.
+
+        Returns:
+            str: the required KV cache layout. e.g. HND, or NHD.
+            None if the connector does not require a specific layout.
+        """
+
+        if cls is KVConnectorBase_V1:
+            raise TypeError(
+                "get_required_kvcache_layout should not be called "
+                "on the abstract base class"
+            )
+        return None
+
+    def get_finished_count(self) -> int | None:
+        """
+        Get the count of requests expected to complete send/receive operations
+        via this connector. This method is used to initialize the
+        KVOutputAggregator, overwriting the default world_size.
+
+        Returns:
+            int: expected sending or receiving completion count.
+        """
+        return None
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> "KVConnectorStats | None":
+        """
+        KVConnectorStats resolution method. This method allows dynamically
+        registered connectors to return their own KVConnectorStats object,
+        which can implement custom aggregation logic on the data dict.
+        """
+        return None
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: "VllmConfig",
+        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> "KVConnectorPromMetrics | None":
+        """
+        Create a KVConnectorPromMetrics subclass which should register
+        per-connector Prometheus metrics and implement observe() to
+        expose connector transfer stats via Prometheus.
+        """
+        return None
+
+    ##############################
+    # Helper functions
+    ##############################
+    def _process_retrieve_requests(
+        self,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
+
+        for request_tracker in self.request_trackers.values():
+            if request_tracker.state != LMCacheMPRequestState.WAITING_FOR_LOAD:
+                continue
+            r_metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+                request_tracker,
+                blocks_per_chunk,
+                vllm_block_size=self.vllm_block_size,
+            )
+            if r_metadata is not None:
+                metadata.add_request_metadata(r_metadata)
+            request_tracker.state = LMCacheMPRequestState.READY
+
+    def _process_new_requests(
+        self,
+        scheduler_output: SchedulerOutput,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
+
+        for new_request in scheduler_output.scheduled_new_reqs:
+            request_tracker = self._get_request_tracker(new_request.req_id)
+
+            num_new_tokens = scheduler_output.num_scheduled_tokens[new_request.req_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+                request_tracker, blocks_per_chunk, self.vllm_block_size
+            )
+            if r_meta is not None:
+                metadata.add_request_metadata(r_meta)
+
+    def _process_cached_requests(
+        self,
+        scheduler_output: SchedulerOutput,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, request_id in enumerate(cached_reqs.req_ids):
+            request_tracker = self._get_request_tracker(request_id)
+
+            # Update block ids
+            new_block_ids = reformat_block_ids(cached_reqs.new_block_ids[idx])
+            if request_id not in cached_reqs.resumed_req_ids:
+                request_tracker.append_block_ids(new_block_ids)
+
+            # Use the incremental num_scheduled_tokens to
+            # stay consistent with _process_new_requests.
+            num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+                request_tracker, blocks_per_chunk, self.vllm_block_size
+            )
+
+            if r_meta is not None:
+                metadata.add_request_metadata(r_meta)
+
+    def _get_request_tracker(self, request_id: str) -> LMCacheMPRequestTracker:
+        assert request_id in self.request_trackers, (
+            f"Request tracker for request_id {request_id} not found. "
+        )
+        return self.request_trackers[request_id]
+
+    def _get_or_create_request_tracker(
+        self, request: "Request"
+    ) -> LMCacheMPRequestTracker:
+        request_id = request.request_id
+        # Remove the old trackers that is created before the preemption
+        if (
+            request.status == RequestStatus.PREEMPTED
+            and request_id in self.request_trackers
+        ):
+            tracker = self.request_trackers[request_id]
+
+            # NOTE: since this function may be called multiple times
+            # for a single request (because get_num_new_matched_tokens
+            # may be called multiple times) for the same request, we
+            # will only do the remove if the tracker is not in the "fresh"
+            # state, i.e., PREFETCHING
+            if tracker.state != LMCacheMPRequestState.PREFETCHING:
+                self.request_trackers.pop(request_id)
+
+        if request_id not in self.request_trackers:
+            new_tracker = LMCacheMPRequestTracker(request)
+            self.request_trackers[request_id] = new_tracker
+        return self.request_trackers[request_id]
+
+    def _cleanup_request_tracker(self, request_id: str) -> None:
+        """
+        Clean up request tracker and associated lookup future for a request.
+        This should be called when a request is finished to prevent memory leak.
+        """
+        # Clean up request tracker
+        if self.request_trackers.pop(request_id, None):
+            logger.debug(
+                "[KVConnector] Cleaned up request_tracker for request %s",
+                request_id,
+            )

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -1,0 +1,1219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import enum
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import torch
+import zmq
+from lmcache.integration.vllm.utils import (
+    apply_mm_hashes_to_token_ids,
+    extract_mm_features,
+    extract_request_configs_from_request,
+    mla_only,
+)
+from lmcache.utils import init_logger as lmcache_init_logger
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import RequestStatus
+from vllm.v1.utils import ConstantList
+
+try:
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        LMCacheMPSchedulerAdapter,
+        LMCacheMPWorkerAdapter,
+        LoadStoreOp,
+        ParallelStrategy,
+    )
+
+    try:
+        from lmcache.v1.multiprocess.custom_types import RequestAllocationRecord
+    except ImportError:
+        from lmcache.v1.multiprocess.custom_types import (
+            BlockAllocationRecord as RequestAllocationRecord,
+        )
+except ImportError:
+    from lmcache.v1.multiprocess.custom_types import (
+        BlockAllocationRecord as RequestAllocationRecord,
+    )
+
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (
+        LMCacheMPSchedulerAdapter,
+        LMCacheMPWorkerAdapter,
+        LoadStoreOp,
+        ParallelStrategy,
+    )
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_events import KVCacheEvent
+    from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+        KVConnectorPromMetrics,
+        KVConnectorStats,
+        PromMetric,
+        PromMetricT,
+    )
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.core.kv_cache_utils import BlockHash
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = lmcache_init_logger(__name__)
+
+
+# Helper functions
+def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
+    if block_ids is None:
+        return []
+    assert isinstance(block_ids, tuple), (
+        f"Expected block_ids to be a tuple of lists, but got {type(block_ids)}"
+    )
+
+    if len(block_ids) > 1:
+        raise RuntimeError(
+            "LMCacheMPConnector only works without hybrid kv cache manager. "
+            "Please pass --disable-hybrid-kv-cache-manager when starting vllm"
+        )
+
+    return block_ids[0]
+
+
+def build_parallel_strategy(vllm_config: VllmConfig) -> ParallelStrategy:
+    """
+    Build the KV parallel geometry from a vLLM config.
+
+    ``ParallelStrategy`` derives ``kv_world_size`` / ``kv_worker_id`` from the
+    raw vLLM geometry (including the MLA adjustment), so the world size and
+    rank are passed through unmodified.
+
+    Args:
+        vllm_config: The vLLM configuration to read the parallel geometry and
+            MLA setting from.
+
+    Returns:
+        A ``ParallelStrategy`` describing the KV parallel layout for this
+        worker, with ``n_servers`` fixed at 1.
+    """
+    pc = vllm_config.parallel_config
+    return ParallelStrategy(
+        mla_only=mla_only(vllm_config.model_config),
+        vllm_world_size=pc.world_size,
+        vllm_worker_id=pc.rank,
+        tp_size=pc.tensor_parallel_size,
+        pp_size=pc.pipeline_parallel_size,
+        n_servers=1,
+    )
+
+
+def create_scheduler_adapter(
+    server_url: str,
+    zmq_context: zmq.Context,
+    vllm_config: VllmConfig,
+    mq_timeout: float,
+    heartbeat_interval: float,
+) -> LMCacheMPSchedulerAdapter:
+    parallel_strategy = build_parallel_strategy(vllm_config)
+
+    return LMCacheMPSchedulerAdapter(
+        server_urls=[server_url],
+        context=zmq_context,
+        model_name=vllm_config.model_config.model,
+        vllm_block_size=vllm_config.cache_config.block_size,
+        parallel_strategy=parallel_strategy,
+        mq_timeout=mq_timeout,
+        heartbeat_interval=heartbeat_interval,
+    )
+
+
+def create_worker_adapter(
+    server_url: str,
+    zmq_context: zmq.Context,
+    vllm_config: VllmConfig,
+    mq_timeout: float,
+    heartbeat_interval: float,
+) -> LMCacheMPWorkerAdapter:
+    parallel_strategy = build_parallel_strategy(vllm_config)
+
+    return LMCacheMPWorkerAdapter(
+        server_url=server_url,
+        context=zmq_context,
+        model_name=vllm_config.model_config.model,
+        vllm_block_size=vllm_config.cache_config.block_size,
+        parallel_strategy=parallel_strategy,
+        mq_timeout=mq_timeout,
+        heartbeat_interval=heartbeat_interval,
+        extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
+    )
+
+
+class LMCacheMPRequestState(enum.Enum):
+    """
+    State machine:
+    PREFETCHING -- update_state_after_alloc --> WAITING_FOR_LOAD
+    WAITING_FOR_LOAD -- process_loading_requests --> READY
+    """
+
+    PREFETCHING = enum.auto()
+    WAITING_FOR_LOAD = enum.auto()
+    READY = enum.auto()
+
+
+@dataclass
+class LMCacheMPRequestTracker:
+    # NOTE: this class used vLLM data structures, should be part of
+    # vLLM integration code
+
+    request_id: str
+
+    # Read-only lists to track the token ids and block hashes
+    all_token_ids: ConstantList[int]
+    block_hashes: ConstantList["BlockHash"]
+
+    # Block ids and hashes will be updated at update_states_after_alloc and
+    # during the generation
+    allocated_block_ids: list[int] = field(default_factory=list)
+
+    # Number of scheduled tokens in this request. We keep tracking this to
+    # avoid saving half-full blocks.
+    num_scheduled_tokens: int = 0
+
+    # Number of blocks stored will be initialized when lookup the external
+    # hit tokens and will be updated when processing new requests and cached
+    # requests.
+    num_stored_blocks: int = 0
+
+    # Staging load operation -- save vllm and lmcache hit tokens during lookup
+    num_vllm_hit_blocks: int = 0
+    num_lmcache_hit_blocks: int = 0
+
+    # Main state
+    state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
+
+    cache_salt: str = ""
+    request_configs: dict[str, Any] | None = None
+
+    # Prompt token ids with multimodal placeholder spans replaced by values
+    # derived from the items' content hashes. Empty for text-only requests.
+    mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
+
+    def __init__(self, request: "Request"):
+        self.request_id = request.request_id
+        self.cache_salt: str = request.cache_salt or ""
+        self.request_configs = extract_request_configs_from_request(request)
+        self.all_token_ids = request.all_token_ids
+        self.block_hashes = ConstantList(request.block_hashes)
+        self.allocated_block_ids = []
+        self.num_stored_blocks = 0
+        self.num_vllm_hit_blocks = 0
+        self.num_lmcache_hit_blocks = 0
+        self.state = LMCacheMPRequestState.PREFETCHING
+        self.mm_adjusted_prompt_ids = []
+        mm_hashes, mm_positions = extract_mm_features(request)
+        if mm_hashes and mm_positions:
+            prompt_ids = torch.tensor(request.prompt_token_ids)
+            apply_mm_hashes_to_token_ids(prompt_ids, mm_hashes, mm_positions)
+            self.mm_adjusted_prompt_ids = prompt_ids.tolist()
+
+    ####
+    # Check the state of the request
+    ####
+    def needs_retrieve(self) -> bool:
+        """Check whether the current request needs retrieve, will be used
+        update_stage_after_alloc"""
+        return (
+            self.num_lmcache_hit_blocks > self.num_vllm_hit_blocks
+            and self.state != LMCacheMPRequestState.READY
+        )
+
+    def is_ready_for_retrieving(self) -> bool:
+        """Check whether the current request is ready for retrieving,
+        will be used in process_loading_requests"""
+        return (
+            self.state == LMCacheMPRequestState.WAITING_FOR_LOAD
+            and self.needs_retrieve()
+        )
+
+    ####
+    # Update internal states
+    ####
+    def increase_num_scheduled_tokens(self, num_new_tokens: int):
+        self.num_scheduled_tokens += num_new_tokens
+
+    def increase_num_stored_blocks(self, num_new_blocks: int):
+        """Increase the number of stored blocks for the current request
+        This function will be called when processing the cached requests.
+        """
+        self.num_stored_blocks += num_new_blocks
+
+    def append_block_ids(
+        self,
+        new_block_ids: list[int],
+    ):
+        """Update the block ids for the current request
+        This function will be called when processing the cached requests.
+        """
+        self.allocated_block_ids.extend(new_block_ids)
+
+    def get_token_ids(self) -> list[int]:
+        """Return the token ids to use for LMCache key derivation.
+
+        Multimodal placeholder spans carry no content identity, so the
+        MM-adjusted prompt tokens must be used for every LMCache key
+        operation (lookup, store, retrieve, lock management); otherwise two
+        different images with identical placeholder tokens share cache
+        entries. Generated tokens (beyond the prompt) are appended as-is.
+        """
+        if not self.mm_adjusted_prompt_ids:
+            return list(self.all_token_ids)
+        num_prompt_tokens = len(self.mm_adjusted_prompt_ids)
+        return self.mm_adjusted_prompt_ids + list(
+            self.all_token_ids[num_prompt_tokens:]
+        )
+
+    ####
+    # For debugging
+    ####
+    def __repr__(self) -> str:
+        return (
+            f"LMCacheMPRequestTracker(request_id={self.request_id}, "
+            f"num_tokens={len(self.all_token_ids)}, "
+            f"num_block_hashes={len(self.block_hashes)}, "
+            f"num_allocated_blocks={len(self.allocated_block_ids)}, "
+            f"num_stored_blocks={self.num_stored_blocks}, "
+            f"vllm_hit_blocks={self.num_vllm_hit_blocks}, "
+            f"lmcache_hit_blocks={self.num_lmcache_hit_blocks}, "
+            f"state={self.state})"
+        )
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+
+@dataclass
+class LMCacheMPRequestMetadata:
+    request_id: str
+    direction: Literal["STORE", "RETRIEVE"]
+    op: LoadStoreOp
+    cache_salt: str = ""
+    request_configs: dict[str, Any] | None = None
+
+    @staticmethod
+    def GetStoreMetadata(
+        tracker: LMCacheMPRequestTracker,
+        blocks_in_chunk: int,
+        vllm_block_size: int,
+    ) -> "LMCacheMPRequestMetadata | None":
+        """
+        Generate the store metadata for the current request tracker.
+
+        Args:
+            tracker: The request tracker to generate the metadata from.
+            blocks_in_chunk: the number of blocks in a LMCache data chunk
+            vllm_block_size: the block size used in vLLM
+        """
+        # Store the blocks that has block hashes
+        # NOTE: the invariant here is that `num_stored_blocks` should
+        # always be a multiple of `blocks_in_chunk`
+        # TODO: This should be checked everytime we update the num_stored_blocks
+        #
+        # Why computed_blocks uses max(num_vllm_hit_blocks, num_lmcache_hit_blocks):
+        #
+        # Both values represent a prefix of blocks whose KV data is already
+        # available (either from vLLM APC or from LMCache), so they must NOT
+        # be summed (that would double-count the overlapping prefix).
+        #
+        # * num_lmcache_hit_blocks: LMCache-hit blocks are already counted in
+        #   num_stored_blocks (set during lookup), so they must be included
+        #   here to keep the upper bound consistent.  They are NOT re-stored.
+        # * num_vllm_hit_blocks: LMCache stores in units of chunks (N blocks),
+        #   so num_lmcache_hit_blocks is rounded DOWN to the nearest chunk
+        #   boundary.  When vLLM APC hits more blocks than that rounded value
+        #   (e.g. APC=44 blocks, LMCache=32 blocks after chunk alignment),
+        #   using only num_lmcache_hit_blocks would set the upper bound too
+        #   low and silently skip the APC-hit blocks that fall between the
+        #   two values, causing under-storing.  Taking the max ensures we
+        #   always use the tighter (larger) of the two hit counts.
+        computed_blocks = tracker.num_scheduled_tokens // vllm_block_size + max(
+            tracker.num_vllm_hit_blocks, tracker.num_lmcache_hit_blocks
+        )
+        min_available_blocks = min(
+            len(tracker.block_hashes),
+            len(tracker.allocated_block_ids),
+            computed_blocks,
+        )
+        num_staging_blocks = min_available_blocks - tracker.num_stored_blocks
+        num_chunks = num_staging_blocks // blocks_in_chunk
+
+        if num_chunks >= 1:
+            start = tracker.num_stored_blocks
+            end = start + num_chunks * blocks_in_chunk
+            block_ids = tracker.allocated_block_ids[start:end]
+            start_token_idx = start * vllm_block_size
+            end_token_idx = end * vllm_block_size
+            token_ids = tracker.get_token_ids()
+            op = LoadStoreOp(
+                token_ids=token_ids,
+                block_ids=block_ids,
+                start=start_token_idx,
+                end=end_token_idx,
+            )
+
+            ret = LMCacheMPRequestMetadata(
+                request_id=tracker.request_id,
+                direction="STORE",
+                op=op,
+                cache_salt=tracker.cache_salt,
+                request_configs=tracker.request_configs,
+            )
+
+            # Update the request tracker
+            tracker.increase_num_stored_blocks(end - start)
+            return ret
+
+        return None
+
+    @staticmethod
+    def GetRetrieveMetadata(
+        tracker: LMCacheMPRequestTracker,
+        blocks_in_chunk: int,
+        vllm_block_size: int,
+    ) -> "LMCacheMPRequestMetadata | None":
+        """
+        Generate the retrieve metadata for the current request tracker.
+
+        Args:
+            tracker: The request tracker to generate the metadata from.
+            blocks_in_chunk: the number of blocks in a LMCache data chunk
+            vllm_block_size: the block size used in vLLM
+        """
+        if not tracker.is_ready_for_retrieving():
+            return None
+
+        # |---------------------|-----------------|----------------|
+        # | num_vllm_hit_blocks |
+        # | lmcache chunk 1   | lmcache chunk 2   |
+        #                     |  need to retrieve |
+
+        start = tracker.num_vllm_hit_blocks // blocks_in_chunk * blocks_in_chunk
+        end = tracker.num_lmcache_hit_blocks
+        assert end % blocks_in_chunk == 0, (
+            "The number of LMCache hit blocks should be a multiple of the "
+            "number of blocks in a lmcache chunk. "
+        )
+        assert len(tracker.block_hashes) >= end, (
+            "The number of block hashes should be greater than or equal to the "
+            "number of LMCache hit blocks. "
+        )
+        if end > start:
+            block_ids = tracker.allocated_block_ids[start:end]
+            start_token_idx = start * vllm_block_size
+            end_token_idx = end * vllm_block_size
+            token_ids = tracker.get_token_ids()
+
+            # Compute how many tokens at the start of the retrieve range
+            # overlap with APC-shared blocks. The server must skip writing
+            # to these positions to avoid a cross-stream data race: the
+            # retrieve writes on the LMCache CUDA stream while concurrent
+            # requests may read these APC-shared blocks on the vLLM stream.
+            apc_overlap_blocks = tracker.num_vllm_hit_blocks - start
+            skip_first_n_tokens = apc_overlap_blocks * vllm_block_size
+
+            op = LoadStoreOp(
+                token_ids=token_ids,
+                block_ids=block_ids,
+                start=start_token_idx,
+                end=end_token_idx,
+                skip_first_n_tokens=skip_first_n_tokens,
+            )
+
+            ret = LMCacheMPRequestMetadata(
+                request_id=tracker.request_id,
+                direction="RETRIEVE",
+                op=op,
+                cache_salt=tracker.cache_salt,
+                request_configs=tracker.request_configs,
+            )
+            return ret
+
+        return None
+
+
+class LMCacheMPConnectorMetadata(KVConnectorMetadata):
+    def __init__(self):
+        super().__init__()
+        self.requests: list[LMCacheMPRequestMetadata] = []
+
+    def add_request_metadata(self, request_metadata: LMCacheMPRequestMetadata):
+        self.requests.append(request_metadata)
+
+    def __len__(self):
+        return len(self.requests)
+
+    # For debugging
+    def __str__(self):
+        request_strs = []
+        for req_meta in self.requests:
+            request_strs.append(
+                f"RequestMetadata(request_id={req_meta.request_id}, "
+                f"direction={req_meta.direction}, "
+                f"num_blocks={len(req_meta.op.flat_block_ids)}, "
+                f"block_ids={req_meta.op.block_ids})"
+            )
+        return "[" + "\n".join(request_strs) + "]"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class LMCacheMPConnector(KVConnectorBase_V1):
+    """
+    The connector for LMCache multi-process mode.
+
+    Extra configs (kv_transfer_config.extra_config):
+    - lmcache.mp.host: the host of the LMCache server.
+    - lmcache.mp.port: the port of the LMCache server.
+    - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.
+    - lmcache.mp.heartbeat_interval: interval (seconds) between server
+      heartbeat pings.
+    - lmcache.mp.mp_transfer_mode: routing mode for the worker -> server
+      transfer context. One of ``auto`` (default; CUDA -> lmcache_driven,
+      others -> engine_driven), ``lmcache_driven`` (force IPC / SHM
+      zero-copy), ``engine_driven`` (force worker-side gather/scatter
+      copy). Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig | None" = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+
+        assert vllm_config.kv_transfer_config is not None
+        server_host = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.host", "tcp://localhost"
+        )
+        server_port = vllm_config.kv_transfer_config.get_from_extra_config(
+            "lmcache.mp.port", 5555
+        )
+        mq_timeout = float(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.mq_timeout", 300.0
+            )
+        )
+        heartbeat_interval = float(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.heartbeat_interval", 10.0
+            )
+        )
+
+        server_url = f"{server_host}:{server_port}"
+        zmq_context = zmq.Context.instance()
+        if self.role == KVConnectorRole.SCHEDULER:
+            self.scheduler_adapter = create_scheduler_adapter(
+                server_url,
+                zmq_context,
+                vllm_config,
+                mq_timeout,
+                heartbeat_interval,
+            )
+            self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+        elif self.role == KVConnectorRole.WORKER:
+            self.worker_adapter = create_worker_adapter(
+                server_url,
+                zmq_context,
+                vllm_config,
+                mq_timeout,
+                heartbeat_interval,
+            )
+        else:
+            raise ValueError(f"Unknown KVConnectorRole: {self.role}")
+
+        self.vllm_block_size = vllm_config.cache_config.block_size
+
+    @property
+    def role(self) -> KVConnectorRole:
+        return self._role
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def _get_connector_metadata(self) -> KVConnectorMetadata:
+        """Get the connector metadata.
+
+        This function should only be called inside the connector.
+
+        Returns:
+            ConnectorMetadata: the connector metadata.
+        """
+
+        # Should only be called while set to valid metadata.
+        assert self._connector_metadata is not None
+        return self._connector_metadata
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        """
+        Initialize with the KV caches. Useful for pre-registering the
+        KV Caches in the KVConnector (e.g. for NIXL).
+
+        Args:
+            kv_caches: dictionary of layer names, kv cache
+        """
+        logger.info("Registering kv caches!")
+        self.worker_adapter.register_kv_caches(kv_caches)
+        return
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        """
+        Start loading the KV cache from the connector to vLLM's paged
+        KV buffer. This is called from the forward context before the
+        forward pass to enable async loading during model execution.
+
+        Args:
+            forward_context (ForwardContext): the forward context.
+            **kwargs: additional arguments for the load operation
+
+        Note:
+            The number of elements in kv_caches and layer_names should be
+            the same.
+
+        """
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        request_ids = []
+        ops = []
+        cache_salts = []
+        request_configs_list = []
+
+        for meta in metadata.requests:
+            if meta.direction != "RETRIEVE":
+                continue
+            request_ids.append(meta.request_id)
+            ops.append(meta.op)
+            cache_salts.append(meta.cache_salt)
+            request_configs_list.append(meta.request_configs)
+
+        if len(request_ids) == 0:
+            return
+
+        event = self.worker_adapter.create_recorded_event()
+
+        self.worker_adapter.batched_submit_retrieve_requests(
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            request_configs_list=request_configs_list,
+        )
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        """
+        Block until the KV for a specific layer is loaded into vLLM's
+        paged buffer. This is called from within attention layer to ensure
+        async copying from start_load_kv is complete.
+
+        This interface will be useful for layer-by-layer pipelining.
+
+        Args:
+            layer_name: the name of that layer
+        """
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Start saving a layer of KV cache from vLLM's paged buffer
+        to the connector. This is called from within attention layer to
+        enable async copying during execution.
+
+        Args:
+            layer_name (str): the name of the layer.
+            kv_layer (torch.Tensor): the paged KV buffer of the current
+                layer in vLLM.
+            attn_metadata (AttentionMetadata): the attention metadata.
+            **kwargs: additional arguments for the save operation.
+        """
+        return
+
+    def wait_for_save(self):
+        """
+        Block until all the save operations is done. This is called
+        as the forward context exits to ensure that the async saving
+        from save_kv_layer is complete before finishing the forward.
+
+        This prevents overwrites of paged KV buffer before saving done.
+        """
+        # In the MLA scenario, only the KV writer ranks store the KV cache.
+        if not self.worker_adapter.is_kv_writer:
+            return
+
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        request_ids = []
+        ops = []
+        cache_salts = []
+        request_configs_list = []
+        for meta in metadata.requests:
+            if meta.direction != "STORE":
+                continue
+            request_ids.append(meta.request_id)
+            ops.append(meta.op)
+            cache_salts.append(meta.cache_salt)
+            request_configs_list.append(meta.request_configs)
+
+        if len(request_ids) == 0:
+            return
+
+        event = self.worker_adapter.create_recorded_event()
+
+        self.worker_adapter.batched_submit_store_requests(
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            request_configs_list=request_configs_list,
+        )
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        """
+        Notifies worker-side connector ids of requests that have
+        finished generating tokens on the worker.
+        The scheduler process (via the Executors) will use this output
+        to track which workers are done.
+
+        Returns:
+            ids of requests that have finished asynchronous transfer
+            (requests that previously returned True from request_finished()),
+            tuple of (sending/saving ids, recving/loading ids).
+            The finished saves/sends req ids must belong to a set provided in a
+            call to this method (this call or a prior one).
+        """
+        val = self.worker_adapter.get_finished(finished_req_ids)
+        # logger.error("Finished req ids: %s, %s", val[0], val[1])
+        return val
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """
+        Get the set of block IDs that failed to load.
+
+        Returns:
+            Set of block IDs that encountered load errors.
+            Empty set if no load errors occurred.
+
+        Notes:
+            - Applies to both sync- and async-loading requests.
+            - Async loading: failed blocks may be reported in any forward pass
+              up to and including the pass where the request ID is returned by
+              `get_finished()`. Even if failures occur, the request must still
+              be reported via `get_finished()`, and the failed block IDs must
+              appear here no later than that same pass.
+            - Sync loading: failed blocks should be reported in the forward
+              pass in which they are detected.
+        """
+        return self.worker_adapter.get_block_ids_with_load_errors()
+
+    def shutdown(self):
+        """
+        Shutdown the connector. This is called when the worker process
+        is shutting down to ensure that all the async operations are
+        completed and the connector is cleaned up properly.
+        """
+        if hasattr(self, "worker_adapter"):
+            self.worker_adapter.shutdown()
+        return None
+
+    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+        """
+        Get the KV connector stats collected during the last interval.
+        """
+        return None
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        """
+        Get number of new tokens that can be loaded from the
+        external KV cache beyond the num_computed_tokens.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+
+        Returns:
+            A tuple with the following elements:
+                - An optional number of tokens that can be loaded from the
+                  external KV cache beyond what is already computed.
+                  If None, it means that the connector needs more time to
+                  determine the number of matched tokens, and the scheduler
+                  should query for this request again later.
+                - `True` if external KV cache tokens will be loaded
+                  asynchronously (between scheduler steps). Must be
+                  'False' if the first element is 0.
+
+        Notes:
+            The connector should only consider the largest prefix of prompt-
+            tokens for which KV cache is actually available at the time of the
+            call. If the cache cannot be loaded for some tokens (e.g., due to
+            connectivity issues or eviction), those tokens must not be taken
+            into account.
+        """
+        tracker = self._get_or_create_request_tracker(request)
+        # TODO: support loading KV for preempted requests in the future
+        if request.status == RequestStatus.PREEMPTED:
+            return 0, False
+
+        self.scheduler_adapter.maybe_submit_lookup_request(
+            request.request_id,
+            token_ids=tracker.get_token_ids(),
+            cache_salt=tracker.cache_salt,
+            request_configs=tracker.request_configs,
+        )
+
+        ret = self.scheduler_adapter.check_lookup_result(request.request_id)
+        if ret is None:
+            return None, True
+
+        if ret == 0:
+            return 0, False
+
+        assert (
+            ret % (self.scheduler_adapter.num_blocks_per_chunk() * self.vllm_block_size)
+            == 0
+        )
+
+        # Update num stored blocks for the tracker
+        num_vllm_blocks = num_computed_tokens // self.vllm_block_size
+        num_lmcache_blocks = ret // self.vllm_block_size
+        tracker.increase_num_stored_blocks(num_lmcache_blocks)
+
+        # Save the vllm and lmcache hit tokens
+        tracker.num_vllm_hit_blocks = num_vllm_blocks
+        tracker.num_lmcache_hit_blocks = num_lmcache_blocks
+
+        need_to_load = max(0, ret - num_computed_tokens)
+        logger.debug(
+            "vLLM hit is: %d, Need to load is %d", num_computed_tokens, need_to_load
+        )
+        return need_to_load, need_to_load > 0
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        """
+        Update KVConnector state after block allocation.
+
+        If get_num_new_matched_tokens previously returned True for a
+        request, this function may be called twice for that same request -
+        first when blocks are allocated for the connector tokens to be
+        asynchronously loaded into, and second when any additional blocks
+        are allocated, after the load/transfer is complete.
+
+        Args:
+            request (Request): the request object.
+            blocks (KVCacheBlocks): the blocks allocated for the request.
+            num_external_tokens (int): the number of tokens that will be
+                loaded from the external KV cache.
+        """
+        # NOTE: `blocks` comes from kv_cache_manager.get_blocks(request_id),
+        # which returns ALL blocks for the request (not just newly allocated).
+        # This function may be called twice for async-load requests:
+        #   1st call: blocks = initial allocation (APC + fresh)
+        #   2nd call: blocks = all blocks
+        #  (initial + newly allocated for remaining tokens)
+        # We must only append the NEW blocks beyond what's already tracked
+        # to avoid duplication, which would corrupt the store path's block indexing.
+        tracker = self._get_request_tracker(request.request_id)
+        block_ids = reformat_block_ids(blocks.get_block_ids())
+
+        # Only append blocks beyond what's already tracked
+        existing_count = len(tracker.allocated_block_ids)
+        new_block_ids = block_ids[existing_count:]
+        if new_block_ids:
+            tracker.append_block_ids(new_block_ids)
+
+        # Update the state of the tracker
+        condition = tracker.needs_retrieve()
+        if tracker.state == LMCacheMPRequestState.PREFETCHING:
+            # If need to retrieve, change to WAITING_FOR_LOAD
+            # Otherwise, change to READY
+            tracker.state = (
+                LMCacheMPRequestState.WAITING_FOR_LOAD
+                if condition
+                else LMCacheMPRequestState.READY
+            )
+            # Clean up lookup future in scheduler adapter
+            self.scheduler_adapter.cleanup_lookup_result(request.request_id)
+
+            # Free locks on chunks that vLLM already computed and won't
+            # retrieve from LMCache.
+            if tracker.num_lmcache_hit_blocks > 0:
+                if not condition:
+                    # No retrieve needed — free ALL locked chunks
+                    free_end = tracker.num_lmcache_hit_blocks * self.vllm_block_size
+                else:
+                    # Note(Roy): Boundary misalignment between vLLM blocks and LMCache
+                    # blocks is handled in free_lookup_locks. It makes sure that if
+                    # the last vLLM computed block ends in the middle of a LMCache
+                    # block, the end LMCache block is not freed (i.e., floor division)
+                    # since it will still be needed by vLLM and such block's lock will
+                    # be freed by vLLM's retrieve.
+                    free_end = tracker.num_vllm_hit_blocks * self.vllm_block_size
+
+                if free_end > 0:
+                    self.scheduler_adapter.free_lookup_locks(
+                        token_ids=tracker.get_token_ids(),
+                        start=0,
+                        end=free_end,
+                        request_id=request.request_id,
+                        cache_salt=tracker.cache_salt,
+                        request_configs=tracker.request_configs,
+                    )
+                    logger.debug(
+                        "Free locks of tokens %d-%d since it is cached by vLLM.",
+                        0,
+                        free_end,
+                    )
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        """
+        Build the connector metadata for this step.
+
+        This function should NOT modify fields in the scheduler_output.
+        Also, calling this function will reset the state of the connector.
+
+        Args:
+            scheduler_output (SchedulerOutput): the scheduler output object.
+        """
+        metadata = LMCacheMPConnectorMetadata()
+
+        self._process_retrieve_requests(metadata)
+        self._process_new_requests(scheduler_output, metadata)
+        self._process_cached_requests(scheduler_output, metadata)
+
+        if len(metadata) > 0:
+            logger.debug("Final connector metadata: %s", metadata)
+
+        # Report block allocation deltas to LMCache for observability
+        self._report_block_allocation_deltas(scheduler_output)
+
+        return metadata
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        """
+        Update KVConnector state from worker-side connectors output.
+
+        Args:
+            connector_output (KVConnectorOutput): the worker-side
+                connectors output.
+        """
+        return
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called exactly once when a request has finished, before its blocks are
+        freed.
+
+        The connector may assumes responsibility for freeing the blocks
+        asynchronously by returning True.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+
+        params: dict[str, Any] | None = getattr(request, "kv_transfer_params", None)
+        return_params: dict[str, Any] | None = {} if params is not None else None
+
+        if (
+            params is not None
+            and return_params is not None
+            and "num_lmcache_extra_cached_tokens" in params
+        ):
+            request_tracker = self._get_request_tracker(request.request_id)
+            num_extra_cached_blocks = max(
+                0,
+                request_tracker.num_lmcache_hit_blocks
+                - request_tracker.num_vllm_hit_blocks,
+            )
+            return_params["num_lmcache_extra_cached_tokens"] = (
+                num_extra_cached_blocks * self.vllm_block_size
+            )
+
+        # Clean up request tracker to prevent memory leak
+        self._cleanup_request_tracker(request.request_id)
+        # Notify LMCache to end the session for this request
+        self.scheduler_adapter.end_session(request.request_id)
+        # Drop lookup state for a request aborted before its lookup was
+        # consumed (update_state_after_alloc never ran for it).
+        self.scheduler_adapter.cleanup_lookup_result(request.request_id)
+
+        return True, return_params
+
+    def take_events(self) -> Iterable["KVCacheEvent"]:
+        """
+        Take the KV cache events from the connector.
+
+        Yields:
+            New KV cache events since the last call.
+        """
+        return ()
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        """
+        Get the required KV cache layout for this connector.
+        Args:
+            vllm_config (VllmConfig): the vllm config.
+
+        Returns:
+            str: the required KV cache layout. e.g. HND, or NHD.
+            None if the connector does not require a specific layout.
+        """
+
+        if cls is KVConnectorBase_V1:
+            raise TypeError(
+                "get_required_kvcache_layout should not be called "
+                "on the abstract base class"
+            )
+        return None
+
+    def get_finished_count(self) -> int | None:
+        """
+        Get the count of requests expected to complete send/receive operations
+        via this connector. This method is used to initialize the
+        KVOutputAggregator, overwriting the default world_size.
+
+        Returns:
+            int: expected sending or receiving completion count.
+        """
+        return None
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> "KVConnectorStats | None":
+        """
+        KVConnectorStats resolution method. This method allows dynamically
+        registered connectors to return their own KVConnectorStats object,
+        which can implement custom aggregation logic on the data dict.
+        """
+        return None
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: "VllmConfig",
+        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> "KVConnectorPromMetrics | None":
+        """
+        Create a KVConnectorPromMetrics subclass which should register
+        per-connector Prometheus metrics and implement observe() to
+        expose connector transfer stats via Prometheus.
+        """
+        return None
+
+    ##############################
+    # Helper functions
+    ##############################
+    def _process_retrieve_requests(
+        self,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
+
+        for request_tracker in self.request_trackers.values():
+            if request_tracker.state != LMCacheMPRequestState.WAITING_FOR_LOAD:
+                continue
+            r_metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+                request_tracker,
+                blocks_per_chunk,
+                vllm_block_size=self.vllm_block_size,
+            )
+            if r_metadata is not None:
+                metadata.add_request_metadata(r_metadata)
+            request_tracker.state = LMCacheMPRequestState.READY
+
+    def _process_new_requests(
+        self,
+        scheduler_output: SchedulerOutput,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
+
+        for new_request in scheduler_output.scheduled_new_reqs:
+            request_tracker = self._get_request_tracker(new_request.req_id)
+
+            num_new_tokens = scheduler_output.num_scheduled_tokens[new_request.req_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+                request_tracker, blocks_per_chunk, self.vllm_block_size
+            )
+            if r_meta is not None:
+                metadata.add_request_metadata(r_meta)
+
+    def _process_cached_requests(
+        self,
+        scheduler_output: SchedulerOutput,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        blocks_per_chunk = self.scheduler_adapter.num_blocks_per_chunk()
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, request_id in enumerate(cached_reqs.req_ids):
+            request_tracker = self._get_request_tracker(request_id)
+
+            # Update block ids
+            new_block_ids = reformat_block_ids(cached_reqs.new_block_ids[idx])
+            if request_id not in cached_reqs.resumed_req_ids:
+                request_tracker.append_block_ids(new_block_ids)
+
+            # Use the incremental num_scheduled_tokens to
+            # stay consistent with _process_new_requests.
+            num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+
+            r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+                request_tracker, blocks_per_chunk, self.vllm_block_size
+            )
+
+            if r_meta is not None:
+                metadata.add_request_metadata(r_meta)
+
+    def _report_block_allocation_deltas(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        """Gather per-request block allocation deltas and report to LMCache.
+
+        For new requests: all allocated_block_ids and token_ids are new.
+        For cached requests: only newly appended block_ids and token_ids.
+        """
+        records: list[RequestAllocationRecord] = []
+
+        # New requests: send all tokens covering all allocated blocks so
+        # the L0 metrics subscriber can correctly map each block to its
+        # actual token content (not just the newly-scheduled slice).
+        for new_request in scheduler_output.scheduled_new_reqs:
+            tracker = self.request_trackers.get(new_request.req_id)
+            if tracker is None:
+                continue
+            num_blocks = len(tracker.allocated_block_ids)
+            total_tokens = num_blocks * self.vllm_block_size
+            records.append(
+                RequestAllocationRecord(
+                    req_id=new_request.req_id,
+                    new_block_ids=list(tracker.allocated_block_ids),
+                    new_token_ids=tracker.get_token_ids()[:total_tokens],
+                )
+            )
+
+        # Cached requests: only the newly added blocks and their full
+        # token content.  We send all tokens covered by the new blocks
+        # (not just the tokens scheduled this step) so the L0 subscriber
+        # can correctly identify block content.
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, request_id in enumerate(cached_reqs.req_ids):
+            new_block_ids = reformat_block_ids(cached_reqs.new_block_ids[idx])
+            if not new_block_ids:
+                continue
+            tracker = self.request_trackers.get(request_id)
+            if tracker is None:
+                continue
+            # The new blocks sit at the end of the request's block list.
+            # Compute the token range they cover.
+            total_blocks = len(tracker.allocated_block_ids)
+            num_new_blocks = len(new_block_ids)
+            start_token = (total_blocks - num_new_blocks) * self.vllm_block_size
+            end_token = total_blocks * self.vllm_block_size
+            new_token_ids = tracker.get_token_ids()[start_token:end_token]
+            records.append(
+                RequestAllocationRecord(
+                    req_id=request_id,
+                    new_block_ids=new_block_ids,
+                    new_token_ids=new_token_ids,
+                )
+            )
+
+        if records:
+            self.scheduler_adapter.report_block_allocations(records)
+
+    def _get_request_tracker(self, request_id: str) -> LMCacheMPRequestTracker:
+        assert request_id in self.request_trackers, (
+            f"Request tracker for request_id {request_id} not found. "
+        )
+        return self.request_trackers[request_id]
+
+    def _get_or_create_request_tracker(
+        self, request: "Request"
+    ) -> LMCacheMPRequestTracker:
+        request_id = request.request_id
+        # Remove the old trackers that is created before the preemption
+        if (
+            request.status == RequestStatus.PREEMPTED
+            and request_id in self.request_trackers
+        ):
+            tracker = self.request_trackers[request_id]
+
+            # NOTE: since this function may be called multiple times
+            # for a single request (because get_num_new_matched_tokens
+            # may be called multiple times) for the same request, we
+            # will only do the remove if the tracker is not in the "fresh"
+            # state, i.e., PREFETCHING
+            if tracker.state != LMCacheMPRequestState.PREFETCHING:
+                self.request_trackers.pop(request_id)
+
+        if request_id not in self.request_trackers:
+            new_tracker = LMCacheMPRequestTracker(request)
+            self.request_trackers[request_id] = new_tracker
+        return self.request_trackers[request_id]
+
+    def _cleanup_request_tracker(self, request_id: str) -> None:
+        """
+        Clean up request tracker and associated lookup future for a request.
+        This should be called when a request is finished to prevent memory leak.
+        """
+        # Clean up request tracker
+        if self.request_trackers.pop(request_id, None):
+            logger.debug(
+                "[KVConnector] Cleaned up request_tracker for request %s",
+                request_id,
+            )

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -96,7 +96,8 @@ class ExtraConfigDefault(enum.Enum):
     use_vmm_api = False
 
 
-# Shared defaults used by the vLLM and SGLang multiprocess adapters.
+# Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
+# entry point, which still passes these as positional/keyword args.
 DEFAULT_MQ_TIMEOUT: float = ExtraConfigDefault.mq_timeout.default
 DEFAULT_HEARTBEAT_INTERVAL: float = ExtraConfigDefault.heartbeat_interval.default
 

--- a/lmcache/sdk/qringbuffer.py
+++ b/lmcache/sdk/qringbuffer.py
@@ -31,9 +31,9 @@ if TYPE_CHECKING:
         LMCacheMPWorkerAdapter,
         LoadStoreOp,
         StoreResult,
-        _IpcEvent,
     )
     from lmcache.v1.multiprocess.mq import MessagingFuture
+    from lmcache.v1.multiprocess.transfer_context.worker_transfer import IPCEvent
 
 logger = lmcache_init_logger(__name__)
 
@@ -512,7 +512,7 @@ class QRingBufferCapture:
             return list(block_ids[0])
         return None
 
-    def batched_submit_qstore_requests(self, event: "_IpcEvent | None") -> None:
+    def batched_submit_qstore_requests(self, event: IPCEvent | None) -> None:
         """
         Submit a batched Q store request to LMCache.
         A copy of batched_submit_store_requests for Q stores.
@@ -520,8 +520,8 @@ class QRingBufferCapture:
         cache salts for the current forward step.
 
         Args:
-            event: The CUDA event that is recorded after the current
-                model inference step
+            event: The device event that is recorded after the current model
+                inference step.
         """
         state = self.q_step_state
         self.q_step_state = None
@@ -556,7 +556,7 @@ class QRingBufferAdapter:
         self.q_store_futures: dict[
             int, tuple[MessagingFuture[StoreResult], list[int]]
         ] = {}
-        self.q_store_events: dict[int, _IpcEvent] = {}
+        self.q_store_events: dict[int, object] = {}
         self._q_store_seq: int = 0
 
     def register_q_ring(
@@ -675,7 +675,7 @@ class QRingBufferAdapter:
         request_id: str,
         op: LoadStoreOp,
         ring_block_ids: list[int],
-        event: "_IpcEvent",
+        event: IPCEvent,
         cache_salt: str = "",
     ) -> None:
         """Submit a store request for QRingBuffer content at ring_block_ids

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, TypeVar,
 import asyncio
 import functools
 import hashlib
-import inspect
 import re
 import threading
 import traceback
@@ -48,51 +47,22 @@ KVCache = Tuple[Tuple[torch.Tensor, torch.Tensor], ...]
 
 # Device utility functions
 def check_interprocess_event_support() -> None:
-    """Check if the current backend supports interprocess Events.
+    """Check if the current backend supports interprocess device events.
 
-    This function checks if torch_dev.Event exists and exposes the
-    interprocess parameter, which is required for multiprocess IPC.
+    This compatibility helper delegates to the platform event IPC backend for
+    the active device type. Call it only after process-wide IPC configuration
+    has been finalized; mode-aware integrations should validate through their
+    selected transfer context instead.
 
     Raises:
-        RuntimeError: If the backend does not support interprocess Events
-            or if the Event class doesn't expose the interprocess parameter.
+        RuntimeError: If the active backend does not support event IPC.
     """
     # First Party
-    from lmcache import torch_dev, torch_device_type
+    from lmcache import torch_device_type
+    from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
 
-    if not hasattr(torch_dev, "Event"):
-        raise RuntimeError(
-            f"Backend '{torch_device_type}' does not support "
-            "interprocess Events (torch_dev.Event not available). "
-            "Multiprocess IPC requires CUDA."
-        )
-
-    event_cls = torch_dev.Event
-
-    def has_interprocess_parameter(obj) -> bool:
-        try:
-            sig = inspect.signature(obj)
-        except (TypeError, ValueError):
-            return False
-
-        return "interprocess" in sig.parameters
-
-    if not (
-        has_interprocess_parameter(event_cls)
-        or has_interprocess_parameter(event_cls.__new__)
-    ):
-        raise RuntimeError(
-            f"Backend '{torch_device_type}' does not support "
-            "interprocess=True parameter for Events. "
-            "Multiprocess IPC requires CUDA."
-        )
-
-    if not hasattr(torch_dev.Event, "from_ipc_handle"):
-        raise RuntimeError(
-            f"Backend '{torch_device_type}' does not support IPC event "
-            "handles (Event.from_ipc_handle not available). "
-            "Multiprocess IPC requires CUDA."
-        )
+    backend = get_event_ipc_backend(torch_device_type)
+    backend.check_event_support(torch_device_type)
 
 
 # Math utility functions

--- a/lmcache/v1/multiprocess/futures.py
+++ b/lmcache/v1/multiprocess/futures.py
@@ -7,7 +7,10 @@ import threading
 from lmcache import torch_dev
 from lmcache.utils import lmcache_deprecate
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
-from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
 
 T = TypeVar("T")
 
@@ -99,21 +102,37 @@ class MessagingFuture(Generic[T]):
         """
         self._retained_references.append(value)
 
+    def release_references(self) -> None:
+        """Drop resources previously retained on this future.
+
+        Callers that synchronously wait for completion can use this once the
+        remote side has definitively finished with the exported resources.
+        """
+        self._retained_references.clear()
+
     def to_device_future(
         self,
         device: Any | None = None,
+        event_backend: EventIPCBackend | None = None,
     ) -> "DeviceMessagingFuture":
         """Wrap this future in a device-aware future.
 
         Args:
             device: The device whose event backend orders completion. Defaults
                 to the active device.
+            event_backend: Backend already selected and validated by the
+                caller during initialization. When omitted, it is resolved for
+                backward compatibility.
 
         Returns:
             A DeviceMessagingFuture pending on both this future and the event.
         """
         # TODO: need extra type checking for the future type
-        return DeviceMessagingFuture.FromMessagingFuture(self, device)  # type: ignore
+        return DeviceMessagingFuture.FromMessagingFuture(
+            self,  # type: ignore[arg-type]
+            device,
+            event_backend,
+        )
 
     @lmcache_deprecate("Use to_device_future() instead")
     def to_cuda_future(
@@ -146,6 +165,7 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         self,
         raw_future: MessagingFuture[tuple[bytes, T]],
         device: Any | None = None,
+        event_backend: EventIPCBackend | None = None,
     ) -> None:
         super().__init__()
         self.raw_future_ = raw_future
@@ -153,8 +173,10 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         self.result_: T | None = None
         self._raw_response_processed = False
         self.device_ = device if device is not None else torch_dev.current_device()
-        self._event_backend = get_event_ipc_backend(self.device_)
-        self._event_backend.check_event_support(self.device_)
+        if event_backend is None:
+            event_backend = get_event_ipc_backend(self.device_)
+            event_backend.check_event_support(self.device_)
+        self._event_backend = event_backend
 
     def _on_raw_future_complete(self) -> None:
         """
@@ -258,8 +280,9 @@ class DeviceMessagingFuture(MessagingFuture[T]):
     def FromMessagingFuture(
         raw_future: MessagingFuture[tuple[bytes, T]],
         device: Any | None = None,
+        event_backend: EventIPCBackend | None = None,
     ) -> "DeviceMessagingFuture[T]":
-        return DeviceMessagingFuture(raw_future, device)
+        return DeviceMessagingFuture(raw_future, device, event_backend)
 
 
 # Backward-compatible alias for existing imports.

--- a/lmcache/v1/multiprocess/modules/blend/retrieve.py
+++ b/lmcache/v1/multiprocess/modules/blend/retrieve.py
@@ -22,9 +22,8 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache import device_ops, torch_dev, torch_device_type
+from lmcache import device_ops, torch_dev
 from lmcache.logging import init_logger
-from lmcache.utils import check_interprocess_event_support
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -581,6 +580,12 @@ class RetrieveMixin:
                 "send CB_REGISTER_ROPE before CB_RETRIEVE_PRE_COMPUTED."
             )
         gpu_context = entry.cache_context
+        event_backend = entry.event_backend
+        if event_backend is None:
+            raise RuntimeError(
+                "Blend event backend is not initialized; register the KV cache "
+                "before submitting retrieve requests"
+            )
         rope_state = self._cb_rope_state[instance_id]
         chunk_size = self._ctx.chunk_size
         # Blend's read set: attention (+ connector-private aux), never
@@ -615,10 +620,9 @@ class RetrieveMixin:
                 torch_dev.device(gpu_context.device),
                 torch_dev.stream(gpu_context.stream),
             ):
-                check_interprocess_event_support()
-                done_event = torch_dev.Event(interprocess=True)
-                done_event.record()
-                handle = done_event.ipc_handle()
+                done_event = event_backend.create_event(gpu_context.device)
+                event_backend.record_event(done_event, gpu_context.stream)
+                handle = event_backend.export_event(done_event, gpu_context.device)
 
             if reason.publish:
                 self._event_bus.publish(
@@ -803,8 +807,7 @@ class RetrieveMixin:
             torch_dev.device(gpu_context.device),
             torch_dev.stream(retrieve_stream),
         ):
-            check_interprocess_event_support()
-            event = torch_dev.Event(interprocess=True)
+            event = event_backend.create_event(gpu_context.device)
 
             # Resolve each kernel group's block table + block size once by
             # engine_group_idx (kernel groups may share one). CPU tables only.
@@ -849,16 +852,10 @@ class RetrieveMixin:
                 ),
             )
 
-            if not hasattr(torch_dev.Event, "from_ipc_handle"):
-                raise RuntimeError(
-                    f"Backend '{torch_device_type}' does not support IPC "
-                    "event handles (Event.from_ipc_handle not available). "
-                    "Multiprocess IPC requires CUDA."
-                )
-            vllm_event = torch_dev.Event.from_ipc_handle(
-                gpu_context.device, event_ipc_handle
+            vllm_event = event_backend.import_event(
+                event_ipc_handle, gpu_context.device
             )
-            vllm_event.wait(stream=retrieve_stream)
+            event_backend.wait_event(vllm_event, retrieve_stream)
 
             # Stage marks for the scatter_ms log line (CPU enqueue wall time):
             # fetch = prefetched read, plan = table build, exec = native enqueue.
@@ -894,8 +891,11 @@ class RetrieveMixin:
                                 session_id=key.request_id,
                             ),
                         )
-                        event.record()
-                        return event.ipc_handle(), False
+                        event_backend.record_event(event, retrieve_stream)
+                        return (
+                            event_backend.export_event(event, gpu_context.device),
+                            False,
+                        )
 
                     # Per-token scatter handles any cur_st. Each match owns n_read
                     # consecutive memory objects (chunk-major).
@@ -1049,10 +1049,10 @@ class RetrieveMixin:
                     ),
                 )
                 # Fresh server event + False (never echo the client handle).
-                event.record()
-                return event.ipc_handle(), False
+                event_backend.record_event(event, retrieve_stream)
+                return event_backend.export_event(event, gpu_context.device), False
 
-            event.record()
+            event_backend.record_event(event, retrieve_stream)
             self._event_bus.publish_on_stream(
                 gpu_context.cupy_stream,
                 Event(
@@ -1092,4 +1092,4 @@ class RetrieveMixin:
                 session_id=key.request_id,
             ),
         )
-        return event.ipc_handle(), True
+        return event_backend.export_event(event, gpu_context.device), True

--- a/lmcache/v1/multiprocess/modules/experimental/qstore.py
+++ b/lmcache/v1/multiprocess/modules/experimental/qstore.py
@@ -12,12 +12,11 @@ import threading
 import time
 
 # First Party
-from lmcache import torch_dev, torch_device_type
+from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.utils import (
     EngineType,
     _lmcache_nvtx_annotate,
-    check_interprocess_event_support,
 )
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.gpu_connector.utils import LayoutHints
@@ -34,6 +33,9 @@ from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     transfer_kv_per_object_group,
 )
 from lmcache.v1.multiprocess.native_completion import submit_callback_to_stream
+from lmcache.v1.platform.base.event_ipc import (
+    get_event_ipc_backend,
+)
 from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.lmcache_native as lmcache_native
 
@@ -270,6 +272,8 @@ class QStoreModule(InstanceLivenessTarget):
         layout_desc = get_layout_desc(
             cache_context, self._ctx.chunk_size, object_group_id=0
         )
+        event_backend = get_event_ipc_backend(cache_context.device)
+        event_backend.check_event_support(cache_context.device)
         kv_groups_manager = cache_context.kv_layer_groups_manager
         attn_desc = kv_groups_manager.get_attn_desc()
         self._ctx.layout_desc_registry.register(
@@ -283,6 +287,7 @@ class QStoreModule(InstanceLivenessTarget):
                 world_size=world_size,
                 last_seen=now,
                 has_liveness_signal=False,
+                event_backend=event_backend,
             )
 
         logger.info(
@@ -354,7 +359,12 @@ class QStoreModule(InstanceLivenessTarget):
             raise ValueError(f"No Q ring registered for instance ID {instance_id}")
         cache_context = entry.cache_context
         model_name = entry.model_name
-
+        event_backend = entry.event_backend
+        if event_backend is None:
+            raise RuntimeError(
+                "Q ring event backend is not initialized; register the Q cache "
+                "before submitting store requests"
+            )
         num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
         obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
             key, list(range(num_object_groups))
@@ -375,8 +385,7 @@ class QStoreModule(InstanceLivenessTarget):
             torch_dev.device(cache_context.device),
             torch_dev.stream(cache_context.stream),
         ):
-            check_interprocess_event_support()
-            event = torch_dev.Event(interprocess=True)
+            event = event_backend.create_event(cache_context.device)
 
             # Fail closed: every LMCache group must have block IDs covering all
             # chunks. A short list (e.g. a caller/protocol bug) would otherwise
@@ -399,23 +408,17 @@ class QStoreModule(InstanceLivenessTarget):
                     num_chunks,
                     blocks_per_chunk,
                 )
-                event.record()
-                return event.ipc_handle(), False
+                event_backend.record_event(event, cache_context.stream)
+                return event_backend.export_event(event, cache_context.device), False
 
             block_ids_per_group_gpu = downsample_and_stage_block_ids(
                 cache_context, gpu_block_ids
             )
 
-            if not hasattr(torch_dev.Event, "from_ipc_handle"):
-                raise RuntimeError(
-                    f"Backend '{torch_device_type}' does not support IPC event "
-                    "handles (Event.from_ipc_handle not available). "
-                    "Multiprocess IPC requires CUDA."
-                )
-            vllm_event = torch_dev.Event.from_ipc_handle(
-                cache_context.device, event_ipc_handle
+            vllm_event = event_backend.import_event(
+                event_ipc_handle, cache_context.device
             )
-            vllm_event.wait(stream=cache_context.stream)
+            event_backend.wait_event(vllm_event, cache_context.stream)
 
             # CPU-synchronous sentinel: a GPU store is about to be enqueued.
             # Must be published via publish() (not publish_on_stream) so the
@@ -482,9 +485,8 @@ class QStoreModule(InstanceLivenessTarget):
                 store_succeeded = True
             except Exception:
                 logger.exception("Cannot store Q keys due to exception")
-                return event.ipc_handle(), False
             finally:
-                event.record()
+                event_backend.record_event(event, cache_context.stream)
                 # Fail closed: commit the reserved objects only when every chunk
                 # copied successfully; otherwise the whole store is skipped.
                 stored_count = len(all_dict) if store_succeeded else 0
@@ -518,4 +520,4 @@ class QStoreModule(InstanceLivenessTarget):
                 num_chunks * self._ctx.chunk_size,
                 ed - st,
             )
-        return event.ipc_handle(), True
+        return event_backend.export_event(event, cache_context.device), store_succeeded

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -553,7 +553,10 @@ class LMCacheDrivenTransferContext(TransferContext):
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._req_client.store(
             key, instance_id, block_ids, event_ipc_handle
-        ).to_device_future(device=self._device)
+        ).to_device_future(
+            device=self._device,
+            event_backend=self._event_backend,
+        )
 
     def submit_q_store(
         self,
@@ -577,7 +580,10 @@ class LMCacheDrivenTransferContext(TransferContext):
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._req_client.store_q(
             key, instance_id, block_ids, event_ipc_handle
-        ).to_device_future(device=self._device)
+        ).to_device_future(
+            device=self._device,
+            event_backend=self._event_backend,
+        )
 
     def submit_retrieve(
         self,
@@ -628,7 +634,10 @@ class LMCacheDrivenTransferContext(TransferContext):
             block_ids,
             event_ipc_handle,
             skip_first_n_tokens,
-        ).to_device_future(device=self._device)
+        ).to_device_future(
+            device=self._device,
+            event_backend=self._event_backend,
+        )
 
     def close(self) -> None:
         """Release the message queue and cached event-backend state."""

--- a/lmcache/v1/platform/cuda/timeline_semaphore_event_ipc.py
+++ b/lmcache/v1/platform/cuda/timeline_semaphore_event_ipc.py
@@ -30,9 +30,9 @@ supported.
 Slots are assigned per recording stream, so each slot's values are
 stream-ordered and monotonic, keeping the GEQ wait race-free.
 
-Only events from this backend's ``create_event`` can be exported; call
-sites constructing ``torch_dev.Event(interprocess=True)`` directly must be
-migrated before binding this backend to the device spec. See
+Only events from this backend's ``create_event`` can be exported; callers must
+use the platform event helpers rather than constructing backend events
+directly. See
 ``docs/design/v1/platform/cuda/timeline_semaphore_event_ipc.md``.
 """
 

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -8,12 +8,15 @@ Covers:
 """
 
 # Standard
+from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 import argparse
+import gc
 import json
 import threading
 import time
+import weakref
 
 # Third Party
 import msgspec
@@ -1270,7 +1273,6 @@ class TestClientMultiWorker:
             tensor_refs.append(weakref.ref(tensor))
             return [tensor], [object()], [], []
 
-        monkeypatch.setattr(sv_helpers, "_make_event_handle", lambda: b"")
         monkeypatch.setattr(
             sv_helpers,
             "_allocate_cpu_shm_kv_cache",
@@ -1400,3 +1402,241 @@ class TestClientMultiWorker:
             "LOOKUP payload tp_size must equal simulated tp "
             "(is_mla=%s, tp=%d, got=%s)" % (is_mla, tp, lookups[0][1][1])
         )
+
+
+class _ExportedEvent:
+    pass
+
+
+class _LifetimeCheckingFuture:
+    def __init__(
+        self,
+        result: tuple[int, bool],
+        get_event_ref: Callable[[], weakref.ReferenceType[_ExportedEvent] | None],
+        *,
+        raises_timeout: bool = False,
+    ) -> None:
+        self._result = result
+        self._get_event_ref = get_event_ref
+        self.event_was_alive_during_result = False
+        self.retained_references: list[object] = []
+        self.raises_timeout = raises_timeout
+
+    def retain_reference(self, value: object) -> None:
+        self.retained_references.append(value)
+
+    def release_references(self) -> None:
+        self.retained_references.clear()
+
+    def result(self, timeout: float | None = None) -> tuple[int, bool]:
+        event_ref = self._get_event_ref()
+        self.event_was_alive_during_result = (
+            event_ref is not None and event_ref() is not None
+        )
+        if self.raises_timeout:
+            raise TimeoutError
+        return self._result
+
+
+class _LifetimeCheckingClient:
+    def __init__(self, future: _LifetimeCheckingFuture) -> None:
+        self.future = future
+        self.calls: list[tuple[RequestType, list[object]]] = []
+
+    def store(
+        self,
+        key: object,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> _LifetimeCheckingFuture:
+        self.calls.append(
+            (RequestType.STORE, [key, instance_id, block_ids, event_ipc_handle])
+        )
+        return self.future
+
+    def retrieve(
+        self,
+        key: object,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int,
+    ) -> _LifetimeCheckingFuture:
+        self.calls.append(
+            (
+                RequestType.RETRIEVE,
+                [
+                    key,
+                    instance_id,
+                    block_ids,
+                    event_ipc_handle,
+                    skip_first_n_tokens,
+                ],
+            )
+        )
+        return self.future
+
+
+@pytest.mark.parametrize(
+    ("request_type", "invoke", "expected_status"),
+    [
+        (
+            RequestType.STORE,
+            lambda helpers, client, key: helpers._send_store(  # noqa: SLF001
+                client,
+                key,
+                block_size=2,
+                num_engine_group_infos=1,
+                use_gpu=True,
+                use_handle=True,
+            ),
+            "stored",
+        ),
+        (
+            RequestType.RETRIEVE,
+            lambda helpers, client, key: helpers._send_retrieve(  # noqa: SLF001
+                client,
+                key,
+                chunk_size=2,
+                hit_chunks=1,
+                block_size=2,
+                num_engine_group_infos=1,
+                use_gpu=True,
+                use_handle=True,
+            ),
+            "retrieved",
+        ),
+    ],
+)
+def test_handle_mode_keeps_exported_event_alive_until_reply(
+    monkeypatch: pytest.MonkeyPatch,
+    request_type: RequestType,
+    invoke,
+    expected_status: str,
+) -> None:
+    """A blocking handle-mode RPC keeps its producer event until the reply."""
+    # First Party
+    from lmcache.cli.commands.bench.server_bench import helpers as sv_helpers
+
+    event_ref: weakref.ReferenceType[_ExportedEvent] | None = None
+
+    def make_exported_event(
+        event_backend: object | None,
+        use_gpu: bool = True,
+    ) -> tuple[_ExportedEvent, bytes]:
+        nonlocal event_ref
+        event = _ExportedEvent()
+        event_ref = weakref.ref(event)
+        return event, b"evt-handle"
+
+    future = _LifetimeCheckingFuture((0, True), lambda: event_ref)
+    client = _LifetimeCheckingClient(future)
+    key = _make_key((0, 9906, 9906, 9906), request_id="req-handle")
+
+    monkeypatch.setattr(
+        sv_helpers,
+        "_make_exported_event",
+        make_exported_event,
+    )
+
+    status = invoke(sv_helpers, client, key)
+
+    assert status == expected_status
+    assert client.calls == [
+        (
+            request_type,
+            [key, 0, [[0, 1]], b"evt-handle"]
+            if request_type is RequestType.STORE
+            else [key, 0, [[0]], b"evt-handle", 0],
+        )
+    ]
+    assert future.event_was_alive_during_result is True
+    assert event_ref is not None
+    assert future.retained_references == []
+    gc.collect()
+    assert event_ref() is None
+
+
+@pytest.mark.parametrize(
+    ("request_type", "invoke"),
+    [
+        (
+            RequestType.STORE,
+            lambda helpers, client, key: helpers._send_store(  # noqa: SLF001
+                client,
+                key,
+                block_size=2,
+                num_engine_group_infos=1,
+                use_gpu=True,
+                use_handle=True,
+            ),
+        ),
+        (
+            RequestType.RETRIEVE,
+            lambda helpers, client, key: helpers._send_retrieve(  # noqa: SLF001
+                client,
+                key,
+                chunk_size=2,
+                hit_chunks=1,
+                block_size=2,
+                num_engine_group_infos=1,
+                use_gpu=True,
+                use_handle=True,
+            ),
+        ),
+    ],
+)
+def test_handle_mode_timeout_retains_exported_event_on_raw_future(
+    monkeypatch: pytest.MonkeyPatch,
+    request_type: RequestType,
+    invoke,
+) -> None:
+    """Timeout does not release the exported event before the raw future does."""
+    # First Party
+    from lmcache.cli.commands.bench.server_bench import helpers as sv_helpers
+
+    event_ref: weakref.ReferenceType[_ExportedEvent] | None = None
+
+    def make_exported_event(
+        event_backend: object | None,
+        use_gpu: bool = True,
+    ) -> tuple[_ExportedEvent, bytes]:
+        nonlocal event_ref
+        event = _ExportedEvent()
+        event_ref = weakref.ref(event)
+        return event, b"evt-handle"
+
+    future = _LifetimeCheckingFuture(
+        (0, True),
+        lambda: event_ref,
+        raises_timeout=True,
+    )
+    client = _LifetimeCheckingClient(future)
+    key = _make_key((0, 9906, 9906, 9906), request_id="req-handle-timeout")
+
+    monkeypatch.setattr(
+        sv_helpers,
+        "_make_exported_event",
+        make_exported_event,
+    )
+
+    status = invoke(sv_helpers, client, key)
+
+    assert status == "timeout"
+    assert client.calls == [
+        (
+            request_type,
+            [key, 0, [[0, 1]], b"evt-handle"]
+            if request_type is RequestType.STORE
+            else [key, 0, [[0]], b"evt-handle", 0],
+        )
+    ]
+    assert future.event_was_alive_during_result is True
+    assert event_ref is not None
+    gc.collect()
+    assert event_ref() is not None
+    assert len(future.retained_references) == 1
+    future.retained_references.clear()
+    gc.collect()
+    assert event_ref() is None

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -407,6 +407,33 @@ def test_create_transfer_context_force_engine_driven_mode_on_cpu() -> None:
     assert isinstance(context, EngineDrivenTransferContext)
 
 
+def test_auto_non_cuda_context_does_not_require_event_ipc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AUTO non-CUDA routing must not resolve an interprocess event backend."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import worker_transfer
+
+    class MusaDevice:
+        type = "musa"
+
+    monkeypatch.setattr(worker_transfer, "get_device", lambda _tensor: MusaDevice())
+    monkeypatch.setattr(worker_transfer, "_supports_async_primitives", lambda: False)
+
+    def fail_event_backend_resolution(_device: object) -> None:
+        pytest.fail("engine-driven transfer must not resolve an event IPC backend")
+
+    monkeypatch.setattr(
+        worker_transfer,
+        "get_event_ipc_backend",
+        fail_event_backend_resolution,
+    )
+
+    context = worker_transfer.create_transfer_context({"layer_0": MagicMock()})
+
+    assert isinstance(context, worker_transfer.EngineDrivenTransferContext)
+
+
 def test_create_transfer_context_invalid_mode_raises() -> None:
     """Unknown mode strings must raise a clear ValueError."""
     # First Party

--- a/tests/v1/multiprocess/test_futures.py
+++ b/tests/v1/multiprocess/test_futures.py
@@ -806,3 +806,43 @@ def test_device_future_checks_backend_support_during_initialization(
         DeviceMessagingFuture.FromMessagingFuture(
             MessagingFuture[tuple[bytes, int]](), device="dev"
         )
+
+
+def test_device_future_reuses_prevalidated_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hot-path future construction reuses the caller's registered backend."""
+    # First Party
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    class _CachedBackend:
+        device_type = "fake"
+
+        def check_event_support(self, device: object) -> None:
+            raise AssertionError("cached backend must not be checked per request")
+
+        def import_event(self, handle: bytes, device: object) -> object:
+            return (handle, device)
+
+        def synchronize_event(self, event: object, device: object) -> None:
+            return None
+
+        def query_event(self, event: object) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        "lmcache.v1.multiprocess.futures.get_event_ipc_backend",
+        lambda device=None: (_ for _ in ()).throw(
+            AssertionError("cached backend must not be resolved per request")
+        ),
+    )
+
+    raw = MessagingFuture[tuple[bytes, int]]()
+    future = DeviceMessagingFuture.FromMessagingFuture(
+        raw,
+        device="dev",
+        event_backend=_CachedBackend(),  # type: ignore[arg-type]
+    )
+    raw.set_result((b"event", 7))
+
+    assert future.result() == 7

--- a/tests/v1/multiprocess/test_qstore.py
+++ b/tests/v1/multiprocess/test_qstore.py
@@ -43,8 +43,12 @@ def _stub_registration(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Creates a stub for the create_cache_context call to test
     register_q_cache()."""
     create = MagicMock(return_value=MagicMock(num_layers=2))
+    event_backend = MagicMock(name="event_backend")
     monkeypatch.setattr(qstore_mod, "create_cache_context", create)
     monkeypatch.setattr(qstore_mod, "get_layout_desc", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr(
+        qstore_mod, "get_event_ipc_backend", lambda device: event_backend
+    )
     return create
 
 
@@ -158,7 +162,7 @@ class _FakeEvent:
         self.records = 0
         _FakeEvent.created.append(self)
 
-    def record(self) -> None:
+    def record(self, stream=None) -> None:
         self.records += 1
 
     def ipc_handle(self) -> bytes:
@@ -172,6 +176,31 @@ class _FakeEvent:
         return cls()
 
 
+class _FakeEventBackend:
+    def __init__(self) -> None:
+        self.created: list[_FakeEvent] = []
+
+    def create_event(self, device) -> _FakeEvent:
+        event = _FakeEvent()
+        self.created.append(event)
+        return event
+
+    def check_event_support(self, device) -> None:
+        return None
+
+    def record_event(self, event: _FakeEvent, stream=None) -> None:
+        event.record(stream)
+
+    def export_event(self, event: _FakeEvent, device) -> bytes:
+        return event.ipc_handle()
+
+    def import_event(self, handle: bytes, device) -> _FakeEvent:
+        return _FakeEvent.from_ipc_handle(device, handle)
+
+    def wait_event(self, event: _FakeEvent, stream=None) -> None:
+        event.wait(stream)
+
+
 @pytest.fixture
 def stub_device(monkeypatch):
     """Replace the device module so store_q runs on CPU."""
@@ -181,13 +210,14 @@ def stub_device(monkeypatch):
         yield
 
     _FakeEvent.created.clear()
+    backend = _FakeEventBackend()
     monkeypatch.setattr(
         qstore_mod,
         "torch_dev",
         SimpleNamespace(device=_null, stream=_null, Event=_FakeEvent),
     )
-    monkeypatch.setattr(qstore_mod, "check_interprocess_event_support", lambda: None)
-    return _FakeEvent.created
+    monkeypatch.setattr(qstore_mod, "get_event_ipc_backend", lambda device: backend)
+    return backend
 
 
 def test_store_q_unregistered_instance_raises() -> None:
@@ -208,14 +238,17 @@ def test_store_q_block_id_underflow_fails_closed(stub_device) -> None:
     cache_context.kv_layer_groups_manager.num_kernel_groups = 1
     cache_context.calculate_num_blocks.return_value = 2  # 2 chunks * 2 = 4 needed
     module._q_contexts[1] = ContextEntry(
-        cache_context, *REGISTER_ARGS, time.monotonic()
+        cache_context,
+        *REGISTER_ARGS,
+        time.monotonic(),
+        event_backend=stub_device,
     )
 
     handle, ok = module.store_q(MagicMock(), 1, [[0, 1, 2]], b"peer-handle")
 
     assert ok is False
     assert handle == b"event-handle"
-    assert stub_device[0].records == 1
+    assert stub_device.created[0].records == 1
     cast(MagicMock, ctx.storage_manager.reserve_write).assert_not_called()
     cast(MagicMock, ctx.event_bus.publish).assert_not_called()
 

--- a/tests/v1/test_mp_connector_mm_keys.py
+++ b/tests/v1/test_mp_connector_mm_keys.py
@@ -12,6 +12,7 @@ interfaces of ``lmcache_mp_connector``.
 from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+import importlib
 
 # Third Party
 import pytest
@@ -243,3 +244,21 @@ def test_retrieve_metadata_uses_mm_adjusted_token_ids():
     assert metadata.op.token_ids == [1, 2, *v, 3, 4, 5, 6]
     assert metadata.op.start == 0
     assert metadata.op.end == 8
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["lmcache_mp_connector_0180", "lmcache_mp_connector_0201"],
+)
+def test_vendored_tracker_variants_substitute_mm_spans(module_name):
+    """The version-pinned MP connector copies embed the same substitution."""
+    mod = importlib.import_module(f"lmcache.integration.vllm.{module_name}")
+    prompt = [1, 2] + [IMAGE_PLACEHOLDER_ID] * 3 + [3, 4, 5]
+    tracker = mod.LMCacheMPRequestTracker(
+        _make_mm_request(prompt, identifier="0xabcd", offset=2, length=3)
+    )
+    v = list(mm_hash_to_token_values("0xabcd", 3))
+    assert tracker.get_token_ids() == [1, 2, *v, 3, 4, 5]
+
+    text_tracker = mod.LMCacheMPRequestTracker(_FakeRequest(prompt))
+    assert text_tracker.get_token_ids() == prompt

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -69,6 +69,7 @@ def _make_connector(healthy: bool = True) -> Any:
         conn._health_event.set()
     conn._lmcache_chunk_size = _CHUNK_SIZE
     conn._mq_timeout = 5.0
+    conn._event_backend = _FakeEventBackend()
     return conn
 
 
@@ -100,13 +101,33 @@ class _SpyFuture(MessagingFuture):
         super().retain_reference(value)
 
 
+class _TimeoutFuture(MessagingFuture):
+    """Future that records blocking and then raises a timeout."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.result_called = False
+
+    def result(self, timeout=None):
+        self.result_called = True
+        raise TimeoutError
+
+
 class _FakeRaw:
     """Stand-in returning a preset platform-aware completion future."""
 
     def __init__(self, future: MessagingFuture) -> None:
         self._future = future
+        self.retained_references: list[object] = []
 
-    def to_device_future(self, device=None) -> MessagingFuture:
+    def retain_reference(self, value: object) -> None:
+        self.retained_references.append(value)
+
+    def to_device_future(
+        self,
+        device=None,
+        event_backend=None,
+    ) -> MessagingFuture:
         return self._future
 
 
@@ -119,6 +140,17 @@ class _FakeEvent:
 
     def ipc_handle(self) -> bytes:
         return b"fake-ipc-handle"
+
+
+class _FakeEventBackend:
+    def create_event(self, device: object) -> _FakeEvent:
+        return _FakeEvent()
+
+    def record_event(self, event: _FakeEvent, stream: object) -> None:
+        event.record(stream)
+
+    def export_event(self, event: _FakeEvent, device: object) -> bytes:
+        return event.ipc_handle()
 
 
 class _FakeTorchDev:
@@ -341,10 +373,38 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
     # It returns the daemon's own future, and must NOT have blocked on it.
     assert future is sentinel
     assert sentinel.result_called is False
-    # The exporting device event must be pinned to the future so it isn't
-    # garbage-collected before the daemon waits on its IPC handle.
-    assert len(sentinel.retained_references) == 1
-    assert isinstance(sentinel.retained_references[0], _FakeEvent)
+    # The exporting device event must be pinned to the raw future so timeout
+    # callers cannot drop it before the daemon waits on its IPC handle.
+    assert len(conn.req_client.store.return_value.retained_references) == 1
+    assert isinstance(
+        conn.req_client.store.return_value.retained_references[0], _FakeEvent
+    )
+    assert sentinel.retained_references == []
+
+
+def test_store_kv_timeout_retains_exported_event_on_raw_future(
+    monkeypatch,
+) -> None:
+    """Timeouts must not drop the exported event before daemon import."""
+    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    conn = _make_connector(healthy=True)
+    conn.req_client = MagicMock(name="rpc_client")
+    conn.instance_id = 123
+    conn.device = "cpu"
+    conn._slot_mapping_to_block_ids = lambda kv_indices: [0, 1]  # type: ignore[method-assign,assignment]
+    conn._create_key = lambda *args, **kwargs: "fake-key"  # type: ignore[method-assign,assignment]
+
+    timeout_future = _TimeoutFuture()
+    raw = _FakeRaw(timeout_future)
+    monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
+    conn.req_client.store.return_value = raw
+
+    with pytest.raises(TimeoutError):
+        conn.store_kv(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
+
+    assert timeout_future.result_called is True
+    assert len(raw.retained_references) == 1
+    assert isinstance(raw.retained_references[0], _FakeEvent)
 
 
 def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
@@ -372,8 +432,9 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
 
     assert raw_future is raw
     assert future is sentinel
-    assert len(sentinel.retained_references) == 1
-    assert isinstance(sentinel.retained_references[0], _FakeEvent)
+    assert len(raw.retained_references) == 1
+    assert isinstance(raw.retained_references[0], _FakeEvent)
+    assert sentinel.retained_references == []
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/test_tensorrt_mp_adapter.py
+++ b/tests/v1/test_tensorrt_mp_adapter.py
@@ -69,12 +69,17 @@ def test_failed_retrieve_waits_for_device_result_and_fails_closed(
     worker._req_client = MagicMock(name="req_client")
     worker._mq_timeout = 5.0
     worker._instance_id = 42
+    worker._device = "cpu"
     worker._create_key = MagicMock(return_value=SimpleNamespace())
 
     event = MagicMock(name="event")
     event.ipc_handle.return_value = b"producer-event"
-    monkeypatch.setattr(module, "check_interprocess_event_support", MagicMock())
-    monkeypatch.setattr(module.torch_dev, "Event", MagicMock(return_value=event))
+    event_backend = MagicMock(name="event_backend")
+    event_backend.create_event.return_value = event
+    event_backend.export_event.side_effect = (
+        lambda exported_event, device: exported_event.ipc_handle()
+    )
+    worker._event_backend = event_backend
 
     device_future = MagicMock(name="device_future")
     device_future.result.return_value = False
@@ -85,5 +90,51 @@ def test_failed_retrieve_waits_for_device_result_and_fails_closed(
     with pytest.raises(RuntimeError, match="refusing to use unloaded KV blocks"):
         worker.start_load_kv(MagicMock(name="stream"))
 
-    raw_future.to_device_future.assert_called_once_with()
+    raw_future.to_device_future.assert_called_once_with(
+        device="cpu",
+        event_backend=event_backend,
+    )
+    raw_future.retain_reference.assert_called_once_with(event)
+    device_future.result.assert_called_once_with(timeout=5.0)
+
+
+def test_store_wait_retains_event_on_raw_future(
+    trt_mp_module,
+) -> None:
+    """A timed store keeps its exported event alive on the raw future."""
+    module = trt_mp_module
+    worker = module.LMCacheMPKvConnectorWorker.__new__(
+        module.LMCacheMPKvConnectorWorker
+    )
+    worker._metadata = module.LMCacheMPConnectorMetadata(
+        saves={7: module._BlockSpec(tokens=[1, 2], block_ids=[3])}
+    )
+    worker._req_client = MagicMock(name="req_client")
+    worker._mq_timeout = 5.0
+    worker._instance_id = 42
+    worker._device = "cpu"
+    worker._create_key = MagicMock(return_value=SimpleNamespace())
+
+    event = MagicMock(name="event")
+    event.ipc_handle.return_value = b"producer-event"
+    event_backend = MagicMock(name="event_backend")
+    event_backend.create_event.return_value = event
+    event_backend.export_event.side_effect = (
+        lambda exported_event, device: exported_event.ipc_handle()
+    )
+    worker._event_backend = event_backend
+
+    device_future = MagicMock(name="device_future")
+    device_future.result.return_value = True
+    raw_future = MagicMock(name="raw_future")
+    raw_future.to_device_future.return_value = device_future
+    worker._req_client.store.return_value = raw_future
+
+    worker.wait_for_save(MagicMock(name="stream"))
+
+    raw_future.to_device_future.assert_called_once_with(
+        device="cpu",
+        event_backend=event_backend,
+    )
+    raw_future.retain_reference.assert_called_once_with(event)
     device_future.result.assert_called_once_with(timeout=5.0)

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -437,6 +437,38 @@ def test_isolated_ipc_untouched_without_extra_config(
     assert is_isolated_ipc() is True
 
 
+def test_isolated_ipc_is_set_before_transfer_context_creation(
+    fake_adapter, restore_isolated_ipc, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backend selection sees isolated IPC before transfer registration."""
+    calls: list[tuple[str, bool]] = []
+    original_set_isolated_ipc = adapter_mod.set_isolated_ipc
+
+    def record_isolated_ipc(enabled: bool) -> None:
+        original_set_isolated_ipc(enabled)
+        calls.append(("set_isolated_ipc", is_isolated_ipc()))
+
+    transfer_ctx = MagicMock(name="transfer_ctx")
+
+    def create_context(
+        _kv_caches: dict[str, torch.Tensor], mode: str | None
+    ) -> MagicMock:
+        calls.append(("create_transfer_context", is_isolated_ipc()))
+        return transfer_ctx
+
+    monkeypatch.setattr(adapter_mod, "set_isolated_ipc", record_isolated_ipc)
+    monkeypatch.setattr(adapter_mod, "create_transfer_context", create_context)
+
+    adapter = _make_worker_adapter(extra_config={"lmcache.mp.isolated_ipc": True})
+    adapter.register_kv_caches({"layer.0": torch.zeros(1)})
+
+    assert calls == [
+        ("set_isolated_ipc", True),
+        ("create_transfer_context", True),
+    ]
+    transfer_ctx.register.assert_called_once()
+
+
 @pytest.fixture
 def restore_use_vmm_api():
     """Restore the process-global VMM-API switch after the test."""


### PR DESCRIPTION
## Summary
- Add platform-level event helpers for capability checks, creation, recording, waiting, importing, and exporting.
- Replace direct interprocess event construction in vLLM, SGLang, TensorRT-LLM, Blend, Blend V3, QStore, and benchmark paths.
- Keep producer event objects alive across asynchronous vLLM requests and update test doubles to use the platform boundary.

## Validation
- `pytest -q tests/v1/platform/test_event_ipc.py tests/v1/multiprocess/test_qstore.py tests/v1/test_sglang_mp_adapter.py tests/v1/test_tensorrt_mp_adapter.py`
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`

Result: 45 passed, 1 skipped; all non-Rust pre-commit hooks pass on macOS. Rust format/clippy were explicitly skipped because this is a non-Rust change and the repository guidance notes the macOS io-uring limitation.