### PR TITLE
[Refactor]: use vLLM KVCacheLayout names verbatim in layout hints

### DIFF
--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -51,6 +51,10 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.gpu_connector.kv_format.types import (
+    KV_LAYOUT_NAMES,
+    is_hnd_kv_layout,
+)
 from lmcache.v1.gpu_connector.utils import LayoutHints
 
 logger = init_logger(__name__)
@@ -418,9 +422,10 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
             "single-layer KV cache must be a torch.Tensor"
         )
         kv_layout = layout_hints.get("kv_layout", "none")
-        if kv_layout not in ("NHD", "HND"):
+        if kv_layout not in KV_LAYOUT_NAMES:
             raise ValueError(
-                f"Unsupported kv_layout: {kv_layout}. Only NHD and HND are supported."
+                f"Unsupported kv_layout: {kv_layout}; "
+                f"expected one of {', '.join(KV_LAYOUT_NAMES)}."
             )
         num_blocks = kv_cache.shape[0]
         row = kv_cache[0].numel()
@@ -447,12 +452,12 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
                 f"cannot tile a {row}-element state row into {block_size} "
                 f"aligned tokens within the {page_bytes}-byte page"
             )
-        if kv_layout == "NHD":
-            inner = (block_size, 1, head_size)
-            inner_strides = (head_size, head_size, 1)
-        else:
+        if is_hnd_kv_layout(kv_layout):
             inner = (1, block_size, head_size)
             inner_strides = (block_size * head_size, head_size, 1)
+        else:
+            inner = (block_size, 1, head_size)
+            inner_strides = (head_size, head_size, 1)
         return kv_cache.as_strided(
             (num_blocks, *inner), (kv_cache.stride(0), *inner_strides)
         )

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -19,7 +19,6 @@ from lmcache.logging import init_logger
 from lmcache.utils import get_size_bytes as get_size_bytes
 from lmcache.v1.config import LMCacheEngineConfig, load_ec_engine_config
 from lmcache.v1.config_base import apply_remote_configs, fetch_remote_config
-from lmcache.v1.gpu_connector.kv_format.types import KVLayoutName
 
 if TYPE_CHECKING:
     # First Party
@@ -47,38 +46,10 @@ def vllm_layout_hints(vllm_config: "VllmConfig | None" = None) -> "LayoutHints":
     return hints  # type: ignore[return-value]
 
 
-def translate_vllm_kv_cache_layout(kv_cache_layout: str) -> KVLayoutName:
-    """Map a vLLM ``KVCacheLayout`` member name to LMCache's name
-    (``LBNHC`` -> ``NHD``, ``LBHNC`` -> ``HND``).
-
-    Raises:
-        NotImplementedError: for layouts LMCache cannot transfer.
-    """
-    names = {
-        "NHD": "NHD",
-        "HND": "HND",
-        "LBNHC": "NHD",
-        "LBHNC": "HND",
-        "BLHNC": "BLHNC",
-        "BLNHC": "BLNHC",
-    }
-    translated = names.get(kv_cache_layout)
-    if translated is not None:
-        return translated  # type: ignore[return-value]
-    # TODO: support heads-outermost layouts; the transfer kernels address
-    # one contiguous run per (layer, block), which these fragment per head.
-    raise NotImplementedError(
-        f"LMCache does not support the {kv_cache_layout!r} KV cache "
-        "layout: per-block content is fragmented per head. If it was "
-        "selected via VLLM_KV_CACHE_LAYOUT, unset it or choose LBNHC, "
-        "LBHNC, BLHNC, or BLNHC."
-    )
-
-
 def try_get_vllm_kv_cache_layout(
     vllm_config: "VllmConfig | None" = None,
-) -> KVLayoutName | None:
-    """Return vLLM's resolved KV cache layout as LMCache's name.
+) -> "str | None":
+    """Return vLLM's resolved KV cache layout member name.
 
     Returns ``None`` when vLLM is unavailable (i.e. the MP server).
 
