### PR TITLE
[good-first-issue] serde: defer timing log formatting (#4779)

### DIFF
--- a/lmcache/storage_backend/serde/serde.py
+++ b/lmcache/storage_backend/serde/serde.py
@@ -39,7 +39,7 @@ class SerializerDebugWrapper(Serializer):
         bs = self.s.to_bytes(t)
         end = time.perf_counter()
 
-        logger.debug(f"Serialization took {end - start:.2f} seconds")
+        logger.debug("Serialization took %.2f seconds", end - start)
         return bs
 
 
@@ -71,5 +71,5 @@ class DeserializerDebugWrapper(Deserializer):
         ret = self.d.from_bytes(t)
         end = time.perf_counter()
 
-        logger.debug(f"Deserialization took {(end - start) * 1000:.2f} ms")
+        logger.debug("Deserialization took %.2f ms", (end - start) * 1000)
         return ret


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #4779
Refs #3372

Changes the two timing debug logs in `serde.py` from f-strings to deferred logger arguments. The messages keep the same two-decimal formatting, but Python no longer builds them when debug logging is disabled.

**Special notes for your reviewers**:

- This is my first LMCache PR.
- `pre-commit run --all-files` passes.
- `python -m compileall -q lmcache/storage_backend/serde/serde.py` passes.
- I did not add a unit test because this only changes how the existing log messages are formatted.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
