### PR TITLE
[fix] fs_native: warn when max_capacity_gb is set without an eviction block

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -45,6 +45,12 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
     - use_odirect: bypass page cache via O_DIRECT.
     - read_ahead_size: trigger filesystem readahead by
       reading this many bytes first (optional).
+    - max_capacity_gb: declared L2 capacity in GB, used for usage
+      accounting. ``0`` (default) disables it. A value ``> 0`` does
+      **not** bound disk usage on its own -- eviction runs only when
+      the adapter spec also carries an ``eviction`` block, e.g.
+      ``{"eviction": {"eviction_policy": "LRU"}}``. Without one,
+      files accumulate past the declared capacity.
     """
 
     def __init__(
@@ -89,6 +95,16 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         max_capacity_gb = d.get("max_capacity_gb", 0)
         if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
             raise ValueError("max_capacity_gb must be a non-negative number")
+        if max_capacity_gb > 0 and d.get("eviction") is None:
+            logger.warning(
+                "fs_native: max_capacity_gb=%s is declared for %s but no "
+                "'eviction' block is configured, so it is used for usage "
+                "accounting only and will NOT bound disk usage. Add an "
+                "eviction block to enforce it, e.g. "
+                '"eviction": {"eviction_policy": "LRU"}.',
+                max_capacity_gb,
+                base_path,
+            )
 
         return cls(
             base_path=base_path,
@@ -114,9 +130,10 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
             "- read_ahead_size (int): trigger fs "
             "readahead by reading this many bytes "
             "first (optional)\n"
-            "- max_capacity_gb (float): max L2 capacity "
-            "in GB for usage tracking / eviction "
-            "(default 0 = disabled)"
+            "- max_capacity_gb (float): declared L2 capacity in GB "
+            "for usage accounting (default 0 = disabled). Does not "
+            "bound disk usage by itself; add an 'eviction' block "
+            "to enforce it"
         )
 
 

--- a/tests/v1/distributed/test_fs_native_l2_adapter_config.py
+++ b/tests/v1/distributed/test_fs_native_l2_adapter_config.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the fs_native L2 adapter config (no native extension required).
+
+``max_capacity_gb`` only declares capacity for usage accounting; eviction runs
+only when the adapter spec also carries an ``eviction`` block. These tests pin
+the warning that makes that non-enforcement visible, so a declared cap can no
+longer be silently ignored.
+"""
+
+# Standard
+from unittest.mock import patch
+
+# First Party
+from lmcache.v1.distributed.l2_adapters import fs_native_l2_adapter
+from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
+    FSNativeL2AdapterConfig,
+)
+
+BASE = {"type": "fs_native", "base_path": "/data/lmcache"}
+
+
+def _from_dict(**extra):
+    """Parse a config spec, returning (config, warning_calls)."""
+    with patch.object(fs_native_l2_adapter.logger, "warning") as warn:
+        cfg = FSNativeL2AdapterConfig.from_dict({**BASE, **extra})
+    return cfg, warn.call_args_list
+
+
+class TestFSNativeCapacityEvictionWarning:
+    def test_capacity_without_eviction_warns(self):
+        cfg, warnings = _from_dict(max_capacity_gb=4000)
+        assert cfg.max_capacity_gb == 4000
+        assert len(warnings) == 1
+        msg = warnings[0][0][0] % tuple(warnings[0][0][1:])
+        assert "eviction" in msg
+        assert "4000" in msg
+        assert "/data/lmcache" in msg
+
+    def test_capacity_with_eviction_does_not_warn(self):
+        cfg, warnings = _from_dict(
+            max_capacity_gb=4000,
+            eviction={"eviction_policy": "LRU"},
+        )
+        assert cfg.max_capacity_gb == 4000
+        assert warnings == []
+
+    def test_no_capacity_does_not_warn(self):
+        cfg, warnings = _from_dict()
+        assert cfg.max_capacity_gb == 0
+        assert warnings == []
+
+    def test_zero_capacity_does_not_warn(self):
+        cfg, warnings = _from_dict(max_capacity_gb=0)
+        assert cfg.max_capacity_gb == 0
+        assert warnings == []
+
+
+class TestFSNativeCapacityHelpText:
+    def test_help_does_not_claim_to_bound_disk_usage(self):
+        help_text = FSNativeL2AdapterConfig.help()
+        assert "max_capacity_gb" in help_text
+        # The old wording ("max L2 capacity ... for usage tracking / eviction")
+        # read as an enforced cap; it must name the eviction requirement.
+        assert "eviction" in help_text
+        assert "max L2 capacity" not in help_text


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #4725

`max_capacity_gb` on the `fs_native` L2 adapter only declares capacity for usage
accounting — nothing enforces it unless the adapter spec also carries an
`eviction` block (as @zhengfeihe explained in the issue thread). The reporter set
`max_capacity_gb: 4000` and accumulated **14 TB** over two days with no
diagnostic of any kind.

This PR:

- warns from `FSNativeL2AdapterConfig.from_dict` when `max_capacity_gb > 0` and
  the spec has no `eviction` block, naming the value, the path, and the exact
  remediation;
- corrects the `help()` text so it no longer reads as a cap;
- documents `max_capacity_gb` in the class docstring, where it was missing
  entirely.

No behavior change beyond the added warning — no eviction policy is altered and
no config is newly rejected.
