### PR TITLE
[coordinator] Scope coordinator blend matches to the requester's namespace

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -268,9 +268,12 @@ Cross-request, cross-instance blend reuse is served by the **blend index**,
 a derived view of the key directory's token bindings: no separate publish
 path, matches verified token-exact, and eviction exact because it follows
 binding lifecycle. Blend servers query it with `POST
-/directory/blend-lookup` and get `(chunk_hash, old_st, cur_st)` per match,
-which they expand into per-rank object keys with their own model and salt.
-The match window is the fleet chunk size (`CHUNK_SIZE`), probed at
+/directory/blend-lookup` — the same tokens form `/directory/lookup` takes —
+and get `(chunk_hash, old_st, cur_st)` per match, which they expand into
+per-rank object keys with their own model and salt. The query's
+`model_name`/`cache_salt`/`world_size` scope matches to chunks stored in
+that namespace, so a match always expands into keys that exist. The match
+window is the fleet chunk size (`CHUNK_SIZE`), probed at
 `BLEND_PROBE_STRIDE`. See [blend_index.md](blend_index.md).
 
 The previous design — `blend_directory.py` (`GlobalBlendMatcher`) with its own

--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -268,11 +268,11 @@ Cross-request, cross-instance blend reuse is served by the **blend index**,
 a derived view of the key directory's token bindings: no separate publish
 path, matches verified token-exact, and eviction exact because it follows
 binding lifecycle. Blend servers query it with `POST
-/directory/blend-lookup` — the same tokens form `/directory/lookup` takes —
-and get `(chunk_hash, old_st, cur_st)` per match, which they expand into
-per-rank object keys with their own model and salt. The query's
-`model_name`/`cache_salt`/`world_size` scope matches to chunks stored in
-that namespace, so a match always expands into keys that exist. The match
+/directory/blend-lookup` and get `(chunk_hash, old_st, cur_st)` per match,
+which they expand into per-rank object keys with their own model and salt.
+The query's `model_name`/`cache_salt`/`world_size` scope matches to chunks
+stored in that namespace, so a match always expands into keys that exist.
+The match
 window is the fleet chunk size (`CHUNK_SIZE`), probed at
 `BLEND_PROBE_STRIDE`. See [blend_index.md](blend_index.md).
 

--- a/docs/design/v1/mp_coordinator/blend_index.md
+++ b/docs/design/v1/mp_coordinator/blend_index.md
@@ -40,6 +40,7 @@ directory removes:
 | collision | wasted prefetch | candidate skipped |
 | eviction | lazy tombstone, stale entries tolerated | exact, with the binding |
 | placements | unknown; prefetch is blind | known (peer L1 vs shared L2) |
+| identity | one chunk hash, namespace-blind | per-namespace claims on each chunk |
 
 The cost is coordinator memory: verification needs the tokens resident,
 `O(m)` rather than `O(m/C)`. See
@@ -50,30 +51,68 @@ representation that keeps that affordable.
 
 Entries are keyed by a **content fingerprint only** — the 64-bit
 polynomial hash of one chunk's tokens (`POLY_BASE`, fleet-constant).
-Deliberately absent:
+Content is the key; **identity rides on the occupants**.
 
-- **No model, salt, or rank.** A match names a `chunk_hash`; the querying
-  server expands it into `ObjectKey`s with **its own** model, salt, and
-  world size, exactly as the local blend path does. A cross-model or
-  cross-tenant match therefore lands in the requester's own namespace and
-  confirmed-misses at prefetch. Filtering by the *storer's* identity
-  would be wrong: content is shared first-writer-wins, so the first
-  storer's tenant would get pinned and others could never match their own
-  copies.
-- **No prefix.** `chunk_hash` is prefix-chained, so the same text stored
-  after different prefixes is two chunks; both attach to **one** content
-  entry (each with its own `token_offset`), so evicting one leaves the
-  other discoverable.
+- **No prefix in the key.** `chunk_hash` is prefix-chained, so the same
+  text stored after different prefixes is two chunks; both attach to
+  **one** content entry (each with its own `token_offset`), so evicting
+  one leaves the other discoverable.
+- **Each occupant carries its namespaces.** A `chunk_hash` names content
+  and prefix only — everything deciding *whose* KV it is lives on
+  `ObjectKey` beside it. So every occupant records the
+  `BlendNamespace`s that stored it, and a match is offered only to a
+  requester in one of them.
+
+### The namespace
+
+`BlendNamespace` (`api.py`) is `(model_name, cache_salt, world_size)` —
+exactly the three fields `ipc_key_to_object_keys` reads to turn a
+`chunk_hash` into `ObjectKey`s. On the store side it is derived from the
+key itself, `world_size` from the top byte `ComputeKVRank` packed into
+`kv_rank`; on the query side it arrives on the request. `object_group_id`
+is deliberately out: groups partition a server's own layout rather than
+the fleet, and blend servers must not enable `--separate-object-groups`.
+
+**Scoping loses no legitimate reuse.** Each dimension is one the
+requester's own key expansion would miss on anyway: another model's KV is
+not interchangeable, another tenant's salt is isolated by design, and
+another parallel setup shards heads differently. What scoping removes is
+two real defects of a namespace-blind table:
+
+| defect | namespace-blind | with claims |
+| --- | --- | --- |
+| a match no requester key can reach | returned; confirmed-misses at prefetch, burning a blend slot | never offered |
+| the requester's own chunk hidden behind another namespace's | lost hit — one occupant per content is returned, and it may be someone else's | found; the walk skips occupants this namespace does not hold |
+
+The second is the one that costs reuse rather than work: the same
+document cached under a different prefix is a *different* `chunk_hash`,
+so it is a second occupant, and returning only the first silently drops
+it.
+
+The earlier design rejected filtering on the grounds that "the first
+storer's tenant would get pinned and others could never match their own
+copies." That is a consequence of treating a content entry as
+single-tenant. A content entry is inherently multi-tenant: the fix is to
+filter by *membership* — every namespace that stored the chunk — not by
+first-writer identity.
+
+**Residual.** Ranks and object groups within one namespace are not
+tracked individually, so a chunk stored by only some ranks of a world
+size still matches and confirms at expansion, as before.
 
 ## Structure and the recall property
 
 ```
-_contents : dict[fingerprint -> _Entry { token_ids, occupants[] }]   # authoritative
+_contents : dict[fingerprint -> _Entry { token_ids, occupants{} }]   # authoritative
 _slots    : uint8[2^k]  occupancy filter, 1 where any fingerprint lands
 ```
 
-`occupants` is `(chunk_hash, token_offset)` per chunk holding that
-content — usually exactly one.
+`occupants` maps `chunk_hash -> { token_offset, namespaces }`, in
+first-indexed order — usually exactly one chunk, claimed by one
+namespace. A chunk stored under identical prefixes by two tenants is
+**one** occupant with two claims, so the tokens are held once. Cost is
+one small tuple per `(chunk, namespace)` pair, reported as `num_claims`
+in `stats()`.
 
 A match rolls a `chunk_size` window hash over the query
 (`rolling_hash_windows_numba`), gathers `_slots` at every
@@ -105,14 +144,24 @@ Driven entirely by binding lifecycle in `KeyDirectory`:
 
 | directory event | index |
 | --- | --- |
-| `STORE` with `token_ids` | `add(tokens, chunk_hash, token_offset)` |
-| re-`STORE` with different content | old fingerprint removed, new added |
-| `DELETE` of a chunk's last placement | `remove(tokens, chunk_hash)` |
+| `STORE` with `token_ids` | `add(tokens, chunk_hash, token_offset, ns)` |
+| `STORE` first filling a binding's content | `add` for **every** namespace on the binding |
+| re-`STORE` with different content | `remove_chunk`, then re-`add` per namespace |
+| `DELETE` of a namespace's last key for a chunk | `remove(tokens, chunk_hash, ns)` |
+| `DELETE` of a chunk's last placement overall | last `remove` drops the occupant |
 | `fence_instance` (restart / deregistration) | `remove` per dropped chunk |
+
+The namespace comes from the key the event carries, so nothing new is
+published for it. The steady-state store path claims for one namespace
+per entry; only the two content-changing rows walk the binding's keys, so
+per-rank stores do not rehash the content once per rank.
 
 A chunk whose `STORE` carried no tokens (the emitter's bound cache had
 already evicted it) is simply not indexed — a lookup miss, repaired by
-the chunk's next stamped store. Content whose length is not the fleet
+the chunk's next stamped store. A **key** arriving without tokens for a
+chunk whose content is already known is different: it claims the chunk
+for its namespace immediately, so a second tenant storing content the
+fleet already holds is matchable without waiting for a re-store. Content whose length is not the fleet
 `chunk_size` is not indexed either: it can never fill a `chunk_size`
 match window. Both are logged, never errors.
 
@@ -124,10 +173,18 @@ application.
 
 ## HTTP surface
 
-`POST /directory/blend-lookup` takes `tokens_b64` (base64 little-endian
-`uint32`, ~1.4x smaller than a JSON list and decoded in one
-`np.frombuffer`) and returns matches as
-`(chunk_hash, old_st, cur_st)`:
+`POST /directory/blend-lookup` takes **the same tokens form as
+`POST /directory/lookup`** — `token_ids`, `model_name`, `world_size`,
+`cache_salt`, shared as `TokenSequenceForm` in `schemas.py`. The two
+questions differ in where the content may sit, not in how it is
+described, and both need the same identity for the same reason: a
+`chunk_hash` names content only. Prefix lookup uses those fields to
+*build* keys; fragment lookup uses them to keep matches inside the
+namespace the caller can retrieve from. Only the tokens form exists here
+— a fragment query is a search over content, so there is nothing to name
+by key.
+
+It returns matches as `(chunk_hash, old_st, cur_st)`:
 
 - `old_st` — where the chunk sat in the sequence it was stored under
   (the re-RoPE source).
@@ -151,5 +208,9 @@ thread rather than on the event loop.
   reuse; see the future-evolution table in the blend design notes.
 - **Placement-aware ranking.** Matches do not yet prefer a peer holding
   the chunk in L1 over a shared-L2 copy, though the directory knows both.
-- **Cross-model filtering.** Left to the requester's key expansion, as
-  above.
+- **Liveness beyond the binding.** A claim says some instance stored the
+  chunk in that namespace, not that the bytes are reachable *now* — the
+  directory is eventually consistent, so a match is still a hint the
+  owner validates. Filtering on placements would tighten this, at the
+  cost of taking the directory lock on the serving path (see
+  [key_directory.md](key_directory.md)).

--- a/docs/design/v1/mp_coordinator/blend_index.md
+++ b/docs/design/v1/mp_coordinator/blend_index.md
@@ -173,16 +173,18 @@ application.
 
 ## HTTP surface
 
-`POST /directory/blend-lookup` takes **the same tokens form as
-`POST /directory/lookup`** — `token_ids`, `model_name`, `world_size`,
-`cache_salt`, shared as `TokenSequenceForm` in `schemas.py`. The two
-questions differ in where the content may sit, not in how it is
-described, and both need the same identity for the same reason: a
-`chunk_hash` names content only. Prefix lookup uses those fields to
-*build* keys; fragment lookup uses them to keep matches inside the
-namespace the caller can retrieve from. Only the tokens form exists here
-— a fragment query is a search over content, so there is nothing to name
-by key.
+`POST /directory/blend-lookup` takes `tokens_b64` (base64 little-endian
+`uint32`, ~1.4x smaller than a JSON list and decoded in one
+`np.frombuffer`) plus the caller's `model_name`, `world_size`, and
+`cache_salt`.
+
+Those three are the same fields `/directory/lookup`'s tokens form
+carries, for a related but distinct reason: prefix lookup uses them to
+*build* the keys it looks up, while a fragment match already names a
+stored `chunk_hash` and uses them to stay inside the namespace the caller
+can retrieve from. The token encodings deliberately differ for now — a
+fragment query is the request's whole sequence, so the compact form earns
+its place — and the two endpoints are free to converge later.
 
 It returns matches as `(chunk_hash, old_st, cur_st)`:
 

--- a/docs/design/v1/mp_coordinator/blend_index.md
+++ b/docs/design/v1/mp_coordinator/blend_index.md
@@ -117,8 +117,19 @@ in `stats()`.
 A match rolls a `chunk_size` window hash over the query
 (`rolling_hash_windows_numba`), gathers `_slots` at every
 `probe_stride`-th position in one vectorized op, and resolves the few
-survivors through `_contents`. Then it **verifies the query window
-against `entry.token_ids` token-for-token** before accepting.
+survivors through `_contents`. For each survivor it then picks the
+occupant the requester's namespace claims, and only then **verifies the
+query window against `entry.token_ids` token-for-token** before
+accepting.
+
+That order matters for cost. A set membership test is far cheaper than
+comparing a full window, so content the requester cannot retrieve is
+dropped before the comparison rather than after — on a fleet whose
+tenants mostly cache different documents, that is the common case. On a
+50-tenant index whose content is disjoint from the requester's, the
+reordering cut window comparisons from 100 to 1 for the same result.
+`seen` is still only marked *after* verification, so a fingerprint
+collision cannot consume a chunk's one chance to match.
 
 The filter deliberately stores **no identity** — just "something lands
 here". That is what makes recall complete: two fingerprints sharing a

--- a/docs/design/v1/mp_coordinator/blend_index.md
+++ b/docs/design/v1/mp_coordinator/blend_index.md
@@ -131,6 +131,15 @@ reordering cut window comparisons from 100 to 1 for the same result.
 `seen` is still only marked *after* verification, so a fingerprint
 collision cannot consume a chunk's one chance to match.
 
+The two removals act on different levels, which is why neither can do the
+other's job: `remove_claim` drops **one holder** and the chunk survives for
+the rest (the `DELETE` path), while `remove_chunk` drops **the chunk and
+every claim on it** in one lock acquisition. Retiring per namespace instead
+would leave a window where `match` — which holds only the index lock —
+still finds the chunk under a not-yet-removed namespace while its content
+has already changed, re-RoPEing the new content's KV into the old
+content's position.
+
 The filter deliberately stores **no identity** — just "something lands
 here". That is what makes recall complete: two fingerprints sharing a
 slot both pass the filter and the dict resolves each correctly. A
@@ -158,9 +167,9 @@ Driven entirely by binding lifecycle in `KeyDirectory`:
 | `STORE` with `token_ids` | `add(tokens, chunk_hash, token_offset, ns)` |
 | `STORE` first filling a binding's content | `add` for **every** namespace on the binding |
 | re-`STORE` with different content | `remove_chunk`, then re-`add` per namespace |
-| `DELETE` of a namespace's last key for a chunk | `remove(tokens, chunk_hash, ns)` |
-| `DELETE` of a chunk's last placement overall | last `remove` drops the occupant |
-| `fence_instance` (restart / deregistration) | `remove` per dropped chunk |
+| `DELETE` of a namespace's last key for a chunk | `remove_claim(tokens, chunk_hash, ns)` |
+| `DELETE` of a chunk's last placement overall | the last `remove_claim` drops the occupant |
+| `fence_instance` (restart / deregistration) | `remove_claim` per dropped chunk |
 
 The namespace comes from the key the event carries, so nothing new is
 published for it. The steady-state store path claims for one namespace

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -41,7 +41,8 @@ LOOKUP (blend server, cb_unified_lookup)
   local matcher (always) ─┐
   request tokens          │
     ── POST /directory/blend-lookup ──▶ blend index: roll + filter +
-                                        resolve + verify token-exact
+       (tokens + this server's       │    resolve + verify token-exact
+        model/salt/world_size)       │    + scope to the caller's namespace
     ◀── matches: [(chunk_hash, old_st, cur_st)] ──┘
   → union of both sources
   → non-prefix set (drop prefix-covered, leftmost-greedy overlap dedup)
@@ -61,21 +62,24 @@ Consequences of being event-fed rather than blend-published:
 
 ## Identity and scope
 
-The index is keyed by **content only** — no model, salt, or rank. A match
-names a `chunk_hash`, and the querying server expands it into per-rank
-`ObjectKey`s using **its own** `cache_salt`, `model_name`, and
-`world_size` (`ipc_key_to_object_keys`), exactly as the local path does.
-So a cross-salt or cross-model match lands in the requester's own
-namespace and confirmed-misses at the sparse prefetch unless a matching
-copy exists — tenant isolation holds with **one index for the fleet**.
-Filtering by the *storer's* identity would be wrong: content is shared
-first-writer-wins, so the first storer's tenant would get pinned and
-others could never match their own copies of identical content.
+Entries are keyed by **content**, but each chunk under that content
+records the namespaces that stored it — `(model_name, cache_salt,
+world_size)`, the same three fields `ipc_key_to_object_keys` reads. The
+lookup query carries the requester's, and matches are restricted to
+chunks some instance stored in it, so every match expands into
+`ObjectKey`s that exist. Tenant isolation holds with **one index for the
+fleet**, and it is now enforced rather than merely survived: a
+cross-tenant match is not returned at all, instead of being returned and
+confirmed-missing at the sparse prefetch.
 
-The cost is that a cross-tenant match with no same-salt copy is a wasted
-prefetch — the already-tolerated stale-entry failure mode. The index does
-reveal cross-salt content *existence* to the trusted mp-servers, and the
-coordinator sees raw tokens (content), not just opaque hashes:
+Scoping loses no reuse — cross-model KV is not interchangeable and
+cross-salt is isolated by design — and recovers reuse the blind table
+lost, since the requester's own copy of a document cached under a
+different prefix is a *different* `chunk_hash` that a single untagged
+occupant would hide. See [blend_index.md](blend_index.md) — Identity and
+scope.
+
+The coordinator still sees raw tokens (content), not just opaque hashes:
 acceptable for trusted fleet infra, revisit if not.
 
 ## Lookup flow in `cb_unified_lookup`
@@ -146,7 +150,8 @@ still works locally in that case — the fleet leg is simply absent.
 | emitter token-binding evicted | chunk unindexed fleet-wide | same |
 | fingerprint collision | candidate skipped | token verification rejects it |
 | chunk evicted from peer L1, no L2 copy | wasted prefetch | miss → recompute |
-| cross-salt / cross-model match, no local copy | wasted prefetch | requester-identity ObjectKey misses → recompute |
+| content held only by another model/tenant/world size | no fleet match | scoped out coordinator-side; local matches still apply |
+| chunk stored by only some ranks of the caller's world size | wasted prefetch | claims are per namespace, not per rank → ObjectKey misses → recompute |
 
 ## Future evolution
 

--- a/docs/design/v1/mp_coordinator/views/key_directory.md
+++ b/docs/design/v1/mp_coordinator/views/key_directory.md
@@ -101,11 +101,11 @@ The lookups this serves:
   window is verified against `binding.token_ids` (exact), and the
   binding's keys give the placements. Discovery uses blend's cheap
   polynomial hash family; the index itself never needs a
-  content-addressed key because every hit is token-verified. It takes
-  the same tokens form as the prefix lookup and reads its
-  `model_name`/`cache_salt`/`world_size` as the namespace to scope
-  matches to, so a match names a chunk the caller's own key expansion
-  can reach. Implemented as a derived view over these bindings — see
+  content-addressed key because every hit is token-verified. The query
+  carries the caller's `model_name`/`cache_salt`/`world_size` as the
+  namespace to scope matches to, so a match names a chunk the caller's
+  own key expansion can reach. Implemented as a derived view over these
+  bindings — see
   [blend_index.md](blend_index.md), served by `POST
   /directory/blend-lookup`.
 

--- a/docs/design/v1/mp_coordinator/views/key_directory.md
+++ b/docs/design/v1/mp_coordinator/views/key_directory.md
@@ -101,8 +101,11 @@ The lookups this serves:
   window is verified against `binding.token_ids` (exact), and the
   binding's keys give the placements. Discovery uses blend's cheap
   polynomial hash family; the index itself never needs a
