### PR TITLE
feat(mp): add lmcache.mp.enable_lookup to skip lookups in MP connector

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -771,6 +771,12 @@ All connector-level options are passed through
      - ``10``
      - Maximum number of finished requests selected each time the
        lazy-offload threshold is met.
+   * - ``lmcache.mp.enable_lookup``
+     - ``true``
+     - When ``false``, the connector skips all LMCache lookups and only
+       stores KV caches. Useful in vLLM MultiConnector topologies where
+       another connector (e.g. Mooncake) handles KV loading and LMCache
+       is only used as an offload/distributed store.
    * - ``lmcache.mp.mp_transfer_mode``
      - ``auto``
      - Routing mode for the worker -> server transfer context. One of

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -448,6 +448,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
       heartbeat pings.
     - lmcache.mp.eager_prefetch: submit the LMCache lookup when a request
       enters vLLM's waiting queue. Disabled by default.
+    - lmcache.mp.enable_lookup: when False, the connector skips all LMCache
+      lookups and only stores KV caches (default True). Useful in
+      MultiConnector topologies where another connector handles KV loading
+      and LMCache is only used as an offload/distributed store.
     """
 
     def __init__(
@@ -563,6 +567,16 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # deferred until some threshold is reached, rather than submitted at every step
         self.lazy_offload = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache.mp.lazy_offload", False
+        )
+
+        # When False, the connector skips all LMCache lookups and only stores
+        # KV caches. Useful in MultiConnector topologies where another
+        # connector (e.g. Mooncake) handles PD transfer and LMCache is only
+        # used as an offload/distributed store.
+        self.enable_lookup: bool = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.enable_lookup", True
+            )
         )
 
         if self.role == KVConnectorRole.SCHEDULER:
@@ -991,6 +1005,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             into account.
         """
         tracker = self._get_or_create_request_tracker(request)
+
+        if not self.enable_lookup:
+            return 0, False
+
         # TODO: support loading KV for preempted requests in the future
         if request.status == RequestStatus.PREEMPTED:
             return 0, False


### PR DESCRIPTION
## What this PR does / why we need it

The LMCache MP connector performs lookups unconditionally for every request via `get_num_new_matched_tokens`. This blocks an important deployment topology: **vLLM MultiConnector with PD disaggregation + LMCache offload**.

In this topology:
- A **Mooncake connector** handles PD KV transfer (P→D)
- An **LMCache MP connector** serves as an offload/distributed store — D nodes store decode KV so P nodes can reuse it later

On D nodes, the Mooncake connector already provides the KV via PD transfer. LMCache lookup is unnecessary — it wastes bandwidth and conflicts with MultiConnector's load-selection logic. But the store path must remain active so that decode-produced KV enters the distributed store for future P-node reuse.

This PR adds `lmcache.mp.enable_lookup` (default `True`, fully backward-compatible). When set to `false`:
- `get_num_new_matched_tokens` returns `(0, False)` immediately after tracker creation
- No LOOKUP requests are sent to the LMCache server
- The store path (`_process_new_requests` / `_process_cached_requests` / `wait_for_save`) is completely unaffected
- The request tracker is still created, so `update_state_after_alloc` and downstream store logic work unchanged

### Usage

```json
{
  "kv_connector": "LMCacheMPConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "lmcache.mp.enable_lookup": false
  }
}
```

### Why not reuse `kv_role`?

`kv_role` is a vLLM-level field expressing PD topology role (`kv_producer`/`kv_consumer`/`kv_both`), not a lookup/store toggle. The MP connector currently ignores it entirely (see also #4665). Overloading `kv_role=kv_producer` to mean "skip lookup" would be a semantic mismatch — a D node is not a producer — and would conflict with vLLM framework code that reads `kv_role` for PD-role decisions. A dedicated `enable_lookup` flag is cleaner and orthogonal to PD semantics.

## Special notes for your reviewers

- This is the minimal change to unblock the MultiConnector + Mooncake PD topology. A follow-up PR will address the `update_state_after_alloc` contract violation (PR #46865 in vLLM) where the MP connector should use `num_external_tokens == 0` rather than tracker state to decide whether to load.
- Related issue: #4665 (MP connector ignores `kv_role` / `skip_save` — this PR addresses the lookup half).

## If applicable

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests