### PR TITLE
fix(vllm): support resolved DCP-interleaved Mamba cache geometry

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -604,12 +604,22 @@ Decode context parallelism (DCP)
 ``--decode-context-parallel-size`` is supported. Under DCP, vLLM shards the
 attention KV cache across ranks along the token axis, so each rank holds only
 a strided ``1/dcp`` slice and one block ID spans ``block_size * dcp`` tokens.
-LMCache stores each rank's slice as its own object and a chunk counts as a hit
-only when every rank's slice is present.
+LMCache stores each rank's opaque page as its own object and a chunk counts as
+a hit only when every rank's slice is present. Non-trivial
+``--cp-kv-cache-interleave-size`` values are supported when they evenly divide
+every resolved attention cache block size. Because interleave changes the
+token-to-slot byte layout, the connector automatically adds the DCP size and
+interleave value to its internal cache namespace. This prevents pages written
+by one interleave layout from being loaded by another. It does not change the
+model name served by vLLM, but the decorated cache model name is visible in MP
+metric labels so operators can distinguish incompatible cache layouts.
 
 One configuration change is required: the LMCache chunk size must be a
-multiple of ``block_size * decode_context_parallel_size``, not just
-``block_size``. If it is smaller, vLLM fails at connector startup with the
+multiple of vLLM's resolved scheduler block size. For a single attention
+group, that is ``block_size * decode_context_parallel_size``. For a hybrid
+model, it is the least common multiple of every attention group's DCP-scaled
+block span and every recurrent-state group's unscaled physical block span. If
+the chunk size is incompatible, vLLM fails at connector startup with the
 required multiple in the message (the LMCache server itself starts fine).
 
 The example model also needs a vLLM build that can run it under DCP:
@@ -640,11 +650,13 @@ DCP. These combinations are rejected at startup:
      - Reason
    * - ``--prefill-context-parallel-size > 1``
      - Adds a second KV shard axis this connector does not map.
-   * - ``--cp-kv-cache-interleave-size != 1``
-     - Changes the token-to-rank mapping, which would store the wrong KV.
    * - Fewer than ``dcp_size`` ranks per LMCache server
      - No server holds a complete set of shards, and lookup takes the
        minimum hit count across servers, so it reports no hits.
+
+An interleave value that is non-positive, larger than a resolved attention
+cache block, or does not evenly divide every resolved attention block is
+rejected at connector startup.
 
 ``decode_context_parallel_size > tensor_parallel_size`` is rejected by vLLM
 itself, so this connector does not re-check it.

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -404,10 +404,12 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         padding, and any sibling layers on a shared pool, live between
         row and S).
 
-        Output for NHD: [num_blocks, block_size, 1, head_size] with
-        strides (S, head_size, head_size, 1). HND swaps dims 1 and 2:
-        [num_blocks, 1, block_size, head_size] with strides
-        (S, block_size * head_size, head_size, 1).
+        Output for NHD/BLNHC: [num_blocks, block_size, 1, head_size]
+        with strides (S, head_size, head_size, 1). HND/BLHNC swaps dims
+        1 and 2: [num_blocks, 1, block_size, head_size] with strides
+        (S, block_size * head_size, head_size, 1). Blocks-first layouts
+        preserve the input's block stride so it can continue spanning
+        sibling layers and object groups in the shared pool.
 
         head_size = ceil(row / block_size), rounded up to the kernels'
         vector alignment, and block_size * head_size may exceed the row
@@ -418,9 +420,10 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
             "single-layer KV cache must be a torch.Tensor"
         )
         kv_layout = layout_hints.get("kv_layout", "none")
-        if kv_layout not in ("NHD", "HND"):
+        if kv_layout not in ("NHD", "HND", "BLHNC", "BLNHC"):
             raise ValueError(
-                f"Unsupported kv_layout: {kv_layout}. Only NHD and HND are supported."
+                f"Unsupported kv_layout: {kv_layout}. Expected NHD, HND, "
+                "BLHNC, or BLNHC."
             )
         num_blocks = kv_cache.shape[0]
         row = kv_cache[0].numel()
@@ -447,7 +450,7 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
                 f"cannot tile a {row}-element state row into {block_size} "
                 f"aligned tokens within the {page_bytes}-byte page"
             )