-  content-addressed key because every hit is token-verified. Implemented
-  as a derived view over these bindings — see
+  content-addressed key because every hit is token-verified. It takes
+  the same tokens form as the prefix lookup and reads its
+  `model_name`/`cache_salt`/`world_size` as the namespace to scope
+  matches to, so a match names a chunk the caller's own key expansion
+  can reach. Implemented as a derived view over these bindings — see
   [blend_index.md](blend_index.md), served by `POST
   /directory/blend-lookup`.
 
@@ -222,7 +225,8 @@ yet (see [ingest.md](ingest.md)).
 Type placement:
 
 - **`api.py`** — the cache-event vocabulary (`CacheEventType`,
-`CacheEventEntry`, `CacheEventBatch`): the contract between the
+`CacheEventEntry`, `CacheEventBatch`) plus the blend vocabulary
+(`BlendMatch`, `BlendNamespace`): the contract between the
 MP-server emitter and the directory. Plain dataclasses with intrinsic
 invariants in `__post_init__` (the `ObjectKey` pattern: `seq >= 1`,
 concrete tier, non-empty ids are unconstructible anywhere).

--- a/docs/source/cli/query.rst
+++ b/docs/source/cli/query.rst
@@ -298,8 +298,16 @@ Directory size, and how much of it is fragment-matchable by CacheBlend:
    ----------------- Blend index ------------------
    Contents:                                     91
    Chunks:                                     1740
+   Claims:                                     1802
+   Namespaces:                                    3
    Table size:                                 1740
    ================================================
+
+``Claims`` counts ``(chunk, namespace)`` pairs and ``Namespaces`` the
+distinct ``(model, salt, world size)`` triples holding indexed content. A
+match is only offered to a requester whose namespace claims the chunk, so
+``Claims`` above ``Chunks`` means tenants are sharing content — the signal
+``Chunks`` alone cannot give.
 
 A page of keys and their placements. ``--limit`` sets the page size (default
 20; the endpoint accepts 1–10000, and a value outside that range is rejected

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -1429,9 +1429,9 @@ only). Matching is chunked at the coordinator's ``--chunk-size`` — which must
 equal the MP servers' ``--chunk-size`` — probing every
 ``--blend-probe-stride`` positions.
 
-**Request body** — the same tokens form ``/directory/lookup`` takes, since
-both questions describe content the same way. The identity fields are not
-optional here: they name the namespace matches are scoped to.
+**Request body** — the query tokens plus the caller's identity, which names
+the namespace matches are scoped to. ``model_name`` is not optional: without
+it there is no namespace to scope to.
 
 .. list-table::
    :header-rows: 1
@@ -1440,9 +1440,10 @@ optional here: they name the namespace matches are scoped to.
    * - Field
      - Type
      - Description
-   * - ``token_ids``
-     - list[int]
-     - The request's full query token sequence. Required.
+   * - ``tokens_b64``
+     - string
+     - Query tokens packed as base64 little-endian ``uint32`` (see
+       ``encode_tokens`` / ``decode_tokens`` in ``schemas.py``). Required.
    * - ``model_name``
      - string
      - Model the caller retrieves under. Required.
@@ -1453,6 +1454,13 @@ optional here: they name the namespace matches are scoped to.
    * - ``cache_salt``
      - string
      - The caller's per-tenant isolation salt. Defaults to ``""``.
+
+``model_name`` / ``world_size`` / ``cache_salt`` are the same three fields
+``/directory/lookup``'s tokens form carries, but serve a different purpose
+here: prefix lookup uses them to *build* the keys it resolves, while a
+fragment match already names a stored chunk hash and uses them to stay in
+the namespace the caller can retrieve from. The token encodings differ
+between the two endpoints for now.
 
 **Response** (``200 OK``):
 
@@ -1483,7 +1491,7 @@ match rather than one that misses at prefetch.
 **HTTP status codes:**
 
 - ``200``: lookup completed (an empty match list is not an error).
-- ``400``: ``token_ids`` exceeds the per-request cap.
-- ``422``: ``token_ids`` is missing, or supplied without ``model_name``.
+- ``422``: ``tokens_b64`` is not valid base64 or not a whole number of
+  ``uint32`` tokens, or it is supplied without ``model_name``.
 
 Index counts are reported under the ``blend`` key of ``GET /directory/stats``.

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -1429,7 +1429,9 @@ only). Matching is chunked at the coordinator's ``--chunk-size`` — which must
 equal the MP servers' ``--chunk-size`` — probing every
 ``--blend-probe-stride`` positions.
 
-**Request body:**
+**Request body** — the same tokens form ``/directory/lookup`` takes, since
+both questions describe content the same way. The identity fields are not
+optional here: they name the namespace matches are scoped to.
 
 .. list-table::
    :header-rows: 1
@@ -1438,10 +1440,19 @@ equal the MP servers' ``--chunk-size`` — probing every
    * - Field
      - Type
      - Description
-   * - ``tokens_b64``
+   * - ``token_ids``
+     - list[int]
+     - The request's full query token sequence. Required.
+   * - ``model_name``
      - string
-     - Query tokens packed as base64 little-endian ``uint32`` (see
-       ``encode_tokens`` / ``decode_tokens`` in ``schemas.py``).
+     - Model the caller retrieves under. Required.
+   * - ``world_size``
+     - int
+     - The caller's world size (TP x PP), selecting its rank fan-out.
+       Defaults to ``1``.
+   * - ``cache_salt``
+     - string
+     - The caller's per-tenant isolation salt. Defaults to ``""``.
 
 **Response** (``200 OK``):
 
@@ -1462,10 +1473,17 @@ position in the query (re-RoPE target). Matches are sorted ascending by
 them resolves overlaps itself. A query shorter than one chunk, or a coordinator
 without ``--enable-blend-lookup``, returns ``{"matches": []}``.
 
+Only chunks some instance stored under the request's
+``model_name`` / ``cache_salt`` / ``world_size`` are returned. A chunk hash
+names content and prefix only, so an unscoped match could name KV under
+another model or tenant, which the caller's own key expansion could never
+retrieve. Content held solely by another namespace therefore returns no
+match rather than one that misses at prefetch.
+
 **HTTP status codes:**
 
 - ``200``: lookup completed (an empty match list is not an error).
-- ``422``: ``tokens_b64`` is not valid base64 or not a whole number of
-  ``uint32`` tokens.
+- ``400``: ``token_ids`` exceeds the per-request cap.
+- ``422``: ``token_ids`` is missing, or supplied without ``model_name``.
 
 Index counts are reported under the ``blend`` key of ``GET /directory/stats``.

--- a/lmcache/cli/commands/query/_coordinator.py
+++ b/lmcache/cli/commands/query/_coordinator.py
@@ -174,7 +174,11 @@ def _render_health(body: Any, metrics: Metrics) -> None:
 
 
 def _render_directory_stats(body: Any, metrics: Metrics) -> None:
-    """Key-directory size, and how much of it is fragment-matchable."""
+    """Key-directory size, and how much of it is fragment-matchable.
+
+    Claims and namespaces separate a chunk many tenants share from many
+    chunks held one apiece -- the same ``num_chunks`` reads either way.
+    """
     metrics.add("num_keys", "Keys", body.get("num_keys"))
     metrics.add("num_placements", "Placements", body.get("num_placements"))
     blend = body.get("blend") or {}
@@ -182,6 +186,8 @@ def _render_directory_stats(body: Any, metrics: Metrics) -> None:
     for key, label in (
         ("num_contents", "Contents"),
         ("num_chunks", "Chunks"),
+        ("num_claims", "Claims"),
+        ("num_namespaces", "Namespaces"),
         ("table_size", "Table size"),
     ):
         section.add(key, label, blend.get(key))

--- a/lmcache/cli/commands/query/_coordinator.py
+++ b/lmcache/cli/commands/query/_coordinator.py
@@ -174,11 +174,7 @@ def _render_health(body: Any, metrics: Metrics) -> None:
 
 
 def _render_directory_stats(body: Any, metrics: Metrics) -> None:
-    """Key-directory size, and how much of it is fragment-matchable.
-
-    Claims and namespaces separate a chunk many tenants share from many
-    chunks held one apiece -- the same ``num_chunks`` reads either way.
-    """
+    """Key-directory size, and how much of it is fragment-matchable."""
     metrics.add("num_keys", "Keys", body.get("num_keys"))
     metrics.add("num_placements", "Placements", body.get("num_placements"))
     blend = body.get("blend") or {}

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -216,6 +216,21 @@ class ObjectKey:
             | local_rank
         )
 
+    @staticmethod
+    def WorldSizeFromKVRank(kv_rank: int) -> int:
+        """Recover the world size :meth:`ComputeKVRank` packed into a rank.
+
+        The inverse of that packing's top byte, kept beside it so the bit
+        layout has exactly one owner.
+
+        Args:
+            kv_rank: A ``kv_rank`` produced by :meth:`ComputeKVRank`.
+
+        Returns:
+            The parallel setup's world size (TP x PP).
+        """
+        return (kv_rank >> 24) & 0xFF
+
 
 @dataclass(frozen=True)
 class EncodedObjectKey:

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -220,9 +220,6 @@ class ObjectKey:
     def WorldSizeFromKVRank(kv_rank: int) -> int:
         """Recover the world size :meth:`ComputeKVRank` packed into a rank.
 
-        The inverse of that packing's top byte, kept beside it so the bit
-        layout has exactly one owner.
-
         Args:
             kv_rank: A ``kv_rank`` produced by :meth:`ComputeKVRank`.
 

--- a/lmcache/v1/mp_coordinator/api.py
+++ b/lmcache/v1/mp_coordinator/api.py
@@ -45,16 +45,9 @@ class CacheEventType(str, Enum):
 class BlendNamespace:
     """The retrieval namespace a chunk hash is reachable in.
 
-    A ``chunk_hash`` is content-and-prefix only: everything that decides
-    *whose* KV it names lives on :class:`ObjectKey` beside it. A blend
-    match is therefore usable only by a requester whose key expansion
-    lands in the same namespace -- another model's KV is not
-    interchangeable, another tenant's salt is isolated on purpose, and
-    another parallel setup shards heads differently.
-
-    ``object_group_id`` is deliberately absent: groups partition a
-    server's own layout rather than the fleet, and blend servers must not
-    enable ``--separate-object-groups``.
+    A blend match is usable only by a requester whose key expansion lands
+    in the same namespace. ``object_group_id`` is excluded: blend servers
+    must not enable ``--separate-object-groups``.
 
     Attributes:
         model_name: Model the KV belongs to.

--- a/lmcache/v1/mp_coordinator/api.py
+++ b/lmcache/v1/mp_coordinator/api.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 # First Party
-from lmcache.v1.distributed.api import EncodedObjectKey, Tier
+from lmcache.v1.distributed.api import EncodedObjectKey, ObjectKey, Tier
 
 # ``token_offset`` value meaning "the emitter did not report a position".
 # Distinct from 0, which is a real position (a chunk at the start of its
@@ -39,6 +39,49 @@ class CacheEventType(str, Enum):
     DELETE = "delete"
     ACCESS = "access"
     CONFIG = "config"
+
+
+@dataclass(frozen=True)
+class BlendNamespace:
+    """The retrieval namespace a chunk hash is reachable in.
+
+    A ``chunk_hash`` is content-and-prefix only: everything that decides
+    *whose* KV it names lives on :class:`ObjectKey` beside it. A blend
+    match is therefore usable only by a requester whose key expansion
+    lands in the same namespace -- another model's KV is not
+    interchangeable, another tenant's salt is isolated on purpose, and
+    another parallel setup shards heads differently.
+
+    ``object_group_id`` is deliberately absent: groups partition a
+    server's own layout rather than the fleet, and blend servers must not
+    enable ``--separate-object-groups``.
+
+    Attributes:
+        model_name: Model the KV belongs to.
+        cache_salt: Per-tenant isolation salt applied to the keys.
+        world_size: Parallel world size (TP x PP) selecting the rank
+            fan-out.
+    """
+
+    model_name: str
+    cache_salt: str = ""
+    world_size: int = 1
+
+    @classmethod
+    def from_object_key(cls, key: "ObjectKey") -> "BlendNamespace":
+        """Return the namespace ``key`` was stored in.
+
+        Args:
+            key: A stored key, whose ``kv_rank`` carries the world size.
+
+        Returns:
+            The namespace a requester must share to reach ``key``.
+        """
+        return cls(
+            model_name=key.model_name,
+            cache_salt=key.cache_salt,
+            world_size=ObjectKey.WorldSizeFromKVRank(key.kv_rank),
+        )
 
 
 @dataclass(frozen=True)

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -20,8 +20,7 @@ import threading
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.mp_coordinator.api import BlendMatch
-from lmcache.v1.mp_coordinator.schemas import encode_tokens
+from lmcache.v1.mp_coordinator.api import BlendMatch, BlendNamespace
 
 logger = init_logger(__name__)
 
@@ -38,6 +37,7 @@ class _MatchItem:
 
     rid: str
     tokens: list[int]
+    namespace: BlendNamespace
 
 
 class BlendCoordinatorClient:
@@ -107,18 +107,22 @@ class BlendCoordinatorClient:
         )
         self._worker.start()
 
-    def submit_match(self, rid: str, tokens: list[int]) -> None:
+    def submit_match(
+        self, rid: str, tokens: list[int], namespace: BlendNamespace
+    ) -> None:
         """Submit a match query for a request once (idempotent per ``rid``).
 
         Args:
             rid: Request id, the poll key.
             tokens: The request tokens (the coordinator hashes and probes them).
+            namespace: This server's retrieval namespace, which scopes the
+                matches to chunk hashes its own key expansion can reach.
         """
         with self._results_lock:
             if rid in self._results:
                 return
             self._results[rid] = PENDING
-        self._match_q.put(_MatchItem(rid=rid, tokens=tokens))
+        self._match_q.put(_MatchItem(rid=rid, tokens=tokens, namespace=namespace))
 
     def poll_match(self, rid: str) -> object:
         """Return the match state for a request.
@@ -202,7 +206,12 @@ class BlendCoordinatorClient:
             body = self._request(
                 "POST",
                 "/directory/blend-lookup",
-                {"tokens_b64": encode_tokens(item.tokens)},
+                {
+                    "token_ids": item.tokens,
+                    "model_name": item.namespace.model_name,
+                    "cache_salt": item.namespace.cache_salt,
+                    "world_size": item.namespace.world_size,
+                },
             )
             matches = [
                 BlendMatch(

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -21,6 +21,7 @@ import threading
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.mp_coordinator.api import BlendMatch, BlendNamespace
+from lmcache.v1.mp_coordinator.schemas import encode_tokens
 
 logger = init_logger(__name__)
 
@@ -207,7 +208,7 @@ class BlendCoordinatorClient:
                 "POST",
                 "/directory/blend-lookup",
                 {
-                    "token_ids": item.tokens,
+                    "tokens_b64": encode_tokens(item.tokens),
                     "model_name": item.namespace.model_name,
                     "cache_salt": item.namespace.cache_salt,
                     "world_size": item.namespace.world_size,

--- a/lmcache/v1/mp_coordinator/blend_index.py
+++ b/lmcache/v1/mp_coordinator/blend_index.py
@@ -6,10 +6,8 @@ request's tokens contain, and where? A strided rolling-hash probe
 discovers candidates; each is then verified token-exact.
 
 One content can be held by several chunk hashes (the same text stored
-after different prefixes), each claimed by the namespaces that stored it.
-A match therefore names a ``chunk_hash`` the *requester's* namespace
-claims, so it expands into keys that exist rather than into another
-model's or tenant's.
+after different prefixes), each claimed by the namespaces that stored it;
+a match names one the requester's own namespace claims.
 
 Owns its lock and never calls back into the directory, so the only lock
 order is directory → index.
@@ -57,8 +55,7 @@ class BlendIndexStats:
     Attributes:
         num_contents: Distinct chunk contents indexed.
         num_chunks: Chunks indexed across those contents.
-        num_claims: ``(chunk, namespace)`` pairs across those chunks —
-            what a chunk stored by several models or tenants costs.
+        num_claims: ``(chunk, namespace)`` pairs across those chunks.
         num_namespaces: Distinct namespaces holding indexed content.
         table_size: Slots in the occupancy filter.
     """
@@ -75,11 +72,9 @@ class _Occupant:
     """One chunk hash holding an entry's content.
 
     Attributes:
-        token_offset: The chunk's position in its stored sequence;
-            per chunk, since identical content can be stored at
-            different positions.
-        namespaces: Every namespace that stored this chunk. A match is
-            offered only to a requester in one of them, and the occupant
+        token_offset: The chunk's position in its stored sequence; per
+            chunk, since identical content can sit at different offsets.
+        namespaces: Every namespace that stored this chunk. The occupant
             is dropped when the last one goes.
     """
 
@@ -147,9 +142,8 @@ class BlendIndex:
         """Record that ``namespace`` stores ``chunk_hash`` with this content.
 
         Idempotent, and additive in the namespace: a second namespace
-        storing the same chunk joins the existing occupant rather than
-        replacing its claim. Content whose length is not ``chunk_size``
-        is ignored.
+        joins the existing occupant rather than replacing its claim.
+        Content whose length is not ``chunk_size`` is ignored.
 
         Args:
             token_ids: The chunk's tokens. Held by reference, so the
@@ -221,9 +215,8 @@ class BlendIndex:
     def remove_chunk(self, token_ids: np.ndarray, chunk_hash: bytes) -> None:
         """Drop ``chunk_hash`` and every namespace's claim on it.
 
-        Serves the one case where the chunk itself stops holding this
-        content — a re-store under the same hash with different tokens —
-        which invalidates every namespace's claim at once.
+        For a re-store under the same hash with different tokens, which
+        invalidates every claim at once.
 
         Args:
             token_ids: The content the chunk was indexed under.
@@ -243,8 +236,7 @@ class BlendIndex:
 
         Every candidate is verified token-exact, then narrowed to the
         occupants ``namespace`` stores. Content held only by other
