### PR TITLE
feat: add stable fs_native placement and stale KV GC

### DIFF
--- a/benchmarks/microbenchmark/stable_disk_placement_benchmark.py
+++ b/benchmarks/microbenchmark/stable_disk_placement_benchmark.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+#!/usr/bin/env python3
+"""Benchmark stable multi-disk placement and restart directory scanning.
+
+The placement comparison uses the modulo rule from PR #4260 as the baseline
+and the rendezvous rule used by the stable ``striped`` policy as the candidate.
+It reports routing throughput, balance, and the fraction of keys remapped when
+one disk is added. The scan case creates a temporary fs-native directory and
+measures recovery metadata discovery separately from file creation.
+
+Run with::
+
+    python benchmarks/microbenchmark/stable_disk_placement_benchmark.py \
+        --keys 100000 --disks 8 --scan-files 10000
+"""
+
+# Standard
+from collections import Counter
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+import argparse
+import json
+import math
+import tempfile
+import time
+import uuid
+
+# Third Party
+import blake3
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_key_codec import object_key_to_filename
+from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+    FSNativeL2AdapterConfig,
+    scan_existing_cache_entries,
+)
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+    rendezvous_adapter_indices_for_keys,
+)
+
+T = TypeVar("T")
+
+
+def _make_keys(count: int) -> list[ObjectKey]:
+    return [
+        ObjectKey(
+            chunk_hash=ObjectKey.IntHash2Bytes(index),
+            model_name="benchmark/model",
+            kv_rank=index % 8,
+            object_group_id=index % 4,
+        )
+        for index in range(count)
+    ]
+
+
+def _make_adapters(count: int) -> list[AdapterDescriptor]:
+    adapters: list[AdapterDescriptor] = []
+    for index in range(count):
+        config = FSNativeL2AdapterConfig(base_path=f"/benchmark/disk-{index}")
+        config.placement_id = str(uuid.uuid5(uuid.NAMESPACE_URL, config.base_path))
+        adapters.append(AdapterDescriptor(index=index, config=config))
+    return adapters
+
+
+def _modulo_owner_ids(
+    keys: list[ObjectKey],
+    adapters: list[AdapterDescriptor],
+) -> list[str]:
+    """Return owners selected by the PR #4260 ``BLAKE3(key) % N`` rule."""
+    sorted_adapters = sorted(adapters, key=lambda adapter: adapter.index)
+    owners: list[str] = []
+    for key in keys:
+        digest = blake3.blake3(str(key).encode()).digest(length=8)
+        slot = int.from_bytes(digest, "big") % len(sorted_adapters)
+        placement_id = sorted_adapters[slot].placement_id
+        assert placement_id is not None
+        owners.append(placement_id)
+    return owners
+
+
+def _rendezvous_owner_ids(
+    keys: list[ObjectKey],
+    adapters: list[AdapterDescriptor],
+) -> list[str]:
+    by_index = {adapter.index: adapter for adapter in adapters}
+    owners: list[str] = []
+    for adapter_index in rendezvous_adapter_indices_for_keys(keys, adapters):
+        placement_id = by_index[adapter_index].placement_id
+        assert placement_id is not None
+        owners.append(placement_id)
+    return owners
+
+
+def _best_seconds(function: Callable[[], T], repetitions: int) -> float:
+    best = float("inf")
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        function()
+        best = min(best, time.perf_counter() - started)
+    return best
+
+
+def _remap_ratio(before: list[str], after: list[str]) -> float:
+    return sum(left != right for left, right in zip(before, after, strict=True)) / len(
+        before
+    )
+
+
+def _distribution_cv(owners: list[str], disk_count: int) -> float:
+    counts = list(Counter(owners).values())
+    counts.extend([0] * (disk_count - len(counts)))
+    mean = len(owners) / disk_count
+    variance = sum((count - mean) ** 2 for count in counts) / disk_count
+    return math.sqrt(variance) / mean
+
+
+def benchmark_placement(
+    key_count: int,
+    disk_count: int,
+    repetitions: int,
+) -> dict[str, object]:
+    """Benchmark routing and add-one-disk remapping.
+
+    Args:
+        key_count: Number of deterministic object keys.
+        disk_count: Number of disks before the topology change.
+        repetitions: Timing repetitions; the best wall time is reported.
+
+    Returns:
+        JSON-serializable placement metrics for modulo and rendezvous hashing.
+
+    Raises:
+        ValueError: If an argument is not positive.
+    """
+    if key_count <= 0 or disk_count <= 0 or repetitions <= 0:
+        raise ValueError("key_count, disk_count, and repetitions must be positive")
+
+    keys = _make_keys(key_count)
+    before = _make_adapters(disk_count)
+    after = _make_adapters(disk_count + 1)
+
+    modulo_before = _modulo_owner_ids(keys, before)
+    modulo_after = _modulo_owner_ids(keys, after)
+    rendezvous_before = _rendezvous_owner_ids(keys, before)
+    rendezvous_after = _rendezvous_owner_ids(keys, after)
+
+    modulo_seconds = _best_seconds(lambda: _modulo_owner_ids(keys, before), repetitions)
+    rendezvous_seconds = _best_seconds(
+        lambda: _rendezvous_owner_ids(keys, before), repetitions
+    )
+    return {
+        "keys": key_count,
+        "disks_before": disk_count,
+        "disks_after": disk_count + 1,
+        "ideal_add_disk_remap_ratio": 1 / (disk_count + 1),
+        "modulo": {
+            "remap_ratio": _remap_ratio(modulo_before, modulo_after),
+            "keys_per_second": key_count / modulo_seconds,
+            "distribution_cv": _distribution_cv(modulo_before, disk_count),
+        },
+        "rendezvous": {
+            "remap_ratio": _remap_ratio(rendezvous_before, rendezvous_after),
+            "keys_per_second": key_count / rendezvous_seconds,
+            "distribution_cv": _distribution_cv(rendezvous_before, disk_count),
+        },
+    }
+
+
+def benchmark_recovery_scan(file_count: int) -> dict[str, object]:
+    """Benchmark recursive recovery scanning over generated cache files.
+
+    Args:
+        file_count: Number of valid ``.data`` files to generate.
+
+    Returns:
+        JSON-serializable scan latency and throughput metrics. File creation is
+        intentionally excluded from the timed region.
+
+    Raises:
+        ValueError: If ``file_count`` is not positive.
+    """
+    if file_count <= 0:
+        raise ValueError("file_count must be positive")
+
+    keys = _make_keys(file_count)
+    with tempfile.TemporaryDirectory(prefix="lmcache-recovery-bench-") as temp_dir:
+        root = Path(temp_dir)
+        for key in keys:
+            (root / object_key_to_filename(key)).touch()
+
+        started = time.perf_counter()
+        recovered, skipped = scan_existing_cache_entries(temp_dir)
+        elapsed = time.perf_counter() - started
+
+    return {
+        "files": file_count,
+        "recovered": len(recovered),
+        "skipped": skipped,
+        "seconds": elapsed,
+        "files_per_second": file_count / elapsed,
+    }
+
+
+def main() -> None:
+    """Parse command-line arguments, run benchmarks, and print JSON."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keys", type=int, default=100_000)
+    parser.add_argument("--disks", type=int, default=8)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--scan-files", type=int, default=10_000)
+    args = parser.parse_args()
+
+    results = {
+        "placement": benchmark_placement(args.keys, args.disks, args.repetitions),
+        "recovery_scan": benchmark_recovery_scan(args.scan_files),
+    }
+    print(json.dumps(results, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/microbenchmark/stable_disk_placement_benchmark.py
+++ b/benchmarks/microbenchmark/stable_disk_placement_benchmark.py
@@ -38,7 +38,7 @@ from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
-    rendezvous_adapter_indices_for_keys,
+    RendezvousHashRouter,
 )
 
 T = TypeVar("T")
@@ -84,10 +84,11 @@ def _modulo_owner_ids(
 def _rendezvous_owner_ids(
     keys: list[ObjectKey],
     adapters: list[AdapterDescriptor],
+    router: RendezvousHashRouter,
 ) -> list[str]:
     by_index = {adapter.index: adapter for adapter in adapters}
     owners: list[str] = []
-    for adapter_index in rendezvous_adapter_indices_for_keys(keys, adapters):
+    for adapter_index in router.select_adapters(keys):
         placement_id = by_index[adapter_index].placement_id
         assert placement_id is not None
         owners.append(placement_id)
@@ -141,15 +142,21 @@ def benchmark_placement(
     keys = _make_keys(key_count)
     before = _make_adapters(disk_count)
     after = _make_adapters(disk_count + 1)
+    before_router = RendezvousHashRouter()
+    before_router.update_adapters(before)
+    after_router = RendezvousHashRouter()
+    after_router.update_adapters(after)
 
     modulo_before = _modulo_owner_ids(keys, before)
     modulo_after = _modulo_owner_ids(keys, after)
-    rendezvous_before = _rendezvous_owner_ids(keys, before)
-    rendezvous_after = _rendezvous_owner_ids(keys, after)
+    rendezvous_before = _rendezvous_owner_ids(keys, before, before_router)
+    rendezvous_after = _rendezvous_owner_ids(keys, after, after_router)
 
     modulo_seconds = _best_seconds(lambda: _modulo_owner_ids(keys, before), repetitions)
+    # Adapter preparation is intentionally outside the timed region: the
+    # production policies update the router only when adapters attach or detach.
     rendezvous_seconds = _best_seconds(
-        lambda: _rendezvous_owner_ids(keys, before), repetitions
+        lambda: _rendezvous_owner_ids(keys, before, before_router), repetitions
     )
     return {
         "keys": key_count,

--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -28,22 +28,25 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Unsalted:
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   Salted:
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   @<cache_salt>
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
-  //   Salted  :
-  //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
-  //
-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
-  // format, so existing cache directories remain valid.
+  //   Unsalted:
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>
+  //   @<chunk_hash_hex>.data
+  //   Salted:
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>
+  //   @<chunk_hash_hex>@<cache_salt>.data
   //
   // NOTE: both model_name and cache_salt are forbidden from containing
   // '@' (invariant enforced on the Python side), so splitting on '@'
   // is unambiguous — no marker, no rsplit.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Split on '@' — must yield 4 (unsalted) or 5 (salted) fields.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -52,29 +55,32 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() != 4 && parts.size() != 5) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 4 or 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+  const std::string& object_group_id = parts[2];
+  const std::string& chunk_hash = parts[3];
+  const std::string cache_salt = parts.size() == 5 ? parts[4] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
-  // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
+  // Emit the reversible filename used by the Python filesystem adapter.
   std::string result;
-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+  result.reserve(safe_model.size() + kv_rank_hex.size() +
+                 object_group_id.size() + chunk_hash.size() +
                  cache_salt.size() + 32);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
+  result += KEY_SEP;
+  result += object_group_id;
   result += KEY_SEP;
   result += chunk_hash;
   if (!cache_salt.empty()) {
@@ -299,7 +305,12 @@ bool FSConnector::do_single_delete(WorkerFSConn& conn, const std::string& key) {
   std::string filename = key_to_filename(key);
   auto file_path = conn.base_path / filename;
   std::error_code ec;
-  return std::filesystem::remove(file_path, ec);
+  bool removed = std::filesystem::remove(file_path, ec);
+  if (ec) {
+    throw std::runtime_error("remove failed: " + file_path.string() + ": " +
+                             ec.message());
+  }
+  return removed;
 }
 
 }  // namespace connector

--- a/docs/source/mp/l2_storage/fs_native.rst
+++ b/docs/source/mp/l2_storage/fs_native.rst
@@ -29,6 +29,16 @@ I/O queue depth on a single Python thread.
 
 .. important::
 
+   ``max_capacity_gb`` supplies capacity accounting; it does not delete files
+   by itself. Configure an adapter-level ``eviction`` policy to enforce the
+   watermark. On restart, ``fs_native`` scans the flat ``.data`` file layout
+   produced by the native connector and restores sizes and a best-effort LRU
+   order from ``max(atime, mtime)``. Mount options such as ``noatime`` can
+   reduce the precision of this recovered order; live accesses are tracked
+   normally after startup.
+
+.. important::
+
    ``O_DIRECT`` has two independent alignment requirements:
 
    1. **Length alignment.**  The transfer length must be a multiple of
@@ -67,6 +77,33 @@ I/O queue depth on a single Python thread.
 
     # O_DIRECT for real-disk benchmarking
     --l2-adapter '{"type": "fs_native", "base_path": "/data/lmcache/l2", "num_workers": 32, "use_odirect": true}'
+
+Stable multi-disk striping
+---------------------------
+
+Use one ``fs_native`` adapter per independently mounted disk and select the
+``striped`` store and prefetch policies. Each mount receives a persistent
+``.lmcache_disk_uuid`` file. Rendezvous hashing uses that UUID, so adapter
+configuration order does not affect placement and adding one disk remaps only
+approximately ``1 / (N + 1)`` of keys.
+
+.. code-block:: bash
+
+    lmcache server \
+        --host 0.0.0.0 --port 5555 \
+        --l1-size-gb 32 --l1-use-lazy \
+        --l2-store-policy striped \
+        --l2-prefetch-policy striped \
+        --l2-adapter '{"type":"fs_native","base_path":"/mnt/nvme0/lmcache","max_capacity_gb":3500,"eviction":{"eviction_policy":"LRU","trigger_watermark":0.8,"eviction_ratio":0.2}}' \
+        --l2-adapter '{"type":"fs_native","base_path":"/mnt/nvme1/lmcache","max_capacity_gb":3500,"eviction":{"eviction_policy":"LRU","trigger_watermark":0.8,"eviction_ratio":0.2}}'
+
+All striped adapters must be ``fs_native`` and expose distinct disk UUIDs.
+Keep ``.lmcache_disk_uuid`` with its physical mount across restarts; never copy
+one disk's UUID file to another disk. After the disk set changes, files on a
+former owner are recovered into that disk's normal LRU index and reclaimed
+under capacity pressure. Status output reports ``placement_id``,
+``recovered_keys``, ``recovered_bytes``, and ``recovery_skipped_files`` for
+each adapter.
 
 **Buffer-only mode example.**  L1 acts as a pure write buffer that
 absorbs the peak burst of in-flight chunks while the C++ worker pool

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -355,6 +355,25 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
     ):
         raise ValueError("gds-l1-path cannot be used with l1-devdax-path")
 
+    striped_store = config.store_policy == "striped"
+    striped_prefetch = config.prefetch_policy == "striped"
+    if striped_store != striped_prefetch:
+        raise ValueError(
+            "striped placement requires both l2-store-policy and "
+            "l2-prefetch-policy to be 'striped'"
+        )
+    if striped_store:
+        unsupported = [
+            get_type_name_for_config(adapter)
+            for adapter in config.l2_adapter_config.adapters
+            if get_type_name_for_config(adapter) != "fs_native"
+        ]
+        if unsupported:
+            raise ValueError(
+                "striped placement currently supports only fs_native "
+                f"adapters; got {unsupported}"
+            )
+
     memory_config = config.l1_manager_config.memory_config
     if not (memory_config.devdax_path and memory_config.devdax_size_in_bytes):
         return

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -360,6 +360,39 @@ class L2AdapterInterface(ABC):
         """Register a listener to receive L2 adapter events."""
         self._listeners.append(listener)
 
+    def seed_existing_keys(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Seed byte accounting for entries recovered before startup.
+
+        This method deliberately does not publish events or notify listeners.
+        A recovering adapter must replay the recovered snapshot to each
+        listener when that listener registers.
+
+        Args:
+            keys: Existing keys not yet counted by this adapter instance.
+            sizes: On-disk byte size corresponding to each key.
+
+        Raises:
+            ValueError: If a size is negative or the list lengths differ.
+        """
+        bytes_by_salt: dict[str, int] = {}
+        total_bytes = 0
+        for key, size in zip(keys, sizes, strict=True):
+            if size < 0:
+                raise ValueError("existing key size must be non-negative")
+            bytes_by_salt[key.cache_salt] = bytes_by_salt.get(key.cache_salt, 0) + size
+            total_bytes += size
+
+        with self._usage_lock:
+            self._total_bytes_used += total_bytes
+            for cache_salt, size in bytes_by_salt.items():
+                self._bytes_by_cache_salt[cache_salt] = (
+                    self._bytes_by_cache_salt.get(cache_salt, 0) + size
+                )
+
     def set_backend_identity(self, name: str, shared: bool = False) -> None:
         """Set the identity used to tag this adapter's cache events.
 

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -180,6 +180,11 @@ class L2AdapterConfigBase(ABC):
     #: Defaults to ``PersistConfig()`` (persist enabled).
     persist_config: PersistConfig = PersistConfig()
 
+    #: Stable identifier used by placement policies that must survive process
+    #: restarts and adapter reordering. Backends without a persistent identity
+    #: leave this as ``None`` and cannot participate in those policies.
+    placement_id: str | None = None
+
     #: Populated by ``_parse_serde_config`` after ``from_dict``; ``None``
     #: means serde is disabled for this adapter. When set,
     #: ``StorageManager`` wraps the adapter with

--- a/lmcache/v1/distributed/l2_adapters/fs_key_codec.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_key_codec.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared reversible filename codec for filesystem L2 adapters."""
+
+# Future
+from __future__ import annotations
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+
+_KEY_SEP = "@"
+_PATH_SLASH_REPLACEMENT = "-SEP-"
+_FILE_EXT = ".data"
+
+
+def object_key_to_filename(key: ObjectKey) -> str:
+    """Encode an object key as a reversible filesystem-safe filename.
+
+    Args:
+        key: Object key to encode.
+
+    Returns:
+        A ``.data`` filename containing every identity field of ``key``.
+    """
+    safe_model = key.model_name.replace("/", _PATH_SLASH_REPLACEMENT)
+    base = (
+        f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}"
+        f"{_KEY_SEP}{key.object_group_id:x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    )
+    if key.cache_salt:
+        return f"{base}{_KEY_SEP}{key.cache_salt}{_FILE_EXT}"
+    return f"{base}{_FILE_EXT}"
+
+
+def filename_to_object_key(filename: str) -> ObjectKey | None:
+    """Decode a filesystem cache filename into an object key.
+
+    Args:
+        filename: Cache file basename to decode.
+
+    Returns:
+        The decoded key, or ``None`` when the filename is not a valid
+        LMCache data filename.
+    """
+    if not filename.endswith(_FILE_EXT):
+        return None
+    stem = filename[: -len(_FILE_EXT)]
+    parts = stem.split(_KEY_SEP)
+    if len(parts) == 4:
+        safe_model, kv_rank_str, object_group_str, chunk_hash_hex = parts
+        cache_salt = ""
+    elif len(parts) == 5:
+        safe_model, kv_rank_str, object_group_str, chunk_hash_hex, cache_salt = parts
+    else:
+        return None
+
+    model_name = safe_model.replace(_PATH_SLASH_REPLACEMENT, "/")
+    try:
+        return ObjectKey(
+            chunk_hash=bytes.fromhex(chunk_hash_hex),
+            model_name=model_name,
+            kv_rank=int(kv_rank_str, 16),
+            object_group_id=int(object_group_str, 16),
+            cache_salt=cache_salt,
+        )
+    except ValueError:
+        return None

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -45,11 +45,15 @@ from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
 from lmcache.v1.distributed.l2_adapters.fs_key_codec import (
-    # Preserve the existing module-level test/debug import path.
-    filename_to_object_key as _filename_to_object_key,  # noqa: F401
+    filename_to_object_key,
+)
+from lmcache.v1.distributed.l2_adapters.fs_key_codec import (
     object_key_to_filename as _object_key_to_filename,
 )
 from lmcache.v1.platform import create_event_notifier
