### PR TITLE
fix: tolerate optional adapter import failures

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/factory.py
+++ b/lmcache/v1/distributed/l2_adapters/factory.py
@@ -104,19 +104,18 @@ def ensure_adapter_loaded(name: str) -> None:
     been tried).
 
     Raises:
-        ImportError: If a module fails to import due to
-            a missing third-party dependency **and** it
-            was the last candidate.
+        Exception: If an adapter module fails during import
+            and it was the last candidate.
     """
     if name in _L2_ADAPTER_FACTORY_REGISTRY:
         return
 
-    last_err: ImportError | None = None
+    last_err: Exception | None = None
     while _PENDING_MODULES:
         mod_path = _PENDING_MODULES.pop(0)
         try:
             importlib.import_module(mod_path)
-        except ImportError as exc:
+        except Exception as exc:
             logger.debug(
                 "Skipping module %s (import failed: %s)",
                 mod_path,
@@ -129,7 +128,7 @@ def ensure_adapter_loaded(name: str) -> None:
             return
 
     # If we exhausted all pending modules and still
-    # didn't find the name, the last ImportError (if
+    # didn't find the name, the last import error (if
     # any) might be the root cause.
     if last_err is not None and name not in _L2_ADAPTER_FACTORY_REGISTRY:
         raise last_err
@@ -145,10 +144,12 @@ def load_all_adapters() -> None:
         mod_path = _PENDING_MODULES.pop(0)
         try:
             importlib.import_module(mod_path)
-        except ImportError:
+        except Exception as exc:
             logger.debug(
-                "Skipping module %s during bulk load",
+                "Skipping module %s during bulk load (%s: %s)",
                 mod_path,
+                type(exc).__name__,
+                exc,
             )
 
 

--- a/tests/v1/distributed/test_l2_adapter_factory.py
+++ b/tests/v1/distributed/test_l2_adapter_factory.py
@@ -5,6 +5,7 @@ PluginL2AdapterConfig.
 """
 
 # Standard
+from typing import cast
 import os
 import tempfile
 import types
@@ -563,6 +564,25 @@ class TestLazyLoading:
         with pytest.raises(ImportError, match="bad_b"):
             fmod.ensure_adapter_loaded("missing")
 
+    def test_ensure_skips_non_import_error_until_found(self, monkeypatch) -> None:
+        """An optional adapter's import-time error does not block another."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters import factory as fmod
+
+        def _selective_import(path: str) -> None:
+            if path == "broken_optional":
+                raise TypeError("incompatible protobuf")
+            fmod._L2_ADAPTER_FACTORY_REGISTRY["target"] = cast(
+                fmod.L2AdapterFactory, lambda c, d: None
+            )
+
+        monkeypatch.setattr("importlib.import_module", _selective_import)
+        fmod._PENDING_MODULES.extend(["broken_optional", "target_module"])
+
+        fmod.ensure_adapter_loaded("target")
+
+        assert "target" in fmod._L2_ADAPTER_FACTORY_REGISTRY
+
     def test_ensure_no_error_when_not_found_silently(self, monkeypatch):
         """When pending modules import OK but name is
         still missing, no error is raised (no last_err).
@@ -609,6 +629,26 @@ class TestLazyLoading:
 
         monkeypatch.setattr("importlib.import_module", _selective_import)
         fmod._PENDING_MODULES.extend(["good1", "bad", "good2"])
+        fmod.load_all_adapters()
+
+        assert imported == ["good1", "good2"]
+        assert len(fmod._PENDING_MODULES) == 0
+
+    def test_load_all_adapters_skips_non_import_errors(self, monkeypatch) -> None:
+        """CLI adapter discovery survives optional dependency incompatibility."""
+        # First Party
+        from lmcache.v1.distributed.l2_adapters import factory as fmod
+
+        imported: list[str] = []
+
+        def _selective_import(path: str) -> None:
+            if path == "broken_bigtable":
+                raise TypeError("Descriptors cannot be created directly")
+            imported.append(path)
+
+        monkeypatch.setattr("importlib.import_module", _selective_import)
+        fmod._PENDING_MODULES.extend(["good1", "broken_bigtable", "good2"])
+
         fmod.load_all_adapters()
 
         assert imported == ["good1", "good2"]


### PR DESCRIPTION
## Summary
- prevent optional adapter import-time exceptions from crashing `lmcache server --help`
- continue lazy adapter discovery when an unrelated optional adapter raises a non-`ImportError` exception
- preserve the underlying import exception when the requested adapter cannot be loaded
- add regression coverage for protobuf-style `TypeError` failures

Fixes #4204

## Validation
- `TMPDIR=$PWD/.tmp-build MAX_JOBS=1 NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `.venv/bin/python -m pytest -q tests/cli/commands/test_server.py tests/v1/distributed/test_l2_adapter_factory.py` (55 passed, 1 skipped)
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`