### PR TITLE
fix(cli): only fall back to chat when completions is unsupported

### DIFF
--- a/lmcache/cli/commands/query/_request.py
+++ b/lmcache/cli/commands/query/_request.py
@@ -4,12 +4,14 @@
 # Standard
 from typing import Any, Optional
 import json
+import re
 import sys
 import time
 import urllib.error
 import urllib.request
 
 _MAX_ERR = 65536
+_HTTP_STATUS_RE = re.compile(r"\bHTTP (\d{3})\b")
 MetricValue = tuple[str, Any]
 MetricMap = dict[str, MetricValue]
 _METRIC_NAMES = {
@@ -180,10 +182,14 @@ def _stream(
             t1 = time.time()
     except urllib.error.HTTPError as e:
         err_body = e.read().decode("utf-8", errors="replace")
-        _raise_json_blob_error(err_body)
-        raise RuntimeError(
-            _clip(f"POST {url} failed (HTTP {e.code}):\n{_clip(err_body)}")
-        ) from e
+        http_prefix = f"POST {url} failed (HTTP {e.code})"
+        try:
+            _raise_json_blob_error(err_body)
+        except RuntimeError as json_err:
+            # Keep the status in the message so fallback can tell 404/405
+            # from auth, rate-limit, and server errors.
+            raise RuntimeError(_clip(f"{http_prefix}: {json_err}")) from e
+        raise RuntimeError(_clip(f"{http_prefix}:\n{_clip(err_body)}")) from e
     except urllib.error.URLError as e:
         raise RuntimeError(f"POST {url} failed: {getattr(e, 'reason', e)}") from e
 
@@ -252,6 +258,24 @@ def _weak_completions_error(msg: str) -> bool:
     )
 
 
+def _http_status(exc: BaseException) -> Optional[int]:
+    """Return the HTTP status embedded in a request error, if any."""
+    match = _HTTP_STATUS_RE.search(str(exc))
+    return int(match.group(1)) if match else None
+
+
+def _should_fallback_to_chat(exc: BaseException) -> bool:
+    """True when ``/v1/completions`` is unsupported or returned no usable output.
+
+    Authentication, transport, rate-limit, and 5xx failures must not retry
+    ``/v1/chat/completions`` — those are real request errors, not a missing
+    completions endpoint.
+    """
+    if _http_status(exc) in (404, 405):
+        return True
+    return _weak_completions_error(str(exc))
+
+
 class Request:
     """Build and send one query request against an OpenAI-compatible endpoint."""
 
@@ -317,7 +341,14 @@ class Request:
         return str(first["id"])
 
     def _query_with_fallback(self, request_data: dict[str, Any]) -> dict[str, Any]:
-        """Send one query and fallback between completions/chat endpoints."""
+        """Send one query, falling back only when the first endpoint is unsupported.
+
+        Default order is ``/v1/completions`` then ``/v1/chat/completions``.
+        The chat fallback runs only when completions returned HTTP 404/405 or
+        produced no completion output. Authentication, transport, rate-limit,
+        and server errors are raised immediately. ``chat_first`` still falls
+        back to completions only when the chat API reports a missing template.
+        """
         if request_data["completions_only"]:
             return self._query(request_data, chat=False)
         try:
@@ -330,6 +361,8 @@ class Request:
                     "chat API failed (no chat template); retrying with /v1/completions"
                 )
                 return self._query(request_data, chat=False)
+            if not _should_fallback_to_chat(first_err):
+                raise
             _info("/v1/completions failed; retrying with /v1/chat/completions")
             try:
                 return self._query(request_data, chat=True)

