### PR TITLE
fix(mp): complete pending futures on client close

### DIFF
--- a/lmcache/v1/multiprocess/futures.py
+++ b/lmcache/v1/multiprocess/futures.py
@@ -1,21 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from collections.abc import Callable
+from concurrent.futures import CancelledError
 from typing import Any, Generic, Optional, TypeVar, cast
 import threading
 
 # First Party
 from lmcache import torch_dev
-from lmcache.utils import lmcache_deprecate
+from lmcache.utils import init_logger, lmcache_deprecate
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
 from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
 
 T = TypeVar("T")
+logger = init_logger(__name__)
 
 
 class MessagingFuture(Generic[T]):
     def __init__(self) -> None:
         self.is_done_ = threading.Event()
         self.result_: T | None = None
+        self._exception: BaseException | None = None
+        self._completion_lock = threading.RLock()
+        self._done_callbacks: list[Callable[["MessagingFuture[T]"], None]] = []
         self._retained_references: list[object] = []
 
     def query(self) -> bool:
@@ -57,7 +63,10 @@ class MessagingFuture(Generic[T]):
         flag = self.wait(timeout)
         if not flag:
             raise LMCacheTimeoutError("Future result not available within timeout")
-        return cast(T, self.result_)
+        with self._completion_lock:
+            if self._exception is not None:
+                raise self._exception
+            return cast(T, self.result_)
 
     def set_result(self, result: T) -> None:
         """
@@ -68,8 +77,92 @@ class MessagingFuture(Generic[T]):
         Args:
             result (T): The result to set.
         """
-        self.result_ = result
-        self.is_done_.set()
+        callbacks: list[Callable[[MessagingFuture[T]], None]]
+        with self._completion_lock:
+            if self.is_done_.is_set():
+                return
+            self.result_ = result
+            self.is_done_.set()
+            callbacks = self._done_callbacks
+            self._done_callbacks = []
+        self._run_done_callbacks(callbacks)
+
+    def set_exception(self, exception: BaseException) -> None:
+        """Complete the future with ``exception``.
+
+        Args:
+            exception: Error raised by subsequent calls to :meth:`result`.
+        """
+        callbacks: list[Callable[[MessagingFuture[T]], None]]
+        with self._completion_lock:
+            if self.is_done_.is_set():
+                return
+            self._exception = exception
+            self.is_done_.set()
+            callbacks = self._done_callbacks
+            self._done_callbacks = []
+        self._run_done_callbacks(callbacks)
+
+    def cancel(self) -> bool:
+        """Cancel an unfinished future.
+
+        Returns:
+            True if this call cancelled the future, or False if it had already
+            reached a terminal state.
+        """
+        callbacks: list[Callable[[MessagingFuture[T]], None]]
+        with self._completion_lock:
+            if self.is_done_.is_set():
+                return False
+            self._exception = CancelledError("Message queue client closed")
+            self.is_done_.set()
+            callbacks = self._done_callbacks
+            self._done_callbacks = []
+        self._run_done_callbacks(callbacks)
+        return True
+
+    def cancelled(self) -> bool:
+        """Return whether this future completed through cancellation."""
+        with self._completion_lock:
+            return self.is_done_.is_set() and isinstance(
+                self._exception, CancelledError
+            )
+
+    def exception(self, timeout: Optional[float] = None) -> BaseException | None:
+        """Return the terminal exception, waiting up to ``timeout`` seconds.
+
+        Args:
+            timeout: Maximum time to wait, or None to wait indefinitely.
+
+        Returns:
+            The terminal exception, or None after successful completion.
+
+        Raises:
+            TimeoutError: If the future is not done within ``timeout``.
+        """
+        if not self.wait(timeout):
+            raise LMCacheTimeoutError("Future result not available within timeout")
+        with self._completion_lock:
+            return self._exception
+
+    def add_done_callback(
+        self,
+        callback: Callable[["MessagingFuture[T]"], None],
+    ) -> None:
+        """Invoke ``callback`` once this future reaches a terminal state.
+
+        The callback runs synchronously in the thread that completes the
+        future. If the future is already done, it runs before this method
+        returns.
+
+        Args:
+            callback: Callable receiving this future.
+        """
+        with self._completion_lock:
+            if not self.is_done_.is_set():
+                self._done_callbacks.append(callback)
+                return
+        self._run_done_callbacks([callback])
 
     def retain_reference(self, value: object) -> None:
         """Keep a resource alive for at least the lifetime of this future.
@@ -81,6 +174,17 @@ class MessagingFuture(Generic[T]):
             value: Resource whose lifetime must be tied to this future.
         """
         self._retained_references.append(value)