-        if kv_layout == "NHD":
+        if kv_layout in ("NHD", "BLNHC"):
             inner = (block_size, 1, head_size)
             inner_strides = (head_size, head_size, 1)
         else:

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -109,6 +109,9 @@ if TYPE_CHECKING:
 
 logger = lmcache_init_logger(__name__)
 
+_DCP_LAYOUT_NAMESPACE = "##lmcache-dcp-layout-v1-"
+_MAX_LCM_EXPANSION_FACTOR = 4
+
 
 # Helper functions
 def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
@@ -145,7 +148,124 @@ def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
     return False
 
 
-def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
+def _iter_kv_cache_specs(kv_cache_config: "KVCacheConfig | None") -> Iterable[Any]:
+    """Yield leaf KV cache specs without depending on a vLLM helper API."""
+    if kv_cache_config is None:
+        return
+    for group in kv_cache_config.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
+        if isinstance(per_layer_specs, dict):
+            yield from per_layer_specs.values()
+        else:
+            yield group_spec
+
+
+def get_group_tokens_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> list[int]:
+    """Return each engine group's block span in scheduler token coordinates.
+
+    Attention pages are local DCP shards and therefore cover
+    ``spec.block_size * dcp_size`` global tokens. Recurrent-state pages are
+    replicated and retain their physical ``spec.block_size`` span. When vLLM
+    does not provide group metadata, preserve the legacy single-group rule.
+    """
+    dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
+    groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    return [
+        get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in groups
+    ] or [vllm_config.cache_config.block_size * dcp_size]
+
+
+def get_lmcache_scheduler_block_size(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> int:
+    """Resolve the scheduling block shared by every engine KV cache group."""
+    group_spans = get_group_tokens_per_block(vllm_config, kv_cache_config)
+    scheduler_block_size = math.lcm(*group_spans)
+    largest_group_span = max(group_spans)
+    if scheduler_block_size > largest_group_span * _MAX_LCM_EXPANSION_FACTOR:
+        logger.warning(
+            "LMCache resolved a scheduler block of %d tokens from group spans "
+            "%s (%0.1fx the largest span). Near-coprime group geometry can "
+            "make cache chunks too coarse to be useful.",
+            scheduler_block_size,
+            group_spans,
+            scheduler_block_size / largest_group_span,
+        )
+    return scheduler_block_size
+
+
+def get_lmcache_model_name(vllm_config: VllmConfig) -> str:
+    """Return a cache key namespace that isolates DCP interleave layouts.
+
+    A DCP rank's page is an opaque byte image whose token-to-slot mapping
+    changes with ``cp_kv_cache_interleave_size``. The existing ``kv_rank``
+    identity distinguishes DCP shard counts but not interleave values, so a
+    deployment changing only interleave could otherwise retrieve incompatible
+    pages left by the earlier deployment. ``model_name`` is also exposed as a
+    label by MP observability subscribers, so metrics use this decorated value;
+    callers can recover the served model name with
+    :func:`get_lmcache_base_model_name`. Keep legacy keys unchanged unless a
+    non-trivial DCP interleave is active. The ``##`` separator follows the SDK
+    cache-kind namespace convention.
+    """
+    model_name = vllm_config.model_config.model
+    parallel_config = vllm_config.parallel_config
+    dcp_size = getattr(parallel_config, "decode_context_parallel_size", 1)
+    interleave = getattr(parallel_config, "cp_kv_cache_interleave_size", 1)
+    if dcp_size <= 1 or interleave == 1:
+        return model_name
+    return f"{model_name}{_DCP_LAYOUT_NAMESPACE}d{dcp_size}-interleave{interleave}"
+
+
+def get_lmcache_base_model_name(model_name: str) -> str:
+    """Remove the connector's DCP layout namespace from a cache model name.
+
+    Args:
+        model_name: A served model name or an LMCache-decorated model name.
+
+    Returns:
+        The undecorated model name used by the serving API and model config.
+    """
+    return model_name.partition(_DCP_LAYOUT_NAMESPACE)[0]
+
+
+def get_resolved_attention_block_sizes(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> set[int]:
+    """Return physical block sizes for resolved attention cache groups.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        The resolved attention block sizes. Falls back to vLLM's cache block
+        size when group metadata is unavailable.
+    """
+    block_sizes = {
+        spec.block_size
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if any(cls.__name__ == "AttentionSpec" for cls in type(spec).__mro__)
+    }
+    if block_sizes:
+        return block_sizes
+    return {vllm_config.cache_config.block_size}
+
+
+def validate_mamba_step_alignment(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> None:
     """Reject scheduler configs whose steps cannot advance a whole Mamba block.
 
     In ``mamba_cache_mode="align"`` vLLM snapshots the recurrent state only at
@@ -169,7 +289,21 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
     """
     if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
         return
-    block_size = vllm_config.cache_config.block_size
+    mamba_block_sizes = {
+        spec.block_size
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if any(cls.__name__ == "MambaSpec" for cls in type(spec).__mro__)
+    }
+    if len(mamba_block_sizes) > 1:
+        raise ValueError(
+            "All Mamba KV cache groups must use one physical block size; got "
+            f"{sorted(mamba_block_sizes)}."
+        )
+    block_size = (
+        next(iter(mamba_block_sizes))
+        if mamba_block_sizes
+        else vllm_config.cache_config.block_size
+    )
     max_batched = vllm_config.scheduler_config.max_num_batched_tokens
     if max_batched < block_size:
         raise ValueError(
@@ -181,7 +315,11 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
         )
 
 
-def validate_dcp_support(vllm_config: VllmConfig, n_servers: int) -> None:
+def validate_dcp_support(
+    vllm_config: VllmConfig,
+    n_servers: int,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> None:
     """Reject decode-context-parallel topologies this connector cannot serve.
 
     These would silently store wrong or incomplete KV, so fail at startup
@@ -204,13 +342,25 @@ def validate_dcp_support(vllm_config: VllmConfig, n_servers: int) -> None:
             f"together with DCP (got pcp={pcp_size}, dcp={dcp_size})."
         )
 
-    # Fail-closed, not fundamental: the interleave sets each object's byte
-    # layout but is absent from cache identity, and k != 1 is unvalidated.
     interleave = getattr(pc, "cp_kv_cache_interleave_size", 1)
-    if interleave != 1:
+    if interleave < 1:
         raise ValueError(
-            "LMCacheMPConnector requires cp_kv_cache_interleave_size == 1 "
+            "LMCacheMPConnector requires cp_kv_cache_interleave_size >= 1 "
             f"under DCP (got {interleave})."
+        )
+    attention_block_sizes = get_resolved_attention_block_sizes(
+        vllm_config, kv_cache_config
+    )
+    incompatible_block_sizes = sorted(
+        block_size
+        for block_size in attention_block_sizes
+        if interleave > block_size or block_size % interleave != 0
+    )
+    if incompatible_block_sizes:
+        raise ValueError(
+            f"cp_kv_cache_interleave_size ({interleave}) must be no greater "
+            "than and evenly divide every resolved attention block size; "
+            f"incompatible sizes: {incompatible_block_sizes}."
         )
 
     ranks_per_server = pc.world_size // n_servers
@@ -300,8 +450,17 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         super().__init__(vllm_config, role, kv_cache_config)
 
         # Fail fast, before the server handshake below.
-        validate_mamba_step_alignment(vllm_config)
-        validate_kv_cache_groups(getattr(self, "_kv_cache_config", None))
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        validate_mamba_step_alignment(vllm_config, kv_cache_config)
+        validate_kv_cache_groups(kv_cache_config)
+
+        group_tokens_per_block = get_group_tokens_per_block(
+            vllm_config, kv_cache_config
+        )
+        scheduler_block_size = get_lmcache_scheduler_block_size(
+            vllm_config, kv_cache_config
+        )
+        cache_model_name = get_lmcache_model_name(vllm_config)
 
         assert vllm_config.kv_transfer_config is not None
 
@@ -340,7 +499,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # The server count is derived from lmcache.mp.server_urls.
         n_servers = len(server_urls)
 
-        validate_dcp_support(vllm_config, n_servers)
+        validate_dcp_support(vllm_config, n_servers, kv_cache_config)
+
+        logger.info(
+            "Resolved LMCache MP geometry: group_tokens_per_block=%s, "
+            "scheduler_block_size=%d, cache_model_name=%s",
+            group_tokens_per_block,
+            scheduler_block_size,
+            cache_model_name,
+        )
 
         assert vllm_config.parallel_config.world_size % n_servers == 0, (
             f"world_size ({vllm_config.parallel_config.world_size}) must be "
@@ -394,8 +561,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.scheduler_adapter = LMCacheMPSchedulerAdapter(
                 server_urls=server_urls,
                 context=zmq_context,
-                model_name=vllm_config.model_config.model,
-                vllm_block_size=vllm_config.cache_config.block_size * dcp_size,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
@@ -421,8 +588,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.worker_adapter = LMCacheMPWorkerAdapter(
                 server_url=local_server_url,
                 context=zmq_context,
-                model_name=vllm_config.model_config.model,
-                vllm_block_size=vllm_config.cache_config.block_size * dcp_size,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
@@ -446,21 +613,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         else:
             raise ValueError(f"Unknown KVConnectorRole: {self.role}")
 
-        kv_cache_config = getattr(self, "_kv_cache_config", None)
-        vllm_groups = (
-            getattr(kv_cache_config, "kv_cache_groups", ()) or ()
-            if kv_cache_config is not None
-            else ()
-        )
         # Tokens covered by one paged chunk (one block ID) of each engine
         # group, from the group's KV cache spec. Hybrid models can mix
         # different values (e.g. gemma-4: sliding-window groups 32,
         # full-attention groups 16; DeepSeek V4: 256/64/8/4). Falls back to
         # the engine's base block size when no group metadata is available
         # (single non-hybrid group).
-        self._group_tokens_per_block: list[int] = [
-            get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in vllm_groups
-        ] or [vllm_config.cache_config.block_size * dcp_size]
+        self._group_tokens_per_block = group_tokens_per_block
         for engine_group_idx, tokens_per_block in enumerate(
             self._group_tokens_per_block
         ):

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -6,10 +6,12 @@ and ``get_tokens_per_block`` (attention-only block scaling). No GPU needed."""
 # Standard
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from typing import Literal
 import importlib.util
 
 # Third Party
 import pytest
+import torch
 
 # First Party
 from lmcache.integration.vllm.kv_cache_groups import get_tokens_per_block
@@ -248,6 +250,14 @@ class _FakeMambaSpec:
 
 
 @dataclass
+class MambaSpec:
+    """Mamba spec double detected by its public class name."""
+
+    block_size: int
+    mamba_cache_mode: str = "align"
+
+
+@dataclass
 class AttentionSpec:
     """Double for vLLM's AttentionSpec base; detection is by class name."""
 
@@ -304,6 +314,160 @@ def test_hybrid_layout_produces_mixed_spans():
     assert math.lcm(*spans) == 2048  # scheduler commit granularity
 
 
+def _import_connector_geometry_helpers():
+    """Import helpers lazily because their module imports vLLM."""
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_group_tokens_per_block,
+        get_lmcache_model_name,
+        get_lmcache_scheduler_block_size,
+        validate_mamba_step_alignment,
+    )
+
+    return (
+        get_group_tokens_per_block,
+        get_lmcache_model_name,
+        get_lmcache_scheduler_block_size,
+        validate_mamba_step_alignment,
+    )
+
+
+def _hybrid_kv_cache_config(
+    attention_block_size: int = 2304,
+    mamba_block_size: int = 2304,
+) -> SimpleNamespace:
+    """Resolved GLM-like groups after platform page-size equalization."""
+    return SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=_attention_spec(attention_block_size)),
+            SimpleNamespace(kv_cache_spec=MambaSpec(mamba_block_size)),
+        ]
+    )
+
+
+def _geometry_config(
+    *,
+    dcp_size: int = 4,
+    interleave: int = 4,
+    base_block_size: int = 256,
+    max_num_batched_tokens: int = 4096,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model="org/glm-5.3-flash"),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+            cp_kv_cache_interleave_size=interleave,
+        ),
+        cache_config=SimpleNamespace(
+            block_size=base_block_size,
+            mamba_cache_mode="align",
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=max_num_batched_tokens),
+    )
+
+
+@requires_vllm
+def test_glm_dcp4_geometry_resolves_physical_mamba_block():
+    (
+        get_group_tokens_per_block,
+        _,
+        get_lmcache_scheduler_block_size,
+        _,
+    ) = _import_connector_geometry_helpers()
+    config = _geometry_config()
+    kv_config = _hybrid_kv_cache_config()
+
+    assert get_group_tokens_per_block(config, kv_config) == [9216, 2304]
+    assert get_lmcache_scheduler_block_size(config, kv_config) == 9216
+
+
+@requires_vllm
+def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
+    *_, validate_mamba_step_alignment = _import_connector_geometry_helpers()
+    kv_config = _hybrid_kv_cache_config()
+
+    with pytest.raises(ValueError, match=r"block_size=2304"):
+        validate_mamba_step_alignment(
+            _geometry_config(max_num_batched_tokens=2048), kv_config
+        )
+
+    validate_mamba_step_alignment(
+        _geometry_config(max_num_batched_tokens=4096), kv_config
+    )
+
+
+@requires_vllm
+@pytest.mark.parametrize(
+    ("kv_layout", "expected_shape"),
+    [
+        ("BLHNC", (3, 1, 4, 4)),
+        ("BLNHC", (3, 4, 1, 4)),
+    ],
+)
+def test_mamba_unified_view_preserves_blocks_first_pool_stride(
+    kv_layout: Literal["BLHNC", "BLNHC"], expected_shape: tuple[int, ...]
+):
+    """Jovian's shared blocks-first pool remains a zero-copy strided view."""
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        _MambaUnifiedViewEdit,
+    )
+
+    num_blocks, num_layers, row, page_elems = 3, 2, 13, 16
+    pool = torch.arange(num_blocks * num_layers * page_elems, dtype=torch.float32)
+    layer = pool.as_strided(
+        (num_blocks, 1, 1, row),
+        (num_layers * page_elems, row, row, 1),
+        storage_offset=page_elems,
+    )
+    spec = SimpleNamespace(block_size=4, page_size_bytes=64)
+
+    edited = _MambaUnifiedViewEdit().apply(spec, layer, {"kv_layout": kv_layout})
+
+    assert edited.shape == expected_shape
+    assert edited.stride(0) == num_layers * page_elems
+    assert edited.data_ptr() == layer.data_ptr()
+
+
+@requires_vllm
+def test_dcp_interleave_participates_in_cache_identity():
+    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_lmcache_base_model_name,
+    )
+
+    interleave4 = get_lmcache_model_name(_geometry_config(interleave=4))
+    interleave8 = get_lmcache_model_name(_geometry_config(interleave=8))
+    assert interleave4 != interleave8
+    assert interleave4.endswith("##lmcache-dcp-layout-v1-d4-interleave4")
+    assert get_lmcache_base_model_name(interleave4) == "org/glm-5.3-flash"
+
+
+@requires_vllm
+def test_base_model_name_preserves_undecorated_names():
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_lmcache_base_model_name,
+    )
+
+    assert get_lmcache_base_model_name("org/glm-5.3-flash") == ("org/glm-5.3-flash")
+
+
+@requires_vllm
+def test_trivial_interleave_preserves_legacy_cache_identity():
+    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+
+    assert (
+        get_lmcache_model_name(_geometry_config(dcp_size=4, interleave=1))
+        == "org/glm-5.3-flash"
+    )
+    assert (
+        get_lmcache_model_name(_geometry_config(dcp_size=1, interleave=4))
+        == "org/glm-5.3-flash"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # validate_dcp_support: fail closed on unproven topologies                     #
 # --------------------------------------------------------------------------- #
@@ -324,6 +488,7 @@ def _config(
     pp_size: int = 1,
     interleave: int = 1,
     tp_size: int = 8,
+    cache_block_size: int = 256,
 ) -> SimpleNamespace:
     """Minimal stand-in exposing only the parallel_config fields read."""
     return SimpleNamespace(
@@ -334,7 +499,8 @@ def _config(
             cp_kv_cache_interleave_size=interleave,
             tensor_parallel_size=tp_size,
             world_size=tp_size * pp_size,
-        )
+        ),
+        cache_config=SimpleNamespace(block_size=cache_block_size),
     )
 
 
