### PR TITLE
[MP][Coordinator] Let a quota registry and an LRU name their durable section

### DIFF
--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -52,7 +52,16 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
     def __init__(
         self,
         default_destination: EvictionDestination = EvictionDestination.DISCARD,
+        section_name: str = "lru_order",
     ):
+        """Args:
+        default_destination: Where victims go when no destination is
+            registered.
+        section_name: Name of this policy's section in a durable
+            checkpoint. A coordinator keeps one ordering per enforced
+            tier, and two sections cannot share a name.
+        """
+        self._section_name = section_name
         self._lock = threading.Lock()
         # cache_salt -> ordered {ObjectKey: None} (oldest first).
         self._per_salt_order: dict[str, OrderedDict[ObjectKey, None]] = {}
@@ -202,7 +211,7 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
     @property
     def name(self) -> str:
         """Name of this policy's section in a durable checkpoint."""
-        return "lru_order"
+        return self._section_name
 
     def capture(self) -> Mapping[str, object]:
         """Return each bucket's eviction order, least-recently-used first.

--- a/lmcache/v1/distributed/quota_manager.py
+++ b/lmcache/v1/distributed/quota_manager.py
@@ -42,7 +42,13 @@ class QuotaManager:
     cycle (no restart needed).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, section_name: str = "quotas") -> None:
+        """Args:
+        section_name: Name of this registry's section in a durable
+            document. A coordinator holds one registry per enforced
+            tier, and two sections cannot share a name.
+        """
+        self._section_name = section_name
         self._lock = threading.Lock()
         # cache_salt -> limit in bytes
         self._limits: dict[str, int] = {}
@@ -147,7 +153,7 @@ class QuotaManager:
     @property
     def name(self) -> str:
         """Name of this registry's section in a durable document."""
-        return "quotas"
+        return self._section_name
 
     def capture(self) -> Mapping[str, object]:
         """Return the limits in durable form.

--- a/tests/v1/distributed/test_isolated_lru_eviction_policy.py
+++ b/tests/v1/distributed/test_isolated_lru_eviction_policy.py
@@ -160,3 +160,38 @@ class TestDurableState:
         assert [key.chunk_hash for key in victims[0].keys] == [
             ObjectKey.IntHash2Bytes(2)
         ]
+
+
+class TestSectionName:
+    """The durable section an ordering writes to is its own, so a process
+    keeping one ordering per tier can checkpoint them side by side."""
+
+    def test_defaults_to_the_single_ordering_name(self):
+        assert IsolatedLRUEvictionPolicy().name == "lru_order"
+
+    def test_a_named_ordering_writes_its_own_section(self):
+        assert IsolatedLRUEvictionPolicy(section_name="l1_lru_order").name == (
+            "l1_lru_order"
+        )
+
+    def test_two_orderings_do_not_share_a_section(self):
+        """A checkpoint is keyed by section name, and refuses a duplicate."""
+        l1 = IsolatedLRUEvictionPolicy(section_name="l1_lru_order")
+        l2 = IsolatedLRUEvictionPolicy()
+        l1.on_keys_created([_key(1)])
+        l2.on_keys_created([_key(2)])
+
+        assert l1.name != l2.name
+        assert l1.capture()["buckets"][""] == [encode_key(_key(1))]
+        assert l2.capture()["buckets"][""] == [encode_key(_key(2))]
+
+    def test_the_section_name_does_not_change_ordering_behavior(self):
+        policy = IsolatedLRUEvictionPolicy(section_name="l1_lru_order")
+        policy.on_keys_created([_key(i) for i in (1, 2)])
+        policy.on_keys_touched([_key(1)])
+
+        victims = policy.get_eviction_actions(expected_ratio=0.5, cache_salt="")
+
+        assert [key.chunk_hash for key in victims[0].keys] == [
+            ObjectKey.IntHash2Bytes(2)
+        ]

--- a/tests/v1/distributed/test_quota_manager.py
+++ b/tests/v1/distributed/test_quota_manager.py
@@ -245,3 +245,39 @@ class TestQuotaManagerDefaultLimit:
         qm = QuotaManager()
         with pytest.raises(ValueError):
             qm.set_default_limit_bytes(-1)
+
+
+class TestQuotaManagerSectionName:
+    """The durable section a registry writes to is its own, so a process
+    holding one registry per tier can persist them side by side."""
+
+    def test_defaults_to_the_single_registry_name(self):
+        assert QuotaManager().name == "quotas"
+
+    def test_a_named_registry_writes_its_own_section(self):
+        assert QuotaManager(section_name="l1_quotas").name == "l1_quotas"
+
+    def test_two_registries_do_not_share_a_section(self):
+        """An artifact is keyed by section name, so a shared one would
+        make the second registry silently overwrite the first."""
+        l1 = QuotaManager(section_name="l1_quotas")
+        l2 = QuotaManager()
+        l1.set_quota("alice", 1024)
+        l2.set_quota("alice", 4096)
+
+        assert l1.name != l2.name
+        sections = {q.name: q.capture() for q in (l1, l2)}
+        assert len(sections) == 2
+        assert sections["l1_quotas"]["limits"] == {"alice": 1024}
+        assert sections["quotas"]["limits"] == {"alice": 4096}
+
+    def test_a_named_registry_round_trips(self):
+        source = QuotaManager(section_name="l1_quotas")
+        source.set_quota("alice", 2048)
+        source.set_default_limit_bytes(0)
+
+        restored = QuotaManager(section_name="l1_quotas")
+        restored.restore(source.capture())
+
+        assert restored.get_limit_bytes("alice") == 2048
+        assert restored.get_default_limit_bytes() == 0


### PR DESCRIPTION
**What this PR does / why we need it**:

`QuotaManager` and `IsolatedLRUEvictionPolicy` each hard-code the name of the
durable section they write — `"quotas"` and `"lru_order"`. That is fine while a
process holds one of each, and blocks it from holding two: a document is keyed by
section name, so a second registry would silently overwrite the first.

This makes the name a constructor argument, defaulting to today's value. No
behavior change, no migration, and every existing call site is untouched.


**Special notes for your reviewers**:

- Purely additive: a keyword argument with the current name as its default. The
  other ~30 call sites in the tree construct these with no arguments and are
  unaffected.
- The section name is deliberately not derived from a tier. These classes know
  nothing about tiers, and are reused by the MP server's node-local enforcement,
  which has no tier dimension at all — the caller holding two registries is the
  only thing that knows why they differ.
- The in-tree eviction controller is unchanged: it still builds one of each and
  still writes `"quotas"` and `"lru_order"`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
