### PR TITLE
ci: pre-merge PR base before pipeline expansion

### DIFF
--- a/.buildkite/correctness/pipeline.correctness.steps.yml
+++ b/.buildkite/correctness/pipeline.correctness.steps.yml
@@ -1,0 +1,18 @@
+steps:
+  - label: ":rocket: vLLM correctness"
+    key: "correctness"
+    timeout_in_minutes: 60
+    command: |
+      set -euo pipefail
+
+      echo "[INFO] HOME: $HOME"
+      echo "[INFO] PWD: $PWD"
+
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+
+      chmod +x .buildkite/scripts/vllm-correctness.sh
+      BUILD_ID="${BUILDKITE_BUILD_ID}" .buildkite/scripts/vllm-correctness.sh
+
+    artifact_paths:
+      - "build_${BUILDKITE_BUILD_ID}.log"

--- a/.buildkite/correctness/pipeline.correctness.yml
+++ b/.buildkite/correctness/pipeline.correctness.yml
@@ -1,16 +1,8 @@
 steps:
-  - label: ":rocket: vLLM correctness"
-    key: "correctness"
-    timeout_in_minutes: 60
-    commands:
-      - |
-        set -euo pipefail
-
-        echo "[INFO] HOME: $HOME"
-        echo "[INFO] PWD: $PWD"
-
-        chmod +x .buildkite/scripts/vllm-correctness.sh
-        BUILD_ID="${BUILDKITE_BUILD_ID}" .buildkite/scripts/vllm-correctness.sh
-
-    artifact_paths:
-      - "build_${BUILDKITE_BUILD_ID}.log"
+  - label: ":pipeline: Upload merged correctness pipeline"
+    key: "upload_correctness"
+    command: |
+      set -euo pipefail
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+      buildkite-agent pipeline upload .buildkite/correctness/pipeline.correctness.steps.yml

--- a/.buildkite/k3_harness/setup-sglang-env.sh
+++ b/.buildkite/k3_harness/setup-sglang-env.sh
@@ -8,6 +8,7 @@ trap 'echo "ERROR: setup-sglang-env.sh failed at line $LINENO (exit code $?)" >&
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
+merge_pr_base_branch
 
 echo "--- :wrench: System tools (rustup, protoc, libnuma1)"
 # rustup: sglang-grpc needs Rust 1.85+ (apt's rustc is too old).

--- a/.buildkite/k3_tests/amd/run-unit-tests.sh
+++ b/.buildkite/k3_tests/amd/run-unit-tests.sh
@@ -6,6 +6,11 @@ export AMD_SERIALIZE_KERNEL=1
 echo "AMD kernel mode: serialized"
 echo "$PWD" # for debugging
 
+# Keep the AMD pod aligned with the PR + latest target branch, matching the
+# k3 harness behavior used by the other test suites.
+source .buildkite/k3_tests/common_scripts/helpers.sh
+merge_pr_base_branch
+
 uv venv --python 3.12 ".venv-${BUILDKITE_BUILD_ID}"
 # shellcheck disable=SC1090 # Buildkite generates a unique virtualenv path per build.
 source ".venv-${BUILDKITE_BUILD_ID}/bin/activate"

--- a/.buildkite/k3_tests/common_scripts/helpers.sh
+++ b/.buildkite/k3_tests/common_scripts/helpers.sh
@@ -23,13 +23,47 @@ github_https_remote_url() {
     esac
 }
 
