### PR TITLE
[MP][Coordinator] Evict local L2 by routing deletes to the owning instance

### DIFF
--- a/docs/design/v1/mp_coordinator/usage_and_eviction.md
+++ b/docs/design/v1/mp_coordinator/usage_and_eviction.md
@@ -81,8 +81,9 @@ MP server (store/lookup)
   execute_evictions():
     for each tracked salt:
       limit = quota (default 0 → evict all)
-      if usage ≥ watermark·limit → select LRU keys,
-        fire-and-forget DELETE /cache/objects to a holder
+      if usage ≥ watermark·limit → select LRU keys whose copies are reachable,
+        fire-and-forget DELETE /cache/objects to each holder
+        (shared pool → any server; local L2 → its owning instance)
 ```
 
 ## Wire types (`schemas.py`)
@@ -214,23 +215,64 @@ accounting lives in ``CacheUsageManager``; the LRU only tracks order.
 - ``on_lookup(key)`` — touch (``policy.on_keys_touched``, move to MRU end).
 - ``on_remove(key)`` — drop from the LRU (``policy.on_keys_removed``); the paired
   byte decrement happens in the usage view consuming the same event.
-- ``compute_eviction_plan() -> dict[str, list[ObjectKey]]`` — **pure**: for each
-  tracked salt, fire when ``usage ≥ trigger_watermark · quota`` (quota 0 ⇒ evict
-  all), selecting ``eviction_ratio`` of the salt's LRU keys via
-  ``policy.get_eviction_actions``. Salts without an explicit quota use the
-  registry's default limit; while it is unset (``None``) they are skipped
-  entirely — see QuotaManager above. No network, no mutation.
+- Selection (internal to ``execute_evictions``) — for each tracked salt, fire
+  when ``usage ≥ trigger_watermark · quota`` (quota 0 ⇒ evict all), selecting
+  ``eviction_ratio`` of the salt's LRU keys via ``policy.get_eviction_actions``.
+  Salts without an explicit quota use the registry's default limit; while it is
+  unset (``None``) they are skipped entirely — see QuotaManager above. Pinned
+  keys and keys no registered server can delete (see Routing below) are not
+  selected. The result is one plan object carrying both the victims and each
+  victim's routes: deciding whether a key is evictable already means resolving
+  where it would be deleted, so routing is a by-product of selection rather
+  than a second pass.
 - ``run(registry, http_client, check_interval)`` — the control loop
   itself, started as an asyncio task by the app lifespan and cancelled on
   shutdown. ``EVICTION_CHECK_INTERVAL = 0`` disables it (the task is
   never created).
 - ``execute_evictions(registry, http_client)`` — one pass: computes the plan and
-  **fire-and-forget** ``DELETE /cache/objects`` to a holder MP server for each
-  salt's victims; on confirmed deletion ``on_remove`` drops them from tracking.
-  The plan's keys are split into chunks of at most ``MAX_DELETE_BATCH`` (imported
-  from the MP server's ``object_service``) and each chunk is dispatched as its
-  own request, because the endpoint rejects any single delete over that cap with
+  **fire-and-forget** ``DELETE /cache/objects`` to each holder of each victim;
+  on confirmed deletion ``on_remove`` drops the key from tracking. Each holder's
+  keys are split into chunks of at most ``MAX_DELETE_BATCH`` (imported from the
+  MP server's ``object_service``) and each chunk is dispatched as its own
+  request, because the endpoint rejects any single delete over that cap with
   HTTP 400 — a full-salt eviction (quota dropped to 0) routinely exceeds it.
+
+#### Routing: shared vs local
+
+``DELETE /cache/objects`` is **node-scoped** — it removes keys from the backend
+of the server it reaches. That makes the victim's placement, not the fleet, the
+address of the delete. The controller reads it from the ``KeyDirectory`` view
+(the same placements the cache-event stream maintains) and the
+``InstanceRegistry``:
+
+| Placement of the victim | Where the DELETE goes | Copies deleted |
+| --- | --- | --- |
+| ``shared=True`` (fleet pool, e.g. S3) | The placement's reporter if still registered, else any registered server | One request; one copy |
+| ``shared=False`` (local L2, e.g. per-node disk) | The **owning** instance | One request per owner — N private copies cost N deletes |
+| Local, owner deregistered | Nowhere; the key is **skipped** | None |
+| No L2 placement in the directory | Any registered server, primary adapter | Best-effort single request |
+
+Each request also names the placement's ``tier`` and its ``backend`` (as the
+``adapter`` selector — the adapter's ``type_name``, the same identity the store
+event carried), so a multi-adapter server deletes from the one that actually
+holds the key rather than its primary. Keys with no known placement carry no
+selector and fall back to the primary adapter, which is what every delete used
+to do.
+
+A route is ``(instance, tier, backend)`` and the tier is request data, not an
+assumption: resolution filters the directory's placements to the tier being
+evicted and the request states it, rather than relying on the endpoint's ``l2``
+default. Eviction plans the ``l2`` tier today — that is what the LRU tracks and
+what quotas are accounted against — so ``l2`` is what the planner passes; the
+routing and dispatch path itself is tier-neutral.
+
+Skipping stranded keys is what keeps eviction converging: a local copy whose
+owner has left cannot be deleted by anyone, and dispatching it to another server
+would delete nothing, produce no ``DELETE`` event, and leave the key at the LRU
+head to be re-selected — burning the salt's eviction budget every cycle while
+its deletable keys stay put. The bytes stay counted against the salt until the
+owner rejoins (its disk contents survive the restart) or an operator deletes
+them out of band.
 
 ## REST endpoints (`quota_api.py`)
 
@@ -295,11 +337,14 @@ Both also accept CLI flags (``--coordinator-event-reporting``,
 | Coordinator restart | Usage/LRU state lost | Rebuilt from the cache-event stream as events arrive; usage under-reports until it catches up |
 | Flush timeout | One batch delayed | Next flush sends new batch; no retry of old batch |
 | Usage accounting drift | Quota enforcement imprecise | Self-correcting as new events arrive |
+| Local-L2 owner leaves the fleet | Its copies are undeletable | Those keys are skipped by the planner (not dispatched elsewhere) and stay counted against the salt until the owner re-registers |
 
 ## Scope
 
 Additive: no change to per-server eviction, L2 adapter store/lookup paths, or
-the coordinator's membership/health loop. Composes via the ``L2AdapterListener``
+the coordinator's membership/health loop. Quota scope is unchanged too — the
+limit is per ``cache_salt`` across the whole fleet, and a key held privately by
+N instances counts N times, exactly as the usage view already accounted for it. Composes via the ``L2AdapterListener``
 interface and the ``http_apis`` auto-discovery — a new router reading
 ``app.state``, plus the opt-in event listener — with no edits to existing
 controllers or adapters beyond passing ``sizes`` through to

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -407,7 +407,7 @@ target the empty-string salt.
 
    Do **not** use the MP server's node-local ``/quota`` API together with the
    coordinator's. The two are independent, unsynchronized quota registries
-   enforcing eviction on the **same shared L2**: the server-side enforcer
+   enforcing eviction on the **same L2 contents**: the server-side enforcer
    (active when the server runs a per-salt eviction policy) uses strict
    allowlist semantics — any salt missing from *its own* table is fully
    evicted — and it never sees quotas registered on the coordinator, and vice
@@ -452,15 +452,31 @@ detected.
 **Active eviction loop.** Every ``--eviction-check-interval`` seconds, the
 coordinator inspects per-salt usage against the registered quotas and,
 for any salt over the trigger watermark, picks LRU victims and
-dispatches a single ``DELETE /cache/objects`` to a uniformly random registered MP
-server. Because all MP servers share the same backing L2 (e.g. one S3
-bucket), one dispatch evicts the keys for the whole fleet. The MP
-server's L2 adapter fires ``on_l2_keys_deleted`` listeners after the
+dispatches ``DELETE /cache/objects`` to the MP servers that hold them.
+``DELETE /cache/objects`` is node-scoped — it removes keys from the L2 adapter
+of the server it reaches — so the coordinator reads each victim's placements
+from the key directory and routes accordingly:
+
+* **Shared L2** (``shared: true`` on the adapter, e.g. one S3 bucket the whole
+  fleet mounts): one dispatch to any registered server evicts the keys for the
+  whole fleet.
+* **Local L2** (the default, e.g. per-node disk): the bytes live on the
+  instance that stored them, so one dispatch goes to each owning instance. A
+  key held privately by three servers costs three deletes.
+
+Each request also names the placement's tier and its backend (as the ``adapter``
+selector), so a server running several L2 adapters deletes from the one that
+actually holds the key. A local copy whose owning instance is no longer
+registered cannot be deleted by anyone; the coordinator skips it — rather than
+spending the salt's eviction budget on it every cycle — and its bytes stay
+counted against the salt until that instance rejoins.
+
+The MP server's L2 adapter fires ``on_l2_keys_deleted`` listeners after the
 delete completes; those listeners ship ``delete`` events back through
 ``POST /events``, which is what updates the coordinator's LRU +
 per-salt totals. Dispatch failures or no-instances-registered fall
 through to the next cycle — at-least-once semantics, safe because the
-S3 delete is idempotent.
+underlying delete is idempotent.
 
 **Cold start.** The coordinator's trackers are in-memory and are built
 only from the cache-event stream, so after a restart per-salt usage

--- a/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
+++ b/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fleet-wide per-``cache_salt`` L2 eviction control loop.
 
+Dispatch is placement-aware: a shared pool is reachable through any
+registered server, a local one only through its owner.
+
 See ``docs/design/v1/mp_coordinator/usage_and_eviction.md``.
 """
 
@@ -9,7 +12,7 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Mapping
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, cast
 import asyncio
 
@@ -30,6 +33,7 @@ from lmcache.v1.mp_coordinator.persistence.durable_component import (
     DurableComponent,
     PersistenceType,
 )
+from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 from lmcache.v1.multiprocess.cache_control.object_service import (
     MAX_DELETE_BATCH,
@@ -46,6 +50,49 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+@dataclass(frozen=True)
+class _DeleteRoute:
+    """Where one live copy of a victim key has to be deleted.
+
+    Attributes:
+        instance_id: MP server owning the copy; ``""`` means any registered
+            one will do, resolved against the registry at dispatch time
+            rather than at plan time.
+        tier: Tier the copy lives on, sent as the request's ``tier``.
+        backend: Backend within that tier holding the copy, sent as the
+            request's ``adapter``; ``""`` selects the target's default.
+    """
+
+    instance_id: str
+    tier: Tier
+    backend: str
+
+
+@dataclass(frozen=True)
+class _EvictionPlan:
+    """What one cycle decided to evict, and where each victim lives.
+
+    Attributes:
+        victims: Keys to evict, per ``cache_salt``.
+        routes: Every victim's live copies, keyed by victim. A victim
+            always has at least one — a key with nowhere to delete it is
+            not selected.
+    """
+
+    victims: dict[str, list[ObjectKey]]
+    routes: dict[ObjectKey, list[_DeleteRoute]]
+
+    def keys_by_route(self) -> dict[_DeleteRoute, list[ObjectKey]]:
+        """Group the victims by the route their delete takes, so each
+        route's keys travel in one request."""
+        grouped: dict[_DeleteRoute, list[ObjectKey]] = {}
+        for keys in self.victims.values():
+            for key in keys:
+                for route in self.routes[key]:
+                    grouped.setdefault(route, []).append(key)
+        return grouped
+
+
 class FleetEvictionController(Controller):
     """Per-``cache_salt`` L2 eviction controller for the fleet.
 
@@ -58,6 +105,8 @@ class FleetEvictionController(Controller):
             right, registered on the broadcaster **before** this
             controller so it has accounted a batch by the time
             :meth:`consume` reads sizes from it.
+        key_directory: The fleet key directory view; supplies each
+            victim's L2 placements, which decide where its delete goes.
         eviction_ratio: Fraction of tracked keys to evict per cycle.
         trigger_watermark: Eviction fires when usage reaches this
             fraction of the quota.
@@ -66,11 +115,13 @@ class FleetEvictionController(Controller):
     def __init__(
         self,
         usage_manager: CacheUsageManager,
+        key_directory: KeyDirectory,
         eviction_ratio: float = 0.5,
         trigger_watermark: float = 1.0,
     ) -> None:
         self._quota_manager = QuotaManager()
         self._usage_manager = usage_manager
+        self._key_directory = key_directory
         self._eviction_ratio = max(0.0, min(1.0, eviction_ratio))
         self._trigger_watermark = trigger_watermark
         self._policy = IsolatedLRUEvictionPolicy()
@@ -161,9 +212,10 @@ class FleetEvictionController(Controller):
     ) -> "FleetEvictionController":
         """Build the controller from configuration and the fleet's views.
 
-        The usage view comes from the registry rather than being made
-        here: the coordinator has exactly one, and the eviction plan is
-        only correct if it reads the same bytes the fleet reported.
+        The views come from the registry rather than being made here:
+        the coordinator has exactly one of each, and the eviction plan is
+        only correct if it reads the same bytes and placements the fleet
+        reported.
 
         Args:
             config: The coordinator configuration.
@@ -172,6 +224,7 @@ class FleetEvictionController(Controller):
         """
         return cls(
             usage_manager=views.get(CacheUsageManager),
+            key_directory=views.get(KeyDirectory),
             eviction_ratio=config.eviction_ratio,
             trigger_watermark=config.trigger_watermark,
         )
@@ -238,61 +291,6 @@ class FleetEvictionController(Controller):
         for key in keys:
             self._pin_counts.pop(key, None)
 
-    def compute_eviction_plan(self) -> dict[str, list[ObjectKey]]:
-        """Select eviction candidates per ``cache_salt``.
-
-        Salts over ``watermark * quota`` get ``eviction_ratio`` of
-        their LRU keys; a quota of ``0`` means full eviction. Salts
-        without an explicit quota use the registry's default limit
-        (``QuotaManager.effective_limit_bytes``): until the external
-        quota controller sets one (``PUT /quota/config``), the
-        coordinator will not start evicting unquota'd salts.
-        """
-        tracked_salts = self._policy.get_tracked_salts()
-        eviction_plan: dict[str, list[ObjectKey]] = {}
-
-        for cache_salt in tracked_salts:
-            current_bytes = self._usage_manager.get_salt_bytes(Tier.L2, cache_salt)
-            if current_bytes <= 0:
-                continue
-            limit = self._quota_manager.effective_limit_bytes(cache_salt)
-            if limit is None:
-                # No explicit quota and no default configured yet —
-                # exempt until the quota controller arms enforcement.
-                continue
-            if current_bytes < self._trigger_watermark * limit:
-                continue
-
-            effective_ratio = 1.0 if limit == 0 else self._eviction_ratio
-            actions = self._policy.get_eviction_actions(
-                effective_ratio,
-                cache_salt=cache_salt,
-                key_eligible_filter=lambda key: key not in self._pin_counts,
-            )
-            keys_to_evict: list[ObjectKey] = []
-            for action in actions:
-                keys_to_evict.extend(action.keys)
-
-            if keys_to_evict:
-                eviction_plan[cache_salt] = keys_to_evict
-                evict_bytes = sum(
-                    self._usage_manager.get_key_bytes(Tier.L2, k) for k in keys_to_evict
-                )
-                logger.info(
-                    "Eviction plan for cache_salt=%r: %d keys "
-                    "(%d bytes) to free; usage=%d, quota=%d, "
-                    "watermark=%.2f, ratio=%.2f",
-                    cache_salt,
-                    len(keys_to_evict),
-                    evict_bytes,
-                    current_bytes,
-                    limit,
-                    self._trigger_watermark,
-                    effective_ratio,
-                )
-
-        return eviction_plan
-
     async def run(
         self,
         registry: InstanceRegistry,
@@ -320,62 +318,222 @@ class FleetEvictionController(Controller):
         registry: InstanceRegistry,
         http_client: httpx.AsyncClient,
     ) -> dict[str, list[ObjectKey]]:
-        """Compute the plan and fire-and-forget ``DELETE /cache/objects``
-        to one random registered MP server.
+        """Compute the plan and fire-and-forget the ``DELETE /cache/objects``
+        requests that carry it out.
 
-        Keys are chunked at ``MAX_DELETE_BATCH`` because the MP endpoint
-        rejects a larger single request with HTTP 400. Returns as soon as
-        the dispatch tasks are spawned; the LRU clears only when the
-        matching ``delete`` event comes back on the cache-event stream.
-        At-least-once, safe because the delete is idempotent.
+        One request per ``(MP server, tier, backend)`` holding a victim, so a
+        key stored privately on three instances costs three deletes. Keys are
+        chunked at ``MAX_DELETE_BATCH`` because the MP endpoint rejects a
+        larger single request with HTTP 400.
+
+        Args:
+            registry: Fleet membership; resolves a route to a live address.
+            http_client: Client for the outbound DELETE requests.
+
+        Returns:
+            The plan, as soon as the dispatch tasks are spawned; the LRU
+            clears only when the matching ``delete`` event comes back on the
+            cache-event stream. At-least-once, safe because the delete is
+            idempotent.
         """
-        plan = self.compute_eviction_plan()
-        if not plan:
-            return plan
+        plan = self._compute_eviction_plan(registry)
+        if not plan.victims:
+            return plan.victims
 
-        target = registry.random_instance()
-        if target is None:
-            logger.warning(
-                "Eviction plan computed (%d salts) but no MP servers are "
-                "registered; skipping dispatch",
-                len(plan),
+        for route, keys in plan.keys_by_route().items():
+            target = (
+                registry.get(route.instance_id)
+                if route.instance_id
+                else registry.random_instance()
             )
-            return plan
-
-        url = f"http://{target.ip}:{target.http_port}/cache/objects"
-        all_keys: list[ObjectKey] = [k for keys in plan.values() for k in keys]
-
-        for start in range(0, len(all_keys), MAX_DELETE_BATCH):
-            chunk = all_keys[start : start + MAX_DELETE_BATCH]
-            body = {"keys": [asdict(k.to_encoded_object_key()) for k in chunk]}
-            task = asyncio.create_task(
-                self._dispatch_eviction(
-                    http_client=http_client,
-                    url=url,
-                    body=body,
-                    instance_id=target.instance_id,
-                    key_count=len(chunk),
-                    salt_count=len({k.cache_salt for k in chunk}),
+            if target is None:
+                logger.warning(
+                    "Eviction plan holds %d keys on %s; skipping dispatch",
+                    len(keys),
+                    f"{route.instance_id}, which left the fleet mid-cycle"
+                    if route.instance_id
+                    else "a shared pool, but no MP server is registered",
                 )
-            )
-            self._in_flight_dispatches.add(task)
-            task.add_done_callback(self._in_flight_dispatches.discard)
-        return plan
+                continue
+            url = f"http://{target.ip}:{target.http_port}/cache/objects"
+            for start in range(0, len(keys), MAX_DELETE_BATCH):
+                chunk = keys[start : start + MAX_DELETE_BATCH]
+                body: dict[str, object] = {
+                    "keys": [asdict(k.to_encoded_object_key()) for k in chunk],
+                    # Stated rather than left to the endpoint's default, so
+                    # the request says which tier it is deleting from.
+                    "tier": route.tier.value,
+                }
+                if route.backend:
+                    body["adapter"] = route.backend
+                task = asyncio.create_task(
+                    self._dispatch_eviction(
+                        http_client=http_client,
+                        url=url,
+                        body=body,
+                        instance_id=target.instance_id,
+                        tier=route.tier,
+                        backend=route.backend,
+                        key_count=len(chunk),
+                        salt_count=len({k.cache_salt for k in chunk}),
+                    )
+                )
+                self._in_flight_dispatches.add(task)
+                task.add_done_callback(self._in_flight_dispatches.discard)
+        return plan.victims
 
     async def wait_for_in_flight_dispatches(self) -> None:
         """Await every outstanding fire-and-forget dispatch."""
         await asyncio.gather(*self._in_flight_dispatches, return_exceptions=True)
 
+    # -- Internals ------------------------------------------------------------
+
+    def _compute_eviction_plan(self, registry: InstanceRegistry) -> _EvictionPlan:
+        """Plan this cycle's eviction: what to drop, and where from.
+
+        A salt fires at ``watermark * quota`` and gives up ``eviction_ratio``
+        of its LRU keys (quota ``0`` ⇒ all of them); one without an explicit
+        quota falls back to the default limit, and is exempt while that is
+        unset. Pinned keys and keys no live server can delete are skipped.
+
+        Args:
+            registry: Fleet membership; decides which copies are reachable.
+        """
+        tracked_salts = self._policy.get_tracked_salts()
+        eviction_plan: dict[str, list[ObjectKey]] = {}
+        # Routing is a by-product of the eligibility check, which has to
+        # resolve it anyway; only the selected keys' routes are kept.
+        resolved: dict[ObjectKey, list[_DeleteRoute]] = {}
+
+        for cache_salt in tracked_salts:
+            current_bytes = self._usage_manager.get_salt_bytes(Tier.L2, cache_salt)
+            if current_bytes <= 0:
+                continue
+            limit = self._quota_manager.effective_limit_bytes(cache_salt)
+            if limit is None:
+                # No explicit quota and no default configured yet —
+                # exempt until the quota controller arms enforcement.
+                continue
+            if current_bytes < self._trigger_watermark * limit:
+                continue
+
+            effective_ratio = 1.0 if limit == 0 else self._eviction_ratio
+            actions = self._policy.get_eviction_actions(
+                effective_ratio,
+                cache_salt=cache_salt,
+                key_eligible_filter=lambda key: self._is_evictable(
+                    key, registry, Tier.L2, resolved
+                ),
+            )
+            keys_to_evict: list[ObjectKey] = []
+            for action in actions:
+                keys_to_evict.extend(action.keys)
+
+            if keys_to_evict:
+                eviction_plan[cache_salt] = keys_to_evict
+                evict_bytes = sum(
+                    self._usage_manager.get_key_bytes(Tier.L2, k) for k in keys_to_evict
+                )
+                logger.info(
+                    "Eviction plan for cache_salt=%r: %d keys "
+                    "(%d bytes) to free; usage=%d, quota=%d, "
+                    "watermark=%.2f, ratio=%.2f",
+                    cache_salt,
+                    len(keys_to_evict),
+                    evict_bytes,
+                    current_bytes,
+                    limit,
+                    self._trigger_watermark,
+                    effective_ratio,
+                )
+
+        return _EvictionPlan(
+            victims=eviction_plan,
+            routes={
+                key: resolved[key] for keys in eviction_plan.values() for key in keys
+            },
+        )
+
+    def _is_evictable(
+        self,
+        key: ObjectKey,
+        registry: InstanceRegistry,
+        tier: Tier,
+        routes: dict[ObjectKey, list[_DeleteRoute]],
+    ) -> bool:
+        """Whether ``key`` may be selected as a victim this cycle.
+
+        True when it carries no pin and at least one ``tier`` copy is
+        reachable. ``routes`` memoizes the resolution for the caller.
+
+        Runs under the LRU policy's lock and takes the key directory's, an
+        order nothing reverses — the directory never reaches into eviction.
+        """
+        if key in self._pin_counts:
+            return False
+        key_routes = routes.get(key)
+        if key_routes is None:
+            key_routes = self._resolve_routes(key, registry, tier)
+            routes[key] = key_routes
+        return bool(key_routes)
+
+    def _resolve_routes(
+        self, key: ObjectKey, registry: InstanceRegistry, tier: Tier
+    ) -> list[_DeleteRoute]:
+        """Resolve where every live ``tier`` copy of ``key`` must be deleted.
+
+        A shared placement is one pool the whole fleet mounts, so any
+        registered server deletes it — preferably its reporter, which
+        certainly mounts that backend. A private placement is the reporter's
+        own storage: only that instance can delete it, and once it leaves the
+        fleet the copy is unreachable.
+
+        Args:
+            key: The victim to route.
+            registry: Fleet membership; decides which owners are live.
+            tier: The tier being evicted; placements on others are ignored.
+
+        Returns:
+            One route per deletable copy, deduplicated; one best-effort route
+            to any registered server when the directory knows no placement on
+            ``tier``, so a directory blind spot cannot stall eviction; empty
+            when every known copy is stranded on a departed instance.
+        """
+        placements = [p for p in self._key_directory.lookup([key])[0] if p.tier == tier]
+        if not placements:
+            return [_DeleteRoute(instance_id="", tier=tier, backend="")]
+        routes: list[_DeleteRoute] = []
+        for placement in placements:
+            if placement.shared:
+                instance_id = (
+                    placement.instance_id
+                    if registry.contains(placement.instance_id)
+                    else ""
+                )
+            elif registry.contains(placement.instance_id):
+                instance_id = placement.instance_id
+            else:
+                continue
+            route = _DeleteRoute(
+                instance_id=instance_id, tier=tier, backend=placement.backend
+            )
+            if route not in routes:
+                routes.append(route)
+        return routes
+
     @staticmethod
     async def _dispatch_eviction(
         http_client: httpx.AsyncClient,
         url: str,
-        body: dict,
+        body: dict[str, object],
         instance_id: str,
+        tier: Tier,
+        backend: str,
         key_count: int,
         salt_count: int,
     ) -> None:
         """Send the DELETE and log the outcome. Failures are not retried."""
+        target = f"{instance_id}/{tier.value}/{backend or 'default backend'}"
         try:
             # ``httpx.AsyncClient.delete`` doesn't accept ``json=``;
             # ``request("DELETE", ...)`` is the supported form.
@@ -384,14 +542,14 @@ class FleetEvictionController(Controller):
         except (httpx.HTTPError, ValueError) as e:
             logger.warning(
                 "Eviction dispatch to %s (%d keys) failed: %s",
-                instance_id,
+                target,
                 key_count,
                 e,
             )
             return
         logger.info(
             "Eviction dispatched to %s: %d keys across %d salts",
-            instance_id,
+            target,
             key_count,
             salt_count,
         )

--- a/tests/v1/mp_coordinator/persistence/test_checkpoint.py
+++ b/tests/v1/mp_coordinator/persistence/test_checkpoint.py
@@ -43,7 +43,9 @@ class _Coordinator:
     def __init__(self) -> None:
         self.directory = KeyDirectory()
         self.usage = CacheUsageManager()
-        self.controller = FleetEvictionController(usage_manager=self.usage)
+        self.controller = FleetEvictionController(
+            usage_manager=self.usage, key_directory=KeyDirectory()
+        )
         broadcaster = CacheEventBroadcaster()
         broadcaster.register_consumer(self.directory)
         broadcaster.register_consumer(self.usage)

--- a/tests/v1/mp_coordinator/persistence/test_durable_components.py
+++ b/tests/v1/mp_coordinator/persistence/test_durable_components.py
@@ -43,7 +43,9 @@ def _pipeline() -> tuple[
     """The real path: the usage view consumes before the controller, which
     reads it for the same batch (as ``create_app`` orders them)."""
     usage_manager = CacheUsageManager()
-    controller = FleetEvictionController(usage_manager=usage_manager)
+    controller = FleetEvictionController(
+        usage_manager=usage_manager, key_directory=KeyDirectory()
+    )
     broadcaster = CacheEventBroadcaster()
     broadcaster.register_consumer(usage_manager)
     broadcaster.register_consumer(controller)

--- a/tests/v1/mp_coordinator/persistence/test_metadata.py
+++ b/tests/v1/mp_coordinator/persistence/test_metadata.py
@@ -16,6 +16,7 @@ from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
 )
 from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
 from lmcache.v1.mp_coordinator.persistence.store import LocalArtifactStore
+from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 
 
@@ -24,7 +25,9 @@ def _key(chunk_id: int) -> ObjectKey:
 
 
 def _controller() -> FleetEvictionController:
-    return FleetEvictionController(usage_manager=CacheUsageManager())
+    return FleetEvictionController(
+        usage_manager=CacheUsageManager(), key_directory=KeyDirectory()
+    )
 
 
 class TestRoundTrip:

--- a/tests/v1/mp_coordinator/persistence/test_restore_without_replay.py
+++ b/tests/v1/mp_coordinator/persistence/test_restore_without_replay.py
@@ -30,7 +30,9 @@ class _Coordinator:
     def __init__(self) -> None:
         self.directory = KeyDirectory()
         self.usage = CacheUsageManager()
-        self.controller = FleetEvictionController(usage_manager=self.usage)
+        self.controller = FleetEvictionController(
+            usage_manager=self.usage, key_directory=KeyDirectory()
+        )
         self.broadcaster = CacheEventBroadcaster()
         self.broadcaster.register_consumer(self.directory)
         self.broadcaster.register_consumer(self.usage)

--- a/tests/v1/mp_coordinator/test_cache_api.py
+++ b/tests/v1/mp_coordinator/test_cache_api.py
@@ -5,6 +5,10 @@ Quota writes, usage events, and status reads moved to the ``/quota`` group --
 see ``test_quota_api.py``.
 """
 
+# Standard
+import asyncio
+import time
+
 # Third Party
 from fastapi.testclient import TestClient
 import httpx
@@ -21,6 +25,7 @@ from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
+from lmcache.v1.mp_coordinator.registry import MPInstance
 from lmcache.v1.multiprocess.cache_control.key_resolver import resolve_object_keys
 
 
@@ -122,6 +127,27 @@ def _pin_body(salt: str = "alice") -> dict:
     }
 
 
+def _eviction_plan(ctx) -> dict[str, list[ObjectKey]]:
+    """Run one eviction pass and return its plan.
+
+    Selection is only observable through ``execute_evictions``, so the
+    DELETEs the pass issues are absorbed by a mock transport. Dispatch does
+    not touch the LRU, so calling this twice is safe.
+    """
+    eviction = ctx.controllers.get(FleetEvictionController)
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"ok": True})
+    )
+
+    async def run() -> dict[str, list[ObjectKey]]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            plan = await eviction.execute_evictions(ctx.registry, client)
+            await eviction.wait_for_in_flight_dispatches()
+        return plan
+
+    return asyncio.run(run())
+
+
 def _resolve(ctx, salt: str = "alice") -> list[ObjectKey]:
     """Resolve the pin body's keys the same way the handler will."""
     keys, _ = resolve_object_keys(
@@ -134,16 +160,27 @@ def test_pin_then_unpin_tracks_l2_eviction():
     """Pin excludes the resolved keys from L2 eviction; unpin restores them."""
     with _pin_client() as client:
         ctx = client.app.state.ctx
-        eviction = ctx.controllers.get(FleetEvictionController)
         keys = _resolve(ctx)
         assert keys  # 2 chunks x world_size 1
 
         # Arm allowlist enforcement (unquota'd salts are exempt until the
         # default limit is set), then track the keys in the L2 eviction LRU
         # with no quota (evict-all), so the plan would evict them unless
-        # pinned.
+        # pinned. ``mp-1`` must be a fleet member: the reported placements
+        # are local to it, so only it can delete them and the planner skips
+        # them while it is out of the fleet.
         assert (
             client.put("/quota/config", json={"default_limit_gb": 0}).status_code == 200
+        )
+        now = time.time()
+        ctx.registry.register(
+            MPInstance(
+                instance_id="mp-1",
+                ip="10.0.0.1",
+                http_port=8000,
+                registration_time=now,
+                last_heartbeat_time=now,
+            )
         )
         for seq, k in enumerate(keys, start=1):
             ctx.event_gate.ingest(
@@ -159,7 +196,7 @@ def test_pin_then_unpin_tracks_l2_eviction():
                     ],
                 )
             )
-        assert eviction.compute_eviction_plan()["alice"]
+        assert _eviction_plan(ctx)["alice"]
 
         resp = client.post("/cache/pins", json=_pin_body())
         assert resp.status_code == 200, resp.text
@@ -169,7 +206,7 @@ def test_pin_then_unpin_tracks_l2_eviction():
             "status": "pinned",
         }
         # Pinned: the keys drop out of the eviction plan.
-        assert eviction.compute_eviction_plan() == {}
+        assert _eviction_plan(ctx) == {}
 
         resp = client.request("DELETE", "/cache/pins", json=_pin_body())
         assert resp.status_code == 200, resp.text
@@ -179,7 +216,7 @@ def test_pin_then_unpin_tracks_l2_eviction():
             "status": "unpinned",
         }
         # Unpinned: the keys are eligible for eviction again.
-        assert eviction.compute_eviction_plan()["alice"]
+        assert _eviction_plan(ctx)["alice"]
 
 
 def test_pin_short_sequence_is_noop():

--- a/tests/v1/mp_coordinator/test_eviction_controller.py
+++ b/tests/v1/mp_coordinator/test_eviction_controller.py
@@ -21,6 +21,7 @@ from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry, MPInstance
+from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 
 
@@ -37,6 +38,7 @@ def _setup(
     eviction_ratio: float = 0.5,
     trigger_watermark: float = 1.0,
     default_limit_bytes: int | None = 0,
+    key_directory: KeyDirectory | None = None,
 ) -> tuple[FleetEvictionController, QuotaManager, CacheUsageManager]:
     """Build the controller plus the quota registry it owns and the
     usage view it reads.
@@ -46,15 +48,53 @@ def _setup(
     ``PUT /quota/config`` after re-syncing quotas — so most tests exercise
     armed behavior. Pass ``default_limit_bytes=None`` to exercise the
     exempt boot state instead.
+
+    ``key_directory`` defaults to an empty one: with no L2 placement
+    recorded, every victim routes to "any registered server, primary
+    adapter", which is what the plan-shape tests below care about. Pass a
+    populated one to exercise placement-aware routing.
     """
     usage = CacheUsageManager()
     ctrl = FleetEvictionController(
         usage_manager=usage,
+        key_directory=key_directory if key_directory is not None else KeyDirectory(),
         eviction_ratio=eviction_ratio,
         trigger_watermark=trigger_watermark,
     )
     ctrl.quota.set_default_limit_bytes(default_limit_bytes)
     return ctrl, ctrl.quota, usage
+
+
+def _plan(
+    ctrl: FleetEvictionController, registry: InstanceRegistry | None = None
+) -> dict[str, list[ObjectKey]]:
+    """Return the plan one eviction pass produces against ``registry``.
+
+    Selection is only observable through :meth:`execute_evictions`, so this
+    runs a real pass and absorbs the deletes it issues in a mock transport.
+    Dispatch does not touch the LRU, so calling this twice is safe.
+
+    Fleet membership only narrows the plan for victims the directory has a
+    local placement for, so tests that assert plan *shape* pass no fleet.
+    """
+    return asyncio.run(
+        _run_eviction_pass(
+            ctrl, registry if registry is not None else InstanceRegistry()
+        )
+    )
+
+
+async def _run_eviction_pass(
+    ctrl: FleetEvictionController, registry: InstanceRegistry
+) -> dict[str, list[ObjectKey]]:
+    """One ``execute_evictions`` pass whose DELETEs all succeed."""
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"ok": True})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        plan = await ctrl.execute_evictions(registry, client)
+        await ctrl.wait_for_in_flight_dispatches()
+    return plan
 
 
 def _l2_batch(
@@ -101,7 +141,7 @@ def test_on_store_tracks_key():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
     _store(ctrl, kd, k, 100)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result["a"] == [k]
 
 
@@ -112,7 +152,7 @@ def test_on_lookup_touches_key():
     _store(ctrl, kd, k1, 100)
     _store(ctrl, kd, k2, 100)
     ctrl.on_lookup(k1)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result["a"][0] == k2
 
 
@@ -125,7 +165,7 @@ def test_on_lookup_unknown_key_is_noop():
     # mustn't show up in the plan.
     other = _make_key("a", h="ff")
     _store(ctrl, kd, other, 100)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert k not in result.get("a", [])
 
 
@@ -139,7 +179,7 @@ def test_on_remove():
     # _remove drops k1 from both the LRU and the directory's ledger.
     assert kd.get_key_bytes(Tier.L2, k1) == 0
     assert kd.get_key_bytes(Tier.L2, k2) > 0
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result["a"] == [k2]
 
 
@@ -161,7 +201,7 @@ def test_on_remove_cleans_empty_bucket():
     _store(ctrl, kd, k, 100)
     _remove(ctrl, kd, k)
     assert kd.get_salt_bytes(Tier.L2, "a") == 0
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result == {}
 
 
@@ -170,7 +210,7 @@ def test_no_quota_evicts_all_when_default_armed():
     ctrl, _, kd = _setup(eviction_ratio=1.0)
     k = _make_key("a")
     _store(ctrl, kd, k, 1000)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" in result
     assert result["a"] == [k]
 
@@ -187,7 +227,7 @@ def test_unquotad_salt_exempt_until_default_set():
     ctrl, _, kd = _setup(eviction_ratio=1.0, default_limit_bytes=None)
     _store(ctrl, kd, _make_key("a", h="01"), 1000)
     _store(ctrl, kd, _make_key("b", h="02"), 2000)
-    assert ctrl.compute_eviction_plan() == {}
+    assert _plan(ctrl) == {}
 
 
 def test_explicit_quota_enforced_even_while_default_unset():
@@ -200,7 +240,7 @@ def test_explicit_quota_enforced_even_while_default_unset():
     _store(ctrl, kd, ka, 1000)
     _store(ctrl, kd, kb, 1000)
     qs.set_quota("a", 500)  # over quota
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result.get("a") == [ka]
     assert "b" not in result  # unquota'd, default unset ⇒ exempt
 
@@ -211,10 +251,10 @@ def test_setting_default_zero_arms_allowlist_eviction():
     ctrl, qs, kd = _setup(eviction_ratio=1.0, default_limit_bytes=None)
     k = _make_key("a")
     _store(ctrl, kd, k, 1000)
-    assert ctrl.compute_eviction_plan() == {}
+    assert _plan(ctrl) == {}
 
     qs.set_default_limit_bytes(0)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result.get("a") == [k]
 
 
@@ -226,7 +266,7 @@ def test_positive_default_acts_as_budget_for_unquotad_salts():
     over = _make_key("b", h="02")
     _store(ctrl, kd, under, 1000)  # under the 1500 default
     _store(ctrl, kd, over, 2000)  # over it
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" not in result
     assert result.get("b") == [over]
 
@@ -235,7 +275,7 @@ def test_under_quota():
     ctrl, qs, kd = _setup()
     qs.set_quota("a", 2000)
     _store(ctrl, kd, _make_key("a"), 1000)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result == {}
 
 
@@ -246,7 +286,7 @@ def test_over_quota():
     k2 = _make_key("a", h="02")
     _store(ctrl, kd, k1, 400)
     _store(ctrl, kd, k2, 600)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" in result
     assert k1 in result["a"]
     assert k2 in result["a"]
@@ -259,7 +299,7 @@ def test_eviction_ratio():
     k2 = _make_key("a", h="02")
     _store(ctrl, kd, k1, 200)
     _store(ctrl, kd, k2, 800)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" in result
     assert len(result["a"]) == 1
     assert result["a"][0] == k1
@@ -270,7 +310,7 @@ def test_zero_quota_evicts_all():
     qs.set_quota("a", 0)
     k = _make_key("a")
     _store(ctrl, kd, k, 1000)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" in result
     assert result["a"] == [k]
 
@@ -283,7 +323,7 @@ def test_multiple_salts_independent():
     kb = _make_key("b", h="02")
     _store(ctrl, kd, ka, 500)
     _store(ctrl, kd, kb, 1000)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" in result
     assert "b" not in result
 
@@ -292,7 +332,7 @@ def test_watermark_below_threshold_skips():
     ctrl, qs, kd = _setup(trigger_watermark=0.8)
     qs.set_quota("a", 1000)
     _store(ctrl, kd, _make_key("a"), 700)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert result == {}
 
 
@@ -301,7 +341,7 @@ def test_watermark_above_threshold_evicts():
     qs.set_quota("a", 1000)
     k = _make_key("a")
     _store(ctrl, kd, k, 900)
-    result = ctrl.compute_eviction_plan()
+    result = _plan(ctrl)
     assert "a" in result
     assert result["a"] == [k]
 
@@ -373,12 +413,13 @@ async def test_execute_evictions_dispatches_to_registered_instance():
                 "object_group_id": 0,
                 "cache_salt": "alice",
             }
-        ]
+        ],
+        "tier": "l2",
     }
     # LRU + usage are UNCHANGED at this point — the DELETE event hasn't
     # arrived yet. Cleanup happens once the MP server flushes its
     # ``on_l2_keys_deleted`` events back through the cache-event stream.
-    assert ctrl.compute_eviction_plan() == {"alice": [k]}
+    assert await _run_eviction_pass(ctrl, registry) == {"alice": [k]}
     assert kd.get_salt_bytes(Tier.L2, "alice") == 100
 
 
@@ -403,7 +444,7 @@ async def test_execute_evictions_no_instances_skips_dispatch_and_keeps_lru():
 
     assert plan == {"alice": [k]}
     # LRU UNCHANGED — the same plan should re-emerge next cycle.
-    assert ctrl.compute_eviction_plan() == {"alice": [k]}
+    assert await _run_eviction_pass(ctrl, registry) == {"alice": [k]}
 
 
 @pytest.mark.asyncio
@@ -426,7 +467,7 @@ async def test_execute_evictions_http_failure_keeps_lru():
 
     assert plan == {"alice": [k]}
     # LRU UNCHANGED — retry on the next cycle.
-    assert ctrl.compute_eviction_plan() == {"alice": [k]}
+    assert await _run_eviction_pass(ctrl, registry) == {"alice": [k]}
 
 
 @pytest.mark.asyncio
@@ -501,7 +542,7 @@ def test_pin_excludes_key_from_eviction_plan():
     _store(ctrl, kd, k2, 100)
 
     ctrl.pin([k1])
-    plan = ctrl.compute_eviction_plan()
+    plan = _plan(ctrl)
     assert k1 not in plan.get("a", [])
     assert k2 in plan["a"]
 
@@ -513,10 +554,10 @@ def test_unpin_restores_eviction_eligibility():
     _store(ctrl, kd, k, 100)
 
     ctrl.pin([k])
-    assert ctrl.compute_eviction_plan() == {}
+    assert _plan(ctrl) == {}
 
     ctrl.unpin([k])
-    assert ctrl.compute_eviction_plan()["a"] == [k]
+    assert _plan(ctrl)["a"] == [k]
 
 
 def test_pin_is_reference_counted():
@@ -527,13 +568,13 @@ def test_pin_is_reference_counted():
 
     ctrl.pin([k])
     ctrl.pin([k])
-    assert ctrl.compute_eviction_plan() == {}
+    assert _plan(ctrl) == {}
 
     ctrl.unpin([k])
-    assert ctrl.compute_eviction_plan() == {}  # still pinned once
+    assert _plan(ctrl) == {}  # still pinned once
 
     ctrl.unpin([k])
-    assert ctrl.compute_eviction_plan()["a"] == [k]
+    assert _plan(ctrl)["a"] == [k]
 
 
 def test_unpin_unknown_key_is_noop():
@@ -543,7 +584,7 @@ def test_unpin_unknown_key_is_noop():
     _store(ctrl, kd, k, 100)
 
     ctrl.unpin([_make_key("a", h="ff")])  # never pinned
-    assert ctrl.compute_eviction_plan()["a"] == [k]
+    assert _plan(ctrl)["a"] == [k]
 
 
 # =============================================================================
@@ -572,7 +613,7 @@ def test_drop_pins_purges_pin_regardless_of_count():
 
     ctrl.drop_pins([k])
     # A single drop clears all pin counts: the key is evictable again.
-    assert ctrl.compute_eviction_plan()["a"] == [k]
+    assert _plan(ctrl)["a"] == [k]
     assert ctrl.filter_unpinned([k]) == [k]
 
 
@@ -595,11 +636,11 @@ def test_consume_maps_l2_events_onto_the_lru():
     for k in (k1, k2):
         _broadcast(ctrl, kd, _l2_batch(CacheEventType.STORE, k, 100))
     _broadcast(ctrl, kd, _l2_batch(CacheEventType.ACCESS, k1))
-    plan = ctrl.compute_eviction_plan()
+    plan = _plan(ctrl)
     assert plan["a"][0] == k2  # k1 touched to MRU
 
     _broadcast(ctrl, kd, _l2_batch(CacheEventType.DELETE, k2))
-    assert ctrl.compute_eviction_plan()["a"] == [k1]
+    assert _plan(ctrl)["a"] == [k1]
 
 
 def test_consume_keeps_key_in_lru_while_another_placement_remains():
@@ -626,7 +667,7 @@ def test_consume_keeps_key_in_lru_while_another_placement_remains():
     # Delete the private copy; the shared copy remains.
     _broadcast(ctrl, kd, _l2_batch(CacheEventType.DELETE, k))
     assert kd.get_key_bytes(Tier.L2, k) == 100
-    assert ctrl.compute_eviction_plan()["a"] == [k]  # still evictable
+    assert _plan(ctrl)["a"] == [k]  # still evictable
 
     # Delete the last placement: now the LRU lets go.
     delete_shared = CacheEventBatch(
@@ -641,7 +682,7 @@ def test_consume_keeps_key_in_lru_while_another_placement_remains():
     )
     _broadcast(ctrl, kd, delete_shared)
     assert kd.get_key_bytes(Tier.L2, k) == 0
-    assert ctrl.compute_eviction_plan() == {}
+    assert _plan(ctrl) == {}
 
 
 def test_consume_ignores_l1_batches():
@@ -657,7 +698,7 @@ def test_consume_ignores_l1_batches():
         entries=[CacheEventEntry(key=k.to_encoded_object_key(), size_bytes=100)],
     )
     _broadcast(ctrl, kd, batch)
-    assert ctrl.compute_eviction_plan() == {}
+    assert _plan(ctrl) == {}
 
 
 def test_l1_batches_leave_the_l2_rollup_untouched():
@@ -691,7 +732,7 @@ def test_broadcast_order_feeds_usage_before_the_lru():
     _store(ctrl, kd, k, 100)
 
     assert kd.get_salt_bytes(Tier.L2, "a") == 100
-    assert ctrl.compute_eviction_plan()["a"] == [k]
+    assert _plan(ctrl)["a"] == [k]
 
 
 def test_fence_instance_keeps_l2_usage_and_lru():
@@ -704,7 +745,7 @@ def test_fence_instance_keeps_l2_usage_and_lru():
     ctrl.fence_instance("node-a")
 
     assert kd.get_salt_bytes(Tier.L2, "a") == 100
-    assert ctrl.compute_eviction_plan()["a"] == [k]
+    assert _plan(ctrl)["a"] == [k]
 
 
 # ============================================================================
@@ -777,3 +818,241 @@ async def test_run_sleeps_before_the_first_check():
             await task
 
     assert dispatched == []
+
+
+# =============================================================================
+# Placement-aware routing (local vs shared L2)
+# =============================================================================
+
+
+def _placement_batch(
+    key: ObjectKey,
+    instance_id: str,
+    backend: str,
+    shared: bool,
+    seq: int = 1,
+    size: int = 100,
+) -> CacheEventBatch:
+    """An L2 STORE batch carrying one placement's identity."""
+    return CacheEventBatch(
+        instance_id=instance_id,
+        incarnation=1,
+        seq=seq,
+        event_type=CacheEventType.STORE,
+        tier=Tier.L2,
+        backend=backend,
+        shared=shared,
+        entries=[CacheEventEntry(key=key.to_encoded_object_key(), size_bytes=size)],
+    )
+
+
+def _record(
+    directory: KeyDirectory,
+    ctrl: FleetEvictionController,
+    usage: CacheUsageManager,
+    batch: CacheEventBatch,
+) -> None:
+    """Feed one batch the way the ingest path does: the directory and the
+    usage view before the controller, which reads both."""
+    directory.consume(batch)
+    _broadcast(ctrl, usage, batch)
+
+
+async def _capture_dispatches(
+    ctrl: FleetEvictionController, registry: InstanceRegistry
+) -> tuple[dict[str, list[ObjectKey]], list[tuple[str, str | None, str | None, int]]]:
+    """Run one eviction pass against a mock transport.
+
+    Returns the plan plus one ``(url, tier, adapter, key_count)`` tuple per
+    DELETE the pass issued.
+    """
+    # Standard
+    import json as _json
+
+    sent: list[tuple[str, str | None, str | None, int]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = _json.loads((request.read() or b"").decode())
+        sent.append(
+            (
+                str(request.url),
+                body.get("tier"),
+                body.get("adapter"),
+                len(body["keys"]),
+            )
+        )
+        return httpx.Response(200, json={"requested": len(body["keys"]), "ok": True})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        plan = await ctrl.execute_evictions(registry, client)
+        await ctrl.wait_for_in_flight_dispatches()
+    return plan, sent
+
+
+@pytest.mark.asyncio
+async def test_local_l2_victim_is_deleted_on_its_owner():
+    """A private (local) L2 copy only exists on the instance that stored it,
+    so the DELETE must go there — not to an arbitrary registered server."""
+    registry = _make_registry(
+        _instance("mp-1", ip="10.0.0.1"), _instance("mp-2", ip="10.0.0.2")
+    )
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=1.0, key_directory=directory)
+    k = _make_key("alice", h="aa")
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-2", "fs", shared=False))
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [k]}
+    assert sent == [("http://10.0.0.2:8000/cache/objects", "l2", "fs", 1)]
+
+
+@pytest.mark.asyncio
+async def test_every_local_copy_is_deleted_on_its_own_owner():
+    """The same key held privately by two instances costs two DELETEs — one
+    per owner — since each owns distinct bytes the salt's usage counts."""
+    registry = _make_registry(
+        _instance("mp-1", ip="10.0.0.1"), _instance("mp-2", ip="10.0.0.2")
+    )
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=1.0, key_directory=directory)
+    k = _make_key("alice", h="aa")
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-1", "fs", shared=False))
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-2", "fs", shared=False))
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [k]}
+    assert sorted(sent) == [
+        ("http://10.0.0.1:8000/cache/objects", "l2", "fs", 1),
+        ("http://10.0.0.2:8000/cache/objects", "l2", "fs", 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_shared_l2_victim_is_deleted_once_through_its_reporter():
+    """A fleet-shared pool holds one copy however many servers mount it, so
+    one DELETE suffices — addressed to the directory's reporter for the
+    placement (the most recent one), which certainly mounts that backend."""
+    registry = _make_registry(
+        _instance("mp-1", ip="10.0.0.1"), _instance("mp-2", ip="10.0.0.2")
+    )
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=1.0, key_directory=directory)
+    k = _make_key("alice", h="aa")
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-1", "s3", shared=True))
+    # A second reporter of the same shared pool is the same placement; the
+    # directory keeps the latest reporter (mp-2) as its contact.
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-2", "s3", shared=True))
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [k]}
+    assert sent == [("http://10.0.0.2:8000/cache/objects", "l2", "s3", 1)]
+
+
+@pytest.mark.asyncio
+async def test_shared_l2_victim_falls_back_when_reporter_left():
+    """A shared pool outlives its reporter: any remaining server can delete
+    from it, so the plan still dispatches."""
+    registry = _make_registry(_instance("mp-2", ip="10.0.0.2"))
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=1.0, key_directory=directory)
+    k = _make_key("alice", h="aa")
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-1", "s3", shared=True))
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [k]}
+    assert sent == [("http://10.0.0.2:8000/cache/objects", "l2", "s3", 1)]
+
+
+@pytest.mark.asyncio
+async def test_local_l2_victim_of_departed_owner_is_not_planned():
+    """Nobody can delete a local copy whose owner has left the fleet, so it
+    is not selected — dispatching it elsewhere would delete nothing and the
+    key would never leave the LRU."""
+    registry = _make_registry(_instance("mp-2", ip="10.0.0.2"))
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=1.0, key_directory=directory)
+    k = _make_key("alice", h="aa")
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-9", "fs", shared=False))
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {}
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_departed_owners_keys_do_not_starve_deletable_ones():
+    """The stranded key sits at the LRU head, but it must not consume the
+    cycle's eviction budget — the reachable key behind it is still freed."""
+    registry = _make_registry(_instance("mp-1", ip="10.0.0.1"))
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=0.5, key_directory=directory)
+    stranded = _make_key("alice", h="01")
+    reachable = _make_key("alice", h="02")
+    _record(
+        directory, ctrl, usage, _placement_batch(stranded, "mp-9", "fs", shared=False)
+    )
+    _record(
+        directory, ctrl, usage, _placement_batch(reachable, "mp-1", "fs", shared=False)
+    )
+    qs.set_quota("alice", 0)  # over quota; ratio 0.5 of 2 keys ⇒ 1 victim
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [reachable]}
+    assert sent == [("http://10.0.0.1:8000/cache/objects", "l2", "fs", 1)]
+
+
+@pytest.mark.asyncio
+async def test_victim_without_known_placement_uses_primary_adapter():
+    """A key the directory has no L2 placement for still gets one best-effort
+    DELETE on a registered server's primary adapter — the pre-routing
+    behavior."""
+    registry = _make_registry(_instance("mp-1", ip="10.0.0.1"))
+    ctrl, qs, usage = _setup(eviction_ratio=1.0)
+    k = _make_key("alice", h="aa")
+    _store(ctrl, usage, k, 100)
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [k]}
+    assert sent == [("http://10.0.0.1:8000/cache/objects", "l2", None, 1)]
+
+
+@pytest.mark.asyncio
+async def test_routing_ignores_placements_on_other_tiers():
+    """Routing is scoped to the tier being evicted. The key's L1 copy lives
+    on a departed instance, but only its L2 placement decides the delete —
+    and the request names that tier explicitly."""
+    registry = _make_registry(_instance("mp-1", ip="10.0.0.1"))
+    directory = KeyDirectory()
+    ctrl, qs, usage = _setup(eviction_ratio=1.0, key_directory=directory)
+    k = _make_key("alice", h="aa")
+    directory.consume(
+        CacheEventBatch(
+            instance_id="mp-9",
+            incarnation=1,
+            seq=1,
+            event_type=CacheEventType.STORE,
+            tier=Tier.L1,
+            backend="dram",
+            entries=[CacheEventEntry(key=k.to_encoded_object_key(), size_bytes=100)],
+        )
+    )
+    _record(directory, ctrl, usage, _placement_batch(k, "mp-1", "fs", shared=False))
+    qs.set_quota("alice", 0)
+
+    plan, sent = await _capture_dispatches(ctrl, registry)
+
+    assert plan == {"alice": [k]}
+    assert sent == [("http://10.0.0.1:8000/cache/objects", "l2", "fs", 1)]


### PR DESCRIPTION
**What this PR does / why we need it**:

Coordinator-side L2 eviction only worked for a fleet-*shared* L2 pool. `DELETE /cache/objects` is node-scoped — it removes keys from the L2 adapter of whichever server receives it — but `execute_evictions` sent every victim to `registry.random_instance()` with the primary adapter. That is fine for one S3 bucket the whole fleet mounts; for a **local** (private) L2 the bytes live on the storing instance's own disk, so the delete hit the wrong node, removed nothing, produced no `DELETE` event back on the cache-event stream, and the key stayed in the coordinator's LRU and usage totals forever — re-planned every cycle, never converging.

`FleetEvictionController` is now placement-aware. It takes the `KeyDirectory` view (via `from_config`) and resolves each victim's L2 placements into delete routes:

| Placement | DELETE goes to | Requests |
| --- | --- | --- |
| `shared=True` | The placement's reporter, else any registered server | 1 |
| `shared=False` (local) | The **owning** instance | 1 per owner |
| Local, owner deregistered | Nowhere — key is skipped | 0 |
| No directory placement | Any server, primary adapter (prior behavior) | 1 |

Each request also names the placement's `backend` as the `adapter` selector, so a multi-adapter server deletes from the one that actually holds the key.

Stranded keys are excluded during *planning*, not just dispatch. That matters: a departed owner's key sits at the LRU head, and letting it consume the salt's `eviction_ratio` budget every cycle would stall the deletable keys behind it.

**Special notes for your reviewers**:

- Quota semantics are unchanged: the limit is still per `cache_salt` across the whole fleet, and a key held privately by N instances counts N times — which is what `CacheUsageManager` already accounted for. Per-instance budgets for local L2 would be a separate design.
- Two signature changes, all callers updated here: `FleetEvictionController.__init__` gained a required `key_directory` (production builds it through `from_config` → `views.get(KeyDirectory)`), and `compute_eviction_plan()` became `compute_eviction_plan(registry)` — a victim's eligibility depends on whether anyone can still delete it. `execute_evictions(registry, http_client)` is unchanged. No subclasses.
- `_is_evictable` runs under the LRU policy's lock and takes the directory's; nothing reverses that order (the directory never reaches into eviction). Route resolution is memoized per cycle, so the policy does one directory lookup per candidate it scans, not per tracked key.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
