### PR TITLE
feat(mp): forward request configs

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -8,6 +8,45 @@ server.  Arguments are grouped by the config module that defines them.
    :local:
    :depth: 2
 
+Per-request LMCache configuration
+---------------------------------
+
+vLLM clients can attach request-scoped LMCache metadata through the top-level
+``kv_transfer_params`` field.  When vLLM uses ``LMCacheMPConnector``, entries
+whose keys start with ``lmcache.`` are forwarded with the request across the
+MP scheduler and worker IPC paths.  Other ``kv_transfer_params`` entries are
+reserved for the transfer layer and are not forwarded to LMCache.
+
+For example:
+
+.. code-block:: bash
+
+   curl -X POST http://localhost:8000/v1/completions \
+       -H "Content-Type: application/json" \
+       -d '{
+           "model": "Qwen/Qwen3-14B",
+           "prompt": "Explain KV cache reuse.",
+           "max_tokens": 32,
+           "kv_transfer_params": {
+               "lmcache.tag.tenant": "example-tenant",
+               "lmcache.ttl": 60
+           }
+       }'
+
+The connector carries these values on lookup, prefetch, store, retrieve, and
+lookup-lock cleanup operations so server-side features can inspect the same
+request metadata throughout the request lifecycle.
+
+.. important::
+
+   Forwarding a value does not by itself make the MP server act on it or make
+   it part of cache identity.  The current MP server treats request configs as
+   metadata.  Do not rely on ``lmcache.tag.*``, ``lmcache.ttl``,
+   ``lmcache.skip_save``, or another request config for isolation, expiration,
+   or cache-control behavior in MP mode unless the selected server-side
+   feature explicitly documents support for it.  The in-process
+   ``LMCacheConnectorV1`` may interpret these values differently.
+
 MP Server
 ---------
 

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -575,6 +575,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         request_ids = []
         ops = []
         cache_salts = []
+        request_configs_list = []
 
         for meta in metadata.requests:
             if meta.direction != "RETRIEVE":
@@ -582,6 +583,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             request_ids.append(meta.request_id)
             ops.append(meta.op)
             cache_salts.append(meta.cache_salt)
+            request_configs_list.append(meta.request_configs)
 
         if len(request_ids) == 0:
             return
@@ -589,7 +591,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         event = self.worker_adapter.create_recorded_event()
 
         self.worker_adapter.batched_submit_retrieve_requests(
-            request_ids, ops, event, cache_salts=cache_salts
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            request_configs_list=request_configs_list,
         )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -649,12 +655,14 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         request_ids = []
         ops = []
         cache_salts = []
+        request_configs_list = []
         for meta in metadata.requests:
             if meta.direction != "STORE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
             cache_salts.append(meta.cache_salt)
+            request_configs_list.append(meta.request_configs)
 
         if len(request_ids) == 0:
             if self.dispatcher is not None:
@@ -664,7 +672,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         event = self.worker_adapter.create_recorded_event()
 
         self.worker_adapter.batched_submit_store_requests(
-            request_ids, ops, event, cache_salts=cache_salts
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            request_configs_list=request_configs_list,
         )
         if self.dispatcher is not None:
             dispatch(self.dispatcher, "wait_for_save", event=event)
@@ -852,6 +864,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             request.request_id,
             token_ids=tracker.get_token_ids(),
             cache_salt=tracker.cache_salt,
+            request_configs=tracker.request_configs,
         )
 
         ret = self.scheduler_adapter.check_lookup_result(request.request_id)
@@ -907,6 +920,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             request.request_id,
             token_ids=list(request.all_token_ids),
             cache_salt=tracker.cache_salt,
+            request_configs=tracker.request_configs,
         )
 
     def update_state_after_alloc(
@@ -989,6 +1003,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                         end=free_end,
                         request_id=request.request_id,
                         cache_salt=tracker.cache_salt,
+                        request_configs=tracker.request_configs,
                     )
                     logger.debug(
                         "Free locks of tokens %d-%d since it is cached by vLLM.",

--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -9,8 +9,14 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 import zmq
 from lmcache import torch_dev, torch_device_type
-from lmcache.integration.vllm.utils import mla_enabled
-from lmcache.utils import check_interprocess_event_support, init_logger as lmcache_init_logger
+from lmcache.integration.vllm.utils import (
+    extract_request_configs_from_request,
+    mla_enabled,
+)
+from lmcache.utils import (
+    check_interprocess_event_support,
+    init_logger as lmcache_init_logger,
+)
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -202,9 +208,11 @@ class LMCacheMPRequestTracker:
 
     # Main state
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
+    request_configs: dict[str, Any] | None = None
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
+        self.request_configs = extract_request_configs_from_request(request)
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
         self.allocated_block_ids = []
@@ -277,6 +285,7 @@ class LMCacheMPRequestMetadata:
     request_id: str
     direction: Literal["STORE", "RETRIEVE"]
     op: LoadStoreOp
+    request_configs: dict[str, Any] | None = None
 
     @staticmethod
     def GetStoreMetadata(
@@ -343,6 +352,7 @@ class LMCacheMPRequestMetadata:
                 request_id=tracker.request_id,
                 direction="STORE",
                 op=op,
+                request_configs=tracker.request_configs,
             )
 
             # Update the request tracker
@@ -409,6 +419,7 @@ class LMCacheMPRequestMetadata:
                 request_id=tracker.request_id,
                 direction="RETRIEVE",
                 op=op,
+                request_configs=tracker.request_configs,
             )
             return ret
 
