### PR TITLE
[Ascend][MP] Add NPU pin-memory backend via AscendCL aclrtHostRegister for async MP transfers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: "CPU only unit tests"
         run: |
-          pytest -m "not cuda and not musa and not xpu"
+          pytest -m "not cuda and not musa and not xpu and not npu and not neuron"
 
   raw-block-tests:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: "CPU only unit tests"
         run: |
-          pytest -m "not cuda and not musa and not xpu and not npu and not neuron"
+          pytest -m "not (cuda or musa or xpu or npu or neuron)"
 
   raw-block-tests:
     needs: changes

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -20,7 +20,7 @@ from lmcache.integration.request_telemetry.factory import RequestTelemetryFactor
 from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
-from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.gpu_connector.utils import LayoutHints, get_device
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     IPCCacheServerKey,
@@ -1371,7 +1371,7 @@ class LMCacheMPWorkerAdapter:
                 mq_timeout.
         """
         self.kv_caches = kv_caches
-        self._kv_device = next(iter(kv_caches.values())).device
+        self._kv_device = get_device(next(iter(kv_caches.values())))
         self._event_ipc_backend = get_event_ipc_backend(self._kv_device)
         transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
         layout_hints = self._layout_hints

--- a/lmcache/sdk/qringbuffer.py
+++ b/lmcache/sdk/qringbuffer.py
@@ -15,6 +15,7 @@ import torch
 # First Party
 from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
+from lmcache.v1.gpu_connector.utils import get_device
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocol import RequestType
 
@@ -289,7 +290,7 @@ class QRingBufferCapture:
             if isinstance(raw_dtype, torch.dtype)
             else getattr(torch, str(raw_dtype))
         )
-        device = next(iter(kv_caches.values())).device
+        device = get_device(next(iter(kv_caches.values())))
         block_size = vllm_config.cache_config.block_size
 
         cfg = vllm_config.kv_transfer_config

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -120,6 +120,11 @@ def round_down(x: int, y: int) -> int:
     return (x // y) * y
 
 
+def round_up(x: int, y: int) -> int:
+    """Round up x to the nearest multiple of y."""
+    return ((x + y - 1) // y) * y
+
+
 def compress_slot_mapping(slots: list[int]) -> list[Union[int, list[int]]]:
     """Compress a list of slot indices into ranges while preserving order.
 

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -197,7 +197,7 @@ def _get_kv_device(kv_caches: dict[str, torch.Tensor]) -> torch.device:
     """
     if not kv_caches:
         raise ValueError("LMCache-driven transfer requires at least one KV cache")
-    return next(iter(kv_caches.values())).device
+    return get_device(next(iter(kv_caches.values())))
 
 
 class TransferContext(ABC):

--- a/lmcache/v1/platform/npu/__init__.py
+++ b/lmcache/v1/platform/npu/__init__.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING
 
 # First Party
 from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
+from lmcache.v1.platform.npu.pin_memory import NpuPinMemoryBackend
 
 if TYPE_CHECKING:
     # First Party
@@ -47,6 +49,10 @@ class NpuDeviceSpec(DeviceSpec):
         from lmcache.v1.platform.npu.device_ops import NpuDeviceOps
 
         return NpuDeviceOps
+
+    @property
+    def pin_memory_backend(self) -> type[PinMemoryBackend] | None:
+        return NpuPinMemoryBackend
 
     def is_available(self) -> bool:
         """Check NPU availability without importing ``lmcache.__init__``.

--- a/lmcache/v1/platform/npu/pin_memory.py
+++ b/lmcache/v1/platform/npu/pin_memory.py
@@ -165,6 +165,34 @@ def _load_libascendcl() -> _AclRuntime | None:
     return _LibascendclRuntime(lib)
 
 
+def _torch_npu_available() -> bool:
+    """Whether ``torch`` exposes a usable ``torch.npu``.
+
+    Returns:
+        True when ``torch.npu`` is present and reports at least one usable
+        device, False otherwise.
+    """
+    try:
+        # Third Party
+        import torch
+
+        npu = getattr(torch, "npu", None)
+        if npu is not None and npu.is_available():
+            return True
+        logger.info(
+            "NpuPinMemoryBackend: NPU unavailable; host pinning disabled "
+            "(copies will be synchronous)"
+        )
+        return False
+    except Exception as exc:
+        logger.warning(
+            "NpuPinMemoryBackend: cannot probe NPU availability for "
+            "pinning: %r; copies will be synchronous",
+            exc,
+        )
+        return False
+
+
 class NpuPinMemoryBackend(PinMemoryBackend):
     """Pin host memory for NPU DMA via AscendCL ``aclrtHostRegister``.
 
@@ -177,9 +205,9 @@ class NpuPinMemoryBackend(PinMemoryBackend):
         _rt: ``acl.rt``-shaped runtime, or ``None`` when unavailable.
         _registered_bases: Maps the caller's original pointer to the
             page-aligned registered base.
-        _no_npu: Latched when the NPU is unavailable or no ACL context can be
-            established; makes :attr:`is_pin_supported` report ``False``
-            thereafter.
+        _no_npu: Latched at construction when the NPU is unavailable (or
+            later, when context setup fails on a broken installation); makes
+            :attr:`is_pin_supported` report ``False``.
         _tls: Per-thread "context ensured" flag; ACL contexts are
             thread-local.
     """
@@ -189,12 +217,16 @@ class NpuPinMemoryBackend(PinMemoryBackend):
 
         Notes:
             Discovery prefers the vendor ``acl`` module and falls back to
-            ``libascendcl`` via :mod:`ctypes`. When both fail the backend
-            stays unsupported and pin/unpin return ``False``.
+            ``libascendcl`` via :mod:`ctypes`. NPU availability is probed
+            here so :attr:`is_pin_supported` is accurate before any pin
+            attempt -- callers such as the ``use_lazy`` auto-disable guard
+            consult it ahead of the first registration. When the runtime
+            binding or the NPU is unavailable the backend stays unsupported
+            and pin/unpin return ``False``.
         """
         self._rt: _AclRuntime | None = _load_acl_rt() or _load_libascendcl()
         self._registered_bases: dict[int, int] = {}
-        self._no_npu: bool = False
+        self._no_npu: bool = not _torch_npu_available()
         self._tls = threading.local()
 
     def _ensure_context(self) -> bool:
@@ -204,11 +236,12 @@ class NpuPinMemoryBackend(PinMemoryBackend):
         context) when the thread has never touched the device. Worker threads
         are covered (torch_npu creates the context on first device op), but a
         cache-server thread that only manages host memory may have none, so
-        the first pin attempt on each thread establishes one.
+        the first pin attempt on each thread establishes one. Availability
+        itself was already probed in ``__init__``.
 
         Returns:
-            True when a context is current, False when the NPU is unavailable
-            (latched into ``_no_npu``).
+            True when a context is current, False when the NPU is
+            unavailable or context setup fails (latched into ``_no_npu``).
         """
         if self._no_npu:
             return False
@@ -219,11 +252,13 @@ class NpuPinMemoryBackend(PinMemoryBackend):
             import torch
 
             npu = getattr(torch, "npu", None)
-            if npu is None or not npu.is_available():
+            if npu is None:
+                # Defensive: torch.npu vanished after __init__ (e.g. tests
+                # monkeypatching it away); treat as unavailable.
                 self._no_npu = True
-                logger.info(
-                    "NpuPinMemoryBackend: NPU unavailable; host pinning "
-                    "disabled (copies will be synchronous)"
+                logger.warning(
+                    "NpuPinMemoryBackend: torch.npu disappeared after "
+                    "construction; host pinning disabled"
                 )
                 return False
             try:
@@ -235,8 +270,7 @@ class NpuPinMemoryBackend(PinMemoryBackend):
                 # device 0 is the fallback.
                 npu.set_device(0)
         except Exception as exc:
-            # Accessing torch.npu lazily imports torch_npu, which can itself
-            # raise on a broken CANN setup.
+            # set_device can raise on a broken CANN setup.
             self._no_npu = True
             logger.warning(
                 "NpuPinMemoryBackend: cannot establish NPU context for "
@@ -326,7 +360,7 @@ class NpuPinMemoryBackend(PinMemoryBackend):
         """Whether AscendCL host registration is usable.
 
         Returns:
-            True when a runtime binding loaded and the NPU has not been found
-            unavailable, False otherwise.
+            True when a runtime binding loaded and construction found the
+            NPU available, False otherwise.
         """
         return self._rt is not None and not self._no_npu

--- a/lmcache/v1/platform/npu/pin_memory.py
+++ b/lmcache/v1/platform/npu/pin_memory.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NPU host-memory pinning: try the CANN ``acl`` module first, then
+``libascendcl`` via ctypes."""
+
+# Standard
+from typing import Protocol, cast
+import ctypes
+import ctypes.util
+import glob
+import os
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import round_down, round_up
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
+
+logger = init_logger(__name__)
+
+#: ``aclrtHostRegisterType``: ``ACL_HOST_REGISTER_MAPPED`` is the only defined
+#: value.
+_ACL_HOST_REGISTER_MAPPED = 0
+
+_ACL_SUCCESS = 0
+
+try:
+    _PAGE_SIZE = os.sysconf("SC_PAGESIZE")
+except (AttributeError, ValueError, OSError):
+    _PAGE_SIZE = 4096
+
+
+class _AclRuntime(Protocol):
+    """``acl.rt`` surface required for host-memory registration.
+
+    Satisfied by the CANN ``acl.rt`` module and by :class:`_LibascendclRuntime`.
+    ``host_register`` mirrors the C ``aclrtHostRegister`` including its
+    out-param: it returns ``(dev_ptr, ret_code)``. The device-mapped alias is
+    unused -- torch ``copy_`` keeps addressing the original host pointer, which
+    the registration page-locks for DMA.
+    """
+
+    def host_register(self, ptr: int, size: int, flags: int) -> tuple[int, int]:
+        """Register one host range; return ``(dev_ptr, ret_code)``."""
+        ...
+
+    def host_unregister(self, ptr: int) -> int:
+        """Unregister one host range; return the AscendCL status code."""
+        ...
+
+
+class _LibascendclRuntime:
+    """Adapter giving a ctypes-loaded ``libascendcl`` the ``acl.rt`` shape."""
+
+    def __init__(self, lib: ctypes.CDLL) -> None:
+        """Adapt an already symbol-bound library handle."""
+        self._lib = lib
+
+    def host_register(self, ptr: int, size: int, flags: int) -> tuple[int, int]:
+        """Call ``aclrtHostRegister``; return ``(dev_ptr, ret_code)``."""
+        dev_ptr = ctypes.c_void_p(0)
+        ret = self._lib.aclrtHostRegister(
+            ctypes.c_void_p(ptr),
+            ctypes.c_uint64(size),
+            ctypes.c_int32(flags),
+            ctypes.byref(dev_ptr),
+        )
+        return dev_ptr.value or 0, ret
+
+    def host_unregister(self, ptr: int) -> int:
+        """Call ``aclrtHostUnregister``; return the AscendCL status code."""
+        return self._lib.aclrtHostUnregister(ctypes.c_void_p(ptr))
+
+
+def _load_acl_rt() -> _AclRuntime | None:
+    """Return the CANN ``acl.rt`` runtime module for host registration.
+
+    The vendor module ships with CANN and shares the runtime instance
+    ``torch_npu`` already loaded, so registrations issued through it are
+    visible to ``copy_(..., non_blocking=True)``.
+
+    Returns:
+        ``acl.rt``, or ``None`` when the module or its register/unregister
+        entry points are unavailable.
+    """
+    try:
+        # Third Party
+        import acl
+    except ImportError as exc:
+        logger.debug("NpuPinMemoryBackend: CANN acl module unavailable: %s", exc)
+        return None
+
+    rt = getattr(acl, "rt", None)
+    if (
+        rt is None
+        or not callable(getattr(rt, "host_register", None))
+        or not callable(getattr(rt, "host_unregister", None))
+    ):
+        logger.debug("NpuPinMemoryBackend: acl.rt host registration unavailable")
+        return None
+    return cast(_AclRuntime, rt)
+
+
+def _candidate_lib_paths() -> list[str]:
+    """Return ``libascendcl`` search candidates, most-specific first.
+
+    Honors ``$ASCEND_HOME_PATH`` and the standard CANN install layout
+    (``/usr/local/Ascend/cann*/<arch>-linux/lib64``). Filesystem probes only:
+    :func:`ctypes.util.find_library` is intentionally not used here because it
+    forks ``ldconfig``.
+    """
+    home = os.environ.get("ASCEND_HOME_PATH")
+    if home:
+        return [os.path.join(home, "lib64", "libascendcl.so")]
+    return sorted(glob.glob("/usr/local/Ascend/cann*/*-linux/lib64/libascendcl.so"))
+
+
+def _bind_libascendcl(paths: list[str]) -> ctypes.CDLL | None:
+    """dlopen the first path whose register/unregister symbols bind.
+
+    ``dlopen`` returns the instance already loaded by ``torch_npu`` when one
+    exists, so the handle shares ``torch_npu``'s device context.
+
+    Returns:
+        The bound library, or ``None`` when every candidate fails.
+    """
+    for path in paths:
+        try:
+            lib = ctypes.CDLL(path)
+            lib.aclrtHostRegister.restype = ctypes.c_int32
+            lib.aclrtHostRegister.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_uint64,
+                ctypes.c_int32,
+                ctypes.POINTER(ctypes.c_void_p),
+            ]
+            lib.aclrtHostUnregister.restype = ctypes.c_int32
+            lib.aclrtHostUnregister.argtypes = [ctypes.c_void_p]
+            logger.info("NpuPinMemoryBackend: loaded libascendcl from %s", path)
+            return lib
+        except (OSError, AttributeError):
+            continue
+    return None
+
+
+def _load_libascendcl() -> _AclRuntime | None:
+    """Load ``libascendcl`` via ctypes as an ``acl.rt``-shaped fallback.
+
+    The :func:`ctypes.util.find_library` probe is only paid when the cheap
+    candidates fail, because it forks ``ldconfig``.
+
+    Returns:
+        The adapted runtime, or ``None`` when no usable library is found.
+    """
+    lib = _bind_libascendcl(_candidate_lib_paths())
+    if lib is None:
+        found = ctypes.util.find_library("ascendcl")
+        if found:
+            lib = _bind_libascendcl([found])
+    if lib is None:
+        logger.warning(
+            "NpuPinMemoryBackend: libascendcl not available; NPU host "
+            "pinning disabled, D2H/H2D will be synchronous"
+        )
+        return None
+    return _LibascendclRuntime(lib)
+
+
+class NpuPinMemoryBackend(PinMemoryBackend):
+    """Pin host memory for NPU DMA via AscendCL ``aclrtHostRegister``.
+
+    AscendCL requires a page-aligned ``ptr`` and a page-multiple ``size``, so
+    every registration is widened to whole pages; the caller's original
+    pointer is kept as the bookkeeping key so :meth:`unpin_memory` can reverse
+    the registration when handed that same pointer.
+
+    Attributes:
+        _rt: ``acl.rt``-shaped runtime, or ``None`` when unavailable.
+        _registered_bases: Maps the caller's original pointer to the
+            page-aligned registered base.
+        _no_npu: Latched when the NPU is unavailable or no ACL context can be
+            established; makes :attr:`is_pin_supported` report ``False``
+            thereafter.
+        _tls: Per-thread "context ensured" flag; ACL contexts are
+            thread-local.
+    """
+
+    def __init__(self) -> None:
+        """Discover a runtime binding without raising on Ascend-less hosts.
+
+        Notes:
+            Discovery prefers the vendor ``acl`` module and falls back to
+            ``libascendcl`` via :mod:`ctypes`. When both fail the backend
+            stays unsupported and pin/unpin return ``False``.
+        """
+        self._rt: _AclRuntime | None = _load_acl_rt() or _load_libascendcl()
+        self._registered_bases: dict[int, int] = {}
+        self._no_npu: bool = False
+        self._tls = threading.local()
+
+    def _ensure_context(self) -> bool:
+        """Ensure an ACL device context is current on the calling thread.
+
+        ``aclrtHostRegister`` fails with AscendCL ``107002`` (no current
+        context) when the thread has never touched the device. Worker threads
+        are covered (torch_npu creates the context on first device op), but a
+        cache-server thread that only manages host memory may have none, so
+        the first pin attempt on each thread establishes one.
+
+        Returns:
+            True when a context is current, False when the NPU is unavailable
+            (latched into ``_no_npu``).
+        """
+        if self._no_npu:
+            return False
+        if getattr(self._tls, "ensured", False):
+            return True
+        try:
+            # Third Party
+            import torch
+
+            npu = getattr(torch, "npu", None)
+            if npu is None or not npu.is_available():
+                self._no_npu = True
+                logger.info(
+                    "NpuPinMemoryBackend: NPU unavailable; host pinning "
+                    "disabled (copies will be synchronous)"
+                )
+                return False
+            try:
+                # Re-bind the current device instead of a hardcoded index so
+                # worker ranks already bound to device N are not shifted.
+                npu.set_device(npu.current_device())
+            except Exception:
+                # current_device() can raise before torch_npu initializes;
+                # device 0 is the fallback.
+                npu.set_device(0)
+        except Exception as exc:
+            # Accessing torch.npu lazily imports torch_npu, which can itself
+            # raise on a broken CANN setup.
+            self._no_npu = True
+            logger.warning(
+                "NpuPinMemoryBackend: cannot establish NPU context for "
+                "pinning: %r; copies will be synchronous",
+                exc,
+            )
+            return False
+        self._tls.ensured = True
+        return True
+
+    def pin_memory(self, ptr: int, size: int, flags: int = 0) -> bool:
+        """Page-lock ``[ptr, ptr + size)`` for async NPU DMA.
+
+        Args:
+            ptr: Raw host pointer to the memory region.
+            size: Region size in bytes.
+            flags: Unused; AscendCL's only register type is
+                ``ACL_HOST_REGISTER_MAPPED``.
+
+        Returns:
+            True if registration succeeded, False otherwise (callers degrade
+            to synchronous copies).
+        """
+        rt = self._rt
+        if rt is None or ptr == 0 or size <= 0:
+            return False
+        if not self._ensure_context():
+            return False
+
+        base = round_down(ptr, _PAGE_SIZE)
+        reg_size = round_up(size + (ptr - base), _PAGE_SIZE)
+        try:
+            _, ret = rt.host_register(base, reg_size, _ACL_HOST_REGISTER_MAPPED)
+        except Exception as exc:
+            logger.warning(
+                "aclrtHostRegister failed for ptr=%#x size=%d: %s", ptr, size, exc
+            )
+            return False
+        if ret != _ACL_SUCCESS:
+            logger.warning(
+                "aclrtHostRegister failed: ptr=%#x base=%#x size=%d ret=%d; "
+                "D2H/H2D will be synchronous",
+                ptr,
+                base,
+                reg_size,
+                ret,
+            )
+            return False
+        self._registered_bases[ptr] = base
+        return True
+
+    def unpin_memory(self, ptr: int) -> bool:
+        """Unregister a previously pinned region.
+
+        The bookkeeping entry is only dropped on success, so a failed
+        unregistration can be retried with the same pointer.
+
+        Args:
+            ptr: The original pointer passed to :meth:`pin_memory`.
+
+        Returns:
+            True if unregistration succeeded or nothing was registered for
+            ``ptr``; False when the backend is unavailable or AscendCL
+            reports an error.
+        """
+        rt = self._rt
+        if rt is None:
+            return False
+        base = self._registered_bases.get(ptr)
+        if base is None:
+            return True
+        try:
+            ret = rt.host_unregister(base)
+        except Exception as exc:
+            logger.warning("aclrtHostUnregister failed for ptr=%#x: %s", ptr, exc)
+            return False
+        if ret != _ACL_SUCCESS:
+            logger.warning(
+                "aclrtHostUnregister failed: ptr=%#x base=%#x ret=%d", ptr, base, ret
+            )
+            return False
+        del self._registered_bases[ptr]
+        return True
+
+    @property
+    def is_pin_supported(self) -> bool:
+        """Whether AscendCL host registration is usable.
+
+        Returns:
+            True when a runtime binding loaded and the NPU has not been found
+            unavailable, False otherwise.
+        """
+        return self._rt is not None and not self._no_npu

--- a/lmcache/v1/platform/npu/pin_memory.py
+++ b/lmcache/v1/platform/npu/pin_memory.py
@@ -32,11 +32,11 @@ except (AttributeError, ValueError, OSError):
 class _AclRuntime(Protocol):
     """``acl.rt`` surface required for host-memory registration.
 
-    Satisfied by the CANN ``acl.rt`` module and by :class:`_LibascendclRuntime`.
-    ``host_register`` mirrors the C ``aclrtHostRegister`` including its
-    out-param: it returns ``(dev_ptr, ret_code)``. The device-mapped alias is
-    unused -- torch ``copy_`` keeps addressing the original host pointer, which
-    the registration page-locks for DMA.
+    Satisfied by the CANN ``acl.rt`` module and by
+    :class:`_LibascendclRuntime`. ``host_register`` returns
+    ``(dev_ptr, ret_code)`` mirroring the C out-param; the device-mapped
+    alias is unused -- torch ``copy_`` keeps addressing the original host
+    pointer.
     """
 
     def host_register(self, ptr: int, size: int, flags: int) -> tuple[int, int]:
@@ -74,9 +74,9 @@ class _LibascendclRuntime:
 def _load_acl_rt() -> _AclRuntime | None:
     """Return the CANN ``acl.rt`` runtime module for host registration.
 
-    The vendor module ships with CANN and shares the runtime instance
-    ``torch_npu`` already loaded, so registrations issued through it are
-    visible to ``copy_(..., non_blocking=True)``.
+    The vendor module shares the runtime instance ``torch_npu`` already
+    loaded, so registrations issued through it are visible to
+    ``copy_(..., non_blocking=True)``.
 
     Returns:
         ``acl.rt``, or ``None`` when the module or its register/unregister
@@ -104,9 +104,8 @@ def _candidate_lib_paths() -> list[str]:
     """Return ``libascendcl`` search candidates, most-specific first.
 
     Honors ``$ASCEND_HOME_PATH`` and the standard CANN install layout
-    (``/usr/local/Ascend/cann*/<arch>-linux/lib64``). Filesystem probes only:
-    :func:`ctypes.util.find_library` is intentionally not used here because it
-    forks ``ldconfig``.
+    (``/usr/local/Ascend/cann*/<arch>-linux/lib64``). Filesystem probes
+    only: :func:`ctypes.util.find_library` forks ``ldconfig``.
     """
     home = os.environ.get("ASCEND_HOME_PATH")
     if home:
@@ -145,8 +144,8 @@ def _bind_libascendcl(paths: list[str]) -> ctypes.CDLL | None:
 def _load_libascendcl() -> _AclRuntime | None:
     """Load ``libascendcl`` via ctypes as an ``acl.rt``-shaped fallback.
 
-    The :func:`ctypes.util.find_library` probe is only paid when the cheap
-    candidates fail, because it forks ``ldconfig``.
+    The :func:`ctypes.util.find_library` probe forks ``ldconfig`` and is
+    only paid when the cheap candidates fail.
 
     Returns:
         The adapted runtime, or ``None`` when no usable library is found.
@@ -196,55 +195,42 @@ def _torch_npu_available() -> bool:
 class NpuPinMemoryBackend(PinMemoryBackend):
     """Pin host memory for NPU DMA via AscendCL ``aclrtHostRegister``.
 
-    AscendCL requires a page-aligned ``ptr`` and a page-multiple ``size``, so
-    every registration is widened to whole pages; the caller's original
-    pointer is kept as the bookkeeping key so :meth:`unpin_memory` can reverse
-    the registration when handed that same pointer.
-
-    Attributes:
-        _rt: ``acl.rt``-shaped runtime, or ``None`` when unavailable.
-        _registered_bases: Maps the caller's original pointer to the
-            page-aligned registered base.
-        _no_npu: Latched at construction when the NPU is unavailable (or
-            later, when context setup fails on a broken installation); makes
-            :attr:`is_pin_supported` report ``False``.
-        _tls: Per-thread "context ensured" flag; ACL contexts are
-            thread-local.
+    AscendCL requires a page-aligned ``ptr`` and a page-multiple ``size``,
+    so registrations are widened to whole pages and keyed by the caller's
+    original pointer (:meth:`unpin_memory` reverses them with that key).
+    ``_rt`` is the single availability flag -- ``None`` when the NPU is
+    unavailable, no binding loaded, or a context failure latched the
+    backend off. ACL contexts are thread-local; ``_tls`` tracks which
+    threads already have one.
     """
 
     def __init__(self) -> None:
         """Discover a runtime binding without raising on Ascend-less hosts.
 
-        Notes:
-            Discovery prefers the vendor ``acl`` module and falls back to
-            ``libascendcl`` via :mod:`ctypes`. NPU availability is probed
-            here so :attr:`is_pin_supported` is accurate before any pin
-            attempt -- callers such as the ``use_lazy`` auto-disable guard
-            consult it ahead of the first registration. When the runtime
-            binding or the NPU is unavailable the backend stays unsupported
-            and pin/unpin return ``False``.
+        The NPU is probed first because no ACL context can be established
+        without ``torch.npu``; library discovery (the ``acl`` module, then
+        ``libascendcl`` via ctypes) is skipped when it is absent. Probing
+        here keeps :attr:`is_pin_supported` accurate before the first pin.
         """
-        self._rt: _AclRuntime | None = _load_acl_rt() or _load_libascendcl()
         self._registered_bases: dict[int, int] = {}
-        self._no_npu: bool = not _torch_npu_available()
         self._tls = threading.local()
+        if _torch_npu_available():
+            self._rt: _AclRuntime | None = _load_acl_rt() or _load_libascendcl()
+        else:
+            self._rt = None
 
     def _ensure_context(self) -> bool:
         """Ensure an ACL device context is current on the calling thread.
 
-        ``aclrtHostRegister`` fails with AscendCL ``107002`` (no current
-        context) when the thread has never touched the device. Worker threads
-        are covered (torch_npu creates the context on first device op), but a
-        cache-server thread that only manages host memory may have none, so
-        the first pin attempt on each thread establishes one. Availability
-        itself was already probed in ``__init__``.
+        ``aclrtHostRegister`` fails with ``107002`` when the thread has no
+        current context, and torch_npu only creates one on first device
+        use -- so a thread that only manages host memory establishes one
+        here on its first pin.
 
         Returns:
-            True when a context is current, False when the NPU is
-            unavailable or context setup fails (latched into ``_no_npu``).
+            True when a context is current. False latches the backend off
+            by clearing ``_rt``.
         """
-        if self._no_npu:
-            return False
         if getattr(self._tls, "ensured", False):
             return True
         try:
@@ -255,7 +241,7 @@ class NpuPinMemoryBackend(PinMemoryBackend):
             if npu is None:
                 # Defensive: torch.npu vanished after __init__ (e.g. tests
                 # monkeypatching it away); treat as unavailable.
-                self._no_npu = True
+                self._rt = None
                 logger.warning(
                     "NpuPinMemoryBackend: torch.npu disappeared after "
                     "construction; host pinning disabled"
@@ -271,7 +257,7 @@ class NpuPinMemoryBackend(PinMemoryBackend):
                 npu.set_device(0)
         except Exception as exc:
             # set_device can raise on a broken CANN setup.
-            self._no_npu = True
+            self._rt = None
             logger.warning(
                 "NpuPinMemoryBackend: cannot establish NPU context for "
                 "pinning: %r; copies will be synchronous",
@@ -360,7 +346,7 @@ class NpuPinMemoryBackend(PinMemoryBackend):
         """Whether AscendCL host registration is usable.
 
         Returns:
-            True when a runtime binding loaded and construction found the
-            NPU available, False otherwise.
+            True while a runtime binding is loaded; construction-time
+            unavailability or a context-failure latch clears it.
         """
-        return self._rt is not None and not self._no_npu
+        return self._rt is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ warn_return_any = false
 follow_imports = "silent"
 
 [tool.codespell]
-ignore-words-list = "afterall,allready,notin,te,CANN"
+ignore-words-list = "afterall,allready,notin,te,cann"
 skip = "operator/config/crd/bases/*,lmcache/integration/vllm/lmcache_mp_connector_*.py"
 # Base64 image payloads in executed notebooks are random-looking and will
 # eventually contain something that looks like a typo.

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     cuda: Tests that can only run with CUDA runtime
     xpu: Tests that can only run with XPU runtime
     musa: Tests that can only run with MUSA runtime
+    npu: Tests that can only run with Ascend NPU runtime
     neuron: Tests that can only run with Neuron (AWS Trainium) runtime
     sglang: Tests for SGLang connector/integration
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from lmcache.utils import (
     parse_cache_key,
     parse_mixed_slot_mapping,
     round_down,
+    round_up,
 )
 
 
@@ -56,6 +57,20 @@ class TestRoundDown:
 
     def test_zero(self):
         assert round_down(0, 5) == 0
+
+
+class TestRoundUp:
+    def test_exact_multiple(self):
+        assert round_up(10, 5) == 10
+
+    def test_not_exact_multiple(self):
+        assert round_up(7, 3) == 9
+
+    def test_smaller_than_y(self):
+        assert round_up(2, 5) == 5
+
+    def test_zero(self):
+        assert round_up(0, 5) == 0
 
 
 # ============================================================

--- a/tests/v1/platform/npu/test_npu_pin_memory.py
+++ b/tests/v1/platform/npu/test_npu_pin_memory.py
@@ -5,6 +5,7 @@
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
+import os
 import sys
 
 # Third Party
@@ -16,8 +17,17 @@ from lmcache.v1.platform.npu import NpuDeviceSpec
 from lmcache.v1.platform.npu import pin_memory as pin_memory_module
 from lmcache.v1.platform.npu.pin_memory import NpuPinMemoryBackend
 
-#: Page size the module under test computes alignments against.
-PAGE = 0x1000
+#: Page size, computed exactly like the module under test so alignment
+#: expectations hold on any host (e.g. aarch64 64K-page kernels).
+try:
+    PAGE = os.sysconf("SC_PAGESIZE")
+except (AttributeError, ValueError, OSError):
+    PAGE = 4096
+
+#: None of these tests allocate through the shared allocator, and the
+#: autouse fixture's 5GB pinned allocation fails on hosts where the
+#: lmcache_ascend plugin is installed but no ACL context can be established.
+pytestmark = pytest.mark.no_shared_allocator
 
 
 class _FakeAclRt:
@@ -99,12 +109,14 @@ def test_pin_widens_region_to_whole_pages_and_unpin_uses_base(
     rt = _FakeAclRt()
     backend = _make_backend(monkeypatch, rt)
 
-    ptr, size = 0x2ABC, 0x1000
+    # An offset region spanning two pages: the registration must cover
+    # exactly the page containing the pointer plus the one it spills into.
+    ptr, size = 2 * PAGE + 0xABC, PAGE
     assert backend.pin_memory(ptr, size) is True
-    assert rt.register_calls == [(0x2000, 0x2000, 0)]
+    assert rt.register_calls == [(2 * PAGE, 2 * PAGE, 0)]
 
     assert backend.unpin_memory(ptr) is True
-    assert rt.unregister_calls == [0x2000]
+    assert rt.unregister_calls == [2 * PAGE]
 
 
 def test_unpin_of_never_pinned_pointer_is_noop_success(
@@ -113,7 +125,7 @@ def test_unpin_of_never_pinned_pointer_is_noop_success(
     """A pointer that was never pinned unpins as a no-op success."""
     rt = _FakeAclRt()
     backend = _make_backend(monkeypatch, rt)
-    backend.pin_memory(0x2000, PAGE)
+    backend.pin_memory(PAGE, PAGE)
 
     assert backend.unpin_memory(0x99999) is True
     assert rt.unregister_calls == []
@@ -125,11 +137,11 @@ def test_failed_unregister_keeps_region_for_retry(
     """A failed unregistration stays undoable instead of being dropped."""
     rt = _FakeAclRt(unregister_codes=[507911, 0])
     backend = _make_backend(monkeypatch, rt)
-    backend.pin_memory(0x2000, PAGE)
+    backend.pin_memory(PAGE, PAGE)
 
-    assert backend.unpin_memory(0x2000) is False
-    assert backend.unpin_memory(0x2000) is True
-    assert rt.unregister_calls == [0x2000, 0x2000]
+    assert backend.unpin_memory(PAGE) is False
+    assert backend.unpin_memory(PAGE) is True
+    assert rt.unregister_calls == [PAGE, PAGE]
 
 
 def test_pin_returns_false_on_acl_error_code(
@@ -138,8 +150,8 @@ def test_pin_returns_false_on_acl_error_code(
     """A nonzero AscendCL registration status is not reported as success."""
     backend = _make_backend(monkeypatch, _FakeAclRt(register_code=507899))
 
-    assert backend.pin_memory(0x1000, PAGE) is False
-    assert backend.unpin_memory(0x1000) is True
+    assert backend.pin_memory(PAGE, PAGE) is False
+    assert backend.unpin_memory(PAGE) is True
 
 
 def test_pin_fails_without_raising_and_latches_when_npu_unavailable(
@@ -150,9 +162,29 @@ def test_pin_fails_without_raising_and_latches_when_npu_unavailable(
     monkeypatch.delattr(torch, "npu", raising=False)
     assert backend.is_pin_supported is True
 
-    assert backend.pin_memory(0x2000, PAGE) is False
+    assert backend.pin_memory(PAGE, PAGE) is False
     assert backend.is_pin_supported is False
-    assert backend.pin_memory(0x2000, PAGE) is False
+    assert backend.pin_memory(PAGE, PAGE) is False
+
+
+def test_unavailable_npu_latches_at_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Construction-time unavailability flips the gate without a pin attempt.
+
+    ``is_pin_supported`` must be accurate before any ``pin_memory`` call,
+    because callers such as the ``use_lazy`` auto-disable guard consult it
+    ahead of the first registration.
+    """
+    rt = _FakeAclRt()
+    _install_acl_rt(monkeypatch, rt)
+    monkeypatch.delattr(torch, "npu", raising=False)
+
+    backend = NpuPinMemoryBackend()
+
+    assert backend.is_pin_supported is False
+    assert backend.pin_memory(PAGE, PAGE) is False
+    assert rt.register_calls == []
 
 
 def test_backend_without_acl_or_lib_is_unsupported(
@@ -169,8 +201,8 @@ def test_backend_without_acl_or_lib_is_unsupported(
     backend = NpuPinMemoryBackend()
 
     assert backend.is_pin_supported is False
-    assert backend.pin_memory(0x2000, PAGE) is False
-    assert backend.unpin_memory(0x2000) is False
+    assert backend.pin_memory(PAGE, PAGE) is False
+    assert backend.unpin_memory(PAGE) is False
 
 
 def test_ctypes_fallback_used_when_acl_module_missing(
@@ -197,14 +229,14 @@ def test_ctypes_fallback_used_when_acl_module_missing(
     assert backend.is_pin_supported is True
     assert dlopen_paths == ["/opt/ascend/ascend-toolkit/lib64/libascendcl.so"]
 
-    assert backend.pin_memory(0x2000, PAGE) is True
+    assert backend.pin_memory(PAGE, PAGE) is True
     base_arg = register.call_args.args[0]
     size_arg = register.call_args.args[1]
-    assert base_arg.value == 0x2000
+    assert base_arg.value == PAGE
     assert size_arg.value == PAGE
 
-    assert backend.unpin_memory(0x2000) is True
-    assert unregister.call_args.args[0].value == 0x2000
+    assert backend.unpin_memory(PAGE) is True
+    assert unregister.call_args.args[0].value == PAGE
 
 
 @pytest.mark.npu

--- a/tests/v1/platform/npu/test_npu_pin_memory.py
+++ b/tests/v1/platform/npu/test_npu_pin_memory.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock
 import os
 import sys
+import threading
 
 # Third Party
 import pytest
@@ -185,6 +186,69 @@ def test_unavailable_npu_latches_at_construction(
     assert backend.is_pin_supported is False
     assert backend.pin_memory(PAGE, PAGE) is False
     assert rt.register_calls == []
+
+
+def test_unavailable_npu_skips_library_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Construction never probes for ACL bindings without ``torch.npu``.
+
+    No ACL context can be established without ``torch.npu``, so library
+    discovery would be dead work -- and its ``ctypes`` fallback forks
+    ``ldconfig`` on every Ascend-less construction.
+    """
+    load_acl_rt = MagicMock(return_value=None)
+    load_libascendcl = MagicMock(return_value=None)
+    monkeypatch.setattr(pin_memory_module, "_load_acl_rt", load_acl_rt)
+    monkeypatch.setattr(pin_memory_module, "_load_libascendcl", load_libascendcl)
+    monkeypatch.delattr(torch, "npu", raising=False)
+
+    backend = NpuPinMemoryBackend()
+
+    assert backend.is_pin_supported is False
+    load_acl_rt.assert_not_called()
+    load_libascendcl.assert_not_called()
+
+
+def test_unpin_refuses_after_context_failure_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A context-failure latch stops unpin from touching AscendCL.
+
+    The latch clears the runtime binding, so ``unpin_memory`` for an
+    earlier registration returns False instead of issuing an unregister
+    against the broken runtime; the page-lock is abandoned with it.
+    """
+    rt = _FakeAclRt()
+    backend = _make_backend(monkeypatch, rt)
+    assert backend.pin_memory(PAGE, PAGE) is True
+
+    def broken_set_device(device: int) -> None:
+        raise RuntimeError("CANN broken")
+
+    monkeypatch.setattr(
+        torch,
+        "npu",
+        SimpleNamespace(
+            is_available=lambda: True,
+            current_device=lambda: 0,
+            set_device=broken_set_device,
+        ),
+    )
+
+    # A thread that has never pinned runs the full context-setup path.
+    pin_results: list[bool] = []
+
+    def pin_on_fresh_thread() -> None:
+        pin_results.append(backend.pin_memory(2 * PAGE, PAGE))
+
+    thread = threading.Thread(target=pin_on_fresh_thread)
+    thread.start()
+    thread.join()
+
+    assert pin_results == [False]
+    assert backend.unpin_memory(PAGE) is False
+    assert rt.unregister_calls == []
 
 
 def test_backend_without_acl_or_lib_is_unsupported(

--- a/tests/v1/platform/npu/test_npu_pin_memory.py
+++ b/tests/v1/platform/npu/test_npu_pin_memory.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for the NPU host-memory pin backend (no Ascend hardware)."""
+
+# Standard
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+import sys
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.platform.npu import NpuDeviceSpec
+from lmcache.v1.platform.npu import pin_memory as pin_memory_module
+from lmcache.v1.platform.npu.pin_memory import NpuPinMemoryBackend
+
+#: Page size the module under test computes alignments against.
+PAGE = 0x1000
+
+
+class _FakeAclRt:
+    """``acl.rt`` double that records host-registration calls."""
+
+    def __init__(
+        self,
+        register_code: int = 0,
+        unregister_codes: list[int] | None = None,
+    ) -> None:
+        """Record calls and replay the configured AscendCL status codes.
+
+        Args:
+            register_code: Status code every ``host_register`` call returns.
+            unregister_codes: Status codes ``host_unregister`` returns in
+                order; the last one repeats once the list is exhausted.
+        """
+        self.register_code = register_code
+        self.unregister_codes = unregister_codes if unregister_codes else [0]
+        self.register_calls: list[tuple[int, int, int]] = []
+        self.unregister_calls: list[int] = []
+
+    def host_register(self, ptr: int, size: int, flags: int) -> tuple[int, int]:
+        """Record and emulate ``acl.rt.host_register``."""
+        self.register_calls.append((ptr, size, flags))
+        return 0xDEAD0000, self.register_code
+
+    def host_unregister(self, ptr: int) -> int:
+        """Record and emulate ``acl.rt.host_unregister``."""
+        self.unregister_calls.append(ptr)
+        index = min(len(self.unregister_calls), len(self.unregister_codes)) - 1
+        return self.unregister_codes[index]
+
+
+def _install_acl_rt(
+    monkeypatch: pytest.MonkeyPatch,
+    rt: Any,
+) -> None:
+    """Expose a fake ``acl`` module for one test (``None`` forces ImportError)."""
+    module = None if rt is None else SimpleNamespace(rt=rt)
+    monkeypatch.setitem(sys.modules, "acl", module)
+
+
+def _install_fake_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a fake ``torch.npu`` so context setup works without torch_npu."""
+    monkeypatch.setattr(
+        torch,
+        "npu",
+        SimpleNamespace(
+            is_available=lambda: True,
+            current_device=lambda: 0,
+            set_device=lambda device: None,
+        ),
+        raising=False,
+    )
+
+
+def _make_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    rt: Any = "default",
+) -> NpuPinMemoryBackend:
+    """Build a backend against the fake ``acl``/``torch.npu`` seams."""
+    if rt == "default":
+        rt = _FakeAclRt()
+    _install_acl_rt(monkeypatch, rt)
+    _install_fake_npu(monkeypatch)
+    return NpuPinMemoryBackend()
+
+
+def test_device_spec_registers_npu_pin_backend() -> None:
+    """The NPU device specification registers the NPU pinning adapter."""
+    assert NpuDeviceSpec().pin_memory_backend is NpuPinMemoryBackend
+
+
+def test_pin_widens_region_to_whole_pages_and_unpin_uses_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registration widens to page boundaries and unpin reverses the base."""
+    rt = _FakeAclRt()
+    backend = _make_backend(monkeypatch, rt)
+
+    ptr, size = 0x2ABC, 0x1000
+    assert backend.pin_memory(ptr, size) is True
+    assert rt.register_calls == [(0x2000, 0x2000, 0)]
+
+    assert backend.unpin_memory(ptr) is True
+    assert rt.unregister_calls == [0x2000]
+
+
+def test_unpin_of_never_pinned_pointer_is_noop_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pointer that was never pinned unpins as a no-op success."""
+    rt = _FakeAclRt()
+    backend = _make_backend(monkeypatch, rt)
+    backend.pin_memory(0x2000, PAGE)
+
+    assert backend.unpin_memory(0x99999) is True
+    assert rt.unregister_calls == []
+
+
+def test_failed_unregister_keeps_region_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed unregistration stays undoable instead of being dropped."""
+    rt = _FakeAclRt(unregister_codes=[507911, 0])
+    backend = _make_backend(monkeypatch, rt)
+    backend.pin_memory(0x2000, PAGE)
+
+    assert backend.unpin_memory(0x2000) is False
+    assert backend.unpin_memory(0x2000) is True
+    assert rt.unregister_calls == [0x2000, 0x2000]
+
+
+def test_pin_returns_false_on_acl_error_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nonzero AscendCL registration status is not reported as success."""
+    backend = _make_backend(monkeypatch, _FakeAclRt(register_code=507899))
+
+    assert backend.pin_memory(0x1000, PAGE) is False
+    assert backend.unpin_memory(0x1000) is True
+
+
+def test_pin_fails_without_raising_and_latches_when_npu_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing torch.npu degrades pin to False and the gate to unsupported."""
+    backend = _make_backend(monkeypatch)
+    monkeypatch.delattr(torch, "npu", raising=False)
+    assert backend.is_pin_supported is True
+
+    assert backend.pin_memory(0x2000, PAGE) is False
+    assert backend.is_pin_supported is False
+    assert backend.pin_memory(0x2000, PAGE) is False
+
+
+def test_backend_without_acl_or_lib_is_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No vendor module and no installable library means no pinning."""
+    _install_acl_rt(monkeypatch, None)
+    monkeypatch.delenv("ASCEND_HOME_PATH", raising=False)
+    monkeypatch.setattr(pin_memory_module.glob, "glob", lambda pattern: [])
+    monkeypatch.setattr(
+        pin_memory_module.ctypes.util, "find_library", lambda name: None
+    )
+
+    backend = NpuPinMemoryBackend()
+
+    assert backend.is_pin_supported is False
+    assert backend.pin_memory(0x2000, PAGE) is False
+    assert backend.unpin_memory(0x2000) is False
+
+
+def test_ctypes_fallback_used_when_acl_module_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the ``acl`` module the ctypes path honors $ASCEND_HOME_PATH."""
+    _install_acl_rt(monkeypatch, None)
+    _install_fake_npu(monkeypatch)
+    monkeypatch.setenv("ASCEND_HOME_PATH", "/opt/ascend/ascend-toolkit")
+
+    register = MagicMock(return_value=0)
+    unregister = MagicMock(return_value=0)
+    dlopen_paths: list[str] = []
+
+    def fake_cdll(path: str) -> Any:
+        dlopen_paths.append(path)
+        return SimpleNamespace(
+            aclrtHostRegister=register, aclrtHostUnregister=unregister
+        )
+
+    monkeypatch.setattr(pin_memory_module.ctypes, "CDLL", fake_cdll)
+
+    backend = NpuPinMemoryBackend()
+    assert backend.is_pin_supported is True
+    assert dlopen_paths == ["/opt/ascend/ascend-toolkit/lib64/libascendcl.so"]
+
+    assert backend.pin_memory(0x2000, PAGE) is True
+    base_arg = register.call_args.args[0]
+    size_arg = register.call_args.args[1]
+    assert base_arg.value == 0x2000
+    assert size_arg.value == PAGE
+
+    assert backend.unpin_memory(0x2000) is True
+    assert unregister.call_args.args[0].value == 0x2000
+
+
+@pytest.mark.npu
+def test_real_npu_runtime_registers_and_unregisters() -> None:
+    """Optionally smoke-test one real unaligned registration lifecycle."""
+    pytest.importorskip("torch_npu")
+    backend = NpuPinMemoryBackend()
+    if not backend.is_pin_supported:
+        pytest.skip("AscendCL host-registration binding is unavailable")
+
+    size = 1 << 20
+    buffer = torch.empty(size + PAGE, dtype=torch.uint8)
+    ptr = buffer.data_ptr() + 1  # exercise the page-widening path
+    assert backend.pin_memory(ptr, size) is True
+    assert backend.unpin_memory(ptr) is True

--- a/tests/v1/test_musa_support.py
+++ b/tests/v1/test_musa_support.py
@@ -314,4 +314,4 @@ def test_lmcache_exports_torch_dev_and_torch_device_type() -> None:
     importlib.reload(lmc)
     assert hasattr(lmc, "torch_dev")
     assert isinstance(lmc.torch_device_type, str)
-    assert lmc.torch_device_type in {"cuda", "musa", "xpu", "hpu", "cpu"}
+    assert lmc.torch_device_type in {"cuda", "musa", "xpu", "hpu", "npu", "cpu"}

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -235,6 +235,28 @@ def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     assert len(args[2]) == 1
 
 
+def test_register_kv_caches_tuple_caches_extract_device(fake_adapter, monkeypatch):
+    """Per-layer (K, V) tuple caches register and yield the tensor device."""
+    adapter, send_mock, _ = fake_adapter
+    monkeypatch.setattr(
+        "lmcache.integration.vllm.utils.vllm_layout_hints",
+        lambda: {},
+        raising=False,
+    )
+    # NL_X_TWO_X_NB_BS_NH_HS layout: [NB, BS, NH, HS] per plane.
+    k = torch.randn(2, 8, 4, 8)
+    v = torch.randn(2, 8, 4, 8)
+    tuple_kv = {"layer.0": (k, v), "layer.1": (k, v)}
+
+    adapter.register_kv_caches(tuple_kv)
+
+    assert adapter._kv_device == k.device
+    assert adapter.kv_caches is tuple_kv
+    assert send_mock.call_count == 1
+    args, _kwargs = send_mock.call_args
+    assert args[1] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+
+
 def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
     """submit_store_request stores the returned future in store_futures."""
     adapter, _send_mock, _ = fake_adapter


### PR DESCRIPTION
**What this PR does / why we need it**:

refer to issue #4061

Adds `NpuPinMemoryBackend`, the Ascend NPU implementation of the `PinMemoryBackend` platform abstraction, and wires it into `NpuDeviceSpec.pin_memory_backend` (`lmcache/v1/platform/npu/pin_memory.py`, mirroring `CudaPinMemoryBackend`).
  
  Refs #3968: the engine-driven MP transfer path (`EngineDrivenContextShm._pin_shm_buffer`) relies on the platform pin backend to page-lock the worker's SHM pool. On NPU this was previously a no-op, so every `copy_(..., non_blocking=True)` fell back to a synchronous D2H/H2D and stalled the worker per chunk during MP gather/scatter. With the pool registered through AscendCL `aclrtHostRegister`, the copies become genuinely async.

Implementation notes:
  
- Loads `libascendcl` via `ctypes`, honoring `$ASCEND_HOME_PATH`, the standard CANN install layout, and `ctypes.util.find_library` as a fallback. `dlopen` returns the instance already loaded by `torch_npu`, so the backend shares its device context (no separate `aclrtSetDevice`).
- Page-aligns the region defensively before registering: AscendCL rejects non-page-aligned pointers / non-page-multiple sizes (error `507899`). The  caller's original pointer is mapped to the registered (aligned) base so `unpin_memory` can reverse the registration from the pointer the SHM lifecycle stores.
- Ensures a per-thread ACL context before the first registration (`aclrtHostRegister` fails with `107002` on a context-less thread, e.g. a cache-server thread that never touches the device). Worker threads get an idempotent no-op.
 - Degrades gracefully: if `libascendcl`, its symbols, or the NPU itself are unavailable, pinning reports unsupported and copies stay synchronous (logged once) instead of failing.
- `pyproject.toml`: add `cann` to the codespell ignore list.

**Special notes for your reviewers**:

- Tests run without Ascend hardware: `libascendcl` is faked with mocks, and the per-thread context check is bypassed in CI (no `torch_npu` there).
- The `devPtr` out-parameter of `aclrtHostRegister` is unused by design -- torch's `copy_` keeps addressing the original host pointer, which the registration page-locks for DMA (rationale in the module docstring).
- Behavior on real hardware (async D2H/H2D, no per-chunk stall) was validated on an Ascend box on top of #3968.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
