### PR TITLE
fix(serde): support fused KV layout in TurboQuant

### DIFF
--- a/lmcache/v1/distributed/serde/turboquant/turboquant.py
+++ b/lmcache/v1/distributed/serde/turboquant/turboquant.py
@@ -11,7 +11,13 @@ Supported presets:
 - turboquant_k3v4_nc
 - turboquant_3bit_nc
 
-Input KV layout: [2, num_layers, num_tokens, hidden_dim]
+Input KV layout: [kv_size, num_layers, num_tokens, hidden_dim]
+
+* ``kv_size == 2``: split K/V layout, ``hidden_dim = num_heads * head_dim``.
+* ``kv_size == 1``: fused blocks-first K/V layout (vLLM >= 0.26 attention
+  backends), ``hidden_dim = num_heads * 2 * head_dim`` with the per-head
+  ``[K | V]`` pair packed in the trailing dimension.
+
 Serialized layout: [num_layers, num_blocks, block_size, num_heads, slot_size]
 """
 
@@ -163,20 +169,31 @@ def _validate_layout_shape(
 ) -> tuple[int, int, int, int]:
     """Validate LMCache KV layout and return L, T, H, D.
 
-    Expected input shape:
-        [2, num_layers, num_tokens, hidden_dim]
+    Accepted input shapes:
+
+    * Split K/V: ``[2, num_layers, num_tokens, num_heads * head_dim]``
+    * Fused K/V (vLLM >= 0.26 attention backends): ``[1, num_layers,
+      num_tokens, num_heads * 2 * head_dim]`` with the per-head ``[K | V]``
+      pair packed in the trailing dimension.
 
     Returns:
         num_layers, num_tokens, num_heads, head_dim
+
+    Raises:
+        ValueError: If the tensor is not 4D, if the first dimension is not
+            1 (fused) or 2 (split K/V), or if the hidden dimension is not
+            divisible by the expected per-head size.
     """
     if len(shape) != 4:
         raise ValueError(
             "TurboQuant serde expects 4D KV tensor "
-            f"[2, L, T, hidden_dim], got {tuple(shape)}"
+            f"[kv_size, L, T, hidden_dim], got {tuple(shape)}"
         )
-    if int(shape[0]) != 2:
+    kv_size = int(shape[0])
+    if kv_size not in (1, 2):
         raise ValueError(
-            f"TurboQuant serde expects first dim kv_size=2, got {int(shape[0])}"
+            "TurboQuant serde expects first dim kv_size 1 (fused K/V) "
+            f"or 2 (split K/V), got {kv_size}"
         )
 
     num_layers = int(shape[1])
@@ -184,12 +201,16 @@ def _validate_layout_shape(
     hidden_dim = int(shape[3])
     head_dim = cfg.head_dim
 
-    if hidden_dim % head_dim != 0:
+    # Fused K/V packs the per-head [K | V] pair in the trailing dimension,
+    # so the per-head element count is 2 * head_dim instead of head_dim.
+    per_head = 2 * head_dim if kv_size == 1 else head_dim
+    if hidden_dim % per_head != 0:
         raise ValueError(
-            f"hidden_dim={hidden_dim} must be divisible by head_dim={head_dim}"
+            f"hidden_dim={hidden_dim} must be divisible by "
+            f"per_head={per_head} (kv_size={kv_size}, head_dim={head_dim})"
         )
 
-    num_heads = hidden_dim // head_dim
+    num_heads = hidden_dim // per_head
     return num_layers, num_tokens, num_heads, head_dim
 
 
@@ -205,9 +226,9 @@ def _raw_group_nbytes(
     dtype: torch.dtype,
     num_layers: int,
 ) -> int:
-    _, _, num_tokens, hidden_dim = shape
+    kv_size, _, num_tokens, hidden_dim = shape
     return (
-        2
+        kv_size
         * num_layers
         * int(num_tokens)
         * int(hidden_dim)
@@ -532,7 +553,8 @@ class TurboQuantSerializer(Serializer):
 
         Args:
             src: Source memory object containing a KV tensor with shape
-                ``[2, num_layers, num_tokens, hidden_dim]``.
+                ``[kv_size, num_layers, num_tokens, hidden_dim]`` where
+                ``kv_size`` is 2 (split K/V) or 1 (fused K/V).
             dst: Destination memory object containing a ``torch.uint8`` tensor
                 used as the serialized byte buffer.
             key: Object key for this pair (unused: TurboQuant is
@@ -598,6 +620,7 @@ class TurboQuantSerializer(Serializer):
         num_layers, num_tokens, num_heads, head_dim = _validate_layout_shape(
             src_work.shape, cfg
         )
+        kv_size = int(src_work.shape[0])
         quant_start, quant_end = _layer_ranges(num_layers, cfg)
         quant_layers = quant_end - quant_start
         dst_flat = dst_work.flatten()[:n_bytes]
@@ -624,19 +647,28 @@ class TurboQuantSerializer(Serializer):
             )
             slot_mapping = _make_slot_mapping(num_tokens, cuda_device)
 
-            # LMCache layout: [2, L, T, hidden_dim]
+            # LMCache layout: [kv_size, L, T, hidden_dim]
             # Kernel input layout per layer: key/value [T, H, D]
             for compressed_idx, layer_idx in enumerate(range(quant_start, quant_end)):
-                k_tensor = (
-                    src_work[0, layer_idx]
-                    .view(num_tokens, num_heads, head_dim)
-                    .contiguous()
-                )
-                value = (
-                    src_work[1, layer_idx]
-                    .view(num_tokens, num_heads, head_dim)
-                    .contiguous()
-                )
+                if kv_size == 1:
+                    # Fused K/V: per-head [K | V] packed in the trailing
+                    # dimension, split here so K and V use their own quantizer.
+                    layer = src_work[0, layer_idx].view(
+                        num_tokens, num_heads, 2 * head_dim
+                    )
+                    k_tensor = layer[..., :head_dim].contiguous()
+                    value = layer[..., head_dim:].contiguous()
+                else:
+                    k_tensor = (
+                        src_work[0, layer_idx]
+                        .view(num_tokens, num_heads, head_dim)
+                        .contiguous()
+                    )
+                    value = (
+                        src_work[1, layer_idx]
+                        .view(num_tokens, num_heads, head_dim)
+                        .contiguous()
+                    )
                 pi_t, midpoints, _ = _make_tq_tensors_for_layer(
                     cfg, layer_idx, cuda_device
                 )
@@ -683,7 +715,8 @@ class TurboQuantDeserializer(Deserializer):
             src: Source memory object containing the serialized TurboQuant
                 byte buffer as a ``torch.uint8`` tensor.
             dst: Destination memory object containing the reconstructed KV
-                tensor with shape ``[2, num_layers, num_tokens, hidden_dim]``.
+                tensor with shape ``[kv_size, num_layers, num_tokens,
+                hidden_dim]`` matching the original (split or fused) layout.
             key: Object key for this pair (unused: TurboQuant is
                 content-agnostic).
 
@@ -749,7 +782,8 @@ class TurboQuantDeserializer(Deserializer):
         num_layers, num_tokens, num_heads, head_dim = _validate_layout_shape(
             dst_work.shape, cfg
         )
-        hidden_dim = num_heads * head_dim
+        kv_size = int(dst_work.shape[0])
+        hidden_dim = int(dst_work.shape[3])
         quant_start, quant_end = _layer_ranges(num_layers, cfg)
         quant_layers = quant_end - quant_start
         src_flat = src_work.flatten()[:n_bytes]
@@ -758,7 +792,7 @@ class TurboQuantDeserializer(Deserializer):
         first_raw_bytes = _raw_group_nbytes(dst_work.shape, dst_work.dtype, quant_start)
         if first_raw_bytes:
             raw = torch.empty(
-                (2, quant_start, num_tokens, hidden_dim),
+                (kv_size, quant_start, num_tokens, hidden_dim),
                 dtype=dst_work.dtype,
                 device=cuda_device,
             )
@@ -840,15 +874,33 @@ class TurboQuantDeserializer(Deserializer):
                     k_layer = torch.matmul(
                         k_layer.to(torch.float32), pi_t.T.contiguous()
                     ).to(k_out.dtype)
-                k_tensor = k_layer.contiguous().view(num_tokens, hidden_dim)
+                k_tensor = k_layer.contiguous().view(num_tokens, num_heads, head_dim)
                 value = (
                     v_out[0, :, :num_tokens, :]
                     .transpose(0, 1)
                     .contiguous()
-                    .view(num_tokens, hidden_dim)
+                    .view(num_tokens, num_heads, head_dim)
                 )
-                dst_work[0, layer_idx].copy_(k_tensor.to(dst_work.dtype))
-                dst_work[1, layer_idx].copy_(value.to(dst_work.dtype))
+                if kv_size == 2:
+                    dst_work[0, layer_idx].copy_(
+                        k_tensor.reshape(num_tokens, hidden_dim).to(dst_work.dtype)
+                    )
+                    dst_work[1, layer_idx].copy_(
+                        value.reshape(num_tokens, hidden_dim).to(dst_work.dtype)
+                    )
+                else:
+                    # Re-pack the per-head [K | V] pair to restore the
+                    # original fused layout exactly.
+                    fused_layer = torch.empty(
+                        (num_tokens, num_heads, 2 * head_dim),
+                        dtype=dst_work.dtype,
+                        device=cuda_device,
+                    )
+                    fused_layer[..., :head_dim].copy_(k_tensor.to(dst_work.dtype))
+                    fused_layer[..., head_dim:].copy_(value.to(dst_work.dtype))
+                    dst_work[0, layer_idx].copy_(
+                        fused_layer.reshape(num_tokens, hidden_dim)
+                    )
             offset += compressed_bytes
 
         last_raw_layers = num_layers - quant_end
@@ -857,7 +909,7 @@ class TurboQuantDeserializer(Deserializer):
                 dst_work.shape, dst_work.dtype, last_raw_layers
             )
             raw = torch.empty(
-                (2, last_raw_layers, num_tokens, hidden_dim),
+                (kv_size, last_raw_layers, num_tokens, hidden_dim),
                 dtype=dst_work.dtype,
                 device=cuda_device,
             )

--- a/tests/v1/distributed/serde/test_turboquant.py
+++ b/tests/v1/distributed/serde/test_turboquant.py
@@ -156,11 +156,11 @@ def test_estimate_serialized_size_rejects_invalid_kv_size() -> None:
     serializer = TurboQuantSerializer(cfg)
 
     layout = MemoryLayoutDesc(
-        shapes=[torch.Size([1, 3, 20, 512])],
+        shapes=[torch.Size([3, 3, 20, 512])],
         dtypes=[torch.bfloat16],
     )
 
-    with pytest.raises(ValueError, match="kv_size=2"):
+    with pytest.raises(ValueError, match="kv_size 1 \\(fused K/V\\) or 2"):
         serializer.estimate_serialized_size(layout)
 
 

--- a/tests/v1/distributed/serde/test_turboquant_fused_layout.py
+++ b/tests/v1/distributed/serde/test_turboquant_fused_layout.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for TurboQuant serde with fused blocks-first K/V layout.
+
+vLLM >= 0.26 attention backends produce fused KV cache tensors with
+``kv_size == 1`` and the per-head ``[K | V]`` pair packed in the trailing
+dimension (``hidden_dim = num_heads * 2 * head_dim``). TurboQuant serde
+originally hardcoded the split K/V layout (``kv_size == 2``) and rejected
+fused tensors with ``ValueError``. These tests lock in fused-layout support
+and guard the split-layout path from regressions.
+"""
+
+# Standard
+from typing import cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache import torch_dev, torch_device_type
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.serde.turboquant import (
+    TurboQuantDeserializer,
+    TurboQuantSerdeConfig,
+    TurboQuantSerializer,
+)
+from lmcache.v1.distributed.serde.turboquant.turboquant import (
+    _raw_group_nbytes,
+    _validate_layout_shape,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+# Same correlation thresholds as the existing split-layout round-trip tests.
+_FUSED_CORR_LOWER_BOUND = {
+    "turboquant_k8v4": 0.95,
+    "turboquant_4bit_nc": 0.90,
+    "turboquant_k3v4_nc": 0.85,
+    "turboquant_3bit_nc": 0.80,
+}
+
+_HEAD_DIM = 128
+_NUM_HEADS = 4
+# Fused hidden dim: num_heads * 2 * head_dim.
+_FUSED_HIDDEN = _NUM_HEADS * 2 * _HEAD_DIM
+# Split hidden dim: num_heads * head_dim.
+_SPLIT_HIDDEN = _NUM_HEADS * _HEAD_DIM
+
+
+def _make_turboquant_object_key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="turboquant_fused_test_model",
+        kv_rank=0,
+    )
+
+
+def _fused_shape(num_layers: int = 3, num_tokens: int = 20) -> torch.Size:
+    return torch.Size([1, num_layers, num_tokens, _FUSED_HIDDEN])
+
+
+def _split_shape(num_layers: int = 3, num_tokens: int = 20) -> torch.Size:
+    return torch.Size([2, num_layers, num_tokens, _SPLIT_HIDDEN])
+
+
+def _make_fused_cfg(
+    preset: str = "turboquant_k8v4",
+    **kwargs,
+) -> TurboQuantSerdeConfig:
+    return TurboQuantSerdeConfig(
+        preset=preset,
+        head_dim=_HEAD_DIM,
+        block_size=16,
+        **kwargs,
+    )
+
+
+# =============================================================================
+# Fused layout validation (no device required)
+# =============================================================================
+
+
+def test_validate_layout_shape_accepts_fused_kv() -> None:
+    cfg = _make_fused_cfg()
+    num_layers, num_tokens, num_heads, head_dim = _validate_layout_shape(
+        _fused_shape(), cfg
+    )
+    assert (num_layers, num_tokens, num_heads, head_dim) == (
+        3,
+        20,
+        _NUM_HEADS,
+        _HEAD_DIM,
+    )
+
+
+def test_validate_layout_shape_split_kv_unchanged() -> None:
+    cfg = _make_fused_cfg()
+    num_layers, num_tokens, num_heads, head_dim = _validate_layout_shape(
+        _split_shape(), cfg
+    )
+    assert (num_layers, num_tokens, num_heads, head_dim) == (
+        3,
+        20,
+        _NUM_HEADS,
+        _HEAD_DIM,
+    )
+
+
+@pytest.mark.parametrize("kv_size", [0, 3, -1])
+def test_validate_layout_shape_rejects_unsupported_kv_size(kv_size: int) -> None:
+    cfg = _make_fused_cfg()
+    shape = torch.Size([kv_size, 3, 20, _FUSED_HIDDEN])
+    with pytest.raises(ValueError, match="kv_size 1 \\(fused K/V\\) or 2"):
+        _validate_layout_shape(shape, cfg)
+
+
+def test_validate_layout_shape_rejects_fused_bad_hidden_dim() -> None:
+    cfg = _make_fused_cfg()
+    # A kv_size==1 tensor whose hidden dim is not a multiple of 2 * head_dim
+    # is not a fused K/V tensor (e.g. an MLA index cache) and must be
+    # rejected rather than silently mis-split.
+    shape = torch.Size([1, 3, 20, _FUSED_HIDDEN + _HEAD_DIM])
+    with pytest.raises(ValueError, match="must be divisible"):
+        _validate_layout_shape(shape, cfg)
+
+
+def test_validate_layout_shape_rejects_split_bad_hidden_dim() -> None:
+    cfg = _make_fused_cfg()
+    shape = torch.Size([2, 3, 20, _SPLIT_HIDDEN + 1])
+    with pytest.raises(ValueError, match="must be divisible"):
+        _validate_layout_shape(shape, cfg)
+
+
+# =============================================================================
+# Serialized size accounting (no device required)
+# =============================================================================
+
+
+def test_estimate_serialized_size_accepts_fused_kv() -> None:
+    """The fused layout must no longer be rejected at size estimation."""
+    cfg = _make_fused_cfg()
+    serializer = TurboQuantSerializer(cfg)
+    layout = MemoryLayoutDesc(
+        shapes=[_fused_shape()],
+        dtypes=[torch.bfloat16],
+    )
+    # No exception raised; expected size matches the raw split-equivalent.
+    assert serializer.estimate_serialized_size(layout) > 0
+
+
+def test_serialized_size_fused_matches_split() -> None:
+    """Equivalent fused and split layouts must serialize to the same size."""
+    num_layers, num_tokens = 4, 32
+    cfg = _make_fused_cfg(
+        skip_first_layers=2,
+        skip_last_layers=2,
+    )
+    serializer = TurboQuantSerializer(cfg)
+    fused = MemoryLayoutDesc(
+        shapes=[_fused_shape(num_layers, num_tokens)],
+        dtypes=[torch.bfloat16],
+    )
+    split = MemoryLayoutDesc(
+        shapes=[_split_shape(num_layers, num_tokens)],
+        dtypes=[torch.bfloat16],
+    )
+    assert serializer.estimate_serialized_size(
+        fused
+    ) == serializer.estimate_serialized_size(split)
+
+
+def test_raw_group_nbytes_fused_matches_split() -> None:
+    num_layers, num_tokens = 4, 32
+    dtype = torch.float16
+    fused_bytes = _raw_group_nbytes(
+        _fused_shape(num_layers, num_tokens), dtype, num_layers
+    )
+    split_bytes = _raw_group_nbytes(
+        _split_shape(num_layers, num_tokens), dtype, num_layers
+    )
+    assert fused_bytes == split_bytes
+    assert fused_bytes == num_layers * num_tokens * _FUSED_HIDDEN * dtype.itemsize
+
+
+def test_fused_asymmetric_presets_use_distinct_kv_bits() -> None:
+    """Guard that the asymmetric presets really differ, so the fused
+    round-trip below exercises separate K/V quantization paths."""
+    for preset in ("turboquant_k8v4", "turboquant_k3v4_nc"):
+        cfg = _make_fused_cfg(preset)
+        assert cfg.key_quant_bits != cfg.value_quant_bits, (
+            f"{preset} must be asymmetric to exercise K/V split"
+        )
+
+
+# =============================================================================
+# Fused round-trip (GPU)
+# =============================================================================
+
+
+class _FakeMemoryObj:
+    def __init__(self, tensor: torch.Tensor):
+        self.tensor = tensor
+
+
+@pytest.mark.skipif(
+    not torch_dev.is_available(),
+    reason="Requires torch_device_type",
+)
+@pytest.mark.parametrize("preset", list(_FUSED_CORR_LOWER_BOUND))
+def test_turboquant_fused_direct_roundtrip_cuda(preset: str) -> None:
+    """Direct GPU round-trip through TurboQuant serializer/deserializer on a
+    fused K/V tensor (kv_size == 1).
+
+    Verifies:
+    - the reconstructed shape exactly matches the input fused shape;
+    - the reconstructed dtype matches the input dtype;
+    - both the K half and the V half of the trailing dimension reconstruct
+      within the preset's correlation bound (catches implementations that
+      wrongly quantize fused K/V as a single tensor).
+    """
+    device = torch.device(f"{torch_device_type}:0")
+    dtype = torch.float16
+
+    num_layers = 4
+    num_tokens = 128
+    cfg = _make_fused_cfg(preset, skip_first_layers=0, skip_last_layers=0)
+
+    torch.manual_seed(2026)
+    shape = torch.Size([1, num_layers, num_tokens, _NUM_HEADS * 2 * _HEAD_DIM])
+    original = torch.randn(shape, dtype=dtype, device=device)
+
+    serializer = TurboQuantSerializer(cfg)
+    deserializer = TurboQuantDeserializer(cfg)
+
+    layout = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+    n_bytes = serializer.estimate_serialized_size(layout)
+
+    compressed = torch.empty(n_bytes, dtype=torch.uint8, device=device)
+    recovered = torch.empty_like(original)
+
+    written = serializer.serialize(
+        cast(MemoryObj, _FakeMemoryObj(original)),
+        cast(MemoryObj, _FakeMemoryObj(compressed)),
+        _make_turboquant_object_key(0),
+    )
+    assert written == n_bytes
+
+    deserializer.deserialize(
+        cast(MemoryObj, _FakeMemoryObj(compressed)),
+        cast(MemoryObj, _FakeMemoryObj(recovered)),
+        _make_turboquant_object_key(0),
+    )
+
+    assert recovered.shape == original.shape
+    assert recovered.dtype == original.dtype
+
+    orig_view = original[0].view(num_layers, num_tokens, _NUM_HEADS, 2 * _HEAD_DIM)
+    rec_view = recovered[0].view(num_layers, num_tokens, _NUM_HEADS, 2 * _HEAD_DIM)
+
+    corr_lower_bound = _FUSED_CORR_LOWER_BOUND[preset]
+    full_corr = torch.corrcoef(
+        torch.stack([original.float().flatten(), recovered.float().flatten()])
+    )[0, 1].item()
+    k_corr = torch.corrcoef(
+        torch.stack(
+            [
+                orig_view[..., :_HEAD_DIM].float().flatten(),
+                rec_view[..., :_HEAD_DIM].float().flatten(),
+            ]
+        )
+    )[0, 1].item()
+    v_corr = torch.corrcoef(
+        torch.stack(
+            [
+                orig_view[..., _HEAD_DIM:].float().flatten(),
+                rec_view[..., _HEAD_DIM:].float().flatten(),
+            ]
+        )
+    )[0, 1].item()
+
+    assert full_corr > corr_lower_bound, (
+        f"low corr for preset={preset}: full={full_corr}, k={k_corr}, v={v_corr}"
+    )
+    assert k_corr > corr_lower_bound, f"low K-half corr for preset={preset}: k={k_corr}"
+    assert v_corr > corr_lower_bound, f"low V-half corr for preset={preset}: v={v_corr}"
+
+
+@pytest.mark.skipif(
+    not torch_dev.is_available(),
+    reason="Requires torch_device_type",
+)
+def test_turboquant_fused_skipped_layers_raw_exact_cuda() -> None:
+    """Layers outside the quantized range are stored raw and must round-trip
+    bit-exactly for the fused layout too."""
+    device = torch.device(f"{torch_device_type}:0")
+    dtype = torch.float16
+
+    num_layers = 4
+    num_tokens = 64
+    cfg = _make_fused_cfg("turboquant_k8v4")
+    # Default skip_first_layers=2 / skip_last_layers=2 leaves no layers to
+    # quantize; the whole tensor is stored raw.
+    assert cfg.skip_first_layers + cfg.skip_last_layers >= num_layers
+
+    torch.manual_seed(7)
+    shape = torch.Size([1, num_layers, num_tokens, _NUM_HEADS * 2 * _HEAD_DIM])
+    original = torch.randn(shape, dtype=dtype, device=device)
+
+    serializer = TurboQuantSerializer(cfg)
+    deserializer = TurboQuantDeserializer(cfg)
+
+    layout = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+    n_bytes = serializer.estimate_serialized_size(layout)
+
+    compressed = torch.empty(n_bytes, dtype=torch.uint8, device=device)
+    recovered = torch.empty_like(original)
+
+    serializer.serialize(
+        cast(MemoryObj, _FakeMemoryObj(original)),
+        cast(MemoryObj, _FakeMemoryObj(compressed)),
+        _make_turboquant_object_key(0),
+    )
+    deserializer.deserialize(
+        cast(MemoryObj, _FakeMemoryObj(compressed)),
+        cast(MemoryObj, _FakeMemoryObj(recovered)),
+        _make_turboquant_object_key(0),
+    )
+
+    assert recovered.shape == original.shape
+    assert torch.equal(recovered, original)


