### PR TITLE
fix: invalidate stale S3 object-size cache on out-of-band deletion

### DIFF
--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -402,6 +402,11 @@ class S3Connector(RemoteConnector):
             if not is_connection_error:
                 # Log non-connection errors
                 logger.error("Failed to download %s from S3: %s", key_str, e)
+                # The object could not be fetched (e.g. deleted out-of-band by a
+                # lifecycle policy, a TTL, or another writer). Drop the stale
+                # size-cache entry so a later exists()/get() re-validates against
+                # the store instead of reporting a permanent false-positive hit.
+                self.object_size_cache.pop(key_str, None)
 
             memory_obj.ref_count_down()
             return None
@@ -420,6 +425,7 @@ class S3Connector(RemoteConnector):
         memory_objs: List[Optional[MemoryObj]] = []
         futures = []
         future_to_memobj_idx = []
+        future_to_key: List[str] = []
 
         for idx, key in enumerate(keys):
             key_str = key.to_string()
@@ -467,6 +473,7 @@ class S3Connector(RemoteConnector):
             fut = asyncio.wrap_future(s3_req.finished_future)
             futures.append(fut)
             future_to_memobj_idx.append(len(memory_objs) - 1)
+            future_to_key.append(key_str)
 
         # Use return_exceptions to prevent one failure from stopping all downloads
         results = await asyncio.gather(*futures, return_exceptions=True)
@@ -488,6 +495,10 @@ class S3Connector(RemoteConnector):
                         memobj_idx,
                         error_msg,
                     )
+                    # Object missing out-of-band: drop the stale size-cache entry
+                    # so a later exists()/get() re-validates instead of reporting
+                    # a permanent false-positive hit.
+                    self.object_size_cache.pop(future_to_key[future_idx], None)
                 # Release the memory object for failed download
                 memobj = memory_objs[memobj_idx]
                 if memobj is not None:


### PR DESCRIPTION
## Problem

`S3Connector` caches object sizes in `object_size_cache`, and `exists()` / `get()` trust it **without re-checking the store** — as the code notes, *"We assume S3 cache is never evicted and read-only for now."*

If an object is removed **out-of-band** (a bucket lifecycle rule, a TTL, another writer, or manual cleanup — anything LMCache doesn't control, since the connector never evicts its own objects), the cache entry is never cleared:

- `exists_sync()` keeps returning `True` from the stale entry:
  ```python
  if key_str in self.object_size_cache:
      return self.object_size_cache[key_str] > 0
  ```
- `get()` / `batched_get()` then keep failing the download (`404`) and returning `None` **without dropping the entry**.

So the key becomes a **permanent false-positive "hit" that never self-heals** — the scheduler repeatedly sees a hit it cannot retrieve for that key.

## Fix

Drop the stale `object_size_cache` entry when a (non-connection) download fails, in both `get()` and `batched_get()`. The next `exists()` / `get()` then re-validates against the store via `HEAD` and correctly reports a miss, leading to recompute / re-store.

Only object-level failures invalidate; connection errors are left to the existing circuit breaker (a network blip shouldn't evict a still-present object). A transient object-level error at worst costs one extra `HEAD` on the next access.

This mirrors what the **NIXL backend already does** — it discards its presence-cache entry on a failed transfer (`_cache_discard` in `storage_to_mem`), so it self-heals; the S3 connector was the one that didn't.

## Backward compatibility

No API or config change; behavior only differs on the failure path (a stale entry is now removed instead of retained). No effect when objects are not deleted out-of-band.

## Testing

`py_compile` + `ruff check` clean. Reproduced the stale-hit against a non-AWS S3 endpoint (Alluxio): store an object, delete it out-of-band, then observe `exists()` returning a permanent false positive before the fix and a correct miss after.