+pr_base_merge_mode() {
+    local raw_mode="${LMCACHE_PR_BASE_MERGE:-auto}"
+    local normalized_mode
+    normalized_mode="$(printf '%s' "${raw_mode}" | tr '[:upper:]' '[:lower:]')"
+    case "${normalized_mode}" in
+        ""|auto|pr)
+            printf 'auto\n'
+            ;;
+        1|true|yes|on|always|force)
+            printf 'always\n'
+            ;;
+        0|false|no|off|never|skip)
+            printf 'never\n'
+            ;;
+        *)
+            echo "ERROR: invalid LMCACHE_PR_BASE_MERGE=${raw_mode}" >&2
+            echo "Expected one of: auto, always, never" >&2
+            return 1
+            ;;
+    esac
+}
+
 # Merge the PR base branch into the current checkout for Buildkite PR builds.
 # Buildkite's checkout step may leave the pod on the raw PR head commit rather
 # than a synthetic merge commit, so tests can miss conflicts/regressions that
 # only appear once the latest base branch is merged in.
 merge_pr_base_branch() {
+    local merge_mode
+    merge_mode="$(pr_base_merge_mode)"
+    case "${merge_mode}" in
+        never)
+            echo "--- :git: PR-base pre-merge disabled (LMCACHE_PR_BASE_MERGE=${LMCACHE_PR_BASE_MERGE:-auto})"
+            return 0
+            ;;
+        always)
+            echo "--- :git: PR-base pre-merge forced (LMCACHE_PR_BASE_MERGE=${LMCACHE_PR_BASE_MERGE})"
+            ;;
+    esac
+
     local pr_number="${BUILDKITE_PULL_REQUEST:-false}"
-    if [[ -z "${pr_number}" || "${pr_number}" == "false" ]]; then
+    if [[ "${merge_mode}" == "auto" && ( -z "${pr_number}" || "${pr_number}" == "false" ) ]]; then
         echo "--- :git: Not a PR build; skipping base-branch pre-merge"
         return 0
     fi

--- a/.buildkite/k3_tests/common_scripts/upload-pipeline.sh
+++ b/.buildkite/k3_tests/common_scripts/upload-pipeline.sh
@@ -19,8 +19,12 @@ set -euo pipefail
 PIPELINE_FILE="${1:?Usage: upload-pipeline.sh <path/to/pipeline.yml>}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# shellcheck source=path-filter.sh
+# shellcheck source=.buildkite/k3_tests/common_scripts/helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+# shellcheck source=.buildkite/k3_tests/common_scripts/path-filter.sh
 source "${SCRIPT_DIR}/path-filter.sh"
+
+merge_pr_base_branch
 
 if should_skip_ci; then
     echo "+++ :fast_forward: Skipping CI — only trivial files changed"

--- a/.buildkite/operator/integration/pipeline.yaml
+++ b/.buildkite/operator/integration/pipeline.yaml
@@ -3,10 +3,13 @@ steps:
     key: "operator_detect_changes"
     command: |
       set -eu
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
 
-      BASE_REF="origin/dev"
+      BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-dev}"
+      BASE_REF="origin/$$BASE_BRANCH"
 
-      if ! git fetch --quiet origin dev 2>/dev/null; then
+      if ! git fetch --quiet origin "$$BASE_BRANCH" 2>/dev/null; then
         echo "WARN: could not fetch $$BASE_REF; running tests defensively."
         buildkite-agent pipeline upload .buildkite/operator/integration/tests.yaml
         exit 0

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,49 +1,8 @@
-env:
-  PATH: "$HOME/.local/bin:$PATH"
-
 steps:
-  - label: "Unit Tests"
-    key: "unit_tests"
-    timeout_in_minutes: 60
+  - label: ":pipeline: Upload merged unit-test pipeline"
+    key: "upload_unit_tests"
     command: |
-      echo $PWD # for debugging
-
-      uv venv --python 3.12 .venv-$BUILDKITE_BUILD_ID
-      source .venv-$BUILDKITE_BUILD_ID/bin/activate
-      uv pip install --upgrade pip setuptools wheel
-
-      source .buildkite/scripts/pick-free-gpu.sh 18000
-      export CUDA_LAUNCH_BLOCKING=1
-      # Pin torch to a version compatible with the CI machine's CUDA 12.x driver
-      uv pip install "torch>=2.6.0,<2.11.0"
-
-      uv pip install -r requirements/common.txt
-      uv pip install -r requirements/test.txt
-      uv pip install -e . --no-build-isolation
-      uv pip freeze
-
-      LMCACHE_TRACK_USAGE="false" \
-      pytest --maxfail=1 --cov=lmcache \
-        --cov-report term --cov-report=html:coverage-test \
-        --cov-report=xml:coverage-test.xml --html=durations/test.html \
-        --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
-        --ignore=tests/v1/test_nixl_batched_contains.py \
-        --ignore=tests/v1/test_device_id_race.py \
-        --ignore=tests/v1/test_nixl_multipath.py \
-        --ignore=tests/skipped \
-        --ignore=tests/v1/storage_backend/test_eic.py
-
-
-      cat << EOF | buildkite-agent annotate --style "info"
-        Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>
-      EOF
-
-      export TARGET="$PWD"
-      echo "Deleting current workspace $TARGET"
-      cd /
-      sudo rm -rf "$TARGET"
-
-    artifact_paths:
-      - "durations/test.html"
-      - "coverage-test.xml"
-      - "coverage-test/**/*"
+      set -euo pipefail
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+      buildkite-agent pipeline upload .buildkite/pipelines/unit-tests.steps.yml

