### PR TITLE
ci: gate ROCm wheel builds in PR full build

### DIFF
--- a/.github/workflows/pr_full_build.yml
+++ b/.github/workflows/pr_full_build.yml
@@ -1,9 +1,10 @@
 name: PR Full Build
 
-# Build all release artifacts (sdist + CUDA wheel, CLI wheel, cu129 wheel)
-# on PRs carrying the `full` label. The `full` label is added automatically
-# by automerge-labeler.yml when auto-merge is enabled on a code-change PR,
-# so this acts as a pre-merge sanity check that wheels still build.
+# Build all release artifacts (sdist + CUDA wheel, CLI wheel, cu129 wheel,
+# standard ROCm wheel, ROCm torch 2.10 wheel) on PRs carrying the `full` label.
+# The `full` label is added automatically by automerge-labeler.yml when
+# auto-merge is enabled on a code-change PR, so this acts as a pre-merge sanity
+# check that wheels still build.
 #
 # No tests, no code-quality checks, no publishing — those are covered by
 # test.yml / code_quality_checks.yml (per-PR) and publish.yml (on merge).
@@ -54,4 +55,16 @@ jobs:
         uses: ./.github/workflows/build_cu129_artifacts.yml
         # Fork PRs won't expose DOCKERHUB_TOKEN even with `inherit`; the login
         # step in build_cu129_artifacts.yml guards on the token being non-empty.
+        secrets: inherit
+
+    build-rocm:
+        name: Build ROCm
+        if: contains(github.event.pull_request.labels.*.name, 'full')
+        uses: ./.github/workflows/build_rocm_artifacts.yml
+        secrets: inherit
+
+    build-rocm-torch210:
+        name: Build ROCm torch 2.10
+        if: contains(github.event.pull_request.labels.*.name, 'full')
+        uses: ./.github/workflows/build_rocm_torch210_artifacts.yml
         secrets: inherit


### PR DESCRIPTION
## Summary

- add the standard ROCm wheel build to the PR Full Build workflow
- add the ROCm 7.2.4 / torch 2.10 wheel build to the same workflow
- keep both large container builds gated by the existing `full` label

## Why

This follows the review discussion on #4683. Both ROCm release variants are
published, but neither was exercised by the repository's opt-in PR full-build
gate. Adding both reusable workflows closes that coverage gap without running
the large builds unconditionally on every pull request.

## Validation

- `actionlint .github/workflows/pr_full_build.yml`
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`
- `git diff --check`