-        namespaces yields nothing: its keys do not exist for this
-        requester, so offering it would buy a confirmed miss.
+        namespaces yields nothing.
 
         Args:
             tokens: The query token ids (any dtype castable to
@@ -275,10 +267,8 @@ class BlendIndex:
                 if not np.array_equal(query[cur_st : cur_st + window], entry.token_ids):
                     continue  # fingerprint collision: content differs
                 for chunk_hash, occupant in entry.occupants.items():
-                    # Walk past occupants this namespace cannot retrieve —
-                    # the same content stored under another model, tenant,
-                    # or parallel setup, or already emitted elsewhere in
-                    # the query.
+                    # Skip occupants this namespace cannot retrieve, and
+                    # chunks already emitted elsewhere in the query.
                     if chunk_hash in seen or namespace not in occupant.namespaces:
                         continue
                     seen.add(chunk_hash)

--- a/lmcache/v1/mp_coordinator/blend_index.py
+++ b/lmcache/v1/mp_coordinator/blend_index.py
@@ -5,9 +5,14 @@ Answers the blend-style fragment lookup: which cached chunks does a
 request's tokens contain, and where? A strided rolling-hash probe
 discovers candidates; each is then verified token-exact.
 
+One content can be held by several chunk hashes (the same text stored
+after different prefixes), each claimed by the namespaces that stored it.
+A match therefore names a ``chunk_hash`` the *requester's* namespace
+claims, so it expands into keys that exist rather than into another
+model's or tenant's.
+
 Owns its lock and never calls back into the directory, so the only lock
-order is directory → index. Matches name a ``chunk_hash`` only, with no
-model or salt awareness.
+order is directory → index.
 
 See ``docs/design/v1/mp_coordinator/blend_index.md``.
 """
@@ -24,7 +29,7 @@ import numpy as np
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.mp_coordinator.api import BlendMatch
+from lmcache.v1.mp_coordinator.api import BlendMatch, BlendNamespace
 from lmcache.v1.multiprocess.token_hasher import (
     chunk_hash_windows_numba,
     rolling_hash_windows_numba,
@@ -52,12 +57,34 @@ class BlendIndexStats:
     Attributes:
         num_contents: Distinct chunk contents indexed.
         num_chunks: Chunks indexed across those contents.
+        num_claims: ``(chunk, namespace)`` pairs across those chunks —
+            what a chunk stored by several models or tenants costs.
+        num_namespaces: Distinct namespaces holding indexed content.
         table_size: Slots in the occupancy filter.
     """
 
     num_contents: int
     num_chunks: int
+    num_claims: int
+    num_namespaces: int
     table_size: int
+
+
+@dataclass
+class _Occupant:
+    """One chunk hash holding an entry's content.
+
+    Attributes:
+        token_offset: The chunk's position in its stored sequence;
+            per chunk, since identical content can be stored at
+            different positions.
+        namespaces: Every namespace that stored this chunk. A match is
+            offered only to a requester in one of them, and the occupant
+            is dropped when the last one goes.
+    """
+
+    token_offset: int
+    namespaces: set[BlendNamespace] = field(default_factory=set)
 
 
 @dataclass
@@ -68,16 +95,16 @@ class _FingerprintEntry:
     undiscoverable rather than being wrongly matched."""
 
     token_ids: np.ndarray
-    # (chunk_hash, token_offset); the offset is per chunk, since identical
-    # content can be stored at different positions.
-    occupants: list[tuple[bytes, int]] = field(default_factory=list)
+    # chunk_hash -> occupant, in first-indexed order.
+    occupants: dict[bytes, _Occupant] = field(default_factory=dict)
 
 
 class BlendIndex:
     """Thread-safe content fingerprint index for fragment lookups.
 
-    Mutations arrive through :meth:`add` and :meth:`remove` (driven by
-    binding lifecycle); reads through :meth:`match` and :meth:`stats`.
+    Mutations arrive through :meth:`add`, :meth:`remove`, and
+    :meth:`remove_chunk` (driven by binding lifecycle); reads through
+    :meth:`match` and :meth:`stats`.
     """
 
     def __init__(self, chunk_size: int = 256, probe_stride: int = 1) -> None:
@@ -110,16 +137,26 @@ class BlendIndex:
         # only costs a dict miss), so rebuild once they outgrow the entries.
         self._bits_set = 0
 
-    def add(self, token_ids: np.ndarray, chunk_hash: bytes, token_offset: int) -> None:
-        """Index ``chunk_hash``'s content, or attach it to an existing entry.
+    def add(
+        self,
+        token_ids: np.ndarray,
+        chunk_hash: bytes,
+        token_offset: int,
+        namespace: BlendNamespace,
+    ) -> None:
+        """Record that ``namespace`` stores ``chunk_hash`` with this content.
 
-        Idempotent. Content whose length is not ``chunk_size`` is ignored.
+        Idempotent, and additive in the namespace: a second namespace
+        storing the same chunk joins the existing occupant rather than
+        replacing its claim. Content whose length is not ``chunk_size``
+        is ignored.
 
         Args:
             token_ids: The chunk's tokens. Held by reference, so the
                 caller must not mutate it afterwards.
             chunk_hash: The chunk's ``ObjectKey.chunk_hash``.
             token_offset: The chunk's position in its stored sequence.
+            namespace: The namespace the chunk was stored in.
         """
         if token_ids.shape[0] != self._chunk_size:
             logger.warning(
@@ -134,27 +171,59 @@ class BlendIndex:
         with self._lock:
             entry = self._fingerprint_table.get(poly)
             if entry is None:
-                self._fingerprint_table[poly] = _FingerprintEntry(
-                    token_ids=token_ids, occupants=[(chunk_hash, token_offset)]
-                )
+                entry = _FingerprintEntry(token_ids=token_ids)
+                self._fingerprint_table[poly] = entry
                 slot = poly & int(self._mask)
                 if not self._slots[slot]:
                     self._slots[slot] = 1
                     self._bits_set += 1
                 if _TABLE_GROWTH * len(self._fingerprint_table) > self._slots.shape[0]:
                     self._rebuild_table()
+            occupant = entry.occupants.get(chunk_hash)
+            if occupant is None:
+                entry.occupants[chunk_hash] = _Occupant(
+                    token_offset=token_offset, namespaces={namespace}
+                )
                 return
-            for index, (held_hash, _) in enumerate(entry.occupants):
-                if held_hash == chunk_hash:
-                    entry.occupants[index] = (chunk_hash, token_offset)
-                    return
-            entry.occupants.append((chunk_hash, token_offset))
+            occupant.token_offset = token_offset
+            occupant.namespaces.add(namespace)
 
-    def remove(self, token_ids: np.ndarray, chunk_hash: bytes) -> None:
-        """Drop ``chunk_hash`` from the entry for ``token_ids``.
+    def remove(
+        self, token_ids: np.ndarray, chunk_hash: bytes, namespace: BlendNamespace
+    ) -> None:
+        """Drop ``namespace``'s claim on ``chunk_hash``.
 
-        The content is dropped with its last chunk; removing an unknown
-        chunk or content is a no-op.
+        The chunk survives while another namespace still stores it, and
+        the content is dropped with its last chunk. Removing an unknown
+        claim, chunk, or content is a no-op.
+
+        Args:
+            token_ids: The content the chunk was indexed under.
+            chunk_hash: The chunk to release.
+            namespace: The namespace releasing it.
+        """
+        if token_ids.shape[0] != self._chunk_size:
+            return
+        poly = self._fingerprint(token_ids)
+        with self._lock:
+            entry = self._fingerprint_table.get(poly)
+            if entry is None:
+                return
+            occupant = entry.occupants.get(chunk_hash)
+            if occupant is None:
+                return
+            occupant.namespaces.discard(namespace)
+            if occupant.namespaces:
+                return
+            del entry.occupants[chunk_hash]
+            self._drop_entry_if_empty(poly, entry)
+
+    def remove_chunk(self, token_ids: np.ndarray, chunk_hash: bytes) -> None:
+        """Drop ``chunk_hash`` and every namespace's claim on it.
+
+        Serves the one case where the chunk itself stops holding this
+        content — a re-store under the same hash with different tokens —
+        which invalidates every namespace's claim at once.
 
         Args:
             token_ids: The content the chunk was indexed under.
@@ -165,27 +234,22 @@ class BlendIndex:
         poly = self._fingerprint(token_ids)
         with self._lock:
             entry = self._fingerprint_table.get(poly)
-            if entry is None:
+            if entry is None or entry.occupants.pop(chunk_hash, None) is None:
                 return
-            entry.occupants = [
-                occupant for occupant in entry.occupants if occupant[0] != chunk_hash
-            ]
-            if entry.occupants:
-                return
-            del self._fingerprint_table[poly]
-            # The bit stays until a rebuild: clearing it here could hide a
-            # different fingerprint sharing the bucket.
-            if self._bits_set > 2 * len(self._fingerprint_table):
-                self._rebuild_table()
+            self._drop_entry_if_empty(poly, entry)
 
-    def match(self, tokens: np.ndarray) -> list[BlendMatch]:
-        """Find indexed chunks contained in ``tokens``.
+    def match(self, tokens: np.ndarray, namespace: BlendNamespace) -> list[BlendMatch]:
+        """Find chunks ``namespace`` can retrieve, contained in ``tokens``.
 
-        Every candidate is verified token-exact before acceptance.
+        Every candidate is verified token-exact, then narrowed to the
+        occupants ``namespace`` stores. Content held only by other
+        namespaces yields nothing: its keys do not exist for this
+        requester, so offering it would buy a confirmed miss.
 
         Args:
             tokens: The query token ids (any dtype castable to
                 ``uint64``).
+            namespace: The requester's retrieval namespace.
 
         Returns:
             Matches in ascending ``cur_st`` order, at most one per chunk.
@@ -210,14 +274,18 @@ class BlendIndex:
                 cur_st = position * self._probe_stride
                 if not np.array_equal(query[cur_st : cur_st + window], entry.token_ids):
                     continue  # fingerprint collision: content differs
-                for chunk_hash, token_offset in entry.occupants:
-                    if chunk_hash in seen:
+                for chunk_hash, occupant in entry.occupants.items():
+                    # Walk past occupants this namespace cannot retrieve —
+                    # the same content stored under another model, tenant,
+                    # or parallel setup, or already emitted elsewhere in
+                    # the query.
+                    if chunk_hash in seen or namespace not in occupant.namespaces:
                         continue
                     seen.add(chunk_hash)
                     matches.append(
                         BlendMatch(
                             chunk_hash=chunk_hash,
-                            old_st=token_offset,
+                            old_st=occupant.token_offset,
                             cur_st=cur_st,
                         )
                     )
@@ -228,18 +296,38 @@ class BlendIndex:
         """Return a point-in-time summary of index contents.
 
         Returns:
-            Distinct contents, total chunks, and the table size.
+            Distinct contents, chunks, namespace claims, distinct
+            namespaces, and the table size.
         """
         with self._lock:
+            num_chunks = 0
+            num_claims = 0
+            namespaces: set[BlendNamespace] = set()
+            for entry in self._fingerprint_table.values():
+                num_chunks += len(entry.occupants)
+                for occupant in entry.occupants.values():
+                    num_claims += len(occupant.namespaces)
+                    namespaces |= occupant.namespaces
             return BlendIndexStats(
                 num_contents=len(self._fingerprint_table),
-                num_chunks=sum(
-                    len(entry.occupants) for entry in self._fingerprint_table.values()
-                ),
+                num_chunks=num_chunks,
+                num_claims=num_claims,
+                num_namespaces=len(namespaces),
                 table_size=int(self._slots.shape[0]),
             )
 
     # -- Internals -------------------------------------------------------------
+
+    def _drop_entry_if_empty(self, poly: int, entry: _FingerprintEntry) -> None:
+        """Retire ``entry`` once no chunk holds its content. Call with the
+        lock held."""
+        if entry.occupants:
+            return
+        del self._fingerprint_table[poly]
+        # The bit stays until a rebuild: clearing it here could hide a
+        # different fingerprint sharing the bucket.
+        if self._bits_set > 2 * len(self._fingerprint_table):
+            self._rebuild_table()
 
     def _fingerprint(self, token_ids: np.ndarray) -> int:
         """Return the 64-bit polynomial fingerprint of one chunk's content."""

--- a/lmcache/v1/mp_coordinator/blend_index.py
+++ b/lmcache/v1/mp_coordinator/blend_index.py
@@ -97,7 +97,7 @@ class _FingerprintEntry:
 class BlendIndex:
     """Thread-safe content fingerprint index for fragment lookups.
 
-    Mutations arrive through :meth:`add`, :meth:`remove`, and
+    Mutations arrive through :meth:`add`, :meth:`remove_claim`, and
     :meth:`remove_chunk` (driven by binding lifecycle); reads through
     :meth:`match` and :meth:`stats`.
     """
@@ -182,7 +182,7 @@ class BlendIndex:
             occupant.token_offset = token_offset
             occupant.namespaces.add(namespace)
 
-    def remove(
+    def remove_claim(
         self, token_ids: np.ndarray, chunk_hash: bytes, namespace: BlendNamespace
     ) -> None:
         """Drop ``namespace``'s claim on ``chunk_hash``.
@@ -210,7 +210,13 @@ class BlendIndex:
             if occupant.namespaces:
                 return
             del entry.occupants[chunk_hash]
-            self._drop_entry_if_empty(poly, entry)
+            if entry.occupants:
+                return
+            del self._fingerprint_table[poly]
+            # The bit stays until a rebuild: clearing it here could hide a
+            # different fingerprint sharing the bucket.
+            if self._bits_set > 2 * len(self._fingerprint_table):
+                self._rebuild_table()
 
     def remove_chunk(self, token_ids: np.ndarray, chunk_hash: bytes) -> None:
         """Drop ``chunk_hash`` and every namespace's claim on it.
@@ -229,7 +235,13 @@ class BlendIndex:
             entry = self._fingerprint_table.get(poly)
             if entry is None or entry.occupants.pop(chunk_hash, None) is None:
                 return
-            self._drop_entry_if_empty(poly, entry)
+            if entry.occupants:
+                return
+            del self._fingerprint_table[poly]
+            # The bit stays until a rebuild: clearing it here could hide a
+            # different fingerprint sharing the bucket.
+            if self._bits_set > 2 * len(self._fingerprint_table):
+                self._rebuild_table()
 
     def match(self, tokens: np.ndarray, namespace: BlendNamespace) -> list[BlendMatch]:
         """Find chunks ``namespace`` can retrieve, contained in ``tokens``.
@@ -263,25 +275,24 @@ class BlendIndex:
                 entry = self._fingerprint_table.get(int(probe[position]))
                 if entry is None:
                     continue  # bucket shared with another fingerprint
-                # Choose the occupant before verifying: a set membership
-                # test is far cheaper than comparing a full window, so
-                # content this namespace cannot retrieve is dropped
-                # without paying for the comparison.
-                candidate = self._retrievable_occupant(entry, namespace, seen)
-                if candidate is None:
-                    continue
-                cur_st = position * self._probe_stride
-                if not np.array_equal(query[cur_st : cur_st + window], entry.token_ids):
-                    continue  # fingerprint collision: content differs
-                chunk_hash, token_offset = candidate
-                seen.add(chunk_hash)
-                matches.append(
-                    BlendMatch(
-                        chunk_hash=chunk_hash,
-                        old_st=token_offset,
-                        cur_st=cur_st,
+                for chunk_hash, occupant in entry.occupants.items():
+                    if chunk_hash in seen or namespace not in occupant.namespaces:
+                        continue
+                    # Verifying only here spares foreign content the comparison.
+                    cur_st = position * self._probe_stride
+                    if not np.array_equal(
+                        query[cur_st : cur_st + window], entry.token_ids
+                    ):
+                        break  # fingerprint collision: content differs
+                    seen.add(chunk_hash)
+                    matches.append(
+                        BlendMatch(
+                            chunk_hash=chunk_hash,
+                            old_st=occupant.token_offset,
+                            cur_st=cur_st,
+                        )
                     )
-                )
+                    break  # occupants are content-identical; one suffices
         return matches
 
     def stats(self) -> BlendIndexStats:
@@ -309,41 +320,6 @@ class BlendIndex:
             )
 
     # -- Internals -------------------------------------------------------------
-
-    @staticmethod
-    def _retrievable_occupant(
-        entry: _FingerprintEntry, namespace: BlendNamespace, seen: set[bytes]
-    ) -> tuple[bytes, int] | None:
-        """Return the chunk of ``entry`` that ``namespace`` should be offered.
-
-        Occupants are content-identical, so the first one this namespace
-        claims and has not already been offered suffices. Call with the
-        lock held.
-
-        Args:
-            entry: The content entry whose occupants to choose from.
-            namespace: The requester's retrieval namespace.
-            seen: Chunk hashes already emitted for this query.
-
-        Returns:
-            ``(chunk_hash, token_offset)``, or ``None`` when this
-            namespace holds no unoffered chunk of the content.
-        """
-        for chunk_hash, occupant in entry.occupants.items():
-            if chunk_hash not in seen and namespace in occupant.namespaces:
-                return chunk_hash, occupant.token_offset
-        return None
-
-    def _drop_entry_if_empty(self, poly: int, entry: _FingerprintEntry) -> None:
-        """Retire ``entry`` once no chunk holds its content. Call with the
-        lock held."""
-        if entry.occupants:
-            return
-        del self._fingerprint_table[poly]
-        # The bit stays until a rebuild: clearing it here could hide a
-        # different fingerprint sharing the bucket.
-        if self._bits_set > 2 * len(self._fingerprint_table):
-            self._rebuild_table()
 
     def _fingerprint(self, token_ids: np.ndarray) -> int:
         """Return the 64-bit polynomial fingerprint of one chunk's content."""

--- a/lmcache/v1/mp_coordinator/blend_index.py
+++ b/lmcache/v1/mp_coordinator/blend_index.py
@@ -234,9 +234,9 @@ class BlendIndex:
     def match(self, tokens: np.ndarray, namespace: BlendNamespace) -> list[BlendMatch]:
         """Find chunks ``namespace`` can retrieve, contained in ``tokens``.
 
-        Every candidate is verified token-exact, then narrowed to the
-        occupants ``namespace`` stores. Content held only by other
-        namespaces yields nothing.
+        Candidates are narrowed to the occupants ``namespace`` stores,
+        then verified token-exact. Content held only by other namespaces
+        yields nothing, and is rejected before the comparison.
 
         Args:
             tokens: The query token ids (any dtype castable to
@@ -263,23 +263,25 @@ class BlendIndex:
                 entry = self._fingerprint_table.get(int(probe[position]))
                 if entry is None:
                     continue  # bucket shared with another fingerprint
+                # Choose the occupant before verifying: a set membership
+                # test is far cheaper than comparing a full window, so
+                # content this namespace cannot retrieve is dropped
+                # without paying for the comparison.
+                candidate = self._retrievable_occupant(entry, namespace, seen)
+                if candidate is None:
+                    continue
                 cur_st = position * self._probe_stride
                 if not np.array_equal(query[cur_st : cur_st + window], entry.token_ids):
                     continue  # fingerprint collision: content differs
-                for chunk_hash, occupant in entry.occupants.items():
-                    # Skip occupants this namespace cannot retrieve, and
-                    # chunks already emitted elsewhere in the query.
-                    if chunk_hash in seen or namespace not in occupant.namespaces:
-                        continue
-                    seen.add(chunk_hash)
-                    matches.append(
-                        BlendMatch(
-                            chunk_hash=chunk_hash,
-                            old_st=occupant.token_offset,
-                            cur_st=cur_st,
-                        )
+                chunk_hash, token_offset = candidate
+                seen.add(chunk_hash)
+                matches.append(
+                    BlendMatch(
+                        chunk_hash=chunk_hash,
+                        old_st=token_offset,
+                        cur_st=cur_st,
                     )
-                    break  # occupants are content-identical; one suffices
+                )
         return matches
 
     def stats(self) -> BlendIndexStats:
@@ -307,6 +309,30 @@ class BlendIndex:
             )
 
     # -- Internals -------------------------------------------------------------
+
+    @staticmethod
+    def _retrievable_occupant(
+        entry: _FingerprintEntry, namespace: BlendNamespace, seen: set[bytes]
+    ) -> tuple[bytes, int] | None:
+        """Return the chunk of ``entry`` that ``namespace`` should be offered.
+
+        Occupants are content-identical, so the first one this namespace
+        claims and has not already been offered suffices. Call with the
+        lock held.
+
+        Args:
+            entry: The content entry whose occupants to choose from.
+            namespace: The requester's retrieval namespace.
+            seen: Chunk hashes already emitted for this query.
+
+        Returns:
+            ``(chunk_hash, token_offset)``, or ``None`` when this
+            namespace holds no unoffered chunk of the content.
+        """
+        for chunk_hash, occupant in entry.occupants.items():
+            if chunk_hash not in seen and namespace in occupant.namespaces:
+                return chunk_hash, occupant.token_offset
+        return None
 
     def _drop_entry_if_empty(self, poly: int, entry: _FingerprintEntry) -> None:
         """Retire ``entry`` once no chunk holds its content. Call with the

--- a/lmcache/v1/mp_coordinator/http_apis/directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/directory_api.py
@@ -14,7 +14,6 @@ import asyncio
 
 # Third Party
 from fastapi import APIRouter, HTTPException, Query, Request
-import numpy as np
 
 # First Party
 from lmcache.v1.distributed.api import Tier
@@ -29,12 +28,10 @@ from lmcache.v1.mp_coordinator.schemas import (
     DirectoryListResponse,
     DirectoryLookupRequest,
     DirectoryLookupResponse,
+    decode_tokens,
 )
 from lmcache.v1.mp_coordinator.views.key_directory import DirectoryStats, KeyDirectory
-from lmcache.v1.multiprocess.cache_control.key_resolver import (
-    MAX_TOKEN_IDS,
-    resolve_object_keys,
-)
+from lmcache.v1.multiprocess.cache_control.key_resolver import resolve_object_keys
 
 router = APIRouter()
 
@@ -111,11 +108,9 @@ async def blend_lookup(
     be a prefix, and each match reports both where the content sits in
     the query and where it sat when stored, so the caller can re-RoPE it.
 
-    Takes the same tokens form as ``/directory/lookup`` and reads its
-    identity fields the same way -- as the namespace the caller's chunk
-    hashes resolve in. Matches are restricted to it, so every match
-    expands into keys that exist rather than into another model's or
-    tenant's.
+    Matches are restricted to the namespace the body names, so every one
+    of them expands into keys that exist for this caller rather than into
+    another model's or tenant's.
 
     Args:
         body: The query tokens and the caller's key-resolution
@@ -124,20 +119,9 @@ async def blend_lookup(
 
     Returns:
         Matched chunks, ascending by query position.
-
-    Raises:
-        HTTPException: 400 when the token sequence exceeds the
-            per-request cap.
     """
-    if len(body.token_ids) > MAX_TOKEN_IDS:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"too many token_ids in a single request "
-                f"(limit={MAX_TOKEN_IDS}, got={len(body.token_ids)})"
-            ),
-        )
     directory = get_context(request).views.get(KeyDirectory)
+    tokens = decode_tokens(body.tokens_b64)
     namespace = BlendNamespace(
         model_name=body.model_name,
         cache_salt=body.cache_salt,
@@ -146,7 +130,6 @@ async def blend_lookup(
 
     def _match() -> BlendLookupResponse:
         """Run the fragment match and shape it for the wire."""
-        tokens = np.asarray(body.token_ids, dtype=np.uint64)
         return BlendLookupResponse(
             matches=[
                 BlendMatchModel(

--- a/lmcache/v1/mp_coordinator/http_apis/directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/directory_api.py
@@ -108,9 +108,7 @@ async def blend_lookup(
     be a prefix, and each match reports both where the content sits in
     the query and where it sat when stored, so the caller can re-RoPE it.
 
-    Matches are restricted to the namespace the body names, so every one
-    of them expands into keys that exist for this caller rather than into
-    another model's or tenant's.
+    Matches are restricted to the namespace the body names.
 
     Args:
         body: The query tokens and the caller's key-resolution

--- a/lmcache/v1/mp_coordinator/http_apis/directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/directory_api.py
@@ -14,9 +14,11 @@ import asyncio
 
 # Third Party
 from fastapi import APIRouter, HTTPException, Query, Request
+import numpy as np
 
 # First Party
 from lmcache.v1.distributed.api import Tier
+from lmcache.v1.mp_coordinator.api import BlendNamespace
 from lmcache.v1.mp_coordinator.http_apis.dependencies import get_context
 from lmcache.v1.mp_coordinator.schemas import (
     BlendLookupRequest,
@@ -27,10 +29,12 @@ from lmcache.v1.mp_coordinator.schemas import (
     DirectoryListResponse,
     DirectoryLookupRequest,
     DirectoryLookupResponse,
-    decode_tokens,
 )
 from lmcache.v1.mp_coordinator.views.key_directory import DirectoryStats, KeyDirectory
-from lmcache.v1.multiprocess.cache_control.key_resolver import resolve_object_keys
+from lmcache.v1.multiprocess.cache_control.key_resolver import (
+    MAX_TOKEN_IDS,
+    resolve_object_keys,
+)
 
 router = APIRouter()
 
@@ -107,18 +111,42 @@ async def blend_lookup(
     be a prefix, and each match reports both where the content sits in
     the query and where it sat when stored, so the caller can re-RoPE it.
 
+    Takes the same tokens form as ``/directory/lookup`` and reads its
+    identity fields the same way -- as the namespace the caller's chunk
+    hashes resolve in. Matches are restricted to it, so every match
+    expands into keys that exist rather than into another model's or
+    tenant's.
+
     Args:
-        body: The query tokens.
+        body: The query tokens and the caller's key-resolution
+            parameters.
         request: The FastAPI request carrying the coordinator context.
 
     Returns:
         Matched chunks, ascending by query position.
+
+    Raises:
+        HTTPException: 400 when the token sequence exceeds the
+            per-request cap.
     """
+    if len(body.token_ids) > MAX_TOKEN_IDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"too many token_ids in a single request "
+                f"(limit={MAX_TOKEN_IDS}, got={len(body.token_ids)})"
+            ),
+        )
     directory = get_context(request).views.get(KeyDirectory)
-    tokens = decode_tokens(body.tokens_b64)
+    namespace = BlendNamespace(
+        model_name=body.model_name,
+        cache_salt=body.cache_salt,
+        world_size=body.world_size,
+    )
 
     def _match() -> BlendLookupResponse:
         """Run the fragment match and shape it for the wire."""
+        tokens = np.asarray(body.token_ids, dtype=np.uint64)
         return BlendLookupResponse(
             matches=[
                 BlendMatchModel(
@@ -126,7 +154,7 @@ async def blend_lookup(
                     old_st=match.old_st,
                     cur_st=match.cur_st,
                 )
-                for match in directory.blend_match(tokens)
+                for match in directory.blend_match(tokens, namespace)
             ]
         )
 

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -11,7 +11,6 @@ This module holds HTTP models only.
 
 # Standard
 from typing import Annotated
-import base64
 
 # Third Party
 from pydantic import (
@@ -21,55 +20,12 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-import numpy as np
 
 # First Party
 from lmcache.v1.distributed.api import EncodedObjectKey  # noqa: F401  re-exported
 from lmcache.v1.distributed.api import Tier
 from lmcache.v1.mp_coordinator.api import CacheEventBatch
 from lmcache.v1.mp_coordinator.views.key_directory import Placement
-
-
-def encode_tokens(tokens: "list[int] | np.ndarray") -> str:
-    """Encode token ids into a compact base64 wire string.
-
-    Token ids fit in ``uint32``, so a little-endian ``uint32`` buffer is far
-    smaller than a JSON integer list and decodes in one ``np.frombuffer`` call.
-
-    Args:
-        tokens: Token ids (a ``list[int]`` or any array castable to ``uint32``).
-
-    Returns:
-        Base64 of the little-endian ``uint32`` token buffer.
-    """
-    arr = np.ascontiguousarray(np.asarray(tokens, dtype="<u4"))
-    return base64.b64encode(arr.tobytes()).decode("ascii")
-
-
-def decode_tokens(tokens_b64: str) -> np.ndarray:
-    """Decode a base64 token string produced by :func:`encode_tokens`.
-
-    Args:
-        tokens_b64: Base64 of a little-endian ``uint32`` token buffer.
-
-    Returns:
-        A ``uint64`` array of token ids (widened so it feeds the hashers
-        directly).
-
-    Raises:
-        ValueError: If ``tokens_b64`` is not valid base64 or not a multiple of
-            4 bytes.
-    """
-    try:
-        raw = base64.b64decode(tokens_b64, validate=True)
-    except Exception as exc:
-        raise ValueError(f"tokens_b64 is not valid base64: {exc}") from exc
-    if len(raw) % 4 != 0:
-        raise ValueError(
-            f"tokens_b64 byte length {len(raw)} is not a multiple of 4 "
-            "(malformed uint32 token buffer)"
-        )
-    return np.frombuffer(raw, dtype="<u4").astype(np.uint64)
 
 
 class RegisterRequest(BaseModel):
@@ -326,34 +282,63 @@ class CacheEventsResponse(BaseModel):
     stale: int = 0
 
 
-class DirectoryLookupRequest(BaseModel):
+class TokenSequenceForm(BaseModel):
+    """A token sequence plus the identity that resolves it to keys.
+
+    The shared shape of every directory query that speaks tokens rather
+    than keys: a `chunk_hash` names content only, so the model, salt, and
+    rank fan-out that turn it into an :class:`EncodedObjectKey` have to
+    travel with it. ``/directory/lookup`` uses them to *build* keys;
+    ``/directory/blend-lookup`` uses them to keep matches inside the
+    namespace the caller can actually retrieve from.
+
+    Chunk hashes are prefix-chained, so ``token_ids`` must be the
+    request's **full** sequence from position 0; a mid-request slice
+    resolves to different keys. Trailing incomplete chunks are ignored.
+
+    Attributes:
+        token_ids: The request's full token sequence.
+        model_name: Model whose rank fan-out to use.
+        world_size: World size selecting the per-rank fan-out.
+        cache_salt: Per-tenant isolation salt applied to produced keys.
+    """
+
+    token_ids: list[int] = Field(default_factory=list)
+    model_name: str = ""
+    world_size: int = Field(default=1, ge=1)
+    cache_salt: str = ""
+
+    @model_validator(mode="after")
+    def _validate_token_identity(self) -> "TokenSequenceForm":
+        """Reject a token sequence with no model to resolve it against.
+
+        Returns:
+            The unchanged request once any token sequence names a model.
+
+        Raises:
+            ValueError: If ``token_ids`` is supplied without
+                ``model_name``.
+        """
+        if self.token_ids and not self.model_name:
+            raise ValueError("'model_name' is required with 'token_ids'")
+        return self
+
+
+class DirectoryLookupRequest(TokenSequenceForm):
     """Body of ``POST /directory/lookup``.
 
     Supply exactly one of the two lookup forms:
 
     * ``keys`` — resolve these keys directly.
-    * ``token_ids`` (with ``model_name`` / ``world_size``) — resolve a
-      request's token sequence to the object keys of its complete
-      chunks, the same fan-out the pin APIs use. Chunk hashes are
-      prefix-chained, so this must be the request's **full** token
-      sequence from position 0; a mid-request slice resolves to
-      different keys. Trailing incomplete chunks are ignored.
+    * the inherited tokens form — resolve a request's token sequence to
+      the object keys of its complete chunks, the same fan-out the pin
+      APIs use.
 
     Attributes:
         keys: The keys to resolve (keys form).
-        token_ids: The request's full token sequence (tokens form).
-        model_name: Model whose rank fan-out to use (tokens form).
-        world_size: World size selecting the per-rank fan-out
-            (tokens form).
-        cache_salt: Per-tenant isolation salt applied to produced keys
-            (tokens form).
     """
 
     keys: list[EncodedObjectKey] = Field(default_factory=list)
-    token_ids: list[int] = Field(default_factory=list)
-    model_name: str = ""
-    world_size: int = Field(default=1, ge=1)
-    cache_salt: str = ""
 
     @field_validator("keys")
     @classmethod
@@ -382,12 +367,10 @@ class DirectoryLookupRequest(BaseModel):
 
         Raises:
             ValueError: If both or neither of ``keys`` / ``token_ids``
-                is supplied, or the tokens form omits ``model_name``.
+                is supplied.
         """
         if bool(self.keys) == bool(self.token_ids):
             raise ValueError("supply exactly one of 'keys' or 'token_ids'")
-        if self.token_ids and not self.model_name:
-            raise ValueError("'model_name' is required with 'token_ids'")
         return self
 
 
@@ -453,38 +436,32 @@ class DirectoryListResponse(BaseModel):
     keys: list[DirectoryKeyInfo] = Field(default_factory=list)
 
 
-class BlendLookupRequest(BaseModel):
+class BlendLookupRequest(TokenSequenceForm):
     """Body of ``POST /directory/blend-lookup``.
 
-    Unlike ``/directory/lookup`` the query need not be a prefix.
+    The same tokens form ``/directory/lookup`` takes -- the two questions
+    differ in where the content may sit, not in how it is described. Only
+    the tokens form exists here: a fragment query is a search over
+    content, so there is nothing to name by key.
 
-    Attributes:
-        tokens_b64: The query tokens, packed via :func:`encode_tokens`
-            (base64 little-endian ``uint32``).
+    Unlike ``/directory/lookup`` the query need not be a prefix, but the
+    identity fields matter just as much: they scope matches to chunks the
+    caller's own key expansion can retrieve.
     """
 
-    tokens_b64: str = ""
-
-    @field_validator("tokens_b64")
-    @classmethod
-    def _validate_tokens_b64(cls, value: str) -> str:
-        """Reject a malformed token buffer at request validation.
-
-        Validating here returns 422 rather than the 500 a decode failure
-        inside the handler would produce.
-
-        Args:
-            value: The base64 ``tokens_b64`` field.
+    @model_validator(mode="after")
+    def _validate_tokens_present(self) -> "BlendLookupRequest":
+        """Enforce that a query sequence was supplied.
 
         Returns:
-            The unchanged value once it is confirmed decodable.
+            The unchanged request once it carries tokens.
 
         Raises:
-            ValueError: If ``value`` is not valid base64 or not a whole
-                number of ``uint32`` tokens.
+            ValueError: If ``token_ids`` is empty.
         """
-        decode_tokens(value)
-        return value
+        if not self.token_ids:
+            raise ValueError("'token_ids' is required")
+        return self
 
 
 class BlendMatchModel(BaseModel):

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -457,17 +457,8 @@ class BlendLookupRequest(BaseModel):
     """Body of ``POST /directory/blend-lookup``.
 
     Unlike ``/directory/lookup`` the query need not be a prefix. It
-    carries the same identity fields for a different reason: prefix
-    lookup uses them to *build* keys, while a fragment match already
-    names a stored ``chunk_hash`` and uses them to stay inside the
-    namespace the caller can retrieve from. A `chunk_hash` names content
-    and prefix only, so without them a match could name another model's
-    or tenant's KV.
-
-    The query tokens ride as ``tokens_b64`` rather than
-    ``/directory/lookup``'s ``token_ids`` list: a fragment query is the
-    request's whole sequence and the compact form saves the wire. The two
-    endpoints are free to converge later.
+    carries the same identity fields, but uses them to scope matches to
+    the caller's namespace rather than to build keys.
 
     Attributes:
         tokens_b64: The query tokens, packed via :func:`encode_tokens`

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -11,6 +11,7 @@ This module holds HTTP models only.
 
 # Standard
 from typing import Annotated
+import base64
 
 # Third Party
 from pydantic import (
@@ -20,12 +21,55 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+import numpy as np
 
 # First Party
 from lmcache.v1.distributed.api import EncodedObjectKey  # noqa: F401  re-exported
 from lmcache.v1.distributed.api import Tier
 from lmcache.v1.mp_coordinator.api import CacheEventBatch
 from lmcache.v1.mp_coordinator.views.key_directory import Placement
+
+
+def encode_tokens(tokens: "list[int] | np.ndarray") -> str:
+    """Encode token ids into a compact base64 wire string.
+
+    Token ids fit in ``uint32``, so a little-endian ``uint32`` buffer is far
+    smaller than a JSON integer list and decodes in one ``np.frombuffer`` call.
+
+    Args:
+        tokens: Token ids (a ``list[int]`` or any array castable to ``uint32``).
+
+    Returns:
+        Base64 of the little-endian ``uint32`` token buffer.
+    """
+    arr = np.ascontiguousarray(np.asarray(tokens, dtype="<u4"))
+    return base64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def decode_tokens(tokens_b64: str) -> np.ndarray:
+    """Decode a base64 token string produced by :func:`encode_tokens`.
+
+    Args:
+        tokens_b64: Base64 of a little-endian ``uint32`` token buffer.
+
+    Returns:
+        A ``uint64`` array of token ids (widened so it feeds the hashers
+        directly).
+
+    Raises:
+        ValueError: If ``tokens_b64`` is not valid base64 or not a multiple of
+            4 bytes.
+    """
+    try:
+        raw = base64.b64decode(tokens_b64, validate=True)
+    except Exception as exc:
+        raise ValueError(f"tokens_b64 is not valid base64: {exc}") from exc
+    if len(raw) % 4 != 0:
+        raise ValueError(
+            f"tokens_b64 byte length {len(raw)} is not a multiple of 4 "
+            "(malformed uint32 token buffer)"
+        )
+    return np.frombuffer(raw, dtype="<u4").astype(np.uint64)
 
 
 class RegisterRequest(BaseModel):
@@ -282,63 +326,34 @@ class CacheEventsResponse(BaseModel):
     stale: int = 0
 
 
-class TokenSequenceForm(BaseModel):
-    """A token sequence plus the identity that resolves it to keys.
-
-    The shared shape of every directory query that speaks tokens rather
-    than keys: a `chunk_hash` names content only, so the model, salt, and
-    rank fan-out that turn it into an :class:`EncodedObjectKey` have to
-    travel with it. ``/directory/lookup`` uses them to *build* keys;
-    ``/directory/blend-lookup`` uses them to keep matches inside the
-    namespace the caller can actually retrieve from.
-
-    Chunk hashes are prefix-chained, so ``token_ids`` must be the
-    request's **full** sequence from position 0; a mid-request slice
-    resolves to different keys. Trailing incomplete chunks are ignored.
-
-    Attributes:
-        token_ids: The request's full token sequence.
-        model_name: Model whose rank fan-out to use.
-        world_size: World size selecting the per-rank fan-out.
-        cache_salt: Per-tenant isolation salt applied to produced keys.
-    """
-
-    token_ids: list[int] = Field(default_factory=list)
-    model_name: str = ""
-    world_size: int = Field(default=1, ge=1)
-    cache_salt: str = ""
-
-    @model_validator(mode="after")
-    def _validate_token_identity(self) -> "TokenSequenceForm":
-        """Reject a token sequence with no model to resolve it against.
-
-        Returns:
-            The unchanged request once any token sequence names a model.
-
-        Raises:
-            ValueError: If ``token_ids`` is supplied without
-                ``model_name``.
-        """
-        if self.token_ids and not self.model_name:
-            raise ValueError("'model_name' is required with 'token_ids'")
-        return self
-
-
-class DirectoryLookupRequest(TokenSequenceForm):
+class DirectoryLookupRequest(BaseModel):
     """Body of ``POST /directory/lookup``.
 
     Supply exactly one of the two lookup forms:
 
     * ``keys`` — resolve these keys directly.
-    * the inherited tokens form — resolve a request's token sequence to
-      the object keys of its complete chunks, the same fan-out the pin
-      APIs use.
+    * ``token_ids`` (with ``model_name`` / ``world_size``) — resolve a
+      request's token sequence to the object keys of its complete
+      chunks, the same fan-out the pin APIs use. Chunk hashes are
+      prefix-chained, so this must be the request's **full** token
+      sequence from position 0; a mid-request slice resolves to
+      different keys. Trailing incomplete chunks are ignored.
 
     Attributes:
         keys: The keys to resolve (keys form).
+        token_ids: The request's full token sequence (tokens form).
+        model_name: Model whose rank fan-out to use (tokens form).
+        world_size: World size selecting the per-rank fan-out
+            (tokens form).
+        cache_salt: Per-tenant isolation salt applied to produced keys
+            (tokens form).
     """
 
     keys: list[EncodedObjectKey] = Field(default_factory=list)
+    token_ids: list[int] = Field(default_factory=list)
+    model_name: str = ""
+    world_size: int = Field(default=1, ge=1)
+    cache_salt: str = ""
 
     @field_validator("keys")
     @classmethod
@@ -367,10 +382,12 @@ class DirectoryLookupRequest(TokenSequenceForm):
 
         Raises:
             ValueError: If both or neither of ``keys`` / ``token_ids``
-                is supplied.
+                is supplied, or the tokens form omits ``model_name``.
         """
         if bool(self.keys) == bool(self.token_ids):
             raise ValueError("supply exactly one of 'keys' or 'token_ids'")
+        if self.token_ids and not self.model_name:
+            raise ValueError("'model_name' is required with 'token_ids'")
         return self
 
 
@@ -436,31 +453,71 @@ class DirectoryListResponse(BaseModel):
     keys: list[DirectoryKeyInfo] = Field(default_factory=list)
 
 
-class BlendLookupRequest(TokenSequenceForm):
+class BlendLookupRequest(BaseModel):
     """Body of ``POST /directory/blend-lookup``.
 
-    The same tokens form ``/directory/lookup`` takes -- the two questions
-    differ in where the content may sit, not in how it is described. Only
-    the tokens form exists here: a fragment query is a search over
-    content, so there is nothing to name by key.
+    Unlike ``/directory/lookup`` the query need not be a prefix. It
+    carries the same identity fields for a different reason: prefix
+    lookup uses them to *build* keys, while a fragment match already
+    names a stored ``chunk_hash`` and uses them to stay inside the
+    namespace the caller can retrieve from. A `chunk_hash` names content
+    and prefix only, so without them a match could name another model's
+    or tenant's KV.
 
-    Unlike ``/directory/lookup`` the query need not be a prefix, but the
-    identity fields matter just as much: they scope matches to chunks the
-    caller's own key expansion can retrieve.
+    The query tokens ride as ``tokens_b64`` rather than
+    ``/directory/lookup``'s ``token_ids`` list: a fragment query is the
+    request's whole sequence and the compact form saves the wire. The two
+    endpoints are free to converge later.
+
+    Attributes:
+        tokens_b64: The query tokens, packed via :func:`encode_tokens`
+            (base64 little-endian ``uint32``).
+        model_name: Model the caller retrieves under; matches are
+            restricted to chunks stored for it.
+        world_size: The caller's world size (TP x PP), selecting its rank
+            fan-out.
+        cache_salt: The caller's per-tenant isolation salt.
     """
 
-    @model_validator(mode="after")
-    def _validate_tokens_present(self) -> "BlendLookupRequest":
-        """Enforce that a query sequence was supplied.
+    tokens_b64: str = ""
+    model_name: str = ""
+    world_size: int = Field(default=1, ge=1)
+    cache_salt: str = ""
+
+    @field_validator("tokens_b64")
+    @classmethod
+    def _validate_tokens_b64(cls, value: str) -> str:
+        """Reject a malformed token buffer at request validation.
+
+        Validating here returns 422 rather than the 500 a decode failure
+        inside the handler would produce.
+
+        Args:
+            value: The base64 ``tokens_b64`` field.
 
         Returns:
-            The unchanged request once it carries tokens.
+            The unchanged value once it is confirmed decodable.
 
         Raises:
-            ValueError: If ``token_ids`` is empty.
+            ValueError: If ``value`` is not valid base64 or not a whole
+                number of ``uint32`` tokens.
         """
-        if not self.token_ids:
-            raise ValueError("'token_ids' is required")
+        decode_tokens(value)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_namespace(self) -> "BlendLookupRequest":
+        """Enforce that the query names the namespace to scope it to.
+
+        Returns:
+            The unchanged request once a query sequence names a model.
+
+        Raises:
+            ValueError: If ``tokens_b64`` is supplied without
+                ``model_name``.
+        """
+        if self.tokens_b64 and not self.model_name:
+            raise ValueError("'model_name' is required with 'tokens_b64'")
         return self
 
 

--- a/lmcache/v1/mp_coordinator/views/key_directory.py
+++ b/lmcache/v1/mp_coordinator/views/key_directory.py
@@ -623,11 +623,7 @@ class KeyDirectory(View):
             return
         token_ids.flags.writeable = False
         binding = self._token_bindings[chunk_hash]
-        # One chunk hash holding two contents means a hash collision or a
-        # misreporting emitter; retire the old fingerprint for every
-        # namespace, or the chunk stays discoverable under content it no
-        # longer has. Guarded on the index being live so a fleet without
-        # blend lookup never pays for the comparison.
+        # Content changed under a known hash: retire the stale fingerprint.
         replaced = (
             self._blend_lookup_enabled
             and bool(binding.token_ids.size)
@@ -675,7 +671,9 @@ class KeyDirectory(View):
                 BlendNamespace.from_object_key(held) == namespace
                 for held in binding.keys
             ):
-                self._blend_index.remove(binding.token_ids, key.chunk_hash, namespace)
+                self._blend_index.remove_claim(
+                    binding.token_ids, key.chunk_hash, namespace
+                )
         if not binding.keys:
             del self._token_bindings[key.chunk_hash]
 

--- a/lmcache/v1/mp_coordinator/views/key_directory.py
+++ b/lmcache/v1/mp_coordinator/views/key_directory.py
@@ -278,10 +278,9 @@ class KeyDirectory(View):
 
         Unlike :meth:`lookup` the query need not be a prefix. Matches name
         a ``chunk_hash`` only, which the caller expands with its own
-        model, salt, and world size -- so they are restricted to chunks
-        some instance stored in ``namespace``, whose expansion therefore
-        names keys that exist. Takes the blend index's lock, not the
-        directory's.
+        model, salt, and world size, so they are restricted to chunks some
+        instance stored in ``namespace``. Takes the blend index's lock,
+        not the directory's.
 
         Args:
             tokens: The query token ids.
@@ -636,10 +635,9 @@ class KeyDirectory(View):
         binding.token_ids = token_ids
         binding.token_offset = entry.token_offset
         if fresh_content:
-            # Keys of other namespaces may have attached while the binding
-            # had no content (or held content this store just replaced),
-            # so claim it for all of them. Steady-state stores take the
-            # single-key path below instead of rehashing per rank.
+            # Other namespaces' keys may have attached while the binding had
+            # no content, so claim it for all of them. Steady-state stores
+            # take the single-key path instead of rehashing per rank.
             self._index_binding(chunk_hash, binding)
         else:
             self._claim_binding(chunk_hash, binding, key)
@@ -667,8 +665,8 @@ class KeyDirectory(View):
         binding.keys.discard(key)
         if self._blend_lookup_enabled and binding.token_ids.size:
             namespace = BlendNamespace.from_object_key(key)
-            # Ranks and object groups of the same namespace hold the same
-            # bytes, so the claim survives until the last of them goes.
+            # The namespace's other ranks and groups hold the same bytes,
+            # so the claim survives until the last of them goes.
             if not any(
                 BlendNamespace.from_object_key(held) == namespace
                 for held in binding.keys
@@ -688,8 +686,7 @@ class KeyDirectory(View):
         """Claim ``chunk_hash`` in the blend index for ``key``'s namespace.
 
         A no-op while blend lookup is off, before the binding has content,
-        or without a stored position -- the cases a fragment match cannot
-        be served from anyway.
+        or without a stored position.
         """
         if not self._blend_lookup_enabled:
             return

--- a/lmcache/v1/mp_coordinator/views/key_directory.py
+++ b/lmcache/v1/mp_coordinator/views/key_directory.py
@@ -623,13 +623,17 @@ class KeyDirectory(View):
             return
         token_ids.flags.writeable = False
         binding = self._token_bindings[chunk_hash]
-        replaced = bool(binding.token_ids.size) and not np.array_equal(
-            binding.token_ids, token_ids
+        # One chunk hash holding two contents means a hash collision or a
+        # misreporting emitter; retire the old fingerprint for every
+        # namespace, or the chunk stays discoverable under content it no
+        # longer has. Guarded on the index being live so a fleet without
+        # blend lookup never pays for the comparison.
+        replaced = (
+            self._blend_lookup_enabled
+            and bool(binding.token_ids.size)
+            and not np.array_equal(binding.token_ids, token_ids)
         )
-        if self._blend_lookup_enabled and replaced:
-            # Re-store with different content: retire the old fingerprint
-            # for every namespace, or the chunk stays discoverable under
-            # content it no longer has.
+        if replaced:
             self._blend_index.remove_chunk(binding.token_ids, chunk_hash)
         fresh_content = replaced or not binding.token_ids.size
         binding.token_ids = token_ids

--- a/lmcache/v1/mp_coordinator/views/key_directory.py
+++ b/lmcache/v1/mp_coordinator/views/key_directory.py
@@ -28,6 +28,7 @@ from lmcache.v1.distributed.api import ObjectKey, Tier
 from lmcache.v1.mp_coordinator.api import (
     UNKNOWN_TOKEN_OFFSET,
     BlendMatch,
+    BlendNamespace,
     CacheEventBatch,
     CacheEventEntry,
     CacheEventType,
@@ -270,16 +271,21 @@ class KeyDirectory(View):
                 for key in keys
             ]
 
-    def blend_match(self, tokens: np.ndarray) -> list[BlendMatch]:
-        """Find cached chunks contained anywhere in ``tokens``.
+    def blend_match(
+        self, tokens: np.ndarray, namespace: BlendNamespace
+    ) -> list[BlendMatch]:
+        """Find chunks ``namespace`` can retrieve, anywhere in ``tokens``.
 
         Unlike :meth:`lookup` the query need not be a prefix. Matches name
         a ``chunk_hash`` only, which the caller expands with its own
-        model, salt, and world size. Takes the blend index's lock, not
-        the directory's.
+        model, salt, and world size -- so they are restricted to chunks
+        some instance stored in ``namespace``, whose expansion therefore
+        names keys that exist. Takes the blend index's lock, not the
+        directory's.
 
         Args:
             tokens: The query token ids.
+            namespace: The requester's retrieval namespace.
 
         Returns:
             Matches in ascending ``cur_st`` order, at most one per chunk;
@@ -289,7 +295,7 @@ class KeyDirectory(View):
         """
         if not self._blend_lookup_enabled:
             return []
-        return self._blend_index.match(tokens)
+        return self._blend_index.match(tokens, namespace)
 
     def blend_stats(self) -> BlendIndexStats:
         """Return a point-in-time summary of the blend index.
@@ -468,8 +474,7 @@ class KeyDirectory(View):
                 token_ids.flags.writeable = False
                 binding.token_ids = token_ids
                 binding.token_offset = token_offset
-                if self._blend_lookup_enabled and token_offset != UNKNOWN_TOKEN_OFFSET:
-                    self._blend_index.add(token_ids, chunk_hash, token_offset)
+                self._index_binding(chunk_hash, binding)
             for instance_id, positions_ in l1_by_instance.items():
                 for position in positions_:
                     if not 0 <= position < len(key_table):
@@ -529,7 +534,7 @@ class KeyDirectory(View):
             else:
                 record.placements[index] = placement
             if entry.token_ids:
-                self._create_token_binding(key.chunk_hash, entry)
+                self._create_token_binding(key, entry)
             record.last_access = max(record.last_access, batch.ts)
             if batch.tier == Tier.L1:
                 l1_keys.add(key)
@@ -594,8 +599,8 @@ class KeyDirectory(View):
         l1_keys.clear()
         return removed
 
-    def _create_token_binding(self, chunk_hash: bytes, entry: CacheEventEntry) -> None:
-        """Record ``entry``'s token content on ``chunk_hash``'s binding.
+    def _create_token_binding(self, key: ObjectKey, entry: CacheEventEntry) -> None:
+        """Record ``entry``'s token content on ``key``'s chunk binding.
 
         Token ids outside ``uint32`` leave the binding as it was, so one
         bad entry is a lookup miss rather than a failed batch. An entry
@@ -605,9 +610,10 @@ class KeyDirectory(View):
         no stored position would re-RoPE from the wrong source.
 
         Args:
-            chunk_hash: Chunk hash whose binding to fill.
+            key: The stored key whose chunk binding to fill.
             entry: The store entry carrying the token ids and offset.
         """
+        chunk_hash = key.chunk_hash
         try:
             token_ids = np.asarray(entry.token_ids, dtype=_TOKEN_DTYPE)
         except (OverflowError, TypeError, ValueError):
@@ -618,44 +624,83 @@ class KeyDirectory(View):
             return
         token_ids.flags.writeable = False
         binding = self._token_bindings[chunk_hash]
-        if (
-            self._blend_lookup_enabled
-            and binding.token_ids.size
-            and not np.array_equal(binding.token_ids, token_ids)
-        ):
-            # Re-store with different content: retire the old fingerprint,
-            # or the chunk stays discoverable under content it no longer has.
-            self._blend_index.remove(binding.token_ids, chunk_hash)
+        replaced = bool(binding.token_ids.size) and not np.array_equal(
+            binding.token_ids, token_ids
+        )
+        if self._blend_lookup_enabled and replaced:
+            # Re-store with different content: retire the old fingerprint
+            # for every namespace, or the chunk stays discoverable under
+            # content it no longer has.
+            self._blend_index.remove_chunk(binding.token_ids, chunk_hash)
+        fresh_content = replaced or not binding.token_ids.size
         binding.token_ids = token_ids
         binding.token_offset = entry.token_offset
-        if not self._blend_lookup_enabled:
-            return
-        if entry.token_offset == UNKNOWN_TOKEN_OFFSET:
-            return
-        self._blend_index.add(token_ids, chunk_hash, entry.token_offset)
+        if fresh_content:
+            # Keys of other namespaces may have attached while the binding
+            # had no content (or held content this store just replaced),
+            # so claim it for all of them. Steady-state stores take the
+            # single-key path below instead of rehashing per rank.
+            self._index_binding(chunk_hash, binding)
+        else:
+            self._claim_binding(chunk_hash, binding, key)
 
     def _add_token_binding(self, key: ObjectKey) -> None:
         """Index ``key`` under its chunk's token binding, creating an
-        empty binding on first reference."""
+        empty binding on first reference. A key joining a binding that
+        already has content claims it for the key's namespace."""
         binding = self._token_bindings.get(key.chunk_hash)
         if binding is None:
             self._token_bindings[key.chunk_hash] = _TokenBinding(
                 token_ids=_NO_TOKENS, token_offset=UNKNOWN_TOKEN_OFFSET, keys={key}
             )
-        else:
-            binding.keys.add(key)
+            return
+        binding.keys.add(key)
+        self._claim_binding(key.chunk_hash, binding, key)
 
     def _remove_token_binding(self, key: ObjectKey) -> None:
-        """Remove ``key`` from its chunk's token binding, dropping the
-        binding — and its blend-index entry — with its last key."""
+        """Remove ``key`` from its chunk's token binding, releasing the
+        chunk's blend claim with the namespace's last key and dropping the
+        binding with its last key overall."""
         binding = self._token_bindings.get(key.chunk_hash)
         if binding is None:
             return
         binding.keys.discard(key)
+        if self._blend_lookup_enabled and binding.token_ids.size:
+            namespace = BlendNamespace.from_object_key(key)
+            # Ranks and object groups of the same namespace hold the same
+            # bytes, so the claim survives until the last of them goes.
+            if not any(
+                BlendNamespace.from_object_key(held) == namespace
+                for held in binding.keys
+            ):
+                self._blend_index.remove(binding.token_ids, key.chunk_hash, namespace)
         if not binding.keys:
             del self._token_bindings[key.chunk_hash]
-            if self._blend_lookup_enabled and binding.token_ids.size:
-                self._blend_index.remove(binding.token_ids, key.chunk_hash)
+
+    def _index_binding(self, chunk_hash: bytes, binding: _TokenBinding) -> None:
+        """Claim ``chunk_hash`` for every namespace holding it."""
+        for held in binding.keys:
+            self._claim_binding(chunk_hash, binding, held)
+
+    def _claim_binding(
+        self, chunk_hash: bytes, binding: _TokenBinding, key: ObjectKey
+    ) -> None:
+        """Claim ``chunk_hash`` in the blend index for ``key``'s namespace.
+
+        A no-op while blend lookup is off, before the binding has content,
+        or without a stored position -- the cases a fragment match cannot
+        be served from anyway.
+        """
+        if not self._blend_lookup_enabled:
+            return
+        if not binding.token_ids.size or binding.token_offset == UNKNOWN_TOKEN_OFFSET:
+            return
+        self._blend_index.add(
+            binding.token_ids,
+            chunk_hash,
+            binding.token_offset,
+            BlendNamespace.from_object_key(key),
+        )
 
 
 # -- Durable encoding ---------------------------------------------------------

--- a/lmcache/v1/mp_coordinator/views/key_directory.py
+++ b/lmcache/v1/mp_coordinator/views/key_directory.py
@@ -473,7 +473,8 @@ class KeyDirectory(View):
                 token_ids.flags.writeable = False
                 binding.token_ids = token_ids
                 binding.token_offset = token_offset
-                self._index_binding(chunk_hash, binding)
+                for held in binding.keys:
+                    self._claim_binding(chunk_hash, binding, held)
             for instance_id, positions_ in l1_by_instance.items():
                 for position in positions_:
                     if not 0 <= position < len(key_table):
@@ -638,7 +639,8 @@ class KeyDirectory(View):
             # Other namespaces' keys may have attached while the binding had
             # no content, so claim it for all of them. Steady-state stores
             # take the single-key path instead of rehashing per rank.
-            self._index_binding(chunk_hash, binding)
+            for held in binding.keys:
+                self._claim_binding(chunk_hash, binding, held)
         else:
             self._claim_binding(chunk_hash, binding, key)
 
@@ -676,11 +678,6 @@ class KeyDirectory(View):
                 )
         if not binding.keys:
             del self._token_bindings[key.chunk_hash]
-
-    def _index_binding(self, chunk_hash: bytes, binding: _TokenBinding) -> None:
-        """Claim ``chunk_hash`` for every namespace holding it."""
-        for held in binding.keys:
-            self._claim_binding(chunk_hash, binding, held)
 
     def _claim_binding(
         self, chunk_hash: bytes, binding: _TokenBinding, key: ObjectKey

--- a/lmcache/v1/multiprocess/modules/blend/lookup.py
+++ b/lmcache/v1/multiprocess/modules/blend/lookup.py
@@ -26,6 +26,7 @@ from lmcache.v1.distributed.api import (
 )
 from lmcache.v1.distributed.bitmap_ops.fold import fold_unfold_ranked
 from lmcache.v1.distributed.storage_manager import PrefetchHandle
+from lmcache.v1.mp_coordinator.api import BlendNamespace
 from lmcache.v1.mp_coordinator.blend_client import PENDING
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import (
@@ -713,6 +714,9 @@ class LookupMixin:
     def _submit_coordinator_match(self, key: IPCCacheServerKey) -> bool:
         """Issue a fleet directory match query (best-effort).
 
+        The query carries this server's retrieval namespace, so the
+        coordinator returns only chunk hashes this server can expand.
+
         Returns:
             ``True`` if a query was submitted (the finalize step should poll),
             ``False`` when there is no coordinator or submission failed.
@@ -724,7 +728,15 @@ class LookupMixin:
             tokens = list(key.token_ids)
             if len(tokens) < self._ctx.chunk_size:
                 return False
-            coordinator.submit_match(key.request_id, tokens)
+            coordinator.submit_match(
+                key.request_id,
+                tokens,
+                BlendNamespace(
+                    model_name=key.model_name,
+                    cache_salt=key.cache_salt,
+                    world_size=key.world_size,
+                ),
+            )
             return True
         except Exception:
             logger.warning(

--- a/tests/v1/cli/test_query_coordinator.py
+++ b/tests/v1/cli/test_query_coordinator.py
@@ -257,8 +257,6 @@ class TestOtherApis:
         metrics = _json(_render("directory", body))["metrics"]
         assert metrics["num_keys"] == 3
         assert metrics["blend"]["table_size"] == 1024
-        # Claims exceed chunks when tenants share content -- the signal
-        # num_chunks alone cannot give.
         assert metrics["blend"]["num_claims"] == 3
         assert metrics["blend"]["num_namespaces"] == 2
 

--- a/tests/v1/cli/test_query_coordinator.py
+++ b/tests/v1/cli/test_query_coordinator.py
@@ -246,11 +246,21 @@ class TestOtherApis:
         body = {
             "num_keys": 3,
             "num_placements": 4,
-            "blend": {"num_contents": 1, "num_chunks": 2, "table_size": 1024},
+            "blend": {
+                "num_contents": 1,
+                "num_chunks": 2,
+                "num_claims": 3,
+                "num_namespaces": 2,
+                "table_size": 1024,
+            },
         }
         metrics = _json(_render("directory", body))["metrics"]
         assert metrics["num_keys"] == 3
         assert metrics["blend"]["table_size"] == 1024
+        # Claims exceed chunks when tenants share content -- the signal
+        # num_chunks alone cannot give.
+        assert metrics["blend"]["num_claims"] == 3
+        assert metrics["blend"]["num_namespaces"] == 2
 
 
 class TestPaths:

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -11,11 +11,13 @@ from collections.abc import Callable
 import time
 
 # Third Party
+import numpy as np
 import pytest
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey, Tier
 from lmcache.v1.mp_coordinator.api import (
+    BlendNamespace,
     CacheEventBatch,
     CacheEventEntry,
     CacheEventType,
@@ -24,10 +26,12 @@ from lmcache.v1.mp_coordinator.blend_client import (
     PENDING,
     BlendCoordinatorClient,
 )
-from lmcache.v1.mp_coordinator.schemas import decode_tokens
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 CHUNK = 3
+MODEL = "m"
+WORLD_SIZE = 1
+NS = BlendNamespace(model_name=MODEL, world_size=WORLD_SIZE)
 
 
 def _directory_request(
@@ -37,7 +41,13 @@ def _directory_request(
 
     def request(method: str, path: str, payload: dict) -> dict:
         if method == "POST" and path == "/directory/blend-lookup":
-            matches = directory.blend_match(decode_tokens(payload["tokens_b64"]))
+            namespace = BlendNamespace(
+                model_name=payload["model_name"],
+                cache_salt=payload["cache_salt"],
+                world_size=payload["world_size"],
+            )
+            tokens = np.asarray(payload["token_ids"], dtype=np.uint64)
+            matches = directory.blend_match(tokens, namespace)
             return {
                 "matches": [
                     {
@@ -68,7 +78,14 @@ def _stored(directory: KeyDirectory, chunks: list[list[int]]) -> list[bytes]:
                 entries=[
                     CacheEventEntry(
                         key=ObjectKey(
-                            chunk_hash=chunk_hash, model_name="m", kv_rank=0
+                            chunk_hash=chunk_hash,
+                            model_name=MODEL,
+                            kv_rank=ObjectKey.ComputeKVRank(
+                                world_size=WORLD_SIZE,
+                                global_rank=0,
+                                local_world_size=WORLD_SIZE,
+                                local_rank=0,
+                            ),
                         ).to_encoded_object_key(),
                         size_bytes=100,
                         token_ids=tokens,
@@ -101,7 +118,7 @@ def test_match_finds_chunks_the_event_stream_reported():
     hashes = _stored(directory, [[1, 2, 3], [4, 5, 6]])
     client = BlendCoordinatorClient(request_fn=_directory_request(directory))
     try:
-        client.submit_match("r1", [1, 2, 3, 4, 5, 6])
+        client.submit_match("r1", [1, 2, 3, 4, 5, 6], NS)
         matches = _wait_match(client, "r1")
         assert isinstance(matches, list)
         # chunk_hash arrives as bytes, matching a local CBMatchResult.hash.
@@ -116,7 +133,7 @@ def test_match_finds_chunks_the_event_stream_reported():
 def test_match_is_empty_when_nothing_is_cached():
     client = BlendCoordinatorClient(request_fn=_directory_request(_directory()))
     try:
-        client.submit_match("r1", [1, 2, 3])
+        client.submit_match("r1", [1, 2, 3], NS)
         assert _wait_match(client, "r1") == []
     finally:
         client.close()
@@ -135,8 +152,8 @@ def test_submit_is_idempotent():
     _stored(directory, [[1, 2, 3]])
     client = BlendCoordinatorClient(request_fn=_directory_request(directory))
     try:
-        client.submit_match("r1", [1, 2, 3])
-        client.submit_match("r1", [1, 2, 3])  # no-op
+        client.submit_match("r1", [1, 2, 3], NS)
+        client.submit_match("r1", [1, 2, 3], NS)  # no-op
         matches = _wait_match(client, "r1")
         assert isinstance(matches, list) and len(matches) == 1
     finally:
@@ -149,7 +166,7 @@ def test_match_error_degrades_to_empty():
 
     client = BlendCoordinatorClient(request_fn=boom)
     try:
-        client.submit_match("r1", [1, 2, 3])
+        client.submit_match("r1", [1, 2, 3], NS)
         matches = _wait_match(client, "r1")
         assert matches == []  # failure -> local-only, never hangs
     finally:
@@ -161,7 +178,7 @@ def test_take_match_clears():
     _stored(directory, [[1, 2, 3]])
     client = BlendCoordinatorClient(request_fn=_directory_request(directory))
     try:
-        client.submit_match("r1", [1, 2, 3])
+        client.submit_match("r1", [1, 2, 3], NS)
         _wait_match(client, "r1")
         client.take_match("r1")
         assert client.poll_match("r1") is None
@@ -197,3 +214,42 @@ def test_maybe_create_rejects_bad_concurrency():
 
 def test_pending_sentinel_distinct():
     assert PENDING is not None and not isinstance(PENDING, list)
+
+
+def test_match_carries_the_namespace_to_the_coordinator():
+    """The server's own model, salt, and world size travel with the query
+    so the coordinator can scope matches to keys this server can expand."""
+    sent: list[dict] = []
+
+    def capture(method: str, path: str, payload: dict) -> dict:
+        sent.append(payload)
+        return {"matches": []}
+
+    client = BlendCoordinatorClient(request_fn=capture)
+    try:
+        namespace = BlendNamespace(
+            model_name="llama", cache_salt="tenant-a", world_size=4
+        )
+        client.submit_match("r1", [1, 2, 3], namespace)
+        _wait_match(client, "r1")
+        assert sent == [
+            {
+                "token_ids": [1, 2, 3],
+                "model_name": "llama",
+                "cache_salt": "tenant-a",
+                "world_size": 4,
+            }
+        ]
+    finally:
+        client.close()
+
+
+def test_another_namespace_gets_no_match_for_the_same_content():
+    directory = _directory()
+    _stored(directory, [[1, 2, 3]])
+    client = BlendCoordinatorClient(request_fn=_directory_request(directory))
+    try:
+        client.submit_match("r1", [1, 2, 3], BlendNamespace(model_name="other"))
+        assert _wait_match(client, "r1") == []
+    finally:
+        client.close()

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -218,8 +218,7 @@ def test_pending_sentinel_distinct():
 
 
 def test_match_carries_the_namespace_to_the_coordinator():
-    """The server's own model, salt, and world size travel with the query
-    so the coordinator can scope matches to keys this server can expand."""
+    """The server's model, salt, and world size travel with the query."""
     sent: list[dict] = []
 
     def capture(method: str, path: str, payload: dict) -> dict:

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -11,7 +11,6 @@ from collections.abc import Callable
 import time
 
 # Third Party
-import numpy as np
 import pytest
 
 # First Party
@@ -26,6 +25,7 @@ from lmcache.v1.mp_coordinator.blend_client import (
     PENDING,
     BlendCoordinatorClient,
 )
+from lmcache.v1.mp_coordinator.schemas import decode_tokens, encode_tokens
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 CHUNK = 3
@@ -46,8 +46,9 @@ def _directory_request(
                 cache_salt=payload["cache_salt"],
                 world_size=payload["world_size"],
             )
-            tokens = np.asarray(payload["token_ids"], dtype=np.uint64)
-            matches = directory.blend_match(tokens, namespace)
+            matches = directory.blend_match(
+                decode_tokens(payload["tokens_b64"]), namespace
+            )
             return {
                 "matches": [
                     {
@@ -234,7 +235,7 @@ def test_match_carries_the_namespace_to_the_coordinator():
         _wait_match(client, "r1")
         assert sent == [
             {
-                "token_ids": [1, 2, 3],
+                "tokens_b64": encode_tokens([1, 2, 3]),
                 "model_name": "llama",
                 "cache_salt": "tenant-a",
                 "world_size": 4,

--- a/tests/v1/mp_coordinator/test_blend_index.py
+++ b/tests/v1/mp_coordinator/test_blend_index.py
@@ -14,6 +14,7 @@ import pytest
 # First Party
 from lmcache.v1.distributed.api import ObjectKey, Tier
 from lmcache.v1.mp_coordinator.api import (
+    BlendNamespace,
     CacheEventBatch,
     CacheEventEntry,
     CacheEventType,
@@ -22,6 +23,11 @@ from lmcache.v1.mp_coordinator.blend_index import BlendIndex
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 CHUNK = 4
+
+# The namespace most index-level tests store and query in; matches are
+# scoped to it, so a test that does not care about identity uses one.
+NS = BlendNamespace(model_name="m", world_size=1)
+OTHER_NS = BlendNamespace(model_name="other", world_size=1)
 
 
 def _content(*tokens: int) -> np.ndarray:
@@ -41,9 +47,9 @@ def _tuples(matches) -> list[tuple[bytes, int, int]]:
 
 def test_content_is_found_at_its_query_offset():
     index = _index()
-    index.add(_content(10, 11, 12, 13), b"A", token_offset=0)
+    index.add(_content(10, 11, 12, 13), b"A", token_offset=0, namespace=NS)
 
-    matches = index.match(np.asarray([7, 8, 10, 11, 12, 13, 9], dtype=np.uint64))
+    matches = index.match(np.asarray([7, 8, 10, 11, 12, 13, 9], dtype=np.uint64), NS)
     assert _tuples(matches) == [(b"A", 0, 2)]
 
 
@@ -51,41 +57,41 @@ def test_old_st_is_the_stored_position_not_the_query_position():
     """re-RoPE shifts from where the chunk was stored to where it is
     needed, so the two positions must be reported independently."""
     index = _index()
-    index.add(_content(10, 11, 12, 13), b"A", token_offset=1024)
+    index.add(_content(10, 11, 12, 13), b"A", token_offset=1024, namespace=NS)
 
-    [match] = index.match(np.asarray([0, 10, 11, 12, 13], dtype=np.uint64))
+    [match] = index.match(np.asarray([0, 10, 11, 12, 13], dtype=np.uint64), NS)
     assert (match.old_st, match.cur_st) == (1024, 1)
 
 
 def test_several_chunks_are_found_in_one_query_ascending():
     index = _index()
-    index.add(_content(1, 2, 3, 4), b"A", token_offset=0)
-    index.add(_content(5, 6, 7, 8), b"B", token_offset=4)
+    index.add(_content(1, 2, 3, 4), b"A", token_offset=0, namespace=NS)
+    index.add(_content(5, 6, 7, 8), b"B", token_offset=4, namespace=NS)
 
-    matches = index.match(np.asarray([9, 5, 6, 7, 8, 1, 2, 3, 4], dtype=np.uint64))
+    matches = index.match(np.asarray([9, 5, 6, 7, 8, 1, 2, 3, 4], dtype=np.uint64), NS)
     assert _tuples(matches) == [(b"B", 4, 1), (b"A", 0, 5)]
 
 
 def test_repeated_content_matches_once_at_its_first_position():
     index = _index()
-    index.add(_content(1, 2, 3, 4), b"A", token_offset=0)
+    index.add(_content(1, 2, 3, 4), b"A", token_offset=0, namespace=NS)
 
-    matches = index.match(np.asarray([1, 2, 3, 4, 1, 2, 3, 4], dtype=np.uint64))
+    matches = index.match(np.asarray([1, 2, 3, 4, 1, 2, 3, 4], dtype=np.uint64), NS)
     assert _tuples(matches) == [(b"A", 0, 0)]
 
 
 def test_query_shorter_than_the_window_matches_nothing():
     index = _index()
-    index.add(_content(1, 2, 3, 4), b"A", token_offset=0)
+    index.add(_content(1, 2, 3, 4), b"A", token_offset=0, namespace=NS)
 
-    assert index.match(np.asarray([1, 2, 3], dtype=np.uint64)) == []
+    assert index.match(np.asarray([1, 2, 3], dtype=np.uint64), NS) == []
 
 
 def test_absent_content_matches_nothing():
     index = _index()
-    index.add(_content(1, 2, 3, 4), b"A", token_offset=0)
+    index.add(_content(1, 2, 3, 4), b"A", token_offset=0, namespace=NS)
 
-    assert index.match(np.asarray([5, 6, 7, 8, 9], dtype=np.uint64)) == []
+    assert index.match(np.asarray([5, 6, 7, 8, 9], dtype=np.uint64), NS) == []
 
 
 # -- Token-exact verification ------------------------------------------------
@@ -95,17 +101,17 @@ def test_near_miss_content_is_rejected():
     """Discovery is by hash but acceptance is by content, so a window
     differing in one token must not match."""
     index = _index()
-    index.add(_content(10, 11, 12, 13), b"A", token_offset=0)
+    index.add(_content(10, 11, 12, 13), b"A", token_offset=0, namespace=NS)
 
-    assert index.match(np.asarray([10, 11, 12, 99], dtype=np.uint64)) == []
+    assert index.match(np.asarray([10, 11, 12, 99], dtype=np.uint64), NS) == []
 
 
 def test_verification_uses_the_indexed_content_not_the_stored_length():
     index = _index()
-    index.add(_content(10, 11, 12, 13), b"A", token_offset=0)
+    index.add(_content(10, 11, 12, 13), b"A", token_offset=0, namespace=NS)
 
     # A superset window containing the content still matches at its offset.
-    [match] = index.match(np.asarray([10, 11, 12, 13, 14], dtype=np.uint64))
+    [match] = index.match(np.asarray([10, 11, 12, 13, 14], dtype=np.uint64), NS)
     assert match.cur_st == 0
 
 
@@ -115,8 +121,8 @@ def test_verification_uses_the_indexed_content_not_the_stored_length():
 def test_add_is_idempotent():
     index = _index()
     content = _content(1, 2, 3, 4)
-    index.add(content, b"A", token_offset=0)
-    index.add(content, b"A", token_offset=0)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"A", token_offset=0, namespace=NS)
 
     stats = index.stats()
     assert (stats.num_contents, stats.num_chunks) == (1, 1)
@@ -125,10 +131,10 @@ def test_add_is_idempotent():
 def test_readding_a_chunk_updates_its_offset():
     index = _index()
     content = _content(1, 2, 3, 4)
-    index.add(content, b"A", token_offset=0)
-    index.add(content, b"A", token_offset=256)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"A", token_offset=256, namespace=NS)
 
-    [match] = index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64))
+    [match] = index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS)
     assert match.old_st == 256
     assert index.stats().num_chunks == 1
 
@@ -136,22 +142,22 @@ def test_readding_a_chunk_updates_its_offset():
 def test_remove_makes_content_undiscoverable():
     index = _index()
     content = _content(1, 2, 3, 4)
-    index.add(content, b"A", token_offset=0)
-    index.remove(content, b"A")
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.remove(content, b"A", NS)
 
-    assert index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64)) == []
+    assert index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS) == []
     assert index.stats().num_contents == 0
 
 
 def test_remove_of_unknown_chunk_or_content_is_a_noop():
     index = _index()
     content = _content(1, 2, 3, 4)
-    index.add(content, b"A", token_offset=0)
+    index.add(content, b"A", token_offset=0, namespace=NS)
 
-    index.remove(content, b"UNKNOWN")
-    index.remove(_content(9, 9, 9, 9), b"A")
+    index.remove(content, b"UNKNOWN", NS)
+    index.remove(_content(9, 9, 9, 9), b"A", NS)
 
-    assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64))) == [
+    assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS)) == [
         (b"A", 0, 0)
     ]
 
