### PR TITLE
fix(cli): handle coordinator query timeouts

### DIFF
--- a/lmcache/cli/commands/query/_coordinator.py
+++ b/lmcache/cli/commands/query/_coordinator.py
@@ -65,6 +65,9 @@ def _fetch(url: str, timeout: int = _TIMEOUT) -> str:
             pass
         logger.error("Coordinator returned %s: %s", e.code, detail)
         sys.exit(1)
+    except TimeoutError as e:
+        logger.error("Timed out contacting %s after %ds (%s)", url, timeout, e)
+        sys.exit(1)
     except urllib.error.URLError as e:
         logger.error(
             "Cannot reach %s -- is the coordinator running? (%s)", url, e.reason

--- a/tests/v1/cli/test_query_coordinator.py
+++ b/tests/v1/cli/test_query_coordinator.py
@@ -14,7 +14,7 @@ import argparse
 import pytest
 
 # First Party
-from lmcache.cli.commands.query._coordinator import APIS, normalize_url
+from lmcache.cli.commands.query._coordinator import APIS, get_text, normalize_url
 from lmcache.cli.commands.query.coordinator_command import CoordinatorQueryCommand
 from lmcache.cli.metrics import Metrics, get_formatter
 from lmcache.cli.metrics.section import sections_to_dict
@@ -286,3 +286,33 @@ class TestRequiredArguments:
 
     def test_metrics_is_the_only_non_json_api(self) -> None:
         assert {name for name, api in APIS.items() if api.raw} == {"metrics"}
+
+
+class TestFetchErrors:
+    def test_timeout_exits_without_traceback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A coordinator timeout is reported as a normal CLI failure."""
+        errors: list[tuple[object, ...]] = []
+
+        def raise_timeout(_url: str, timeout: int) -> None:
+            raise TimeoutError(f"timed out after {timeout}s")
+
+        monkeypatch.setattr(
+            "lmcache.cli.commands.query._coordinator.urllib.request.urlopen",
+            raise_timeout,
+        )
+        monkeypatch.setattr(
+            "lmcache.cli.commands.query._coordinator.logger.error",
+            lambda *args: errors.append(args),
+        )
+
+        with pytest.raises(SystemExit, match="1"):
+            get_text("http://127.0.0.1:9300/health")
+
+        assert errors[0][:3] == (
+            "Timed out contacting %s after %ds (%s)",
+            "http://127.0.0.1:9300/health",
+            10,
+        )
+        assert str(errors[0][3]) == "timed out after 10s"


### PR DESCRIPTION
## Summary

- handle bare `TimeoutError` exceptions raised by `urllib.request.urlopen`
- report coordinator timeouts as normal CLI errors instead of leaking a traceback
- include the target URL and configured timeout in the error message
- add a regression test covering the public `get_text()` path

## Why

`lmcache query coordinator` promises to turn connection failures into a concise CLI error. Python's `urlopen()` can raise `TimeoutError` directly (including `socket.timeout`), but `_fetch()` only handled `HTTPError` and `URLError`, so a slow coordinator produced an uncaught traceback.

## Validation

- `NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `.venv/bin/pytest -xvs tests/v1/cli` — 22 passed
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files` — passed
- `.venv/bin/python -m py_compile lmcache/cli/commands/query/_coordinator.py tests/v1/cli/test_query_coordinator.py`
