### PR TITLE
[BugFix] Recover local disk KV cache after restart (#1175)

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -4,6 +4,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
+import json
 import os
 import threading
 import time
@@ -15,7 +16,13 @@ import torch
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
-from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
+from lmcache.utils import (
+    STR_DTYPE_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_STR_DTYPE,
+    CacheEngineKey,
+    DiskCacheMetadata,
+    _lmcache_nvtx_annotate,
+)
 from lmcache.v1.cache_controller.message import OpType
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
@@ -207,13 +214,124 @@ class LocalDiskBackend(StorageBackendInterface):
     ) -> str:
         return os.path.join(self.path, key.to_string().replace("/", "-") + ".pt")
 
+    def _meta_path(self, path: str) -> str:
+        """Sidecar path holding the metadata needed to reconstruct a chunk.
+
+        The ``.pt`` file stores raw KV bytes only (see ``write_file``), so
+        shape / dtype / format are persisted alongside it to survive a
+        restart (issue #1175).
+        """
+        return path + ".meta"
+
+    def _persist_metadata(
+        self,
+        path: str,
+        size: int,
+        shape: Optional[torch.Size],
+        dtype: Optional[torch.dtype],
+        fmt: Optional[MemoryFormat],
+        cached_positions: Optional[torch.Tensor],
+    ) -> None:
+        """Write the sidecar metadata for a stored chunk.
+
+        The write is atomic (temp file + ``os.replace``) so a crash mid-write
+        never leaves a half-written sidecar that recovery would trust.
+        """
+        meta = {
+            "size": int(size),
+            "shape": list(shape) if shape is not None else None,
+            "dtype": (
+                TORCH_DTYPE_TO_STR_DTYPE.get(dtype) if dtype is not None else None
+            ),
+            "fmt": fmt.value if fmt is not None else None,
+            "cached_positions": (
+                cached_positions.tolist() if cached_positions is not None else None
+            ),
+        }
+        meta_path = self._meta_path(path)
+        tmp_path = meta_path + ".tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(meta, f)
+            os.replace(tmp_path, meta_path)
+        except OSError as e:
+            logger.warning("Failed to persist disk cache metadata for %s: %s", path, e)
+
+    def _recover_from_disk(self, key: CacheEngineKey) -> bool:
+        """Rebuild an in-memory index entry from a chunk already on disk.
+
+        A fresh backend starts with an empty ``self.dict``, so a chunk written
+        by a previous run would be a miss and get recomputed (issue #1175).
+        When an in-memory lookup misses, we fall back to the filesystem: if the
+        deterministic ``.pt`` path and its sidecar both exist, the entry is
+        reconstructed and inserted into ``self.dict``.
+
+        :returns: True if the key is now present in ``self.dict``.
+        """
+        # A chunk whose write is still in flight may have an incomplete file
+        # or no sidecar yet — never recover it.
+        if self.exists_in_put_tasks(key):
+            return False
+
+        path = self._key_to_path(key)
+        meta_path = self._meta_path(path)
+        if not (os.path.exists(path) and os.path.exists(meta_path)):
+            return False
+
+        try:
+            with open(meta_path, "r") as f:
+                meta = json.load(f)
+            shape = torch.Size(meta["shape"]) if meta.get("shape") is not None else None
+            dtype_str = meta.get("dtype")
+            dtype = (
+                STR_DTYPE_TO_TORCH_DTYPE[dtype_str] if dtype_str is not None else None
+            )
+            fmt = MemoryFormat(meta["fmt"]) if meta.get("fmt") is not None else None
+            cached_positions = (
+                torch.tensor(meta["cached_positions"])
+                if meta.get("cached_positions") is not None
+                else None
+            )
+            size = int(meta.get("size", os.path.getsize(path)))
+        except (OSError, KeyError, ValueError, json.JSONDecodeError) as e:
+            logger.warning(
+                "Failed to recover disk cache metadata from %s: %s", meta_path, e
+            )
+            return False
+
+        with self.disk_lock:
+            if key in self.dict:
+                # Another thread recovered it first.
+                return True
+            self.dict[key] = DiskCacheMetadata(
+                path, size, shape, dtype, cached_positions, fmt, 0
+            )
+            self.cache_policy.update_on_put(key)
+            self.current_cache_size += size
+            self.usage += size
+
+        self.stats_monitor.update_local_storage_usage(self.usage)
+        return True
+
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
+        with self.disk_lock:
+            if key in self.dict:
+                if pin:
+                    self.dict[key].pin()
+                    # vllm lookup sets pin to True
+                    self.keys_in_request.append(key)
+                return True
+
+        # Miss in memory: the chunk may still be on disk from a previous run
+        # (issue #1175). Attempt lazy recovery before declaring a miss.
+        if not self._recover_from_disk(key):
+            return False
+
         with self.disk_lock:
             if key not in self.dict:
                 return False
             if pin:
                 self.dict[key].pin()