@@ -101,21 +72,30 @@ def try_get_vllm_kv_cache_layout(
         return None
 
     # vllm#51718 and later: vLLM owns alias resolution, unknown-name
-    # validation, and the not-yet-resolved error.
+    # validation, and the not-yet-resolved error. The member name is the
+    # hint as-is; there is no LMCache spelling.
     if hasattr(cache_config, "get_resolved_kv_cache_layout"):
-        return translate_vllm_kv_cache_layout(
-            cache_config.get_resolved_kv_cache_layout().name
+        kv_layout = cache_config.get_resolved_kv_cache_layout().name
+    else:
+        try:
+            # Third Party
+            from vllm.v1.attention.backends.utils import (  # type: ignore[import-untyped]
+                get_kv_cache_layout,
+            )
+        except Exception:
+            logger.error("Could not query the KV cache layout from this vLLM version")
+            return None
+        kv_layout = get_kv_cache_layout()
+    # TODO: support heads-outermost layouts; the transfer kernels address
+    # one contiguous run per (layer, block), which these fragment per head.
+    if kv_layout in ("LHBNC", "BHLNC"):
+        raise NotImplementedError(
+            f"LMCache does not support the {kv_layout!r} KV cache layout: "
+            "per-block content is fragmented per head. If it was selected "
+            "via VLLM_KV_CACHE_LAYOUT, unset it or choose LBNHC, LBHNC, "
+            "BLHNC, or BLNHC."
         )
-
-    try:
-        # Third Party
-        from vllm.v1.attention.backends.utils import (  # type: ignore[import-untyped]
-            get_kv_cache_layout,
-        )
-    except Exception:
-        logger.error("Could not query the KV cache layout from this vLLM version")
-        return None
-    return translate_vllm_kv_cache_layout(get_kv_cache_layout())
+    return kv_layout
 
 
 def lmcache_get_or_create_config() -> LMCacheEngineConfig:

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -19,6 +19,7 @@ from lmcache.v1.gpu_connector.kv_format.types import (
     KV_LAYOUT_NAMES,
     DiscoverableKVCache,
     LayoutHints,
+    is_hnd_kv_layout,
 )
 import lmcache.lmcache_native as lmcache_native
 
@@ -33,8 +34,9 @@ def resolve_vllm_kv_layout(
             f"kv_layout hint {kv_layout!r} is not a layout LMCache supports; "
             f"expected one of {', '.join(KV_LAYOUT_NAMES)}."
         )
-    # The CPU attention backend allocates HND but hints NHD.
-    if cpu_attention_backend and kv_layout in ("NHD", "HND"):
+    # Pre-#51718 vLLM misreports the CPU backend's layout as NHD; since
+    # #51718 the backend declares LBHNC and this override is a no-op.
+    if cpu_attention_backend and kv_layout not in ("BLHNC", "BLNHC"):
         return "HND"
     return kv_layout
 
@@ -50,7 +52,7 @@ class VLLM_Detector(EngineDetector):
         kv_layout = resolve_vllm_kv_layout(
             layout_hints, cpu_attention_backend=torch_device_type == "cpu"
         )
-        is_hnd = kv_layout in ("HND", "BLHNC")
+        is_hnd = is_hnd_kv_layout(kv_layout)
 
         # Fused K/V is the only rank-4 vLLM layout, so its raw rank
         # identifies it unambiguously (a 5-D split would collide with

--- a/lmcache/v1/gpu_connector/kv_format/types.py
+++ b/lmcache/v1/gpu_connector/kv_format/types.py
@@ -8,7 +8,7 @@ sites.
 """
 
 # Standard
-from typing import Literal, TypedDict, Union, get_args
+from typing import Literal, TypedDict, Union
 
 # Third Party
 import torch
@@ -22,8 +22,15 @@ import torch
 # for unwrapping to this form before calling the helpers.
 DiscoverableKVCache = Union[torch.Tensor, list["DiscoverableKVCache"]]
 
-KVLayoutName = Literal["NHD", "HND", "BLHNC", "BLNHC"]
-KV_LAYOUT_NAMES: tuple[str, ...] = get_args(KVLayoutName)
+# Accepted ``LayoutHints.kv_layout`` values: vLLM ``KVCacheLayout`` member
+# names plus the legacy per-layer spellings.
+KV_LAYOUT_NAMES: tuple[str, ...] = ("NHD", "HND", "LBNHC", "LBHNC", "BLHNC", "BLNHC")
+
+
+def is_hnd_kv_layout(kv_layout: str) -> bool:
+    """Heads before block tokens within a block (``HND`` == ``LBHNC``;
+    ``BLHNC`` is HND-ordered with blocks outermost)."""
+    return kv_layout in ("HND", "LBHNC", "BLHNC")
 
 
 class LayoutHints(TypedDict, total=False):
@@ -54,7 +61,7 @@ class LayoutHints(TypedDict, total=False):
         head_dim: Per-head dimension. Used by TRT-LLM (same).
     """
 
-    kv_layout: KVLayoutName
+    kv_layout: str
     num_kv_heads: int
     tokens_per_block: int
     kv_list_layout: Literal["k_v"]

--- a/tests/v1/test_vllm_kv_layout_discovery.py
+++ b/tests/v1/test_vllm_kv_layout_discovery.py
@@ -16,7 +16,6 @@ import pytest
 
 # First Party
 from lmcache.integration.vllm.utils import (
-    translate_vllm_kv_cache_layout,
     try_get_vllm_kv_cache_layout,
     vllm_layout_hints,
 )
@@ -59,29 +58,10 @@ def stub_module(
     return module
 
 
-class TestTranslateVllmKVCacheLayout:
-    def test_standardized_names_map_to_lmcache_names(self):
-        assert translate_vllm_kv_cache_layout("LBNHC") == "NHD"
-        assert translate_vllm_kv_cache_layout("LBHNC") == "HND"
-
-    def test_lmcache_names_pass_through(self):
-        for name in ("NHD", "HND", "BLHNC", "BLNHC"):
-            assert translate_vllm_kv_cache_layout(name) == name
-
-    @pytest.mark.parametrize("name", UNSUPPORTED_LAYOUTS)
-    def test_unsupported_layouts_fail_loudly(self, name):
-        with pytest.raises(NotImplementedError, match=name):
-            translate_vllm_kv_cache_layout(name)
-
-    def test_unknown_name_raises(self):
-        with pytest.raises(NotImplementedError, match="XYZ"):
-            translate_vllm_kv_cache_layout("XYZ")
-
-
 class TestTryGetVllmKVCacheLayout:
-    def test_resolved_layout_from_explicit_config(self):
+    def test_resolved_member_name_is_the_hint(self):
         config = make_vllm_config("LBNHC")
-        assert try_get_vllm_kv_cache_layout(config) == "NHD"
+        assert try_get_vllm_kv_cache_layout(config) == "LBNHC"
 
     def test_unresolved_layout_error_passes_through(self):
         with pytest.raises(ValueError, match="resolved"):
@@ -96,7 +76,7 @@ class TestTryGetVllmKVCacheLayout:
     def test_ambient_config_is_used_when_not_passed(self, monkeypatch):
         config = make_vllm_config("LBHNC")
         stub_module(monkeypatch, "vllm.config", get_current_vllm_config=lambda: config)
-        assert try_get_vllm_kv_cache_layout() == "HND"
+        assert try_get_vllm_kv_cache_layout() == "LBHNC"
 
     def test_legacy_vllm_falls_back_to_backend_query(self, monkeypatch):
         stub_module(
@@ -114,9 +94,9 @@ class TestTryGetVllmKVCacheLayout:
 
 
 class TestVllmLayoutHints:
-    def test_hint_present_and_translated(self):
+    def test_hint_carries_the_member_name(self):
         config = make_vllm_config("LBHNC")
-        assert vllm_layout_hints(config) == {"kv_layout": "HND"}
+        assert vllm_layout_hints(config) == {"kv_layout": "LBHNC"}
 
     def test_unresolved_layout_raises_through_hints(self):
         with pytest.raises(ValueError, match="resolved"):


### PR DESCRIPTION
Follow-up to #4729 (RFC #3560).

The `kv_layout` hint now carries vLLM's `KVCacheLayout` member name as-is; the legacy query still yields `NHD`/`HND`, which stay accepted. Spelling equivalence (`HND` == `LBHNC`) lives in one predicate, `is_hnd_kv_layout`, consumed by detection and the mamba view edit. Deletes `translate_vllm_kv_cache_layout` and the `KVLayoutName` Literal in favor of the runtime `KV_LAYOUT_NAMES` tuple.

The CPU-backend override in `resolve_vllm_kv_layout` is documented as pre-#51718 compat only: since vllm-project/vllm#51718, `cpu_attn` declares `LBHNC` via `supported_kv_cache_layouts` and resolution reports it correctly.

Validation: unit suites pass on this branch; MP-mode E2E with this exact content (bit-identical outputs + external-hit evidence) on Qwen3, MiniMax, DeepSeek-V2-Lite, GLM-4.7, DeepSeek-V4, Kimi-Linear, Qwen3-Next, plus forced `VLLM_KV_CACHE_LAYOUT=BLHNC` and `BLNHC` runs.