### PR TITLE
fix(cuda): use packed head size for fused HND caches

### DIFF
--- a/csrc/cuda/mem_kernels.cu
+++ b/csrc/cuda/mem_kernels.cu
@@ -294,19 +294,20 @@ page_buffer_offset(const int k_or_v, const int token_idx,
            head_offset;
   } else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||
                        format == EngineKVFormat::NL_X_NB_NH_BS_CS) {
-    const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
+    // Fused format specs report the packed K/V content width as head_size.
+    const int packed_head_size = head_size;
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
-    const int head_idx = scalar_offset / hs2;
-    const int head_offset = scalar_offset % hs2;
-    const int num_heads = scalars_per_token / hs2;
+    const int head_idx = scalar_offset / packed_head_size;
+    const int head_offset = scalar_offset % packed_head_size;
+    const int num_heads = scalars_per_token / packed_head_size;
     // vLLM blocks-first pools pass the real per-block step; 0 means tight.
     const int64_t block_step =
         block_stride_xwords > 0
             ? block_stride_xwords
-            : static_cast<int64_t>(num_heads) * block_size * hs2;
-    return block_idx * block_step + head_idx * block_size * hs2 +
-           block_offset * hs2 + head_offset;
+            : static_cast<int64_t>(num_heads) * block_size * packed_head_size;
+    return block_idx * block_step + head_idx * block_size * packed_head_size +
+           block_offset * packed_head_size + head_offset;
   } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS ||
                        format == EngineKVFormat::NL_X_NB_BS_NH_CS) {
     const int block_idx = token_idx / block_size;

--- a/tests/v1/gpu_connector/test_blocks_first_kernel_roundtrip.py
+++ b/tests/v1/gpu_connector/test_blocks_first_kernel_roundtrip.py
@@ -89,7 +89,7 @@ def test_kernel_roundtrip_matches_torch(order, pad_layers):
         int(lmcache_native.TransferDirection.D2H),
         int(fmt),
         BS,
-        CS // 2,
+        CS,
         0,
         block_stride,
     )
@@ -110,7 +110,7 @@ def test_kernel_roundtrip_matches_torch(order, pad_layers):
         int(lmcache_native.TransferDirection.H2D),
         int(fmt),
         BS,
-        CS // 2,
+        CS,
         0,
         block_stride,
     )


### PR DESCRIPTION
## Summary
- fix fused HND page-buffer addressing to treat `head_size` as the already-packed K/V content width
- stop doubling `CS` a second time when decomposing scalar offsets
- update the blocks-first GPU round-trip test to pass the same `CS` value used by the real connector

This fixes a regression exposed by #4729: `get_head_size()` returns the trailing packed `CS` dimension for fused formats, but the CUDA kernel interpreted it as the unpacked attention head size. That computed half as many heads and incorrect offsets for `BLHNC` transfers.

## Validation
- `.venv/bin/python -m pytest -q tests/v1/gpu_connector/test_blocks_first_detection.py tests/v1/gpu_connector/test_blocks_first_kernel_roundtrip.py` (6 passed, 4 GPU-only skipped)
- `TMPDIR="$PWD/.tmp-build" MAX_JOBS=1 NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`

GPU hardware is unavailable on this runner; the corrected CUDA round-trip cases are enabled for GPU CI.