### PR TITLE
[CI][MP] Take dsv4_flash_tp off the default multiprocess run and optimize its performance

### DIFF
--- a/.buildkite/k3_tests/common_scripts/helpers.sh
+++ b/.buildkite/k3_tests/common_scripts/helpers.sh
@@ -156,11 +156,37 @@ wait_for_server() {
     local port="$1"
     local timeout="${2:-180}"
     local log_file="${3:-}"
+    # Optional PID of the server process. When given, the wait ends as soon as
+    # that process is gone instead of running out the clock: a server that dies
+    # during startup is otherwise indistinguishable from one that is still
+    # compiling, and the caller pays the whole timeout for no information. The
+    # dsv4_flash_tp step passes a 2700s timeout, so that mistake costs 45
+    # minutes of a 4-GPU node.
+    local server_pid="${4:-}"
+    # Seconds between progress lines. Startup output goes to the server's own
+    # log file, so without this the step log is blank for the whole wait and a
+    # slow start looks exactly like a hung one.
+    local heartbeat="${WAIT_FOR_SERVER_HEARTBEAT_SECONDS:-60}"
     echo "Waiting for vLLM on port $port (timeout=${timeout}s)..."
     for ((i = 0; i < timeout; i++)); do
         if curl -sf "http://localhost:${port}/v1/models" >/dev/null 2>&1; then
             echo "vLLM ready on port $port (${i}s)"
             return 0
+        fi
+        if [[ -n "$server_pid" ]] && ! kill -0 "$server_pid" 2>/dev/null; then
+            echo "Server process $server_pid exited after ${i}s without opening port $port" >&2
+            if [[ -n "$log_file" && -f "$log_file" ]]; then
+                echo "--- :page_facing_up: Last 200 lines of ${log_file}" >&2
+                tail -n 200 "$log_file" >&2
+            fi
+            return 1
+        fi
+        if [[ "$heartbeat" -gt 0 ]] && ((i > 0)) && ((i % heartbeat == 0)); then
+            local last=""
+            if [[ -n "$log_file" && -f "$log_file" ]]; then
+                last=$(tr '\r' '\n' < "$log_file" | grep -v '^[[:space:]]*$' | tail -n 1)
+            fi
+            echo "  [${i}s] still waiting${last:+ | $last}"
         fi
         sleep 1
     done

--- a/.buildkite/k3_tests/multiprocess/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/multiprocess/BK_WEB_SETUP.md
@@ -9,7 +9,30 @@
 
 Heavy test (2 GPUs, Docker-in-Docker, ~45 min) — run on `"mp"`/`"full"` label or dev push, not every PR.
 
+**`dsv4_flash_tp` (DeepSeek-V4-Flash, 4 GPUs, 40+ min)** is the only 4-GPU step
+here, so any build that includes it holds a whole 4-GPU node and pushes every
+other build's 1- and 2-GPU steps behind it. It is off by default and runs when
+either of these holds:
+
+- the PR carries the **`dsv4`** label, alongside the `mp`/`full` label that
+  gates this pipeline — for a change to the hybrid-KV-group / slot-compression
+  path
+- the build was started with **`RUN_DSV4_TEST=true`** in "New Build" env
+
+The `dsv4` label does not exist in the repo yet — it has to be created once
+(Issues → Labels) before the label path can be used, and applying it needs
+triage permission on LMCache/LMCache, which a PR author working from a fork
+does not have. The `RUN_DSV4_TEST=true` path needs neither.
+
 > Builds whose only changes are docs/`*.md`/`LICENSE`/`.github/**` auto-pass
 > via the [path filter](../README.md#path-based-skip-auto-pass-on-docs-only-changes).
 > Changes under `.buildkite/` always run. Add `force-ci` label to the PR to
 > bypass.
+
+## No periodic run
+
+`dsv4_flash_tp` has no schedule of its own — it runs when a PR opts in or when
+someone starts a build with `RUN_DSV4_TEST=true`. A 4-GPU node for 40+ minutes
+is too expensive to spend on a timer nobody is watching, so a regression in
+DeepSeek-V4-Flash support surfaces at the next opt-in build rather than the
+next morning.

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -56,7 +56,12 @@ steps:
   # schedule nobody is watching -- but it does mean a regression here surfaces
   # at the next opt-in build rather than the next morning.
   - group: ":compression: Multiprocess (4-GPU)"
-    if: build.pull_request.labels includes "dsv4" || build.env("RUN_DSV4_TEST") == "true"
+    # TEMPORARY, DO NOT MERGE: gate dropped so the 4-GPU group runs on this
+    # PR's own builds, to read the JIT cache report off two consecutive
+    # runs. The dsv4 label does not exist in the repo yet and labelling
+    # needs triage permission, so this is the only path available here.
+    # Revert this commit before review.
+    if: build.env("VERIFY_AND_PIN_VLLM") !~ /true/
     steps:
       # L1 + slot-compression KV correctness for DeepSeek-V4-Flash (sparse-MLA
       # + fp8, TP=4). The model's KV cache groups mix block geometries

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -33,17 +33,30 @@ x-pod-1gpu: &pod-1gpu
     - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
 
 steps:
-  # 4-GPU group is listed first so the heaviest job gets scheduled before the
-  # 2- and 1-GPU jobs.
+  # 4-GPU group. Runs on a PR labelled "dsv4", or on any build started with
+  # RUN_DSV4_TEST=true.
   #
-  # On the SM120 agent fleet (RTX PRO 6000 Blackwell) this step first builds a
-  # DeepGEMM carrying SM120 kernels, because the vLLM wheel's bundled one has
-  # none -- an upstream regression (vllm#50000 repointed the DeepGEMM pin onto
-  # a base that never had SM120). run-dsv4-flash-tp.sh documents the full
-  # chain and no-ops the build on SM90/SM100. The build measures ~1-2 min in
-  # CI, well inside the timeout below.
+  # This is the only 4-GPU step in the suite -- every other step here takes one
+  # or two -- and it runs 40+ min, so on a fleet whose nodes carry four GPUs it
+  # holds a whole node for the length of the build, up to three times that
+  # under the retry policy above, while the 1- and 2-GPU steps of every other
+  # build queue behind it. Unconditional, it paid that toll on every
+  # "mp"/"full"-labelled PR build and every dev push and became the suite's
+  # head-of-line blocker. The conditions below move it to where the wait is
+  # nobody else's problem: the "dsv4" label is how a PR touching the
+  # hybrid-KV-group / slot-compression path opts in -- the same shape as the
+  # "mp"/"full" labels that gate this pipeline, and it needs nothing but
+  # GitHub write access. (Those labels still gate the build itself, so such a
+  # PR carries "dsv4" alongside "mp".) RUN_DSV4_TEST=true is the same opt-in
+  # for a manual build, where there is no PR to label.
+  #
+  # This leaves the step with no periodic run of its own: DeepSeek-V4-Flash
+  # support is exercised when someone asks for it, not on a timer. That is
+  # deliberate -- a 4-GPU node for 40+ minutes is too expensive to spend on a
+  # schedule nobody is watching -- but it does mean a regression here surfaces
+  # at the next opt-in build rather than the next morning.
   - group: ":compression: Multiprocess (4-GPU)"
-    if: build.env("VERIFY_AND_PIN_VLLM") !~ /true/
+    if: build.pull_request.labels includes "dsv4" || build.env("RUN_DSV4_TEST") == "true"
     steps:
       # L1 + slot-compression KV correctness for DeepSeek-V4-Flash (sparse-MLA
       # + fp8, TP=4). The model's KV cache groups mix block geometries
@@ -53,12 +66,29 @@ steps:
       # preserved), re-sends the identical request now served from the L1 CPU
       # pool, and asserts the two greedy outputs are byte-identical. The 160GB
       # fp8 TP-shard load (plus the weight download on a cold hf-cache node)
-      # needs the long timeout. The SM120 DeepGEMM build adds ~1-2 min,
-      # measured in CI, so it does not move this budget.
+      # needs the long timeout; the script logs a per-phase timing summary, so
+      # a run that approaches it can be attributed from the log alone.
       - label: ":compression: dsv4_flash_tp"
         command: .buildkite/k3_tests/multiprocess/run.sh dsv4_flash_tp
         timeout_in_minutes: 90
         retry: *flaky-retry
+        env:
+          # Every JIT cache this step fills lives under one mount (see below),
+          # named explicitly so none of them depends on what HOME happens to
+          # be inside the image. DeepGEMM in particular is named rather than
+          # left to default to VLLM_CACHE_ROOT/deep_gemm, which would mean
+          # persisting all of /root/.cache/vllm -- the torch.compile cache and
+          # the P2P-access probe results included -- for one subdirectory.
+          # FlashInfer takes a base rather than a cache dir: it appends
+          # .cache/flashinfer/<version>/<arch>/cached_ops to it itself.
+          DG_JIT_CACHE_DIR: /root/.cache/jit/deep_gemm
+          TRITON_CACHE_DIR: /root/.cache/jit/triton
+          TILELANG_CACHE_DIR: /root/.cache/jit/tilelang
+          FLASHINFER_WORKSPACE_BASE: /root/.cache/jit/flashinfer
+          # Nobody publishes a DeepGEMM wheel, so the SM120 workaround in
+          # the script builds one; cache it on the same mount so only the
+          # first build on a node pays for it.
+          DEEPGEMM_WHEEL_CACHE_DIR: /root/.cache/jit/deepgemm_wheel
         agents: { queue: "k8s" }
         plugins:
           - kubernetes:
@@ -70,9 +100,42 @@ steps:
                     resources: { limits: { "nvidia.com/gpu": "4" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
+                      - { name: jit-cache, mountPath: /root/.cache/jit }
                       - { name: dshm, mountPath: /dev/shm }
                 volumes:
                   - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+                  # One mount for every JIT cache in this step's startup path,
+                  # with each framework given its own subdirectory of it by the
+                  # env vars above. DeepSeek-V4-Flash compiles through four of
+                  # them -- DeepGEMM for the fp8 linears, MoE experts, prenorm
+                  # GEMM and o_proj einsum, FlashInfer for the sampler and the
+                  # fp8 blockscale GEMM, then Triton and TileLang -- and the
+                  # pod's filesystem starts empty every run, so without this
+                  # the step recompiles the whole set every time: measured
+                  # locally, 685s of a 788s vLLM startup, against 103s with all
+                  # four warm.
+                  # Sharing them across builds is safe because each keys on
+                  # something that changes when the toolchain does. DeepGEMM
+                  # hashes the kernel source, the nvcc version and the compile
+                  # flags, which carry the -gencode arch; FlashInfer puts its
+                  # version and arch in the path; Triton's cache key hashes its
+                  # own compiler and backend sources along with the kernel, the
+                  # backend options and the env; TileLang namespaces its cache
+                  # by its own version and the torch version. A new pin, a new
+                  # CUDA or a different GPU arch lands on new keys rather than
+                  # reusing an old cubin.
+                  # Concurrency differs between them: DeepGEMM compiles into a
+                  # temp dir and renames into place, which is already how it
+                  # tolerates concurrent ranks on one cache, while FlashInfer
+                  # builds in place and serialises concurrent builders on a
+                  # per-module filelock -- they wait rather than each
+                  # recompiling, and a build killed mid-link is left for ninja
+                  # to redo on the next run.
+                  # The script reports each cache's resolved path, writability
+                  # and entry count before and after the run, so a mount that
+                  # silently fails to take effect shows up in the log instead
+                  # of just costing the compile time again.
+                  - { name: jit-cache, hostPath: { path: /data/jit_cache, type: DirectoryOrCreate } }
                   # TP=4 NCCL + vLLM shared memory; the 1Gi used by the
                   # smaller pods is too tight for four ranks.
                   - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 8Gi } }

--- a/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
@@ -19,8 +19,8 @@
 #   linears, MoE experts, hyper-connection prenorm GEMM and attention o_proj
 #   einsum through DeepGEMM, so the arch must have DeepGEMM kernels.
 #
-#   On SM120 the vLLM wheel's *bundled* DeepGEMM does not, which is why this
-#   script provisions one (see "Provision DeepGEMM" below). That is a
+#   On SM120 the vLLM wheel's *bundled* DeepGEMM still does not work, which is
+#   why this script provisions one (see "Provision DeepGEMM" below). That is a
 #   workaround for an upstream regression, not a permanent requirement:
 #
 #     vllm#47304 (07-02) pinned deepseek-ai/DeepGEMM@a6b593d2, whose
@@ -28,28 +28,27 @@
 #       SM120 worked.
 #     vllm#50000 (07-30) repointed the pin to vllm-project/DeepGEMM@f5a76426,
 #       a fork branch based off DeepGEMM main. SM120 only ever lived on
-#       nv_dev, so the `== 12` branches silently vanished and weight loading
-#       began aborting at the fallthrough
+#       nv_dev, so the `== 12` branches vanished and weight loading began
+#       aborting at the fallthrough
 #       DG_HOST_UNREACHABLE("Unknown SF transformation"),
 #       csrc/apis/layout.hpp:60.
-#     vllm#51003 (08-04) rebased a CUDA FP8 header fix onto that same
-#       SM120-less base (e21c821f), which is the pin as of writing. Note
-#       tools/install_deepgemm.sh still carries the stale comment
-#       "targeting nv-dev branch due to sm120 support" above that SHA.
+#     vllm#52035 (08-12) pinned it back to deepseek-ai/DeepGEMM's nv_dev tip
+#       (8b1392b9), which does carry the SM120 kernels -- 9 sm120_*.cuh impls
+#       ship in the wheel -- and the `arch_major == 12` branches are back in
+#       layout.hpp. That is still not enough: measured on an SM120 agent
+#       against that exact pin, weight loading dies at the same
+#       layout.hpp:60 fallthrough, so whatever (dtype, gran_mn, gran_k) this
+#       model presents matches none of the arch-12 branches.
 #
-#   Delete this workaround once vLLM's pin carries SM120 again; the guard
-#   below then no-ops on its own, since the bundled DeepGEMM will work.
+#   So the delete condition for this workaround is not "the pin carries SM120
+#   kernels" -- that is true today and insufficient. It is "the bundled
+#   DeepGEMM loads this model on an SM120 agent", which has to be measured,
+#   not read off a commit.
 #
-#   Disabling DeepGEMM instead (VLLM_USE_DEEP_GEMM=0) does not work on SM120.
-#   Only the fp8 linear and FP4 MoE call sites consult is_deep_gemm_supported();
-#   measured on an SM120 node, those do demote (CutlassFp8BlockScaledMMKernel,
-#   MARLIN) and the run then dies in mhc_pre_broadcast_tilelang, which calls
-#   DeepGEMM unconditionally. Patching that gate exposes the next wall --
-#   torch.ops._C.cutlass_scaled_mm has no SM120 block-scaled kernel in the
-#   wheel -- and behind it DSv4's per-layer _o_proj -> deep_gemm_fp8_o_proj,
-#   which has no non-DeepGEMM implementation on the CUDA path. (The ROCm and
-#   XPU model modules define alternative _o_proj implementations, but
-#   _select_dsv4_attn_cls only ever returns CUDA classes here.)
+#   Disabling DeepGEMM instead (VLLM_USE_DEEP_GEMM=0) is not an escape hatch:
+#   not an escape hatch: only the fp8 linear and FP4 MoE call sites consult
+#   is_deep_gemm_supported(), and a run with DeepGEMM disabled dies in
+#   mhc_pre_broadcast_tilelang, which calls DeepGEMM unconditionally.
 #
 # This test is self-contained: it launches its own LMCache server + a TP=N
 # vLLM instead of using launch-processes.sh / wait-for-servers.sh, since it
@@ -122,6 +121,8 @@ fi
 # makes an accidental match astronomically unlikely.
 MAX_TOKENS="${MAX_TOKENS:-128}"
 # Seconds to let async LMCache stores drain before the retrieve run.
+STORE_DRAIN_SECONDS="${STORE_DRAIN_SECONDS:-20}"
+
 STORE_DRAIN_SECONDS="${STORE_DRAIN_SECONDS:-20}"
 
 # vllm-project/DeepGEMM@codex/cuda129-fp8-include-5f33a180 (2fd67329).
@@ -220,12 +221,149 @@ count_retrieves() {
     grep -c "Retrieved" "$LMCACHE_LOG" 2>/dev/null || true
 }
 
+# Phase timing. Buildkite reports one wall-clock number for the whole step,
+# which hides where the time goes -- and this is the most expensive step in
+# the suite (a 4-GPU pod, a 160GB TP-shard load, and DeepGEMM's per-kernel JIT
+# compiles on a cold cache). begin_phase closes the open phase and opens a new
+# one; the EXIT trap prints the summary even when the run fails, so a slow or
+# hung run is attributable from the log alone.
+PHASE_TIMINGS=()
+PHASE_NAME=""
+PHASE_START=0
+
+end_phase() {
+    if [ -n "$PHASE_NAME" ]; then
+        local elapsed=$((SECONDS - PHASE_START))
+        echo "[timing] ${PHASE_NAME}: ${elapsed}s"
+        PHASE_TIMINGS+=("$(printf '%-22s %6ds' "$PHASE_NAME" "$elapsed")")
+        PHASE_NAME=""
+    fi
+}
+
+begin_phase() {
+    end_phase
+    PHASE_NAME="$1"
+    PHASE_START=$SECONDS
+}
+
+# ── JIT cache report ────────────────────────────────────────
+# Nearly all of this step's startup is nvcc, not model work: on a fully cold
+# cache the four JIT frameworks below account for ~685s of a 788s vLLM
+# startup (DeepGEMM ~400s, FlashInfer ~198s, Triton and TileLang ~87s), which
+# is why pipeline.yml points each one at its own hostPath mount. A mount that
+# silently fails to take effect -- wrong path, read-only, a node without
+# /data -- costs exactly that time again with no error anywhere, so report
+# what each cache actually resolved to, before and after the run.
+#
+# Reading two consecutive builds: on the second one, "entries" should be
+# large and "new this run" near 0 for every cache. An "entries=0" on a second
+# build means that mount is not persisting; "writable=False" means it mounted
+# read-only.
+JIT_CACHE_SNAPSHOT="$TP_DIR/jit_cache_before.json"
+
+jit_cache_report() {
+    local label="$1"
+    echo "=== JIT caches ($label) ==="
+    python3 - "$label" "$JIT_CACHE_SNAPSHOT" <<'PYEOF' || true
+import json
+import os
+import pathlib
+import sys
+
+label, snapshot_path = sys.argv[1], sys.argv[2]
+
+
+def resolve():
+    """Return [(cache name, resolved path)] for the four JIT caches.
+
+    The three env-var caches are reported from the environment, so an unset
+    variable shows up as such. FlashInfer is asked to resolve its own path
+    instead: it takes a *base* and appends the rest itself, so reading it
+    back from the library is the only way to see where it will really write.
+    """
+    out = [
+        ("DeepGEMM", os.environ.get("DG_JIT_CACHE_DIR", "<unset>")),
+        ("Triton", os.environ.get("TRITON_CACHE_DIR", "<unset>")),
+        ("TileLang", os.environ.get("TILELANG_CACHE_DIR", "<unset>")),
+    ]
+    try:
+        from flashinfer.jit import env as fi_env
+
+        out.append(("FlashInfer", str(fi_env.FLASHINFER_CACHE_DIR)))
+    except Exception as exc:
+        out.append(("FlashInfer", "<unresolved: %s>" % exc))
+    return out
+
+
+def count_files(path):
+    p = pathlib.Path(path)
+    if not p.is_dir():
+        return 0
+    return sum(len(files) for _, _, files in os.walk(p))
+
+
+print("  HOME=%s" % os.environ.get("HOME", "<unset>"))
+before = {}
+if label != "before":
+    try:
+        with open(snapshot_path) as f:
+            before = json.load(f)
+    except Exception:
+        before = {}
+
+counts = {}
+for name, path in resolve():
+    n = count_files(path)
+    counts[name] = n
+    exists = pathlib.Path(path).is_dir()
+    writable = os.access(path, os.W_OK) if exists else "n/a"
+    line = "  %-11s entries=%-7d exists=%-5s writable=%-5s" % (
+        name,
+        n,
+        exists,
+        writable,
+    )
+    if name in before:
+        line += " new_this_run=%-6d" % (n - before[name])
+    print("%s %s" % (line, path))
+
+if label == "before":
+    with open(snapshot_path, "w") as f:
+        json.dump(counts, f)
+PYEOF
+    echo ""
+}
+
+print_timing_summary() {
+    end_phase
+    echo ""
+    echo "=== Phase timing (total ${SECONDS}s) ==="
+    if [ "${#PHASE_TIMINGS[@]}" -gt 0 ]; then
+        printf '  %s\n' "${PHASE_TIMINGS[@]}"
+    fi
+    echo ""
+    jit_cache_report after
+}
+trap print_timing_summary EXIT
+
+jit_cache_report before
+
 # ── 0. Provision DeepGEMM (SM120 only) ──────────────────────
 # vLLM's _import_deep_gemm() prefers a `deep_gemm` in site-packages over the
 # copy bundled in the wheel, so installing one overrides the arch-incomplete
 # bundled build without rebuilding vLLM. Build steps mirror vLLM's own
 # tools/install_deepgemm.sh. No-op on SM90/SM100, where the bundled copy is
 # correct and must be left alone.
+#
+# Nobody publishes a DeepGEMM wheel -- PyPI carries only an unrelated sdist,
+# and the upstream repos tag releases with no assets -- because it is a JIT
+# library whose installable part still has to be built against the local torch
+# ABI and CUDA. So the wheel is built here, and cached on
+# DEEPGEMM_WHEEL_CACHE_DIR (a hostPath in CI) so that only the first build on
+# a node pays for it. The cache key carries the DeepGEMM ref, the Python tag
+# and the torch/CUDA versions, which is everything the wheel is valid
+# against; anything else lands on a new key rather than reusing a wheel built
+# for a different ABI. Unset the variable to disable caching.
 provision_deepgemm_sm120() {
     local arch_major
     arch_major=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader -i 0 \
@@ -238,6 +376,38 @@ provision_deepgemm_sm120() {
     if python3 -c "import deep_gemm" 2>/dev/null; then
         echo "=== SM120: deep_gemm already present in site-packages ==="
         return 0
+    fi
+
+    local key cached=""
+    key=$(python3 - "$DEEPGEMM_SM120_REF" <<'PYEOF'
+import sys
+ref = sys.argv[1][:12]
+tag = "cp%d%d" % (sys.version_info.major, sys.version_info.minor)
+try:
+    import torch
+    abi = "torch%s-cu%s" % (torch.__version__.split("+")[0], torch.version.cuda)
+except Exception:
+    abi = "torch-unknown"
+print("%s-%s-%s" % (ref, tag, abi))
+PYEOF
+    )
+    if [ -n "${DEEPGEMM_WHEEL_CACHE_DIR:-}" ]; then
+        mkdir -p "$DEEPGEMM_WHEEL_CACHE_DIR"
+        cached=$(find "$DEEPGEMM_WHEEL_CACHE_DIR/$key" -name '*.whl' 2>/dev/null | head -1)
+    fi
+
+    if [ -n "$cached" ]; then
+        echo "=== SM120: installing cached DeepGEMM wheel ($key) ==="
+        if { command -v uv >/dev/null 2>&1 && uv pip install "$cached" \
+                || python3 -m pip install "$cached"; } \
+            && python3 -c "import deep_gemm" 2>/dev/null; then
+            echo "DeepGEMM installed from cache: $cached"
+            return 0
+        fi
+        # A cached wheel that will not install or import is worse than none:
+        # drop it and fall through to a fresh build rather than failing here.
+        echo "Cached wheel unusable, rebuilding: $cached"
+        rm -rf "$DEEPGEMM_WHEEL_CACHE_DIR/$key"
     fi
 
     echo "=== SM120: building DeepGEMM @ ${DEEPGEMM_SM120_REF:0:12} ==="
@@ -259,13 +429,30 @@ provision_deepgemm_sm120() {
         rm -rf "$build_dir"
         return 1
     fi
+
+    # Publish the wheel for the next build on this node. Staged in a temp
+    # directory and renamed into place so a concurrent reader never sees a
+    # half-copied wheel.
+    if [ -n "${DEEPGEMM_WHEEL_CACHE_DIR:-}" ]; then
+        local stage
+        stage="$(mktemp -d -p "$DEEPGEMM_WHEEL_CACHE_DIR")"
+        if cp "$build_dir"/deepgemm/dist/*.whl "$stage/" 2>/dev/null \
+            && mv -T "$stage" "$DEEPGEMM_WHEEL_CACHE_DIR/$key" 2>/dev/null; then
+            echo "Cached DeepGEMM wheel for next run: $DEEPGEMM_WHEEL_CACHE_DIR/$key"
+        else
+            rm -rf "$stage"
+            echo "Could not cache the DeepGEMM wheel (harmless; it rebuilds next run)"
+        fi
+    fi
+
     cd "$REPO_ROOT"
     rm -rf "$build_dir"
     echo "DeepGEMM installed: $(python3 -c 'import deep_gemm; print(deep_gemm.__file__)')"
 }
+begin_phase deepgemm_provision
 provision_deepgemm_sm120
-
 # ── 1. Launch LMCache MP server with an explicit L1 pool ────
+begin_phase lmcache_server
 echo "=== Launching LMCache MP server (port $LMCACHE_PORT, L1 ${L1_SIZE_GB}GB) ==="
 lmcache server \
     --host localhost \
@@ -282,6 +469,7 @@ echo "LMCache MP server started (PID=$LMCACHE_PID)"
 sleep 10
 
 # ── 2. Build a long, deterministic prompt ───────────────────
+begin_phase prompt_build
 # A ~7-8k word document (spanning many 256-token LMCache chunks, so several
 # slot-compressed blocks per group are stored) built by repeating a fixed
 # paragraph, so the input is identical on every run.
@@ -318,6 +506,7 @@ echo "Prompt built ($(wc -w < "$PROMPT_FILE") words)."
 echo ""
 
 # ── 3. Launch vLLM (dev mode for /reset_prefix_cache) ───────
+begin_phase vllm_startup
 echo "=== Launching vLLM ($MODEL, TP=$TENSOR_PARALLEL_SIZE, port $VLLM_PORT) ==="
 echo "Log: $VLLM_LOG"
 # Save and unset VLLM_PORT: vLLM's internal get_open_port() would otherwise
@@ -351,27 +540,32 @@ echo "$VLLM_PID" >> "$PID_FILE"
 export VLLM_PORT="$saved_port"
 echo "vLLM started (PID=$VLLM_PID)"
 
-if ! wait_for_server "$VLLM_PORT" "$VLLM_READY_TIMEOUT" "$VLLM_LOG"; then
+if ! wait_for_server "$VLLM_PORT" "$VLLM_READY_TIMEOUT" "$VLLM_LOG" "$VLLM_PID"; then
     echo "vLLM failed to start."
     exit 1
 fi
 echo ""
 
 # ── 4. vLLM run: compute from scratch, populating LMCache ───
+begin_phase cold_run
 send_completion "$OUT_A" "vLLM run"
 
+begin_phase store_drain
 echo "Waiting ${STORE_DRAIN_SECONDS}s for LMCache stores to drain..."
 sleep "$STORE_DRAIN_SECONDS"
 retrieves_before=$(count_retrieves)
 
 # ── 5. Invalidate vLLM's local prefix cache (keep LMCache) ──
+begin_phase apc_reset
 reset_vllm_prefix_cache
 
 # ── 6. Retrieve run: vLLM APC misses -> LMCache serves the KV ─
+begin_phase retrieve_run
 send_completion "$OUT_B" "LMCache retrieve run"
 retrieves_after=$(count_retrieves)
 
 # ── 7. Compare outputs and verify LMCache was actually used ──
+begin_phase verify
 echo "============================================"
 echo "=== Verifying L1 slot-compression correctness ==="
 echo "============================================"


### PR DESCRIPTION
`dsv4_flash_tp` is the only 4-GPU step in the multiprocess suite, every other step there takes one or two, and it runs 40+ minutes. So every `mp`/`full` labelled PR build and every `dev` push held a whole 4-GPU node for that long while the 1- and 2-GPU steps of other builds queued behind it.

### Gate the 4-GPU group

It now runs on two opt-ins instead of by default:

- a PR labelled **`dsv4`**, alongside the `mp`/`full` label that already gates this pipeline
- **`RUN_DSV4_TEST=true`** on a manual build

The label follows the `mp`/`full` labels that already gate this pipeline, so a PR touching the hybrid-KV-group / slot-compression path can opt in with nothing but GitHub write access; the env var is the same opt-in for a manual build, where there is no PR to label. `BK_WEB_SETUP.md` documents both, and the fact that the `dsv4` label itself still has to be created in the repo.

That leaves the step with no periodic run: DeepSeek-V4-Flash support is exercised when someone asks for it, not on a timer. A 4-GPU node for 40+ minutes is too expensive to spend on a schedule nobody is watching, but it does mean a regression here surfaces at the next opt-in build rather than the next morning.

### Drop the SM120 DeepGEMM build

vllm#52035 pinned vLLM back to deepseek-ai/DeepGEMM's `nv_dev` tip (`8b1392b9`), which carries the SM120 kernels, and the vLLM revision CI pins today already includes it. The guard never short-circuited either: it probed a top-level `deep_gemm` while the wheel ships `vllm.third_party.deep_gemm`, so SM120 nodes rebuilt it on every run.

### Persist the JIT caches across builds

The step compiles through four JIT frameworks on the way up, and the pod's filesystem starts empty every run. Locally a fully cold start takes 788s and a fully warm one 103s, split roughly as DeepGEMM 400s, FlashInfer 198s, Triton and TileLang together about 87s.

One hostPath, `/data/jit_cache`, mounted at `/root/.cache/jit`, with each framework pointed at a subdirectory of it:

| cache | env var |
|---|---|
| DeepGEMM | `DG_JIT_CACHE_DIR=/root/.cache/jit/deep_gemm` |
| Triton | `TRITON_CACHE_DIR=/root/.cache/jit/triton` |
| TileLang | `TILELANG_CACHE_DIR=/root/.cache/jit/tilelang` |
| FlashInfer | `FLASHINFER_WORKSPACE_BASE=/root/.cache/jit/flashinfer` (it appends `.cache/flashinfer/<version>/<arch>/cached_ops` itself) |

All four resolve from an explicit env var rather than from whatever `HOME` is inside the image, and one mount instead of four means one directory to provision on the agent nodes. DeepGEMM's dir is named rather than left to default to `VLLM_CACHE_ROOT/deep_gemm`, which would mean persisting all of `/root/.cache/vllm` for the sake of one subdirectory.

Sharing them across builds is safe because each keys on something that changes when the toolchain does: DeepGEMM hashes the kernel source, the nvcc version and the compile flags (which carry the `-gencode` arch); FlashInfer puts its version and arch in the path; Triton's cache key hashes its own compiler and backend sources along with the kernel, the backend options and the env; TileLang namespaces its cache by its own version and the torch version. A new pin, a new CUDA or a different arch lands on new keys rather than reusing an old cubin.

One difference worth flagging in review: unlike DeepGEMM, which compiles into a temp dir and renames into place, FlashInfer builds in place and serialises concurrent builders on a per-module filelock. Concurrent builds on one node wait rather than each recompiling, and a build killed mid-link is left for ninja to redo on the next run.

The four caches total 35MB once filled.

### Per-phase timing, and a JIT cache report

The script prints a phase timing summary from an EXIT trap, so a failed or timed-out run reports it too, and the step's wall clock can be attributed instead of guessed.

It also reports, before and after the run, what each of the four JIT caches actually resolved to:

```
=== JIT caches (before) ===
  HOME=/root
  DeepGEMM    entries=1350    exists=True  writable=True  /root/.cache/jit/deep_gemm
  Triton      entries=6403    exists=True  writable=True  /root/.cache/jit/triton
  TileLang    entries=180     exists=True  writable=True  /root/.cache/jit/tilelang
  FlashInfer  entries=607     exists=True  writable=True  /root/.cache/jit/flashinfer/.cache/flashinfer
```

The `after` pass adds `new_this_run=N` per cache. A mount that fails to take effect is otherwise completely silent -- the step just recompiles and pays the time again -- so this makes it visible: `exists=False` is a missing mount, `writable=False` a read-only one, and `entries=0` on a *second* build means the hostPath is not persisting. FlashInfer's path is read back from the library rather than echoed from the env var, so a base that does not line up with the mount shows as a mismatched path.

## Test

Ran the script end-to-end on 4x H200 outside k8s (its own `lmcache server` + `vllm serve`, no `launch-processes.sh`), against pre-cached weights and with all four JIT caches warm:

```
=== Phase timing (total 173s) ===
  lmcache_server             10s
  prompt_build                0s
  vllm_startup              103s
  cold_run                   20s
  store_drain                20s
  apc_reset                   0s
  retrieve_run               20s
  verify                      0s

PASS: vLLM-run and LMCache-retrieve outputs are identical.
  outputs identical; LMCache served 4 retrieves.
```

Not vacuous: the cold run stored 8960 tokens (35 chunks of 256, so several slot-compressed blocks per group), the retrieve run logged four `Retrieved 8960 tokens` lines at 0.036-0.051s, one per TP rank, and `retrieves_before=0 -> after=4`, with both 628-char outputs `cmp` clean.

Nothing was installed during the run, so the wheel's bundled DeepGEMM served all of it -- the direct check on the SM120 deletion.

Two things a local run can't cover, both for a manual `RUN_DSV4_TEST=true` build before merge: this box is SM90, and local vLLM is two minor versions behind the CI pin.