+
+    def _run_done_callbacks(
+        self,
+        callbacks: list[Callable[["MessagingFuture[T]"], None]],
+    ) -> None:
+        """Run terminal callbacks without holding the completion lock."""
+        for callback in callbacks:
+            try:
+                callback(self)
+            except Exception:
+                logger.exception("MessagingFuture done callback failed")
 
     def to_device_future(
         self,
@@ -143,17 +247,20 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         """
         Update the device event and result when the raw future is complete.
         """
-        if self._raw_response_processed:
-            return
+        with self._completion_lock:
+            if self._raw_response_processed or self.is_done_.is_set():
+                return
+            event_bytes, result = self.raw_future_.result()
+            self.result_ = result
+            self.event_ = (
+                self._event_backend.import_event(event_bytes, self.device_)
+                if event_bytes
+                else None
+            )
+            self._raw_response_processed = True
 
-        event_bytes, result = self.raw_future_.result()
-        event = None
-        if event_bytes:
-            event = self._event_backend.import_event(event_bytes, self.device_)
-
-        self.result_ = result
-        self.event_ = event
-        self._raw_response_processed = True
+        if self.event_ is None:
+            MessagingFuture.set_result(self, result)
 
     def wait(self, timeout: Optional[float] = None) -> bool:
         """
@@ -171,20 +278,33 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         Notes:
             This function does not support waiting for a specific time.
         """
-        if self._raw_response_processed:
-            if self.event_ is not None:
-                self._event_backend.synchronize_event(self.event_, self.device_)
+        if self.is_done_.is_set():
             return True
 
-        flag = self.raw_future_.wait(timeout)
-        if not flag:
-            return False
+        if not self._raw_response_processed:
+            flag = self.raw_future_.wait(timeout)
+            if not flag:
+                return False
 
-        self._on_raw_future_complete()
+            try:
+                self._on_raw_future_complete()
+            except BaseException as error:
+                MessagingFuture.set_exception(self, error)
+                return True
 
-        if self.event_ is not None:
+        if self.is_done_.is_set():
+            return True
+
+        if self.event_ is None:
+            MessagingFuture.set_result(self, cast(T, self.result_))
+            return True
+
+        try:
             self._event_backend.synchronize_event(self.event_, self.device_)
-
+        except BaseException as error:
+            MessagingFuture.set_exception(self, error)
+            return True
+        MessagingFuture.set_result(self, cast(T, self.result_))
         return True
 
     def result(self, timeout: Optional[float] = None) -> T:
@@ -209,8 +329,10 @@ class DeviceMessagingFuture(MessagingFuture[T]):
                 "DeviceMessagingFuture result not available within timeout"
             )
 
-        assert self.result_ is not None
-        return self.result_
+        with self._completion_lock:
+            if self._exception is not None:
+                raise self._exception
+            return cast(T, self.result_)
 
     def query(self) -> bool:
         """
@@ -219,16 +341,26 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         Returns:
             bool: True if the future is done, False otherwise.
         """
-        if self._raw_response_processed:
-            if self.event_ is None:
-                return True
-            return self._event_backend.query_event(self.event_)
+        if self.is_done_.is_set():
+            return True
 
-        if self.raw_future_.query():
-            self._on_raw_future_complete()
-            if self.event_ is None:
+        if not self._raw_response_processed and self.raw_future_.query():
+            try:
+                self._on_raw_future_complete()
+            except BaseException as error:
+                MessagingFuture.set_exception(self, error)
                 return True
-            return self._event_backend.query_event(self.event_)
+
+        if self.is_done_.is_set():
+            return True
+
+        if self._raw_response_processed and self.event_ is None:
+            MessagingFuture.set_result(self, cast(T, self.result_))
+            return True
+
+        if self.event_ is not None and self._event_backend.query_event(self.event_):
+            MessagingFuture.set_result(self, cast(T, self.result_))
+            return True
 
         return False
 
@@ -236,6 +368,11 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         raise NotImplementedError(
             "DeviceMessagingFuture does not support set_result directly"
         )
