### PR TITLE
fix(disk): roll back in-flight put markers on admission failure

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -88,6 +88,19 @@ class LocalDiskWorker:
         with self.put_lock:
             self.put_tasks.append(key)
 
+    def try_insert_put_task(self, key: CacheEngineKey) -> bool:
+        """Register ``key`` as in-flight if it is not already registered.
+
+        Returns:
+            True if this caller now owns the in-flight slot. False if another
+            put for the same key is already in progress.
+        """
+        with self.put_lock:
+            if key in self.put_tasks:
+                return False
+            self.put_tasks.append(key)
+            return True
+
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
         with self.put_lock:
             return key in self.put_tasks
@@ -331,40 +344,57 @@ class LocalDiskBackend(StorageBackendInterface):
         """
         assert memory_obj.tensor is not None
 
-        # skip repeated save
-        if self.exists_in_put_tasks(key):
+        # TODO(Jiayi): Fragmentation is not considered here.
+        required_size = memory_obj.get_physical_size()
+
+        # skip repeated save — claim the in-flight slot atomically so two
+        # concurrent puts for the same key cannot both schedule work.
+        if not self.disk_worker.try_insert_put_task(key):
             logger.debug("Put task for %s is already in progress.", key)
             return None
 
-        self.disk_worker.insert_put_task(key)
-
-        # TODO(Jiayi): Fragmentation is not considered here.
-        required_size = memory_obj.get_physical_size()
         all_evict_keys = []
         evict_success = True
         with self.disk_lock:
-            while self.current_cache_size + required_size > self.max_cache_size:
-                evict_keys = self.cache_policy.get_evict_candidates(
-                    self.dict, num_candidates=1
+            deficit = self.current_cache_size + required_size - self.max_cache_size
+            if deficit > 0:
+                # Count evictable bytes first. Do not call get_evict_candidates()
+                # speculatively: LFU mutates policy state when candidates are
+                # selected, and a request that cannot fit must not delete valid
+                # resident entries before failing.
+                evictable_bytes = sum(
+                    meta.size for meta in self.dict.values() if meta.can_evict
                 )
-                if not evict_keys:
+                if evictable_bytes < deficit:
                     logger.warning(
                         "No eviction candidates found. Disk space under pressure."
                     )
                     evict_success = False
-                    break
+                else:
+                    while self.current_cache_size + required_size > self.max_cache_size:
+                        evict_keys = self.cache_policy.get_evict_candidates(
+                            self.dict, num_candidates=1
+                        )
+                        if not evict_keys:
+                            logger.warning(
+                                "No eviction candidates found. "
+                                "Disk space under pressure."
+                            )
+                            evict_success = False
+                            break
 
-                for evict_key in evict_keys:
-                    self.current_cache_size -= self.dict[evict_key].size
+                        for evict_key in evict_keys:
+                            self.current_cache_size -= self.dict[evict_key].size
 
-                self.batched_remove(evict_keys, force=False)
+                        self.batched_remove(evict_keys, force=False)
 
-                all_evict_keys.extend(evict_keys)
+                        all_evict_keys.extend(evict_keys)
             if evict_success:
                 self.current_cache_size += required_size
                 self.cache_policy.update_on_put(key)
 
         if not evict_success:
+            self.disk_worker.remove_put_task(key)
             return None
 
         memory_obj.ref_count_up()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -610,3 +610,129 @@ class TestBatchedGetBlocking:
         results = local_disk_backend.batched_get_blocking([])
         assert results == []
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+def _fake_memory_obj(size: int) -> MagicMock:
+    memory_obj = MagicMock(spec=MemoryObj)
+    memory_obj.tensor = torch.tensor([1.0])
+    memory_obj.get_physical_size.return_value = size
+    return memory_obj
+
+
+def _inject_resident(
+    backend: LocalDiskBackend,
+    key: CacheEngineKey,
+    size: int,
+    *,
+    pin: bool = False,
+) -> None:
+    meta = DiskCacheMetadata(
+        path="/nonexistent/disk-admission.pt",
+        size=size,
+        shape=torch.Size([1]),
+        dtype=torch.float32,
+        cached_positions=None,
+        fmt=MemoryFormat.KV_2LTD,
+        pin_count=1 if pin else 0,
+    )
+    with backend.disk_lock:
+        backend.dict[key] = meta
+        backend.current_cache_size += size
+        backend.cache_policy.update_on_put(key)
+
+
+class TestDiskPutAdmission:
+    """Rollback-safe disk put admission (issue #4659)."""
+
+    def test_rejected_put_can_be_retried(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A rejected put must not stay in put_tasks, so a later retry proceeds."""
+        backend = local_disk_backend
+        backend.max_cache_size = 100
+        resident = create_test_key(401)
+        retry_key = create_test_key(402)
+        _inject_resident(backend, resident, 100, pin=True)
+
+        backend.submit_put_task(retry_key, _fake_memory_obj(40))
+
+        assert not backend.exists_in_put_tasks(retry_key)
+        assert resident in backend.dict
+
+        with backend.disk_lock:
+            backend.dict.pop(resident)
+            backend.current_cache_size = 0
+
+        with patch(
+            "lmcache.v1.storage_backend.local_disk_backend.asyncio.run_coroutine_threadsafe"
+        ):
+            backend.submit_put_task(retry_key, _fake_memory_obj(40))
+
+        assert backend.exists_in_put_tasks(retry_key)
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_insufficient_capacity_does_not_evict(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Failing admission must not delete valid resident entries."""
+        backend = local_disk_backend
+        backend.max_cache_size = 100
+        key_a = create_test_key(411)
+        key_b = create_test_key(412)
+        key_new = create_test_key(413)
+        _inject_resident(backend, key_a, 50)
+        _inject_resident(backend, key_b, 50)
+
+        with patch.object(backend.cache_policy, "get_evict_candidates") as mock_evict:
+            backend.submit_put_task(key_new, _fake_memory_obj(120))
+            mock_evict.assert_not_called()
+
+        assert key_a in backend.dict
+        assert key_b in backend.dict
+        assert not backend.exists_in_put_tasks(key_new)
+        assert backend.current_cache_size == 100
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_oversized_object_fails_before_eviction(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A chunk larger than the full budget is rejected without eviction."""
+        backend = local_disk_backend
+        backend.max_cache_size = 100
+        resident = create_test_key(421)
+        oversized = create_test_key(422)
+        _inject_resident(backend, resident, 80)
+
+        with patch.object(backend.cache_policy, "get_evict_candidates") as mock_evict:
+            backend.submit_put_task(oversized, _fake_memory_obj(120))
+            mock_evict.assert_not_called()
+
+        assert resident in backend.dict
+        assert not backend.exists_in_put_tasks(oversized)
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_concurrent_duplicate_registration(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Only one concurrent submit_put_task for the same key is admitted."""
+        backend = local_disk_backend
+        backend.max_cache_size = 100
+        key = create_test_key(431)
+        barrier = threading.Barrier(2)
+
+        def worker() -> None:
+            barrier.wait()
+            backend.submit_put_task(key, _fake_memory_obj(10))
+
+        with patch(
+            "lmcache.v1.storage_backend.local_disk_backend.asyncio.run_coroutine_threadsafe"
+        ) as mock_coro:
+            threads = [threading.Thread(target=worker) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert mock_coro.call_count == 1
+        assert backend.exists_in_put_tasks(key)
+        backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## What this PR does / why we need it

`LocalDiskBackend.submit_put_task()` registered a key in `put_tasks` before disk-capacity admission succeeded. If admission then failed, the marker was left behind, so a later retry of the same key was skipped forever. The eviction loop also deleted resident entries incrementally before it knew the new object could fit, so a too-large put could wipe valid cache and still fail.

This change:

- claims the in-flight slot with atomic `try_insert_put_task()`
- counts currently evictable bytes under `disk_lock` before calling `get_evict_candidates()` (LFU mutates policy state on selection)
- rejects without eviction when evictable bytes cannot cover the deficit, including objects larger than the full disk budget
- removes the in-flight marker on every pre-submit admission failure

Fixes #4659

## Special notes for your reviewers

Related but independent of #4655 (resident-key double-count) and #4546 (usage not decremented on external removal).

## If applicable

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Made with [Cursor](https://cursor.com)