@@ -560,12 +571,14 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         request_ids = []
         ops = []
+        request_configs_list = []
 
         for meta in metadata.requests:
             if meta.direction != "RETRIEVE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
+            request_configs_list.append(meta.request_configs)
 
         if len(request_ids) == 0:
             return
@@ -575,7 +588,12 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             event = torch_dev.Event(interprocess=True)
             event.record()
 
-        self.worker_adapter.batched_submit_retrieve_requests(request_ids, ops, event)
+        self.worker_adapter.batched_submit_retrieve_requests(
+            request_ids,
+            ops,
+            event,
+            request_configs_list=request_configs_list,
+        )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         """
@@ -624,11 +642,13 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         request_ids = []
         ops = []
+        request_configs_list = []
         for meta in metadata.requests:
             if meta.direction != "STORE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
+            request_configs_list.append(meta.request_configs)
 
         if len(request_ids) == 0:
             return
@@ -638,7 +658,12 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             event = torch_dev.Event(interprocess=True)
             event.record()
 
-        self.worker_adapter.batched_submit_store_requests(request_ids, ops, event)
+        self.worker_adapter.batched_submit_store_requests(
+            request_ids,
+            ops,
+            event,
+            request_configs_list=request_configs_list,
+        )
 
     def get_finished(
         self, finished_req_ids: set[str]
@@ -740,6 +765,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         self.scheduler_adapter.maybe_submit_lookup_request(
             request.request_id,
             token_ids=list(request.all_token_ids),
+            request_configs=tracker.request_configs,
         )
 
         ret = self.scheduler_adapter.check_lookup_result(request.request_id)
@@ -838,6 +864,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                         start=0,
                         end=free_end,
                         request_id=request.request_id,
+                        request_configs=tracker.request_configs,
                     )
                     logger.debug(
                         "Free locks of tokens %d-%d since it is cached by vLLM.",

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 import zmq
 from lmcache import torch_dev, torch_device_type
-from lmcache.integration.vllm.utils import mla_only
+from lmcache.integration.vllm.utils import (
+    extract_request_configs_from_request,
+    mla_only,
+)
 from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.utils import check_interprocess_event_support
 
@@ -196,10 +199,12 @@ class LMCacheMPRequestTracker:
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
 
     cache_salt: str = ""
+    request_configs: dict[str, Any] | None = None
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
         self.cache_salt: str = request.cache_salt or ""
+        self.request_configs = extract_request_configs_from_request(request)
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
         self.allocated_block_ids = []
@@ -273,6 +278,7 @@ class LMCacheMPRequestMetadata:
     direction: Literal["STORE", "RETRIEVE"]
     op: LoadStoreOp
     cache_salt: str = ""
+    request_configs: dict[str, Any] | None = None
 
     @staticmethod
     def GetStoreMetadata(
@@ -340,6 +346,7 @@ class LMCacheMPRequestMetadata:
                 direction="STORE",
                 op=op,
                 cache_salt=tracker.cache_salt,
+                request_configs=tracker.request_configs,
             )
 
             # Update the request tracker
@@ -407,6 +414,7 @@ class LMCacheMPRequestMetadata:
                 direction="RETRIEVE",
                 op=op,
                 cache_salt=tracker.cache_salt,
+                request_configs=tracker.request_configs,
             )
             return ret
 
@@ -564,6 +572,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         request_ids = []
         ops = []
         cache_salts = []
+        request_configs_list = []
 
         for meta in metadata.requests:
             if meta.direction != "RETRIEVE":
@@ -571,6 +580,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             request_ids.append(meta.request_id)
             ops.append(meta.op)
             cache_salts.append(meta.cache_salt)
+            request_configs_list.append(meta.request_configs)
 
         if len(request_ids) == 0:
             return
@@ -580,7 +590,11 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             event.record()
 
         self.worker_adapter.batched_submit_retrieve_requests(
-            request_ids, ops, event, cache_salts=cache_salts
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            request_configs_list=request_configs_list,
         )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
@@ -635,12 +649,14 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         request_ids = []
         ops = []
         cache_salts = []
+        request_configs_list = []
         for meta in metadata.requests:
             if meta.direction != "STORE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
             cache_salts.append(meta.cache_salt)
+            request_configs_list.append(meta.request_configs)
 
         if len(request_ids) == 0:
             return
@@ -650,7 +666,11 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             event.record()
 
         self.worker_adapter.batched_submit_store_requests(
-            request_ids, ops, event, cache_salts=cache_salts
+            request_ids,
+            ops,
+            event,
+            cache_salts=cache_salts,
+            request_configs_list=request_configs_list,
         )
 
     def get_finished(
@@ -754,6 +774,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             request.request_id,
             token_ids=list(request.all_token_ids),
             cache_salt=tracker.cache_salt,
+            request_configs=tracker.request_configs,
         )
 
         ret = self.scheduler_adapter.check_lookup_result(request.request_id)
@@ -852,6 +873,8 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                         start=0,
                         end=free_end,
                         request_id=request.request_id,
+                        cache_salt=tracker.cache_salt,
+                        request_configs=tracker.request_configs,
                     )
                     logger.debug(
                         "Free locks of tokens %d-%d since it is cached by vLLM.",

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 import enum
 
 # Third Party
@@ -17,6 +17,7 @@ import torch
 from lmcache.integration.vllm.utils import (
     apply_mm_hashes_to_token_ids,
     extract_mm_features,
+    extract_request_configs_from_request,
 )
 from lmcache.integration.vllm.vllm_multi_process_adapter import LoadStoreOp
 from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
@@ -72,12 +73,14 @@ class LMCacheMPRequestTracker:
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
 
     cache_salt: str = ""
+    request_configs: dict[str, Any] | None = None
 
     mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
         self.cache_salt: str = request.cache_salt or ""
+        self.request_configs = extract_request_configs_from_request(request)
         self.all_token_ids = request.all_token_ids
         self.allocated_block_ids = {}
         self.num_stored_tokens = 0
@@ -179,6 +182,7 @@ class LMCacheMPRequestMetadata:
     direction: Literal["STORE", "RETRIEVE"]
     op: LoadStoreOp
     cache_salt: str = ""
+    request_configs: dict[str, Any] | None = None
 
     @staticmethod
     def GetStoreMetadata(
@@ -266,6 +270,7 @@ class LMCacheMPRequestMetadata:
                 direction="STORE",
                 op=op,
                 cache_salt=tracker.cache_salt,
+                request_configs=tracker.request_configs,
             )
 
             # Update the request tracker
@@ -342,6 +347,7 @@ class LMCacheMPRequestMetadata:
                 direction="RETRIEVE",
                 op=op,
                 cache_salt=tracker.cache_salt,
+                request_configs=tracker.request_configs,
             )
             return ret
 

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Optional, Tuple
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 import hashlib
 import os
 import string
@@ -116,6 +117,39 @@ def try_get_vllm_kv_cache_layout(
         logger.error("Could not query the KV cache layout from this vLLM version")
         return None
     return translate_vllm_kv_cache_layout(get_kv_cache_layout())
+
+
+def extract_request_configs_from_sampling_params(
+    sampling_params: object,
+) -> dict[str, Any] | None:
+    """Extract LMCache request configs from a vLLM sampling-params object.
+
+    Only ``lmcache.*`` entries from ``extra_args["kv_transfer_params"]`` are
+    forwarded. Other transfer params are transport-only metadata and must not
+    participate in LMCache key derivation.
+    """
+    extra_args = getattr(sampling_params, "extra_args", None)
+    if not isinstance(extra_args, Mapping):
+        return None
+    kv_transfer_params = extra_args.get("kv_transfer_params")
+    if not isinstance(kv_transfer_params, Mapping):
+        return None
+
+    request_configs = {
+        key: value
+        for key, value in kv_transfer_params.items()
+        if isinstance(key, str) and key.startswith("lmcache.")
+    }
+    return request_configs or None
+
+
+def extract_request_configs_from_request(
+    request: "Request",
+) -> dict[str, Any] | None:
+    """Extract LMCache request configs from a vLLM request object."""
+    return extract_request_configs_from_sampling_params(
+        getattr(request, "sampling_params", None)
+    )
 
 
 def lmcache_get_or_create_config() -> LMCacheEngineConfig:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -649,7 +649,9 @@ class LMCacheMPSchedulerAdapter:
         self._pending_lookups: set[str] = set()
         self._finished_lookup_results: dict[str, int] = {}
         self._per_server_hits: dict[str, dict[str, int]] = {}
-        self._lookup_params: dict[str, tuple[list[int], str]] = {}
+        self._lookup_params: dict[
+            str, tuple[list[int], str, dict[str, Any] | None]
+        ] = {}
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
@@ -742,6 +744,7 @@ class LMCacheMPSchedulerAdapter:
         request_id: str,
         token_ids: list[int],
         cache_salt: str = "",
+        request_configs: dict[str, Any] | None = None,
     ):
         """
         Submit a new lookup request to LMCache if there is no ongoing request.
@@ -756,6 +759,8 @@ class LMCacheMPSchedulerAdapter:
             token_ids: Token IDs to lookup from LMCache
             cache_salt: Per-user isolation salt. Requests with different
                 cache_salt values produce separate cache entries.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
 
         Returns:
             None
@@ -786,6 +791,7 @@ class LMCacheMPSchedulerAdapter:
             end=aligned_end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         ).no_worker_id_version()
 
         futures: dict[str, MessagingFuture[Any]] = {
@@ -811,7 +817,7 @@ class LMCacheMPSchedulerAdapter:
                 return
 
         self._pending_lookups.add(request_id)
-        self._lookup_params[request_id] = (token_ids, cache_salt)
+        self._lookup_params[request_id] = (token_ids, cache_salt, request_configs)
 
     def _free_inconsistent_lookup_locks(
         self,
@@ -831,7 +837,9 @@ class LMCacheMPSchedulerAdapter:
             per_server: Per-server hit chunk counts.
             min_chunks: Minimum hit chunk count across all servers.
         """
-        token_ids_l, cs = self._lookup_params.pop(request_id, (None, None))
+        token_ids_l, cs, request_configs = self._lookup_params.pop(
+            request_id, (None, None, None)
+        )
         if token_ids_l is not None:
             for url, hit_chunks in per_server.items():
                 if hit_chunks <= min_chunks:
@@ -845,6 +853,7 @@ class LMCacheMPSchedulerAdapter:
                     end=tail_end,
                     request_id=request_id,
                     cache_salt=cs or "",
+                    request_configs=request_configs,
                 ).no_worker_id_version()
                 send_lmcache_request(
                     self.mq_clients[url],
@@ -964,6 +973,7 @@ class LMCacheMPSchedulerAdapter:
         end: int,
         request_id: str,
         cache_salt: str = "",
+        request_configs: dict[str, Any] | None = None,
     ) -> None:
         """Release read locks acquired during lookup without a full retrieve.
 
@@ -984,6 +994,8 @@ class LMCacheMPSchedulerAdapter:
             end: End token index.
             request_id: The request ID.
             cache_salt: Per-user isolation salt.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
         """
         if not self.is_healthy:
             return
@@ -995,6 +1007,7 @@ class LMCacheMPSchedulerAdapter:
             end=end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         ).no_worker_id_version()
         for url in self._server_urls:
             send_lmcache_request(
@@ -1050,6 +1063,7 @@ class LMCacheMPSchedulerAdapter:
         end: int,
         request_id: str,
         cache_salt: str = "",
+        request_configs: dict[str, Any] | None = None,
     ) -> IPCCacheServerKey:
         """Convert token IDs to an IPC cache engine key.
 
@@ -1059,6 +1073,8 @@ class LMCacheMPSchedulerAdapter:
             end: End token index.
             request_id: The request ID.
             cache_salt: Per-user isolation salt.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
 
         Returns:
             IPCCacheServerKey: The constructed key.
@@ -1075,6 +1091,7 @@ class LMCacheMPSchedulerAdapter:
             end=end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )
 
     def update_pending_store_count(self, req_id: str, count: int) -> bool:
@@ -1507,6 +1524,7 @@ class LMCacheMPWorkerAdapter:
         op: LoadStoreOp,
         event: _IpcEvent,
         cache_salt: str = "",
+        request_configs: dict[str, Any] | None = None,
     ):
         """
         Submit a KV cache store request to LMCache
@@ -1517,6 +1535,8 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
             cache_salt: Per-user isolation salt.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
         """
         self._ensure_heartbeat_started()
 
@@ -1533,6 +1553,7 @@ class LMCacheMPWorkerAdapter:
             op.end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )
         if self.transfer_ctx is None:
             raise RuntimeError(
@@ -1558,6 +1579,7 @@ class LMCacheMPWorkerAdapter:
         op: LoadStoreOp,
         event: _IpcEvent,
         cache_salt: str = "",
+        request_configs: dict[str, Any] | None = None,
     ) -> None:
         """
         Submit a KV cache retrieve request to LMCache
@@ -1572,6 +1594,8 @@ class LMCacheMPWorkerAdapter:
             event: The CUDA event that is recorded after the current
                 model inference step
             cache_salt: Per-user isolation salt.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
         """
         self._ensure_heartbeat_started()
 
@@ -1587,6 +1611,7 @@ class LMCacheMPWorkerAdapter:
             op.end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )
         if self.transfer_ctx is None:
             raise RuntimeError(
@@ -1613,6 +1638,7 @@ class LMCacheMPWorkerAdapter:
         ops: list[LoadStoreOp],
         event: _IpcEvent,
         cache_salts: list[str] | None = None,
+        request_configs_list: list[dict[str, Any] | None] | None = None,
     ):
         """
         Submit a batched store request to LMCache
@@ -1626,11 +1652,33 @@ class LMCacheMPWorkerAdapter:
             cache_salts: Per-user isolation salts, one per request. If None,
                 all requests use cache_salt="". The list length should be the same as
                 request_ids.
+            request_configs_list: Optional LMCache request configs, one per
+                request.
         """
         if cache_salts is None:
             cache_salts = [""] * len(request_ids)
-        for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
-            self.submit_store_request(request_id, op, event, cache_salt=salt)
+        if request_configs_list is None:
+            request_configs_list = [None] * len(request_ids)
+        if not (
+            len(request_ids)
+            == len(ops)
+            == len(cache_salts)
+            == len(request_configs_list)
+        ):
+            raise ValueError(
+                "request_ids, ops, cache_salts, and request_configs_list "
+                "must have the same length"
+            )
+        for request_id, op, salt, request_configs in zip(
+            request_ids, ops, cache_salts, request_configs_list, strict=True
+        ):
+            self.submit_store_request(
+                request_id,
+                op,
+                event,
+                cache_salt=salt,
+                request_configs=request_configs,
+            )
 
     @_lmcache_nvtx_annotate
     def batched_submit_retrieve_requests(
@@ -1639,6 +1687,7 @@ class LMCacheMPWorkerAdapter:
         ops: list[LoadStoreOp],
         event: _IpcEvent,
         cache_salts: list[str] | None = None,
+        request_configs_list: list[dict[str, Any] | None] | None = None,
     ):
         """
         Submit a batched retrieve request to LMCache
@@ -1652,11 +1701,33 @@ class LMCacheMPWorkerAdapter:
             cache_salts: Per-user isolation salts, one per request. If None,
                 all requests use cache_salt="". The list length should be same as
                 request_ids.
+            request_configs_list: Optional LMCache request configs, one per
+                request.
         """
         if cache_salts is None:
             cache_salts = [""] * len(request_ids)
-        for request_id, op, salt in zip(request_ids, ops, cache_salts, strict=False):
-            self.submit_retrieve_request(request_id, op, event, cache_salt=salt)
+        if request_configs_list is None:
+            request_configs_list = [None] * len(request_ids)
+        if not (
+            len(request_ids)
+            == len(ops)
+            == len(cache_salts)
+            == len(request_configs_list)
+        ):
+            raise ValueError(
+                "request_ids, ops, cache_salts, and request_configs_list "
+                "must have the same length"
+            )
+        for request_id, op, salt, request_configs in zip(
+            request_ids, ops, cache_salts, request_configs_list, strict=True
+        ):
+            self.submit_retrieve_request(
+                request_id,
+                op,
+                event,
+                cache_salt=salt,
+                request_configs=request_configs,
+            )
 
     def _process_finished_stores(
         self,
@@ -2031,6 +2102,7 @@ class LMCacheMPWorkerAdapter:
         end: int,
         request_id: str,
         cache_salt: str = "",
+        request_configs: dict[str, Any] | None = None,
     ) -> IPCCacheServerKey:
         """Convert token IDs to an IPC cache engine key.
 
@@ -2040,6 +2112,8 @@ class LMCacheMPWorkerAdapter:
             end: End token index.
             request_id: The request ID.
             cache_salt: Per-user isolation salt.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
 
         Returns:
             IPCCacheServerKey: The constructed key.
@@ -2054,4 +2128,5 @@ class LMCacheMPWorkerAdapter:
             end=end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -34,6 +34,7 @@ from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
     extract_mm_features,
+    extract_request_configs_from_sampling_params,
     lmcache_get_or_create_config,
 )
 from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
@@ -96,15 +97,7 @@ tmp_disagg_tracker: dict[str, DisaggSpec] = {}
 
 
 def extract_request_configs(sampling_params: SamplingParams) -> Optional[dict]:
-    request_configs = None
-    if sampling_params and sampling_params.extra_args is not None:
-        if kv_transfer_params := sampling_params.extra_args.get("kv_transfer_params"):
-            for k, v in kv_transfer_params.items():
-                if k.startswith("lmcache."):
-                    if request_configs is None:
-                        request_configs = {}
-                    request_configs[k] = v
-    return request_configs
+    return extract_request_configs_from_sampling_params(sampling_params)
 
 
 @dataclass

--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -278,6 +278,7 @@ class LMCacheSDKContext:
         request_id: str,
         token_ids: list[int],
         cache_salt: str = "",
+        request_configs: dict[str, object] | None = None,
     ) -> None:
         """Submit a LOOKUP request for the given token IDs.
         Modification from lmcache/integration/vllm/vllm_multi_process_adapter.py.
@@ -288,6 +289,8 @@ class LMCacheSDKContext:
             request_id: Unique ID for this lookup request.
             token_ids: List of token IDs to look up.
             cache_salt: Optional cache salt string for the lookup.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
         """
         if request_id in self._pending_lookups:
             # Skip if there is already a lookup request
@@ -301,6 +304,7 @@ class LMCacheSDKContext:
             end=aligned_end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         ).no_worker_id_version()
 
         future = self._mq_client.submit_request(
@@ -386,12 +390,15 @@ class LMCacheSDKContext:
         self,
         tokens: Sequence[int],
         cache_salt: str = "",
+        request_configs: dict[str, object] | None = None,
     ) -> torch.Tensor | None:
         """Retrieve KV cache tensors for the given token IDs.
 
         Args:
             tokens: The list of token IDs to retrieve KV cache for.
             cache_salt: Optional cache salt string for the lookup.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
 
         Returns:
             A contiguous CPU tensor containing the retrieved KV cache for
@@ -420,6 +427,7 @@ class LMCacheSDKContext:
             request_id,
             token_ids=list(tokens[:total_tokens]),
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )
 
         start_time = time.time()
@@ -452,6 +460,7 @@ class LMCacheSDKContext:
             end=num_prefetched_tokens,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
             worker_id=0,
         )
         try:
@@ -464,6 +473,7 @@ class LMCacheSDKContext:
         kv: torch.Tensor,
         tokens: Sequence[int],
         cache_salt: str = "",
+        request_configs: dict[str, object] | None = None,
     ) -> bool:
         """Store KV cache tensors for the given token IDs.
 
@@ -471,6 +481,8 @@ class LMCacheSDKContext:
             kv: The KV cache tensor to store, of shape [2, L, T, D].
             tokens: The list of token IDs corresponding to the KV cache tensor.
             cache_salt: Optional cache salt string for the store.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
 
         Returns:
             True if the store operation is successful, False otherwise.
@@ -493,6 +505,7 @@ class LMCacheSDKContext:
             end=total_tokens,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
             worker_id=0,
         )
 
@@ -510,6 +523,7 @@ class LMCacheSDKContext:
         end: int,
         request_id: str,
         cache_salt: str = "",
+        request_configs: dict[str, object] | None = None,
         worker_id: int | None = None,
     ) -> IPCCacheServerKey:
         """Convert token IDs to an IPC cache engine key.
@@ -520,6 +534,8 @@ class LMCacheSDKContext:
             end: End token index.
             request_id: The request ID.
             cache_salt: Per-user isolation salt.
+            request_configs: Optional LMCache request configs to include in
+                the IPC key.
             worker_id: Optional worker ID for the key.
                 If None, the key will be created without a worker ID (for lookups).
 
@@ -536,4 +552,5 @@ class LMCacheSDKContext:
             end=end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -60,6 +60,10 @@ class IPCCacheServerKey:
     # ObjectKey.cache_salt). Validated in __post_init__.
     cache_salt: str = ""
 
+    # Request-scoped LMCache configuration passed across the IPC boundary.
+    # It is metadata, not part of cache identity.
+    request_configs: dict[str, Any] | None = field(default=None, compare=False)
+
     # Number of workers that retrieve this key's object; the server reserves
     # that many read locks (see ``require_num_kv_readers``). 0 = not sent;
     # lookups reject it.
@@ -95,6 +99,7 @@ class IPCCacheServerKey:
         request_id: str = "",
         cache_salt: str = "",
         num_kv_readers: int = 1,
+        request_configs: dict[str, Any] | None = None,
     ) -> "IPCCacheServerKey":
         """Create a key from token ids. Only used by the tests."""
         return cls(
@@ -107,6 +112,7 @@ class IPCCacheServerKey:
             end=end,
             request_id=request_id,
             cache_salt=cache_salt,
+            request_configs=request_configs,
         )
 
     def require_num_kv_readers(self) -> int:
@@ -138,6 +144,7 @@ class IPCCacheServerKey:
             end=self.end,
             request_id=self.request_id,
             cache_salt=self.cache_salt,
+            request_configs=self.request_configs,
         )
 
 

--- a/tests/v1/multiprocess/test_custom_types.py
+++ b/tests/v1/multiprocess/test_custom_types.py
@@ -70,6 +70,40 @@ def test_ipc_cache_engine_key_serialization_with_cache_salt():
     assert decoded_key.cache_salt == "alice"
 
 
+def test_ipc_cache_server_key_roundtrip_preserves_request_configs():
+    """Request configuration survives IPC serialization but is not identity."""
+    original_key = IPCCacheServerKey.from_token_ids(
+        model_name="test_model",
+        world_size=4,
+        worker_id=1,
+        token_ids=list(range(256)),
+        start=0,
+        end=256,
+        request_id="test_request",
+        request_configs={"lmcache.skip_save": True, "lmcache.priority": "high"},
+    )
+
+    encoded = msgspec.msgpack.encode(original_key)
+    decoded_key = msgspec.msgpack.decode(encoded, type=IPCCacheServerKey)
+    key_without_configs = IPCCacheServerKey.from_token_ids(
+        model_name="test_model",
+        world_size=4,
+        worker_id=1,
+        token_ids=list(range(256)),
+        start=0,
+        end=256,
+        request_id="test_request",
+    )
+
+    assert decoded_key == original_key
+    assert decoded_key.request_configs == original_key.request_configs
+    assert original_key == key_without_configs
+    assert decoded_key.no_worker_id_version().request_configs == {
+        "lmcache.skip_save": True,
+        "lmcache.priority": "high",
+    }
+
+
 @pytest.mark.cuda
 @pytest.mark.skipif(
     not (torch_dev.is_available() and torch_device_type == "cuda"),

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -320,6 +320,7 @@ def test_adapter_free_lookup_locks_sends_request():
         start=0,
         end=512,
         request_id="req-1",
+        request_configs={"lmcache.skip_save": True},
     )
 
     mock_client.submit_request.assert_called_once()
@@ -337,6 +338,7 @@ def test_adapter_free_lookup_locks_sends_request():
     assert key.worker_id is None
     assert key.model_name == "test_model"
     assert key.request_id == "req-1"
+    assert key.request_configs == {"lmcache.skip_save": True}
     assert payloads[1] == 1  # tp_size
 
 
@@ -374,7 +376,11 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
 
     # Submit lookup – patch heartbeat to avoid spawning a real thread
     with patch.object(adapter, "_ensure_heartbeat_started"):
-        adapter.maybe_submit_lookup_request("req-1", token_ids)
+        adapter.maybe_submit_lookup_request(
+            "req-1",
+            token_ids,
+            request_configs={"lmcache.skip_save": True},
+        )
     lookup_call = mock_client.submit_request.call_args
     lookup_payloads = lookup_call[0][1]
     lookup_key = lookup_payloads[0]
@@ -389,6 +395,7 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
         start=0,
         end=aligned_end,
         request_id="req-1",
+        request_configs={"lmcache.skip_save": True},
     )
     free_call = mock_client.submit_request.call_args
     free_payloads = free_call[0][1]
@@ -405,6 +412,7 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     assert lookup_key.end == free_key.end
     assert lookup_key.request_id == free_key.request_id
     assert lookup_key.token_ids == free_key.token_ids
+    assert lookup_key.request_configs == free_key.request_configs
 
 
 def test_server_free_lookup_locks_honors_the_session_lock_model():

--- a/tests/v1/test_mp_connector_mm_keys.py
+++ b/tests/v1/test_mp_connector_mm_keys.py
@@ -10,6 +10,8 @@ interfaces of ``lmcache_mp_connector``.
 
 # Standard
 from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 # Third Party
 import pytest
@@ -17,9 +19,15 @@ import pytest
 pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
 
 # Third Party
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (  # noqa: E402
+    KVConnectorRole,
+)
 from vllm.v1.utils import ConstantList  # noqa: E402
 
 # First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+)
 from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
     LMCacheMPRequestMetadata,
     LMCacheMPRequestState,
@@ -42,6 +50,11 @@ class _FakeMMFeature:
     mm_position: _FakePlaceholder
 
 
+@dataclass
+class _FakeSamplingParams:
+    extra_args: dict[str, object] | None = None
+
+
 class _FakeRequest:
     """Duck-typed vLLM Request carrying only what the tracker reads."""
 
@@ -50,13 +63,18 @@ class _FakeRequest:
         prompt_token_ids: list[int],
         mm_features: list[_FakeMMFeature] | None = None,
         cache_salt: str = "",
+        sampling_params_extra_args: dict[str, object] | None = None,
     ):
         self.request_id = "req-0"
+        self.resumable = False
         self.cache_salt = cache_salt
         self.prompt_token_ids = list(prompt_token_ids)
         self._live_token_ids = list(prompt_token_ids)
         self.all_token_ids = ConstantList(self._live_token_ids)
         self.mm_features = mm_features or []
+        self.sampling_params = _FakeSamplingParams(
+            extra_args=sampling_params_extra_args
+        )
 
     def append_decode_token(self, token_id: int):
         """Simulate vLLM appending a decode token to the live token list."""
@@ -117,6 +135,52 @@ def test_decode_tokens_appended_unchanged():
     assert tracker.get_token_ids() == [1, 2, fill, fill, 3, 500, 501]
 
 
+def test_tracker_extracts_request_configs():
+    tracker = LMCacheMPRequestTracker(
+        _FakeRequest(
+            [1, 2, 3, 4],
+            sampling_params_extra_args={
+                "kv_transfer_params": {
+                    "lmcache.skip_save": True,
+                    "lmcache.priority": "high",
+                    "temperature": 0.8,
+                }
+            },
+        )
+    )
+
+    assert tracker.request_configs == {
+        "lmcache.skip_save": True,
+        "lmcache.priority": "high",
+    }
+
+
+def test_eager_prefetch_forwards_request_configs():
+    request = _FakeRequest(
+        [1, 2, 3],
+        sampling_params_extra_args={
+            "kv_transfer_params": {"lmcache.skip_save": True},
+        },
+    )
+    tracker = LMCacheMPRequestTracker(request)
+    scheduler_adapter = MagicMock()
+    connector = SimpleNamespace(
+        role=KVConnectorRole.SCHEDULER,
+        _eager_prefetch=True,
+        scheduler_adapter=scheduler_adapter,
+        _get_or_create_request_tracker=MagicMock(return_value=tracker),
+    )
+
+    LMCacheMPConnector.on_new_request(connector, request)
+
+    scheduler_adapter.maybe_submit_lookup_request.assert_called_once_with(
+        request.request_id,
+        token_ids=[1, 2, 3],
+        cache_salt="",
+        request_configs={"lmcache.skip_save": True},
+    )
+
+
 def _prepare_storable_tracker(request: _FakeRequest) -> LMCacheMPRequestTracker:
     """Give the tracker enough scheduled tokens and blocks to emit one
     store op covering the whole 8-token prompt (chunk size 4)."""
@@ -140,6 +204,24 @@ def test_store_metadata_uses_mm_adjusted_token_ids():
     assert metadata.op.token_ids == [1, 2, fill, fill, 3, 4, 5, 6]
     assert metadata.op.start == 0
     assert metadata.op.end == 8
+
+
+def test_store_metadata_preserves_request_configs():
+    tracker = _prepare_storable_tracker(
+        _FakeRequest(
+            list(range(8)),
+            sampling_params_extra_args={
+                "kv_transfer_params": {"lmcache.skip_save": True}
+            },
+        )
+    )
+
+    metadata = LMCacheMPRequestMetadata.GetStoreMetadata(
+        tracker, lmcache_tokens_per_chunk=4, group_tokens_per_block=[4]
+    )
+
+    assert metadata is not None
+    assert metadata.request_configs == {"lmcache.skip_save": True}
 
 
 def test_retrieve_metadata_uses_mm_adjusted_token_ids():

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -248,10 +248,18 @@ def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
     adapter.transfer_ctx = transfer_ctx
     op = LoadStoreOp(token_ids=[1, 2, 3, 4], block_ids=[[0]], start=0, end=4)
 
-    adapter.submit_store_request("req-1", op, event=MagicMock())
+    adapter.submit_store_request(
+        "req-1",
+        op,
+        event=MagicMock(),
+        request_configs={"lmcache.skip_save": True},
+    )
 
     assert transfer_ctx.submit_store.called
     assert transfer_ctx.submit_store.call_args.kwargs == {}
+    assert transfer_ctx.submit_store.call_args.args[1].request_configs == {
+        "lmcache.skip_save": True
+    }
     assert transfer_ctx.submit_store.call_args.args[4] == [[0]]
     assert adapter.store_futures["req-1"] is fake_future
 
@@ -306,12 +314,42 @@ def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatc
         skip_first_n_tokens=1,
     )
 
-    adapter.submit_retrieve_request("req-1", op, event=MagicMock())
+    adapter.submit_retrieve_request(
+        "req-1",
+        op,
+        event=MagicMock(),
+        request_configs={"lmcache.skip_save": True},
+    )
 
     assert transfer_ctx.submit_retrieve.called
     assert transfer_ctx.submit_retrieve.call_args.kwargs == {"skip_first_n_tokens": 1}
+    assert transfer_ctx.submit_retrieve.call_args.args[1].request_configs == {
+        "lmcache.skip_save": True
+    }
     assert transfer_ctx.submit_retrieve.call_args.args[4] == [[0]]
     assert adapter.retrieve_futures["req-1"] == (fake_future, [0])
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["batched_submit_store_requests", "batched_submit_retrieve_requests"],
+)
+def test_batched_submit_rejects_mismatched_parallel_lists(
+    fake_adapter, method_name: str
+) -> None:
+    adapter, _send_mock, _future = fake_adapter
+    method = getattr(adapter, method_name)
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        method(["req-1"], [], MagicMock())
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        method(
+            ["req-1"],
+            [_op([[0]])],
+            MagicMock(),
+            request_configs_list=[],
+        )
 
 
 def test_load_store_op_accepts_per_group_block_ids():


### PR DESCRIPTION
## Summary

Forwards `lmcache.*` request configs from vLLM sampling params to multiprocess scheduler and worker IPC keys. This covers lookup, eager prefetch, store/retrieve, lock release, legacy connector paths, and `LMCacheSDKContext`.

Request configs are carried as metadata only.