@@ -162,13 +168,13 @@ def test_identical_content_under_two_prefixes_survives_one_eviction():
     other discoverable."""
     index = _index()
     content = _content(1, 2, 3, 4)
-    index.add(content, b"A", token_offset=0)
-    index.add(content, b"B", token_offset=512)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"B", token_offset=512, namespace=NS)
     assert index.stats().num_chunks == 2
 
-    index.remove(content, b"A")
+    index.remove(content, b"A", NS)
 
-    assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64))) == [
+    assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS)) == [
         (b"B", 512, 0)
     ]
 
@@ -176,8 +182,8 @@ def test_identical_content_under_two_prefixes_survives_one_eviction():
 def test_content_of_the_wrong_length_is_not_indexed():
     """Only full-chunk content can match a full-chunk window."""
     index = _index()
-    index.add(_content(1, 2, 3), b"SHORT", token_offset=0)
-    index.add(_content(1, 2, 3, 4, 5), b"LONG", token_offset=0)
+    index.add(_content(1, 2, 3), b"SHORT", token_offset=0, namespace=NS)
+    index.add(_content(1, 2, 3, 4, 5), b"LONG", token_offset=0, namespace=NS)
 
     assert index.stats().num_contents == 0
 
@@ -189,21 +195,23 @@ def test_many_contents_stay_matchable_across_growth_and_compaction():
     index = _index()
     contents = {bytes([i]): _content(i, i + 1, i + 2, i + 3) for i in range(1, 200)}
     for chunk_hash, content in contents.items():
-        index.add(content, chunk_hash, token_offset=0)
+        index.add(content, chunk_hash, token_offset=0, namespace=NS)
 
     for chunk_hash, content in contents.items():
-        matches = index.match(content.astype(np.uint64))
+        matches = index.match(content.astype(np.uint64), NS)
         assert _tuples(matches) == [(chunk_hash, 0, 0)]
 
     # Drop most of them: compaction must not lose the survivors.
     survivors = {k: v for k, v in contents.items() if k[0] % 20 == 0}
     for chunk_hash, content in contents.items():
         if chunk_hash not in survivors:
-            index.remove(content, chunk_hash)
+            index.remove(content, chunk_hash, NS)
 
     assert index.stats().num_contents == len(survivors)
     for chunk_hash, content in survivors.items():
-        assert _tuples(index.match(content.astype(np.uint64))) == [(chunk_hash, 0, 0)]
+        assert _tuples(index.match(content.astype(np.uint64), NS)) == [
+            (chunk_hash, 0, 0)
+        ]
 
 
 # -- Stride ------------------------------------------------------------------
@@ -211,12 +219,12 @@ def test_many_contents_stay_matchable_across_growth_and_compaction():
 
 def test_stride_skips_offsets_between_probes():
     index = _index(probe_stride=CHUNK)
-    index.add(_content(10, 11, 12, 13), b"A", token_offset=0)
+    index.add(_content(10, 11, 12, 13), b"A", token_offset=0, namespace=NS)
 
     # Aligned with a probe position -> found.
-    assert index.match(np.asarray([10, 11, 12, 13], dtype=np.uint64))
+    assert index.match(np.asarray([10, 11, 12, 13], dtype=np.uint64), NS)
     # One token off a probe position -> missed (recall traded for CPU).
-    assert index.match(np.asarray([0, 10, 11, 12, 13], dtype=np.uint64)) == []
+    assert index.match(np.asarray([0, 10, 11, 12, 13], dtype=np.uint64), NS) == []
 
 
 # -- Construction ------------------------------------------------------------
@@ -266,7 +274,7 @@ def test_matches_a_brute_force_scan_on_random_input():
         chunk_hash = f"c{i}".encode()
         offset = i * chunk
         contents[chunk_hash] = (content, offset)
-        index.add(content, chunk_hash, token_offset=offset)
+        index.add(content, chunk_hash, token_offset=offset, namespace=NS)
 
     for _ in range(20):
         query: list[int] = []
@@ -277,7 +285,7 @@ def test_matches_a_brute_force_scan_on_random_input():
             else:
                 query.extend(rng.randrange(1, 5000) for _ in range(chunk))
         expected = _reference(contents, query, chunk)
-        actual = _tuples(index.match(np.asarray(query, dtype=np.uint64)))
+        actual = _tuples(index.match(np.asarray(query, dtype=np.uint64), NS))
         assert actual == expected
 
 
@@ -292,7 +300,7 @@ def test_concurrent_add_and_match_stay_consistent():
     def writer() -> None:
         try:
             for i in range(1, 400):
-                index.add(_content(i, i + 1, i + 2, i + 3), bytes([i % 256]), i)
+                index.add(_content(i, i + 1, i + 2, i + 3), bytes([i % 256]), i, NS)
         except BaseException as exc:  # noqa: BLE001 — surfaced below
             errors.append(exc)
         finally:
@@ -302,7 +310,7 @@ def test_concurrent_add_and_match_stay_consistent():
         try:
             probe = np.asarray([5, 6, 7, 8], dtype=np.uint64)
             while not stop.is_set():
-                index.match(probe)
+                index.match(probe, NS)
         except BaseException as exc:  # noqa: BLE001 — surfaced below
             errors.append(exc)
 
@@ -313,14 +321,32 @@ def test_concurrent_add_and_match_stay_consistent():
         thread.join(timeout=30)
 
     assert not errors
-    assert index.match(np.asarray([5, 6, 7, 8], dtype=np.uint64))
+    assert index.match(np.asarray([5, 6, 7, 8], dtype=np.uint64), NS)
 
 
 # -- Key directory integration -----------------------------------------------
 
 
-def _key(hash_byte: int, kv_rank: int = 0) -> ObjectKey:
-    return ObjectKey(chunk_hash=bytes([hash_byte]) * 4, model_name="m", kv_rank=kv_rank)
+def _key(
+    hash_byte: int,
+    rank: int = 0,
+    world_size: int = 1,
+    model_name: str = "m",
+    cache_salt: str = "",
+) -> ObjectKey:
+    """Build a key the way a server would, so ``kv_rank`` carries the
+    world size the namespace is derived from."""
+    return ObjectKey(
+        chunk_hash=bytes([hash_byte]) * 4,
+        model_name=model_name,
+        kv_rank=ObjectKey.ComputeKVRank(
+            world_size=world_size,
+            global_rank=rank,
+            local_world_size=world_size,
+            local_rank=rank,
+        ),
+        cache_salt=cache_salt,
+    )
 
 
 def _store(
@@ -349,6 +375,11 @@ def _store(
     )
 
 
+# The namespace ``_key`` stores in, and therefore the one directory-level
+# queries must ask from.
+DIR_NS = BlendNamespace(model_name="m", world_size=1)
+
+
 def _directory() -> KeyDirectory:
     directory = KeyDirectory()
     directory.enable_blend_lookup(chunk_size=CHUNK, probe_stride=1)
@@ -359,7 +390,9 @@ def test_a_stored_chunk_becomes_fragment_matchable():
     directory = _directory()
     directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=1, token_offset=256))
 
-    matches = directory.blend_match(np.asarray([0, 10, 11, 12, 13], dtype=np.uint64))
+    matches = directory.blend_match(
+        np.asarray([0, 10, 11, 12, 13], dtype=np.uint64), DIR_NS
+    )
     assert _tuples(matches) == [(_key(1).chunk_hash, 256, 1)]
 
 
@@ -370,26 +403,48 @@ def test_deleting_the_last_placement_removes_it_from_fragment_matching():
     directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=1))
     directory.consume(_store([_key(1)], [], seq=2, event_type=CacheEventType.DELETE))
 
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
     assert directory.blend_stats().num_contents == 0
 
 
 def test_chunk_stays_matchable_while_any_rank_holds_it():
+    """Ranks of one namespace hold the same bytes, so the claim survives
+    until the last of them is deleted."""
     directory = _directory()
+    namespace = BlendNamespace(model_name="m", world_size=2)
     directory.consume(
-        _store([_key(1, kv_rank=0), _key(1, kv_rank=1)], [10, 11, 12, 13], seq=1)
+        _store(
+            [_key(1, rank=0, world_size=2), _key(1, rank=1, world_size=2)],
+            [10, 11, 12, 13],
+            seq=1,
+        )
     )
     directory.consume(
-        _store([_key(1, kv_rank=0)], [], seq=2, event_type=CacheEventType.DELETE)
+        _store(
+            [_key(1, rank=0, world_size=2)],
+            [],
+            seq=2,
+            event_type=CacheEventType.DELETE,
+        )
     )
 
     query = np.asarray([10, 11, 12, 13], dtype=np.uint64)
-    assert _tuples(directory.blend_match(query)) == [(_key(1).chunk_hash, 0, 0)]
+    assert _tuples(directory.blend_match(query, namespace)) == [
+        (_key(1).chunk_hash, 0, 0)
+    ]
 
     directory.consume(
-        _store([_key(1, kv_rank=1)], [], seq=3, event_type=CacheEventType.DELETE)
+        _store(
+            [_key(1, rank=1, world_size=2)],
+            [],
+            seq=3,
+            event_type=CacheEventType.DELETE,
+        )
     )
-    assert directory.blend_match(query) == []
+    assert directory.blend_match(query, namespace) == []
 
 
 def test_restoring_a_chunk_with_new_content_retires_the_old_fingerprint():
@@ -399,9 +454,12 @@ def test_restoring_a_chunk_with_new_content_retires_the_old_fingerprint():
     directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=1))
     directory.consume(_store([_key(1)], [20, 21, 22, 23], seq=2))
 
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
     assert _tuples(
-        directory.blend_match(np.asarray([20, 21, 22, 23], dtype=np.uint64))
+        directory.blend_match(np.asarray([20, 21, 22, 23], dtype=np.uint64), DIR_NS)
     ) == [(_key(1).chunk_hash, 0, 0)]
     assert directory.blend_stats().num_contents == 1
 
@@ -413,7 +471,10 @@ def test_a_tokenless_store_is_not_fragment_matchable():
     directory.consume(_store([_key(1)], [], seq=1))
 
     assert directory.blend_stats().num_contents == 0
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
 
 
 def test_incarnation_fencing_removes_fragment_matches():
@@ -422,7 +483,10 @@ def test_incarnation_fencing_removes_fragment_matches():
 
     directory.fence_instance("node-a")
 
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
 
 
 def test_chunk_with_unreported_offset_is_not_fragment_matchable():
@@ -453,7 +517,10 @@ def test_chunk_with_unreported_offset_is_not_fragment_matchable():
     # Content known, but with no position it cannot be indexed.
     assert directory.get_token_ids([_key(1).chunk_hash]) == [(10, 11, 12, 13)]
     assert directory.blend_stats().num_chunks == 0
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
 
 
 def test_a_later_offset_bearing_store_makes_the_chunk_matchable():
@@ -465,7 +532,9 @@ def test_a_later_offset_bearing_store_makes_the_chunk_matchable():
 
     directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=2, token_offset=256))
 
-    matches = directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64))
+    matches = directory.blend_match(
+        np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS
+    )
     assert _tuples(matches) == [(_key(1).chunk_hash, 256, 0)]
 
 
@@ -477,7 +546,10 @@ def test_blend_lookup_is_off_until_enabled():
     directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=1, token_offset=0))
 
     assert directory.blend_stats().num_chunks == 0
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
     # The token binding itself is still recorded for introspection.
     assert directory.get_token_ids([_key(1).chunk_hash]) == [(10, 11, 12, 13)]
 
@@ -490,6 +562,167 @@ def test_enabling_does_not_retroactively_index_earlier_stores():
 
     directory.enable_blend_lookup(chunk_size=CHUNK, probe_stride=1)
 
-    assert directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64)) == []
+    assert (
+        directory.blend_match(np.asarray([10, 11, 12, 13], dtype=np.uint64), DIR_NS)
+        == []
+    )
     directory.consume(_store([_key(2)], [20, 21, 22, 23], seq=2, token_offset=0))
-    assert directory.blend_match(np.asarray([20, 21, 22, 23], dtype=np.uint64))
+    assert directory.blend_match(np.asarray([20, 21, 22, 23], dtype=np.uint64), DIR_NS)
+
+
+# -- Namespace scoping -------------------------------------------------------
+
+
+def test_content_stored_by_another_namespace_is_not_offered():
+    """A chunk hash names content only; the model, salt, and parallel
+    setup that make it retrievable live on the key beside it. Offering
+    another namespace's chunk would expand into keys that exist nowhere,
+    buying a confirmed miss and a burned blend slot."""
+    index = _index()
+    index.add(_content(1, 2, 3, 4), b"A", token_offset=0, namespace=OTHER_NS)
+
+    assert index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS) == []
+    assert _tuples(
+        index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), OTHER_NS)
+    ) == [(b"A", 0, 0)]
+
+
+def test_the_requester_s_own_chunk_is_found_behind_another_namespace_s():
+    """The regression this scoping exists for: the same text stored after
+    different prefixes yields several chunk hashes for one content. With
+    a single untagged occupant the first-indexed one wins and hides the
+    requester's own copy, which is a lost hit, not just a wasted one."""
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"THEIRS", token_offset=0, namespace=OTHER_NS)
+    index.add(content, b"MINE", token_offset=512, namespace=NS)
+
+    assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS)) == [
+        (b"MINE", 512, 0)
+    ]
+
+
+def test_one_chunk_shared_by_two_namespaces_serves_both():
+    """Identical prefixes across namespaces produce the same chunk hash,
+    so both claims ride on one occupant and one copy of the content."""
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"A", token_offset=0, namespace=OTHER_NS)
+
+    query = np.asarray([1, 2, 3, 4], dtype=np.uint64)
+    assert _tuples(index.match(query, NS)) == [(b"A", 0, 0)]
+    assert _tuples(index.match(query, OTHER_NS)) == [(b"A", 0, 0)]
+    stats = index.stats()
+    assert (stats.num_chunks, stats.num_claims, stats.num_namespaces) == (1, 2, 2)
+
+
+def test_releasing_one_namespace_leaves_the_other_matching():
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"A", token_offset=0, namespace=OTHER_NS)
+
+    index.remove(content, b"A", NS)
+
+    query = np.asarray([1, 2, 3, 4], dtype=np.uint64)
+    assert index.match(query, NS) == []
+    assert _tuples(index.match(query, OTHER_NS)) == [(b"A", 0, 0)]
+    assert index.stats().num_contents == 1
+
+
+def test_releasing_the_last_namespace_drops_the_content():
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"A", token_offset=0, namespace=OTHER_NS)
+
+    index.remove(content, b"A", NS)
+    index.remove(content, b"A", OTHER_NS)
+
+    assert index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), OTHER_NS) == []
+    assert index.stats().num_contents == 0
+
+
+def test_remove_chunk_retires_every_namespace_at_once():
+    """Re-storing a chunk hash with different content invalidates it for
+    everyone, not just the namespace that re-stored it."""
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"A", token_offset=0, namespace=NS)
+    index.add(content, b"A", token_offset=0, namespace=OTHER_NS)
+
+    index.remove_chunk(content, b"A")
+
+    query = np.asarray([1, 2, 3, 4], dtype=np.uint64)
+    assert index.match(query, NS) == []
+    assert index.match(query, OTHER_NS) == []
+    assert index.stats().num_contents == 0
+
+
+@pytest.mark.parametrize(
+    "requester",
+    [
+        BlendNamespace(model_name="other", world_size=1),
+        BlendNamespace(model_name="m", cache_salt="tenant-b", world_size=1),
+        BlendNamespace(model_name="m", world_size=2),
+    ],
+    ids=["other-model", "other-salt", "other-world-size"],
+)
+def test_directory_does_not_offer_matches_across_namespaces(
+    requester: BlendNamespace,
+):
+    """Each dimension of the namespace is one the requester's own key
+    expansion would miss on: another model's KV is not interchangeable,
+    another tenant's salt is isolated by design, and another parallel
+    setup shards heads differently."""
+    directory = _directory()
+    directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=1))
+
+    query = np.asarray([10, 11, 12, 13], dtype=np.uint64)
+    assert directory.blend_match(query, requester) == []
+    assert _tuples(directory.blend_match(query, DIR_NS)) == [(_key(1).chunk_hash, 0, 0)]
+
+
+def test_directory_offers_a_chunk_two_tenants_stored_to_each_of_them():
+    directory = _directory()
+    tenant_a = _key(1, cache_salt="a")
+    tenant_b = _key(1, cache_salt="b")
+    directory.consume(_store([tenant_a, tenant_b], [10, 11, 12, 13], seq=1))
+
+    query = np.asarray([10, 11, 12, 13], dtype=np.uint64)
+    for salt in ("a", "b"):
+        namespace = BlendNamespace(model_name="m", cache_salt=salt, world_size=1)
+        assert _tuples(directory.blend_match(query, namespace)) == [
+            (tenant_a.chunk_hash, 0, 0)
+        ]
+    assert directory.blend_stats().num_claims == 2
+
+
+def test_directory_releases_a_namespace_claim_when_its_last_key_goes():
+    """The other tenant still holds the chunk, so the content stays
+    indexed — but the departing tenant must stop matching it."""
+    directory = _directory()
+    tenant_a = _key(1, cache_salt="a")
+    tenant_b = _key(1, cache_salt="b")
+    directory.consume(_store([tenant_a, tenant_b], [10, 11, 12, 13], seq=1))
+    directory.consume(_store([tenant_a], [], seq=2, event_type=CacheEventType.DELETE))
+
+    query = np.asarray([10, 11, 12, 13], dtype=np.uint64)
+    ns_a = BlendNamespace(model_name="m", cache_salt="a", world_size=1)
+    ns_b = BlendNamespace(model_name="m", cache_salt="b", world_size=1)
+    assert directory.blend_match(query, ns_a) == []
+    assert _tuples(directory.blend_match(query, ns_b)) == [(tenant_b.chunk_hash, 0, 0)]
+
+
+def test_a_namespace_joining_a_bound_chunk_without_tokens_still_claims_it():
+    """The second storer's emitter had already evicted the tokens, so its
+    store carries none. The content is already known, so the claim must
+    be recorded from the key alone rather than waiting for a re-store."""
+    directory = _directory()
+    directory.consume(_store([_key(1, cache_salt="a")], [10, 11, 12, 13], seq=1))
+    directory.consume(_store([_key(1, cache_salt="b")], [], seq=2))
+
+    query = np.asarray([10, 11, 12, 13], dtype=np.uint64)
+    ns_b = BlendNamespace(model_name="m", cache_salt="b", world_size=1)
+    assert _tuples(directory.blend_match(query, ns_b)) == [(_key(1).chunk_hash, 0, 0)]