--- a/tests/cli/commands/test_query_request.py
+++ b/tests/cli/commands/test_query_request.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache query engine`` HTTP fallback behavior."""
+
+# Standard
+from email.message import Message
+from io import BytesIO
+from typing import Any
+from unittest.mock import patch
+import json
+import urllib.error
+import urllib.request
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.query._request import Request
+
+
+def _sse_lines(text: str, *, chat: bool) -> list[bytes]:
+    payload = (
+        {"choices": [{"delta": {"content": text}}]}
+        if chat
+        else {"choices": [{"text": text}]}
+    )
+    usage = {"usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+    return [
+        f"data: {json.dumps(payload)}\n".encode(),
+        f"data: {json.dumps(usage)}\n".encode(),
+        b"data: [DONE]\n",
+    ]
+
+
+class _FakeResponse:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def readline(self) -> bytes:
+        return self._lines.pop(0) if self._lines else b""
+
+    def read(self) -> bytes:
+        return b"".join(self._lines)
+
+
+def _http_error(url: str, code: int, body: bytes) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, code, "error", Message(), BytesIO(body))
+
+
+def _is_completions(url: str) -> bool:
+    return url.rstrip("/").endswith("/completions") and "/chat/completions" not in url
+
+
+def _is_chat(url: str) -> bool:
+    return "/chat/completions" in url
+
+
+def _request() -> Request:
+    return Request(
+        "http://engine:8000/v1",
+        "test-model",
+        max_tokens=8,
+        timeout=5.0,
+    )
+
+
+def _patch_urlopen(side_effect: Any) -> Any:
+    return patch(
+        "lmcache.cli.commands.query._request.urllib.request.urlopen",
+        side_effect=side_effect,
+    )
+
+
+class TestQueryEngineCompletionsFallback:
+    def test_http_404_falls_back_to_chat(self) -> None:
+        calls: list[str] = []
+
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            url = req.full_url
+            calls.append(url)
+            if _is_completions(url):
+                raise _http_error(url, 404, b"Not Found")
+            assert _is_chat(url)
+            return _FakeResponse(_sse_lines("from-chat", chat=True))
+
+        with _patch_urlopen(fake_urlopen):
+            answer, _metrics = _request().send_request("hello")
+
+        assert answer == "from-chat"
+        assert any(_is_completions(url) for url in calls)
+        assert any(_is_chat(url) for url in calls)
+
+    def test_http_405_falls_back_to_chat(self) -> None:
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            url = req.full_url
+            if _is_completions(url):
+                raise _http_error(url, 405, b"Method Not Allowed")
+            return _FakeResponse(_sse_lines("ok", chat=True))
+
+        with _patch_urlopen(fake_urlopen):
+            answer, _metrics = _request().send_request("hello")
+        assert answer == "ok"
+
+    def test_empty_completions_response_falls_back_to_chat(self) -> None:
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            url = req.full_url
+            if _is_completions(url):
+                return _FakeResponse([b"data: [DONE]\n"])
+            return _FakeResponse(_sse_lines("recovered", chat=True))
+
+        with _patch_urlopen(fake_urlopen):
+            answer, _metrics = _request().send_request("hello")
+        assert answer == "recovered"
+
+    def test_json_404_body_still_falls_back_to_chat(self) -> None:
+        """OpenAI-style 404 JSON must still be treated as unsupported, not a
+        generic API error, so the chat endpoint is tried."""
+        body = json.dumps({"error": {"message": "Not Found", "code": "not_found"}})
+
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            url = req.full_url
+            if _is_completions(url):
+                raise _http_error(url, 404, body.encode())
+            return _FakeResponse(_sse_lines("from-chat", chat=True))
+
+        with _patch_urlopen(fake_urlopen):
+            answer, _metrics = _request().send_request("hello")
+        assert answer == "from-chat"
+
+    @pytest.mark.parametrize("code", [401, 429, 500])
+    def test_non_compatibility_http_errors_do_not_retry_chat(self, code: int) -> None:
+        calls: list[str] = []
+
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            url = req.full_url
+            calls.append(url)
+            raise _http_error(url, code, b'{"error":{"message":"nope"}}')
+
+        with _patch_urlopen(fake_urlopen), pytest.raises(RuntimeError, match="HTTP"):
+            _request().send_request("hello")
+
+        assert calls
+        assert all(_is_completions(url) for url in calls)
+        assert not any(_is_chat(url) for url in calls)
+
+    def test_timeout_does_not_retry_chat(self) -> None:
+        calls: list[str] = []
+
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            calls.append(req.full_url)
+            raise urllib.error.URLError("timed out")
+
+        with (
+            _patch_urlopen(fake_urlopen),
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            _request().send_request("hello")
+
+        assert calls == ["http://engine:8000/v1/completions"]
+
+    def test_completions_only_never_retries_chat(self) -> None:
+        calls: list[str] = []
+
+        def fake_urlopen(req: urllib.request.Request, timeout: float = 0) -> Any:
+            calls.append(req.full_url)
+            raise _http_error(req.full_url, 404, b"Not Found")
+
+        req = Request(
+            "http://engine:8000/v1",
+            "test-model",
+            max_tokens=8,
+            timeout=5.0,
+            completions_only=True,
+        )
+        with (
+            _patch_urlopen(fake_urlopen),
+            pytest.raises(RuntimeError, match="HTTP 404"),
+        ):
+            req.send_request("hello")
+
+        assert calls == ["http://engine:8000/v1/completions"]

--- a/tests/cli/commands/test_query_request.py
+++ b/tests/cli/commands/test_query_request.py
@@ -18,12 +18,9 @@ from lmcache.cli.commands.query._request import Request
 
 
 def _sse_lines(text: str, *, chat: bool) -> list[bytes]:
-    payload = (
-        {"choices": [{"delta": {"content": text}}]}
-        if chat
-        else {"choices": [{"text": text}]}
-    )
-    usage = {"usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+    choice: dict[str, Any] = {"delta": {"content": text}} if chat else {"text": text}
+    payload: dict[str, Any] = {"choices": [choice]}
+    usage: dict[str, Any] = {"usage": {"prompt_tokens": 1, "completion_tokens": 1}}
     return [
         f"data: {json.dumps(payload)}\n".encode(),
         f"data: {json.dumps(usage)}\n".encode(),


### PR DESCRIPTION
## What this PR does / why we need it

`lmcache query engine` treated every `RuntimeError` from `POST /v1/completions` as a reason to retry `/v1/chat/completions`. Authentication failures, 5xx responses, and timeouts therefore issued a second request and could duplicate work on a stream that had already started.

Fallback to chat now happens only when completions is actually unsupported:

- HTTP 404 / 405
- empty completion / no SSE output

401, 429, 500, and transport errors are raised immediately. `--completions` still never retries chat. `--chat-first` is unchanged (still falls back only on a missing chat template).

HTTP error messages now keep the status code even when the body is an OpenAI-style JSON error, so a 404 JSON payload is not mistaken for a generic API failure.

Fixes #4646

## Special notes for your reviewers

JSON 404 bodies previously lost the HTTP status after `_raise_json_blob_error`. The status is now prefixed onto that `RuntimeError` so the fallback predicate can distinguish `Not Found` from auth/server errors.

## If applicable

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Made with [Cursor](https://cursor.com)