### PR TITLE
[fix]  derive fused-packed rope geometry from the format spec fact

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -37,6 +37,7 @@ from lmcache.v1.distributed.api import (
 from lmcache.v1.distributed.bitmap_ops.fold import fold_unfold_ranked
 from lmcache.v1.distributed.storage_manager import PrefetchHandle
 from lmcache.v1.gpu_connector.gpu_ops import lmcache_memcpy_async_h2d
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.mp_coordinator.blend_client import PENDING
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -576,17 +577,12 @@ def _cb_group_rope_geometry(
             "(2), fused-packed K/V, key-only (1), and declared-MLA "
             "layouts are supported."
         )
-    _ekf = getattr(group, "engine_kv_format", None)
-    # Both spellings of blocks-first fused K/V must be recognised. The vLLM
-    # detector used to split the trailing 2*head_size axis and report
-    # *_TWO_HS; it now keeps the tensor raw and reports *_CS. Matching only
-    # *_TWO_HS leaves fused_packed False on current vLLM, which halves
-    # per_head, doubles n_heads, and re-RoPEs across the V plane.
-    fused_packed = _ekf is not None and int(_ekf) in (
-        int(lmcache_native.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
-        int(lmcache_native.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS),
-        int(lmcache_native.EngineKVFormat.NL_X_NB_NH_BS_CS),
-        int(lmcache_native.EngineKVFormat.NL_X_NB_BS_NH_CS),
+    # Use the spec fact, not a format list: a missed fused format is treated
+    # as split K/V and the V half of every head gets re-RoPE'd.
+    engine_kv_format = getattr(group, "engine_kv_format", None)
+    fused_packed = (
+        engine_kv_format is not None
+        and get_spec_class(engine_kv_format).is_fused_packed
     )
     per_head = head_size * (2 if fused_packed else 1)
     n_heads = hidden_dim // per_head

--- a/tests/v1/multiprocess/test_cb_fused_geometry.py
+++ b/tests/v1/multiprocess/test_cb_fused_geometry.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CB re-RoPE geometry must follow each format's ``is_fused_packed`` spec fact.
+
+Fused blocks-first K/V packs K and V into one ``2 * head_size`` row per head
+(``kv_size == 1``). If ``_cb_group_rope_geometry`` misclassifies such a group
+as split K/V it halves ``per_head``, doubles ``n_heads``, and the rope kernel
+then rotates the V half of every head. The helper used to decide this from a
+hardcoded format list, so any fused format added later silently took the
+split path; these tests pin the decision to the spec fact for every
+``EngineKVFormat`` so a new format cannot regress it. CPU only.
+"""
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
+from lmcache.v1.multiprocess.modules.blend import _cb_group_rope_geometry
+import lmcache.lmcache_native as lmcache_native
+
+F = lmcache_native.EngineKVFormat
+NH, HS = 8, 64
+
+
+def _group(engine_kv_format, tokens_per_block: int = 4) -> SimpleNamespace:
+    """Minimal kernel-group stand-in carrying only what the helper reads."""
+    return SimpleNamespace(
+        tokens_per_block=tokens_per_block,
+        slots_per_block=tokens_per_block,
+        engine_kv_format=engine_kv_format,
+    )
+
+
+def _all_formats() -> list:
+    return [v for v in vars(F).values() if isinstance(v, F)]
+
+
+@pytest.mark.parametrize("fmt", _all_formats(), ids=lambda f: f.name)
+def test_fused_packed_follows_spec_fact(fmt):
+    """For every format, the rope geometry agrees with the spec's fused fact:
+    fused rows are ``2 * head_size`` wide and the head count is unchanged."""
+    spec = get_spec_class(fmt)
+    kv_size = 1 if (spec.is_fused_packed or spec.is_mla) else 2
+    per_head_expected = 2 * HS if spec.is_fused_packed else HS
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group(fmt), kv_size, NH * per_head_expected, HS, 0
+    )
+    assert fused == spec.is_fused_packed, fmt.name
+    assert (per_head, n_heads, rot_offset) == (per_head_expected, NH, 0), fmt.name
+
+
+def test_fused_format_keeps_v_half_out_of_the_rope_window():
+    """Regression: a fused group must rotate NH heads of width 2*HS (K half
+    only), not 2*NH heads of width HS (which re-RoPEs the V half)."""
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group(F.NL_X_NB_NH_BS_CS), 1, NH * 2 * HS, HS, 0
+    )
+    assert (fused, per_head, n_heads, rot_offset) == (True, 2 * HS, NH, 0)
+
+
+def test_untagged_group_infers_split_kv():
+    """A group with no recorded format (legacy stand-ins) keeps the plain
+    split-K/V inference."""
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group(None), 2, NH * HS, HS, 0
+    )
+    assert (fused, per_head, n_heads, rot_offset) == (False, HS, NH, 0)


### PR DESCRIPTION
**Descriptions**:

`_cb_group_rope_geometry` previously decided fused K/V packing from a hardcoded list of four EngineKVFormat members. Any fused format added later -- e.g. the blocks-first cross-layer NB_NL_NH_BS_CS / NB_NL_BS_NH_CS formats in #4729 -- was therefore classified as split K/V: per_head halved, n_heads doubled, and the re-RoPE kernel rotated the V half of every packed head.

Read `is_fused_packed` off `get_spec_class(fmt)` instead, as docs/design/v1/gpu_connector/layout-invariant.md requires (consumers must not re-list formats). Behavior is unchanged for every existing format; the new test pins the helper to the spec fact for all EngineKVFormat members so a future format cannot regress it.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
