### PR TITLE
perf(vllm/mp): make block allocation reports optional

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -703,6 +703,13 @@ All connector-level options are passed through
        allowing L2-to-L1 KV staging to overlap with scheduler queue wait.
        Resumable requests are skipped because their token IDs may be incomplete
        at enqueue time.
+   * - ``lmcache.mp.report_block_allocations``
+     - ``true``
+     - Publish per-step GPU block allocation records for L0 observability.
+       Set to ``false`` to skip scheduler-thread record construction and the
+       downstream serialization and ZMQ sends. L0 block-allocation logs and
+       metrics are then unavailable; cache lookup and transfer behavior is
+       unchanged.
    * - ``lmcache.mp.lazy_offload``
      - ``false``
      - Defer store operations and submit finished requests in FIFO batches.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -289,6 +289,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
       heartbeat pings.
     - lmcache.mp.eager_prefetch: submit the LMCache lookup when a request
       enters vLLM's waiting queue. Disabled by default.
+    - lmcache.mp.report_block_allocations: publish per-step GPU block allocation
+      records for L0 observability. Enabled by default.
     """
 
     def __init__(
@@ -308,6 +310,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         self._eager_prefetch: bool = bool(
             vllm_config.kv_transfer_config.get_from_extra_config(
                 "lmcache.mp.eager_prefetch", False
+            )
+        )
+        self._report_block_allocations_enabled: bool = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.report_block_allocations", True
             )
         )
 
@@ -1307,6 +1314,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         For cached requests: only newly appended block_ids and token_ids.
         The L0 allocation telemetry is flat today, so HMA reports engine group 0.
         """
+        if not self._report_block_allocations_enabled:
+            return
+
         records: list[RequestAllocationRecord] = []
 
         # New requests: send all tokens covering all allocated blocks so

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -542,6 +542,53 @@ def test_failed_full_retrieve_is_recomputed_instead_of_retried_remotely() -> Non
     assert tracker.state == LMCacheMPRequestState.READY
 
 
+def test_disabled_block_allocation_reports_skip_scheduler_output() -> None:
+    """Disabling L0 allocation telemetry avoids all per-step record work."""
+    pytest.importorskip("vllm")
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector._report_block_allocations_enabled = False
+    connector.scheduler_adapter = MagicMock(name="scheduler_adapter")
+
+    # ``object()`` has none of SchedulerOutput's fields, so this call proves
+    # the disabled path returns before traversing requests or token lists.
+    connector._report_block_allocation_deltas(object())  # type: ignore[arg-type]
+
+    connector.scheduler_adapter.report_block_allocations.assert_not_called()
+
+
+def test_enabled_block_allocation_reports_preserve_existing_records() -> None:
+    """The default path still reports the same block and token payload."""
+    pytest.importorskip("vllm")
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector._report_block_allocations_enabled = True
+    connector._group_tokens_per_block = {0: 4}
+    connector.scheduler_adapter = MagicMock(name="scheduler_adapter")
+    tracker = MagicMock(name="tracker")
+    tracker.allocated_block_ids = {0: [7, 8]}
+    tracker.get_token_ids.return_value = list(range(8))
+    connector.request_trackers = {"req-1": tracker}
+
+    scheduler_output = MagicMock(name="scheduler_output")
+    scheduler_output.scheduled_new_reqs = [MagicMock(req_id="req-1")]
+    scheduler_output.scheduled_cached_reqs.req_ids = []
+
+    connector._report_block_allocation_deltas(scheduler_output)
+
+    records = connector.scheduler_adapter.report_block_allocations.call_args.args[0]
+    assert len(records) == 1
+    assert records[0].req_id == "req-1"
+    assert records[0].new_block_ids == [7, 8]
+    assert records[0].new_token_ids == list(range(8))
+
+
 def test_instance_id_is_uuid_derived_63_bit_int(fake_adapter) -> None:
     """instance_id is a 63-bit int, not the PID, and unique per adapter."""
     adapter, _send_mock, _ = fake_adapter


### PR DESCRIPTION
## Summary

- add `lmcache.mp.report_block_allocations`, enabled by default;
- return before traversing scheduler requests and token lists when the option is disabled;
- document that disabling the reports removes L0 block-allocation logs and metrics without changing cache lookup or transfer behavior;
- cover both the disabled fast path and the existing enabled payload.

## Motivation

`LMCacheMPConnector` constructs per-step GPU block allocation records on the vLLM scheduler path. These records feed only the MP L0 observability event; cache admission, eviction, lookup, and transfer do not consume them.

Deployments that do not use the L0 block-allocation logs or metrics should be able to avoid the scheduler-side list traversal and copying, as well as the downstream message serialization and ZMQ traffic. The default remains `true`, so existing observability behavior is unchanged.

Example:

```json
{
  "kv_connector": "LMCacheMPConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "lmcache.mp.report_block_allocations": false
  }
}
```

## Benchmark

Base: `ca2f474412e3b881c2f39e62561414c9676653dc`

Environment: AMD EPYC 7532, Python 3.12.14, vLLM `0.23.1rc1.dev2794+gb8ae402f2`. Ten measured rounds per case after warmup; seed `4797`.

| Scheduler-output shape | Reports enabled | Reports disabled | Saved per call |
|---|---:|---:|---:|
| 1 new request, 32K tokens / 2,048 blocks | 70.073 µs | 0.062 µs | 70.011 µs |
| 1 cached request, one new block | 1.120 µs | 0.068 µs | 1.053 µs |
| 32 cached requests, one new block each | 25.373 µs | 0.073 µs | 25.300 µs |

This is a connector microbenchmark of record construction plus the adapter call; it does not measure end-to-end TTFT, GPU kernels, or live ZMQ latency. MessagePack encoding is performed on the MQ polling thread on current `dev`, so it is intentionally excluded from the scheduler-latency table.

## Validation

- new regression tests: 2 passed;
- existing block-allocation serialization, MQ, and EventBus tests: 6 passed;
- `ruff check` / `ruff format --check` (v0.11.7): passed;
- `isort --check-only` (v6.0.1): passed;
- `codespell` (v2.4.1): passed;
- `git diff --check`: passed.

Closes #4797.