--- a/.buildkite/pipelines/end-to-end-tests.steps.yml
+++ b/.buildkite/pipelines/end-to-end-tests.steps.yml
@@ -1,0 +1,53 @@
+steps:
+  - label: ":pip: E2E Tests"
+    key: "e2e"
+    command: |
+      echo $PWD # for debugging
+
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+
+      uv venv --python 3.12 .venv-$BUILDKITE_BUILD_ID
+      source .venv-$BUILDKITE_BUILD_ID/bin/activate
+
+      uv pip install --upgrade pip setuptools wheel
+      uv pip install -r requirements/common.txt
+      uv pip install -r requirements/test.txt
+      uv pip install -e . --no-build-isolation
+      uv pip install matplotlib
+      uv pip install pandas
+      # ">=0.0.0.dev0" explicitly limits vLLM to be the only pre-release package.
+      uv pip install -U "vllm>=0.0.0.dev0" --extra-index-url https://wheels.vllm.ai/nightly
+      uv pip freeze
+
+      source .buildkite/scripts/pick-free-gpu.sh 18000
+
+      bash .buildkite/scripts/end-to-end-test.sh
+    artifact_paths:
+      - "test_local_cpu_experimental.csv"
+      - "test_local_cpu_experimental.pdf"
+      - "test_local_disk_experimental.csv"
+      - "test_local_disk_experimental.pdf"
+      - "lmcache-cpu-stdout.log"
+      - "lmcache-cpu-stderr.log"
+      - "vllm-cpu-stdout.log"
+      - "vllm-cpu-stderr.log"
+      - "lmcache-disk-stdout.log"
+      - "lmcache-disk-stderr.log"
+      - "vllm-disk-stdout.log"
+      - "vllm-disk-stderr.log"
+
+  - label: ":wastebasket: Kill all"
+    key: "clean"
+    depends_on: "e2e"
+    allow_dependency_failure: true
+    command: bash .buildkite/scripts/bare-machine-cleanup.sh
+
+  - label: "Clean up"
+    depends_on:
+      - "clean"
+    command: |
+      export TARGET="$PWD"
+      echo "Deleting current workspace $TARGET"
+      cd /
+      sudo rm -rf "$TARGET"

--- a/.buildkite/pipelines/end-to-end-tests.yml
+++ b/.buildkite/pipelines/end-to-end-tests.yml
@@ -1,51 +1,8 @@
 steps:
-  - label: ":pip: E2E Tests"
-    key: "e2e"
+  - label: ":pipeline: Upload merged e2e pipeline"
+    key: "upload_e2e"
     command: |
-      echo $PWD # for debugging
-
-      uv venv --python 3.12 .venv-$BUILDKITE_BUILD_ID
-      source .venv-$BUILDKITE_BUILD_ID/bin/activate
-
-      uv pip install --upgrade pip setuptools wheel 
-      uv pip install -r requirements/common.txt
-      uv pip install -r requirements/test.txt
-      uv pip install -e . --no-build-isolation
-      uv pip install matplotlib
-      uv pip install pandas
-      # ">=0.0.0.dev0" explicitly limits vLLM to be the only pre-release package.
-      uv pip install -U "vllm>=0.0.0.dev0" --extra-index-url https://wheels.vllm.ai/nightly
-      uv pip freeze
-
-
-      source .buildkite/scripts/pick-free-gpu.sh 18000
-
-      bash .buildkite/scripts/end-to-end-test.sh
-    artifact_paths:
-      - "test_local_cpu_experimental.csv"
-      - "test_local_cpu_experimental.pdf"
-      - "test_local_disk_experimental.csv"
-      - "test_local_disk_experimental.pdf"
-      - "lmcache-cpu-stdout.log"
-      - "lmcache-cpu-stderr.log"
-      - "vllm-cpu-stdout.log"
-      - "vllm-cpu-stderr.log"
-      - "lmcache-disk-stdout.log"
-      - "lmcache-disk-stderr.log"
-      - "vllm-disk-stdout.log"
-      - "vllm-disk-stderr.log"
-
-  - label: ":wastebasket: Kill all"
-    key: "clean"
-    depends_on: "e2e"
-    allow_dependency_failure: true
-    command: bash .buildkite/scripts/bare-machine-cleanup.sh
-
-  - label: "Clean up"
-    depends_on:
-        - "clean"
-    command: |
-      export TARGET="$PWD"
-      echo "Deleting current workspace $TARGET"
-      cd /
-      sudo rm -rf "$TARGET"
+      set -euo pipefail
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+      buildkite-agent pipeline upload .buildkite/pipelines/end-to-end-tests.steps.yml

