### PR TITLE
[Platform][CUDA] env-selectable event IPC backend — makes the timeline-semaphore backend (#4551) reachable

### DIFF
--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -49,16 +49,30 @@ class CudaDeviceSpec(DeviceSpec):
         """Return the CUDA event IPC backend."""
         backend = self._event_backend_cache
         if backend is None:
-            # Third Party
-            import torch
+            # Standard
+            import os
 
-            # First Party
-            from lmcache.v1.platform.base.event_ipc import DefaultEventIPCBackend
+            choice = os.getenv("LMCACHE_EVENT_IPC_BACKEND", "default").lower()
+            if choice in ("timeline_semaphore", "semaphore"):
+                # First Party
+                from lmcache.v1.platform.cuda.timeline_semaphore_event_ipc import (
+                    TimelineSemaphoreEventIPCBackend,
+                )
 
-            backend = DefaultEventIPCBackend(
-                event_module=torch.cuda,
-                device_type=self.device_type,
-            )
+                backend = TimelineSemaphoreEventIPCBackend()
+            else:
+                # Third Party
+                import torch
+
+                # First Party
+                from lmcache.v1.platform.base.event_ipc import (
+                    DefaultEventIPCBackend,
+                )
+
+                backend = DefaultEventIPCBackend(
+                    event_module=torch.cuda,
+                    device_type=self.device_type,
+                )
             self._event_backend_cache = backend
         return backend
 


### PR DESCRIPTION
## What

`CudaDeviceSpec.event_ipc_backend` hardcodes `DefaultEventIPCBackend`, so the timeline-semaphore event IPC backend added in #4551 (d79c537) is currently **unreachable in any deployment** — built, tested, documented, but nothing selects it.

This adds an opt-in selector: `LMCACHE_EVENT_IPC_BACKEND=timeline_semaphore` (default behavior unchanged; any other value or unset keeps `DefaultEventIPCBackend`).

## Why

The semaphore backend's own design doc motivates it with the CUDA interprocess *event*-handle hazard: *"empirically (driver 580, CUDA 13) those only resolve when both processes share a /dev/shm tmpfs."* We operate exactly that platform — **NVIDIA GB10 (DGX Spark), driver 580.173.02, CUDA 13, integrated unified-memory GPU** — and observe the hazard in its worst form with MP mode: `lmcache_driven` STOREs work (server-side pulls land; hundreds of objects on L1+fs-L2 across a 2-node TP=2 vLLM pair), but any large RETRIEVE blocks silently until the serving engine's watchdog kills it. No error is logged by either side. We're preparing a full issue with py-spy stacks of the live hang and will link it here.

With this selector, the semaphore backend allocates and initializes cleanly on that hardware (`Allocated timeline-semaphore event buffer on cuda:0 (4096 slots)`), giving platforms with unreliable event-handle IPC a deployable escape hatch.

## Notes

- Happy to move the knob into MP config / `extra_config` instead of an env var if that fits the config surface better — env chosen because backend choice must agree across independently-launched processes (server and every engine rank), and env is the one channel they all share.
- Selector is intentionally minimal; no behavior change unless explicitly opted in.
- Tested on 2x DGX Spark TP=2 (vLLM 0.25.2 lane, `LMCacheMPConnector`).