@@ -365,10 +531,36 @@ def test_validate_rejects_pcp_with_dcp():
 
 
 @requires_vllm
-def test_validate_rejects_nontrivial_interleave():
-    """The silent-corruption guard: wrong KV stored, no crash, without it."""
-    with pytest.raises(ValueError, match="cp_kv_cache_interleave_size"):
-        _import_validate_dcp_support()(_config(dcp_size=2, interleave=64), 1)
+def test_validate_accepts_interleave_when_layout_is_namespaced():
+    """Opaque per-rank pages round-trip when their key namespace is isolated."""
+    _import_validate_dcp_support()(
+        _config(dcp_size=4, interleave=4), 1, _hybrid_kv_cache_config()
+    )
+
+
+@requires_vllm
+def test_validate_uses_resolved_attention_block_for_interleave():
+    """The resolved 2304 page, rather than the CLI 256 page, is authoritative."""
+    validate = _import_validate_dcp_support()
+    kv_config = _hybrid_kv_cache_config(attention_block_size=2304)
+
+    validate(_config(dcp_size=4, interleave=768), 1, kv_config)
+
+
+@requires_vllm
+def test_validate_rejects_interleave_not_dividing_resolved_attention_block():
+    with pytest.raises(ValueError, match="evenly divide"):
+        _import_validate_dcp_support()(
+            _config(dcp_size=4, interleave=1000),
+            1,
+            _hybrid_kv_cache_config(attention_block_size=2304),
+        )
+
+
+@requires_vllm
+def test_validate_rejects_nonpositive_interleave():
+    with pytest.raises(ValueError, match=">= 1"):
+        _import_validate_dcp_support()(_config(dcp_size=4, interleave=0), 1)
 
 
 @requires_vllm


### PR DESCRIPTION
## What this PR does / why we need it

Follow-up to #4679: make the multiprocess connector use vLLM's resolved KV-cache geometry for hybrid Mamba models under decode-context parallelism (DCP).

The connector previously derived its scheduler page from `cache_config.block_size * dcp_size`. That is the CLI/base attention block, not necessarily the physical block produced by vLLM's hybrid KV-cache manager. On GLM5Next with a base block of 256, vLLM resolves 2,304-token physical pages; DCP4 makes the sharded attention span 9,216 scheduler tokens while the replicated Mamba span remains 2,304. The safe connector chunk is their LCM: 9,216 tokens.

This PR:

- resolves attention and recurrent token spans from `KVCacheConfig` leaf specs;
- uses their LCM for scheduler and worker adapter geometry;
- validates Mamba scheduler budgets and CP interleave against the resolved blocks;
- permits non-trivial interleave because each rank's page is stored as an opaque, separately keyed byte object;
- namespaces cache identity by DCP size and interleave (`##lmcache-dcp-layout-v1-...`) so layouts with different token-to-slot mappings cannot collide;
- preserves legacy cache keys for DCP-disabled and interleave-1 configurations;
- logs the resolved geometry and warns when a pathological LCM would make caching ineffective; and
- documents the chunk-alignment and metrics-label implications.

Opaque per-rank pages make interleave safe without connector-side gather or deinterleave: the connector never interprets the page contents, and a hit requires every DCP shard. Safety therefore depends on fixed topology plus distinct cache identity, which the versioned namespace supplies.

## Testing

- focused DCP/Mamba module: `67 passed`
- adjacent MP connector, hybrid-group, DCP, multimodal-key, and layout suite: `141 passed`
- repeated after formatting: `141 passed`
- `pre-commit run --files` passed for all three changed files (SPDX, device guards, TimeoutError guard, isort, Ruff, Ruff format, codespell, mypy; C++/Rust hooks not applicable)

The production DCP4 configuration additionally resolved attention/Mamba spans of `9216/2304`, accepted chunk size `9216`, stored all four rank-sharded objects, restored aligned partial prefixes, and exercised DRAM-to-native-filesystem eviction and restart accounting.

Base: LMCache `dev` at `0c2a6801b7ad8ad714c40c44f727358dfc3a4261`.
