### PR TITLE
[CI]: clamp the vLLM pin past the broken 0.28.1rc1 nightlies

### DIFF
--- a/.buildkite/k3_harness/resolve-pinned-vllm.sh
+++ b/.buildkite/k3_harness/resolve-pinned-vllm.sh
@@ -81,6 +81,20 @@ if [[ -z "${PINNED_VLLM_VERSION}" && "${USE_PINNED_VLLM}" == "true" ]]; then
     fi
 fi
 
+# The 0.28.1rc1 nightlies break DeepSeek-V4-Flash sparse decode on SM120
+# ("eidx must be contiguous", flashinfer _sparse_mla_sm120) at engine start.
+# The canary verifies nightlies with vllm_bench only, so it green-lit that
+# range and dsv4_flash_tp went red from the re-pin onward -- it was green on
+# 0.27.1 the same morning with everything else equal, and the same stack
+# passes on SM90. Clamp back to the last good release until a nightly passes
+# dsv4 again. TODO: drop the clamp and have the canary verify dsv4_flash_tp.
+if [[ "${PINNED_VLLM_VERSION}" == 0.28.1rc1.* ]]; then
+    echo "[resolve-pinned-vllm] pin ${PINNED_VLLM_VERSION} is in the"          "known-bad 0.28.1rc1 range for dsv4_flash_tp; clamping to 0.27.1" >&2
+    PINNED_VLLM_VERSION="0.27.1"
+    PINNED_VLLM_ARCHIVE_INDEX_URL=""
+    PINNED_VLLM_FULL_SHA=""
+fi
+
 export PINNED_VLLM_VERSION
 export PINNED_VLLM_ARCHIVE_INDEX_URL
 export PINNED_VLLM_FULL_SHA

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -118,16 +118,12 @@ else
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0"
     echo "Installing latest vLLM nightly (no pin)"
 fi
-# flashinfer 0.6.17 breaks DeepSeek-V4 sparse decode on SM120 ("eidx must
-# be contiguous", _sparse_mla_sm120.py) at engine start; dsv4_flash_tp was
-# green the same morning on 0.6.16.post3 with the same vLLM wheel. Current
-# nightlies hard-pin flashinfer-python==0.6.17, so a co-installed requirement
-# is unsatisfiable -- an overrides file is the supported way to outrank a
-# dependency pin. TODO: drop once flashinfer ships the fix.
-FLASHINFER_OVERRIDES_FILE="$(mktemp)"
-echo 'flashinfer-python==0.6.16.post3' > "${FLASHINFER_OVERRIDES_FILE}"
-uv pip install -U "${VLLM_INSTALL_SPEC}" \
-    --overrides "${FLASHINFER_OVERRIDES_FILE}" \
+# flashinfer resolves unpinned by the vllm extra, so a flashinfer release
+# can flip the environment under an unchanged vLLM pin. 0.6.17 broke
+# DeepSeek-V4 sparse decode on SM120 ("eidx must be contiguous",
+# _sparse_mla_sm120.py); dsv4_flash_tp was green on 0.6.16 the same
+# morning with the same vLLM. TODO: unpin once flashinfer ships the fix.
+uv pip install -U "${VLLM_INSTALL_SPEC}" "flashinfer-python==0.6.16" \
     --reinstall-package transformers \
     --reinstall-package tokenizers \
     --reinstall-package huggingface-hub \

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -118,12 +118,16 @@ else
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0"
     echo "Installing latest vLLM nightly (no pin)"
 fi
-# flashinfer resolves unpinned by the vllm extra, so a flashinfer release
-# can flip the environment under an unchanged vLLM pin. 0.6.17 broke
-# DeepSeek-V4 sparse decode on SM120 ("eidx must be contiguous",
-# _sparse_mla_sm120.py); dsv4_flash_tp was green on 0.6.16 the same
-# morning with the same vLLM. TODO: unpin once flashinfer ships the fix.
-uv pip install -U "${VLLM_INSTALL_SPEC}" "flashinfer-python==0.6.16" \
+# flashinfer 0.6.17 breaks DeepSeek-V4 sparse decode on SM120 ("eidx must
+# be contiguous", _sparse_mla_sm120.py) at engine start; dsv4_flash_tp was
+# green the same morning on 0.6.16.post3 with the same vLLM wheel. Current
+# nightlies hard-pin flashinfer-python==0.6.17, so a co-installed requirement
+# is unsatisfiable -- an overrides file is the supported way to outrank a
+# dependency pin. TODO: drop once flashinfer ships the fix.
+FLASHINFER_OVERRIDES_FILE="$(mktemp)"
+echo 'flashinfer-python==0.6.16.post3' > "${FLASHINFER_OVERRIDES_FILE}"
+uv pip install -U "${VLLM_INSTALL_SPEC}" \
+    --overrides "${FLASHINFER_OVERRIDES_FILE}" \
     --reinstall-package transformers \
     --reinstall-package tokenizers \
     --reinstall-package huggingface-hub \

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -118,7 +118,12 @@ else
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0"
     echo "Installing latest vLLM nightly (no pin)"
 fi
