### PR TITLE
fix(mp): don't let one bad frame kill the shared client polling loop

### DIFF
--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -253,7 +253,17 @@ class ClientPollingLoop:
                 if event & zmq.POLLIN:
                     owner = self._socket_to_client.get(sock)
                     if owner is not None:
-                        owner.process_inbound()
+                        try:
+                            owner.process_inbound()
+                        except Exception:
+                            # This loop is shared by every client in the
+                            # process, so one undecodable or unexpected frame
+                            # must not terminate it: that would strand all
+                            # other clients' pending and future requests.
+                            logger.exception(
+                                "process_inbound failed; dropping this frame "
+                                "and continuing the shared polling loop"
+                            )
 
         # Drain remaining ops so any waiting threads unblock.
         self._process_ops()

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -4,9 +4,11 @@ from multiprocessing.synchronize import Event as EventClass
 from typing import Any, Callable
 import multiprocessing as mp
 import sys
+import threading
 import time
 
 # Third Party
+import msgspec
 import pytest
 import torch
 import zmq
@@ -685,6 +687,61 @@ def test_shared_loop_dispatch():
         assert ClientPollingLoop._instance is None
     finally:
         server.close()
+
+
+def test_client_survives_undecodable_response() -> None:
+    """
+    Test that an undecodable response does not stop later requests working.
+
+    RequestType is an enum.auto() enum, so its wire values are declaration
+    positions. A peer running a newer protocol can answer with a value this
+    build's enum does not contain, which fails to decode on arrival.
+
+    All MessageQueueClient instances in a process are serviced by one shared
+    polling loop, so if such a response tears that loop down every client is
+    stranded. The observable contract is that only the offending request is
+    lost: a later, well-formed request must still complete normally.
+    """
+    server_url = "tcp://127.0.0.1:16030"
+    context = zmq.Context.instance()
+
+    unknown_value = max(member.value for member in RequestType) + 1
+    b_unknown = msgspec.msgpack.encode(unknown_value)
+    chunk_size = 256
+
+    router = context.socket(zmq.ROUTER)
+    router.bind(server_url)
+
+    def serve() -> None:
+        """Answer the first request undecodably, then the second correctly."""
+        identity, b_uid, _b_type, *_ = router.recv_multipart()
+        router.send_multipart([identity, b_uid, b_unknown])
+
+        identity, b_uid, b_type, *_ = router.recv_multipart()
+        router.send_multipart(
+            [identity, b_uid, b_type, msgspec.msgpack.encode(chunk_size)]
+        )
+
+    threading.Thread(target=serve, daemon=True).start()
+
+    try:
+        client = MessageQueueClient(server_url, context)
+
+        # The poisoned request cannot be resolved: without a decodable
+        # request_type there is no way to match it to its future, so it times
+        # out. That much is expected -- what matters is what happens after.
+        poisoned = client.submit_request(RequestType.GET_CHUNK_SIZE, [])
+        with pytest.raises(TimeoutError):
+            poisoned.result(timeout=1)
+
+        # A later, well-formed request must still be served. If the bad
+        # response tore down the shared polling loop, this times out too.
+        healthy = client.submit_request(RequestType.GET_CHUNK_SIZE, [])
+        assert healthy.result(timeout=5) == chunk_size
+
+        client.close()
+    finally:
+        router.close()
 
 
 def test_shared_loop_recreate():

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -20,6 +20,7 @@ from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     IPCCacheServerKey,
 )
+from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,
@@ -730,13 +731,17 @@ def test_client_survives_undecodable_response() -> None:
         # The poisoned request cannot be resolved: without a decodable
         # request_type there is no way to match it to its future, so it times
         # out. That much is expected -- what matters is what happens after.
