### PR TITLE
[MP][Coordinator] Make controller plugables

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -58,12 +58,10 @@ lmcache/v1/mp_coordinator/
   app.py                # create_app + lifespan + router discovery + health/eviction loops
   __main__.py           # uvicorn entrypoint (`python -m lmcache.v1.mp_coordinator`)
   config.py             # MPCoordinatorConfig (CLI flags only, no env vars)
-  registry.py           # InstanceRegistry + MPInstance (pure membership)
   schemas.py            # Pydantic request/response models (shared wire contract)
   registrar.py          # mp-server-side register/heartbeat/deregister helpers
   blend_index.py      # BlendIndex: fragment (blend) lookup over those bindings
   blend_client.py       # mp-server-side fragment-lookup query client
-  server_config.py      # ServerConfigRegistry: per-server module capacities (from registration)
   ingest/
     __init__.py
     event_gate.py       # EventGate: incarnation fencing, seq dedup, gap detection
@@ -72,13 +70,16 @@ lmcache/v1/mp_coordinator/
   views/                # read models of the fleet: what is cached, and how much
     __init__.py         # build_views: scans this package
     base.py             # View: the marker; may depend on other views only
+    instance_registry.py  # InstanceRegistry + MPInstance: fleet membership
     key_directory.py    # KeyDirectory: placements + token bindings (a consumer)
+    server_config.py    # ServerConfigRegistry: per-server capacities (from registration)
     usage_manager.py    # per-tier usage view, by salt and by instance (a consumer)
   controllers/          # policy: loops and request handling, reading the views
-    __init__.py         # build_controllers: scans this package
-    base.py             # Controller: the marker; may depend on views and peers
+    __init__.py         # build_controllers: scans this package + named ones
+    base.py             # Controller: construction + run(); views only
     eviction_controller.py  # the fleet L2 control loop: quota + usage + LRU + pins
     prefetch_manager.py # dispatches warm prefetch to a named MP server
+  http_routes.py        # HttpRoutes: a controller registering its own endpoints
   http_apis/
     __init__.py
     dependencies.py     # shared FastAPI dependencies (registry, key directory, ...)
@@ -278,10 +279,10 @@ The previous design — `blend_directory.py` (`GlobalBlendMatcher`) with its own
   on shutdown. `HEALTH_CHECK_INTERVAL = 0` disables the stale-instance loop
   (it does not affect the L2 eviction loop, which is gated separately by
   `EVICTION_CHECK_INTERVAL`).
-- The L2 eviction loop is a second asyncio task started in the lifespan,
-  running `FleetEvictionController.run` (the controller owns its own
-  cadence); it is cancelled on shutdown. `EVICTION_CHECK_INTERVAL = 0`
-  disables it.
+- The L2 eviction loop is the controller's own, not the app's: the lifespan
+  enters every controller's `run` and names none of them.
+  `EVICTION_CHECK_INTERVAL = 0` makes `FleetEvictionController.start`
+  create no task.
 - Registration is idempotent: re-registering replaces the entry. The registry
   is ephemeral — rebuilt from heartbeats after a coordinator restart. Durable
   state (registered quotas) belongs in an external store, not here. The

--- a/docs/design/v1/mp_coordinator/controllers/README.md
+++ b/docs/design/v1/mp_coordinator/controllers/README.md
@@ -209,14 +209,18 @@ coordinator the endpoints that belong to no controller, nor the controllers
 that did start. Whatever the failed one does is then simply not happening,
 and the log is the only notice of that.
 
+Three steps, in this order: start the work, `yield` exactly once, and shut it
+down in a `finally` -- so teardown runs whether shutdown was clean or an
+exception unwound the stack.
+
 ```python
 @asynccontextmanager
 async def run(self, runtime: ControllerRuntime) -> AsyncIterator[None]:
-    task = asyncio.create_task(self._loop(runtime.http_client))
+    task = asyncio.create_task(self._loop(runtime.http_client))   # 1. start
     try:
-        yield
+        yield                                                     # 2. serve
     finally:
-        task.cancel()
+        task.cancel()                                             # 3. stop
 ```
 
 The lifespan owns only what is not any one controller's: the health-check

--- a/docs/design/v1/mp_coordinator/controllers/README.md
+++ b/docs/design/v1/mp_coordinator/controllers/README.md
@@ -6,17 +6,162 @@ Subclassing the marker in
 the whole of adding one: `build_controllers` scans this package and constructs
 every class it finds.
 
-The marker carries construction and nothing else. Consuming the cache-event
-stream and holding durable state are **protocols**, matched structurally:
-implement `consume` (`CacheEventConsumer`) and the fan-out subscribes you,
-implement `get_durable_components` (`Durability`) and your state is routed to
-an artifact. A controller
-that does neither declares neither, and a class outside these packages can
-still satisfy either -- which is why the ingest gate is captured without being
-a view or a controller.
+The marker carries **construction and lifetime**, both defaulted: override
+`from_config` to read configuration or a view, `run` to do something in the
+background for as long as the app serves. Every controller has a lifetime, so
+these are interface members rather than an opt-in protocol -- as in
+`StorageControllerInterface` under `lmcache/v1/distributed/`.
+
+What a controller might do *besides* that is a **protocol**, matched
+structurally:
+
+| Implement | Protocol | And startup |
+| --- | --- | --- |
+| `consume` | `CacheEventConsumer` | subscribes you to the cache-event fan-out |
+| `get_durable_components` | `Durability` | routes your state to an artifact |
+| `get_routers` | `HttpRoutes` | mounts your endpoints on the coordinator |
+
+A controller implementing none of them declares none, and a class outside
+these packages can still satisfy any -- which is why the ingest gate is
+captured without being a view or a controller.
 
 A setting a controller needs but the core config does not name goes in
-`MPCoordinatorConfig.extra_config`, so shipping one stays a single file.
+`MPCoordinatorConfig.extra_config`, so shipping one needs no edit here either
+-- including which out-of-tree packages to load, below.
+
+## Registering HTTP endpoints
+
+The routers in `http_apis/` resolve their collaborator with
+`ctx.controllers.get(FleetEvictionController)`, which works only for a class
+the coordinator already imports. A controller that ships elsewhere instead
+implements `get_routers`, returning routers built around itself:
+
+```python
+class WidgetController(Controller):
+    def get_routers(self) -> tuple[APIRouter, ...]:
+        router = APIRouter()
+
+        @router.get("/widget/status")
+        async def status() -> dict[str, int]:
+            return {"pending": self.pending}   # closes over self
+
+        return (router,)
+```
+
+`create_app` mounts these after the `http_apis` routers, so an in-tree path
+wins a collision. Handlers bind to `self` rather than looking the owner up
+per request -- that lookup is what the protocol removes.
+
+Discovery walks subpackages, so a controller past one file can be a directory
+(`controllers/widget/{controller.py, http_api.py}`) without anything outside
+naming either half.
+
+## Shipping a controller outside this tree
+
+Nothing has to land in these directories. Name an importable package and it is
+scanned the same way as this one -- `discover` takes a list of names, and the
+built-in package is just the first of them.
+
+A worked example. The package is ordinary Python, installed or just on
+`PYTHONPATH`, and imports from lmcache but is never imported by it:
+
+```
+acme_controllers/
+  __init__.py
+  reaper/
+    __init__.py
+    controller.py      # the controller
+    http_api.py        # the endpoints it owns
+```
+
+```python
+# acme_controllers/reaper/controller.py
+from contextlib import asynccontextmanager
+import asyncio
+
+from lmcache.v1.mp_coordinator.controllers.base import Controller, ControllerRuntime
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
+
+from acme_controllers.reaper.http_api import build_router
+
+
+class ReaperController(Controller):
+    """Logs the fleet size on a cadence, and reports it over HTTP."""
+
+    def __init__(self, registry: InstanceRegistry, interval: float) -> None:
+        self._registry = registry
+        self._interval = interval
+        self.last_seen = 0
+
+    @classmethod
+    def from_config(cls, config, views) -> "ReaperController":
+        # In-tree views come from the registry; settings the core config
+        # does not name come from extra_config.
+        return cls(
+            registry=views.get(InstanceRegistry),
+            interval=float(config.extra_config.get("acme.reaper_interval", 30.0)),
+        )
+
+    @asynccontextmanager
+    async def run(self, runtime: ControllerRuntime):
+        task = asyncio.create_task(self._sweep())
+        try:
+            yield
+        finally:
+            task.cancel()
+
+    def get_routers(self):
+        return build_router(self)
+
+    async def _sweep(self) -> None:
+        while True:
+            await asyncio.sleep(self._interval)
+            self.last_seen = len(self._registry.all_instances())
+```
+
+```python
+# acme_controllers/reaper/http_api.py
+from fastapi import APIRouter
+
+
+def build_router(reaper) -> tuple[APIRouter, ...]:
+    router = APIRouter()
+
+    @router.get("/acme/reaper")
+    async def status() -> dict[str, int]:
+        return {"last_seen": reaper.last_seen}   # closes over the controller
+
+    return (router,)
+```
+
+Then point the coordinator at it. One blob carries both the package and the
+controller's own settings:
+
+```bash
+lmcache coordinator --extra-config '{
+  "controller_packages": ["acme_controllers"],
+  "acme.reaper_interval": 10
+}'
+```
+
+Startup discovers `ReaperController`, builds it via `from_config`, enters its
+`run`, and mounts `/acme/reaper` -- with no edit to `create_app`, the config
+class, or the CLI.
+
+It rides in `extra_config` rather than on a flag of its own, for the same
+reason anything else a controller needs does: the core config should not grow
+a field per out-of-tree concern. A name may address a package (walked entire)
+or a single module. A name that does not import raises rather than being
+skipped -- an operator asked for it, so a silent skip would look like a
+controller that loaded and did nothing.
+
+**Controllers only.** There is no `--view-package`: a view is shared fleet
+state, so which views exist is the coordinator's contract. An out-of-tree
+controller reads the in-tree views like any other, and whatever it needs
+beyond them is its own state.
+
+This is the model vLLM uses to find the LMCache connector: the host names an
+importable path, and nothing in the host imports the plugin.
 
 ## Why discovery rather than a list
 
@@ -29,17 +174,58 @@ The marker matters as much as the scan: it separates a controller from the
 collaborators one owns, so a helper that happens to live in this directory is
 not built a second time behind its owner's back.
 
-## Dependencies between controllers
+## What a controller may depend on
 
-The eviction controller reads the usage view, and its plan is only correct if
-that is the same view the fleet reported into. So `ControllerRegistry` builds
-**on first request**: `FleetEvictionController.from_config` asks for
-`CacheUsageManager` and gets it, built if needed.
+Views, and nothing else. The eviction controller reads the usage view, and its
+plan is only correct if that is the same view the fleet reported into, so the
+registry builds **on first request**: `FleetEvictionController.from_config`
+asks for `CacheUsageManager` and gets it, built if needed. That removes
+construction order as a thing anyone has to reason about -- no topological
+sort, no "declare your dependencies", no relying on the alphabet.
 