+
+# Preserve the existing module-level test/debug import path.
+_filename_to_object_key = filename_to_object_key
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -44,17 +44,14 @@ from lmcache.v1.distributed.l2_adapters.config import (
 from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
+from lmcache.v1.distributed.l2_adapters.fs_key_codec import (
+    # Preserve the existing module-level test/debug import path.
+    filename_to_object_key as _filename_to_object_key,  # noqa: F401
+    object_key_to_filename as _object_key_to_filename,
+)
 from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
-
-_KEY_SEP = "@"
-# ``@`` in both ``model_name`` and ``cache_salt`` is rejected by
-# ObjectKey.__post_init__, so splitting on ``@`` is unambiguous.
-# Kept in sync with native_connector_l2_adapter.py and
-# csrc/storage_backends/fs/connector.cpp.
-_PATH_SLASH_REPLACEMENT = "-SEP-"
-_FILE_EXT = ".data"
 
 
 def _readinto_full(
@@ -94,74 +91,6 @@ async def _async_readinto_full(
             break
         total += n
     return total
-
-
-def _object_key_to_filename(key: ObjectKey) -> str:
-    """Build a reversible, filesystem-safe filename.
-
-    Unsalted::
-
-        <safe_model>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>.data
-
-    Salted (trailing ``cache_salt``)::
-
-        <safe_model>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>.data
-
-    ``kv_rank`` is written in ``0x`` prefixed hex so each byte
-    of the bitmap ``(ws<<24)|(rank<<16)|(local_ws<<8)|local``
-    is directly readable. ``object_group_id`` is written in plain hex.
-    """
-    safe_model = key.model_name.replace("/", _PATH_SLASH_REPLACEMENT)
-    base = (
-        f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}"
-        f"{_KEY_SEP}{key.object_group_id:x}{_KEY_SEP}{key.chunk_hash.hex()}"
-    )
-    if key.cache_salt:
-        return f"{base}{_KEY_SEP}{key.cache_salt}{_FILE_EXT}"
-    return f"{base}{_FILE_EXT}"
-
-
-def _filename_to_object_key(
-    filename: str,
-) -> Optional[ObjectKey]:
-    """Reverse ``_object_key_to_filename``.
-
-    Accepts both the 4-field unsalted shape and the 5-field salted
-    shape (trailing ``cache_salt``). Returns ``None`` for anything
-    else. Since ``model_name`` is guaranteed not to contain ``@``,
-    plain ``split`` suffices — no marker, no rsplit.
-    """
-    if not filename.endswith(_FILE_EXT):
-        return None
-    stem = filename[: -len(_FILE_EXT)]
-    parts = stem.split(_KEY_SEP)
-    if len(parts) == 4:
-        safe_model, kv_rank_str, object_group_str, chunk_hash_hex = parts
-        cache_salt = ""
-    elif len(parts) == 5:
-        safe_model, kv_rank_str, object_group_str, chunk_hash_hex, cache_salt = parts
-    else:
-        return None
-
-    model_name = safe_model.replace(_PATH_SLASH_REPLACEMENT, "/")
-    try:
-        chunk_hash = bytes.fromhex(chunk_hash_hex)
-        kv_rank = int(kv_rank_str, 16)
-        object_group_id = int(object_group_str, 16)
-        # ObjectKey.__post_init__ raises ValueError when the decoded
-        # model_name / cache_salt violate the forbidden-char or length
-        # invariants (e.g. a stray file from another tool on disk).
-        # The contract here is to return None for anything unparsable,
-        # so keep the constructor inside the try block.
-        return ObjectKey(
-            chunk_hash=chunk_hash,
-            model_name=model_name,
-            kv_rank=kv_rank,
-            object_group_id=object_group_id,
-            cache_salt=cache_salt,
-        )
-    except ValueError:
-        return None
 
 
 class FSL2AdapterConfig(L2AdapterConfigBase):

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -10,7 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
 from __future__ import annotations
 
 # Standard
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+import fcntl
+import os
+import uuid
 
 if TYPE_CHECKING:
     from lmcache.v1.distributed.internal_api import (
@@ -19,6 +23,7 @@ if TYPE_CHECKING:
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
 )
@@ -29,8 +34,163 @@ from lmcache.v1.distributed.l2_adapters.config import (
 from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
+from lmcache.v1.distributed.l2_adapters.fs_key_codec import (
+    filename_to_object_key,
+    object_key_to_filename,
+)
 
 logger = init_logger(__name__)
+
+_DISK_UUID_FILENAME = ".lmcache_disk_uuid"
+_DISK_UUID_LOCK_FILENAME = ".lmcache_disk_uuid.lock"
+
+
+def _read_disk_uuid(path: Path) -> str:
+    """Read and validate a persisted disk UUID without following symlinks."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+        with os.fdopen(fd, encoding="ascii") as uuid_file:
+            value = uuid_file.read(128).strip()
+    except (OSError, UnicodeError) as e:
+        raise RuntimeError(f"Unable to read fs_native disk UUID {path!s}: {e}") from e
+    try:
+        return str(uuid.UUID(value))
+    except ValueError as e:
+        raise RuntimeError(
+            f"Invalid fs_native disk UUID in {path!s}; refusing to remap cache data"
+        ) from e
+
+
+def get_or_create_disk_uuid(base_path: str) -> str:
+    """Return the persistent UUID associated with one cache mount.
+
+    Args:
+        base_path: Root directory of one independently mounted cache disk.
+
+    Returns:
+        Canonical UUID string persisted below ``base_path``.
+
+    Raises:
+        RuntimeError: If the directory or identity file cannot be created,
+            read, or validated.
+    """
+    base = Path(base_path)
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise RuntimeError(
+            f"Unable to create fs_native cache directory {base!s}: {e}"
+        ) from e
+
+    uuid_path = base / _DISK_UUID_FILENAME
+    lock_path = base / _DISK_UUID_LOCK_FILENAME
+    lock_flags = (
+        os.O_RDWR
+        | os.O_CREAT
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        lock_fd = os.open(lock_path, lock_flags, 0o644)
+    except OSError as e:
+        raise RuntimeError(
+            f"Unable to lock fs_native disk identity in {base!s}: {e}"
+        ) from e
+
+    temp_path: Path | None = None
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        if uuid_path.exists() or uuid_path.is_symlink():
+            return _read_disk_uuid(uuid_path)
+
+        value = str(uuid.uuid4())
+        temp_path = base / f"{_DISK_UUID_FILENAME}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+        temp_flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        temp_fd = os.open(temp_path, temp_flags, 0o644)
+        try:
+            os.write(temp_fd, f"{value}\n".encode("ascii"))
+            os.fsync(temp_fd)
+        finally:
+            os.close(temp_fd)
+        os.replace(temp_path, uuid_path)
+        temp_path = None
+        directory_fd = os.open(base, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        return value
+    except OSError as e:
+        raise RuntimeError(
+            f"Unable to persist fs_native disk identity in {base!s}: {e}"
+        ) from e
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+def scan_existing_cache_entries(
+    base_path: str,
+) -> tuple[list[tuple[ObjectKey, int, int]], int]:
+    """Scan the native connector's flat cache directory for recovery.
+
+    Args:
+        base_path: Root directory containing cache files.
+
+    Returns:
+        ``(entries, skipped_files)``. Each entry contains the key, size, and
+        best-effort last-access time ``max(atime_ns, mtime_ns)``.
+
+    Raises:
+        RuntimeError: If the cache directory or a candidate file cannot be
+            read.
+    """
+    base = Path(base_path)
+    recovered: dict[ObjectKey, tuple[ObjectKey, int, int]] = {}
+    skipped_files = 0
+
+    try:
+        with os.scandir(base) as entries:
+            for entry in entries:
+                try:
+                    if not entry.name.endswith(".data"):
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        skipped_files += 1
+                        continue
+                    key = filename_to_object_key(entry.name)
+                    if key is None or object_key_to_filename(key) != entry.name:
+                        skipped_files += 1
+                        continue
+                    stat = entry.stat(follow_symlinks=False)
+                except FileNotFoundError:
+                    # A concurrent cleanup removed the entry after scandir.
+                    continue
+                except OSError as e:
+                    raise RuntimeError(
+                        f"Unable to inspect fs_native cache file {entry.path!r}: {e}"
+                    ) from e
+
+                last_access_ns = max(stat.st_atime_ns, stat.st_mtime_ns)
+                recovered[key] = (key, stat.st_size, last_access_ns)
+    except OSError as e:
+        raise RuntimeError(
+            f"Unable to scan fs_native cache directory {base!s}: {e}"
+        ) from e
+
+    return list(recovered.values()), skipped_files
 
 
 class FSNativeL2AdapterConfig(L2AdapterConfigBase):
@@ -56,12 +216,18 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         read_ahead_size: Optional[int] = None,
         max_capacity_gb: float = 0,
     ):
+        relative_tmp_path = Path(relative_tmp_dir)
+        if relative_tmp_path.is_absolute() or ".." in relative_tmp_path.parts:
+            raise ValueError(
+                "relative_tmp_dir must stay within the fs_native base_path"
+            )
         self.base_path = base_path
         self.num_workers = num_workers
         self.relative_tmp_dir = relative_tmp_dir
         self.use_odirect = use_odirect
         self.read_ahead_size = read_ahead_size
         self.max_capacity_gb = max_capacity_gb
+        self.placement_id = None
 
     @classmethod
     def from_dict(cls, d: dict) -> "FSNativeL2AdapterConfig":
@@ -76,7 +242,6 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         relative_tmp_dir = d.get("relative_tmp_dir", "")
         if not isinstance(relative_tmp_dir, str):
             raise ValueError("relative_tmp_dir must be a string")
-
         use_odirect = d.get("use_odirect", False)
         if not isinstance(use_odirect, bool):
             raise ValueError("use_odirect must be a boolean")
@@ -141,9 +306,21 @@ def _create_fs_native_l2_adapter(
     # First Party
     from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (  # noqa: E501
         NativeConnectorL2Adapter,
+        RecoveredL2Entry,
     )
 
     assert isinstance(config, FSNativeL2AdapterConfig)
+    config.placement_id = get_or_create_disk_uuid(config.base_path)
+    scanned_entries, skipped_files = scan_existing_cache_entries(config.base_path)
+    recovered_entries = [
+        RecoveredL2Entry(
+            key=key,
+            size_bytes=size,
+            last_access_ns=last_access_ns,
+        )
+        for key, size, last_access_ns in scanned_entries
+    ]
+
     native_client = LMCacheFSClient(
         config.base_path,
         config.num_workers,
@@ -151,24 +328,38 @@ def _create_fs_native_l2_adapter(
         config.use_odirect,
         config.read_ahead_size or 0,
     )
+    try:
+        adapter = NativeConnectorL2Adapter(
+            native_client,
+            max_capacity_gb=config.max_capacity_gb,
+            type_name="FSNativeL2Adapter",
+            extra_status={
+                "base_path": config.base_path,
+                "placement_id": config.placement_id,
+                "use_odirect": config.use_odirect,
+                "num_workers": config.num_workers,
+                "read_ahead_size": config.read_ahead_size,
+                "recovery_skipped_files": skipped_files,
+            },
+            recovered_entries=recovered_entries,
+        )
+    except Exception:
+        native_client.close()
+        raise
     logger.info(
-        "Created FS native L2 adapter: %s (workers=%d, odirect=%s, read_ahead=%s)",
+        "Created FS native L2 adapter: %s (placement_id=%s, workers=%d, "
+        "odirect=%s, read_ahead=%s, recovered_keys=%d, "
+        "recovered_bytes=%d, skipped=%d)",
         config.base_path,
+        config.placement_id,
         config.num_workers,
         config.use_odirect,
         config.read_ahead_size,
+        len(recovered_entries),
+        sum(entry.size_bytes for entry in recovered_entries),
+        skipped_files,
     )
-    return NativeConnectorL2Adapter(
-        native_client,
-        max_capacity_gb=config.max_capacity_gb,
-        type_name="FSNativeL2Adapter",
-        extra_status={
-            "base_path": config.base_path,
-            "use_odirect": config.use_odirect,
-            "num_workers": config.num_workers,
-            "read_ahead_size": config.read_ahead_size,
-        },
-    )
+    return adapter
 
 
 register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 # Standard
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any
 import select
 import threading
@@ -30,7 +31,10 @@ import threading
 from lmcache.lmcache_native import Bitmap
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.internal_api import L2StoreResult
+from lmcache.v1.distributed.internal_api import (
+    L2AdapterListener,
+    L2StoreResult,
+)
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -81,6 +85,22 @@ def _obj_to_memoryview(
     return obj.byte_array  # type: ignore[return-value]
 
 
+@dataclass(frozen=True)
+class RecoveredL2Entry:
+    """An object discovered on persistent storage before adapter startup.
+
+    Attributes:
+        key: Decoded object key.
+        size_bytes: Persisted object size.
+        last_access_ns: Best-effort restart LRU timestamp recovered by the
+            backing connector.
+    """
+
+    key: ObjectKey
+    size_bytes: int
+    last_access_ns: int = 0
+
+
 class NativeConnectorL2Adapter(L2AdapterInterface):
     """
     Wraps a pybind-wrapped C++ IStorageConnector to
@@ -108,12 +128,33 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         max_capacity_gb: float = 0,
         type_name: str = "",
         extra_status: dict[str, Any] | None = None,
+        recovered_entries: list[RecoveredL2Entry] | None = None,
     ) -> None:
         super().__init__(max_capacity_bytes=int(max_capacity_gb * (1024**3)))
         self._client = native_client
         self._client_fd: int = int(native_client.event_fd())
         self._type_name: str = type_name or type(native_client).__name__
         self._extra_status: dict[str, Any] = dict(extra_status or {})
+
+        recovered_by_key: dict[ObjectKey, RecoveredL2Entry] = {}
+        for entry in recovered_entries or []:
+            if entry.size_bytes < 0:
+                raise ValueError("recovered entry size must be non-negative")
+            previous = recovered_by_key.get(entry.key)
+            if previous is None or entry.last_access_ns > previous.last_access_ns:
+                recovered_by_key[entry.key] = entry
+        # LRU batch creation iterates in reverse. Newest-first here therefore
+        # reconstructs an oldest-first eviction order at listener bootstrap.
+        self._recovered_entries = tuple(
+            sorted(
+                recovered_by_key.values(),
+                key=lambda entry: (
+                    entry.last_access_ns,
+                    _object_key_to_string(entry.key),
+                ),
+                reverse=True,
+            )
+        )
 
         # 3 distinct cross-platform notifiers for the L2 adapter
         # interface
@@ -148,7 +189,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         # at delete time (the native completion only carries booleans, not
         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
         # and per-user totals live in the base class — see ``get_usage``.
-        self._key_sizes: dict[ObjectKey, int] = {}
+        self._key_sizes: dict[ObjectKey, int] = {
+            entry.key: entry.size_bytes for entry in self._recovered_entries
+        }
+        self._recovered_keys = set(self._key_sizes)
+        self.seed_existing_keys(
+            list(self._key_sizes),
+            list(self._key_sizes.values()),
+        )
         # Pending store sizes: native future_id -> (keys, per_key_sizes).
         # Bridges the async store submit → demux completion gap so the
         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
@@ -341,6 +389,28 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     # class tracks aggregate + per-user totals via ``_notify_keys_*``;
     # we feed it the byte sizes from each store/delete completion.
 
+    def register_listener(self, listener: L2AdapterListener) -> None:
+        """Register a listener and replay the recovered-key snapshot.
+
+        Args:
+            listener: Listener receiving future events and currently
+                recovered keys.
+        """
+        super().register_listener(listener)
+        if not self._recovered_entries:
+            return
+        with self._lock:
+            current_entries = [
+                (entry.key, self._key_sizes[entry.key])
+                for entry in self._recovered_entries
+                if entry.key in self._key_sizes
+            ]
+        if not current_entries:
+            return
+        keys = [key for key, _size in current_entries]
+        sizes = [size for _key, size in current_entries]
+        listener.on_l2_keys_stored(keys, sizes)
+
     # ---------------------------------------------------------------
     # Status Interface
     # ---------------------------------------------------------------
@@ -362,6 +432,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             "type": self._type_name,
         }
         status.update(self._extra_status)
+        status.update(
+            {
+                "recovered_keys": len(self._recovered_entries),
+                "recovered_bytes": sum(
+                    entry.size_bytes for entry in self._recovered_entries
+                ),
+            }
+        )
         return status
 
     # ---------------------------------------------------------------
@@ -505,16 +583,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         self._load_efd.notify()
 
                     elif op_type == self._OP_DELETE:
-                        if result_bools is not None and lookup_keys is not None:
-                            for i, deleted in enumerate(result_bools):
-                                if not deleted:
-                                    continue
-                                key = lookup_keys[i]
-                                # Only notify (with size) for keys we've
-                                # actually accounted for via a prior store.
+                        if ok and lookup_keys is not None:
+                            if result_bools is None:
+                                acknowledged_keys = lookup_keys
+                            else:
+                                acknowledged_keys = [
+                                    key
+                                    for key, deleted in zip(
+                                        lookup_keys, result_bools, strict=False
+                                    )
+                                    if deleted or key in self._recovered_keys
+                                ]
+                            for key in acknowledged_keys:
                                 if key in self._key_sizes:
                                     sizes_deleted.append(self._key_sizes.pop(key))
                                     keys_deleted.append(key)
+                                    self._recovered_keys.discard(key)
                         evt = self._pending_delete_events.pop(task_id, None)
                         if evt is not None:
                             delete_done_events.append(evt)

--- a/lmcache/v1/distributed/storage_controllers/adapter_lifecycle.py
+++ b/lmcache/v1/distributed/storage_controllers/adapter_lifecycle.py
@@ -30,6 +30,8 @@ class AddAdapterOp:
     adapter: L2AdapterInterface
     descriptor: AdapterDescriptor
     done: threading.Event
+    error: Exception | None = None
+    """Policy validation error raised while attaching the adapter."""
 
 
 @dataclass

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -175,6 +175,38 @@ def trim_load_plan_with_mask(
     return trimmed_plan
 
 
+def remap_lookup_bitmap(
+    subset_bitmap: Bitmap,
+    key_indices: list[int],
+    num_keys: int,
+) -> Bitmap:
+    """Remap a targeted lookup result into global request positions.
+
+    Args:
+        subset_bitmap: Bitmap indexed relative to the adapter's key subset.
+        key_indices: Global request index for every subset position.
+        num_keys: Total number of keys in the request.
+
+    Returns:
+        Bitmap of size ``num_keys`` with matching global positions set.
+
+    Raises:
+        ValueError: If the adapter bitmap refers past ``key_indices`` or a
+            mapped global index is outside the request.
+    """
+    global_bitmap = Bitmap(num_keys)
+    for subset_index in subset_bitmap.get_indices_list():
+        if subset_index >= len(key_indices):
+            raise ValueError(
+                "adapter returned an out-of-range targeted lookup bitmap index"
+            )
+        global_index = key_indices[subset_index]
+        if global_index < 0 or global_index >= num_keys:
+            raise ValueError("prefetch policy returned an out-of-range key index")
+        global_bitmap.set(global_index)
+    return global_bitmap
+
+
 # Poll timeout in milliseconds for the prefetch loop
 PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
 
@@ -213,6 +245,9 @@ class InFlightPrefetchRequest:
     pending_lookup_tasks: dict[int, L2TaskId] = field(default_factory=dict)
     # Lookup phase: adapter_idx -> bitmap (populated as results arrive)
     lookup_results: dict[int, Bitmap] = field(default_factory=dict)
+    # Targeted lookup maps each adapter's subset-local bitmap positions back
+    # to indices in ``keys``. ``None`` means the request was broadcast.
+    lookup_key_indices: dict[int, list[int]] | None = None
     # L2 read locks currently held (adapter_idx -> key indices).
     # _release_l2_locks subtracts keys as their locks are returned.
     l2_adapter2readlocks: dict[int, Bitmap] = field(default_factory=dict)
@@ -292,6 +327,7 @@ class PrefetchController(StorageControllerInterface):
             desc.index: desc for desc in adapter_descriptors
         }
         self._policy = policy
+        self._policy.validate_adapters(adapter_descriptors)
         self._max_in_flight = max_in_flight
 
         # Adapters that are being drained and will be removed after all
@@ -879,8 +915,7 @@ class PrefetchController(StorageControllerInterface):
         request_id: PrefetchRequestId,
         spec: PrefetchRequestSpec,
     ) -> None:
