### PR TITLE
mp: warn when --shm-name is silently disabled by lazy L1 allocation

### DIFF
--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -375,6 +375,8 @@ def add_mp_server_args(
         help="SHM segment name for engine-driven KV transfer. "
         'Default "" (not specified): disable SHM. '
         "Set to a name to create and use that specific SHM segment. "
+        "Requires --no-l1-use-lazy: lazy L1 allocation cannot back a "
+        "named SHM segment, so SHM stays disabled while lazy is on. "
         "(Only use this for engine_driven transfer mode, see "
         "`--supported-transfer-mode`.) ",
     )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -372,7 +372,21 @@ def run_cache_server(
         mem_cfg = storage_manager_config.l1_manager_config.memory_config
         if mp_config.shm_name is not None:
             mem_cfg.shm_name = mp_config.shm_name
-        if mem_cfg.shm_name and sys.platform.startswith("linux"):
+        if mem_cfg.shm_name and (mem_cfg.use_lazy or mem_cfg.devdax_path):
+            # _compute_shm_pool_info advertises an empty pool for these
+            # combinations; warn here where the operator's explicit
+            # --shm-name intent is still visible.
+            logger.warning(
+                "--shm-name %r is set but SHM transfer is disabled: %s. "
+                "Engine-driven workers will fall back to pickle transfers.",
+                mem_cfg.shm_name,
+                "lazy L1 allocation cannot back a named SHM segment "
+                "(--l1-use-lazy defaults to on; pass --no-l1-use-lazy)"
+                if mem_cfg.use_lazy
+                else "a devdax-backed L1 cannot back a named SHM segment "
+                "(unset --l1-devdax-path)",
+            )
+        elif mem_cfg.shm_name and sys.platform.startswith("linux"):
             logger.info("Checking if shm capacity is larger than L1 request")
             try:
                 free_bytes = shutil.disk_usage("/dev/shm").free


### PR DESCRIPTION
## Problem

Starting an MP server with `--supported-transfer-mode auto --shm-name bench_pool`
(and otherwise default flags) does **not** enable SHM transfers, and nothing in
the logs says so:

1. `--l1-use-lazy` defaults to on; a lazy L1 pool cannot back a named POSIX SHM
   segment, so `_compute_shm_pool_info` silently advertises an empty pool.
2. Startup still logs `Checking if shm capacity is larger than L1 request`,
   which suggests SHM is active.
3. At registration the server picks `Using pickle non-GPU transfer strategy`.

An engine-driven CPU client (e.g. `lmcache bench server --mode cpu
--transfer-mode engine_driven`) then commits empty payloads: every STORE hangs
for the full 10s RPC timeout while the server raises
`EOFError: Ran out of input` in `PickleTransferStrategy.commit_store`.
Diagnosing this requires reading three modules.

## Changes

- `server.py`: at the `--shm-name` apply site, warn when lazy L1 (or a devdax
  arena) disables SHM, naming the cause and the remedy; gate the `/dev/shm`
  capacity check behind the same condition so the "Checking..." log only
  appears when SHM will actually engage.
- `config.py`: document the `--no-l1-use-lazy` requirement in `--shm-name`'s
  help text (mirroring how `--l1-devdax-path` already documents its
  constraints).

Log-only + help-text change; no behavior change for working configurations.
The warning is emitted where the operator's explicit `--shm-name` is visible,
so embedded configs using the dataclass default segment name are unaffected.

## Before / After

Before (misleading):
    INFO: Checking if shm capacity is larger than L1 request
    ...
    INFO: Using pickle non-GPU transfer strategy

After:
    WARNING: --shm-name 'bench_pool' is set but SHM transfer is disabled:
    lazy L1 allocation cannot back a named SHM segment (--l1-use-lazy
    defaults to on; pass --no-l1-use-lazy). Engine-driven workers will
    fall back to pickle transfers.

## Testing

- `pre-commit run --all-files`
- Manual matrix on Linux:
  - `--shm-name bench_pool` (lazy default): warning appears at startup, no
    capacity-check log; bench falls back to pickle as before.
  - `--shm-name bench_pool --no-l1-use-lazy`: capacity check runs,
    registration logs `Using shm non-GPU transfer strategy`, bench
    STORE/RETRIEVE succeed with matching cold/warm checksums.

## Follow-ups (out of scope)

- `PickleTransferStrategy.commit_store` crashes with `EOFError` on an empty
  commit payload (the SHM-mode wire contract) instead of failing cleanly.
- `mq.py` blocking handlers swallow exceptions without replying, leaving
  clients to hit their full RPC timeout.