### PR TITLE
feat: support path-style and plain-PUT S3-compatible endpoints

### DIFF
--- a/lmcache/v1/storage_backend/connector/s3_adapter.py
+++ b/lmcache/v1/storage_backend/connector/s3_adapter.py
@@ -36,6 +36,12 @@ class S3ConnectorAdapter(ConnectorAdapter):
         self.s3_region = str(self.s3_region)
         self.s3_enable_s3express = bool(extra_config.get("s3_enable_s3express", False))
         self.disable_tls = bool(extra_config.get("disable_tls", False))
+        # Addressing style ("virtual" | "path") and managed-upload toggle for
+        # S3-compatible (non-AWS) endpoints. Defaults preserve AWS S3 behavior.
+        self.s3_addressing_style = str(
+            extra_config.get("s3_addressing_style", "virtual")
+        )
+        self.s3_managed_upload = bool(extra_config.get("s3_managed_upload", True))
         self.aws_access_key_id = extra_config.get("aws_access_key_id", None)
         self.aws_secret_access_key = extra_config.get("aws_secret_access_key", None)
         if context.metadata is None:
@@ -56,4 +62,6 @@ class S3ConnectorAdapter(ConnectorAdapter):
             disable_tls=self.disable_tls,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
+            s3_addressing_style=self.s3_addressing_style,
+            s3_managed_upload=self.s3_managed_upload,
         )

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -82,6 +82,8 @@ class S3Connector(RemoteConnector):
         disable_tls: bool,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
+        s3_addressing_style: str = "virtual",
+        s3_managed_upload: bool = True,
     ):
         # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
@@ -92,6 +94,22 @@ class S3Connector(RemoteConnector):
         self.s3_part_size = self.full_chunk_size_bytes
 
         self.s3_endpoint = s3_endpoint.removeprefix("s3://")
+        # Addressing style. AWS S3 uses virtual-hosted style (the bucket is part
+        # of the endpoint host, e.g. ``bucket.s3.amazonaws.com``) so the request
+        # path carries only the object key. Many S3-compatible stores (MinIO /
+        # Ceph RGW in path-style, on-prem gateways, Alluxio) instead expect
+        # path-style requests: ``Host: host:port`` and ``/{bucket}/{key}``. When
+        # path-style is selected the bucket is split out of the endpoint here and
+        # re-added to the request path in ``_format_safe_path``; virtual-hosted
+        # (the default) preserves the previous behavior.
+        self.s3_addressing_style = s3_addressing_style
+        self.s3_managed_upload = s3_managed_upload
+        if self.s3_addressing_style == "path":
+            host, _, bucket = self.s3_endpoint.partition("/")
+            self.s3_endpoint = host
+            self.s3_bucket = bucket.strip("/")
+        else:
+            self.s3_bucket = ""
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
@@ -173,7 +191,11 @@ class S3Connector(RemoteConnector):
         any special characters.
         """
         flat_key_str = key_str.replace("/", "_")
-        return "/" + url_quote(flat_key_str)
+        path = "/" + url_quote(flat_key_str)
+        # Path-style endpoints require the bucket in the request path.
+        if self.s3_bucket:
+            path = "/" + self.s3_bucket + path
+        return path
 
     # TODO(Jiayi): optimize this with async
     def _get_object_size(self, key_str: str) -> int:
@@ -532,14 +554,30 @@ class S3Connector(RemoteConnector):
             if done["err"] or done["status"] not in (200, 201):
                 raise RuntimeError(f"Upload failed in S3Connector: {done}")
 
-        s3_req = s3.S3Request(
-            client=self.s3_client,
-            type=s3.S3RequestType.PUT_OBJECT,
-            request=req,
-            credential_provider=self.credentials_provider,
-            region=self.s3_region,
-            on_done=on_done,
-        )
+        # PUT_OBJECT uses awscrt's managed transfer (automatic multipart + trailing
+        # checksum). Many S3-compatible endpoints do not implement managed multipart
+        # uploads and answer such a request with ``501 Not Implemented``. When
+        # ``s3_managed_upload`` is disabled the object is sent as a single plain
+        # ``PutObject`` (DEFAULT request type) instead, which those endpoints accept.
+        if self.s3_managed_upload:
+            s3_req = s3.S3Request(
+                client=self.s3_client,
+                type=s3.S3RequestType.PUT_OBJECT,
+                request=req,
+                credential_provider=self.credentials_provider,
+                region=self.s3_region,
+                on_done=on_done,
+            )
+        else:
+            s3_req = s3.S3Request(
+                client=self.s3_client,
+                type=s3.S3RequestType.DEFAULT,
+                operation_name="PutObject",
+                request=req,
+                credential_provider=self.credentials_provider,
+                region=self.s3_region,
+                on_done=on_done,
+            )
         return s3_req
 
     async def _put(self, key: CacheEngineKey, memory_obj: MemoryObj):


### PR DESCRIPTION
## Motivation

`S3Connector` always issues **virtual-hosted-style** requests and uploads objects with `S3RequestType.PUT_OBJECT` (awscrt's *managed* transfer = automatic multipart + trailing checksum). Both assume AWS S3.

Many S3-compatible object stores reject these:
- a **managed multipart PUT** returns `501 Not Implemented`;
- a **virtual-hosted** request resolves to a bucket-less object path, so the store can't route it.

This affects MinIO / Ceph RGW in path-style mode, on-prem S3 gateways, and Alluxio's S3 endpoint. (The connector already has a `disable_tls` "for non-AWS services" toggle — this extends that support.)

## Changes

Two **opt-in** `extra_config` options, both defaulting to the current AWS behavior so existing deployments are unaffected:

| option | default | effect |
|---|---|---|
| `s3_addressing_style` | `"virtual"` | `"path"` → bucket is split out of the endpoint and placed in the request path (`/{bucket}/{key}`), `Host` set to `host:port` |
| `s3_managed_upload` | `true` | `false` → objects sent as a single plain `PutObject` (`DEFAULT` request type) instead of the managed multipart transfer |

Example config for a path-style, non-managed endpoint:
```yaml
remote_url: "s3://host:9000/my-bucket"
extra_config:
  s3_addressing_style: "path"
  s3_managed_upload: false
  disable_tls: true
  s3_region: "us-east-1"
```

## Backward compatibility

Defaults preserve the existing AWS S3 code path exactly. HEAD/GET already route through `_format_safe_path`, so they pick up path-style consistently with PUT.

## Testing

Validated end to end (store + read, byte-exact) against Alluxio's S3 endpoint with the config above. `ruff check`/`format` clean.