### PR TITLE
fix: support padded NHD content-size KV caches

### DIFF
--- a/csrc/kv_transfer_plan_types.h
+++ b/csrc/kv_transfer_plan_types.h
@@ -39,11 +39,10 @@ struct PageBufferShapeDesc {
   // semantics already absorb every inner-dim extent (including
   // ``kv_size``), so DO NOT pre-multiply by any inner dim.
   //
-  // Honoured today only by NL_X_NB_BS_HS (per-layer [NB, BS, HS],
-  // MLA). NL_X_NB_TWO_BS_NH_HS is restricted to the tight form
-  // upstream and leaves this field at 0; all other formats either
-  // pack non-block info into dim-0 or do not support dim-0 padding,
-  // and ignore this field.
+  // Honoured today by MLA layouts and NL_X_NB_BS_NH_CS (per-layer
+  // [NB, BS, NH, CS]). NL_X_NB_TWO_BS_NH_HS is restricted to the tight
+  // form upstream and leaves this field at 0; all other formats either pack
+  // non-block info into dim-0 or do not support dim-0 padding.
   int block_stride_elems;
 
   template <typename ScalarType>
@@ -59,8 +58,7 @@ struct PageBufferShapeDesc {
   // Per (K or V) block step along dim-0, expressed in ``ScalarType``
   // element units (the kernel's working dtype, e.g. uint4 / uint32_t /
   // uint16_t). Returns the tight ``bs * nh * hs`` by default, or the
-  // physical ``block_stride_elems`` when dim-0 carries padding (today
-  // only NL_X_NB_BS_HS, see ``block_stride_elems`` above). Every
+  // physical ``block_stride_elems`` when dim-0 carries padding. Every
   // ``calculate_engine_global_offset`` branch uses this as the dim-0
   // step, so honouring padding here propagates to all formats without
   // per-branch changes.

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -477,8 +477,8 @@ def get_device(kv_caches: DiscoverableKVCache) -> torch.device:
 # Formats whose per-layer tensor dim-0 is the *block* axis AND for
 # which we currently support dim-0 padding (e.g. DeepSeek V4
 # compressor / indexer caches sharing a KV pool with larger attn
-# groups). Today only the MLA layout (``NL_X_NB_BS_HS``, kv_size==1)
-# is exercised by real mixed-compression workloads.
+# groups). This includes MLA layouts and blocks-first fused NHD attention
+# layouts whose physical row width can be inherited from a larger KV group.
 #
 # ``NL_X_NB_TWO_BS_NH_HS`` *could* in principle also be the block
 # axis on dim-0, but no real serving engine emits a padded layout of
@@ -495,6 +495,7 @@ _BLOCK_AXIS_FORMATS: frozenset = frozenset(
     {
         lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
         lmcache_native.EngineKVFormat.NL_X_NB_BSV_BSS,
+        lmcache_native.EngineKVFormat.NL_X_NB_BS_NH_CS,
     }
 )
 
@@ -574,8 +575,7 @@ def resolve_block_stride_and_log_layout(
                     "resolve_block_stride_and_log_layout: group's probe "
                     f"tensor has dim-0 padding ({padding} elements per "
                     f"block) but engine_kv_format={engine_kv_format!r} is not "
-                    "a supported dim-0-padded format (only "
-                    "NL_X_NB_BS_HS is); downstream transfer kernels "
+                    "a supported dim-0-padded format; downstream transfer kernels "
                     "cannot honour this padding and would read/write "
                     "wrong bytes. "
                     f"layer_idx={layer_idx}, shape={tuple(rep.shape)}, "

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -83,6 +83,7 @@ def _tensor_from_ptr(
     shape: tuple[int, ...],
     dtype: torch.dtype,
     device: torch.device | str | None = None,
+    stride: tuple[int, ...] | None = None,
 ) -> torch.Tensor:
     """
     Create a tensor view over a raw pointer (zero-copy where possible).
@@ -98,6 +99,8 @@ def _tensor_from_ptr(
                 - "cuda" / "cuda:N" / torch.device("cuda", N) → CUDA pointer
                 - "musa" / "musa:N" / torch.device("musa", N) → MUSA pointer
                   If None and ptr looks like a CUDA/MUSA ptr, pass device explicitly.
+        stride: Optional physical strides in elements. When provided, the raw
+            storage span is reconstructed and returned through ``as_strided``.
 
     Returns:
         A tensor that shares memory with the original pointer.
@@ -130,33 +133,50 @@ def _tensor_from_ptr(
     # ------------------------------------------------------------------ #
     # Compute size                                                       #
     # ------------------------------------------------------------------ #
-    numel = 1
-    for dim in shape:
-        numel *= int(dim)
+    if stride is not None and len(stride) != len(shape):
+        raise ValueError("stride and shape must have the same rank")
+    if stride is None:
+        numel = 1
+        for dim in shape:
+            numel *= int(dim)
+    elif any(int(dim) == 0 for dim in shape):
+        numel = 0
+    else:
+        numel = 1 + sum(
+            (int(dim) - 1) * int(dim_stride)
+            for dim, dim_stride in zip(shape, stride, strict=True)
+        )
     element_size = torch.empty((), dtype=dtype).element_size()
     total_bytes = numel * element_size
+    storage_shape = shape if stride is None else (numel,)
 
     # ------------------------------------------------------------------ #
     # CPU path                                                           #
     # ------------------------------------------------------------------ #
     if device.type == "cpu":
-        return _tensor_from_cpu_ptr(ptr, shape, dtype, numel, total_bytes)
+        tensor = _tensor_from_cpu_ptr(ptr, storage_shape, dtype, numel, total_bytes)
 
     # ------------------------------------------------------------------ #
     # CUDA path                                                          #
     # ------------------------------------------------------------------ #
     if device.type == "cuda":
-        return _tensor_from_cuda_ptr(ptr, shape, dtype, device, numel, total_bytes)
+        tensor = _tensor_from_cuda_ptr(
+            ptr, storage_shape, dtype, device, numel, total_bytes
+        )
 
     # ------------------------------------------------------------------ #
     # MUSA path                                                          #
     # ------------------------------------------------------------------ #
     if device.type == "musa":
-        return _tensor_from_musa_ptr(ptr, shape, dtype, device, total_bytes)
+        tensor = _tensor_from_musa_ptr(ptr, storage_shape, dtype, device, total_bytes)
 
-    raise ValueError(
-        f"Unsupported device type: {device.type!r}. Expected 'cpu', 'cuda', or 'musa'."
-    )
+    if device.type not in ("cpu", "cuda", "musa"):
+        raise ValueError(
+            f"Unsupported device type: {device.type!r}. "
+            "Expected 'cpu', 'cuda', or 'musa'."
+        )
+
+    return tensor.as_strided(shape, stride) if stride is not None else tensor
 
 
 # ====================================================================== #
@@ -855,6 +875,25 @@ def _per_layer_paged_shape(
     return (nb, 2, bs, nh, hs)
 
 
+def _per_layer_paged_stride(
+    engine_kv_format: EngineKVFormat,
+    shape_desc: PageBufferShapeDesc,
+) -> tuple[int, ...] | None:
+    """Return a physical per-layer stride when dim 0 is padded."""
+    block_stride = int(getattr(shape_desc, "block_stride_elems", 0))
+    if block_stride <= 0:
+        return None
+
+    nh = int(shape_desc.nh)
+    hs = int(shape_desc.hs)
+    fmt = int(engine_kv_format)
+    if fmt == int(EngineKVFormat.NL_X_NB_BS_HS):
+        return (block_stride, hs, 1)
+    if fmt == int(EngineKVFormat.NL_X_NB_BS_NH_CS):
+        return (block_stride, nh * hs, hs, 1)
+    return None
+
+
 def _infer_kv_dtype(
     paged_buffer_ptrs_tensor: object,
     lmcache_objects_ptrs: object,
@@ -1030,8 +1069,9 @@ def _normalize_paged_layers(
         nh = int(shape_desc.nh)
         hs = int(shape_desc.hs)
         per_shape = _per_layer_paged_shape(engine_kv_format, nb, bs, nh, hs)
+        per_stride = _per_layer_paged_stride(engine_kv_format, shape_desc)
         return [
-            _tensor_from_ptr(int(p.item()), per_shape, dtype, device)
+            _tensor_from_ptr(int(p.item()), per_shape, dtype, device, stride=per_stride)
             for p in paged_buffer_ptrs_tensor
         ]
     if isinstance(paged_buffer_ptrs_tensor, list):

--- a/tests/v1/gpu_connector/test_blocks_first_cs_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_cs_kv_format.py
@@ -36,6 +36,23 @@ def _raw_blocks_first_caches(device: str = "cpu") -> list[torch.Tensor]:
     return [torch.randn(NB, NH, BS, 2 * HS, device=device) for _ in range(NL)]
 
 
+def _padded_nhd_caches(
+    *, canary: float = -123.0
+) -> tuple[list[torch.Tensor], list[torch.Tensor], int]:
+    """Build NHD cache views whose dim-0 stride includes trailing padding."""
+    block_elems = BS * NH * 2 * HS
+    physical_stride = block_elems + 32
+    backings = [torch.full((NB, physical_stride), canary) for _ in range(NL)]
+    views = [
+        backing.as_strided(
+            (NB, BS, NH, 2 * HS),
+            (physical_stride, NH * 2 * HS, 2 * HS, 1),
+        )
+        for backing in backings
+    ]
+    return views, backings, physical_stride
+
+
 def test_discovery_keeps_raw_shape():
     fmt, norm = U.normalize_kv_and_discover_format(
         _raw_blocks_first_caches(), EngineType.VLLM, HINTS
@@ -166,3 +183,61 @@ def test_multi_layer_block_kv_transfer_roundtrip():
 
     for original, recovered in zip(norm, out, strict=True):
         assert torch.equal(original, recovered)
+
+
+def test_padded_nhd_registration_and_pointer_transfer_preserve_padding():
+    """Padded NHD fused caches register and transfer without touching padding."""
+    fmt = lmcache_native.EngineKVFormat.NL_X_NB_BS_NH_CS
+    caches, _, physical_stride = _padded_nhd_caches()
+    for layer_idx, cache in enumerate(caches):
+        cache.copy_(
+            torch.arange(cache.numel(), dtype=cache.dtype).reshape(cache.shape)
+            + layer_idx * cache.numel()
+        )
+
+    block_stride = U.resolve_block_stride_and_log_layout(caches, fmt, 0, 0)
+    assert block_stride == physical_stride
+
+    sd = U.make_page_buffer_shape_desc(
+        caches,
+        fmt,
+        layer_idx=0,
+        num_layers_in_group=NL,
+        num_blocks=NB,
+        block_size=BS,
+        block_stride_elems=block_stride,
+    )
+    assert sd.block_stride_elems == physical_stride
+
+    chunk_tokens = NB * BS
+    obj = torch.zeros((NL, chunk_tokens, NH * 2 * HS), dtype=caches[0].dtype)
+    cache_ptrs = torch.tensor([cache.data_ptr() for cache in caches])
+    fallback_multi_layer_block_kv_transfer(
+        cache_ptrs,
+        [obj.data_ptr()],
+        list(range(NB)),
+        torch.device("cpu"),
+        lmcache_native.TransferDirection.D2H,
+        sd,
+        chunk_tokens,
+        fmt,
+        0,
+    )
+
+    out, out_backings, _ = _padded_nhd_caches()
+    out_ptrs = torch.tensor([cache.data_ptr() for cache in out])
+    fallback_multi_layer_block_kv_transfer(
+        out_ptrs,
+        [obj.data_ptr()],
+        list(range(NB)),
+        torch.device("cpu"),
+        lmcache_native.TransferDirection.H2D,
+        sd,
+        chunk_tokens,
+        fmt,
+        0,
+    )
+
+    for original, recovered, backing in zip(caches, out, out_backings, strict=True):
+        assert torch.equal(original, recovered)
+        assert torch.all(backing[:, original.shape[1] * NH * 2 * HS :] == -123.0)


### PR DESCRIPTION
## Summary
- recognize `NL_X_NB_BS_NH_CS` as a block-axis layout and preserve its physical dim-0 stride
- reconstruct strided paged-buffer views correctly in the Torch pointer fallback
- add a padded NHD round-trip regression test that verifies payload data and padding canaries

Fixes #4771

## Validation
- `TMPDIR=$PWD/.tmp-build MAX_JOBS=1 NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `.venv/bin/python -m pytest -q tests/v1/gpu_connector tests/v1/test_torch_ops.py tests/v1/test_mp_mem_kernels.py` (267 passed, 17 skipped)
- `TMPDIR=$PWD/.tmp-build SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`