-                # vllm lookup sets pin to True
                 self.keys_in_request.append(key)
             return True
 
@@ -273,6 +391,13 @@ class LocalDiskBackend(StorageBackendInterface):
 
             os.remove(path)
 
+            # Remove the recovery sidecar too so it cannot outlive its data
+            # (issue #1175).
+            try:
+                os.remove(self._meta_path(path))
+            except FileNotFoundError:
+                pass
+
             if force:
                 self.cache_policy.update_on_force_evict(key)
 
@@ -306,6 +431,12 @@ class LocalDiskBackend(StorageBackendInterface):
                 self.dict[key] = DiskCacheMetadata(
                     path, size, shape, dtype, cached_positions, fmt, 0
                 )
+
+        # Persist a sidecar so this chunk can be recovered after a restart
+        # (issue #1175). Only for newly stored keys — an existing key already
+        # has its sidecar on disk.
+        if not has_stored:
+            self._persist_metadata(path, size, shape, dtype, fmt, cached_positions)
 
         # Push kv admit msg with batching
         if self.batched_msg_sender is not None and not has_stored:
@@ -612,10 +743,17 @@ class LocalDiskBackend(StorageBackendInterface):
         pin: bool = False,
     ) -> int:
         num_hit_counts = 0
-        with self.disk_lock:
-            for key in keys:
+        for key in keys:
+            with self.disk_lock:
+                present = key in self.dict
+            # Fall back to disk for chunks cached before a restart (#1175).
+            if not present:
+                present = self._recover_from_disk(key)
+            if not present:
+                break
+            with self.disk_lock:
                 if key not in self.dict:
-                    return num_hit_counts
+                    break
                 if pin:
                     self.dict[key].pin()
                     self.keys_in_request.append(key)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -654,3 +654,113 @@ class TestSubmitPutTask:
         memory_obj.get_physical_size.assert_not_called()
         memory_obj.ref_count_up.assert_not_called()
         callback.assert_not_called()
