### PR TITLE
[Fix] explicit bucket boundaries for L1 lifecycle histograms

### DIFF
--- a/lmcache/v1/mp_observability/subscribers/metrics/l1_lifecycle.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l1_lifecycle.py
@@ -23,6 +23,22 @@ from opentelemetry import metrics
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
 
+_LIFECYCLE_BUCKETS_S: tuple[float, ...] = (
+    1.0,
+    5.0,
+    15.0,
+    30.0,
+    60.0,
+    120.0,
+    300.0,
+    600.0,
+    900.0,
+    1800.0,
+    3600.0,
+    7200.0,
+    14400.0,
+)
+
 
 @dataclass
 class _L1ChunkState:
@@ -45,7 +61,10 @@ class L1LifecycleSubscriber(EventSubscriber):
     Parameters:
         sample_rate: Fraction of chunks to track (0, 1.0].  Default 0.01 (1%).
         max_evict_reuse_wait: Maximum seconds to track an evicted chunk
-            waiting for reuse.  Default 300 s (5 min).
+            waiting for reuse.  Must be positive.  Default 300 s (5 min).
+
+    Raises:
+        ValueError: If ``max_evict_reuse_wait`` is not positive.
     """
 
     def __init__(
@@ -56,6 +75,10 @@ class L1LifecycleSubscriber(EventSubscriber):
         assert 0 < sample_rate <= 1.0, (
             f"sample_rate must be in (0, 1.0], got {sample_rate}"
         )
+        if max_evict_reuse_wait <= 0:
+            raise ValueError(
+                f"max_evict_reuse_wait must be positive, got {max_evict_reuse_wait}"
+            )
         self._sample_rate = sample_rate
         self._max_evict_reuse_wait = max_evict_reuse_wait
         # Deterministic sampling via hash: hash(key) % _SAMPLE_PRIME < threshold.
@@ -69,11 +92,13 @@ class L1LifecycleSubscriber(EventSubscriber):
                 "Histogram of L1 chunk lifetime from allocation to eviction (seconds)."
             ),
             unit="s",
+            explicit_bucket_boundaries_advisory=_LIFECYCLE_BUCKETS_S,
         )
         self._idle_hist = meter.create_histogram(
             "lmcache_mp.l1_chunk_idle_before_evict",
             description=("Histogram of idle time before L1 chunk eviction (seconds)."),
             unit="s",
+            explicit_bucket_boundaries_advisory=_LIFECYCLE_BUCKETS_S,
         )
         self._reuse_gap_hist = meter.create_histogram(
             "lmcache_mp.l1_chunk_reuse_gap",
@@ -82,7 +107,13 @@ class L1LifecycleSubscriber(EventSubscriber):
                 "touches (write or read) of the same L1 chunk (seconds)."
             ),
             unit="s",
+            explicit_bucket_boundaries_advisory=_LIFECYCLE_BUCKETS_S,
         )
+        # The cap must be a boundary: otherwise capped samples land in a wider
+        # bucket and histogram_quantile interpolates values above the cap.
+        evict_reuse_buckets = [
+            b for b in _LIFECYCLE_BUCKETS_S if b < max_evict_reuse_wait
+        ] + [max_evict_reuse_wait]
         self._evict_reuse_gap_hist = meter.create_histogram(
             "lmcache_mp.l1_chunk_evict_reuse_gap",
             description=(
@@ -90,6 +121,7 @@ class L1LifecycleSubscriber(EventSubscriber):
                 "next reuse.  Capped at max_evict_reuse_wait."
             ),
             unit="s",
+            explicit_bucket_boundaries_advisory=evict_reuse_buckets,
         )
 
         # Shadow map: key -> chunk lifecycle state (live chunks).


### PR DESCRIPTION
**Description**:

The four `lmcache_mp.l1_chunk_*` histograms used the OTel SDK default bucket grid (0, 5, ..., 250, 500, 750, ..., 10000), which has no boundary at the 300 s `max_evict_reuse_wait` cap.  Every capped `l1_chunk_evict_reuse_gap` sample therefore fell into the (250, 500] bucket, and `histogram_quantile()` in Grafana interpolated p99 values up to ~500 s even though no recorded value can exceed 300 s.

- Declare seconds-scale `explicit_bucket_boundaries_advisory` on all four lifecycle histograms.
- Use `max_evict_reuse_wait` as the final boundary of the evict-reuse histogram so capped samples land in `le=<cap>`.
- Validate `max_evict_reuse_wait > 0`.

Recorded values are unchanged; only the export-time bucketing differs.

 
**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
