### PR TITLE
[CB] Add --enable-dedup-content to skip duplicate fingerprint registration

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -119,6 +119,11 @@ Source: ``lmcache/v1/multiprocess/config.py``
        L1-resident and only the dropped gap is recomputed, instead of
        truncating the prefix at the gap. No effect for other engines. See
        :doc:`/mp/l2_storage/fault_inject` for a way to exercise it.
+   * - ``--enable-dedup-content``
+     - ``False``
+     - ``--engine-type blend`` only: skip fingerprint registration for a chunk
+       whose content is already indexed, so the same text stored behind two
+       prefixes is indexed once. No effect for other engines.
    * - ``--separate-object-groups`` / ``--no-separate-object-groups``
      - ``False``
      - Split a hybrid model's kernel groups into one object group per

--- a/lmcache/usage_telemetry/messages.py
+++ b/lmcache/usage_telemetry/messages.py
@@ -176,6 +176,7 @@ class MPServerMessage(UsageMessage):
     hash_algorithm: str
     engine_type: str
     enable_segmented_prefix: bool
+    enable_dedup_content: bool
     supported_transfer_mode: str
     separate_object_groups: bool
     max_gpu_workers: int
@@ -246,6 +247,7 @@ class MPServerMessage(UsageMessage):
             hash_algorithm=mp_config.hash_algorithm,
             engine_type=mp_config.engine_type,
             enable_segmented_prefix=mp_config.enable_segmented_prefix,
+            enable_dedup_content=mp_config.enable_dedup_content,
             supported_transfer_mode=mp_config.supported_transfer_mode,
             separate_object_groups=mp_config.separate_object_groups,
             max_gpu_workers=mp_config.max_gpu_workers,

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -62,6 +62,11 @@ class MPServerConfig:
     L1-resident (served by the sparse leg as L1 hits, the hole recomputed)
     instead of truncating the prefix at the gap. No effect for other engines."""
 
+    enable_dedup_content: bool = False
+    """engine_type='blend' only: skip fingerprint registration for a chunk whose
+    content is already indexed, so the same text stored behind two prefixes is
+    indexed once. No effect for other engines."""
+
     supported_transfer_mode: Literal["lmcache_driven", "engine_driven", "auto"] = (
         "lmcache_driven"
     )
@@ -398,6 +403,13 @@ def add_mp_server_args(
         "L1-resident instead of truncating at the gap. No effect otherwise.",
     )
     mp_group.add_argument(
+        "--enable-dedup-content",
+        action="store_true",
+        help="--engine-type blend only: skip fingerprint registration for a "
+        "chunk whose content is already indexed, so the same text stored "
+        "behind different prefixes is indexed once. No effect otherwise.",
+    )
+    mp_group.add_argument(
         "--enable",
         type=str,
         nargs="*",
@@ -440,6 +452,7 @@ def parse_args_to_mp_server_config(
         engine_type=args.engine_type,
         separate_object_groups=args.separate_object_groups,
         enable_segmented_prefix=args.enable_segmented_prefix,
+        enable_dedup_content=args.enable_dedup_content,
         supported_transfer_mode=args.supported_transfer_mode,
         runtime_plugin_config=RuntimePluginConfig(
             locations=(args.runtime_plugin_locations or []),

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -251,13 +251,16 @@ class BlendTokenRangeMatcherV3:
     _TABLE_SIZE: int = 1 << _TABLE_BITS
     _BASE: np.uint64 = np.uint64(0x9E3779B97F4A7C15)  # Fibonacci-hashing const
 
-    def __init__(self, chunk_size: int = 256):
+    def __init__(self, chunk_size: int = 256, dedup_content: bool = False):
         """Initialize the V3 matcher.
 
         Args:
             chunk_size (int): Tokens per non-overlapping fingerprint chunk.