--- a/tests/v1/mp_coordinator/test_blend_index.py
+++ b/tests/v1/mp_coordinator/test_blend_index.py
@@ -24,8 +24,8 @@ from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 CHUNK = 4
 
-# The namespace most index-level tests store and query in; matches are
-# scoped to it, so a test that does not care about identity uses one.
+# The namespace index-level tests store and query in; matches are scoped
+# to it, so a test that does not care about identity uses one.
 NS = BlendNamespace(model_name="m", world_size=1)
 OTHER_NS = BlendNamespace(model_name="other", world_size=1)
 
@@ -574,10 +574,7 @@ def test_enabling_does_not_retroactively_index_earlier_stores():
 
 
 def test_content_stored_by_another_namespace_is_not_offered():
-    """A chunk hash names content only; the model, salt, and parallel
-    setup that make it retrievable live on the key beside it. Offering
-    another namespace's chunk would expand into keys that exist nowhere,
-    buying a confirmed miss and a burned blend slot."""
+    """Another namespace's chunk expands into keys that exist nowhere."""
     index = _index()
     index.add(_content(1, 2, 3, 4), b"A", token_offset=0, namespace=OTHER_NS)
 
@@ -588,10 +585,8 @@ def test_content_stored_by_another_namespace_is_not_offered():
 
 
 def test_the_requester_s_own_chunk_is_found_behind_another_namespace_s():