--- a/.buildkite/pipelines/multiprocessing-test.steps.yml
+++ b/.buildkite/pipelines/multiprocessing-test.steps.yml
@@ -1,0 +1,19 @@
+env:
+  DOCKER_BUILDKIT: 1
+
+steps:
+  - label: ":compression: Multiprocessing tests / {{matrix.request_transport}}"
+    key: "test"
+    timeout_in_minutes: 60
+    matrix:
+      setup:
+        request_transport:
+          - "zmq"
+    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
+    command: |
+      set -euo pipefail
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+      .buildkite/scripts/should-run-comprehensive.sh || exit 0
+      chmod +x .buildkite/scripts/multiprocessing-test/*.sh
+      BUILD_ID=${BUILDKITE_BUILD_ID} .buildkite/scripts/multiprocessing-test/run-mp-test.sh

--- a/.buildkite/pipelines/multiprocessing-test.yml
+++ b/.buildkite/pipelines/multiprocessing-test.yml
@@ -2,15 +2,10 @@ env:
   DOCKER_BUILDKIT: 1
 
 steps:
-  - label: ":compression: Multiprocessing tests / {{matrix.request_transport}}"
-    key: "test"
-    timeout_in_minutes: 60
-    matrix:
-      setup:
-        request_transport:
-          - "zmq"
-    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
-    commands:
-      - .buildkite/scripts/should-run-comprehensive.sh || exit 0 # Reuse the trigger condition for comprehensive tests
-      - chmod +x .buildkite/scripts/multiprocessing-test/*.sh
-      - BUILD_ID=${BUILDKITE_BUILD_ID} .buildkite/scripts/multiprocessing-test/run-mp-test.sh
+  - label: ":pipeline: Upload merged multiprocessing pipeline"
+    key: "upload_test"
+    command: |
+      set -euo pipefail
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+      buildkite-agent pipeline upload .buildkite/pipelines/multiprocessing-test.steps.yml

--- a/.buildkite/pipelines/unit-tests.steps.yml
+++ b/.buildkite/pipelines/unit-tests.steps.yml
@@ -1,0 +1,51 @@
+env:
+  PATH: "$HOME/.local/bin:$PATH"
+
+steps:
+  - label: "Unit Tests"
+    key: "unit_tests"
+    timeout_in_minutes: 60
+    command: |
+      echo $PWD # for debugging
+
+      source .buildkite/k3_tests/common_scripts/helpers.sh
+      merge_pr_base_branch
+
+      uv venv --python 3.12 .venv-$BUILDKITE_BUILD_ID
+      source .venv-$BUILDKITE_BUILD_ID/bin/activate
+      uv pip install --upgrade pip setuptools wheel
+
+      source .buildkite/scripts/pick-free-gpu.sh 18000
+      export CUDA_LAUNCH_BLOCKING=1
+      # Pin torch to a version compatible with the CI machine's CUDA 12.x driver
+      uv pip install "torch>=2.6.0,<2.11.0"
+
+      uv pip install -r requirements/common.txt
+      uv pip install -r requirements/test.txt
+      uv pip install -e . --no-build-isolation
+      uv pip freeze
+
+      LMCACHE_TRACK_USAGE="false" \
+      pytest --maxfail=1 --cov=lmcache \
+        --cov-report term --cov-report=html:coverage-test \
+        --cov-report=xml:coverage-test.xml --html=durations/test.html \
+        --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
+        --ignore=tests/v1/test_nixl_batched_contains.py \
+        --ignore=tests/v1/test_device_id_race.py \
+        --ignore=tests/v1/test_nixl_multipath.py \
+        --ignore=tests/skipped \
+        --ignore=tests/v1/storage_backend/test_eic.py
+
+      cat << EOF | buildkite-agent annotate --style "info"
+        Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>
+      EOF
+
+      export TARGET="$PWD"
+      echo "Deleting current workspace $TARGET"
+      cd /
+      sudo rm -rf "$TARGET"
+
+    artifact_paths:
+      - "durations/test.html"
+      - "coverage-test.xml"
+      - "coverage-test/**/*"

