### PR TITLE
fix(cpu): support MLA with Engine-driven transfer

### DIFF
--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -124,10 +124,7 @@ jobs:
                "first_k_dense_replace": 0, "num_experts_per_tok": 2}
             trust_remote_code: "1"
             mla_disable: "0"
-            # First validate CPU MLA through the LMCache-driven path that
-            # vLLM already covers. Engine-driven MLA is isolated until its
-            # KV-format/store path is fixed.
-            run_engine_driven_e2e: false
+            run_engine_driven_e2e: true
 
     env:
       # Threaded to run-cpu-e2e-validation.sh; server_bench ignores them.

--- a/lmcache/cli/commands/bench/server_bench/client.py
+++ b/lmcache/cli/commands/bench/server_bench/client.py
@@ -903,6 +903,7 @@ class ServerBenchClient:
                 use_gpu=use_gpu,
                 use_handle=use_handle,
                 engine_group_infos=engine_group_infos,
+                num_physical_slots=self._chunk_size,
             )
             self._log(
                 "[rank %d] REGISTER_KV_CACHE: %s"

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -393,6 +393,7 @@ def _send_register_kv_cache(
     use_gpu: bool = True,
     use_handle: bool | None = None,
     engine_group_infos: "list[EngineGroupInfo] | None" = None,
+    num_physical_slots: int | None = None,
 ) -> "bool | RegisterEngineDrivenContextResponse":
     """Register a KV cache context with the MP server.
 
@@ -412,6 +413,9 @@ def _send_register_kv_cache(
     tensors (which the HND layout can swap with ``num_heads``). ``None``
     sends an empty list (single non-hybrid group, geometry discovered
     from the tensors).
+
+    ``num_physical_slots`` is required in data mode and describes the exact
+    physical-slot axis of each gathered chunk. Handle mode ignores it.
     """
     if use_handle is None:
         use_handle = use_gpu
@@ -438,6 +442,8 @@ def _send_register_kv_cache(
         return result is not _TIMEOUT
 
     # CPU mode: use the non-GPU context registration protocol.
+    if num_physical_slots is None:
+        raise ValueError("num_physical_slots is required in data mode")
     # layout_hints carries num_layers, num_heads, head_size, block_size,
     # dtype, kv_size.  hidden_dim_size = num_heads * head_size (NHD).
     hints_d: dict = layout_hints or {}
@@ -469,6 +475,7 @@ def _send_register_kv_cache(
         hidden_dim_size=hidden_dim_size,
         dtype_str=dtype_str,
         use_mla=use_mla,
+        num_physical_slots=num_physical_slots,
     )
     result = _call(
         client, RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT, [payload]

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -118,10 +118,9 @@ def try_get_vllm_kv_cache_layout(
         return None
 
     kv_layout = translate_vllm_kv_cache_layout(get_kv_cache_layout())
-    # Before vllm#51718, the CPU attention backend allocated the layer-compact
-    # layout as HND while the legacy helper could still report NHD. Normalize
-    # that version-specific compatibility issue at the vLLM boundary so an
-    # explicit layout hint is always the physical layout LMCache should trust.
+    # Legacy vLLM could report NHD on CPU even though the CPU attention backend
+    # physically allocated [B, H, N, C] (HND). Post-vllm#51718 layouts are
+    # returned from CacheConfig above, so normalize only this legacy fallback.
     if torch_device_type == "cpu" and kv_layout in ("NHD", "HND"):
         return "HND"
     return kv_layout

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 import torch
 
 # First Party
+from lmcache import torch_device_type
 from lmcache.logging import init_logger
 from lmcache.utils import get_size_bytes as get_size_bytes
 from lmcache.v1.config import LMCacheEngineConfig, load_ec_engine_config
@@ -40,12 +41,10 @@ def is_false(value: str) -> bool:
 
 def vllm_layout_hints(vllm_config: "VllmConfig | None" = None) -> "LayoutHints":
     """Build layout_hints dict by querying vLLM at runtime."""
-    hints: dict[str, str | bool] = {}
-    kv_layout, is_authoritative = _try_get_vllm_kv_cache_layout(vllm_config)
+    hints: dict[str, str] = {}
+    kv_layout = try_get_vllm_kv_cache_layout(vllm_config)
     if kv_layout is not None:
         hints["kv_layout"] = kv_layout
-        if is_authoritative:
-            hints["kv_layout_is_authoritative"] = True
     return hints  # type: ignore[return-value]
 
 
@@ -88,13 +87,6 @@ def try_get_vllm_kv_cache_layout(
         ValueError: from vLLM, if the layout has not been resolved yet;
             hints must be built at KV-cache registration time.
     """
-    return _try_get_vllm_kv_cache_layout(vllm_config)[0]
-
-
-def _try_get_vllm_kv_cache_layout(
-    vllm_config: "VllmConfig | None" = None,
-) -> tuple[KVLayoutName | None, bool]:
-    """Return the translated layout and whether vLLM resolved it centrally."""
     try:
         if vllm_config is None:
             # Third Party
@@ -107,16 +99,13 @@ def _try_get_vllm_kv_cache_layout(
             "vLLM is not available but tried to query kv cache "
             "layout information, cannot get KV cache layout"
         )
-        return None, False
+        return None
 
     # vllm#51718 and later: vLLM owns alias resolution, unknown-name
     # validation, and the not-yet-resolved error.
     if hasattr(cache_config, "get_resolved_kv_cache_layout"):
-        return (
-            translate_vllm_kv_cache_layout(
-                cache_config.get_resolved_kv_cache_layout().name
-            ),
-            True,
+        return translate_vllm_kv_cache_layout(
+            cache_config.get_resolved_kv_cache_layout().name
         )
 
     try:
@@ -126,8 +115,16 @@ def _try_get_vllm_kv_cache_layout(
         )
     except Exception:
         logger.error("Could not query the KV cache layout from this vLLM version")
-        return None, False
-    return translate_vllm_kv_cache_layout(get_kv_cache_layout()), False
+        return None
+
+    kv_layout = translate_vllm_kv_cache_layout(get_kv_cache_layout())
+    # Before vllm#51718, the CPU attention backend allocated the layer-compact
+    # layout as HND while the legacy helper could still report NHD. Normalize
+    # that version-specific compatibility issue at the vLLM boundary so an
+    # explicit layout hint is always the physical layout LMCache should trust.
+    if torch_device_type == "cpu" and kv_layout in ("NHD", "HND"):
+        return "HND"
+    return kv_layout
 
 
 def lmcache_get_or_create_config() -> LMCacheEngineConfig:

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -40,10 +40,12 @@ def is_false(value: str) -> bool:
 
 def vllm_layout_hints(vllm_config: "VllmConfig | None" = None) -> "LayoutHints":
     """Build layout_hints dict by querying vLLM at runtime."""
-    hints: dict[str, str] = {}
-    kv_layout = try_get_vllm_kv_cache_layout(vllm_config)
+    hints: dict[str, str | bool] = {}
+    kv_layout, is_authoritative = _try_get_vllm_kv_cache_layout(vllm_config)
     if kv_layout is not None:
         hints["kv_layout"] = kv_layout
+        if is_authoritative:
+            hints["kv_layout_is_authoritative"] = True
     return hints  # type: ignore[return-value]
 
 
@@ -86,6 +88,13 @@ def try_get_vllm_kv_cache_layout(
         ValueError: from vLLM, if the layout has not been resolved yet;
             hints must be built at KV-cache registration time.
     """
+    return _try_get_vllm_kv_cache_layout(vllm_config)[0]
+
+
+def _try_get_vllm_kv_cache_layout(
+    vllm_config: "VllmConfig | None" = None,
+) -> tuple[KVLayoutName | None, bool]:
+    """Return the translated layout and whether vLLM resolved it centrally."""
     try:
         if vllm_config is None:
             # Third Party
@@ -98,13 +107,16 @@ def try_get_vllm_kv_cache_layout(
             "vLLM is not available but tried to query kv cache "
             "layout information, cannot get KV cache layout"
         )
-        return None
+        return None, False
 
     # vllm#51718 and later: vLLM owns alias resolution, unknown-name
     # validation, and the not-yet-resolved error.
     if hasattr(cache_config, "get_resolved_kv_cache_layout"):
-        return translate_vllm_kv_cache_layout(
-            cache_config.get_resolved_kv_cache_layout().name
+        return (
+            translate_vllm_kv_cache_layout(
+                cache_config.get_resolved_kv_cache_layout().name
+            ),
+            True,
         )
 
     try:
@@ -114,8 +126,8 @@ def try_get_vllm_kv_cache_layout(
         )
     except Exception:
         logger.error("Could not query the KV cache layout from this vLLM version")
-        return None
-    return translate_vllm_kv_cache_layout(get_kv_cache_layout())
+        return None, False
+    return translate_vllm_kv_cache_layout(get_kv_cache_layout()), False
 
 
 def lmcache_get_or_create_config() -> LMCacheEngineConfig:

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -33,8 +33,15 @@ def resolve_vllm_kv_layout(
             f"kv_layout hint {kv_layout!r} is not a layout LMCache supports; "
             f"expected one of {', '.join(KV_LAYOUT_NAMES)}."
         )
-    # The CPU attention backend allocates HND but hints NHD.
-    if cpu_attention_backend and kv_layout in ("NHD", "HND"):
+    # Legacy CPU attention backends allocate HND but report NHD. New vLLM
+    # versions resolve the actual physical layout centrally on CacheConfig;
+    # overriding that authoritative LBNHC/NHD value swaps the token and head
+    # axes for CPU MLA's rank-4 cache.
+    if (
+        cpu_attention_backend
+        and kv_layout in ("NHD", "HND")
+        and not layout_hints.get("kv_layout_is_authoritative", False)
+    ):
         return "HND"
     return kv_layout
 

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -26,23 +26,17 @@ import lmcache.lmcache_native as lmcache_native
 def resolve_vllm_kv_layout(
     layout_hints: LayoutHints, cpu_attention_backend: bool
 ) -> str:
-    """Validate the ``kv_layout`` hint and apply the CPU-backend override."""
-    kv_layout = layout_hints.get("kv_layout", "NHD")
+    """Validate an explicit ``kv_layout`` hint or choose a legacy default."""
+    kv_layout = layout_hints.get("kv_layout")
+    if kv_layout is None:
+        # Registrations predating layout hints relied on the CPU backend's HND
+        # allocation and the NHD default everywhere else.
+        return "HND" if cpu_attention_backend else "NHD"
     if kv_layout not in KV_LAYOUT_NAMES:
         raise ValueError(
             f"kv_layout hint {kv_layout!r} is not a layout LMCache supports; "
             f"expected one of {', '.join(KV_LAYOUT_NAMES)}."
         )
-    # Legacy CPU attention backends allocate HND but report NHD. New vLLM
-    # versions resolve the actual physical layout centrally on CacheConfig;
-    # overriding that authoritative LBNHC/NHD value swaps the token and head
-    # axes for CPU MLA's rank-4 cache.
-    if (
-        cpu_attention_backend
-        and kv_layout in ("NHD", "HND")
-        and not layout_hints.get("kv_layout_is_authoritative", False)
-    ):
-        return "HND"
     return kv_layout
 
 

--- a/lmcache/v1/gpu_connector/kv_format/types.py
+++ b/lmcache/v1/gpu_connector/kv_format/types.py
@@ -40,9 +40,6 @@ class LayoutHints(TypedDict, total=False):
             ``"HND"`` -- heads before block-size (``VLLM_KV_CACHE_LAYOUT=HND``).
             ``"BLHNC"`` / ``"BLNHC"`` -- blocks outermost, all layers
             packed per block (vLLM standardized layouts).
-        kv_layout_is_authoritative: Whether ``kv_layout`` came from an
-            engine-owned, resolved layout descriptor. When false or absent,
-            compatibility workarounds may correct legacy backend hints.
         num_kv_heads: Number of KV heads per layer. Used by TRT-LLM to
             reshape its 4-D pool tensor into the canonical 6-D form.
         tokens_per_block: Tokens per paged block. Used by TRT-LLM (to
@@ -58,7 +55,6 @@ class LayoutHints(TypedDict, total=False):
     """
 
     kv_layout: KVLayoutName
-    kv_layout_is_authoritative: bool
     num_kv_heads: int
     tokens_per_block: int
     kv_list_layout: Literal["k_v"]

--- a/lmcache/v1/gpu_connector/kv_format/types.py
+++ b/lmcache/v1/gpu_connector/kv_format/types.py
@@ -40,6 +40,9 @@ class LayoutHints(TypedDict, total=False):
             ``"HND"`` -- heads before block-size (``VLLM_KV_CACHE_LAYOUT=HND``).
             ``"BLHNC"`` / ``"BLNHC"`` -- blocks outermost, all layers
             packed per block (vLLM standardized layouts).
+        kv_layout_is_authoritative: Whether ``kv_layout`` came from an
+            engine-owned, resolved layout descriptor. When false or absent,
+            compatibility workarounds may correct legacy backend hints.
         num_kv_heads: Number of KV heads per layer. Used by TRT-LLM to
             reshape its 4-D pool tensor into the canonical 6-D form.
         tokens_per_block: Tokens per paged block. Used by TRT-LLM (to
@@ -55,6 +58,7 @@ class LayoutHints(TypedDict, total=False):
     """
 
     kv_layout: KVLayoutName
+    kv_layout_is_authoritative: bool
     num_kv_heads: int
     tokens_per_block: int
     kv_list_layout: Literal["k_v"]

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -157,6 +157,9 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
         hidden_dim_size: Flattened hidden dimension per token.
         dtype_str: Torch dtype name (e.g. ``"float16"``).
         use_mla: Whether the worker KV format is MLA.
+        num_physical_slots: Number of physical KV slots gathered into one
+            LMCache chunk. ``None`` accepts the legacy protocol, where the
+            server assumed one physical slot per logical token.
     """
 
     instance_id: int
@@ -167,6 +170,7 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
     hidden_dim_size: int
     dtype_str: str
     use_mla: bool
+    num_physical_slots: int | None = None
 
 
 @dataclass

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -306,7 +306,8 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
         Args:
             payload: Struct containing all registration fields
                 (instance_id, model_name, world_size, block_size,
-                num_layers, hidden_dim_size, dtype_str, use_mla).
+                num_layers, hidden_dim_size, dtype_str, use_mla,
+                num_physical_slots).
 
         Raises:
             ValueError: If ``payload.dtype_str`` is not a valid torch dtype name.
@@ -335,13 +336,23 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
                 "'bfloat16' for torch.bfloat16, 'float32' for torch.float32)."
             )
 
+        num_physical_slots = payload.num_physical_slots
+        if num_physical_slots is None:
+            # Compatibility with clients from before the physical-slot field
+            # was added. Those clients require one slot per logical token.
+            num_physical_slots = self._ctx.chunk_size
+        elif num_physical_slots <= 0:
+            raise ValueError(
+                f"num_physical_slots must be positive, got {num_physical_slots}"
+            )
+
         shape = (
             torch.Size(
-                [payload.num_layers, self._ctx.chunk_size, payload.hidden_dim_size]
+                [payload.num_layers, num_physical_slots, payload.hidden_dim_size]
             )
             if payload.use_mla
             else torch.Size(
-                [2, payload.num_layers, self._ctx.chunk_size, payload.hidden_dim_size]
+                [2, payload.num_layers, num_physical_slots, payload.hidden_dim_size]
             )
         )
         layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])

--- a/lmcache/v1/multiprocess/modules/server_transfer.py
+++ b/lmcache/v1/multiprocess/modules/server_transfer.py
@@ -219,12 +219,35 @@ class PickleTransferStrategy(TransferStrategy):
                 if obj_key not in reserved_dict:
                     continue
                 if idx >= len(chunks):
+                    logger.error(
+                        "Engine-driven pickle store is missing chunk %d "
+                        "(instance_id=%d, object_keys=%d, chunks=%d)",
+                        idx,
+                        instance_id,
+                        len(obj_keys),
+                        len(chunks),
+                    )
                     continue
                 memory_obj = reserved_dict[obj_key]
                 if memory_obj.tensor is None:
+                    logger.error(
+                        "Engine-driven pickle store reserved an object without "
+                        "a tensor (instance_id=%d, chunk_index=%d)",
+                        instance_id,
+                        idx,
+                    )
                     continue
                 chunk_cpu = chunks[idx]
                 if chunk_cpu.shape != memory_obj.tensor.shape:
+                    logger.error(
+                        "Engine-driven pickle store chunk shape mismatch "
+                        "(instance_id=%d, chunk_index=%d, chunk_shape=%s, "
+                        "object_shape=%s)",
+                        instance_id,
+                        idx,
+                        tuple(chunk_cpu.shape),
+                        tuple(memory_obj.tensor.shape),
+                    )
                     continue
                 memory_obj.tensor.copy_(chunk_cpu)
                 written_keys.append(obj_key)
@@ -232,7 +255,18 @@ class PickleTransferStrategy(TransferStrategy):
             if written_keys:
                 self._storage_manager.finish_write(written_keys)
 
-        return len(written_keys) == len(reserved_dict)
+        success = len(written_keys) == len(reserved_dict)
+        if not success:
+            logger.error(
+                "Engine-driven pickle store incomplete (instance_id=%d, "
+                "object_keys=%d, reserved=%d, chunks=%d, written=%d)",
+                instance_id,
+                len(obj_keys),
+                len(reserved_dict),
+                len(chunks),
+                len(written_keys),
+            )
+        return success
 
     def prepare_retrieve(
         self,

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -719,6 +719,7 @@ class EngineDrivenTransferContext(TransferContext):
                     hidden_dim_size=hidden_dim_size,
                     dtype_str=dtype_str,
                     use_mla=use_mla_flag,
+                    num_physical_slots=blocks_in_chunk * block_size,
                 )
             ],
         )

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -847,6 +847,7 @@ class TestRegisterKVCacheMLA:
                 kv_caches=None,
                 use_gpu=False,
                 use_handle=False,
+                num_physical_slots=128,
             )
             client.close()
             payload = router.last_payload
@@ -862,6 +863,10 @@ class TestRegisterKVCacheMLA:
     def test_classical_sets_use_mla_false(self, router_endpoint: str) -> None:
         payload = self._register(router_endpoint, kv_size=2)
         assert payload.use_mla is False
+
+    def test_sends_num_physical_slots(self, router_endpoint: str) -> None:
+        payload = self._register(router_endpoint, kv_size=1)
+        assert payload.num_physical_slots == 128
 
     def test_mixed_kv_size_defaults_to_non_mla(self, router_endpoint: str) -> None:
         """Heterogeneous specs cannot be expressed in one register call.

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -765,19 +765,18 @@ def test_compute_kv_layout_and_gather_scatter_roundtrip(
             assert torch.allclose(source[name][1], destination[name][5])
 
 
-def test_explicit_cpu_nhd_layout_matches_engine_driven_chunk(
+def test_explicit_cpu_nhd_layout_preserves_physical_geometry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression for DeepSeek MLA on post-vllm#51718 CPU layouts.
 
     vLLM reports LBNHC/NHD and registers a rank-4 per-layer view. Treating it
-    as the legacy CPU HND layout swaps BS and NH, so the worker gathers the
-    right bytes into the wrong shape and the server rejects the store.
+    as the legacy CPU HND layout swaps BS and NH, changing block_size from 16
+    to 1 and hidden_dim from 576 to 9216.
     """
     # First Party
     from lmcache.v1.multiprocess.transfer_context.base import (
         compute_kv_layout,
-        gather_paged_kv_to_cpu,
     )
 
     monkeypatch.setattr(
@@ -796,15 +795,8 @@ def test_explicit_cpu_nhd_layout_matches_engine_driven_chunk(
     block_size, num_layers, hidden_dim, _, _, kv_size = compute_kv_layout(
         source, layout_hints=layout_hints
     )
-    gathered = gather_paged_kv_to_cpu(
-        source,
-        list(range(8)),
-        blocks_per_chunk=8,
-        layout_hints=layout_hints,
-    )
 
     assert (block_size, num_layers, hidden_dim, kv_size) == (16, 2, 576, 1)
-    assert tuple(gathered[0].shape) == (2, 128, 576)
 
 
 def test_engine_driven_register_sends_num_physical_slots(

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -211,11 +211,14 @@ def _make_storage_manager_config(
 
 def _default_register_payload(
     instance_id: int = 1,
+    num_physical_slots: int | None = None,
 ) -> "RegisterEngineDrivenContextPayload":
     """Build a default non-GPU registration payload for server-side tests.
 
     Args:
         instance_id: Worker instance id to register. Defaults to ``1``.
+        num_physical_slots: Physical slots per gathered chunk. ``None`` uses
+            the legacy protocol behavior.
 
     Uses fixed values ``model_name="m"``, ``world_size=1``, ``block_size=4``,
     ``num_layers=2``, ``hidden_dim_size=16``, ``dtype_str="float32"``, and
@@ -233,6 +236,7 @@ def _default_register_payload(
         hidden_dim_size=16,
         dtype_str="float32",
         use_mla=False,
+        num_physical_slots=num_physical_slots,
     )
 
 
@@ -713,8 +717,7 @@ def test_compute_kv_layout_and_gather_scatter_roundtrip(
 
         return torch_device_type if torch_device_type != "cpu" else "cuda"
 
-    # Bypass the CPU-host HND safeguard so the layout hint drives detection
-    # regardless of the host running the test.
+    # Keep format discovery independent of the host running the test.
     monkeypatch.setattr(
         "lmcache.v1.gpu_connector.kv_format.detectors.vllm.torch_device_type",
         _vllm_detector_device_type(),
@@ -762,7 +765,7 @@ def test_compute_kv_layout_and_gather_scatter_roundtrip(
             assert torch.allclose(source[name][1], destination[name][5])
 
 
-def test_authoritative_cpu_nhd_layout_matches_engine_driven_chunk(
+def test_explicit_cpu_nhd_layout_matches_engine_driven_chunk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression for DeepSeek MLA on post-vllm#51718 CPU layouts.
@@ -788,10 +791,7 @@ def test_authoritative_cpu_nhd_layout_matches_engine_driven_chunk(
         num_heads=1,
         head_size=288,
     )
-    layout_hints: LayoutHints = {
-        "kv_layout": "NHD",
-        "kv_layout_is_authoritative": True,
-    }
+    layout_hints: LayoutHints = {"kv_layout": "NHD"}
 
     block_size, num_layers, hidden_dim, _, _, kv_size = compute_kv_layout(
         source, layout_hints=layout_hints
@@ -805,6 +805,57 @@ def test_authoritative_cpu_nhd_layout_matches_engine_driven_chunk(
 
     assert (block_size, num_layers, hidden_dim, kv_size) == (16, 2, 576, 1)
     assert tuple(gathered[0].shape) == (2, 128, 576)
+
+
+def test_engine_driven_register_sends_num_physical_slots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker registration must describe its gathered chunk, not just tokens."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import (
+        RegisterEngineDrivenContextPayload,
+    )
+    from lmcache.v1.multiprocess.transfer_context import (
+        EngineDrivenTransferContext,
+        worker_transfer,
+    )
+
+    monkeypatch.setattr(
+        worker_transfer,
+        "compute_kv_layout",
+        lambda *_args, **_kwargs: (
+            16,
+            2,
+            576,
+            "float32",
+            lmcache_native.EngineKVFormat.NL_X_NB_BS_NH_CS,
+            1,
+        ),
+    )
+    monkeypatch.setattr(
+        worker_transfer,
+        "create_engine_driven_context",
+        lambda *_args, **_kwargs: MagicMock(),
+    )
+    future = MagicMock()
+    future.result.return_value = RegisterEngineDrivenContextResponse()
+    send_request = MagicMock(return_value=future)
+
+    EngineDrivenTransferContext().register(
+        instance_id=1,
+        kv_caches=_make_fused_nhd_kv_caches(),
+        model_name="m",
+        world_size=1,
+        blocks_in_chunk=8,
+        mq_client=MagicMock(),
+        mq_timeout=1.0,
+        send_request=send_request,
+        layout_hints={"kv_layout": "NHD"},
+    )
+
+    payload = send_request.call_args.args[2][0]
+    assert isinstance(payload, RegisterEngineDrivenContextPayload)
+    assert payload.num_physical_slots == 128
 
 
 @pytest.mark.parametrize(
@@ -1195,6 +1246,21 @@ def test_server_register_and_find_non_cuda_context_layout(
     layout = ctx.layout_desc_registry.find("m", 1)
     assert layout is not None
     assert layout.shapes[0] == torch.Size([2, 2, 16, 16])
+
+
+def test_server_register_uses_worker_physical_slots(
+    stub_lmcache_native: Any,
+    server_module_factory: ServerModuleFactory,
+) -> None:
+    """Server must not substitute its logical token chunk for physical slots."""
+    module, _, _, ctx = server_module_factory(chunk_size=256)
+    payload = _default_register_payload(instance_id=11, num_physical_slots=128)
+
+    module.register_kv_cache_engine_driven_context(payload)
+
+    layout = ctx.layout_desc_registry.find("m", 1)
+    assert layout is not None
+    assert layout.shapes[0] == torch.Size([2, 2, 128, 16])
 
 
 def test_server_store_and_retrieve_cpu_chunks(

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -762,6 +762,51 @@ def test_compute_kv_layout_and_gather_scatter_roundtrip(
             assert torch.allclose(source[name][1], destination[name][5])
 
 
+def test_authoritative_cpu_nhd_layout_matches_engine_driven_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for DeepSeek MLA on post-vllm#51718 CPU layouts.
+
+    vLLM reports LBNHC/NHD and registers a rank-4 per-layer view. Treating it
+    as the legacy CPU HND layout swaps BS and NH, so the worker gathers the
+    right bytes into the wrong shape and the server rejects the store.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context.base import (
+        compute_kv_layout,
+        gather_paged_kv_to_cpu,
+    )
+
+    monkeypatch.setattr(
+        "lmcache.v1.gpu_connector.kv_format.detectors.vllm.torch_device_type",
+        "cpu",
+    )
+    source = _make_fused_nhd_kv_caches(
+        num_layers=2,
+        num_blocks=16,
+        block_size=16,
+        num_heads=1,
+        head_size=288,
+    )
+    layout_hints: LayoutHints = {
+        "kv_layout": "NHD",
+        "kv_layout_is_authoritative": True,
+    }
+
+    block_size, num_layers, hidden_dim, _, _, kv_size = compute_kv_layout(
+        source, layout_hints=layout_hints
+    )
+    gathered = gather_paged_kv_to_cpu(
+        source,
+        list(range(8)),
+        blocks_per_chunk=8,
+        layout_hints=layout_hints,
+    )
+
+    assert (block_size, num_layers, hidden_dim, kv_size) == (16, 2, 576, 1)
+    assert tuple(gathered[0].shape) == (2, 128, 576)
+
+
 @pytest.mark.parametrize(
     ("hnd_builder", "expected_format"),
     [

--- a/tests/v1/test_vllm_kv_layout_discovery.py
+++ b/tests/v1/test_vllm_kv_layout_discovery.py
@@ -116,7 +116,19 @@ class TestTryGetVllmKVCacheLayout:
 class TestVllmLayoutHints:
     def test_hint_present_and_translated(self):
         config = make_vllm_config("LBHNC")
-        assert vllm_layout_hints(config) == {"kv_layout": "HND"}
+        assert vllm_layout_hints(config) == {
+            "kv_layout": "HND",
+            "kv_layout_is_authoritative": True,
+        }
+
+    def test_legacy_hint_is_not_marked_authoritative(self, monkeypatch):
+        stub_module(
+            monkeypatch,
+            "vllm.v1.attention.backends.utils",
+            get_kv_cache_layout=lambda: "NHD",
+        )
+        config = SimpleNamespace(cache_config=LegacyCacheConfig())
+        assert vllm_layout_hints(config) == {"kv_layout": "NHD"}
 
     def test_unresolved_layout_raises_through_hints(self):
         with pytest.raises(ValueError, match="resolved"):
@@ -133,6 +145,10 @@ class TestResolveVllmKVLayout:
 
     def test_cpu_backend_forces_head_contiguous(self, resolve):
         assert resolve({"kv_layout": "NHD"}, cpu_attention_backend=True) == "HND"
+
+    def test_cpu_backend_honors_authoritative_layout(self, resolve):
+        hints = {"kv_layout": "NHD", "kv_layout_is_authoritative": True}
+        assert resolve(hints, cpu_attention_backend=True) == "NHD"
 
     def test_missing_hint_defaults_to_nhd(self, resolve):
         assert resolve({}, cpu_attention_backend=False) == "NHD"

--- a/tests/v1/test_vllm_kv_layout_discovery.py
+++ b/tests/v1/test_vllm_kv_layout_discovery.py
@@ -99,10 +99,21 @@ class TestTryGetVllmKVCacheLayout:
         assert try_get_vllm_kv_cache_layout() == "HND"
 
     def test_legacy_vllm_falls_back_to_backend_query(self, monkeypatch):
+        monkeypatch.setattr("lmcache.integration.vllm.utils.torch_device_type", "cuda")
         stub_module(
             monkeypatch,
             "vllm.v1.attention.backends.utils",
             get_kv_cache_layout=lambda: "HND",
+        )
+        config = SimpleNamespace(cache_config=LegacyCacheConfig())
+        assert try_get_vllm_kv_cache_layout(config) == "HND"
+
+    def test_legacy_cpu_nhd_is_normalized_at_vllm_boundary(self, monkeypatch):
+        monkeypatch.setattr("lmcache.integration.vllm.utils.torch_device_type", "cpu")
+        stub_module(
+            monkeypatch,
+            "vllm.v1.attention.backends.utils",
+            get_kv_cache_layout=lambda: "NHD",
         )
         config = SimpleNamespace(cache_config=LegacyCacheConfig())
         assert try_get_vllm_kv_cache_layout(config) == "HND"
@@ -116,19 +127,17 @@ class TestTryGetVllmKVCacheLayout:
 class TestVllmLayoutHints:
     def test_hint_present_and_translated(self):
         config = make_vllm_config("LBHNC")
-        assert vllm_layout_hints(config) == {
-            "kv_layout": "HND",
-            "kv_layout_is_authoritative": True,
-        }
+        assert vllm_layout_hints(config) == {"kv_layout": "HND"}
 
-    def test_legacy_hint_is_not_marked_authoritative(self, monkeypatch):
+    def test_legacy_cpu_hint_is_normalized(self, monkeypatch):
+        monkeypatch.setattr("lmcache.integration.vllm.utils.torch_device_type", "cpu")
         stub_module(
             monkeypatch,
             "vllm.v1.attention.backends.utils",
             get_kv_cache_layout=lambda: "NHD",
         )
         config = SimpleNamespace(cache_config=LegacyCacheConfig())
-        assert vllm_layout_hints(config) == {"kv_layout": "NHD"}
+        assert vllm_layout_hints(config) == {"kv_layout": "HND"}
 
     def test_unresolved_layout_raises_through_hints(self):
         with pytest.raises(ValueError, match="resolved"):
@@ -143,15 +152,14 @@ class TestResolveVllmKVLayout:
         )
         return detectors_vllm.resolve_vllm_kv_layout
 
-    def test_cpu_backend_forces_head_contiguous(self, resolve):
-        assert resolve({"kv_layout": "NHD"}, cpu_attention_backend=True) == "HND"
-
-    def test_cpu_backend_honors_authoritative_layout(self, resolve):
-        hints = {"kv_layout": "NHD", "kv_layout_is_authoritative": True}
-        assert resolve(hints, cpu_attention_backend=True) == "NHD"
+    def test_cpu_backend_honors_explicit_layout(self, resolve):
+        assert resolve({"kv_layout": "NHD"}, cpu_attention_backend=True) == "NHD"
 
     def test_missing_hint_defaults_to_nhd(self, resolve):
         assert resolve({}, cpu_attention_backend=False) == "NHD"
+
+    def test_missing_cpu_hint_keeps_legacy_hnd_default(self, resolve):
+        assert resolve({}, cpu_attention_backend=True) == "HND"
 
     def test_hnd_hint_passes_through(self, resolve):
         assert resolve({"kv_layout": "HND"}, cpu_attention_backend=False) == "HND"


### PR DESCRIPTION
## Summary

Validate and fix DeepSeek-V2-Lite CPU MLA with LMCache after vLLM CPU MLA support landed in https://github.com/vllm-project/vllm/pull/51471.

https://github.com/LMCache/LMCache/pull/4451 has now merged into `dev` and provides the LMCache-driven baseline. This PR is rebased directly on that merged code. It re-enables Engine-driven pickle and SHM coverage, identifies why only those paths exposed the bug, and fixes both the layout root cause and the incomplete Engine-driven registration contract.

## Background: NHD and HND

`NHD` and `HND` describe the physical order of the token (`N`), head (`H`), and per-head content (`D`) axes. For a paged fused-K/V cache, LMCache sees one rank-4 tensor per layer:

- NHD: `[num_blocks, block_size, num_heads, content_size]`
- HND: `[num_blocks, num_heads, block_size, content_size]`

The two middle axes cannot be identified from tensor rank alone, especially for MLA where `num_heads == 1`; LMCache must trust the layout resolved by vLLM.

## Root cause

After https://github.com/vllm-project/vllm/pull/51718, vLLM resolves the physical KV layout centrally. DeepSeek-V2-Lite CPU MLA reports `LBNHC`, which maps to LMCache `NHD`.

LMCache translated that value correctly, but its generic detector then applied an old CPU compatibility workaround and changed explicit `NHD` back to `HND`. This swapped `block_size` and `num_heads`, producing incorrect geometry such as `block_size=1` and an inflated flattened hidden dimension.

The fix moves the old-version CPU normalization to the vLLM integration boundary. Legacy vLLM reports are still corrected to HND, while an explicit resolved layout is now always treated as the physical truth. The temporary `kv_layout_is_authoritative` sideband is no longer needed.

## Why LMCache-driven passed but Engine-driven failed

LMCache-driven carries the engine block metadata and transfers the underlying block storage directly. With this particular single-head MLA shape, swapping the token and head axes preserved the total element count, and the wrong block-size arithmetic canceled out during the symmetric store/retrieve round trip. Passing therefore did not prove that layout detection was correct.

That accidental tolerance will not hold once transfer behavior depends on axis semantics rather than only total bytes, for example with multiple heads, compressed or subpaged state, padded/non-contiguous layouts, per-head strides, or native kernels with head-dimension constraints. LMCache-driven therefore also needed the layout root fix even though this E2E happened to pass.

Engine-driven exposed the problem immediately because the two sides derived the chunk shape independently:

- the worker gathered `[num_layers, blocks_in_chunk * detected_block_size, hidden_dim]`;
- the server assumed `[num_layers, logical_lmcache_chunk_size, hidden_dim]`.

Once the layout was misread, the worker produced a physical-slot axis of `1` or `8`, while the server expected `128`, so the server rejected the chunk instead of benefiting from the byte-count cancellation.

## Engine-driven protocol hardening

Registration now includes optional `num_physical_slots`: the exact number of physical KV slots in one gathered LMCache chunk.

The worker computes it as:

```text
num_physical_slots = blocks_in_chunk * detected_slots_per_block
```

The server uses this value to build the same memory layout as the worker instead of assuming that physical slots always equal logical LMCache tokens. Older clients remain compatible: when the field is absent, the server falls back to the previous logical chunk-size behavior. The field closes a real protocol gap for future layouts where one logical token does not map one-to-one to one physical slot.

## Verification

- [x] Explicit post-vLLM#51718 NHD and legacy CPU layout regression coverage
- [x] Worker/server `num_physical_slots` registration coverage, including logical chunk `256` vs physical slots `128`
- [x] Full pre-commit suite for the Python changes
- [x] Full k3 native-extension unit suite
- [x] DeepSeek-V2-Lite Engine-driven pickle, Engine-driven SHM, and LMCache-driven E2E on Ubuntu and macOS
- [x] opt-125m CPU regression coverage on Ubuntu and macOS

All current PR checks pass. CPU Device Tests after rebasing onto the merged baseline: https://github.com/LMCache/LMCache/actions/runs/33294104210

LMCache-driven baseline: https://github.com/LMCache/LMCache/pull/4451 (merged).