+            dedup_content (bool): When True, skip registering a chunk whose
+                poly hash is already indexed (``--enable-dedup-content``).
         """
         self.chunk_size = chunk_size
+        self._dedup_content = dedup_content
         # poly_chunk_hash -> compact_chunk_id; -1 = empty
         self._table_id = np.full(self._TABLE_SIZE, -1, dtype=np.int64)
         self._mask = np.uint64(self._TABLE_SIZE - 1)
@@ -285,7 +288,9 @@ class BlendTokenRangeMatcherV3:
         Records each new chunk's poly hash + start position so a later
         match_sub_sequence can find it. Chunks whose token hash is already
         indexed are skipped (dedup), so a re-store of the same content
-        registers nothing. Thread-safe (holds the matcher lock).
+        registers nothing; under ``dedup_content``, already-indexed poly
+        hashes are skipped too, so the same text behind different prefixes is
+        indexed once. Thread-safe (holds the matcher lock).
 
         Args:
             token_ids (list[int]): The stored sequence's token IDs.
@@ -308,11 +313,17 @@ class BlendTokenRangeMatcherV3:
             return 0
 
         with self._lock:
-            new_idxs = [
-                i
-                for i in range(start_chunk_idx, n)
-                if token_hashes[i] not in self._token_hash_to_compact_id
-            ]
+            new_idxs: list[int] = []
+            batch_poly: set[int] = set()
+            for i in range(start_chunk_idx, n):
+                if token_hashes[i] in self._token_hash_to_compact_id:
+                    continue
+                if self._dedup_content:
+                    poly_hash = int(chunk_hashes[i])
+                    if poly_hash in batch_poly or self._poly_hash_registered(poly_hash):
+                        continue
+                    batch_poly.add(poly_hash)
+                new_idxs.append(i)
             if not new_idxs:
                 return 0
             n_new = len(new_idxs)
@@ -353,6 +364,26 @@ class BlendTokenRangeMatcherV3:
                 self._compact_id_to_slot[cid] = slot
                 self._token_hash_to_compact_id[th] = cid
         return n_new
+
+    def _poly_hash_registered(self, poly_hash: int) -> bool:
+        """Whether a live chunk with this poly hash is indexed.
+
+        Same probe + full-hash verify as :meth:`match_sub_sequence`, so a
+        bucket-only collision reports False. Caller must hold ``self._lock``.
+
+        Args:
+            poly_hash (int): The chunk's poly hash over its raw token IDs.
+
+        Returns:
+            bool: True if the slot holds a non-evicted chunk with this hash.
+        """
+        cid = int(self._table_id[poly_hash & int(self._mask)])
+        if cid < 0:
+            return False
+        return (
+            self._chunk_poly_hash[cid] == poly_hash
+            and self._chunk_token_hash[cid] is not None
+        )
 
     def match_sub_sequence(
         self,
@@ -700,6 +731,7 @@ class BlendV3Module(InstanceLivenessTarget):
         lmcache_driven_transfer: LMCacheDrivenTransferModule,
         coordinator: "BlendCoordinatorClient | None" = None,
         enable_segmented_prefix: bool = False,
+        enable_dedup_content: bool = False,
     ):
         # Blend reads the attention group + standalone fused-aux group only;
         # resolved per registration via _classify_cb_read_groups.
@@ -712,7 +744,9 @@ class BlendV3Module(InstanceLivenessTarget):
         # purely local matching (publish/query paths skipped).
         self._coordinator = coordinator
 
-        self._token_range_matcher = BlendTokenRangeMatcherV3(ctx.chunk_size)
+        self._token_range_matcher = BlendTokenRangeMatcherV3(
+            ctx.chunk_size, dedup_content=enable_dedup_content
+        )
         self._event_bus = ctx.event_bus
         self._cb_rope_state: dict[int, _CBRopeState] = {}
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -282,6 +282,7 @@ def _build_modules(
             transfer_module,
             coordinator=coordinator,
             enable_segmented_prefix=mp_config.enable_segmented_prefix,
+            enable_dedup_content=mp_config.enable_dedup_content,
         )
         blend_module = blend_v3
         # blend_v3 mirrors per-instance CB rope state, so the reaper must

--- a/tests/v1/multiprocess/test_blend_v3_dedup_content.py
+++ b/tests/v1/multiprocess/test_blend_v3_dedup_content.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Content-fingerprint dedup in the V3 matcher (``--enable-dedup-content``).
+
+The default dedup key is the caller's content hash, which is prefix-chained:
+the same text behind two prefixes is indexed twice, the second registration
+takes over the probe-table slot, and the first entry is orphaned. With
+``dedup_content=True`` the first registration wins and duplicates are skipped.
+"""
+
+# Standard
+import argparse
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.multiprocess.config import (
+    MPServerConfig,
+    add_mp_server_args,
+    parse_args_to_mp_server_config,
+)
+from lmcache.v1.multiprocess.modules.blend_v3 import BlendTokenRangeMatcherV3
+
+CHUNK_SIZE = 256
+
+
+def _chunk(seed: int) -> list[int]:
+    """Deterministic ``CHUNK_SIZE`` tokens derived from seed; unique per seed."""
+    return [seed * CHUNK_SIZE + i + 1 for i in range(CHUNK_SIZE)]
+
+
+def _register(
+    matcher: BlendTokenRangeMatcherV3,
+    tokens: list[int],
+    chunk_hash_seeds: list[int],
+    position_offset: int = 0,
+) -> None:
+    matcher.on_new_token_hashes(
+        tokens,
+        [ObjectKey.IntHash2Bytes(s) for s in chunk_hash_seeds],
+        position_offset=position_offset,
+    )
+
+
+def _matched_hashes(matcher: BlendTokenRangeMatcherV3, query: list[int]) -> set[bytes]:
+    return {m.hash for m in matcher.match_sub_sequence(query)}
+
+
+# -- Off by default -----------------------------------------------------------
+
+
+def test_duplicate_content_registers_twice_by_default():
+    """Without the flag, the second registration takes over the slot."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=CHUNK_SIZE)
+    first, second = ObjectKey.IntHash2Bytes(101), ObjectKey.IntHash2Bytes(202)
+
+    _register(matcher, _chunk(1), [101])
+    _register(matcher, _chunk(1), [202], position_offset=CHUNK_SIZE)
+
+    matches = matcher.match_sub_sequence(_chunk(1))
+    assert [m.hash for m in matches] == [second]
+    assert matches[0].old_st == CHUNK_SIZE
+
+    # The first entry is orphaned: evicting the second loses the text.
+    matcher.remove_chunks([second])
+    assert matcher.match_sub_sequence(_chunk(1)) == []
+    assert first not in _matched_hashes(matcher, _chunk(1))
+
+
+# -- Enabled ------------------------------------------------------------------
+
+
+def test_duplicate_content_is_skipped_when_enabled():
+    """The first registration keeps the slot; the duplicate is not indexed."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=CHUNK_SIZE, dedup_content=True)
+    first, second = ObjectKey.IntHash2Bytes(101), ObjectKey.IntHash2Bytes(202)
+
+    _register(matcher, _chunk(1), [101])
+    _register(matcher, _chunk(1), [202], position_offset=CHUNK_SIZE)
+
+    matches = matcher.match_sub_sequence(_chunk(1))
+    assert [m.hash for m in matches] == [first]
+    assert matches[0].old_st == 0
+
+    # The skipped hash was never indexed, so evicting it changes nothing.
+    matcher.remove_chunks([second])
+    assert _matched_hashes(matcher, _chunk(1)) == {first}
+
+
+def test_distinct_content_still_registers_when_enabled():
+    """Dedup keys on content only — different text is always indexed."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=CHUNK_SIZE, dedup_content=True)
+    _register(matcher, _chunk(1) + _chunk(2) + _chunk(3), [101, 102, 103])
+
+    assert _matched_hashes(matcher, _chunk(1) + _chunk(2) + _chunk(3)) == {
+        ObjectKey.IntHash2Bytes(101),
+        ObjectKey.IntHash2Bytes(102),
+        ObjectKey.IntHash2Bytes(103),
+    }
+
+
+def test_duplicate_content_within_one_batch_is_skipped():
+    """In-batch duplicates are invisible to the probe table — dedup anyway."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=CHUNK_SIZE, dedup_content=True)
+    first, second = ObjectKey.IntHash2Bytes(101), ObjectKey.IntHash2Bytes(102)
+
+    _register(matcher, _chunk(1) + _chunk(1), [101, 102])
+
+    matches = matcher.match_sub_sequence(_chunk(1))
+    assert [m.hash for m in matches] == [first]
+    assert matches[0].old_st == 0
+    matcher.remove_chunks([second])
+    assert _matched_hashes(matcher, _chunk(1)) == {first}
+
+
+def test_content_is_reregistered_after_eviction():
+    """Evicting the retained entry frees the text for a later registration."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=CHUNK_SIZE, dedup_content=True)
+    first, second = ObjectKey.IntHash2Bytes(101), ObjectKey.IntHash2Bytes(202)
+
+    _register(matcher, _chunk(1), [101])
+    matcher.remove_chunks([first])
+    assert matcher.match_sub_sequence(_chunk(1)) == []
+
+    _register(matcher, _chunk(1), [202], position_offset=CHUNK_SIZE)
+    matches = matcher.match_sub_sequence(_chunk(1))
+    assert [m.hash for m in matches] == [second]
+    assert matches[0].old_st == CHUNK_SIZE
+
+
+def test_repeated_registration_of_same_hash_is_idempotent():
+    """The token-hash dedup path is unchanged by the content dedup."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=CHUNK_SIZE, dedup_content=True)
+    _register(matcher, _chunk(1), [101])
+    _register(matcher, _chunk(1), [101], position_offset=CHUNK_SIZE)
+
+    matches = matcher.match_sub_sequence(_chunk(1))
+    assert [m.hash for m in matches] == [ObjectKey.IntHash2Bytes(101)]
+    assert matches[0].old_st == 0
+
+
+# -- Config -------------------------------------------------------------------
+
+
+def _parse_mp(argv: list[str]) -> MPServerConfig:
+    parser = argparse.ArgumentParser()
+    add_mp_server_args(parser)
+    return parse_args_to_mp_server_config(parser.parse_args(argv))
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [([], False), (["--enable-dedup-content"], True)],
+)
+def test_enable_dedup_content_flag(argv, expected):
+    assert _parse_mp(argv).enable_dedup_content is expected


### PR DESCRIPTION
**What this PR does / why we need it**:

The blend V3 matcher dedups fingerprint registration by the caller's chunk content hash, which is prefix-chained: the same chunk text stored behind two different prefixes gets two different hashes and is indexed twice. The second registration takes over the probe-table slot, orphaning the first entry — it keeps a compact ID but can never match.

Adds `--enable-dedup-content` (opt-in, blend only): skip registering a chunk whose content fingerprint is already indexed, so the same text is indexed once and the first registration wins.

**Special notes for your reviewers**:

Off by default; behavior is unchanged without the flag — the registration filter becomes an explicit loop yielding the same indices in the same order.

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests