### PR TITLE
ci: use MUSA naming for smoke test pipeline

### DIFF
--- a/.buildkite/k3_tests/mthread/pipeline.yml
+++ b/.buildkite/k3_tests/mthread/pipeline.yml
@@ -1,9 +1,0 @@
-# MooreThreads smoke test.
-# Minimal validation for pipeline upload and queue routing.
-
-steps:
-  - label: ":wave: MooreThreads Hello"
-    command: echo "hello from the mthread pipeline"
-    timeout_in_minutes: 5
-    agents:
-      queue: "MooreThreads"

--- a/.buildkite/k3_tests/musa/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/musa/BK_WEB_SETUP.md
@@ -8,7 +8,7 @@
 - Skip queued / cancel running branch builds: Yes
 
 This pipeline is intentionally minimal. It validates that the dedicated
-`MUSA` queue, upload wrapper, and repo-hosted pipeline wiring are all
+`MooreThreads` queue, upload wrapper, and repo-hosted pipeline wiring are all
 working by running a single hello step.
 
 ### Trigger strategy
@@ -36,19 +36,19 @@ Steps editor:
 
 ```yaml
 agents:
-  queue: "MUSA"
+  queue: "MooreThreads"
 
 steps:
 - label: ":pipeline: Upload pipeline"
   command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/musa/pipeline.yml
 ```
 
-Keep the Buildkite runner / queue assignment aligned with `MUSA`; this
-repository change only updates the repo-side files.
+Keep the existing `MooreThreads` Buildkite runner / queue assignment; this
+repository change only updates the repo-side files and pipeline naming.
 
 ## What this pipeline does
 
-- Routes the upload step through the `MUSA` queue
+- Routes the upload step through the `MooreThreads` queue
 - Reuses the shared path filter in `common_scripts/upload-pipeline.sh`
 - Uploads `.buildkite/k3_tests/musa/pipeline.yml`
 - Runs a single hello smoke test on the MUSA agent

--- a/.buildkite/k3_tests/musa/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/musa/BK_WEB_SETUP.md
@@ -1,22 +1,22 @@
-# Buildkite Web UI Setup: MooreThreads Smoke Test
+# Buildkite Web UI Setup: MUSA Smoke Test
 
 **Steps editor**: paste the contents of `buildkite-pipeline.yml`.
 
 **GitHub trigger settings**:
-- Filter: `build.pull_request.labels includes "mthread" || build.pull_request.base_branch == "mbl/mthread-ci-test-dev"`
+- Filter: `build.pull_request.labels includes "musa" || build.pull_request.base_branch == "mbl/musa-ci-test-dev"`
 - Rebuild on PR label change: Yes
 - Skip queued / cancel running branch builds: Yes
 
 This pipeline is intentionally minimal. It validates that the dedicated
-`MooreThreads` queue, upload wrapper, and repo-hosted pipeline wiring are all
+`MUSA` queue, upload wrapper, and repo-hosted pipeline wiring are all
 working by running a single hello step.
 
 ### Trigger strategy
 
 | Condition | Result |
 |-----------|--------|
-| PR label includes `mthread` | upload the MooreThreads pipeline |
-| PR base branch is `mbl/mthread-ci-test-dev` | upload the MooreThreads pipeline |
+| PR label includes `musa` | upload the MUSA pipeline |
+| PR base branch is `mbl/musa-ci-test-dev` | upload the MUSA pipeline |
 | any docs/asset-only change | path filter skips upload |
 | any change under `.buildkite/` | path filter forces upload |
 
@@ -36,19 +36,19 @@ Steps editor:
 
 ```yaml
 agents:
-  queue: "MooreThreads"
+  queue: "MUSA"
 
 steps:
 - label: ":pipeline: Upload pipeline"
-  command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/mthread/pipeline.yml
+  command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/musa/pipeline.yml
 ```
 
-Keep the existing MooreThreads runner / queue assignment in the Buildkite
-pipeline configuration; this repository change only adds the repo-side files.
+Keep the Buildkite runner / queue assignment aligned with `MUSA`; this
+repository change only updates the repo-side files.
 
 ## What this pipeline does
 
-- Routes the upload step through the `MooreThreads` queue
+- Routes the upload step through the `MUSA` queue
 - Reuses the shared path filter in `common_scripts/upload-pipeline.sh`
-- Uploads `.buildkite/k3_tests/mthread/pipeline.yml`
-- Runs a single hello smoke test on the MooreThreads agent
+- Uploads `.buildkite/k3_tests/musa/pipeline.yml`
+- Runs a single hello smoke test on the MUSA agent

--- a/.buildkite/k3_tests/musa/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/musa/buildkite-pipeline.yml
@@ -1,7 +1,7 @@
 # Paste this into the Buildkite pipeline's "Steps" editor.
 # It uploads the real pipeline definition from the repo.
 agents:
-  queue: "MUSA"
+  queue: "MooreThreads"
 
 steps:
 - label: ":pipeline: Upload pipeline"

--- a/.buildkite/k3_tests/musa/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/musa/buildkite-pipeline.yml
@@ -1,8 +1,8 @@
 # Paste this into the Buildkite pipeline's "Steps" editor.
 # It uploads the real pipeline definition from the repo.
 agents:
-  queue: "MooreThreads"
+  queue: "MUSA"
 
 steps:
 - label: ":pipeline: Upload pipeline"
-  command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/mthread/pipeline.yml
+  command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/musa/pipeline.yml

--- a/.buildkite/k3_tests/musa/pipeline.yml
+++ b/.buildkite/k3_tests/musa/pipeline.yml
@@ -6,4 +6,4 @@ steps:
     command: echo "hello from the MUSA pipeline"
     timeout_in_minutes: 5
     agents:
-      queue: "MUSA"
+      queue: "MooreThreads"

--- a/.buildkite/k3_tests/musa/pipeline.yml
+++ b/.buildkite/k3_tests/musa/pipeline.yml
@@ -1,0 +1,9 @@
+# MUSA smoke test.
+# Minimal validation for pipeline upload and queue routing.
+
+steps:
+  - label: ":wave: MUSA Hello"
+    command: echo "hello from the MUSA pipeline"
+    timeout_in_minutes: 5
+    agents:
+      queue: "MUSA"


### PR DESCRIPTION
## Summary

- rename `.buildkite/k3_tests/mthread` to `.buildkite/k3_tests/musa`
- replace the `mthread` trigger label and temporary base branch with `musa` naming
- update the pipeline labels and commands to use `MUSA` naming
- keep the existing `MooreThreads` Buildkite agent queue unchanged
- update the Buildkite Web UI setup instructions accordingly

## Validation

- parsed both pipeline YAML files with PyYAML and verified the queue remains `MooreThreads`
- verified `.buildkite/` changes force the shared path filter to run the pipeline
- `SKIP=rust-fmt,rust-clippy python3 -m pre_commit run --all-files`
- `git diff --check`

## Buildkite follow-up

Update the Buildkite Web UI trigger to use the `musa` PR label/filter, and rename the external pipeline slug/display name if applicable. No agent queue rename is required.

Follow-up to #4775.