### PR TITLE
test: enable layer cache key parsing regression

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -510,9 +510,6 @@ class TestCacheKeyParsing:
         assert isinstance(parsed, CacheEngineKey)
         assert parsed == key
 
-    @pytest.mark.xfail(
-        reason="parse_cache_key bug: cannot parse LayerCacheEngineKey with dtype"
-    )
     def test_parse_layer_cache_engine_key(self):
         key = LayerCacheEngineKey(
             model_name="m",


### PR DESCRIPTION
## Summary
- remove the stale `xfail` marker from the `LayerCacheEngineKey` parsing test
- make a future parsing regression fail CI instead of being treated as an expected failure

## Validation
- `.venv/bin/python -m pytest -q tests/test_utils.py::TestCacheKeyParsing::test_parse_layer_cache_engine_key` (1 passed)
- `.venv/bin/python -m pytest -q tests/test_utils.py` (81 passed)
- `TMPDIR="$PWD/.tmp-build" MAX_JOBS=1 NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`