-That removes construction order as a thing anyone has to reason about -- no
-topological sort, no "declare your dependencies", no relying on the alphabet.
-A cycle is caught and named rather than becoming a `RecursionError` deep inside
-discovery.
+`from_config` cannot reach another controller: one that named a peer would
+break when that peer shipped elsewhere. Shared *state* is what a view is for;
+shared *policy* means the two were one controller.
+
+## Background work
+
+`run` is an async context manager: enter it to start background work, and the
+exit half tears it down. It is handed a `ControllerRuntime` carrying only what
+a controller cannot already have -- today the outbound HTTP client, which binds
+to the running event loop. Everything else, including fleet membership (the
+`InstanceRegistry` view), arrives through `from_config`. The runtime is a
+struct rather than a bare argument so a second loop-bound collaborator can be
+added without touching the signature of every controller that never asked for
+one.
+
+A context manager rather than a `start` / `stop` pair because the two failure
+modes it removes are otherwise the caller's to remember: whatever a controller
+started before raising is unwound for it, and one that never entered is never
+torn down.
+
+A controller raising on the way in is logged and skipped rather than fatal --
+any package can supply one, and a broken controller must not cost the
+coordinator the endpoints that belong to no controller, nor the controllers
+that did start. Whatever the failed one does is then simply not happening,
+and the log is the only notice of that.
+
+```python
+@asynccontextmanager
+async def run(self, runtime: ControllerRuntime) -> AsyncIterator[None]:
+    task = asyncio.create_task(self._loop(runtime.http_client))
+    try:
+        yield
+    finally:
+        task.cancel()
+```
+
+The lifespan owns only what is not any one controller's: the health-check
+sweep and the checkpoint timer. It drives everything through an
+`AsyncExitStack`, so registration order is teardown order reversed, and that
+order is load-bearing -- timers stop before controllers so no checkpoint races
+one settling, controllers before the final write so it captures what they
+settled on, and the client closes last because a draining controller is still
+using it.
 
 ## What discovery does not own
 
@@ -51,3 +237,7 @@ depend on.
 
 **Anything outside this package.** The ingest gate holds durable state but is
 neither a view nor a controller, so `create_app` names it.
+
+**Route conflicts.** `http_apis` mounts first, then controllers in discovery
+order. A duplicate path is not detected -- FastAPI serves whichever mounted
+first, so an in-tree route always beats a controller claiming the same one.

--- a/docs/design/v1/mp_coordinator/usage_and_eviction.md
+++ b/docs/design/v1/mp_coordinator/usage_and_eviction.md
@@ -220,10 +220,10 @@ accounting lives in ``CacheUsageManager``; the LRU only tracks order.
   ``policy.get_eviction_actions``. Salts without an explicit quota use the
   registry's default limit; while it is unset (``None``) they are skipped
   entirely — see QuotaManager above. No network, no mutation.
-- ``run(registry, http_client, check_interval)`` — the control loop
-  itself, started as an asyncio task by the app lifespan and cancelled on
-  shutdown. ``EVICTION_CHECK_INTERVAL = 0`` disables it (the task is
-  never created).
+- ``run(runtime)`` — the ``Controller`` lifetime hook, an async context
+  manager. Entering creates the loop task; ``EVICTION_CHECK_INTERVAL = 0``
+  creates none. Exiting cancels the loop, then drains the dispatches
+  already sent so a ``DELETE`` the last sweep launched still arrives.
 - ``execute_evictions(registry, http_client)`` — one pass: computes the plan and
   **fire-and-forget** ``DELETE /cache/objects`` to a holder MP server for each
   salt's victims; on confirmed deletion ``on_remove`` drops them from tracking.

--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -82,7 +82,11 @@ Options
    * - ``--extra-config JSON``
      - JSON object of settings the core flags do not name, read by whichever
        view or controller looks for them. Lets a new one ship with its own
-       settings without a flag here.
+       settings without a flag here. The coordinator reads one key itself,
+       ``controller_packages``: a list of importable paths to load
+       out-of-tree controllers from, e.g.
+       ``--extra-config '{"controller_packages": ["acme.controllers"]}'``.
+       Controllers only; views are in-tree.
    * - ``--timeout-keep-alive SECS``
      - Seconds the HTTP server keeps idle connections open before closing
        them. Must be greater than the MP servers' heartbeat interval

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -104,7 +104,9 @@ keeps the default below.
    * - ``--extra-config``
      - (empty)
      - JSON object of settings the core flags do not name, read by whichever
-       view or controller looks for them.
+       view or controller looks for them. ``controller_packages`` is read by
+       the coordinator itself: a list of importable paths to load
+       out-of-tree controllers from.
    * - ``--timeout-keep-alive``
      - ``10``
      - Seconds the HTTP server keeps idle connections open before closing
@@ -121,6 +123,76 @@ keeps the default below.
      - OTLP gRPC endpoint for metrics push mode. When unset, Prometheus pull
        mode exposes ``/metrics`` on the coordinator HTTP port. When set, the
        local ``/metrics`` endpoint returns 404.
+
+Loading your own controllers
+----------------------------
+
+A **controller** gives the coordinator behaviour of its own — fleet-wide L2
+eviction is one, warm-prefetch dispatch is another. Add yours by putting it in
+any importable package and naming that package in ``--extra-config``. The
+package imports from lmcache; nothing in lmcache imports it.
+
+.. code-block:: python
+
+    # acme_controllers/reaper.py
+    import asyncio
+    from contextlib import asynccontextmanager
+
+    from fastapi import APIRouter
+    from lmcache.v1.mp_coordinator.controllers.base import Controller
+    from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
+
+
+    class ReaperController(Controller):
+        @classmethod
+        def from_config(cls, config, views):
+            obj = cls()
+            obj.registry = views.get(InstanceRegistry)                  # a shared view
+            obj.interval = config.extra_config.get("acme.interval", 30.0)
+            obj.last_seen = 0
+            return obj
+
+        @asynccontextmanager
+        async def run(self, runtime):                    # background work
+            task = asyncio.create_task(self._sweep())
+            try:
+                yield
+            finally:
+                task.cancel()
+
+        def get_routers(self):                           # your endpoints
+            router = APIRouter()
+
+            @router.get("/acme/reaper")
+            async def status():
+                return {"last_seen": self.last_seen}
+
+            return (router,)
+
+        async def _sweep(self):
+            while True:
+                await asyncio.sleep(self.interval)
+                self.last_seen = len(self.registry.all_instances())
+
+The same JSON names the package and carries the controller's own settings:
+
+.. code-block:: bash
+
+    lmcache coordinator --extra-config '{
+      "controller_packages": ["acme_controllers"],
+      "acme.interval": 10
+    }'
+
+    curl -s http://localhost:9300/acme/reaper
+    # -> {"last_seen": 2}
+
+Every hook is optional: write only ``run``, only ``get_routers``, or add
+``consume`` to receive the cache-event stream and ``get_durable_components`` to
+have your state checkpointed. Name a package — scanned entire, so a controller
+that outgrows one file can be a directory — or a single module. A name that
+does not import raises at startup; a controller that raises while starting is
+logged and skipped. Views cannot be added this way: they are the coordinator's
+own shared state, which your controller reads.
 
 Coordinator metrics export
 --------------------------

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -154,11 +154,11 @@ package imports from lmcache; nothing in lmcache imports it.
 
         @asynccontextmanager
         async def run(self, runtime):                    # background work
-            task = asyncio.create_task(self._sweep())
+            task = asyncio.create_task(self._sweep())    # 1. start
             try:
-                yield
+                yield                                    # 2. serve
             finally:
-                task.cancel()
+                task.cancel()                            # 3. stop
 
         def get_routers(self):                           # your endpoints
             router = APIRouter()
@@ -173,6 +173,14 @@ package imports from lmcache; nothing in lmcache imports it.
             while True:
                 await asyncio.sleep(self.interval)
                 self.last_seen = len(self.registry.all_instances())
