### PR TITLE
ci: install ATOM dependencies in ROCm torch 2.10 smoke test

### DIFF
--- a/.github/workflows/build_rocm_torch210_artifacts.yml
+++ b/.github/workflows/build_rocm_torch210_artifacts.yml
@@ -119,9 +119,22 @@ jobs:
                     --entrypoint bash "${ROCM_PYTORCH_IMAGE}" -lc '
                       set -euo pipefail
                       python -m pip uninstall -y lmcache
-                      # Minimal dependencies needed to import the integration
-                      # adapters; never resolve the unpinned torch dependency.
-                      python -m pip install "numpy<=2.2.6" cachetools numba
+                      # Minimal dependencies needed to import the native and ATOM
+                      # integration modules; never resolve the unpinned torch
+                      # dependency from the wheel metadata.
+                      python -m pip install \
+                        aiohttp \
+                        "numpy<=2.2.6" \
+                        cachetools \
+                        msgspec \
+                        numba \
+                        "prometheus-client>=0.18.0,<=0.24.1" \
+                        psutil \
+                        py-cpuinfo \
+                        pyyaml \
+                        "pyzmq>=25.0.0" \
+                        requests \
+                        sortedcontainers
                       python -m pip install --no-deps --force-reinstall /wheel/*.whl
                       cd /tmp
                       python /validate_rocm_torch210_wheel.py


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the ROCm torch 2.10 release smoke test after native ATOM integration was added.

The wheel is intentionally installed with `--no-deps` to preserve the pinned ROCm torch runtime, but the manually installed smoke dependencies did not cover the ATOM adapter's import closure. The release workflow therefore failed with `ModuleNotFoundError: No module named 'zmq'`; after adding that direct dependency, end-to-end validation also exposed the transitive `prometheus_client` requirement.

Install the complete required top-level dependency set reached by the native and ATOM import validation while continuing to leave torch supplied by the pinned ROCm image.

Validation:
- `actionlint .github/workflows/build_rocm_torch210_artifacts.yml`
- targeted pre-commit checks
- recursive ATOM import-closure audit
- clean ROCm torch 2.10 wheel build, ATOM smoke test, and artifact upload: https://github.com/andyluo7/LMCache/actions/runs/33202430298

**Special notes for your reviewers**:

This keeps `--no-deps`; it does not allow pip to replace the pinned AMD ROCm torch build.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
