### PR TITLE
fix(trace): replay legacy prefetch lock records

### DIFF
--- a/lmcache/cli/commands/trace/_dispatch.py
+++ b/lmcache/cli/commands/trace/_dispatch.py
@@ -143,8 +143,8 @@ def _call_sm_method(method_name: str) -> Handler:
 
     The returned callable invokes ``getattr(ctx.sm, method_name)(**args)``
     and discards the result.  Used for every "plain" traced method on
-    StorageManager — ``reserve_write``, ``finish_write``,
-    ``submit_prefetch_task``, ``finish_read_prefetched``.
+    StorageManager — ``reserve_write``, ``finish_write``, and
+    ``submit_prefetch_task``.
 
     Args:
         method_name: Attribute name on the live StorageManager.
@@ -159,6 +159,24 @@ def _call_sm_method(method_name: str) -> Handler:
 
     _handler.__name__ = f"_call_sm_{method_name}"
     return _handler
+
+
+def _finish_read_prefetched(ctx: ReplayContext, args: dict[str, Any]) -> None:
+    """Replay current and legacy finish-read records.
+
+    Traces recorded before the read-lock API cleanup store ``extra_count``,
+    meaning additional locks beyond the default one. Convert that field to
+    the current total ``read_locks`` count before dispatching.
+
+    Args:
+        ctx: Active replay context.
+        args: Decoded record arguments.
+    """
+    migrated_args = dict(args)
+    extra_count = migrated_args.pop("extra_count", None)
+    if extra_count is not None and "read_locks" not in migrated_args:
+        migrated_args["read_locks"] = extra_count + 1
+    ctx.sm.finish_read_prefetched(**migrated_args)
 
 
 def _enter_read_prefetched(ctx: ReplayContext, args: dict[str, Any]) -> None:
@@ -232,12 +250,15 @@ def build_default_dispatcher() -> CallDispatcher:
         "reserve_write",
         "finish_write",
         "submit_prefetch_task",
-        "finish_read_prefetched",
     ):
         dispatcher.register(
             f"{_SM_PREFIX}.{method_name}",
             _call_sm_method(method_name),
         )
+    dispatcher.register(
+        f"{_SM_PREFIX}.finish_read_prefetched",
+        _finish_read_prefetched,
+    )
     dispatcher.register(
         f"{_SM_PREFIX}.read_prefetched_results.__enter__",
         _enter_read_prefetched,

--- a/tests/cli/commands/trace/test_dispatch.py
+++ b/tests/cli/commands/trace/test_dispatch.py
@@ -123,6 +123,34 @@ class TestDefaultDispatcher:
             ),
         ]
 
+    def test_legacy_finish_read_extra_count_is_migrated(self):
+        sm = _FakeSM()
+        ctx = ReplayContext(sm=sm)
+        d = build_default_dispatcher()
+        keys = [_key(1)]
+
+        d.dispatch(
+            f"{_SM_PREFIX}.finish_read_prefetched",
+            ctx,
+            {"keys": keys, "extra_count": 2},
+        )
+
+        assert sm.calls == [("finish_read_prefetched", {"keys": keys, "read_locks": 3})]
+
+    def test_current_finish_read_args_pass_through(self):
+        sm = _FakeSM()
+        ctx = ReplayContext(sm=sm)
+        d = build_default_dispatcher()
+        keys = [_key(1)]
+
+        d.dispatch(
+            f"{_SM_PREFIX}.finish_read_prefetched",
+            ctx,
+            {"keys": keys, "read_locks": 4},
+        )
+
+        assert sm.calls == [("finish_read_prefetched", {"keys": keys, "read_locks": 4})]
+
     def test_read_prefetched_enter_exit_fifo(self):
         """Two overlapping contexts with identical keys exit in FIFO order."""
         sm = _FakeSM()


### PR DESCRIPTION
## Summary
- add a dedicated replay handler for `finish_read_prefetched`
- migrate legacy trace records from `extra_count` to the current total `read_locks` field
- preserve current trace records unchanged

Before #4679, traces recorded `extra_count`, which meant additional locks beyond the default lock. After the API changed to `read_locks`, replay forwarded old arguments directly and failed with `TypeError`. The replay boundary now converts `extra_count=N` to `read_locks=N+1`.

## Validation
- `.venv/bin/python -m pytest -q tests/cli/commands/trace/test_dispatch.py` (10 passed)
- `.venv/bin/python -m pytest -q tests/cli/commands/trace` (27 passed)
- `TMPDIR="$PWD/.tmp-build" MAX_JOBS=1 NO_GPU_EXT=1 uv pip install --python .venv/bin/python -e . --no-build-isolation`
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`