--- a/.buildkite/scripts/amd-vllm-bench.sh
+++ b/.buildkite/scripts/amd-vllm-bench.sh
@@ -26,6 +26,11 @@ esac
 CONTAINER_NAME="lmcache-amd-vllm-bench-${BUILDKITE_BUILD_ID}-${MODE}"
 
 cd "${REPO_ROOT}"
+
+# shellcheck source=.buildkite/k3_tests/common_scripts/helpers.sh
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+merge_pr_base_branch
+
 echo "AMD kernel mode: ${MODE}"
 
 if ! command -v docker >/dev/null 2>&1; then

--- a/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
@@ -6,6 +6,13 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=.buildkite/k3_tests/common_scripts/helpers.sh
+source "${SCRIPT_DIR}/../../k3_tests/common_scripts/helpers.sh"
+if ! merge_pr_base_branch; then
+    echo "Failed to pre-merge PR base branch"
+    exit 1
+fi
+
 # Export container names and configuration for all scripts
 export LMCACHE_CONTAINER_NAME="lmcache-mp-test-$$"
 export VLLM_CONTAINER_NAME="vllm-mp-test-$$"

--- a/.buildkite/scripts/vllm-correctness.sh
+++ b/.buildkite/scripts/vllm-correctness.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 #######################################
 : "${BUILD_ID:?BUILD_ID must be set}"
 
+source .buildkite/k3_tests/common_scripts/helpers.sh
+merge_pr_base_branch
+
 #######################################
 # Configuration
 #######################################


### PR DESCRIPTION
## Summary

This is a follow-up / completion of #4536.

#4536 fixed the most obvious gap by pre-merging the PR base branch inside the main k3 setup scripts, but we still had CI paths that consumed the raw PR checkout before those setup scripts ran. In practice that means some Buildkite jobs could still expand/upload pipeline steps, diff against the base branch, or build/install from source using the unmerged PR head instead of `PR head + latest target branch`.

The current issue is still visible in this Buildkite run:
- https://buildkite.com/lmcache/k3-multiprocess-test/builds/4479

## What this PR changes

- generalize `merge_pr_base_branch()` with `LMCACHE_PR_BASE_MERGE=auto|always|never`
- pre-merge before dynamic pipeline upload in the k3 shared upload helper
- convert several repo-defined pipelines into `bootstrap -> upload merged steps` so the step definitions themselves also come from the merged checkout
- wire the same pre-merge behavior into remaining direct CI entrypoints that install LMCache or build the multiprocessing image
- make the operator integration diff logic follow `BUILDKITE_PULL_REQUEST_BASE_BRANCH` instead of assuming `dev`

## Why this is needed

Without this, #4536 only protects the subset of jobs that happen to reach `setup-env.sh` / `setup-lmcache-only-env.sh` first. Other paths can still validate stale pipeline definitions or stale source state, which is the same class of problem #4536 was meant to eliminate.

## Validation

- `git diff --check`
- `bash -n` on the modified shell entrypoints/helpers
- YAML parse check for the modified/new Buildkite pipeline files
- temporary git-repo simulation confirming `merge_pr_base_branch` creates the expected merge commit, is idempotent on rerun, and can be disabled with `LMCACHE_PR_BASE_MERGE=never`

## Notes

I also ran `SKIP=rust-fmt,rust-clippy python3 -m pre_commit run --all-files` locally. The only remaining failure was an unrelated pre-existing `isort` rewrite of `setup.py`, which is intentionally left out of this PR.
