### PR TITLE
[Bugfix] Default worker heartbeats ON — the controller reaps silent workers after 30s

### DIFF
--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -223,9 +223,17 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": int,
     },
     # the lmcache_worker_heartbeat_time means that sending heartbeat periodically.
+    # Defaults ON: the controller's health check deregisters any worker whose
+    # last heartbeat is older than lmcache_worker_timeout (30s by default),
+    # INCLUDING workers that never sent one - with a None default every
+    # worker was silently deregistered ~30s after registering, emptying the
+    # KV index ("cache misses that shouldn't be occurring") with no error.
+    # Must stay comfortably below lmcache_worker_timeout. Set 0 to disable
+    # heartbeats explicitly (only sensible when the controller's health
+    # check is also disabled via health_check_interval <= 0).
     "lmcache_worker_heartbeat_time": {
         "type": Optional[int],
-        "default": None,
+        "default": 10,
         "env_converter": int,
     },
     # PD-related configurations

--- a/tests/v1/test_worker_heartbeat_default.py
+++ b/tests/v1/test_worker_heartbeat_default.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The worker heartbeat default must be consistent with the controller's
+liveness check: the controller deregisters any worker whose last heartbeat
+is older than lmcache_worker_timeout (default 30s), including workers that
+never sent one. A None default meant every worker was silently deregistered
+~30s after registering - the KV index emptied shortly after startup with no
+error anywhere ("cache misses that shouldn't be occurring")."""
+
+from lmcache.v1.config import LMCacheEngineConfig
+
+
+def test_worker_heartbeat_defaults_on_and_inside_controller_timeout():
+    config = LMCacheEngineConfig.from_defaults()
+    assert config.lmcache_worker_heartbeat_time is not None
+    assert 0 < config.lmcache_worker_heartbeat_time < 30
+    # workers wait heartbeat_delay before the first beat; delay + one period
+    # must also land inside the controller timeout or the first check window
+    # can still reap a healthy worker
+    assert (
+        config.lmcache_worker_heartbeat_delay_time
+        + config.lmcache_worker_heartbeat_time
+        < 30
+    )


### PR DESCRIPTION
**The two defaults contradict each other**: the controller's health check deregisters any worker whose last heartbeat is older than `lmcache_worker_timeout` (30s default) — *including workers that never sent one* — while `lmcache_worker_heartbeat_time` defaults to `None`, meaning workers never send heartbeats by default.

Net effect with an enabled controller, out of the box: **every worker is silently deregistered ~30 seconds after registering**, the controller's KV index empties shortly after startup, and every kv-aware lookup misses from then on. No error surfaces anywhere — from the outside it presents as "cache misses that shouldn't be occurring." We hit this independently in two deployments (a Kubernetes production stack and a bare docker test rig) before tracing it to the defaults.

### Fix

Default `lmcache_worker_heartbeat_time` to **10** — matching the existing `lmcache_worker_heartbeat_delay_time` default and comfortably inside the 30s controller timeout (delay 10 + period 10 = 20s, so even the first health-check window cannot reap a healthy worker). The config comment now documents the interplay with `lmcache_worker_timeout`. Setting `0` still disables heartbeats explicitly, which only makes sense alongside `health_check_interval <= 0`.

Cost of the new default: one small ZMQ message per worker per 10s.

Test added asserting the default is on and that delay + period stays inside the controller timeout.

(Context: found while validating kv-aware routing for vllm-project/production-stack — the enablement work in vllm-project/production-stack#1060 and the troubleshooting doc in vllm-project/production-stack#1062 reference this default as a silent-miss precondition; this PR removes the footgun at the source.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)