### PR DESCRIPTION
Fixes #4744

## Summary

TurboQuant serde only accepted the split K/V layout (`kv_size == 2`).
vLLM >= 0.26 attention backends (FLASH_ATTN, FLASHINFER, TRITON_ATTN)
emit fused blocks-first KV (`kv_size == 1`) with the per-head
`[K | V]` pair packed in the trailing dimension, so enabling
TurboQuant via the L2 serde adapter failed with
`ValueError: TurboQuant serde expects first dim kv_size=2, got 1`.

This PR adds full fused-layout support: the serializer splits each
layer's per-head K/V pair so K and V are quantized with their own
preset bit-widths (including asymmetric presets like `turboquant_k3v4_nc`),
and the deserializer re-packs them to restore the exact input shape.

## Changes

- `lmcache/v1/distributed/serde/turboquant/turboquant.py`
  - Accept `kv_size` 1 (fused) and 2 (split) in layout validation;
    reject other values, and reject incompatible fused shapes whose
    hidden dimension is not divisible by `2 * head_dim`. Note that the
    serde has no model metadata, so layout interpretation relies on the
    shape contract alone.
  - Size raw-copy layer groups from the actual `kv_size`.
  - Split / reassemble the fused per-head `[K | V]` pair around the
    existing K/V quantizer and dequantizer paths.
- `tests/v1/distributed/serde/test_turboquant.py` — updated the invalid
  `kv_size` test (`[1, ...]` is now valid fused; `[3, ...]` is invalid).
- `tests/v1/distributed/serde/test_turboquant_fused_layout.py` (new) —
  fused no-reject, fused round-trip (all 4 presets), asymmetric k3v4
  K/V split check, split-layout regression, raw-layer bit-exactness,
  invalid shapes, serialized-size equivalence.

## Validation

- Split (`kv_size == 2`) behavior is unchanged; all preset roundtrips
  reproduce identical reconstruction error to fused.
- Fused round-trips verified on GPU (real Triton kernels): shape and
  dtype preserved, k3v4 shows independent K (3-bit) and V (4-bit)
  reconstruction quality.
- `ruff check`, `ruff format --check`, and pre-commit hooks pass.

## Notes

Serialized representation and the store/decode kernels are untouched;
K and V still reach the kernels as `[T, H, D]`.