-    """The regression this scoping exists for: the same text stored after
-    different prefixes yields several chunk hashes for one content. With
-    a single untagged occupant the first-indexed one wins and hides the
-    requester's own copy, which is a lost hit, not just a wasted one."""
+    """The regression this scoping exists for: one content can have several
+    chunk hashes, and an untagged occupant list returns only the first."""
     index = _index()
     content = _content(1, 2, 3, 4)
     index.add(content, b"THEIRS", token_offset=0, namespace=OTHER_NS)
@@ -603,8 +598,8 @@ def test_the_requester_s_own_chunk_is_found_behind_another_namespace_s():
 
 
 def test_one_chunk_shared_by_two_namespaces_serves_both():
-    """Identical prefixes across namespaces produce the same chunk hash,
-    so both claims ride on one occupant and one copy of the content."""
+    """Identical prefixes produce one chunk hash, so both claims ride on
+    one occupant and one copy of the content."""
     index = _index()
     content = _content(1, 2, 3, 4)
     index.add(content, b"A", token_offset=0, namespace=NS)
@@ -645,8 +640,8 @@ def test_releasing_the_last_namespace_drops_the_content():
 
 
 def test_remove_chunk_retires_every_namespace_at_once():
-    """Re-storing a chunk hash with different content invalidates it for
-    everyone, not just the namespace that re-stored it."""
+    """New content invalidates the chunk for every namespace, not just the
+    one that re-stored it."""
     index = _index()
     content = _content(1, 2, 3, 4)
     index.add(content, b"A", token_offset=0, namespace=NS)