-        """Read-lock L1-resident keys, then submit lookup_and_lock to all
-        live (non-draining) adapters for a new request."""
+        """Read-lock L1 keys and submit policy-routed L2 lookups."""
         l1_readlocks = self._lock_l1_keys(
             spec.keys, spec.num_kv_readers, spec.policy, spec.attn_desc
         )
@@ -908,11 +943,43 @@ class PrefetchController(StorageControllerInterface):
             self._finish_request(request)
             return
 
-        for adapter_id, adapter in routing_adapters.items():
-            task_id = adapter.submit_lookup_and_lock_task(
-                spec.keys, spec.group_layout_descs
-            )
-            request.pending_lookup_tasks[adapter_id] = task_id
+        routing_descriptors = [
+            descriptor
+            for adapter_id, descriptor in self._adapter_descriptors.items()
+            if adapter_id in routing_adapters
+        ]
+        lookup_targets = self._policy.select_lookup_targets(
+            spec.keys, routing_descriptors
+        )
+        if lookup_targets is None:
+            for adapter_id, adapter in routing_adapters.items():
+                task_id = adapter.submit_lookup_and_lock_task(
+                    spec.keys, spec.group_layout_descs
+                )
+                request.pending_lookup_tasks[adapter_id] = task_id
+        else:
+            request.lookup_key_indices = {}
+            for adapter_id, key_indices in lookup_targets.items():
+                if adapter_id not in routing_adapters:
+                    raise ValueError(
+                        f"prefetch policy selected unavailable adapter {adapter_id}"
+                    )
+                if not key_indices:
+                    continue
+                if any(index < 0 or index >= len(spec.keys) for index in key_indices):
+                    raise ValueError(
+                        "prefetch policy returned an out-of-range key index"
+                    )
+                subset_keys = [spec.keys[index] for index in key_indices]
+                task_id = routing_adapters[adapter_id].submit_lookup_and_lock_task(
+                    subset_keys, spec.group_layout_descs
+                )
+                request.pending_lookup_tasks[adapter_id] = task_id
+                request.lookup_key_indices[adapter_id] = list(key_indices)
+
+        if not request.pending_lookup_tasks:
+            self._finish_request(request)
+            return
         self._in_flight_requests[request_id] = request
         self._status_in_flight_count += 1
         self._status_lookup_phase_count += 1