-uv pip install -U "${VLLM_INSTALL_SPEC}" \
+# flashinfer resolves unpinned by the vllm extra, so a flashinfer release
+# can flip the environment under an unchanged vLLM pin. 0.6.17 broke
+# DeepSeek-V4 sparse decode on SM120 ("eidx must be contiguous",
+# _sparse_mla_sm120.py); dsv4_flash_tp was green on 0.6.16 the same
+# morning with the same vLLM. TODO: unpin once flashinfer ships the fix.
+uv pip install -U "${VLLM_INSTALL_SPEC}" "flashinfer-python==0.6.16" \
     --reinstall-package transformers \
     --reinstall-package tokenizers \
     --reinstall-package huggingface-hub \

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -118,12 +118,7 @@ else
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]>=0.0.0.dev0"
     echo "Installing latest vLLM nightly (no pin)"
 fi
-# flashinfer resolves unpinned by the vllm extra, so a flashinfer release
-# can flip the environment under an unchanged vLLM pin. 0.6.17 broke
-# DeepSeek-V4 sparse decode on SM120 ("eidx must be contiguous",
-# _sparse_mla_sm120.py); dsv4_flash_tp was green on 0.6.16 the same
-# morning with the same vLLM. TODO: unpin once flashinfer ships the fix.
-uv pip install -U "${VLLM_INSTALL_SPEC}" "flashinfer-python==0.6.16" \
+uv pip install -U "${VLLM_INSTALL_SPEC}" \
     --reinstall-package transformers \
     --reinstall-package tokenizers \
     --reinstall-package huggingface-hub \

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1115,14 +1115,16 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
-        """Prefer the head-contiguous layout; None (MLA) defers to vLLM."""
-        model_config = getattr(vllm_config, "model_config", None)
-        if model_config is None or model_config.use_mla:
-            return None
-        if not hasattr(vllm_config.cache_config, "get_resolved_kv_cache_layout"):
-            return "HND"
-        # Not "HND": MultiConnector compares preference strings verbatim.
-        return "LBHNC"
+        """Defer to vLLM; a connector preference is unsafe for now.
+
+        Connector preferences outrank the default in vLLM's layout
+        resolution, but backends that assume a layout without declaring it
+        via ``supported_kv_cache_layouts`` (e.g. the DeepSeek V4 sparse
+        attention, which hardcodes NHD) silently read a pool laid out
+        differently. LMCache handles every resolved layout, so express no
+        preference until such backends declare theirs.
+        """
+        return None
 
     def get_finished_count(self) -> int | None:
         """

--- a/tests/v1/test_mp_connector_layout_preference.py
+++ b/tests/v1/test_mp_connector_layout_preference.py
@@ -36,8 +36,8 @@ def make_config(use_mla: bool = False, legacy: bool = False) -> SimpleNamespace:
     )
 
 
-def test_non_mla_prefers_standardized_head_contiguous_layout(connector_cls):
-    assert connector_cls.get_required_kvcache_layout(make_config()) == "LBHNC"
+def test_non_mla_defers_to_vllm(connector_cls):
+    assert connector_cls.get_required_kvcache_layout(make_config()) is None
 
 
 def test_mla_defers_to_vllm(connector_cls):
@@ -45,7 +45,7 @@ def test_mla_defers_to_vllm(connector_cls):
 
 
 def test_legacy_vllm_gets_legacy_name(connector_cls):
-    assert connector_cls.get_required_kvcache_layout(make_config(legacy=True)) == "HND"
+    assert connector_cls.get_required_kvcache_layout(make_config(legacy=True)) is None
 
 
 def test_missing_model_config_defers(connector_cls):


### PR DESCRIPTION
Unblocks dev CI: every k3-multiprocess build has failed `dsv4_flash_tp` since 08-28 morning.

**Root cause -- the CI vLLM pin advanced, not any LMCache commit.** The canary re-pinned vLLM from stable **0.27.1** to the **0.28.1rc1 nightlies** between dev builds 4514 (last green, 01:26) and 4533 (first red). That nightly range breaks DeepSeek-V4-Flash sparse decode on SM120 -- `eidx must be contiguous` from flashinfer's `_sparse_mla_sm120` during engine start. The canary verifies nightlies with `vllm_bench` only, so it green-lit the range.

Evidence:
- build 4514 (pre-#4729): pinned vLLM **0.27.1** -- dsv4 **green**
- build 4533 (the #4729 merge): pinned 0.28.1rc1.dev43 -- dsv4 red
- build 4556 (**control: pre-#4729 commit rerun**): 0.28.1rc1 -- dsv4 **red on the old code**
- flashinfer version ruled out: pinning 0.6.16.post3 under the 0.28 nightly (build 4570) still fails; the eidx check is byte-identical in 0.6.16.post3 / 0.6.17 / 0.6.18
- the full `dsv4_flash_tp` script passes locally on SM90 with the 0.28 nightly (TP=4, bit-identical outputs, LMCache-served retrieves), so the break is SM120-specific and upstream

**Fix:** `resolve-pinned-vllm.sh` clamps a fetched 0.28.1rc1.* pin back to 0.27.1 (with a TODO to drop the clamp and have the canary verify `dsv4_flash_tp` before re-pinning). Upstream vLLM issue for the SM120 regression to follow.

Also keeps: drop `get_required_kvcache_layout`'s LBHNC preference (not the dsv4 cause, but a preference outranks the default in vLLM's resolution while backends that assume a layout without declaring `supported_kv_cache_layouts` would silently read a flipped pool; LMCache handles every resolved layout).