@@ -672,10 +667,7 @@ def test_remove_chunk_retires_every_namespace_at_once():
 def test_directory_does_not_offer_matches_across_namespaces(
     requester: BlendNamespace,
 ):
-    """Each dimension of the namespace is one the requester's own key
-    expansion would miss on: another model's KV is not interchangeable,
-    another tenant's salt is isolated by design, and another parallel
-    setup shards heads differently."""
+    """Each dimension is one the requester's own key expansion misses on."""
     directory = _directory()
     directory.consume(_store([_key(1)], [10, 11, 12, 13], seq=1))
 
@@ -700,8 +692,8 @@ def test_directory_offers_a_chunk_two_tenants_stored_to_each_of_them():
 
 
 def test_directory_releases_a_namespace_claim_when_its_last_key_goes():
-    """The other tenant still holds the chunk, so the content stays
-    indexed — but the departing tenant must stop matching it."""
+    """The other tenant still holds the chunk, so the content stays indexed
+    — but the departing tenant must stop matching it."""
     directory = _directory()
     tenant_a = _key(1, cache_salt="a")
     tenant_b = _key(1, cache_salt="b")
@@ -716,8 +708,7 @@ def test_directory_releases_a_namespace_claim_when_its_last_key_goes():
 
 
 def test_a_namespace_joining_a_bound_chunk_without_tokens_still_claims_it():
-    """The second storer's emitter had already evicted the tokens, so its
-    store carries none. The content is already known, so the claim must
+    """The second storer's tokens were already evicted, so its claim must
     be recorded from the key alone rather than waiting for a re-store."""
     directory = _directory()
     directory.consume(_store([_key(1, cache_salt="a")], [10, 11, 12, 13], seq=1))

--- a/tests/v1/mp_coordinator/test_blend_index.py
+++ b/tests/v1/mp_coordinator/test_blend_index.py
@@ -143,7 +143,7 @@ def test_remove_makes_content_undiscoverable():
     index = _index()
     content = _content(1, 2, 3, 4)
     index.add(content, b"A", token_offset=0, namespace=NS)
-    index.remove(content, b"A", NS)
+    index.remove_claim(content, b"A", NS)
 
     assert index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS) == []
     assert index.stats().num_contents == 0
@@ -154,8 +154,8 @@ def test_remove_of_unknown_chunk_or_content_is_a_noop():
     content = _content(1, 2, 3, 4)
     index.add(content, b"A", token_offset=0, namespace=NS)
 
-    index.remove(content, b"UNKNOWN", NS)
-    index.remove(_content(9, 9, 9, 9), b"A", NS)
+    index.remove_claim(content, b"UNKNOWN", NS)
+    index.remove_claim(_content(9, 9, 9, 9), b"A", NS)
 
     assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS)) == [
         (b"A", 0, 0)
@@ -172,7 +172,7 @@ def test_identical_content_under_two_prefixes_survives_one_eviction():
     index.add(content, b"B", token_offset=512, namespace=NS)
     assert index.stats().num_chunks == 2
 
-    index.remove(content, b"A", NS)
+    index.remove_claim(content, b"A", NS)
 
     assert _tuples(index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), NS)) == [
         (b"B", 512, 0)
@@ -205,7 +205,7 @@ def test_many_contents_stay_matchable_across_growth_and_compaction():
     survivors = {k: v for k, v in contents.items() if k[0] % 20 == 0}
     for chunk_hash, content in contents.items():
         if chunk_hash not in survivors:
-            index.remove(content, chunk_hash, NS)
+            index.remove_claim(content, chunk_hash, NS)
 
     assert index.stats().num_contents == len(survivors)
     for chunk_hash, content in survivors.items():
@@ -643,7 +643,7 @@ def test_releasing_one_namespace_leaves_the_other_matching():
     index.add(content, b"A", token_offset=0, namespace=NS)
     index.add(content, b"A", token_offset=0, namespace=OTHER_NS)
 
-    index.remove(content, b"A", NS)
+    index.remove_claim(content, b"A", NS)
 
     query = np.asarray([1, 2, 3, 4], dtype=np.uint64)
     assert index.match(query, NS) == []
@@ -657,8 +657,8 @@ def test_releasing_the_last_namespace_drops_the_content():
     index.add(content, b"A", token_offset=0, namespace=NS)
     index.add(content, b"A", token_offset=0, namespace=OTHER_NS)
 
-    index.remove(content, b"A", NS)
-    index.remove(content, b"A", OTHER_NS)
+    index.remove_claim(content, b"A", NS)
+    index.remove_claim(content, b"A", OTHER_NS)
 
     assert index.match(np.asarray([1, 2, 3, 4], dtype=np.uint64), OTHER_NS) == []
     assert index.stats().num_contents == 0

--- a/tests/v1/mp_coordinator/test_blend_index.py
+++ b/tests/v1/mp_coordinator/test_blend_index.py
@@ -597,6 +597,31 @@ def test_the_requester_s_own_chunk_is_found_behind_another_namespace_s():
     ]
 
 
+def test_repeated_content_offers_the_namespace_s_chunk_once():
+    """Choosing the occupant before verifying must not change the
+    at-most-one-per-chunk contract, nor let a foreign occupant leak in
+    when the content recurs."""
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"THEIRS", token_offset=0, namespace=OTHER_NS)
+    index.add(content, b"MINE", token_offset=512, namespace=NS)
+
+    matches = index.match(np.asarray([1, 2, 3, 4, 1, 2, 3, 4], dtype=np.uint64), NS)
+    assert _tuples(matches) == [(b"MINE", 512, 0)]
+
+
+def test_repeated_content_offers_a_second_chunk_of_the_same_namespace():
+    """``seen`` is per chunk, so a namespace holding two chunks of one
+    content gets each of them at its own query position."""
+    index = _index()
+    content = _content(1, 2, 3, 4)
+    index.add(content, b"MINE_A", token_offset=0, namespace=NS)
+    index.add(content, b"MINE_B", token_offset=512, namespace=NS)
+
+    matches = index.match(np.asarray([1, 2, 3, 4, 1, 2, 3, 4], dtype=np.uint64), NS)
+    assert _tuples(matches) == [(b"MINE_A", 0, 0), (b"MINE_B", 512, 4)]
+
+
 def test_one_chunk_shared_by_two_namespaces_serves_both():
     """Identical prefixes produce one chunk hash, so both claims ride on
     one occupant and one copy of the content."""

--- a/tests/v1/mp_coordinator/test_cache_events.py
+++ b/tests/v1/mp_coordinator/test_cache_events.py
@@ -25,6 +25,7 @@ from lmcache.v1.distributed.api import (
 from lmcache.v1.distributed.internal_api import L1ObjectMeta
 from lmcache.v1.mp_coordinator.api import (
     UNKNOWN_TOKEN_OFFSET,
+    BlendNamespace,
     CacheEventBatch,
     CacheEventEntry,
     CacheEventType,
@@ -45,6 +46,10 @@ import lmcache.v1.mp_coordinator.cache_events as cache_events
 
 def _key(hash_byte: int) -> ObjectKey:
     return ObjectKey(chunk_hash=bytes([hash_byte]) * 4, model_name="m", kv_rank=0)
+
+
+# The namespace ``_key`` stores in; fragment queries must ask from it.
+NS = BlendNamespace.from_object_key(_key(0))
 
 
 def _entry(hash_byte: int, size_bytes: int = 0) -> CacheEventEntry:
@@ -797,8 +802,8 @@ def test_token_bindings_feed_the_key_directory_end_to_end():
     ]
     # The offsets survive the emitter -> HTTP -> directory round trip, and
     # reach a match as the re-RoPE source position.
-    (first,) = key_directory.blend_match(np.asarray([1, 2], dtype=np.uint64))
-    (second,) = key_directory.blend_match(np.asarray([3, 4], dtype=np.uint64))
+    (first,) = key_directory.blend_match(np.asarray([1, 2], dtype=np.uint64), NS)
+    (second,) = key_directory.blend_match(np.asarray([3, 4], dtype=np.uint64), NS)
     assert (first.old_st, second.old_st) == (0, 256)
 
 

--- a/tests/v1/mp_coordinator/test_directory_api.py
+++ b/tests/v1/mp_coordinator/test_directory_api.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.mp_coordinator.app import create_app
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+from lmcache.v1.mp_coordinator.schemas import encode_tokens
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 
@@ -255,7 +256,7 @@ def _blend_lookup(
     resp = client.post(
         "/directory/blend-lookup",
         json={
-            "token_ids": tokens,
+            "tokens_b64": encode_tokens(tokens),
             "model_name": model,
             "cache_salt": salt,
             "world_size": world_size,
@@ -291,14 +292,23 @@ def test_blend_lookup_without_a_match_is_empty():
         assert data["matches"] == []
 
 
-def test_blend_lookup_rejects_a_query_missing_its_identity():
-    """The tokens form of ``/directory/lookup`` needs a model to resolve
-    keys with; the fragment form needs the same one to scope matches."""
+def test_blend_lookup_rejects_a_malformed_token_buffer():
     with _blend_client() as client:
-        resp = client.post("/directory/blend-lookup", json={"token_ids": [1, 2, 3]})
+        resp = client.post(
+            "/directory/blend-lookup",
+            json={"tokens_b64": "not!b64", "model_name": MODEL},
+        )
         assert resp.status_code == 422
 
-        resp = client.post("/directory/blend-lookup", json={"model_name": MODEL})
+
+def test_blend_lookup_rejects_a_query_missing_its_namespace():
+    """Without a model there is no namespace to scope matches to, and an
+    unscoped match could name another model's or tenant's KV."""
+    with _blend_client() as client:
+        resp = client.post(
+            "/directory/blend-lookup",
+            json={"tokens_b64": encode_tokens([1, 2, 3])},
+        )
         assert resp.status_code == 422
 
 

--- a/tests/v1/mp_coordinator/test_directory_api.py
+++ b/tests/v1/mp_coordinator/test_directory_api.py
@@ -39,8 +39,8 @@ def _key(
     salt: str = "",
     world_size: int = WORLD_SIZE,
 ) -> dict:
-    """A key shaped the way a server emits one -- ``kv_rank`` packs the
-    parallel setup, which the blend namespace is derived from."""
+    """A key shaped the way a server emits one: ``kv_rank`` packs the
+    parallel setup the blend namespace is derived from."""
     return {
         "chunk_hash_hex": h,
         "model_name": model,
@@ -302,8 +302,7 @@ def test_blend_lookup_rejects_a_malformed_token_buffer():
 
 
 def test_blend_lookup_rejects_a_query_missing_its_namespace():
-    """Without a model there is no namespace to scope matches to, and an
-    unscoped match could name another model's or tenant's KV."""
+    """Without a model there is no namespace to scope matches to."""
     with _blend_client() as client:
         resp = client.post(
             "/directory/blend-lookup",
@@ -313,9 +312,8 @@ def test_blend_lookup_rejects_a_query_missing_its_namespace():
 
 
 def test_blend_lookup_does_not_match_across_namespaces():
-    """The chunk was stored by another model, so its hash expands into
-    keys this caller has nothing under -- offering it would only buy a
-    confirmed miss."""
+    """The chunk was stored by another model, so its hash expands into keys
+    this caller has nothing under."""
     chunk_size = MPCoordinatorConfig().chunk_size
     content = _chunk_tokens(1000, chunk_size)
     with _blend_client() as client:

--- a/tests/v1/mp_coordinator/test_directory_api.py
+++ b/tests/v1/mp_coordinator/test_directory_api.py
@@ -6,9 +6,9 @@ ingestion, placement lookup, and stats)."""
 from fastapi.testclient import TestClient
 
 # First Party
+from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.mp_coordinator.app import create_app
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
-from lmcache.v1.mp_coordinator.schemas import encode_tokens
 from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 
@@ -27,11 +27,28 @@ def _blend_client() -> TestClient:
     return TestClient(create_app(config))
 
 
-def _key(h: str = "aa", model: str = "m", rank: int = 0, salt: str = "") -> dict:
+MODEL = "m"
+WORLD_SIZE = 1
+
+
+def _key(
+    h: str = "aa",
+    model: str = MODEL,
+    rank: int = 0,
+    salt: str = "",
+    world_size: int = WORLD_SIZE,
+) -> dict:
+    """A key shaped the way a server emits one -- ``kv_rank`` packs the
+    parallel setup, which the blend namespace is derived from."""
     return {
         "chunk_hash_hex": h,
         "model_name": model,
-        "kv_rank": rank,
+        "kv_rank": ObjectKey.ComputeKVRank(
+            world_size=world_size,
+            global_rank=rank,
+            local_world_size=world_size,
+            local_rank=rank,
+        ),
         "cache_salt": salt,
     }
 
@@ -228,9 +245,21 @@ def _chunk_tokens(first: int, count: int) -> list[int]:
     return list(range(first, first + count))
 
 
-def _blend_lookup(client: TestClient, tokens: list[int]) -> dict:
+def _blend_lookup(
+    client: TestClient,
+    tokens: list[int],
+    model: str = MODEL,
+    salt: str = "",
+    world_size: int = WORLD_SIZE,
+) -> dict:
     resp = client.post(
-        "/directory/blend-lookup", json={"tokens_b64": encode_tokens(tokens)}
+        "/directory/blend-lookup",
+        json={
+            "token_ids": tokens,
+            "model_name": model,
+            "cache_salt": salt,
+            "world_size": world_size,
+        },
     )
     assert resp.status_code == 200
     return resp.json()
@@ -262,10 +291,34 @@ def test_blend_lookup_without_a_match_is_empty():
         assert data["matches"] == []
 
 
-def test_blend_lookup_rejects_a_malformed_token_buffer():
+def test_blend_lookup_rejects_a_query_missing_its_identity():
+    """The tokens form of ``/directory/lookup`` needs a model to resolve
+    keys with; the fragment form needs the same one to scope matches."""
     with _blend_client() as client:
-        resp = client.post("/directory/blend-lookup", json={"tokens_b64": "not!b64"})
+        resp = client.post("/directory/blend-lookup", json={"token_ids": [1, 2, 3]})
         assert resp.status_code == 422
+
+        resp = client.post("/directory/blend-lookup", json={"model_name": MODEL})
+        assert resp.status_code == 422
+
+
+def test_blend_lookup_does_not_match_across_namespaces():
+    """The chunk was stored by another model, so its hash expands into
+    keys this caller has nothing under -- offering it would only buy a
+    confirmed miss."""
+    chunk_size = MPCoordinatorConfig().chunk_size
+    content = _chunk_tokens(1000, chunk_size)
+    with _blend_client() as client:
+        entry = {
+            "key": _key(model="other"),
+            "size_bytes": 1024,
+            "token_ids": content,
+            "token_offset": 0,
+        }
+        _post_events(client, [_batch(entries=[entry])])
+
+        assert _blend_lookup(client, content)["matches"] == []
+        assert _blend_lookup(client, content, model="other")["matches"]
 
 
 def test_blend_lookup_stops_matching_a_deleted_chunk():
@@ -425,6 +478,8 @@ def test_stats_reports_blend_index_counts():
         assert client.get("/directory/stats").json()["blend"] == {
             "num_contents": 0,
             "num_chunks": 0,
+            "num_claims": 0,
+            "num_namespaces": 0,
             "table_size": 1024,
         }
 
@@ -439,3 +494,5 @@ def test_stats_reports_blend_index_counts():
         data = client.get("/directory/stats").json()["blend"]
         assert data["num_contents"] == 1
         assert data["num_chunks"] == 1
+        assert data["num_claims"] == 1
+        assert data["num_namespaces"] == 1

--- a/tests/v1/mp_coordinator/test_key_directory.py
+++ b/tests/v1/mp_coordinator/test_key_directory.py
@@ -12,6 +12,7 @@ import pytest
 from lmcache.v1.distributed.api import ObjectKey, Tier
 from lmcache.v1.mp_coordinator.api import (
     UNKNOWN_TOKEN_OFFSET,
+    BlendNamespace,
     CacheEventBatch,
     CacheEventEntry,
     CacheEventType,
@@ -21,6 +22,11 @@ from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory
 
 def _key(hash_byte: int) -> ObjectKey:
     return ObjectKey(chunk_hash=bytes([hash_byte]) * 4, model_name="m", kv_rank=0)
+
+
+# The namespace ``_key`` stores in, and therefore the one fragment queries
+# over these fixtures must ask from.
+NS = BlendNamespace.from_object_key(_key(0))
 
 
 def _batch(
@@ -354,7 +360,7 @@ def test_binding_records_the_chunks_token_offset():
     directory.consume(_batch(seq=1, keys=[_key(1)], token_ids=[7, 8], token_offset=512))
 
     assert directory.get_token_ids([_chash(1)]) == [(7, 8)]
-    (match,) = directory.blend_match(np.asarray([7, 8], dtype=np.uint64))
+    (match,) = directory.blend_match(np.asarray([7, 8], dtype=np.uint64), NS)
     assert match.old_st == 512
 
 
@@ -383,10 +389,10 @@ def test_restore_replaces_tokens_and_offset():
     directory.consume(_batch(seq=2, keys=[_key(1)], token_ids=[3, 4], token_offset=256))
 
     assert directory.get_token_ids([_chash(1)]) == [(3, 4)]
-    (match,) = directory.blend_match(np.asarray([3, 4], dtype=np.uint64))
+    (match,) = directory.blend_match(np.asarray([3, 4], dtype=np.uint64), NS)
     assert match.old_st == 256
     # The superseded content is no longer discoverable.
-    assert directory.blend_match(np.asarray([1, 2], dtype=np.uint64)) == []
+    assert directory.blend_match(np.asarray([1, 2], dtype=np.uint64), NS) == []
 
 
 def test_token_ids_outside_uint32_leave_the_binding_unfilled():

--- a/tests/v1/multiprocess/test_blend_store.py
+++ b/tests/v1/multiprocess/test_blend_store.py
@@ -160,7 +160,58 @@ def _coord_engine(chunk_size: int = 4):
     eng._event_bus = MagicMock()
     eng._build_global_segments = BlendModule._build_global_segments.__get__(eng)
     eng._poll_coordinator_match = BlendModule._poll_coordinator_match.__get__(eng)
+    eng._submit_coordinator_match = BlendModule._submit_coordinator_match.__get__(eng)
     return eng
+
+
+def test_submit_coordinator_match_sends_this_server_s_namespace():
+    """The query carries the same model, salt, and world size the retrieve
+    path keys with."""
+    # First Party
+    from lmcache.v1.mp_coordinator.api import BlendNamespace
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+
+    eng = _coord_engine(chunk_size=4)
+    coordinator = MagicMock()
+    eng._coordinator = coordinator
+    key = IPCCacheServerKey(
+        model_name="llama",
+        world_size=4,
+        worker_id=None,
+        token_ids=tuple(range(8)),
+        start=0,
+        end=8,
+        request_id="rid",
+        cache_salt="tenant-a",
+    )
+
+    assert eng._submit_coordinator_match(key) is True
+    coordinator.submit_match.assert_called_once_with(
+        "rid",
+        list(range(8)),
+        BlendNamespace(model_name="llama", cache_salt="tenant-a", world_size=4),
+    )
+
+
+def test_submit_coordinator_match_skips_a_query_shorter_than_a_chunk():
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+
+    eng = _coord_engine(chunk_size=4)
+    coordinator = MagicMock()
+    eng._coordinator = coordinator
+    key = IPCCacheServerKey(
+        model_name="llama",
+        world_size=1,
+        worker_id=None,
+        token_ids=(1, 2),
+        start=0,
+        end=2,
+        request_id="rid",
+    )
+
+    assert eng._submit_coordinator_match(key) is False
+    coordinator.submit_match.assert_not_called()
 
 
 def test_build_global_segments_are_retrievable_cbmatchresults():


### PR DESCRIPTION
**What this PR does / why we need it**:

The coordinator's blend index keys entries by content fingerprint and records one
untagged `chunk_hash` per occupant. But a `chunk_hash` is content-and-prefix only
— the model, salt, and parallel setup that decide *whose* KV it names live on
`ObjectKey` beside it. Two defects follow:

- A match can name a chunk stored only under another model or tenant. The
  requester expands it into its own namespace, the key exists nowhere, and the
  confirmed miss costs a prefetch and a blend slot.
- Worse, `match()` returns at most one occupant per content. The same document
  cached after a different prefix is a *different* `chunk_hash`, so it is a
  second occupant — and the requester's own copy can sit behind someone else's
  and never be returned. That is lost reuse, not just wasted work.

Each occupant now records the `BlendNamespace` — `(model_name, cache_salt,
world_size)` — of every namespace that stored it, derived from the key the cache
event already carries, so there is no new publish path. `match()` walks past
occupants the requester does not hold instead of stopping at the first.

Scoping loses no legitimate reuse: cross-model KV is not interchangeable and
cross-salt is isolated by design. It only removes matches that would have missed
anyway, and recovers the ones that were hidden.

**Special notes for your reviewers**:

- **Wire change on `POST /directory/blend-lookup`**, additive apart from one new
  requirement: the body keeps `tokens_b64` and gains `model_name` (required),
  `world_size`, and `cache_salt`. These are the same three fields
  `/directory/lookup`'s tokens form carries, though for a related but distinct
  reason — prefix lookup uses them to *build* the keys it resolves, while a
  fragment match already names a stored `chunk_hash` and uses them to stay in the
  caller's namespace. The token encodings deliberately stay different for now.
  An old MP server posting `tokens_b64` alone gets a 422; the endpoint is off by
  default behind `--enable-blend-lookup`.
- `world_size` comes from a new `ObjectKey.WorldSizeFromKVRank`, the inverse of
  the top byte `ComputeKVRank` packs, kept beside the packing so the bit layout
  has one owner.
- Claims are per namespace, not per rank — a chunk stored by only some ranks of a
  world size still matches and confirms at expansion. Documented as a residual in
  `blend_index.md`.
- The steady-state store path claims one namespace per event rather than walking
  the binding's keys; otherwise a TP=8 store would rehash the content 64 times
  instead of 8.
- `BlendIndexStats` gains `num_claims` / `num_namespaces`, surfaced by
  `lmcache query coordinator --api directory`.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