+
+``run`` is an async context manager and must do three things, in order:
+
+1. **Start** the background work.
+2. ``yield`` **exactly once** — the coordinator serves for the duration of
+   that yield.
+3. **Stop** the work in a ``finally``, so teardown runs whether shutdown was
+   clean or an exception unwound the stack.
 
 The same JSON names the package and carries the controller's own settings:
 

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -166,7 +166,9 @@ class CoordinatorCommand(BaseCommand):
             default=None,
             help=(
                 "JSON object of settings the core flags do not name, read by "
-                "whichever view or controller looks for them."
+                "whichever view or controller looks for them. The coordinator "
+                'reads "controller_packages": a list of importable paths to '
+                "load out-of-tree controllers from."
             ),
         )
         parser.add_argument(

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -4,26 +4,22 @@
 The coordinator is a FastAPI app. Endpoints are auto-discovered from the
 ``http_apis`` package (the same convention as the mp server's HTTP API) and stay
 thin, operating on the shared collaborators carried on ``app.state``: ``config``,
-``registry``, ``key_directory``, ``eviction_controller`` (which owns quota and
-usage), and the ingest layer's ``event_gate``.
-The lifespan runs background tasks for health-checking (eviction of instances
-whose heartbeats have lapsed) and the fleet L2 eviction control loop, which the
-controller owns (``FleetEvictionController.run``).
+the view and controller registries, and the ingest layer's ``event_gate``.
+The lifespan runs health-checking (eviction of instances whose heartbeats have
+lapsed) and the checkpoint timer, and starts and stops every controller --
+this file names no controller of its own.
 
 Adding a capability = a new ``http_apis/<name>_api.py`` router (auto-discovered)
-that uses those shared collaborators. To push to an mp server, a future router
-resolves the instance's address from the registry (``ip`` + ``http_port``) and
-POSTs to that server's specific endpoint. A domain with real logic/state of its
-own adds a module under ``controllers/`` stashed on ``app.state`` here; thin
-domains (like membership) just use the registry directly.
+that uses those shared collaborators. A controller that ships outside this tree
+cannot be reached from one of those, so it implements ``get_routers`` and brings
+its endpoints with it; either way this file names no controller.
 """
 
 # Standard
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 import asyncio
-import contextlib
 
 # Third Party
 from fastapi import FastAPI
@@ -33,10 +29,9 @@ import httpx
 from lmcache.logging import init_logger
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.controllers import build_controllers
-from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
-    FleetEvictionController,
-)
+from lmcache.v1.mp_coordinator.controllers.base import ControllerRuntime
 from lmcache.v1.mp_coordinator.http_apis.dependencies import CoordinatorContext
+from lmcache.v1.mp_coordinator.http_routes import HttpRoutes
 from lmcache.v1.mp_coordinator.ingest.event_broadcaster import (
     CacheEventBroadcaster,
     CacheEventConsumer,
@@ -57,8 +52,8 @@ from lmcache.v1.mp_coordinator.persistence.store import (
     LocalArtifactStore,
     NullArtifactStore,
 )
-from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views import build_views
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.utils.router_discovery import discover_api_routers
 
@@ -94,10 +89,9 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         collaborators (``config`` plus the :class:`CoordinatorContext`); all
         ``http_apis`` routers are registered.
     """
-    registry = InstanceRegistry()
     views = build_views(config)
+    registry = views.get(InstanceRegistry)
     controllers = build_controllers(config, views)
-    eviction_controller = controllers.get(FleetEvictionController)
     # Resolves pin requests' token_ids to object keys; must match the fleet's
     # chunk size and hash algorithm (see MPCoordinatorConfig).
     token_hasher = TokenHasher(
@@ -132,7 +126,6 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     load_checkpoint(checkpoint_store, checkpoint_components)
 
     ctx = CoordinatorContext(
-        registry=registry,
         views=views,
         controllers=controllers,
         token_hasher=token_hasher,
@@ -171,47 +164,62 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        """Start background tasks and clean up resources on shutdown."""
-        # Shared async client for outbound coordinator → MP server
-        # calls (eviction dispatch). Created inside the lifespan so it
-        # binds to the running event loop.
-        outbound_client = httpx.AsyncClient(timeout=30.0)
-        app.state.outbound_client = outbound_client
-        health_task = None
-        eviction_task = None
-        checkpoint_task = None
-        if config.checkpoint_path and config.checkpoint_interval > 0:
-            checkpoint_task = asyncio.create_task(_checkpoint_loop())
-        if config.health_check_interval > 0:
-            health_task = asyncio.create_task(_health_loop())
-        if config.eviction_check_interval > 0:
-            eviction_task = asyncio.create_task(
-                eviction_controller.run(
-                    registry, outbound_client, config.eviction_check_interval
-                )
+        """Start background work and unwind it in order on shutdown.
+
+        Registration order is teardown order reversed, and the order is
+        load-bearing: timers stop before controllers so no checkpoint
+        races one settling, controllers before the final write so it
+        captures what they settled on, and the client closes last
+        because a draining controller is still using it.
+
+        A controller that raises on the way in is logged and skipped;
+        the rest still run.
+        """
+        async with AsyncExitStack() as stack:
+            # Bound to the running event loop, so it cannot be built with
+            # the rest of the app.
+            outbound_client = await stack.enter_async_context(
+                httpx.AsyncClient(timeout=30.0)
             )
-        logger.info(
-            "MP coordinator listening on http://%s:%d", config.host, config.port
-        )
-        try:
-            yield
-        finally:
-            for task in (health_task, eviction_task, checkpoint_task):
-                if task is not None:
-                    task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await task
+            app.state.outbound_client = outbound_client
             if config.checkpoint_path:
-                # One last write, so a clean restart resumes where this
-                # process stopped rather than an interval-old copy.
-                await asyncio.to_thread(
+                # One last write on the way out, so a clean restart
+                # resumes here rather than at an interval-old copy.
+                stack.push_async_callback(
+                    asyncio.to_thread,
                     save_checkpoint,
                     checkpoint_store,
                     quiesce,
                     checkpoint_components,
                 )
-            await eviction_controller.wait_for_in_flight_dispatches()
-            await outbound_client.aclose()
+            # One controller is not allowed to take the coordinator down
+            # with it: the endpoints belonging to no controller keep
+            # working, and whatever the failed one does simply is not
+            # happening -- the log is the only notice of that.
+            runtime = ControllerRuntime(http_client=outbound_client)
+            for controller in controllers.all():
+                try:
+                    await stack.enter_async_context(controller.run(runtime))
+                except Exception:
+                    logger.exception(
+                        "Controller %s failed to start", type(controller).__name__
+                    )
+            # Nested, so they stop before the stack unwinds. Awaited too:
+            # ``save_checkpoint`` runs in a thread a cancel cannot reach.
+            timers = []
+            if config.checkpoint_path and config.checkpoint_interval > 0:
+                timers.append(asyncio.create_task(_checkpoint_loop()))
+            if config.health_check_interval > 0:
+                timers.append(asyncio.create_task(_health_loop()))
+            logger.info(
+                "MP coordinator listening on http://%s:%d", config.host, config.port
+            )
+            try:
+                yield
+            finally:
+                for timer in timers:
+                    timer.cancel()
+                await asyncio.gather(*timers, return_exceptions=True)
 
     app = FastAPI(title="LMCache MP Coordinator", version="1.0.0", lifespan=lifespan)
     app.state.ctx = ctx
@@ -222,6 +230,13 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     package = f"{__package__}.http_apis"
     for router in discover_api_routers(apis_path, package):
         app.include_router(router)
+    # Then whatever a controller brings itself, so one this file cannot
+    # name still gets its endpoints. In-tree routes are mounted above, so
+    # they win a path collision.
+    for member in (*views.all(), *controllers.all()):
+        if isinstance(member, HttpRoutes):
+            for router in member.get_routers():
+                app.include_router(router)
 
     return app
 

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -57,7 +57,12 @@ class MPCoordinatorConfig:
         extra_config: Settings the core config does not name, keyed by
             whatever reads them. Discovery means a new view or controller
             is one file; without this, giving it a setting would still
-            mean editing this class, the CLI, and the docs.
+            mean editing this class, the CLI, and the docs. The
+            coordinator itself reads one key, ``controller_packages``: a
+            list of importable paths to load controllers from, which is
+            how an out-of-tree controller gets in without anything here
+            importing it. Views have no equivalent -- they are in-tree
+            only.
         metrics_enabled: Whether to initialize OpenTelemetry metrics.
         otlp_endpoint: OTLP gRPC endpoint for metrics push mode. When unset,
             metrics use Prometheus pull mode on the coordinator HTTP port.

--- a/lmcache/v1/mp_coordinator/controllers/__init__.py
+++ b/lmcache/v1/mp_coordinator/controllers/__init__.py
@@ -5,9 +5,14 @@ Controllers are found by scanning this package rather than listed at the
 call site, so dropping a new one in this directory is the whole of adding
 it: startup builds it, hands it out by type, and routes whatever durable
 state it advertises.
+
+A controller that ships elsewhere is named in
+``MPCoordinatorConfig.extra_config`` under ``controller_packages`` and
+scanned the same way.
 """
 
 # Standard
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 # First Party
@@ -22,23 +27,34 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+PACKAGES_KEY = "controller_packages"
+
 
 def build_controllers(
     config: "MPCoordinatorConfig", views: "Registry[View]"
 ) -> Registry[Controller]:
-    """Discover and construct every controller in this package.
+    """Discover and construct every controller available to the coordinator.
 
     Args:
-        config: Passed to each ``from_config``.
+        config: Passed to each ``from_config``, and read for the
+            out-of-tree packages to scan alongside this one.
         views: The fleet's read models, which a controller may depend on.
 
     Returns:
         A registry with every discovered controller built.
+
+    Raises:
+        ValueError: If ``extra_config[PACKAGES_KEY]`` is not a list of
+            importable names.
+        ModuleNotFoundError: If one of those names does not import.
     """
+    packages = (__name__, *_named_packages(config.extra_config))
     registry: Registry[Controller] = Registry(
-        list(discover(__path__, __name__, Controller)),
-        build=lambda controller_type, controllers: controller_type.from_config(
-            config, views, controllers
+        list(discover(packages, Controller)),
+        # A controller cannot reach a peer, so the registry it is
+        # handed for that is ignored here.
+        build=lambda controller_type, _peers: controller_type.from_config(
+            config, views
         ),
     )
     built = registry.all()
@@ -50,4 +66,33 @@ def build_controllers(
     return registry
 
 
-__all__ = ["Controller", "build_controllers"]
+def _named_packages(extra_config: Mapping[str, object]) -> Sequence[str]:
+    """Return the out-of-tree packages an operator named, validated.
+
+    Args:
+        extra_config: The coordinator's untyped settings.
+
+    Returns:
+        The names in the order given, empty when the key is absent.
+
+    Raises:
+        ValueError: If the value is not a list of strings. It arrives as
+            JSON from the command line, so its shape is the operator's to
+            get wrong and worth naming precisely.
+    """
+    named = extra_config.get(PACKAGES_KEY, ())
+    if isinstance(named, str) or not isinstance(named, (list, tuple)):
+        raise ValueError(
+            f"extra_config[{PACKAGES_KEY!r}] must be a list of importable "
+            f"package names, got {type(named).__name__}"
+        )
+    for name in named:
+        if not isinstance(name, str):
+            raise ValueError(
+                f"extra_config[{PACKAGES_KEY!r}] must contain strings, "
+                f"got {type(name).__name__}"
+            )
+    return tuple(named)
+
+
+__all__ = ["PACKAGES_KEY", "Controller", "build_controllers"]

--- a/lmcache/v1/mp_coordinator/controllers/__init__.py
+++ b/lmcache/v1/mp_coordinator/controllers/__init__.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-PACKAGES_KEY = "controller_packages"
+_PACKAGES_KEY = "controller_packages"
 
 
 def build_controllers(
@@ -44,7 +44,7 @@ def build_controllers(
         A registry with every discovered controller built.
 
     Raises:
-        ValueError: If ``extra_config[PACKAGES_KEY]`` is not a list of
+        ValueError: If ``extra_config["controller_packages"]`` is not a list of
             importable names.
         ModuleNotFoundError: If one of those names does not import.
     """
@@ -80,19 +80,19 @@ def _named_packages(extra_config: Mapping[str, object]) -> Sequence[str]:
             JSON from the command line, so its shape is the operator's to
             get wrong and worth naming precisely.
     """
-    named = extra_config.get(PACKAGES_KEY, ())
+    named = extra_config.get(_PACKAGES_KEY, ())
     if isinstance(named, str) or not isinstance(named, (list, tuple)):
         raise ValueError(
-            f"extra_config[{PACKAGES_KEY!r}] must be a list of importable "
+            f"extra_config[{_PACKAGES_KEY!r}] must be a list of importable "
             f"package names, got {type(named).__name__}"
         )
     for name in named:
         if not isinstance(name, str):
             raise ValueError(
-                f"extra_config[{PACKAGES_KEY!r}] must contain strings, "
+                f"extra_config[{_PACKAGES_KEY!r}] must contain strings, "
                 f"got {type(name).__name__}"
             )
     return tuple(named)
 
 
-__all__ = ["PACKAGES_KEY", "Controller", "build_controllers"]
+__all__ = ["Controller", "build_controllers"]

--- a/lmcache/v1/mp_coordinator/controllers/base.py
+++ b/lmcache/v1/mp_coordinator/controllers/base.py
@@ -69,11 +69,21 @@ class Controller:
     async def run(self, runtime: ControllerRuntime) -> AsyncIterator[None]:
         """Run background work for as long as the app is serving.
 
-        Entered once inside the lifespan, so tasks may be created here;
-        the app serves during the ``yield`` and the exit half tears the
-        work down. A context manager rather than a start/stop pair so a
-        controller that fails to enter cannot leave the ones before it
-        running, and one that never entered is never torn down.
+        Start the work, ``yield`` exactly once -- the app serves for the
+        duration of that yield -- then shut it down in a ``finally``, so
+        teardown runs whether shutdown was clean or an exception unwound
+        the stack::
+
+            task = asyncio.create_task(self._loop())
+            try:
+                yield
+            finally:
+                task.cancel()
+
+        Entered once inside the lifespan, so tasks may be created here. A
+        context manager rather than a start/stop pair so a controller that
+        fails to enter cannot leave the ones before it running, and one
+        that never entered is never torn down.
 
         Yielding without starting anything is how configuration switches
         the work off. Defaults to no work at all.

--- a/lmcache/v1/mp_coordinator/controllers/base.py
+++ b/lmcache/v1/mp_coordinator/controllers/base.py
@@ -2,16 +2,19 @@
 """What makes a class in this package a controller.
 
 A controller acts: it holds policy, drives loops, and answers requests
-that change what the fleet does. It reads the fleet's state from views
-rather than keeping its own copy.
-
-Controllers may depend on views and on other controllers. Views cannot
-depend on controllers -- their ``from_config`` is handed no way to reach
-one -- so the direction cannot invert by accident.
+that change what the fleet does. It reads the fleet's state from views,
+and depends on nothing else -- not on another controller, which would
+break as soon as that one shipped elsewhere.
 """
 
 # Standard
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+# Third Party
+import httpx
 
 if TYPE_CHECKING:
     # First Party
@@ -20,13 +23,29 @@ if TYPE_CHECKING:
     from lmcache.v1.mp_coordinator.views.base import View
 
 
+@dataclass(frozen=True)
+class ControllerRuntime:
+    """What a controller can only be handed once the app is running.
+
+    One field today. It stays a struct so that a second loop-bound
+    collaborator can be added without touching the signature of every
+    controller that never asked for it.
+
+    Attributes:
+        http_client: Shared client for outbound calls to mp servers.
+    """
+
+    http_client: httpx.AsyncClient
+
+
 class Controller:
     """A collaborator the coordinator builds once at startup.
 
-    Subclass to have discovery construct it. Consuming the cache-event
-    stream and holding durable state are separate protocols -- implement
-    ``consume`` or ``get_durable_components`` and discovery picks that up
-    too, so a controller that does neither declares neither.
+    Subclass to have discovery construct it. Construction and lifetime
+    are the whole interface, both defaulted. Consuming the cache-event
+    stream, holding durable state and answering HTTP are protocols:
+    implement ``consume``, ``get_durable_components`` or ``get_routers``
+    and discovery picks that up too.
     """
 
     @classmethod
@@ -34,18 +53,33 @@ class Controller:
         cls,
         config: "MPCoordinatorConfig",
         views: "Registry[View]",
-        controllers: "Registry[Controller]",
     ) -> "Controller":
         """Build this controller.
 
-        Defaults to needing none of the arguments, so only a controller
-        that reads configuration or depends on a peer writes this hook.
-        Ask either registry and the peer is built on demand -- there is no
-        construction order to get right.
+        Views are built on demand, so there is no construction order to
+        get right.
 
         Args:
             config: The coordinator configuration.
             views: The fleet's read models.
-            controllers: The registry being populated.
         """
         return cls()
+
+    @asynccontextmanager
+    async def run(self, runtime: ControllerRuntime) -> AsyncIterator[None]:
+        """Run background work for as long as the app is serving.
+
+        Entered once inside the lifespan, so tasks may be created here;
+        the app serves during the ``yield`` and the exit half tears the
+        work down. A context manager rather than a start/stop pair so a
+        controller that fails to enter cannot leave the ones before it
+        running, and one that never entered is never torn down.
+
+        Yielding without starting anything is how configuration switches
+        the work off. Defaults to no work at all.
+
+        Args:
+            runtime: What cannot come from :meth:`from_config`, because
+                it binds to the running event loop.
+        """
+        yield

--- a/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
+++ b/lmcache/v1/mp_coordinator/controllers/eviction_controller.py
@@ -8,10 +8,12 @@ See ``docs/design/v1/mp_coordinator/usage_and_eviction.md``.
 from __future__ import annotations
 
 # Standard
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from dataclasses import asdict
 from typing import TYPE_CHECKING, cast
 import asyncio
+import contextlib
 
 # Third Party
 import httpx
@@ -25,11 +27,15 @@ from lmcache.v1.distributed.eviction_policy.isolated_lru import (
 )
 from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.mp_coordinator.api import CacheEventBatch, CacheEventType
-from lmcache.v1.mp_coordinator.controllers.base import Controller
+from lmcache.v1.mp_coordinator.controllers.base import (
+    Controller,
+    ControllerRuntime,
+)
 from lmcache.v1.mp_coordinator.persistence.durable_component import (
     DurableComponent,
     PersistenceType,
 )
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 from lmcache.v1.multiprocess.cache_control.object_service import (
     MAX_DELETE_BATCH,
@@ -40,8 +46,8 @@ if TYPE_CHECKING:
     from lmcache.v1.distributed.api import ObjectKey
     from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
     from lmcache.v1.mp_coordinator.discovery import Registry
-    from lmcache.v1.mp_coordinator.registry import InstanceRegistry
     from lmcache.v1.mp_coordinator.views.base import View
+    from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 
 logger = init_logger(__name__)
 
@@ -51,28 +57,35 @@ class FleetEvictionController(Controller):
 
     Owns the quota registry it enforces (exposed for the ``/quota``
     endpoints) and reads the fleet usage view on the ``l2`` tier.
-    :meth:`run` is the loop, :meth:`execute_evictions` one pass of it.
+    :meth:`run` drives the loop, :meth:`execute_evictions` one pass of it.
 
     Args:
         usage_manager: The fleet usage view. A consumer in its own
             right, registered on the broadcaster **before** this
             controller so it has accounted a batch by the time
             :meth:`consume` reads sizes from it.
+        registry: The fleet membership view; supplies the address a
+            victim's DELETE is sent to.
         eviction_ratio: Fraction of tracked keys to evict per cycle.
         trigger_watermark: Eviction fires when usage reaches this
             fraction of the quota.
+        check_interval: Seconds between sweeps. Zero runs no loop.
     """
 
     def __init__(
         self,
         usage_manager: CacheUsageManager,
+        registry: InstanceRegistry,
         eviction_ratio: float = 0.5,
         trigger_watermark: float = 1.0,
+        check_interval: float = 0.0,
     ) -> None:
         self._quota_manager = QuotaManager()
         self._usage_manager = usage_manager
+        self._registry = registry
         self._eviction_ratio = max(0.0, min(1.0, eviction_ratio))
         self._trigger_watermark = trigger_watermark
+        self._check_interval = check_interval
         self._policy = IsolatedLRUEvictionPolicy()
         self._in_flight_dispatches: set[asyncio.Task] = set()
         self._pin_counts: dict[ObjectKey, int] = {}
@@ -157,7 +170,6 @@ class FleetEvictionController(Controller):
         cls,
         config: "MPCoordinatorConfig",
         views: "Registry[View]",
-        controllers: "Registry[Controller]",
     ) -> "FleetEvictionController":
         """Build the controller from configuration and the fleet's views.
 
@@ -168,12 +180,13 @@ class FleetEvictionController(Controller):
         Args:
             config: The coordinator configuration.
             views: The fleet's read models.
-            controllers: Unused; this controller depends on no peer.
         """
         return cls(
             usage_manager=views.get(CacheUsageManager),
+            registry=views.get(InstanceRegistry),
             eviction_ratio=config.eviction_ratio,
             trigger_watermark=config.trigger_watermark,
+            check_interval=config.eviction_check_interval,
         )
 
     def get_durable_components(self) -> tuple[DurableComponent, ...]:
@@ -293,31 +306,32 @@ class FleetEvictionController(Controller):
 
         return eviction_plan
 
-    async def run(
-        self,
-        registry: InstanceRegistry,
-        http_client: httpx.AsyncClient,
-        check_interval: float,
-    ) -> None:
-        """Run the control loop until cancelled, sleeping first.
+    @asynccontextmanager
+    async def run(self, runtime: ControllerRuntime) -> AsyncIterator[None]:
+        """Sweep on a cadence while the app serves, then drain.
+
+        A dispatch is fire-and-forget, so one the last sweep launched
+        would otherwise die with the process; the exit half waits for it.
 
         Args:
-            registry: Fleet membership; supplies the dispatch target.
-            http_client: Client for the outbound DELETE requests.
-            check_interval: Seconds between passes; must be positive.
-
-        Raises:
-            ValueError: If ``check_interval`` is not positive.
+            runtime: Supplies the client for the outbound DELETEs.
         """
-        if check_interval <= 0:
-            raise ValueError(f"check_interval must be > 0 (got {check_interval})")
-        while True:
-            await asyncio.sleep(check_interval)
-            await self.execute_evictions(registry, http_client)
+        task: asyncio.Task | None = None
+        if self._check_interval > 0:
+            task = asyncio.create_task(self._sweep_forever(runtime.http_client))
+        else:
+            logger.debug("Eviction loop disabled (check_interval=0)")
+        try:
+            yield
+        finally:
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+            await self.wait_for_in_flight_dispatches()
 
     async def execute_evictions(
         self,
-        registry: InstanceRegistry,
         http_client: httpx.AsyncClient,
     ) -> dict[str, list[ObjectKey]]:
         """Compute the plan and fire-and-forget ``DELETE /cache/objects``
@@ -328,12 +342,19 @@ class FleetEvictionController(Controller):
         the dispatch tasks are spawned; the LRU clears only when the
         matching ``delete`` event comes back on the cache-event stream.
         At-least-once, safe because the delete is idempotent.
+
+        Args:
+            http_client: Client for the outbound DELETE requests.
+
+        Returns:
+            The plan dispatched, keyed by ``cache_salt``; empty when
+            there was nothing to evict or no server to send it to.
         """
         plan = self.compute_eviction_plan()
         if not plan:
             return plan
 
-        target = registry.random_instance()
+        target = self._registry.random_instance()
         if target is None:
             logger.warning(
                 "Eviction plan computed (%d salts) but no MP servers are "
@@ -366,11 +387,17 @@ class FleetEvictionController(Controller):
         """Await every outstanding fire-and-forget dispatch."""
         await asyncio.gather(*self._in_flight_dispatches, return_exceptions=True)
 
+    async def _sweep_forever(self, http_client: httpx.AsyncClient) -> None:
+        """Evict on a cadence until cancelled, sleeping first."""
+        while True:
+            await asyncio.sleep(self._check_interval)
+            await self.execute_evictions(http_client)
+
     @staticmethod
     async def _dispatch_eviction(
         http_client: httpx.AsyncClient,
         url: str,
-        body: dict,
+        body: Mapping[str, object],
         instance_id: str,
         key_count: int,
         salt_count: int,

--- a/lmcache/v1/mp_coordinator/controllers/prefetch_manager.py
+++ b/lmcache/v1/mp_coordinator/controllers/prefetch_manager.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     import httpx
 
     # First Party
-    from lmcache.v1.mp_coordinator.registry import MPInstance
+    from lmcache.v1.mp_coordinator.views.instance_registry import MPInstance
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/mp_coordinator/discovery.py
+++ b/lmcache/v1/mp_coordinator/discovery.py
@@ -9,6 +9,7 @@ ends up forgotten.
 
 # Standard
 from collections.abc import Callable, Iterator, Sequence
+from types import ModuleType
 from typing import Generic, TypeVar, cast
 import importlib
 import inspect
@@ -129,31 +130,54 @@ class Registry(Generic[MemberT]):
 
 
 def discover(
-    package_path: Sequence[str], package_name: str, base: type[MemberT]
+    module_names: Sequence[str], base: type[MemberT]
 ) -> Iterator[type[MemberT]]:
-    """Yield the ``base`` subclasses each module of a package defines.
+    """Yield the ``base`` subclasses the named modules define.
+
+    A name may address a package -- walked entire, subpackages included,
+    so a member needing more than one module can be a directory -- or a
+    single module. The built-in package and one an operator names at
+    startup are the same thing to this function.
 
     Only classes a module defines itself are yielded, so one imported for
     use elsewhere is not built a second time, and ``base`` is skipped --
     it is the definition of a member, not one.
 
     Args:
-        package_path: The package's ``__path__``.
-        package_name: The package's ``__name__``.
+        module_names: Importable dotted paths, in the order given.
         base: The marker every member subclasses.
 
     Yields:
         One class per member found, in module then class-name order.
+
+    Raises:
+        ModuleNotFoundError: If a name does not import. A silent skip
+            would look like a member that loaded and did nothing.
     """
-    for module_info in sorted(
-        pkgutil.iter_modules(package_path), key=lambda info: info.name
-    ):
-        module = importlib.import_module(f"{package_name}.{module_info.name}")
-        for _, candidate in sorted(inspect.getmembers(module, inspect.isclass)):
-            if (
-                candidate.__module__ == module.__name__
-                and candidate is not base
-                and not inspect.isabstract(candidate)
-                and issubclass(candidate, base)
-            ):
-                yield candidate
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        package_path = getattr(module, "__path__", None)
+        if package_path is None:
+            yield from _defined_in(module, base)
+            continue
+        submodules = sorted(
+            pkgutil.walk_packages(package_path, prefix=f"{module_name}."),
+            key=lambda info: info.name,
+        )
+        for info in submodules:
+            yield from _defined_in(importlib.import_module(info.name), base)
+
+
+# -- Internals ---------------------------------------------------------
+
+
+def _defined_in(module: ModuleType, base: type[MemberT]) -> Iterator[type[MemberT]]:
+    """Yield the ``base`` subclasses ``module`` defines itself."""
+    for _, candidate in sorted(inspect.getmembers(module, inspect.isclass)):
+        if (
+            candidate.__module__ == module.__name__
+            and candidate is not base
+            and not inspect.isabstract(candidate)
+            and issubclass(candidate, base)
+        ):
+            yield candidate

--- a/lmcache/v1/mp_coordinator/http_apis/cache_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/cache_api.py
@@ -37,6 +37,7 @@ from lmcache.v1.mp_coordinator.schemas import (
     PrefetchRequest,
     PrefetchResponse,
 )
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.multiprocess.cache_control.key_resolver import resolve_object_keys
 
 router = APIRouter()
@@ -67,7 +68,7 @@ async def request_prefetch(body: PrefetchRequest, request: Request) -> PrefetchR
     """
     ctx = get_context(request)
     prefetch = ctx.controllers.get(PrefetchManager)
-    target = ctx.registry.get(body.instance_id)
+    target = ctx.views.get(InstanceRegistry).get(body.instance_id)
     if target is None:
         raise HTTPException(
             status_code=404,
@@ -121,7 +122,7 @@ async def get_prefetch_status(
     """
     ctx = get_context(request)
     prefetch = ctx.controllers.get(PrefetchManager)
-    target = ctx.registry.get(instance_id)
+    target = ctx.views.get(InstanceRegistry).get(instance_id)
     if target is None:
         raise HTTPException(
             status_code=404,
@@ -246,7 +247,7 @@ async def request_delete(body: DeleteRequest, request: Request) -> DeleteRespons
     """
     ctx = get_context(request)
     eviction = ctx.controllers.get(FleetEvictionController)
-    target = ctx.registry.get(body.instance_id)
+    target = ctx.views.get(InstanceRegistry).get(body.instance_id)
     if target is None:
         raise HTTPException(
             status_code=404,

--- a/lmcache/v1/mp_coordinator/http_apis/dependencies.py
+++ b/lmcache/v1/mp_coordinator/http_apis/dependencies.py
@@ -21,7 +21,6 @@ from lmcache.v1.mp_coordinator.controllers.base import Controller
 from lmcache.v1.mp_coordinator.discovery import Registry
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
-from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.base import View
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
@@ -31,17 +30,20 @@ class CoordinatorContext:
     """Shared collaborators the coordinator's HTTP handlers operate on.
 
     Attributes:
-        registry: Fleet membership (``MPInstance`` by ``instance_id``).
         controllers: The coordinator's controllers, addressed by type --
             ``controllers.get(FleetEvictionController)`` for the fleet L2
             eviction loop (which owns the quota registry and the L2 pin
             set, enforced against the ``l2`` half of the usage view), and
-            ``PrefetchManager`` for warm prefetch.
+            ``PrefetchManager`` for warm prefetch. Addressing by type only
+            works for a class the coordinator imports, so a controller
+            shipped out of tree registers its own routes instead (see
+            ``HttpRoutes``) rather than being resolved here.
         token_hasher: Resolves a pin request's ``token_ids`` to object keys
             (configured to match the fleet's ``chunk_size`` / ``hash_algorithm``).
         views: The fleet's read models, addressed by type --
             ``views.get(KeyDirectory)`` for key → placements,
-            ``CacheUsageManager`` for per-tier byte usage, and
+            ``CacheUsageManager`` for per-tier byte usage,
+            ``InstanceRegistry`` for fleet membership, and
             ``ServerConfigRegistry`` for the declared capacities a usage
             ratio divides by.
         event_gate: Ingest entry point for the fleet cache-event stream
@@ -51,7 +53,6 @@ class CoordinatorContext:
             change survives a restart.
     """
 
-    registry: InstanceRegistry
     controllers: Registry[Controller]
     token_hasher: TokenHasher
     views: Registry[View]

--- a/lmcache/v1/mp_coordinator/http_apis/instances_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/instances_api.py
@@ -19,11 +19,14 @@ from fastapi.responses import JSONResponse
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
-from lmcache.v1.mp_coordinator.registry import MPInstance
 from lmcache.v1.mp_coordinator.schemas import (
     HeartbeatResponse,
     RegisterRequest,
     RegisterResponse,
+)
+from lmcache.v1.mp_coordinator.views.instance_registry import (
+    InstanceRegistry,
+    MPInstance,
 )
 from lmcache.v1.mp_coordinator.views.server_config import (
     ServerConfigRegistry,
@@ -55,7 +58,7 @@ async def register_instance(
     # NTP-safe stale detection (see registry.stale). register() does the
     # exists-check and write under one lock, so the re_registered flag is correct
     # even under concurrent registrations of the same id.
-    re_registered = ctx.registry.register(
+    re_registered = ctx.views.get(InstanceRegistry).register(
         MPInstance(
             instance_id=instance_id,
             ip=body.ip,
@@ -80,7 +83,11 @@ async def heartbeat(instance_id: str, request: Request) -> Any:
         instance is unknown (the caller should re-register via ``POST
         /instances``).
     """
-    if get_context(request).registry.update_heartbeat(instance_id, time.monotonic()):
+    if (
+        get_context(request)
+        .views.get(InstanceRegistry)
+        .update_heartbeat(instance_id, time.monotonic())
+    ):
         return HeartbeatResponse(instance_id=instance_id)
     return JSONResponse(
         status_code=404,
@@ -98,7 +105,7 @@ async def deregister_instance(instance_id: str, request: Request) -> Response:
         An empty 204 response.
     """
     ctx = get_context(request)
-    if ctx.registry.deregister(instance_id) is not None:
+    if ctx.views.get(InstanceRegistry).deregister(instance_id) is not None:
         logger.info("Deregistered instance %s", instance_id)
     else:
         logger.info("Instance %s not registered, skipping deregistration", instance_id)
@@ -130,6 +137,6 @@ async def list_instances(request: Request) -> Any:
             "p2p_advertised_url": instance.p2p_advertised_url,
             "mq_port": instance.mq_port,
         }
-        for instance in get_context(request).registry.all_instances()
+        for instance in get_context(request).views.get(InstanceRegistry).all_instances()
     ]
     return {"instances": instances}

--- a/lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/instances_usage_api.py
@@ -24,6 +24,7 @@ from lmcache.v1.mp_coordinator.schemas import (
     InstanceMemoryStatus,
     ModuleMemoryStatus,
 )
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.server_config import (
     UNDECLARED_CAPACITY,
     ServerConfigRegistry,
@@ -161,7 +162,10 @@ async def fleet_usage(request: Request) -> FleetMemoryResponse:
     """
     ctx = get_context(request)
     declarations = ctx.views.get(ServerConfigRegistry).get_all()
-    registered = {instance.instance_id for instance in ctx.registry.all_instances()}
+    registered = {
+        instance.instance_id
+        for instance in ctx.views.get(InstanceRegistry).all_instances()
+    }
     by_owner = _usage_by_owner(ctx.views.get(CacheUsageManager))
     owned = {owner for owner in by_owner if owner != _SHARED_OWNER}
 
@@ -210,7 +214,7 @@ async def instance_usage(instance_id: str, request: Request) -> InstanceMemorySt
     ctx = get_context(request)
     declared = ctx.views.get(ServerConfigRegistry).get(instance_id)
     used = _usage_by_owner(ctx.views.get(CacheUsageManager)).get(instance_id, {})
-    registered = ctx.registry.contains(instance_id)
+    registered = ctx.views.get(InstanceRegistry).contains(instance_id)
     if not registered and not declared and not used:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/lmcache/v1/mp_coordinator/http_routes.py
+++ b/lmcache/v1/mp_coordinator/http_routes.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registering HTTP endpoints from a controller package.
+
+The routers in ``http_apis`` resolve their collaborator with
+``controllers.get(SomeClass)``, which only reaches a class the coordinator
+already imports -- exactly what an out-of-tree controller is not. Such a
+controller hands over routers built around itself instead.
+"""
+
+# Standard
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+# Third Party
+from fastapi import APIRouter
+
+
+@runtime_checkable
+class HttpRoutes(Protocol):
+    """Something that answers HTTP requests about itself."""
+
+    def get_routers(self) -> Sequence[APIRouter]:
+        """Return the routers to mount, built around this object.
+
+        Called once at startup, after the ``http_apis`` routers, so a path
+        already claimed there wins. Bind handlers to ``self`` rather than
+        resolving the owner per request -- that lookup is what this
+        removes.
+        """
+        ...

--- a/lmcache/v1/mp_coordinator/views/__init__.py
+++ b/lmcache/v1/mp_coordinator/views/__init__.py
@@ -33,7 +33,7 @@ def build_views(config: "MPCoordinatorConfig") -> Registry[View]:
         A registry with every discovered view built.
     """
     registry: Registry[View] = Registry(
-        list(discover(__path__, __name__, View)),
+        list(discover((__name__,), View)),
         build=lambda view_type, views: view_type.from_config(config, views),
     )
     built = registry.all()

--- a/lmcache/v1/mp_coordinator/views/base.py
+++ b/lmcache/v1/mp_coordinator/views/base.py
@@ -7,6 +7,10 @@ to know what the fleet has cached. It holds no policy and drives nothing.
 
 Views may depend on other views, and nothing else -- ``from_config``
 cannot reach a controller, so the direction cannot invert by accident.
+
+In-tree only: which views exist is the coordinator's contract, not
+something an operator adds at startup. An out-of-tree controller reads
+these; what it needs beyond them is its own state.
 """
 
 # Standard

--- a/lmcache/v1/mp_coordinator/views/instance_registry.py
+++ b/lmcache/v1/mp_coordinator/views/instance_registry.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Thread-safe registry of live mp servers known to the coordinator.
 
-The registry is the single source of truth for fleet membership. It is mutated
-and read on the coordinator event loop (register / deregister / heartbeat /
-health-check eviction); access is lock-guarded to stay correct.
+The single source of truth for fleet membership, and a view like any
+other -- whoever needs it asks the view registry rather than being handed
+a copy. Unlike the other views it is fed by the ``/instances`` endpoints
+and the health sweep, not by the cache-event stream: being shared is what
+makes it a view, not what writes it.
+
+It is mutated and read on the coordinator event loop (register / deregister
+/ heartbeat / health-check eviction); access is lock-guarded to stay
+correct.
 
 The registry stores plain membership data only -- ip, http_port, heartbeat
 timestamps, metadata. How to reach an instance for push is derived from its
@@ -18,6 +24,7 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.views.base import View
 
 logger = init_logger(__name__)
 
@@ -52,11 +59,15 @@ class MPInstance:
     mq_port: int = 0
 
 
-class InstanceRegistry:
+class InstanceRegistry(View):
     """Thread-safe in-memory registry of mp servers.
 
     All public methods acquire an internal lock, so the registry stays
     consistent under concurrent access.
+
+    Holds nothing durable: membership rebuilds from the heartbeats that
+    arrive after a restart, so a captured copy would only resurrect
+    instances that may be gone.
     """
 
     def __init__(self) -> None:

--- a/tests/cli/commands/test_coordinator.py
+++ b/tests/cli/commands/test_coordinator.py
@@ -133,7 +133,7 @@ class TestCoordinatorCommandExecute:
             checkpoint_path="/var/lib/lmcache/checkpoint",
             checkpoint_interval=30.0,
             metadata_path="/var/lib/lmcache/metadata.json",
-            extra_config='{"my_view.window": 8}',
+            extra_config='{"my_view.window": 8, "controller_packages": ["acme.c"]}',
             timeout_keep_alive=None,
             disable_metrics=True,
             otlp_endpoint="http://collector:4317",
@@ -164,7 +164,12 @@ class TestCoordinatorCommandExecute:
         assert captured["config"].checkpoint_path == "/var/lib/lmcache/checkpoint"
         assert captured["config"].checkpoint_interval == 30.0
         assert captured["config"].metadata_path == "/var/lib/lmcache/metadata.json"
-        assert captured["config"].extra_config == {"my_view.window": 8}
+        # Out-of-tree controllers ride in here rather than on a flag of
+        # their own, the way vLLM is told where to find a KV connector.
+        assert captured["config"].extra_config == {
+            "my_view.window": 8,
+            "controller_packages": ["acme.c"],
+        }
         assert captured["config"].metrics_enabled is False
         assert captured["config"].otlp_endpoint == "http://collector:4317"
         # Unset flags keep the config defaults.

--- a/tests/v1/mp_coordinator/persistence/test_checkpoint.py
+++ b/tests/v1/mp_coordinator/persistence/test_checkpoint.py
@@ -33,6 +33,7 @@ from lmcache.v1.mp_coordinator.persistence.durable_component import (
 )
 from lmcache.v1.mp_coordinator.persistence.quiesce import QuiesceLock
 from lmcache.v1.mp_coordinator.persistence.store import LocalArtifactStore
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 
@@ -43,7 +44,9 @@ class _Coordinator:
     def __init__(self) -> None:
         self.directory = KeyDirectory()
         self.usage = CacheUsageManager()
-        self.controller = FleetEvictionController(usage_manager=self.usage)
+        self.controller = FleetEvictionController(
+            usage_manager=self.usage, registry=InstanceRegistry()
+        )
         broadcaster = CacheEventBroadcaster()
         broadcaster.register_consumer(self.directory)
         broadcaster.register_consumer(self.usage)

--- a/tests/v1/mp_coordinator/persistence/test_durable_components.py
+++ b/tests/v1/mp_coordinator/persistence/test_durable_components.py
@@ -28,6 +28,7 @@ from lmcache.v1.mp_coordinator.persistence.durable_component import (
     PersistenceType,
 )
 from lmcache.v1.mp_coordinator.persistence.quiesce import QuiesceLock
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 from tests.v1.mp_coordinator.persistence.conftest import capture_consistently
@@ -43,7 +44,9 @@ def _pipeline() -> tuple[
     """The real path: the usage view consumes before the controller, which
     reads it for the same batch (as ``create_app`` orders them)."""
     usage_manager = CacheUsageManager()
-    controller = FleetEvictionController(usage_manager=usage_manager)
+    controller = FleetEvictionController(
+        usage_manager=usage_manager, registry=InstanceRegistry()
+    )
     broadcaster = CacheEventBroadcaster()
     broadcaster.register_consumer(usage_manager)
     broadcaster.register_consumer(controller)

--- a/tests/v1/mp_coordinator/persistence/test_metadata.py
+++ b/tests/v1/mp_coordinator/persistence/test_metadata.py
@@ -16,6 +16,7 @@ from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
 )
 from lmcache.v1.mp_coordinator.persistence.metadata import MetadataPersister
 from lmcache.v1.mp_coordinator.persistence.store import LocalArtifactStore
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 
 
@@ -24,7 +25,9 @@ def _key(chunk_id: int) -> ObjectKey:
 
 
 def _controller() -> FleetEvictionController:
-    return FleetEvictionController(usage_manager=CacheUsageManager())
+    return FleetEvictionController(
+        usage_manager=CacheUsageManager(), registry=InstanceRegistry()
+    )
 
 
 class TestRoundTrip:

--- a/tests/v1/mp_coordinator/persistence/test_restore_without_replay.py
+++ b/tests/v1/mp_coordinator/persistence/test_restore_without_replay.py
@@ -19,6 +19,7 @@ from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
 from lmcache.v1.mp_coordinator.ingest.event_broadcaster import CacheEventBroadcaster
 from lmcache.v1.mp_coordinator.ingest.event_gate import EventGate
 from lmcache.v1.mp_coordinator.persistence.quiesce import QuiesceLock
+from lmcache.v1.mp_coordinator.views.instance_registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 from tests.v1.mp_coordinator.persistence.conftest import capture_consistently
@@ -30,7 +31,9 @@ class _Coordinator:
     def __init__(self) -> None:
         self.directory = KeyDirectory()
         self.usage = CacheUsageManager()
-        self.controller = FleetEvictionController(usage_manager=self.usage)
+        self.controller = FleetEvictionController(
+            usage_manager=self.usage, registry=InstanceRegistry()
+        )
         self.broadcaster = CacheEventBroadcaster()
         self.broadcaster.register_consumer(self.directory)
         self.broadcaster.register_consumer(self.usage)

--- a/tests/v1/mp_coordinator/test_discovery.py
+++ b/tests/v1/mp_coordinator/test_discovery.py
@@ -59,6 +59,7 @@ class TestWhatIsFound:
     def test_the_views_are_the_fleet_read_models(self):
         assert {type(v).__name__ for v in build_views(MPCoordinatorConfig()).all()} == {
             "CacheUsageManager",
+            "InstanceRegistry",
             "KeyDirectory",
             "ServerConfigRegistry",
         }

--- a/tests/v1/mp_coordinator/test_eviction_controller.py
+++ b/tests/v1/mp_coordinator/test_eviction_controller.py
@@ -2,6 +2,7 @@
 """Tests for the coordinator eviction controller."""
 
 # Standard
+from collections.abc import Callable
 import asyncio
 import time
 
@@ -17,10 +18,17 @@ from lmcache.v1.mp_coordinator.api import (
     CacheEventEntry,
     CacheEventType,
 )
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers import build_controllers
+from lmcache.v1.mp_coordinator.controllers.base import ControllerRuntime
 from lmcache.v1.mp_coordinator.controllers.eviction_controller import (
     FleetEvictionController,
 )
-from lmcache.v1.mp_coordinator.registry import InstanceRegistry, MPInstance
+from lmcache.v1.mp_coordinator.views import build_views
+from lmcache.v1.mp_coordinator.views.instance_registry import (
+    InstanceRegistry,
+    MPInstance,
+)
 from lmcache.v1.mp_coordinator.views.usage_manager import CacheUsageManager
 
 
@@ -37,6 +45,8 @@ def _setup(
     eviction_ratio: float = 0.5,
     trigger_watermark: float = 1.0,
     default_limit_bytes: int | None = 0,
+    check_interval: float = 0.0,
+    instances: tuple[MPInstance, ...] = (),
 ) -> tuple[FleetEvictionController, QuotaManager, CacheUsageManager]:
     """Build the controller plus the quota registry it owns and the
     usage view it reads.
@@ -50,8 +60,10 @@ def _setup(
     usage = CacheUsageManager()
     ctrl = FleetEvictionController(
         usage_manager=usage,
+        registry=_make_registry(*instances),
         eviction_ratio=eviction_ratio,
         trigger_watermark=trigger_watermark,
+        check_interval=check_interval,
     )
     ctrl.quota.set_default_limit_bytes(default_limit_bytes)
     return ctrl, ctrl.quota, usage
@@ -335,12 +347,13 @@ async def test_execute_evictions_dispatches_to_registered_instance():
     the right body shape. The LRU is NOT cleared by ``execute_evictions``
     itself — that happens later via the coordinator's cache-event stream
     handler when the MP server reports the deletion back."""
-    ctrl, qs, kd = _setup(eviction_ratio=1.0)
+    ctrl, qs, kd = _setup(
+        eviction_ratio=1.0,
+        instances=(_instance("mp-1", ip="10.0.0.7", port=8765),),
+    )
     k = _make_key("alice", h="aa")
     _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)  # ratio=1.0 → full eviction
-
-    registry = _make_registry(_instance("mp-1", ip="10.0.0.7", port=8765))
 
     captured: dict[str, object] = {}
 
@@ -351,7 +364,7 @@ async def test_execute_evictions_dispatches_to_registered_instance():
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
-        plan = await ctrl.execute_evictions(registry, client)
+        plan = await ctrl.execute_evictions(client)
         # Dispatch is fire-and-forget — wait for the background task
         # to actually issue the HTTP call before the client closes.
         await ctrl.wait_for_in_flight_dispatches()
@@ -386,19 +399,17 @@ async def test_execute_evictions_dispatches_to_registered_instance():
 async def test_execute_evictions_no_instances_skips_dispatch_and_keeps_lru():
     """No registered MP servers ⇒ the plan is logged but neither
     dispatched nor cleared from the LRU."""
-    ctrl, qs, kd = _setup(eviction_ratio=1.0)
+    ctrl, qs, kd = _setup(eviction_ratio=1.0)  # no registered instances
     k = _make_key("alice", h="bb")
     _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)
-
-    registry = _make_registry()  # empty
 
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(
             lambda r: pytest.fail("must not be called")  # type: ignore[arg-type]
         )
     ) as client:
-        plan = await ctrl.execute_evictions(registry, client)
+        plan = await ctrl.execute_evictions(client)
         await ctrl.wait_for_in_flight_dispatches()
 
     assert plan == {"alice": [k]}
@@ -410,18 +421,16 @@ async def test_execute_evictions_no_instances_skips_dispatch_and_keeps_lru():
 async def test_execute_evictions_http_failure_keeps_lru():
     """A non-2xx (or transport error) from the MP server must NOT
     clear the LRU — the next cycle should retry."""
-    ctrl, qs, kd = _setup(eviction_ratio=1.0)
+    ctrl, qs, kd = _setup(eviction_ratio=1.0, instances=(_instance("mp-1"),))
     k = _make_key("alice", h="cc")
     _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)
-
-    registry = _make_registry(_instance("mp-1"))
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, json={"error": "internal"})
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        plan = await ctrl.execute_evictions(registry, client)
+        plan = await ctrl.execute_evictions(client)
         await ctrl.wait_for_in_flight_dispatches()
 
     assert plan == {"alice": [k]}
@@ -440,13 +449,11 @@ async def test_execute_evictions_chunks_large_plan(monkeypatch):
 
     monkeypatch.setattr(em, "MAX_DELETE_BATCH", 2)
 
-    ctrl, qs, kd = _setup(eviction_ratio=1.0)
+    ctrl, qs, kd = _setup(eviction_ratio=1.0, instances=(_instance("mp-1"),))
     keys = [_make_key("alice", h=f"{i:02x}") for i in range(5)]
     for k in keys:
         _store(ctrl, kd, k, 100)
     qs.set_quota("alice", 0)  # ratio=1.0 → full eviction of all 5 keys
-
-    registry = _make_registry(_instance("mp-1"))
 
     # Standard
     import json as _json
@@ -459,7 +466,7 @@ async def test_execute_evictions_chunks_large_plan(monkeypatch):
         return httpx.Response(200, json={"requested": len(body["keys"]), "ok": True})
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        plan = await ctrl.execute_evictions(registry, client)
+        plan = await ctrl.execute_evictions(client)
         await ctrl.wait_for_in_flight_dispatches()
 
     assert plan == {"alice": keys}
@@ -474,14 +481,12 @@ async def test_execute_evictions_empty_plan_is_noop():
     """No salts over threshold ⇒ no HTTP dispatch."""
     ctrl, _, kd = _setup()
 
-    registry = _make_registry(_instance("mp-1"))
-
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(
             lambda r: pytest.fail("must not be called")  # type: ignore[arg-type]
         )
     ) as client:
-        plan = await ctrl.execute_evictions(registry, client)
+        plan = await ctrl.execute_evictions(client)
         await ctrl.wait_for_in_flight_dispatches()
 
     assert plan == {}
@@ -708,60 +713,134 @@ def test_fence_instance_keeps_l2_usage_and_lru():
 
 
 # ============================================================================
-# run (the control loop)
+# start / stop (the control loop)
 # ============================================================================
 
 
-@pytest.mark.asyncio
-async def test_run_rejects_non_positive_check_interval():
-    ctrl, _, kd = _setup()
-    registry = _make_registry()
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={}))
-    ) as client:
-        with pytest.raises(ValueError, match="check_interval"):
-            await ctrl.run(registry, client, 0)
-        with pytest.raises(ValueError, match="check_interval"):
-            await ctrl.run(registry, client, -1.0)
-
-
-@pytest.mark.asyncio
-async def test_run_evicts_on_each_tick_until_cancelled():
-    """The loop dispatches an over-quota salt's victims, and stops when the
-    task is cancelled (how the app lifespan shuts it down)."""
-    ctrl, qs, kd = _setup(eviction_ratio=1.0)
-    k = _make_key("alice", h="aa")
-    _store(ctrl, kd, k, 100)
-    qs.set_quota("alice", 0)  # ratio=1.0 → full eviction
-    registry = _make_registry(_instance("mp-1"))
-
+def _recorder() -> tuple[list[str], Callable[[httpx.Request], httpx.Response]]:
+    """Return a list of dispatched URLs and the handler that fills it."""
     dispatched: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         dispatched.append(str(request.url))
         return httpx.Response(200, json={"requested": 1, "adapter": "s3", "ok": True})
 
+    return dispatched, handler
+
+
+@pytest.mark.asyncio
+async def test_a_zero_interval_starts_no_loop():
+    """The cadence is how an operator switches eviction off, so ``start``
+    has to accept zero rather than reject it -- and ``stop`` must still be
+    safe when nothing was started."""
+    ctrl, qs, kd = _setup(eviction_ratio=1.0, check_interval=0.0)
+    _store(ctrl, kd, _make_key("alice", h="aa"), 100)
+    qs.set_quota("alice", 0)
+    dispatched, handler = _recorder()
+
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        task = asyncio.create_task(ctrl.run(registry, client, 0.01))
-        # Long enough for several ticks, short enough to keep the test fast.
-        await asyncio.sleep(0.1)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        await ctrl.wait_for_in_flight_dispatches()
+        async with ctrl.run(ControllerRuntime(http_client=client)):
+            await asyncio.sleep(0.05)
+
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_the_loop_evicts_on_each_tick_until_stopped():
+    """The loop dispatches an over-quota salt's victims, and ``stop`` ends
+    it (how the app lifespan shuts it down)."""
+    ctrl, qs, kd = _setup(
+        eviction_ratio=1.0, check_interval=0.01, instances=(_instance("mp-1"),)
+    )
+    k = _make_key("alice", h="aa")
+    _store(ctrl, kd, k, 100)
+    qs.set_quota("alice", 0)  # ratio=1.0 → full eviction
+    dispatched, handler = _recorder()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        async with ctrl.run(ControllerRuntime(http_client=client)):
+            # Long enough for several ticks, short enough to keep the test fast.
+            await asyncio.sleep(0.1)
 
     assert dispatched, "the loop never dispatched an eviction"
     assert dispatched[0] == "http://10.0.0.1:8000/cache/objects"
 
 
 @pytest.mark.asyncio
-async def test_run_sleeps_before_the_first_check():
-    """Construction must not race the first pass: nothing is dispatched
-    before one interval has elapsed."""
-    ctrl, qs, kd = _setup(eviction_ratio=1.0)
+async def test_the_loop_sleeps_before_the_first_check():
+    """Startup must not race the first pass: nothing is dispatched before
+    one interval has elapsed."""
+    ctrl, qs, kd = _setup(eviction_ratio=1.0, check_interval=30.0)
     _store(ctrl, kd, _make_key("alice", h="aa"), 100)
     qs.set_quota("alice", 0)
-    registry = _make_registry(_instance("mp-1"))
+    dispatched, handler = _recorder()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        async with ctrl.run(ControllerRuntime(http_client=client)):
+            await asyncio.sleep(0.05)
+
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_a_dispatch_the_last_sweep_sent():
+    """A dispatch is fire-and-forget, so shutdown has to wait for one the
+    loop launched but never awaited, or the DELETE dies with the process."""
+    ctrl, qs, kd = _setup(
+        eviction_ratio=1.0, check_interval=0.01, instances=(_instance("mp-1"),)
+    )
+    _store(ctrl, kd, _make_key("alice", h="aa"), 100)
+    qs.set_quota("alice", 0)
+    arrived = asyncio.Event()
+    released = asyncio.Event()
+    completed: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        arrived.set()
+        await released.wait()
+        completed.append(str(request.url))
+        return httpx.Response(200, json={"requested": 1, "adapter": "s3", "ok": True})
+
+    async def serve(ready: asyncio.Event, done: asyncio.Event) -> None:
+        async with ctrl.run(ControllerRuntime(http_client=client)):
+            ready.set()
+            await done.wait()
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        ready, done = asyncio.Event(), asyncio.Event()
+        serving = asyncio.create_task(serve(ready, done))
+        await asyncio.wait_for(ready.wait(), timeout=5.0)
+        await asyncio.wait_for(arrived.wait(), timeout=5.0)
+        done.set()  # begins the exit half, which must wait for the dispatch
+        await asyncio.sleep(0.05)
+        assert not serving.done(), "exited while a dispatch was in flight"
+        released.set()
+        await asyncio.wait_for(serving, timeout=5.0)
+
+    assert completed, "the in-flight dispatch never finished"
+
+
+# ============================================================================
+# wiring: the controller reads the shared views, not private copies
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_the_controller_dispatches_to_the_shared_membership_view():
+    """Fleet membership is a view, so a controller built by discovery must
+    dispatch to an instance registered *after* it was constructed. A private
+    copy would see an empty fleet and silently evict nothing."""
+    config = MPCoordinatorConfig()
+    views = build_views(config)
+    ctrl = build_controllers(config, views).get(FleetEvictionController)
+    usage = views.get(CacheUsageManager)
+
+    # Registered through the view, well after the controller was built.
+    views.get(InstanceRegistry).register(_instance("mp-late", ip="10.9.9.9"))
+
+    k = _make_key("alice", h="aa")
+    ctrl.quota.set_default_limit_bytes(0)
+    _store(ctrl, usage, k, 100)
 
     dispatched: list[str] = []
 
@@ -770,10 +849,7 @@ async def test_run_sleeps_before_the_first_check():
         return httpx.Response(200, json={"requested": 1, "adapter": "s3", "ok": True})
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        task = asyncio.create_task(ctrl.run(registry, client, 30.0))
-        await asyncio.sleep(0.05)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        assert await ctrl.execute_evictions(client) == {"alice": [k]}
+        await ctrl.wait_for_in_flight_dispatches()
 
-    assert dispatched == []
+    assert dispatched == ["http://10.9.9.9:8000/cache/objects"]

--- a/tests/v1/mp_coordinator/test_health.py
+++ b/tests/v1/mp_coordinator/test_health.py
@@ -11,7 +11,10 @@ from fastapi.testclient import TestClient
 # First Party
 from lmcache.v1.mp_coordinator.app import create_app, evict_stale
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
-from lmcache.v1.mp_coordinator.registry import InstanceRegistry, MPInstance
+from lmcache.v1.mp_coordinator.views.instance_registry import (
+    InstanceRegistry,
+    MPInstance,
+)
 
 
 def _instance(instance_id: str, heartbeat: float) -> MPInstance:

--- a/tests/v1/mp_coordinator/test_pluggable_controllers.py
+++ b/tests/v1/mp_coordinator/test_pluggable_controllers.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A controller the coordinator has never heard of, doing everything.
+
+``create_app`` names no controller, so nothing here imports one either:
+each test drops a controller in at runtime and checks the coordinator
+runs its loop, mounts its endpoints, and finds it when it ships outside
+the tree entirely.
+"""
+
+# Standard
+import sys
+
+# Third Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First Party
+from lmcache.v1.mp_coordinator import controllers as controllers_package
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.controllers import build_controllers
+from lmcache.v1.mp_coordinator.controllers.base import ControllerRuntime
+from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
+from lmcache.v1.mp_coordinator.views import build_views
+
+_OUT_OF_TREE_ROUTES = '''
+# SPDX-License-Identifier: Apache-2.0
+"""The endpoints of a controller that ships outside lmcache."""
+
+from fastapi import APIRouter
+
+
+def build_router(controller):
+    router = APIRouter()
+
+    @router.get("/acme/widget")
+    async def widget() -> dict:
+        return {"source": controller.source}
+
+    return (router,)
+'''
+
+_OUT_OF_TREE = '''
+# SPDX-License-Identifier: Apache-2.0
+"""A controller that ships outside lmcache entirely."""
+
+from lmcache.v1.mp_coordinator.controllers.base import Controller
+
+from acme_controllers.widget.http_api import build_router
+
+
+class WidgetController(Controller):
+    def __init__(self):
+        self.source = "out of tree"
+
+    def get_routers(self):
+        return build_router(self)
+'''
+
+_FAILING_CONTROLLER = '''
+# SPDX-License-Identifier: Apache-2.0
+"""A controller whose startup fails, to check nothing is left running."""
+
+from contextlib import asynccontextmanager
+
+from lmcache.v1.mp_coordinator.controllers.base import Controller
+
+
+class ZzzFailingController(Controller):
+    """Named to sort last, so a well-behaved controller starts first."""
+
+    @asynccontextmanager
+    async def run(self, runtime):
+        raise RuntimeError("this controller cannot start")
+        yield
+'''
+
+_SETTLING_CONTROLLER = '''
+# SPDX-License-Identifier: Apache-2.0
+"""A controller that records when it settles and when it is captured."""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+from lmcache.v1.mp_coordinator.controllers.base import Controller
+from lmcache.v1.mp_coordinator.persistence.durable_component import PersistenceType
+
+ORDER = []
+
+
+class SettlingController(Controller):
+    """Appends to ORDER so a test can see teardown against capture."""
+
+    @asynccontextmanager
+    async def run(self, runtime):
+        try:
+            yield
+        finally:
+            ORDER.append("tearing-down")
+            # Long enough that a live checkpoint timer would fire here.
+            await asyncio.sleep(0.2)
+            # A draining controller is still dispatching, so the client
+            # it was handed must outlive its teardown.
+            ORDER.append("closed-client" if runtime.http_client.is_closed
+                         else "settled")
+
+    def get_durable_components(self):
+        return (self,)
+
+    @property
+    def persistence_type(self):
+        return PersistenceType.CHECKPOINT
+
+    @property
+    def name(self):
+        return "settling"
+
+    def capture(self):
+        ORDER.append("captured")
+        return {}
+
+    def restore(self, state):
+        pass
+'''
+
+_LATE_CONTROLLER = '''
+# SPDX-License-Identifier: Apache-2.0
+"""A controller that exists only for this test."""
+
+from contextlib import asynccontextmanager
+
+from fastapi import APIRouter
+
+from lmcache.v1.mp_coordinator.controllers.base import Controller
+
+CALLS = []
+
+
+class LateController(Controller):
+    """Records what the lifespan does to it, and the runtime it got."""
+
+    def __init__(self):
+        self.greeting = "hello from a controller nothing imports"
+
+    @asynccontextmanager
+    async def run(self, runtime):
+        CALLS.append(("start", runtime.http_client))
+        try:
+            yield
+        finally:
+            CALLS.append(("stop", None))
+
+    def get_routers(self):
+        router = APIRouter()
+
+        @router.get("/late/greeting")
+        async def greeting() -> dict:
+            # Closes over the controller: no registry lookup by class.
+            return {"greeting": self.greeting}
+
+        return (router,)
+'''
+
+
+@pytest.fixture
+def late_controller(tmp_path):
+    """Drop a controller into the package for one test, then take it out.
+
+    Yields the module name, so a test reads what the controller recorded
+    without importing something that does not exist at collection time.
+    """
+    (tmp_path / "late_controller.py").write_text(_LATE_CONTROLLER)
+    module_name = f"{controllers_package.__name__}.late_controller"
+    controllers_package.__path__.append(str(tmp_path))
+    try:
+        yield module_name
+    finally:
+        controllers_package.__path__.remove(str(tmp_path))
+        sys.modules.pop(module_name, None)
+
+
+def _config() -> MPCoordinatorConfig:
+    return MPCoordinatorConfig(health_check_interval=0.0, eviction_check_interval=0.0)
+
+
+def test_a_controller_with_a_loop_is_started_and_stopped(late_controller):
+    """The point of the protocol: a controller nothing imports still runs."""
+    with TestClient(create_app(_config())):
+        calls = sys.modules[late_controller].CALLS
+        assert [name for name, _ in calls] == ["start"]
+        assert calls[0][1] is not None, "start got no client"
+
+    assert [name for name, _ in sys.modules[late_controller].CALLS] == [
+        "start",
+        "stop",
+    ]
+
+
+def test_the_client_is_the_one_the_app_uses(late_controller):
+    """A controller must dispatch on the app's client, not one of its own:
+    the lifespan closes that client, and an outbound call on a closed one
+    fails at shutdown."""
+    app = create_app(_config())
+    with TestClient(app):
+        assert sys.modules[late_controller].CALLS[0][1] is app.state.outbound_client
+
+
+@pytest.mark.asyncio
+async def test_a_controller_with_no_background_work_writes_nothing():
+    """Prefetch answers requests and nothing else. Lifetime is part of
+    every controller's interface, so the default has to be a safe no-op
+    rather than something each such controller reimplements."""
+    prefetch = build_controllers(_config(), build_views(_config())).get(PrefetchManager)
+
+    async with prefetch.run(ControllerRuntime(http_client=None)):
+        pass
+
+
+def test_a_controller_mounts_its_own_endpoints(late_controller):
+    """The route arrives with the thing it operates on, and the handler
+    reaches that thing directly rather than resolving a class name."""
+    with TestClient(create_app(_config())) as client:
+        response = client.get("/late/greeting")
+
+    assert response.status_code == 200
+    assert response.json() == {"greeting": "hello from a controller nothing imports"}
+
+
+def test_a_controller_shipped_outside_the_tree_is_loaded_by_name(tmp_path, monkeypatch):
+    """The vLLM-style path: nothing is dropped into lmcache's directories,
+    the operator names an importable package and the coordinator scans it."""
+    package = tmp_path / "acme_controllers"
+    # A directory, not a file: a controller with routes of its own is two
+    # modules, and neither is named anywhere.
+    widget = package / "widget"
+    widget.mkdir(parents=True)
+    (package / "__init__.py").write_text("")
+    (widget / "__init__.py").write_text("")
+    (widget / "http_api.py").write_text(_OUT_OF_TREE_ROUTES)
+    (widget / "controller.py").write_text(_OUT_OF_TREE)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        extra_config={"controller_packages": ["acme_controllers"]},
+    )
+    try:
+        with TestClient(create_app(config)) as client:
+            response = client.get("/acme/widget")
+    finally:
+        for name in list(sys.modules):
+            if name.startswith("acme_controllers"):
+                del sys.modules[name]
+
+    assert response.status_code == 200
+    assert response.json() == {"source": "out of tree"}
+
+
+@pytest.mark.parametrize("value", ["acme_controllers", 42, {"acme": 1}, ["acme", 7]])
+def test_a_malformed_package_list_is_refused(value):
+    """The names arrive as JSON on the command line, so their shape is the
+    operator's to get wrong. A bare string is the likely slip -- it would
+    otherwise iterate into one package per character."""
+    config = MPCoordinatorConfig(extra_config={"controller_packages": value})
+
+    with pytest.raises(ValueError, match="controller_packages"):
+        build_controllers(config, build_views(config))
+
+
+def test_a_package_that_does_not_import_is_reported():
+    """An operator asked for it by name, so a silent skip would look like
+    a controller that loaded and did nothing."""
+    config = MPCoordinatorConfig(
+        extra_config={"controller_packages": ["no_such_package_here"]}
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="no_such_package_here"):
+        build_controllers(config, build_views(config))
+
+
+def test_a_controller_failing_to_start_does_not_take_the_others_down(
+    late_controller, tmp_path, monkeypatch
+):
+    """A broken controller -- likely a third-party one, since any package
+    can supply them -- must not cost the coordinator the endpoints that
+    belong to no controller, nor the controllers that did start."""
+    # A directory of its own: ``late_controller`` has put ``tmp_path`` on
+    # the controllers package's ``__path__``, so a package written there
+    # would be found twice -- once by the scan, once by name.
+    external = tmp_path / "external"
+    package = external / "acme_failing"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("")
+    (package / "boom.py").write_text(_FAILING_CONTROLLER)
+    monkeypatch.syspath_prepend(str(external))
+
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        extra_config={"controller_packages": ["acme_failing"]},
+    )
+    try:
+        with TestClient(create_app(config)) as client:
+            # An endpoint owned by no controller, and one owned by the
+            # controller that did start.
+            fleet = client.get("/instances")
+            greeting = client.get("/late/greeting")
+        calls = [name for name, _ in sys.modules[late_controller].CALLS]
+    finally:
+        for name in list(sys.modules):
+            if name.startswith("acme_failing"):
+                del sys.modules[name]
+
+    assert fleet.status_code == 200
+    assert greeting.status_code == 200
+    # The healthy one ran for the app's lifetime and was torn down.
+    assert calls == ["start", "stop"]
+
+
+def test_the_final_checkpoint_captures_what_a_controller_settled_on(
+    tmp_path, monkeypatch
+):
+    """Teardown order is load-bearing three times over: a timer still
+    firing would snapshot a controller mid-teardown, a controller still
+    sweeping when the last checkpoint is taken would have a mid-sweep
+    state written, and one draining after the client closed could not
+    finish the dispatch it launched."""
+    package = tmp_path / "acme_settling"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "c.py").write_text(_SETTLING_CONTROLLER)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    config = MPCoordinatorConfig(
+        health_check_interval=0.0,
+        eviction_check_interval=0.0,
+        # A live timer, so the test can see whether it is still firing
+        # while the controller tears down.
+        checkpoint_interval=0.01,
+        checkpoint_path=str(tmp_path / "ckpt"),
+        extra_config={"controller_packages": ["acme_settling"]},
+    )
+    try:
+        with TestClient(create_app(config)):
+            pass
+        order = sys.modules["acme_settling.c"].ORDER
+    finally:
+        for name in list(sys.modules):
+            if name.startswith("acme_settling"):
+                del sys.modules[name]
+
+    # The timer is cancelled before teardown begins, so nothing is
+    # captured while it runs. The final write comes after it, not during.
+    during_teardown = order[order.index("tearing-down") : order.index("settled")]
+    assert "captured" not in during_teardown, order
+    assert order[-2:] == ["settled", "captured"], order

--- a/tests/v1/mp_coordinator/test_prefetch_manager.py
+++ b/tests/v1/mp_coordinator/test_prefetch_manager.py
@@ -11,7 +11,7 @@ import pytest
 
 # First Party
 from lmcache.v1.mp_coordinator.controllers.prefetch_manager import PrefetchManager
-from lmcache.v1.mp_coordinator.registry import MPInstance
+from lmcache.v1.mp_coordinator.views.instance_registry import MPInstance
 
 
 def _instance(instance_id: str, ip: str = "10.0.0.1", port: int = 8000) -> MPInstance:

--- a/tests/v1/mp_coordinator/test_registry.py
+++ b/tests/v1/mp_coordinator/test_registry.py
@@ -5,7 +5,10 @@
 import time
 
 # First Party
-from lmcache.v1.mp_coordinator.registry import InstanceRegistry, MPInstance
+from lmcache.v1.mp_coordinator.views.instance_registry import (
+    InstanceRegistry,
+    MPInstance,
+)
 
 
 def _instance(instance_id: str, heartbeat: float = 0.0) -> MPInstance:


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #4723, addressing @ApostaC's three review items plus runtime
package loading. `create_app` no longer names any controller.

- `Controller` carries construction and lifetime, both defaulted:
  `from_config`, and `run` (an async context manager, driven by an
  `AsyncExitStack` in the lifespan).
- Controllers no longer see each other -- `from_config` drops its
  `controllers` argument.
- A controller can own its endpoints (`get_routers`) and can ship outside
  the tree entirely, named in `extra_config` the way vLLM is told where to
  find a KV connector:

```bash
lmcache coordinator --extra-config '{"controller_packages": ["acme_controllers"]}'
```

- `InstanceRegistry` becomes a view, so fleet membership is reached like
  every other shared read model.

**Special notes for your reviewers**:

- **Breaking:** `Controller.from_config` drops `controllers`. The ABC shipped
  in #4723, so there are no out-of-tree implementers yet.
- The in-tree HTTP APIs have **not** moved. `get_routers` is only the way in
  for a controller that class-name lookup cannot reach.
- Teardown order is load-bearing and tested: timers, controllers, final
  checkpoint, outbound client.
- A controller raising at startup is logged and skipped, not fatal.
- Worked example in `docs/source/mp/coordinator.rst`.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