@@ -1238,7 +1305,7 @@ class PrefetchController(StorageControllerInterface):
         request: InFlightPrefetchRequest,
         signaled_adapters: set[int],
     ) -> None:
-        """Query pending lookup-and-lock results from signaled adapters."""
+        """Query lookup results and normalize them to global key indices."""
         for adapter_idx in list(request.pending_lookup_tasks):
             if adapter_idx not in signaled_adapters:
                 continue
@@ -1248,8 +1315,16 @@ class PrefetchController(StorageControllerInterface):
             )
             if result is None:
                 continue
-            request.lookup_results[adapter_idx] = result
-            request.l2_adapter2readlocks[adapter_idx] = result
+            if request.lookup_key_indices is None:
+                global_result = result
+            else:
+                global_result = remap_lookup_bitmap(
+                    result,
+                    request.lookup_key_indices[adapter_idx],
+                    len(request.keys),
+                )
+            request.lookup_results[adapter_idx] = global_result
+            request.l2_adapter2readlocks[adapter_idx] = global_result
             del request.pending_lookup_tasks[adapter_idx]
 
     def _poll_load_results(

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -664,6 +664,8 @@ class PrefetchController(StorageControllerInterface):
         Raises:
             RuntimeError: If the background loop did not apply the op in
                 time (e.g. the loop is not running).
+            ValueError: If the resulting adapter set is invalid for the
+                prefetch policy.
         """
         op = AddAdapterOp(
             adapter_id=adapter_id,
@@ -678,6 +680,8 @@ class PrefetchController(StorageControllerInterface):
             raise RuntimeError(
                 f"PrefetchController did not attach adapter {adapter_id} in time"
             )
+        if op.error is not None:
+            raise op.error
 
     def request_remove_adapter(self, adapter_id: int) -> threading.Event:
         """Non-blocking function to request the removal of a L2 adapter
@@ -783,6 +787,23 @@ class PrefetchController(StorageControllerInterface):
             self._pending_adapter_ops = []
         for op in ops:
             if isinstance(op, AddAdapterOp):
+                adapters = [
+                    descriptor
+                    for adapter_id, descriptor in self._adapter_descriptors.items()
+                    if adapter_id not in self._draining
+                ]
+                adapters.append(op.descriptor)
+                try:
+                    self._policy.validate_adapters(adapters)
+                except Exception as error:
+                    op.error = error
+                    logger.warning(
+                        "PrefetchController rejected adapter %d: %s",
+                        op.adapter_id,
+                        error,
+                    )
+                    op.done.set()
+                    continue
                 self._l2_adapters[op.adapter_id] = op.adapter
                 self._adapter_descriptors[op.adapter_id] = op.descriptor
                 lookup_efd = op.adapter.get_lookup_and_lock_event_fd()
@@ -797,6 +818,12 @@ class PrefetchController(StorageControllerInterface):
                 if op.adapter_id not in self._l2_adapters:
                     op.done.set()
                     continue
+                adapters = [
+                    descriptor
+                    for adapter_id, descriptor in self._adapter_descriptors.items()
+                    if adapter_id != op.adapter_id and adapter_id not in self._draining
+                ]
+                self._policy.validate_adapters(adapters)
                 # Mark draining; new lookups skip it. The adapter stays
                 # registered so in-flight requests can still complete.
                 self._draining[op.adapter_id] = op.done

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -15,6 +15,7 @@ from lmcache.lmcache_native import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    rendezvous_adapter_indices_for_keys,
 )
 
 
@@ -26,6 +27,14 @@ class PrefetchPolicy(ABC):
     adapters have completed their lookup_and_lock operations. Given the
     lookup results, it decides which adapter should load which keys.
     """
+
+    def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
+        """Validate an adapter set before the controller starts.
+
+        Args:
+            adapters: Configured L2 adapter descriptors.
+        """
+        return None
 
     @abstractmethod
     def select_load_plan(
@@ -49,6 +58,23 @@ class PrefetchPolicy(ABC):
             overlap, and the union of all returned bitmaps should be a subset
             of the union of the input bitmaps.
         """
+
+    def select_lookup_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[int]] | None:
+        """Choose adapters queried during the lookup phase.
+
+        Args:
+            keys: Full list of keys being prefetched.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            ``None`` to query every adapter for every key, or a mapping from
+            adapter index to indices in ``keys`` for targeted lookup.
+        """
+        return None
 
     def select_l1_retentions(
         self,
@@ -189,5 +215,44 @@ class RetainPrefetchPolicy(DefaultPrefetchPolicy):
         return [True] * len(keys)
 
 
+class StripedPrefetchPolicy(DefaultPrefetchPolicy):
+    """Query only the stable rendezvous owner of each striped key."""
+
+    def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
+        """Require adapters accepted by rendezvous placement.
+
+        Args:
+            adapters: Configured L2 adapter descriptors.
+        """
+        if adapters:
+            rendezvous_adapter_indices_for_keys([], adapters)
+
+    def select_lookup_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[int]] | None:
+        """Route each key lookup to exactly one stable adapter.
+
+        Args:
+            keys: Full list of keys being prefetched.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from adapter index to global key indices. With no
+            adapters, returns ``None`` so the controller retains its normal
+            no-adapter completion path.
+        """
+        if not adapters:
+            return None
+
+        targets: dict[int, list[int]] = {adapter.index: [] for adapter in adapters}
+        adapter_indices = rendezvous_adapter_indices_for_keys(keys, adapters)
+        for key_index, adapter_index in enumerate(adapter_indices):
+            targets[adapter_index].append(key_index)
+        return targets
+
+
 register_prefetch_policy("default", DefaultPrefetchPolicy)
 register_prefetch_policy("retain", RetainPrefetchPolicy)
+register_prefetch_policy("striped", StripedPrefetchPolicy)

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -15,7 +15,7 @@ from lmcache.lmcache_native import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
-    rendezvous_adapter_indices_for_keys,
+    RendezvousHashRouter,
 )
 
 
@@ -29,10 +29,11 @@ class PrefetchPolicy(ABC):
     """
 
     def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
-        """Validate an adapter set before the controller starts.
+        """Validate and prepare an adapter set before it is used for routing.
 
         Args:
-            adapters: Configured L2 adapter descriptors.
+            adapters: Active L2 adapter descriptors. The controller calls this
+                before startup and whenever the active adapter set changes.
         """
         return None
 
@@ -218,14 +219,16 @@ class RetainPrefetchPolicy(DefaultPrefetchPolicy):
 class StripedPrefetchPolicy(DefaultPrefetchPolicy):
     """Query only the stable rendezvous owner of each striped key."""
 
+    def __init__(self) -> None:
+        self._router = RendezvousHashRouter()
+
     def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
-        """Require adapters accepted by rendezvous placement.
+        """Validate and cache adapters accepted by rendezvous placement.
 
         Args:
             adapters: Configured L2 adapter descriptors.
         """
-        if adapters:
-            rendezvous_adapter_indices_for_keys([], adapters)
+        self._router.update_adapters(adapters)
 
     def select_lookup_targets(
         self,
@@ -246,9 +249,10 @@ class StripedPrefetchPolicy(DefaultPrefetchPolicy):
         if not adapters:
             return None
 
-        targets: dict[int, list[int]] = {adapter.index: [] for adapter in adapters}
-        adapter_indices = rendezvous_adapter_indices_for_keys(keys, adapters)
-        for key_index, adapter_index in enumerate(adapter_indices):
+        targets: dict[int, list[int]] = {
+            adapter_index: [] for adapter_index in self._router.adapter_indices
+        }
+        for key_index, adapter_index in enumerate(self._router.select_adapters(keys)):
             targets[adapter_index].append(key_index)
         return targets
 

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -239,6 +239,7 @@ class StoreController(StorageControllerInterface):
             desc.index: desc for desc in adapter_descriptors
         }
         self._policy = policy
+        self._policy.validate_adapters(adapter_descriptors)
 
         # Adapters that are being drained and will be removed after all
         # the in-flight operations are done.

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -353,6 +353,8 @@ class StoreController(StorageControllerInterface):
         Raises:
             RuntimeError: If the background loop did not apply the op in
                 time (e.g. the loop is not running).
+            ValueError: If the resulting adapter set is invalid for the store
+                policy.
         """
         op = AddAdapterOp(
             adapter_id=adapter_id,
@@ -367,6 +369,8 @@ class StoreController(StorageControllerInterface):
             raise RuntimeError(
                 f"StoreController did not attach adapter {adapter_id} in time"
             )
+        if op.error is not None:
+            raise op.error
 
     def request_remove_adapter(self, adapter_id: int) -> threading.Event:
         """Non-blocking function to request the removal of a L2 adapter
@@ -509,6 +513,23 @@ class StoreController(StorageControllerInterface):
             self._pending_adapter_ops = []
         for op in ops:
             if isinstance(op, AddAdapterOp):
+                adapters = [
+                    descriptor
+                    for adapter_id, descriptor in self._adapter_descriptors.items()
+                    if adapter_id not in self._draining
+                ]
+                adapters.append(op.descriptor)
+                try:
+                    self._policy.validate_adapters(adapters)
+                except Exception as error:
+                    op.error = error
+                    logger.warning(
+                        "StoreController rejected adapter %d: %s",
+                        op.adapter_id,
+                        error,
+                    )
+                    op.done.set()
+                    continue
                 self._l2_adapters[op.adapter_id] = op.adapter
                 self._adapter_descriptors[op.adapter_id] = op.descriptor
                 efd = op.adapter.get_store_event_fd()
@@ -522,6 +543,12 @@ class StoreController(StorageControllerInterface):
                     # doesn't block.
                     op.done.set()
                     continue
+                adapters = [
+                    descriptor
+                    for adapter_id, descriptor in self._adapter_descriptors.items()
+                    if adapter_id != op.adapter_id and adapter_id not in self._draining
+                ]
+                self._policy.validate_adapters(adapters)
                 # Mark draining; routing skips it immediately. The adapter
                 # stays registered so in-flight completions still process.
                 self._draining[op.adapter_id] = op.done

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -11,6 +11,9 @@ The store policy makes two decisions after data is written to L1:
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+# Third Party
+import blake3
+
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.config import (
@@ -45,6 +48,16 @@ class AdapterDescriptor:
         """
         return get_type_name_for_config(self.config)
 
+    @property
+    def placement_id(self) -> str | None:
+        """Return the adapter's restart-stable placement identifier.
+
+        Returns:
+            The stable identifier supplied by the adapter config, or ``None``
+            when the backend does not provide one.
+        """
+        return self.config.placement_id
+
 
 class StorePolicy(ABC):
     """
@@ -55,6 +68,14 @@ class StorePolicy(ABC):
     2. Which keys to delete from L1 after successful L2 store
        (select_l1_deletions).
     """
+
+    def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
+        """Validate an adapter set before the controller starts.
+
+        Args:
+            adapters: Configured L2 adapter descriptors.
+        """
+        return None
 
     @abstractmethod
     def select_store_targets(
@@ -141,6 +162,111 @@ def create_store_policy(name: str) -> StorePolicy:
     return _STORE_POLICY_REGISTRY[name]()
 
 
+def _routing_key_bytes(key: ObjectKey) -> bytes:
+    """Encode every identity field of an object key without ambiguous joins."""
+    fields = (
+        key.model_name.encode(),
+        str(key.kv_rank).encode(),
+        str(key.object_group_id).encode(),
+        key.chunk_hash,
+        key.cache_salt.encode(),
+    )
+    return b"".join(len(field).to_bytes(8, byteorder="big") + field for field in fields)
+
+
+def _validate_stable_adapters(
+    adapters: list[AdapterDescriptor],
+) -> list[tuple[int, str, bytes]]:
+    """Validate and deterministically order adapters for stable placement."""
+    missing = [adapter.index for adapter in adapters if not adapter.placement_id]
+    if missing:
+        raise ValueError(
+            "striped policy requires a stable placement_id for every adapter; "
+            f"missing on adapter indices {missing}"
+        )
+
+    placement_ids = [adapter.placement_id for adapter in adapters]
+    if len(set(placement_ids)) != len(placement_ids):
+        raise ValueError("striped policy requires unique adapter placement_id values")
+
+    stable_adapters: list[tuple[int, str, bytes]] = []
+    for adapter in sorted(adapters, key=lambda value: value.placement_id or ""):
+        placement_id = adapter.placement_id
+        assert placement_id is not None
+        placement_bytes = placement_id.encode()
+        framed_placement = (
+            len(placement_bytes).to_bytes(8, byteorder="big") + placement_bytes
+        )
+        stable_adapters.append((adapter.index, placement_id, framed_placement))
+    return stable_adapters
+
+
+def rendezvous_adapter_index_for_key(
+    key: ObjectKey,
+    adapters: list[AdapterDescriptor],
+) -> int:
+    """Select one adapter with highest-random-weight rendezvous hashing.
+
+    Args:
+        key: Object key to route.
+        adapters: Candidate adapters. Every adapter must expose a unique,
+            restart-stable ``placement_id``.
+
+    Returns:
+        Runtime index of the selected adapter.
+
+    Raises:
+        ValueError: If no adapters are supplied or placement identifiers are
+            missing or duplicated.
+    """
+    stable_adapters = _validate_stable_adapters(adapters)
+    if not stable_adapters:
+        raise ValueError("rendezvous hashing requires at least one adapter")
+
+    return _rendezvous_adapter_index_for_key(key, stable_adapters)
+
+
+def rendezvous_adapter_indices_for_keys(
+    keys: list[ObjectKey],
+    adapters: list[AdapterDescriptor],
+) -> list[int]:
+    """Route a batch of keys while validating the adapter set only once.
+
+    Args:
+        keys: Object keys to route.
+        adapters: Candidate adapters with unique stable placement identifiers.
+
+    Returns:
+        Adapter indices in the same order as ``keys``.
+
+    Raises:
+        ValueError: If the adapter set is empty or lacks unique stable ids.
+    """
+    stable_adapters = _validate_stable_adapters(adapters)
+    if not stable_adapters:
+        raise ValueError("rendezvous hashing requires at least one adapter")
+    return [_rendezvous_adapter_index_for_key(key, stable_adapters) for key in keys]
+
+
+def _rendezvous_adapter_index_for_key(
+    key: ObjectKey,
+    stable_adapters: list[tuple[int, str, bytes]],
+) -> int:
+    """Route a key over an already validated, non-empty adapter list."""
+    key_bytes = _routing_key_bytes(key)
+    winner_index = -1
+    winner: tuple[bytes, str] | None = None
+    for adapter_index, placement_id, placement_bytes in stable_adapters:
+        score = blake3.blake3(key_bytes + placement_bytes).digest(length=16)
+        candidate = (score, placement_id)
+        # The stable id is a deterministic tie-breaker for the vanishingly
+        # unlikely case of equal 128-bit scores.
+        if winner is None or candidate > winner:
+            winner = candidate
+            winner_index = adapter_index
+    return winner_index
+
+
 class DefaultStorePolicy(StorePolicy):
     """
     Default store policy: store all keys to all adapters,
@@ -209,5 +335,67 @@ class BufferOnlyStorePolicy(DefaultStorePolicy):
         return list(keys)
 
 
+class StripedStorePolicy(StorePolicy):
+    """Store every key on one stable rendezvous-hashed adapter.
+
+    The adapter's persistent placement identifier, rather than its runtime
+    list position, participates in the hash. Adding or removing a disk thus
+    remaps only keys owned by the changed disk set while preserving the
+    single-copy capacity and bandwidth benefits of striping.
+    """
+
+    def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
+        """Require unique, persistent placement identifiers.
+
+        Args:
+            adapters: Configured L2 adapter descriptors.
+        """
+        _validate_stable_adapters(adapters)
+
+    def select_store_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[ObjectKey]]:
+        """Assign every key to exactly one stable adapter.
+
+        Args:
+            keys: Keys that were just written to L1.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from adapter index to its assigned keys. With no adapters,
+            returns an empty mapping.
+        """
+        if not adapters:
+            return {}
+        stable_adapters = _validate_stable_adapters(adapters)
+        targets: dict[int, list[ObjectKey]] = {
+            adapter_index: []
+            for adapter_index, _placement_id, _bytes in stable_adapters
+        }
+        adapter_indices = [
+            _rendezvous_adapter_index_for_key(key, stable_adapters) for key in keys
+        ]
+        for key, adapter_index in zip(keys, adapter_indices, strict=True):
+            targets[adapter_index].append(key)
+        return targets
+
+    def select_l1_deletions(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[ObjectKey]:
+        """Keep successfully stored keys in L1.
+
+        Args:
+            keys: Keys successfully stored in L2.
+
+        Returns:
+            An empty list.
+        """
+        return []
+
+
 register_store_policy("default", DefaultStorePolicy)
 register_store_policy("skip_l1", BufferOnlyStorePolicy)
+register_store_policy("striped", StripedStorePolicy)

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -70,10 +70,11 @@ class StorePolicy(ABC):
     """
 
     def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
-        """Validate an adapter set before the controller starts.
+        """Validate and prepare an adapter set before it is used for routing.
 
         Args:
-            adapters: Configured L2 adapter descriptors.
+            adapters: Active L2 adapter descriptors. The controller calls this
+                before startup and whenever the active adapter set changes.
         """
         return None
 
@@ -201,6 +202,65 @@ def _validate_stable_adapters(
     return stable_adapters
 
 
+class RendezvousHashRouter:
+    """Route keys over a validated, restart-stable adapter set.
+
+    Adapter sorting, duplicate detection, and placement-id encoding happen only
+    when :meth:`update_adapters` is called. Store and prefetch policies can then
+    reuse the cached representation on every request in the data path.
+    """
+
+    def __init__(self) -> None:
+        self._stable_adapters: list[tuple[int, str, bytes]] = []
+        self._adapter_indices: tuple[int, ...] = ()
+
+    def update_adapters(self, adapters: list[AdapterDescriptor]) -> None:
+        """Validate and cache a complete adapter set.
+
+        The existing cache is preserved when validation fails.
+
+        Args:
+            adapters: Active adapters with unique stable placement identifiers.
+
+        Raises:
+            ValueError: If a placement identifier is missing or duplicated.
+        """
+        stable_adapters = _validate_stable_adapters(adapters)
+        adapter_indices = tuple(adapter[0] for adapter in stable_adapters)
+        self._stable_adapters = stable_adapters
+        self._adapter_indices = adapter_indices
+
+    @property
+    def adapter_indices(self) -> tuple[int, ...]:
+        """Return cached runtime indices in stable placement order."""
+        return self._adapter_indices
+
+    def select_adapter(self, key: ObjectKey) -> int:
+        """Return the rendezvous owner for one key.
+
+        Args:
+            key: Object key to route.
+
+        Returns:
+            Runtime index of the selected adapter.
+
+        Raises:
+            ValueError: If the router has no active adapters.
+        """
+        if not self._stable_adapters:
+            raise ValueError("rendezvous hashing requires at least one adapter")
+        return _rendezvous_adapter_index_for_key(key, self._stable_adapters)
+
+    def select_adapters(self, keys: list[ObjectKey]) -> list[int]:
+        """Return rendezvous owners for a batch of keys."""
+        if not self._stable_adapters:
+            raise ValueError("rendezvous hashing requires at least one adapter")
+        return [
+            _rendezvous_adapter_index_for_key(key, self._stable_adapters)
+            for key in keys
+        ]
+
+
 def rendezvous_adapter_index_for_key(
     key: ObjectKey,
     adapters: list[AdapterDescriptor],
@@ -219,11 +279,9 @@ def rendezvous_adapter_index_for_key(
         ValueError: If no adapters are supplied or placement identifiers are
             missing or duplicated.
     """
-    stable_adapters = _validate_stable_adapters(adapters)
-    if not stable_adapters:
-        raise ValueError("rendezvous hashing requires at least one adapter")
-
-    return _rendezvous_adapter_index_for_key(key, stable_adapters)
+    router = RendezvousHashRouter()
+    router.update_adapters(adapters)
+    return router.select_adapter(key)
 
 
 def rendezvous_adapter_indices_for_keys(
@@ -242,10 +300,9 @@ def rendezvous_adapter_indices_for_keys(
     Raises:
         ValueError: If the adapter set is empty or lacks unique stable ids.
     """
-    stable_adapters = _validate_stable_adapters(adapters)
-    if not stable_adapters:
-        raise ValueError("rendezvous hashing requires at least one adapter")
-    return [_rendezvous_adapter_index_for_key(key, stable_adapters) for key in keys]
+    router = RendezvousHashRouter()
+    router.update_adapters(adapters)
+    return router.select_adapters(keys)
 
 
 def _rendezvous_adapter_index_for_key(
@@ -344,13 +401,16 @@ class StripedStorePolicy(StorePolicy):
     single-copy capacity and bandwidth benefits of striping.
     """
 
+    def __init__(self) -> None:
+        self._router = RendezvousHashRouter()
+
     def validate_adapters(self, adapters: list[AdapterDescriptor]) -> None:
-        """Require unique, persistent placement identifiers.
+        """Validate and cache unique, persistent placement identifiers.
 
         Args:
             adapters: Configured L2 adapter descriptors.
         """
-        _validate_stable_adapters(adapters)
+        self._router.update_adapters(adapters)
 
     def select_store_targets(
         self,
@@ -369,15 +429,11 @@ class StripedStorePolicy(StorePolicy):
         """
         if not adapters:
             return {}
-        stable_adapters = _validate_stable_adapters(adapters)
         targets: dict[int, list[ObjectKey]] = {
-            adapter_index: []
-            for adapter_index, _placement_id, _bytes in stable_adapters
+            adapter_index: [] for adapter_index in self._router.adapter_indices
         }
-        adapter_indices = [
-            _rendezvous_adapter_index_for_key(key, stable_adapters) for key in keys
-        ]
-        for key, adapter_index in zip(keys, adapter_indices, strict=True):
+        for key in keys:
+            adapter_index = self._router.select_adapter(key)
             targets[adapter_index].append(key)
         return targets
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -35,7 +35,10 @@ from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import AdapterUsage, L2AdapterInterface
-from lmcache.v1.distributed.l2_adapters.config import L2AdapterConfigBase
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    get_type_name_for_config,
+)
 from lmcache.v1.distributed.l2_adapters.reconfiguration import (
     L2ReconfigurableAdapter,
     L2ReconfigureError,
@@ -79,6 +82,7 @@ class StorageManager:
         # size is a pure function of it.
         self._l1_config = config.l1_manager_config
         self._event_bus = get_event_bus()
+        self._striped_placement = config.store_policy == "striped"
 
         # L1 eviction controller
         self._eviction_controller = L1EvictionController(
@@ -1017,15 +1021,32 @@ class StorageManager:
 
         Returns:
             The stable id assigned to the new adapter.
+
+        Raises:
+            ValueError: If the adapter is incompatible with the active storage
+                policies or makes their adapter set invalid.
         """
         with self._lifecycle_lock:
+            type_name = get_type_name_for_config(config)
+            if self._striped_placement and type_name != "fs_native":
+                raise ValueError(
+                    "striped placement currently supports only fs_native "
+                    f"runtime adapters; got {type_name!r}"
+                )
             adapter_id, adapter, descriptor = self._build_l2_adapter(config)
             for listener in self._registered_l2_listeners:
                 adapter.register_listener(listener)
             with self._adapters_lock:
                 self._l2_adapters[adapter_id] = adapter
                 self._adapter_descriptors[adapter_id] = descriptor
-            self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+            try:
+                self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+            except ValueError:
+                with self._adapters_lock:
+                    self._l2_adapters.pop(adapter_id, None)
+                    self._adapter_descriptors.pop(adapter_id, None)
+                adapter.close()
+                raise
             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
             if self._should_enable_l2_eviction(adapter, config.eviction_config):
                 assert config.eviction_config is not None  # make linter happy

--- a/tests/v1/distributed/test_fs_native_recovery.py
+++ b/tests/v1/distributed/test_fs_native_recovery.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Restart identity and directory-scan tests for ``fs_native``."""
+
+# Standard
+from pathlib import Path
+import os
+import select
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.config import EvictionConfig
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.l2_adapters.factory import (
+    create_l2_adapter_from_registry,
+)
+from lmcache.v1.distributed.l2_adapters.fs_key_codec import object_key_to_filename
+from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+    FSNativeL2AdapterConfig,
+    get_or_create_disk_uuid,
+    scan_existing_cache_entries,
+)
+from lmcache.v1.distributed.storage_controllers.eviction_controller import (
+    L2AdapterEvictionState,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+
+
+def make_key(chunk_id: int) -> ObjectKey:
+    """Create a reversible filesystem test key."""
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="org/test-model",
+        kv_rank=0x01020304,
+        object_group_id=2,
+        cache_salt="tenant-a",
+    )
+
+
+def write_entry(path: Path, key: ObjectKey, size: int, mtime_ns: int) -> Path:
+    """Write one cache file and set a deterministic modification time."""
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / object_key_to_filename(key)
+    file_path.write_bytes(bytes(size))
+    os.utime(file_path, ns=(mtime_ns, mtime_ns))
+    return file_path
+
+
+def make_memory_obj(size: int = 16) -> TensorMemoryObj:
+    """Create a small CPU object accepted by the native connector."""
+    raw_data = torch.arange(size, dtype=torch.uint8)
+    metadata = MemoryObjMetadata(
+        shape=raw_data.shape,
+        dtype=raw_data.dtype,
+        address=0,
+        phy_size=size,
+        ref_count=1,
+        fmt=MemoryFormat.BINARY,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def wait_for_store(
+    adapter: L2AdapterInterface,
+    task_id: int,
+    timeout: float = 5.0,
+) -> None:
+    """Wait for one native adapter store and assert that it succeeded."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        select.select(
+            [adapter.get_store_event_fd()], [], [], min(max(remaining, 0), 0.1)
+        )
+        result = adapter.pop_completed_store_tasks().get(task_id)
+        if result is not None:
+            assert result.is_successful()
+            return
+    raise TimeoutError(f"timed out waiting for store task {task_id}")
+
+
+def test_disk_uuid_is_persistent(tmp_path: Path) -> None:
+    first = get_or_create_disk_uuid(str(tmp_path))
+    second = get_or_create_disk_uuid(str(tmp_path))
+
+    assert first == second
+    assert (tmp_path / ".lmcache_disk_uuid").read_text().strip() == first
+
+
+def test_invalid_disk_uuid_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / ".lmcache_disk_uuid").write_text("not-a-uuid\n")
+
+    with pytest.raises(RuntimeError, match="refusing to remap"):
+        get_or_create_disk_uuid(str(tmp_path))
+
+
+def test_scan_recovers_only_native_connector_flat_entries(tmp_path: Path) -> None:
+    first = make_key(1)
+    second = make_key(2)
+    write_entry(tmp_path, first, size=11, mtime_ns=100)
+    write_entry(tmp_path / "ab" / "cd", second, size=22, mtime_ns=200)
+
+    entries, skipped = scan_existing_cache_entries(str(tmp_path))
+    by_key = {key: (size, mtime_ns) for key, size, mtime_ns in entries}
+
+    assert by_key == {first: (11, 100)}
+    assert skipped == 0
+
+
+def test_scan_prefers_access_time_for_recovered_lru_order(tmp_path: Path) -> None:
+    key = make_key(1)
+    file_path = write_entry(tmp_path, key, size=11, mtime_ns=100)
+    os.utime(file_path, ns=(300, 100))
+
+    entries, skipped = scan_existing_cache_entries(str(tmp_path))
+
+    assert entries == [(key, 11, 300)]
+    assert skipped == 0
+
+
+def test_scan_ignores_subdirectories_and_counts_bad_flat_candidates(
+    tmp_path: Path,
+) -> None:
+    key = make_key(1)
+    write_entry(tmp_path, key, size=11, mtime_ns=100)
+    write_entry(tmp_path / ".tmp", make_key(2), size=33, mtime_ns=300)
+    (tmp_path / "malformed.data").write_bytes(b"bad")
+    (tmp_path / "symlink.data").symlink_to(object_key_to_filename(key))
+    noncanonical = object_key_to_filename(key).replace("@2@", "@02@")
+    (tmp_path / noncanonical).write_bytes(b"duplicate")
+
+    entries, skipped = scan_existing_cache_entries(str(tmp_path))
+
+    assert entries == [(key, 11, 100)]
+    assert skipped == 3
+
+
+def test_real_fs_restart_recovery_exposes_entry_to_lru_gc(tmp_path: Path) -> None:
+    """A persisted salted entry must recover into accounting and LRU GC."""
+    pytest.importorskip("lmcache.lmcache_fs")
+    key = make_key(7)
+    config = FSNativeL2AdapterConfig(
+        base_path=str(tmp_path),
+        max_capacity_gb=0.001,
+    )
+    adapter = create_l2_adapter_from_registry(config)
+    task_id = adapter.submit_store_task([key], [make_memory_obj()])
+    wait_for_store(adapter, task_id)
+    placement_id = config.placement_id
+    adapter.close()
+
+    stored_path = tmp_path / object_key_to_filename(key)
+    assert stored_path.exists()
+
+    restarted_config = FSNativeL2AdapterConfig(
+        base_path=str(tmp_path),
+        max_capacity_gb=0.001,
+    )
+    restarted = create_l2_adapter_from_registry(restarted_config)
+    try:
+        state = L2AdapterEvictionState(
+            adapter_id=0,
+            adapter=restarted,
+            eviction_config=EvictionConfig(
+                eviction_policy="LRU",
+                trigger_watermark=0.8,
+                eviction_ratio=1.0,
+            ),
+        )
+        usage = restarted.get_usage()
+        status = restarted.report_status()
+
+        assert restarted_config.placement_id == placement_id
+        assert usage.total_bytes_used == 16
+        assert status["recovered_keys"] == 1
+        assert status["recovered_bytes"] == 16
+
+        actions = state.eviction_policy.get_eviction_actions(1.0)
+        assert len(actions) == 1
+        assert actions[0].keys == [key]
+        restarted.delete(actions[0].keys)
+
+        assert not stored_path.exists()
+        assert restarted.get_usage().total_bytes_used == 0
+    finally:
+        restarted.close()

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -19,6 +19,7 @@ import torch
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
     NativeConnectorL2Adapter,
+    RecoveredL2Entry,
     _object_key_to_string,
 )
 from lmcache.v1.memory_management import (
@@ -1057,6 +1058,24 @@ class TestFSNativeL2AdapterConfig:
                 }
             )
 
+    @pytest.mark.parametrize("relative_tmp_dir", ["/tmp/lmcache", "../outside"])
+    def test_from_dict_rejects_tmp_dir_outside_base(
+        self, relative_tmp_dir: str
+    ) -> None:
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+            FSNativeL2AdapterConfig,
+        )
+
+        with pytest.raises(ValueError, match="must stay within"):
+            FSNativeL2AdapterConfig.from_dict(
+                {
+                    "type": "fs_native",
+                    "base_path": "/tmp/cache",
+                    "relative_tmp_dir": relative_tmp_dir,
+                }
+            )
+
     def test_from_dict_invalid_use_odirect_raises(self):
         # First Party
         from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
@@ -1248,6 +1267,81 @@ class TestDeleteBackwardCompatibility:
         try:
             key = create_object_key(1)
             adp.delete([key])  # should not raise, just no-op
+        finally:
+            adp.close()
+
+
+# =============================================================================
+# Restart Recovery Tests
+# =============================================================================
+
+
+class TestRestartRecovery:
+    def test_recovered_entries_seed_usage_lru_and_status(self) -> None:
+        # First Party
+        from lmcache.v1.distributed.config import EvictionConfig
+        from lmcache.v1.distributed.storage_controllers.eviction_controller import (
+            L2AdapterEvictionState,
+        )
+
+        older = ObjectKey(
+            chunk_hash=ObjectKey.IntHash2Bytes(1),
+            model_name="test_model",
+            kv_rank=0,
+            cache_salt="alice",
+        )
+        newer = ObjectKey(
+            chunk_hash=ObjectKey.IntHash2Bytes(2),
+            model_name="test_model",
+            kv_rank=0,
+            cache_salt="bob",
+        )
+        adp = NativeConnectorL2Adapter(
+            MockNativeConnector(),
+            max_capacity_gb=1000 / (1024**3),
+            recovered_entries=[
+                RecoveredL2Entry(older, 400, last_access_ns=1),
+                RecoveredL2Entry(newer, 200, last_access_ns=2),
+            ],
+        )
+        try:
+            usage = adp.get_usage()
+            assert usage.total_bytes_used == 600
+            assert usage.usage_fraction == pytest.approx(0.6)
+            assert dict(usage.bytes_by_cache_salt) == {
+                "alice": 400,
+                "bob": 200,
+            }
+
+            state = L2AdapterEvictionState(
+                0,
+                adp,
+                EvictionConfig(eviction_policy="LRU", eviction_ratio=1.0),
+            )
+            actions = state.eviction_policy.get_eviction_actions(1.0)
+            assert len(actions) == 1
+            assert actions[0].keys == [older, newer]
+            assert adp.report_status()["recovered_keys"] == 2
+            assert adp.report_status()["recovered_bytes"] == 600
+        finally:
+            adp.close()
+
+    def test_missing_recovered_file_is_removed_from_accounting(self) -> None:
+        key = create_object_key(1)
+        adp = NativeConnectorL2Adapter(
+            MockNativeConnector(),
+            max_capacity_gb=1000 / (1024**3),
+            recovered_entries=[RecoveredL2Entry(key, 400)],
+        )
+        try:
+            assert adp.get_usage().total_bytes_used == 400
+
+            # The mock backend has no corresponding object, so delete returns
+            # False for the key. A successful delete batch still proves that
+            # the recovered record is a ghost and must be forgotten.
+            adp.delete([key])
+
+            assert adp.get_usage().total_bytes_used == 0
         finally:
             adp.close()
 

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -45,9 +45,11 @@ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
 )
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
+    StripedPrefetchPolicy,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    StripedStorePolicy,
 )
 from lmcache.v1.memory_management import MemoryObjMetadata, TensorMemoryObj
 from tests.v1.distributed.utils import should_use_lazy_alloc
@@ -156,6 +158,13 @@ def make_descriptor(index: int) -> AdapterDescriptor:
     """Create an AdapterDescriptor for testing."""
     config = MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
     return AdapterDescriptor(index=index, config=config)
+
+
+def make_stable_descriptor(index: int) -> AdapterDescriptor:
+    """Create a descriptor with a restart-stable test disk identity."""
+    descriptor = make_descriptor(index)
+    descriptor.config.placement_id = f"disk-{index}"
+    return descriptor
 
 
 def store_keys_in_l2(
@@ -513,6 +522,40 @@ class TestMultiAdapterPrefetch:
         ctrl.stop()
         for a in adapters:
             a.close()
+
+    def test_stable_striped_owner_round_trip(self, l1_manager: L1Manager) -> None:
+        """Striped store and targeted prefetch agree across three adapters."""
+        adapters = [make_adapter(), make_adapter(), make_adapter()]
+        descriptors = [make_stable_descriptor(i) for i in range(3)]
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(12)]
+        store_targets = StripedStorePolicy().select_store_targets(keys, descriptors)
+
+        for adapter_index, adapter_keys in store_targets.items():
+            store_keys_in_l2(adapters[adapter_index], adapter_keys, layout)
+        for key in keys:
+            assert sum(adapter.debug_has_key(key) for adapter in adapters) == 1
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=adapters,
+            adapter_descriptors=descriptors,
+            policy=StripedPrefetchPolicy(),
+        )
+        ctrl.start()
+        try:
+            request_id = ctrl.submit_prefetch_request(
+                PrefetchRequestSpec(keys, {0: layout})
+            )
+            assert wait_for_prefetch_result(ctrl, request_id) == len(keys)
+
+            read_results = l1_manager.unsafe_read(keys)
+            assert all(read_results[key][0] == L1Error.SUCCESS for key in keys)
+            l1_manager.finish_read(keys)
+        finally:
+            ctrl.stop()
+            for adapter in adapters:
+                adapter.close()
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -31,6 +31,7 @@ from lmcache.v1.distributed.api import (
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
 from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
     FaultInjectL2Adapter,
 )
@@ -536,9 +537,10 @@ class TestMultiAdapterPrefetch:
         for key in keys:
             assert sum(adapter.debug_has_key(key) for adapter in adapters) == 1
 
+        controller_adapters: list[L2AdapterInterface] = [*adapters]
         ctrl = PrefetchController(
             l1_manager=l1_manager,
-            l2_adapters=adapters,
+            l2_adapters=controller_adapters,
             adapter_descriptors=descriptors,
             policy=StripedPrefetchPolicy(),
         )

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -530,7 +530,9 @@ class TestMultiAdapterPrefetch:
         descriptors = [make_stable_descriptor(i) for i in range(3)]
         layout = make_layout()
         keys = [make_object_key(i) for i in range(12)]
-        store_targets = StripedStorePolicy().select_store_targets(keys, descriptors)
+        store_policy = StripedStorePolicy()
+        store_policy.validate_adapters(descriptors)
+        store_targets = store_policy.select_store_targets(keys, descriptors)
 
         for adapter_index, adapter_keys in store_targets.items():
             store_keys_in_l2(adapters[adapter_index], adapter_keys, layout)

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -13,9 +13,14 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConf
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
     RetainPrefetchPolicy,
+    StripedPrefetchPolicy,
+)
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+    remap_lookup_bitmap,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    StripedStorePolicy,
 )
 
 # =============================================================================
@@ -35,6 +40,13 @@ def make_object_key(chunk_id: int) -> ObjectKey:
 def make_descriptor(index: int) -> AdapterDescriptor:
     """Create an AdapterDescriptor for testing."""
     config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+    return AdapterDescriptor(index=index, config=config)
+
+
+def make_stable_descriptor(index: int, placement_id: str) -> AdapterDescriptor:
+    """Create a descriptor with a persistent placement identifier."""
+    config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+    config.placement_id = placement_id
     return AdapterDescriptor(index=index, config=config)
 
 
@@ -306,3 +318,32 @@ class TestRetainPrefetchPolicyLoadPlan:
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
         assert plan_to_indices(result) == {0: [0, 1], 1: [2]}
+
+
+class TestStripedPrefetchPolicy:
+    """Targeted lookup must match stable store placement."""
+
+    def test_default_policy_keeps_broadcast_lookup(self) -> None:
+        assert (
+            DefaultPrefetchPolicy().select_lookup_targets(
+                [make_object_key(0)], [make_descriptor(0)]
+            )
+            is None
+        )
+
+    def test_lookup_targets_match_store_targets(self) -> None:
+        keys = [make_object_key(i) for i in range(100)]
+        adapters = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
+        stores = StripedStorePolicy().select_store_targets(keys, adapters)
+        lookups = StripedPrefetchPolicy().select_lookup_targets(keys, adapters)
+
+        assert lookups is not None
+        for adapter_index, stored_keys in stores.items():
+            assert [keys[index] for index in lookups[adapter_index]] == stored_keys
+
+    def test_targeted_bitmap_is_remapped_to_global_positions(self) -> None:
+        subset = make_bitmap(3, [0, 2])
+
+        result = remap_lookup_bitmap(subset, [1, 4, 7], 8)
+
+        assert result.get_indices_list() == [1, 7]

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -10,13 +10,13 @@ prefetch_policy.py.
 from lmcache.lmcache_native import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+    remap_lookup_bitmap,
+)
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
     RetainPrefetchPolicy,
     StripedPrefetchPolicy,
-)
-from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
-    remap_lookup_bitmap,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -6,6 +6,9 @@ Tests are written against the PrefetchPolicy contract defined in
 prefetch_policy.py.
 """
 
+# Standard
+from unittest.mock import patch
+
 # First Party
 from lmcache.lmcache_native import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
@@ -334,12 +337,34 @@ class TestStripedPrefetchPolicy:
     def test_lookup_targets_match_store_targets(self) -> None:
         keys = [make_object_key(i) for i in range(100)]
         adapters = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
-        stores = StripedStorePolicy().select_store_targets(keys, adapters)
-        lookups = StripedPrefetchPolicy().select_lookup_targets(keys, adapters)
+        store_policy = StripedStorePolicy()
+        prefetch_policy = StripedPrefetchPolicy()
+        store_policy.validate_adapters(adapters)
+        prefetch_policy.validate_adapters(adapters)
+        stores = store_policy.select_store_targets(keys, adapters)
+        lookups = prefetch_policy.select_lookup_targets(keys, adapters)
 
         assert lookups is not None
         for adapter_index, stored_keys in stores.items():
             assert [keys[index] for index in lookups[adapter_index]] == stored_keys
+
+    def test_lookup_path_reuses_prepared_adapter_set(self) -> None:
+        keys = [make_object_key(i) for i in range(16)]
+        adapters = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
+        policy = StripedPrefetchPolicy()
+        policy.validate_adapters(adapters)
+
+        with patch(
+            "lmcache.v1.distributed.storage_controllers.store_policy."
+            "_validate_stable_adapters",
+            side_effect=AssertionError("data path repeated adapter preparation"),
+        ):
+            targets = policy.select_lookup_targets(keys, adapters)
+
+        assert targets is not None
+        assert sorted(
+            key_index for key_indices in targets.values() for key_index in key_indices
+        ) == list(range(len(keys)))
 
     def test_targeted_bitmap_is_remapped_to_global_positions(self) -> None:
         subset = make_bitmap(3, [0, 2])

--- a/tests/v1/distributed/test_runtime_adapters.py
+++ b/tests/v1/distributed/test_runtime_adapters.py
@@ -10,6 +10,7 @@ active/draining observability surface.
 """
 
 # Standard
+from dataclasses import replace
 import time
 
 # Third Party
@@ -27,14 +28,25 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
+from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+    FSNativeL2AdapterConfig,
+)
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
     MockL2Adapter,
     MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
+from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+    PrefetchController,
+)
+from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+    StripedPrefetchPolicy,
 )
 from lmcache.v1.distributed.storage_controllers.store_controller import StoreController
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
     DefaultStorePolicy,
+    StripedStorePolicy,
 )
 from lmcache.v1.distributed.storage_manager import StorageManager
 from tests.v1.distributed.utils import should_use_lazy_alloc
@@ -84,6 +96,13 @@ def make_adapter() -> MockL2Adapter:
 
 def make_descriptor(index: int) -> AdapterDescriptor:
     return AdapterDescriptor(index=index, config=make_mock_config())
+
+
+def make_stable_descriptor(index: int, placement_id: str) -> AdapterDescriptor:
+    """Create a runtime adapter descriptor with a stable placement id."""
+    config = make_mock_config()
+    config.placement_id = placement_id
+    return AdapterDescriptor(index=index, config=config)
 
 
 def adapter_by_id(sm: StorageManager, adapter_id: int) -> MockL2Adapter:
@@ -186,6 +205,31 @@ class TestStoreControllerRuntimeAdapters:
             ctrl.stop()
             adapter.close()
 
+    def test_striped_add_validates_before_attach(self, l1_manager):
+        """A runtime adapter without stable identity is rejected at attach."""
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=StripedStorePolicy(),
+        )
+        adapter = make_adapter()
+        ctrl.start()
+        try:
+            with pytest.raises(ValueError, match="stable placement_id"):
+                ctrl.add_adapter(0, adapter, make_descriptor(0))
+
+            status = ctrl.report_status()
+            assert status["thread_alive"] is True
+            assert status["num_l2_adapters"] == 0
+
+            ctrl.add_adapter(1, adapter, make_stable_descriptor(1, "disk-1"))
+            assert ctrl.report_status()["num_active_adapters"] == 1
+            assert ctrl.request_remove_adapter(1).wait(timeout=5.0)
+        finally:
+            ctrl.stop()
+            adapter.close()
+
     def test_remove_adapter_drains_and_detaches(self, l1_manager):
         """request_remove_adapter drains in-flight work then detaches."""
         adapter = make_adapter()
@@ -263,6 +307,38 @@ class TestStoreControllerRuntimeAdapters:
 
 
 # =============================================================================
+# PrefetchController-level tests
+# =============================================================================
+
+
+class TestPrefetchControllerRuntimeAdapters:
+    def test_striped_add_validates_before_attach(self, l1_manager):
+        """Prefetch routing rejects unstable runtime adapters at attach."""
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=StripedPrefetchPolicy(),
+        )
+        adapter = make_adapter()
+        ctrl.start()
+        try:
+            with pytest.raises(ValueError, match="stable placement_id"):
+                ctrl.add_adapter(0, adapter, make_descriptor(0))
+
+            status = ctrl.report_status()
+            assert status["thread_alive"] is True
+            assert status["num_l2_adapters"] == 0
+
+            ctrl.add_adapter(1, adapter, make_stable_descriptor(1, "disk-1"))
+            assert ctrl.report_status()["num_active_adapters"] == 1
+            assert ctrl.request_remove_adapter(1).wait(timeout=5.0)
+        finally:
+            ctrl.stop()
+            adapter.close()
+
+
+# =============================================================================
 # StorageManager-level tests
 # =============================================================================
 
@@ -277,6 +353,55 @@ class TestStorageManagerRuntimeAdapters:
             adapter_id = sm.add_l2_adapter(make_mock_config())
             assert adapter_id == 0
 
+            status = sm.report_status()
+            assert status["num_l2_adapters"] == 1
+            assert status["store_controller"]["num_active_adapters"] == 1
+            assert status["prefetch_controller"]["num_active_adapters"] == 1
+        finally:
+            sm.close()
+
+    def test_striped_runtime_add_rejects_p2p(self, empty_storage_manager_config):
+        """P2P runtime adapters are rejected before client construction."""
+        config = replace(
+            empty_storage_manager_config,
+            store_policy="striped",
+            prefetch_policy="striped",
+        )
+        sm = StorageManager(config)
+        try:
+            p2p_config = P2PL2AdapterConfig(
+                peer_mq_server_url="tcp://127.0.0.1:1",
+                peer_transfer_channel_server_url="tcp://127.0.0.1:2",
+            )
+            with pytest.raises(ValueError, match="only fs_native runtime adapters"):
+                sm.add_l2_adapter(p2p_config)
+
+            assert sm.l2_adapters() == []
+            assert sm.report_status()["num_l2_adapters"] == 0
+        finally:
+            sm.close()
+
+    def test_duplicate_fs_native_runtime_add_rolls_back(
+        self, empty_storage_manager_config, tmp_path
+    ):
+        """A duplicate disk identity is rejected without leaking an adapter."""
+        config = replace(
+            empty_storage_manager_config,
+            store_policy="striped",
+            prefetch_policy="striped",
+        )
+        sm = StorageManager(config)
+        try:
+            disk_path = str(tmp_path / "disk")
+            first_id = sm.add_l2_adapter(
+                FSNativeL2AdapterConfig(disk_path, num_workers=1)
+            )
+            with pytest.raises(ValueError, match="unique adapter placement_id"):
+                sm.add_l2_adapter(FSNativeL2AdapterConfig(disk_path, num_workers=1))
+
+            assert [descriptor.index for descriptor, _ in sm.l2_adapters()] == [
+                first_id
+            ]
             status = sm.report_status()
             assert status["num_l2_adapters"] == 1
             assert status["store_controller"]["num_active_adapters"] == 1

--- a/tests/v1/distributed/test_stable_disk_config.py
+++ b/tests/v1/distributed/test_stable_disk_config.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration tests for stable multi-disk placement."""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    L2AdaptersConfig,
+)
+from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+    FSNativeL2AdapterConfig,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
+
+
+def _storage_config(
+    adapters: list[L2AdapterConfigBase],
+    *,
+    store_policy: str,
+    prefetch_policy: str,
+) -> StorageManagerConfig:
+    """Build the smallest storage-manager config used by these tests."""
+    return StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=1 << 20,
+                use_lazy=False,
+            )
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+        l2_adapter_config=L2AdaptersConfig(adapters=adapters),
+        store_policy=store_policy,
+        prefetch_policy=prefetch_policy,
+    )
+
+
+@pytest.mark.parametrize(
+    ("store_policy", "prefetch_policy"),
+    [("striped", "default"), ("default", "striped")],
+)
+def test_striped_store_and_prefetch_policies_must_be_paired(
+    tmp_path: Path,
+    store_policy: str,
+    prefetch_policy: str,
+) -> None:
+    adapter = FSNativeL2AdapterConfig(str(tmp_path / "disk"))
+
+    with pytest.raises(ValueError, match="requires both"):
+        _storage_config(
+            [adapter],
+            store_policy=store_policy,
+            prefetch_policy=prefetch_policy,
+        )
+
+
+def test_striped_policy_rejects_non_fs_native_adapter() -> None:
+    adapter = MockL2AdapterConfig(max_size_gb=1, mock_bandwidth_gb=1)
+
+    with pytest.raises(ValueError, match="only fs_native"):
+        _storage_config(
+            [adapter],
+            store_policy="striped",
+            prefetch_policy="striped",
+        )
+
+
+def test_striped_policy_accepts_multiple_fs_native_adapters(tmp_path: Path) -> None:
+    adapters = [
+        FSNativeL2AdapterConfig(str(tmp_path / "disk-a")),
+        FSNativeL2AdapterConfig(str(tmp_path / "disk-b")),
+    ]
+
+    config = _storage_config(
+        adapters,
+        store_policy="striped",
+        prefetch_policy="striped",
+    )
+
+    assert config.l2_adapter_config.adapters == adapters

--- a/tests/v1/distributed/test_stable_disk_config.py
+++ b/tests/v1/distributed/test_stable_disk_config.py
@@ -77,7 +77,7 @@ def test_striped_policy_rejects_non_fs_native_adapter() -> None:
 
 
 def test_striped_policy_accepts_multiple_fs_native_adapters(tmp_path: Path) -> None:
-    adapters = [
+    adapters: list[L2AdapterConfigBase] = [
         FSNativeL2AdapterConfig(str(tmp_path / "disk-a")),
         FSNativeL2AdapterConfig(str(tmp_path / "disk-b")),
     ]

--- a/tests/v1/distributed/test_store_policy.py
+++ b/tests/v1/distributed/test_store_policy.py
@@ -6,6 +6,7 @@ Tests are written against the StorePolicy contract defined in store_policy.py.
 """
 
 # Third Party
+import pytest
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
@@ -13,6 +14,8 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConf
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
     DefaultStorePolicy,
+    StripedStorePolicy,
+    rendezvous_adapter_index_for_key,
 )
 
 # =============================================================================
@@ -32,6 +35,13 @@ def make_object_key(chunk_id: int) -> ObjectKey:
 def make_descriptor(index: int) -> AdapterDescriptor:
     """Create an AdapterDescriptor for testing."""
     config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+    return AdapterDescriptor(index=index, config=config)
+
+
+def make_stable_descriptor(index: int, placement_id: str) -> AdapterDescriptor:
+    """Create a descriptor with a persistent placement identifier."""
+    config = MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0)
+    config.placement_id = placement_id
     return AdapterDescriptor(index=index, config=config)
 
 
@@ -117,3 +127,89 @@ class TestDefaultStorePolicyDeletions:
         result = policy.select_l1_deletions([])
 
         assert result == []
+
+
+class TestStripedStorePolicy:
+    """Stable rendezvous placement contract."""
+
+    def test_each_key_has_one_owner(self) -> None:
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(1000)]
+        adapters = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
+
+        targets = policy.select_store_targets(keys, adapters)
+        routed_keys = [key for values in targets.values() for key in values]
+
+        assert set(routed_keys) == set(keys)
+        assert len(routed_keys) == len(keys)
+
+    def test_runtime_order_does_not_change_owner(self) -> None:
+        keys = [make_object_key(i) for i in range(100)]
+        original = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
+        reordered = [original[2], original[0], original[3], original[1]]
+        original_by_index = {adapter.index: adapter for adapter in original}
+        reordered_by_index = {adapter.index: adapter for adapter in reordered}
+
+        original_owners = [
+            original_by_index[
+                rendezvous_adapter_index_for_key(key, original)
+            ].placement_id
+            for key in keys
+        ]
+        reordered_owners = [
+            reordered_by_index[
+                rendezvous_adapter_index_for_key(key, reordered)
+            ].placement_id
+            for key in keys
+        ]
+
+        assert original_owners == reordered_owners
+
+    def test_adding_disk_only_remaps_approximately_ideal_share(self) -> None:
+        keys = [make_object_key(i) for i in range(10_000)]
+        before = [make_stable_descriptor(i, f"disk-{i}") for i in range(8)]
+        after = before + [make_stable_descriptor(8, "disk-8")]
+        before_by_index = {adapter.index: adapter for adapter in before}
+        after_by_index = {adapter.index: adapter for adapter in after}
+
+        remapped = 0
+        for key in keys:
+            before_owner = before_by_index[
+                rendezvous_adapter_index_for_key(key, before)
+            ].placement_id
+            after_owner = after_by_index[
+                rendezvous_adapter_index_for_key(key, after)
+            ].placement_id
+            remapped += before_owner != after_owner
+
+        ratio = remapped / len(keys)
+        assert 0.09 < ratio < 0.14
+
+    def test_removing_disk_preserves_other_owners(self) -> None:
+        keys = [make_object_key(i) for i in range(2000)]
+        before = [make_stable_descriptor(i, f"disk-{i}") for i in range(8)]
+        after = before[:-1]
+        before_by_index = {adapter.index: adapter for adapter in before}
+        after_by_index = {adapter.index: adapter for adapter in after}
+
+        for key in keys:
+            before_owner = before_by_index[
+                rendezvous_adapter_index_for_key(key, before)
+            ].placement_id
+            after_owner = after_by_index[
+                rendezvous_adapter_index_for_key(key, after)
+            ].placement_id
+            if before_owner != "disk-7":
+                assert after_owner == before_owner
+
+    def test_missing_or_duplicate_placement_id_is_rejected(self) -> None:
+        key = make_object_key(0)
+        with pytest.raises(ValueError, match="stable placement_id"):
+            rendezvous_adapter_index_for_key(key, [make_descriptor(0)])
+
+        duplicate = [
+            make_stable_descriptor(0, "same-disk"),
+            make_stable_descriptor(1, "same-disk"),
+        ]
+        with pytest.raises(ValueError, match="unique"):
+            rendezvous_adapter_index_for_key(key, duplicate)

--- a/tests/v1/distributed/test_store_policy.py
+++ b/tests/v1/distributed/test_store_policy.py
@@ -5,6 +5,9 @@ Unit tests for store policy interface and DefaultStorePolicy.
 Tests are written against the StorePolicy contract defined in store_policy.py.
 """
 
+# Standard
+from unittest.mock import patch
+
 # Third Party
 import pytest
 
@@ -137,11 +140,54 @@ class TestStripedStorePolicy:
         keys = [make_object_key(i) for i in range(1000)]
         adapters = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
 
+        policy.validate_adapters(adapters)
         targets = policy.select_store_targets(keys, adapters)
         routed_keys = [key for values in targets.values() for key in values]
 
         assert set(routed_keys) == set(keys)
         assert len(routed_keys) == len(keys)
+
+    def test_data_path_reuses_prepared_adapter_set(self) -> None:
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(16)]
+        adapters = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
+        policy.validate_adapters(adapters)
+
+        with patch(
+            "lmcache.v1.distributed.storage_controllers.store_policy."
+            "_validate_stable_adapters",
+            side_effect=AssertionError("data path repeated adapter preparation"),
+        ):
+            targets = policy.select_store_targets(keys, adapters)
+
+        assert sum(len(adapter_keys) for adapter_keys in targets.values()) == len(keys)
+
+    def test_membership_change_refreshes_cached_router(self) -> None:
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(1000)]
+        before = [make_stable_descriptor(i, f"disk-{i}") for i in range(4)]
+        after = before + [make_stable_descriptor(4, "disk-4")]
+
+        policy.validate_adapters(before)
+        before_targets = policy.select_store_targets(keys, before)
+        before_owners = {
+            key: adapter_index
+            for adapter_index, adapter_keys in before_targets.items()
+            for key in adapter_keys
+        }
+
+        policy.validate_adapters(after)
+        after_targets = policy.select_store_targets(keys, after)
+        after_owners = {
+            key: adapter_index
+            for adapter_index, adapter_keys in after_targets.items()
+            for key in adapter_keys
+        }
+
+        assert after_targets[4]
+        for key in keys:
+            if after_owners[key] != before_owners[key]:
+                assert after_owners[key] == 4
 
     def test_runtime_order_does_not_change_owner(self) -> None:
         keys = [make_object_key(i) for i in range(100)]

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -2,6 +2,7 @@
 """Tests for the native C++ filesystem connector."""
 
 # Standard
+from pathlib import Path
 from typing import Any
 import ctypes
 import os
@@ -10,6 +11,10 @@ import time
 
 # Third Party
 import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_key_codec import object_key_to_filename
 
 
 def _import_fs_client() -> type:
@@ -93,7 +98,7 @@ def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:
         pytest.skip("filesystem block size is unavailable")
 
     size = block_size * 2
-    key = "test_model@00000000@0123456789abcdef"
+    key = "test_model@00000000@0@0123456789abcdef"
     _source_raw, source = _aligned_memoryview(size, block_size)
     _dest_raw, dest = _aligned_memoryview(size, block_size)
     _fill(source)
@@ -119,7 +124,7 @@ def test_odirect_fails_for_misaligned_buffer(tmp_path) -> None:
         pytest.skip("filesystem block size is unavailable")
 
     size = block_size * 2
-    key = "test_model@00000000@fedcba9876543210"
+    key = "test_model@00000000@0@fedcba9876543210"
     _source_raw, source = _misaligned_memoryview(size, block_size)
     _fill(source)
 
@@ -128,5 +133,51 @@ def test_odirect_fails_for_misaligned_buffer(tmp_path) -> None:
         store = _submit_and_wait(client, "submit_batch_set", key, source)
         assert not store[1]
         assert "O_DIRECT buffer address is not aligned" in store[2]
+    finally:
+        client.close()
+
+
+def test_serialized_key_matches_reversible_filename_codec(tmp_path: Path) -> None:
+    """The C++ connector must emit filenames the restart scanner can decode."""
+    LMCacheFSClient = _import_fs_client()
+    key = ObjectKey(
+        chunk_hash=bytes.fromhex("0123456789abcdef"),
+        model_name="org/test-model",
+        kv_rank=0x01020304,
+        object_group_id=2,
+        cache_salt="tenant-a",
+    )
+    serialized = "org/test-model@01020304@2@0123456789abcdef@tenant-a"
+    source = memoryview(bytearray(b"test-data"))
+
+    client = LMCacheFSClient(str(tmp_path), 1, "", False, 0)
+    try:
+        store = _submit_and_wait(client, "submit_batch_set", serialized, source)
+        assert store[1], store[2]
+        assert (tmp_path / object_key_to_filename(key)).read_bytes() == bytes(source)
+    finally:
+        client.close()
+
+
+def test_delete_distinguishes_existing_and_missing_files(tmp_path: Path) -> None:
+    """A successful delete reports whether the flat cache file existed."""
+    LMCacheFSClient = _import_fs_client()
+    serialized = "test-model@00000000@0@0123456789abcdef"
+    source = memoryview(bytearray(b"test-data"))
+
+    client = LMCacheFSClient(str(tmp_path), 1, "", False, 0)
+    try:
+        store = _submit_and_wait(client, "submit_batch_set", serialized, source)
+        assert store[1], store[2]
+
+        first_id = client.submit_batch_delete([serialized])
+        first_delete = _wait_for_completion(client, first_id)
+        assert first_delete[1], first_delete[2]
+        assert first_delete[3] == [True]
+
+        second_id = client.submit_batch_delete([serialized])
+        second_delete = _wait_for_completion(client, second_id)
+        assert second_delete[1], second_delete[2]
+        assert second_delete[3] == [False]
     finally:
         client.close()


### PR DESCRIPTION
## Summary

- give each `fs_native` mount a persistent UUID and use BLAKE3
  Highest-Random-Weight (Rendezvous) hashing for stable striped placement
- route store and prefetch through the same owner-selection policy, including
  targeted lookup and bitmap remapping
- recover native filesystem entries after restart, restore byte and
  per-`cache_salt` accounting, replay LRU state, and expose recovery status
- make recovered stale entries reclaimable through the existing capacity and
  eviction path
- share the filesystem key codec and repair the C++ parser for current
  unsalted and salted key formats
- add a reproducible placement and recovery-scan microbenchmark

## Design context

This Draft implements Option A from #4738. It also includes the striped
store/prefetch baseline currently proposed by #4260 because that behavior is
not present on current `dev`.

Maintainer guidance is requested on whether this should stack on, replace, or
be split from #4260 before the PR is marked ready for review.

## Validation

Both nodes tested the same source tree based on
`0392f250ff7e82785064f92e76cbc2b338e06799`.

RTX 3090 node:

- core store/prefetch/controller/config suite: `136 passed`
- native connector, restart/GC, C++ filesystem, and config suite: `97 passed`
- shared key codec, C++ filesystem, and recovery suite: `48 passed`

RTX 4090 node:

- CUDA 13.0 / PyTorch `2.13.0+cu130` build with
  `TORCH_CUDA_ARCH_LIST=8.9`: passed
- just-built `cuda_ops` and `lmcache_fs` runtime smoke on capability `(8, 9)`:
  passed
- core store/prefetch/controller/config suite: `136 passed`
- native connector, restart/GC, C++ filesystem, and config suite: `97 passed`
- shared key codec, C++ filesystem, and recovery suite: `48 passed`
- real CUDA H2D/D2H memcpy kernel tests, including a transfer crossing a
  64 MiB registration boundary: `2 passed`

Static validation:

- Ruff format and check: passed for all changed/new Python files
- `python -m compileall`: passed for all changed/new Python files
- `git diff --check`: passed
- C++ `clang-format`: no diff
- `mypy`: passed for 10 directly changed core modules
- the updated `fs_native` documentation page rendered without a page-local
  warning

## Benchmark

Command:

```bash
python benchmarks/microbenchmark/stable_disk_placement_benchmark.py \
  --keys 100000 --disks 8 --repetitions 3 --scan-files 10000
```

| Metric | Modulo | Rendezvous |
| --- | ---: | ---: |
| Remap ratio, 8 to 9 disks | 88.706% | 11.232% |
| Ideal remap ratio | - | 11.111% |
| Distribution CV | 0.006687 | 0.007790 |
| Routing rate, 3090 host | 398,590 keys/s | 113,233 keys/s |
| Routing rate, 4090 host | 461,431 keys/s | 110,677 keys/s |

The 10,000-file recovery scan completed with 10,000 recovered and zero skipped:

- 3090 host: `0.166084 s`, `60,210 files/s`
- 4090 host: `0.184995 s`, `54,055 files/s`

The benchmark demonstrates stable remapping and restart-scan cost. It does not
claim a routing-throughput improvement.

## Evidence boundaries

- The available nodes exposed one test filesystem each, not multiple
  independently mounted NVMe devices. Multi-NVMe cold restart,
  add/remove-disk, capacity-pressure GC, and I/O throughput remain to be
  measured.
- Recovered recency uses best-effort `max(atime, mtime)` and is approximate on
  `noatime` or `relatime` mounts; correctness and byte accounting do not depend
  on exact recency.
- This implementation has no production adoption evidence yet.
- Repository-wide `sphinx-build -W` still reports unrelated existing warnings.
  Including `fs_l2_adapter.py` in a broad mypy invocation also exposes its
  existing async read-ahead `memoryview[int]` to `bytes` error.

Addresses #4738.
Related: #4260.