+
+
+class TestRestartPersistence:
+    """Regression tests for issue #1175.
+
+    KV chunks written to the local disk backend must remain reusable after a
+    process restart.  A restart is modelled by dropping a backend and creating
+    a brand-new one over the same directory: the new backend starts with an
+    empty in-memory index (``self.dict``), so it must rebuild index entries
+    from what is already on disk instead of forcing recomputation.
+    """
+
+    _SHAPE = torch.Size([28, 2, 256, 8, 128])
+    _DTYPE = torch.bfloat16
+    _FMT = MemoryFormat.KV_2LTD
+
+    def _make_backend(self, disk_path, loop, cpu_backend) -> LocalDiskBackend:
+        config = create_test_config(disk_path)
+        return LocalDiskBackend(
+            config=config,
+            loop=loop,
+            local_cpu_backend=cpu_backend,
+            dst_device=f"{torch_device_type}:0",
+        )
+
+    def _nbytes(self) -> int:
+        n = self._DTYPE.itemsize
+        for s in self._SHAPE:
+            n *= s
+        return n
+
+    def _store(self, backend: LocalDiskBackend, key: CacheEngineKey) -> bytes:
+        """Persist a chunk through the backend exactly like
+        ``async_save_bytes_to_disk`` does: write the raw ``.pt`` file, then
+        register the key via ``insert_key``.
+        """
+        path = backend._key_to_path(key)
+        data = os.urandom(self._nbytes())
+        with open(path, "wb") as f:
+            f.write(data)
+        backend.insert_key(
+            key,
+            size=len(data),
+            shape=self._SHAPE,
+            dtype=self._DTYPE,
+            fmt=self._FMT,
+        )
+        return data
+
+    def test_contains_after_restart(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """contains() must find a chunk written before a restart."""
+        key = create_test_key(300)
+        b1 = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        data = self._store(b1, key)
+        assert b1.contains(key)
+        path = b1._key_to_path(key)
+
+        # --- restart: fresh backend over the same directory ---
+        b2 = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        assert os.path.exists(path), "the .pt file must survive the restart"
+        assert len(b2.dict) == 0, "a fresh backend starts with an empty index"
+
+        assert b2.contains(key), "cached chunk should be reusable after restart"
+
+        mem = b2.get_blocking(key)
+        assert mem is not None
+        assert bytes(mem.byte_array) == data, "recovered data must be intact"
+        local_cpu_backend.memory_allocator.close()
+
+    def test_batched_async_contains_after_restart(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """The async (batched) lookup path must also recover from disk."""
+        keys = [create_test_key(i) for i in range(310, 313)]
+        b1 = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        for k in keys:
+            self._store(b1, k)
+
+        b2 = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        n = async_loop.run_until_complete(
+            b2.batched_async_contains("lookup", keys, pin=False)
+        )
+        assert n == len(keys)
+        local_cpu_backend.memory_allocator.close()
+
+    def test_no_recovery_without_data(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """A key that was never stored is still a miss after a restart."""
+        b = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        assert not b.contains(create_test_key(320))
+        local_cpu_backend.memory_allocator.close()
+
+    def test_inflight_write_not_recovered(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """A chunk whose write is still in progress must not be recovered as a
+        hit, because its file/metadata may be incomplete."""
+        key = create_test_key(330)
+        b1 = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        self._store(b1, key)
+
+        b2 = self._make_backend(temp_disk_path, async_loop, local_cpu_backend)
+        b2.disk_worker.insert_put_task(key)
+        assert not b2.contains(key), "in-flight write must not be a recovered hit"
+        b2.disk_worker.remove_put_task(key)
+        assert b2.contains(key), "recovery succeeds once the write completes"
+        local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #1175. `LocalDiskBackend` wrote KV chunks to disk but kept its chunk
index only in memory (`self.dict`). After a process restart the index was
empty, so `contains()` missed for chunks that were still on disk, and vLLM
recomputed the prefix and re-wrote identical KV instead of reusing it. This
defeats the purpose of disk offload across restarts and, with the builtin
prefix hash, silently fills the disk with duplicate-content files.

This PR makes disk KV reusable across a restart:

- **Self-describing chunks**: on store, write a small sidecar `<chunk>.pt.meta`
  (JSON: shape / dtype / format / size / cached_positions) next to the `.pt`.
  The `.pt` holds raw bytes only, so the metadata needed to reconstruct a
  `MemoryObj` must be persisted separately. Sidecar writes are atomic
  (temp file + `os.replace`) so a crash never leaves a half-written sidecar.
- **Lazy recovery on lookup**: when an in-memory lookup misses, check the
  deterministic on-disk `.pt` and its sidecar; if both exist, rebuild the
  `DiskCacheMetadata` and register it (with correct size / usage / policy
  accounting). Wired into both lookup entry points, `contains()` and
  `batched_async_contains()`. In-flight writes are skipped
  (`exists_in_put_tasks`), and the sidecar is removed on eviction.

This is the lazy filesystem-query direction suggested on #1175 (no central
manifest, so no manifest consistency / path-traversal surface).

**Special notes for your reviewers**:

- Verified with a real vLLM restart (offline `LLM`, `LMCacheConnectorV1`,
  disk-only offload). Same prompt, store in one process, load in a fresh one:

  | Model | Tokens reused after restart (before -> after) | Retrieve throughput |
  |-------|-----------------------------------------------|---------------------|
  | Qwen2.5-0.5B      | 0 -> 25,856 / 26,009 | -            |
  | Qwen2.5-Coder-3B  | 0 -> 11,008 / 11,009 | 17.1 GB/s    |
  | MegaBeam-Mistral-7B | 0 -> 53,760 / 54,011 | 24.3 GB/s  |
  | Qwen2.5-Coder-32B | 0 -> 11,008 / 11,009 | 23.6 GB/s    |

  Before the fix every reload is a full miss (0 reused). The trailing partial
  chunk is not stored (`save_unfull_chunk=False`), hence the small remainder.

- Cross-restart reuse also requires a stable prefix hash across processes. With
  the builtin hash, `PYTHONHASHSEED` must be set consistently
  (as documented in `token_database.py`); otherwise keys differ per process and
  nothing is reusable regardless of this fix.

**Relationship to #2734**: This overlaps with the earlier (now stale) #2734 by @DongDongJu, which I studied before writing this. That PR explored a metadata manifest and grew large; this one deliberately takes the lighter lazy-recovery + per-chunk sidecar route (no central manifest, so none of the manifest consistency / path-traversal concerns raised there) and keeps the diff small. Happy to consolidate if the maintainers prefer one direction.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
