### PR TITLE
fix(vllm-mp): scheduler-side heartbeat never starts — dict-vs-None guard in _ensure_heartbeat_started

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -692,10 +692,14 @@ class LMCacheMPSchedulerAdapter:
 
     def _ensure_heartbeat_started(self) -> None:
         """Lazily start the heartbeat thread on first use."""
-        if self._heartbeats is not None:
+        # NOTE: _heartbeats is initialized to {}, never None — an `is not None`
+        # guard here always returns immediately and the scheduler-side
+        # heartbeat thread never starts (the worker adapter uses a None
+        # sentinel and the correct guard). Guard on truthiness instead.
+        if self._heartbeats:
             return
         with self._heartbeat_lock:
-            if self._heartbeats is not None:
+            if self._heartbeats:
                 return
             for url, client in self.mq_clients.items():
                 hb = HeartbeatThread(


### PR DESCRIPTION
One-line bug with an outsized blast radius, found while root-causing #4759.

`LMCacheMPSchedulerAdapter._ensure_heartbeat_started` guards with `if self._heartbeats is not None`, but `_heartbeats` is initialized to `{}` (line 670) — never `None` — so the guard always returns and **the scheduler-side heartbeat thread never starts**. The worker adapter initializes its `_heartbeat` sentinel to `None` and uses the identical guard correctly, which is presumably where the copy drifted.

Consequences:
- `_health_events` stays empty → `all()` over it is vacuously `True` → `is_healthy` is **permanently True**
- a dead or restarted LMCache server is never detected by the scheduler, so the `is_healthy` escapes in `maybe_submit_lookup_request` / `check_lookup_result` can never fire
- combined with poll-only lookup completion, a lost server converts every subsequent lookup-hit request into an indefinite park (in our deployment: until vLLM's execute-model watchdog kills the engine, 1800 s later) instead of graceful degradation

Field evidence in #4759: py-spy dumps from a 2x DGX Spark TP=2 deployment show the `lmcache-heartbeat` thread present in both worker processes and absent from the EngineCore process; a cleanly-restarted server (empty contexts) then produced eternal client parks while the server logged `No GPU context found … during lookup!` on every request.

Fix guards on truthiness; the double-checked locking structure is preserved. Sign-off included.