-        poisoned = client.submit_request(RequestType.GET_CHUNK_SIZE, [])
+        poisoned: MessagingFuture[int] = client.submit_request(
+            RequestType.GET_CHUNK_SIZE, []
+        )
         with pytest.raises(TimeoutError):
             poisoned.result(timeout=1)
 
         # A later, well-formed request must still be served. If the bad
         # response tore down the shared polling loop, this times out too.
-        healthy = client.submit_request(RequestType.GET_CHUNK_SIZE, [])
+        healthy: MessagingFuture[int] = client.submit_request(
+            RequestType.GET_CHUNK_SIZE, []
+        )
         assert healthy.result(timeout=5) == chunk_size
 
         client.close()


### PR DESCRIPTION

**What this PR does / why we need it**:

`ClientPollingLoop` runs a single process-wide daemon thread that services every
`MessageQueueClient`, and `_main_loop` dispatches to `owner.process_inbound()` without a guard.
`process_inbound` decodes peer-supplied bytes in four places, so any decode failure propagates out
of the loop and terminates the thread. Nothing supervises or restarts it, so **every client in the
process is stranded**: pending futures never resolve and new requests only ever time out, until the
process is restarted. The traceback goes to the dying thread's stderr, so nothing actionable
surfaces to the application.

This is reachable today between adjacent releases. `RequestType` is an `enum.auto()` enum, so a
member's wire value is its declaration position — and the list is not append-only. Between
**v0.5.2** (36 members) and **v0.5.4** (40), three members were *inserted* at positions 3-5:

| member | v0.5.2 | v0.5.4 |
|---|---|---|
| `STORE` | 3 | 6 |
| `RETRIEVE` | 4 | 7 |
| `LOOKUP` | 5 | 8 |
| `PING` | 19 | 22 |

34 of the 36 existing members shifted by +3 and the range extended past what the older peer knows,
so a peer on the newer protocol answers with values an older peer cannot decode. Because the
cache-server and engine-side images are versioned independently, a mismatched pair is an ordinary
deployment state rather than an exotic one.

This PR wraps the dispatch so an undecodable or otherwise unexpected frame is logged and dropped
while the loop keeps serving. The offending request still times out — without a usable
`request_type` it cannot be matched back to its future — but the blast radius becomes that one
request instead of the whole process.

Measured A/B on one host, driving a raw ZMQ `ROUTER` as the newer peer so the exact bytes are
controlled:

```text
before:  request A (poisoned) -> timeout
         polling threads      -> []            # thread gone
         request B (healthy)  -> timeout       # collateral damage

after:   request A (poisoned) -> timeout
         polling threads      -> ['mq-client-shared-loop']
         request B (healthy)  -> returns immediately
```

**Special notes for your reviewers**:

- Behaviour change is confined to the failure path; no wire format change, no API change, and the
  success paths are untouched. `logger.exception` keeps the full traceback, so the failure is still
  reported — it just no longer takes the loop down with it.
- The regression test asserts the **observable contract through the public API only** (per
  `coding_standards.md` §5.2): after a response the client cannot decode, a later well-formed
  request must still complete. It touches no private members. Without the guard that second request
  times out too, so the test fails on `dev` and passes with the fix.
- The same `_main_loop` also calls `client.process_outbound_task()` unguarded, which is
  structurally the same exposure. I have **not** observed a failure there and have left it alone to
  keep this PR to one thing; happy to extend if you would prefer both covered here.
- The enum drift above has a second consequence that this PR deliberately does **not** address:
  because the shifted values stay *within* the older peer's range, a skewed pair can also silently
  misread one request as another (`STORE`=3 under v0.5.2 decodes as `REGISTER_Q_CACHE` under
  v0.5.4). That looks like a protocol-versioning issue worth its own discussion — I can open a
  separate issue if useful.
- Environment note: on my machine `tests/v1/multiprocess/test_mq.py::test_mq_noop_multiple_clients`
  fails on unmodified `dev` as well (it spawns several client processes and my sandbox is
  CPU-limited), so I believe it is unrelated to this change. Everything else in the file passes.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