+
+    def cancel(self) -> bool:
+        """Cancel both the raw MQ request and this device-aware future."""
+        self.raw_future_.cancel()
+        return MessagingFuture.cancel(self)
 
     @staticmethod
     def FromMessagingFuture(

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -280,6 +280,9 @@ class MessageQueueClient:
         # Pending job's futures
         self._request_counter = itertools.count()
         self.pending_futures: dict[int, MessagingFuture[Any]] = {}
+        self._state_lock = threading.Lock()
+        self._closed = False
+        self._close_complete = threading.Event()
 
         # Register with the shared polling loop
         self._polling_loop = ClientPollingLoop.get_instance()
@@ -292,7 +295,11 @@ class MessageQueueClient:
 
                 # Update the pending futures
                 request_uid = wrapped_request.request_uid
-                self.pending_futures[request_uid] = wrapped_request.future
+                with self._state_lock:
+                    if self._closed:
+                        wrapped_request.future.cancel()
+                        continue
+                    self.pending_futures[request_uid] = wrapped_request.future
 
                 # Send the request
                 b_request_uid = msgspec_encode(request_uid, cls=RequestUID)
@@ -348,8 +355,9 @@ class MessageQueueClient:
         request_type = msgspec_decode(b_request_type, cls=RequestType)
         response_cls = get_response_class(request_type)
 
-        if request_uid in self.pending_futures:
-            future = self.pending_futures.pop(request_uid)
+        with self._state_lock:
+            future = self.pending_futures.pop(request_uid, None)
+        if future is not None:
             if b_response:
                 response = msgspec_decode(b_response[0], cls=response_cls)
                 future.set_result(response)
@@ -373,23 +381,61 @@ class MessageQueueClient:
         Returns:
             MessagingFuture[T]: A future that will hold the response.
         """
-        future: MessagingFuture[T] = MessagingFuture()
-        request_uid = next(self._request_counter)
-        self.input_queue.put(
-            MessageQueueClient.WrappedRequest(
-                request_uid=request_uid,
-                future=future,
-                request_type=request_type,
-                request_payloads=request_payloads,
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("Cannot submit a request on a closed MQ client")
+            future: MessagingFuture[T] = MessagingFuture()
+            request_uid = next(self._request_counter)
+            self.input_queue.put(
+                MessageQueueClient.WrappedRequest(
+                    request_uid=request_uid,
+                    future=future,
+                    request_type=request_type,
+                    request_payloads=request_payloads,
+                )
             )
-        )
         self._polling_loop.notify()
         return future
 
     def close(self) -> None:
-        self._polling_loop.unregister(self)
-        ClientPollingLoop.release_instance()
-        self.socket.close()
+        """Close the client and cancel every request without a response."""
+        with self._state_lock:
+            if self._closed:
+                wait_for_close = True
+            else:
+                wait_for_close = False
+                self._closed = True
+        if wait_for_close:
+            self._close_complete.wait()
+            return
+
+        try:
+            try:
+                self._polling_loop.unregister(self)
+            finally:
+                # unregister() is an acknowledgement from the polling thread: it
+                # can no longer move queued requests into pending_futures or
+                # dispatch a response for this client. Complete both sets before
+                # releasing the shared loop so callers never retain an unresolved
+                # future.
+                with self._state_lock:
+                    futures = list(self.pending_futures.values())
+                    self.pending_futures.clear()
+                    try:
+                        while True:
+                            futures.append(self.input_queue.get_nowait().future)
+                    except queue.Empty:
+                        pass
+                for future in futures:
+                    future.cancel()
+        finally:
+            try:
+                try:
+                    ClientPollingLoop.release_instance()
+                finally:
+                    self.socket.close()
+            finally:
+                self._close_complete.set()
 
 
 ResponseType = TypeVar("ResponseType", covariant=True)

--- a/tests/v1/multiprocess/test_futures.py
+++ b/tests/v1/multiprocess/test_futures.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from concurrent.futures import CancelledError
 import gc
 import multiprocessing as mp
 import threading
@@ -215,6 +216,32 @@ def test_messaging_future_retains_reference_for_its_lifetime() -> None:
     del future
     gc.collect()
     assert resource_ref() is None
+
+
+def test_messaging_future_callback_runs_once_on_completion() -> None:
+    """Terminal callbacks run for both pending and already-finished futures."""
+    future = MessagingFuture[int]()
+    callbacks: list[tuple[MessagingFuture[int], str]] = []
+
+    future.add_done_callback(lambda completed: callbacks.append((completed, "early")))
+    future.set_result(42)
+    future.set_result(99)
+    future.add_done_callback(lambda completed: callbacks.append((completed, "late")))
+
+    assert callbacks == [(future, "early"), (future, "late")]
+    assert future.result(timeout=0) == 42
+
+
+def test_messaging_future_cancel_is_terminal() -> None:
+    """Cancellation wakes waiters and produces a stable caller-visible error."""
+    future = MessagingFuture[int]()
+
+    assert future.cancel() is True
+    assert future.cancel() is False
+    assert future.query() is True
+    assert future.cancelled() is True
+    with pytest.raises(CancelledError, match="Message queue client closed"):
+        future.result(timeout=0)
 
 
 # ==============================================================================
@@ -709,6 +736,21 @@ def test_device_future_stub_end_to_end():
     assert fut.wait() is True
     assert fut.result() == 7
     assert fut.query() is True
+
+
+def test_device_future_propagates_raw_cancellation() -> None:
+    """Closing an MQ client is visible through its device-future wrapper."""
+    # First Party
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    raw = MessagingFuture[tuple[bytes, int]]()
+    future = DeviceMessagingFuture.FromMessagingFuture(raw, device="cpu")
+
+    assert raw.cancel() is True
+    assert future.wait(timeout=0) is True
+    assert future.cancelled() is True
+    with pytest.raises(CancelledError, match="Message queue client closed"):
+        future.result(timeout=0)
 
 
 def test_device_future_delegates_to_backend(monkeypatch):

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from concurrent.futures import CancelledError
 from multiprocessing.synchronize import Event as EventClass
 from typing import Any, Callable
 import multiprocessing as mp
@@ -18,6 +19,7 @@ from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     IPCCacheServerKey,
 )
+from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,
@@ -73,7 +75,7 @@ def _server_process(
     # First Party
     from lmcache.v1.multiprocess.protocol import HandlerType
 
-    context = zmq.Context.instance()
+    context: zmq.Context = zmq.Context.instance()
     server = MessageQueueServer(server_url, context)
 
     # Register all handlers
@@ -133,7 +135,7 @@ def _run_client_test(
     # Small delay to ensure server is fully initialized
     time.sleep(0.1)
 
-    context = zmq.Context.instance()
+    context: zmq.Context = zmq.Context.instance()
     client = MessageQueueClient(server_url, context)
     successful = True
 
@@ -617,7 +619,7 @@ def test_shared_loop_lifecycle():
     # First Party
     from lmcache.v1.multiprocess.mq import ClientPollingLoop
 
-    context = zmq.Context.instance()
+    context: zmq.Context = zmq.Context.instance()
 
     # No loop before any clients exist
     assert ClientPollingLoop._instance is None
@@ -709,6 +711,24 @@ def test_shared_loop_recreate():
     assert second_loop is not first_loop
     client2.close()
     assert ClientPollingLoop._instance is None
+
+
+def test_client_close_cancels_every_unanswered_future() -> None:
+    """Queued and sent requests both become terminal when their client closes."""
+    context: zmq.Context = zmq.Context.instance()
+    client = MessageQueueClient("inproc://unanswered-future-close-test", context)
+    futures: list[MessagingFuture[Any]] = [
+        client.submit_request(RequestType.NOOP, []) for _ in range(4)
+    ]
+
+    client.close()
+
+    for future in futures:
+        assert future.cancelled() is True
+        with pytest.raises(CancelledError, match="Message queue client closed"):
+            future.result(timeout=0)
+    with pytest.raises(RuntimeError, match="closed MQ client"):
+        client.submit_request(RequestType.NOOP, [])
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

- Make `MessagingFuture` completion idempotent and thread-safe.
- Add terminal exception, cancellation, and done-callback semantics.
- Propagate raw message-queue cancellation through `DeviceMessagingFuture`, while preserving device-event completion.
- Reject submissions after `MessageQueueClient.close()` starts.
- Cancel both queued and sent-but-unanswered requests when a client closes.
- Add focused future and message-queue lifecycle tests.

## Motivation

`MessageQueueClient.close()` currently leaves queued and pending futures unresolved. Callers retaining those futures can wait forever, and integrations cannot reliably release resources when an asynchronous operation reaches a terminal state.

This change provides a generic lifecycle contract for every multiprocess client. It is extracted from #4662 so the shared Future/MQ behavior can be reviewed independently from the ATOM integration.

This PR does not add registration-state probing or server fast-restart recovery.

## Validation

- All applicable pre-commit hooks passed: SPDX, import ordering, Ruff, formatting, codespell, and full-repository mypy.
- Python bytecode compilation passed.
- Full CI is running on this branch.