### PR TITLE
[Core] Reject IsolatedLRU on L1 at startup and harden eviction loops

### DIFF
--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -102,6 +102,19 @@ class L1EvictionController(EvictionController):
         super().__init__()
         self._eviction_config = eviction_config
         self._eviction_policy = CreateEvictionPolicy(eviction_config)
+        # Isolation-only policies (e.g. IsolatedLRU) require per-cache_salt
+        # scoping driven by a QuotaManager, which only the L2 tier provides.
+        # Without this guard the misconfiguration surfaces as a ValueError
+        # on the first over-watermark cycle, permanently killing the
+        # eviction thread while the server keeps serving.
+        if self._eviction_policy.support_isolation:
+            raise ValueError(
+                f"Eviction policy {eviction_config.eviction_policy!r} is "
+                "per-cache_salt (isolation-only) and is not supported for "
+                "the L1 tier, which has no quota manager. Use 'LRU' or "
+                "'noop' for --eviction-policy; isolated policies are "
+                "configured per L2 adapter."
+            )
         self._l1_manager = l1_manager
         self._listener = L1EvictionPolicy(self._eviction_policy)
         self._l1_manager.register_listener(self._listener)
@@ -163,31 +176,43 @@ class L1EvictionController(EvictionController):
 
         while not self._stop_flag.is_set():
             time.sleep(1)
-            used_bytes, total_bytes = self._l1_manager.get_memory_usage()
-            if self._eviction_config.extra_logging_enabled:
-                self._maybe_log_memory_usage(used_bytes, total_bytes)
-            usage = 0 if total_bytes == 0 else used_bytes / total_bytes
-            if usage < watermark:
-                logger.debug(
-                    "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
-                    usage,
-                    watermark,
+            # A failure in one cycle must not kill the eviction thread:
+            # the thread is the only thing standing between L1 and a
+            # permanently full cache (allocation does not evict).
+            try:
+                self._eviction_cycle(watermark, eviction_ratio)
+            except Exception:
+                logger.exception(
+                    "L1 eviction cycle failed; retrying next cycle. "
+                    "L1 eviction is degraded until this stops recurring."
                 )
-                self._publish_skipped(usage, watermark)
-                continue
 
-            logger.info(
-                "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+    def _eviction_cycle(self, watermark: float, eviction_ratio: float):
+        used_bytes, total_bytes = self._l1_manager.get_memory_usage()
+        if self._eviction_config.extra_logging_enabled:
+            self._maybe_log_memory_usage(used_bytes, total_bytes)
+        usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+        if usage < watermark:
+            logger.debug(
+                "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
                 usage,
                 watermark,
             )
-            actions = self._eviction_policy.get_eviction_actions(
-                eviction_ratio,
-                key_eligible_filter=self._l1_manager.is_key_evictable,
-            )
-            for action in actions:
-                self.execute_eviction_action(action)
-            self._publish_triggered(usage, watermark)
+            self._publish_skipped(usage, watermark)
+            return
+
+        logger.info(
+            "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+            usage,
+            watermark,
+        )
+        actions = self._eviction_policy.get_eviction_actions(
+            eviction_ratio,
+            key_eligible_filter=self._l1_manager.is_key_evictable,
+        )
+        for action in actions:
+            self.execute_eviction_action(action)
+        self._publish_triggered(usage, watermark)
 
     def execute_eviction_action(self, action: EvictionAction):
         if action.destination == EvictionDestination.DISCARD:
@@ -308,7 +333,15 @@ class L2EvictionController(StorageControllerInterface):
             # calling into it.
             with self._states_lock:
                 for state in self._adapter_states:
-                    self._check_and_evict(state)
+                    # One adapter's failure (network, fs, backend) must not
+                    # kill the shared eviction thread for every adapter.
+                    try:
+                        self._check_and_evict(state)
+                    except Exception:
+                        logger.exception(
+                            "L2 eviction failed for adapter %d; retrying next cycle.",
+                            state.adapter_id,
+                        )
 
     def _check_and_evict(self, state: L2AdapterEvictionState):
         if state.eviction_policy.support_isolation and self._quota_manager is not None:

--- a/tests/v1/distributed/test_isolated_lru_l1_guard.py
+++ b/tests/v1/distributed/test_isolated_lru_l1_guard.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the IsolatedLRU-on-L1 startup guard and eviction loop hardening.
+
+``--eviction-policy`` feeds only the L1 tier, but ``IsolatedLRU`` is an
+isolation-only policy: its ``get_eviction_actions`` requires a
+``cache_salt``, which only the L2 eviction controller (via
+``QuotaManager``) provides. Previously, selecting it made the L1
+eviction thread die with ``ValueError`` on the first over-watermark
+cycle, permanently freezing L1 once full.
+
+Covered here:
+
+1. Startup guard: ``L1EvictionController`` rejects isolation-only
+   policies at construction.
+2. Loop hardening: an unexpected exception in one eviction cycle no
+   longer kills the eviction thread — it logs and retries next cycle.
+3. Regression: the global policies (``LRU``, ``noop``) still construct
+   and ``LRU`` still evicts.
+"""
+
+# Standard
+import threading
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.config import EvictionConfig
+from lmcache.v1.distributed.storage_controllers.eviction_controller import (
+    L1EvictionController,
+)
+
+# How long to wait for the eviction loop (it ticks once per second).
+_LOOP_TIMEOUT_S = 10.0
+
+
+class _FakeL1Manager:
+    """Duck-typed stand-in for ``L1Manager``.
+
+    Reports above-watermark memory usage so the eviction loop's very
+    first cycle triggers eviction, and records deletions.
+    """
+
+    def __init__(self):
+        self.listener = None
+        self.deleted_keys: list[ObjectKey] = []
+
+    def register_listener(self, listener) -> None:
+        self.listener = listener
+
+    def get_memory_usage(self) -> tuple[int, int]:
+        return (90, 100)  # 90% > default 0.8 watermark
+
+    def is_key_evictable(self, key: ObjectKey) -> bool:
+        return True
+
+    def delete(self, keys: list[ObjectKey]) -> None:
+        self.deleted_keys.extend(keys)
+
+
+class _ThreadExceptionCapture:
+    """Capture uncaught exceptions from background threads."""
+
+    def __init__(self):
+        self.exceptions: list[threading.ExceptHookArgs] = []
+        self._old_hook = None
+
+    def __enter__(self):
+        self._old_hook = threading.excepthook
+        threading.excepthook = lambda args: self.exceptions.append(args)
+        return self
+
+    def __exit__(self, *exc_info):
+        threading.excepthook = self._old_hook
+        return False
+
+
+def _make_key(i: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=f"hash-{i}".encode(),
+        model_name="test-model",
+        kv_rank=0,
+        cache_salt="tenant-a",
+    )
+
+
+def _wait_for(predicate, timeout_s: float) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
+
+
+class TestStartupGuard:
+    def test_isolated_lru_on_l1_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="IsolatedLRU.*not supported.*L1"):
+            L1EvictionController(
+                l1_manager=_FakeL1Manager(),
+                eviction_config=EvictionConfig(eviction_policy="IsolatedLRU"),
+            )
+
+    @pytest.mark.parametrize("policy", ["LRU", "noop"])
+    def test_global_policies_still_construct(self, policy):
+        controller = L1EvictionController(
+            l1_manager=_FakeL1Manager(),
+            eviction_config=EvictionConfig(eviction_policy=policy),
+        )
+        assert controller.report_status()["eviction_policy"] == policy
+
+
+class TestLoopResilience:
+    def test_eviction_thread_survives_policy_exception(self):
+        """A cycle that raises must not kill the thread; the next cycle
+        proceeds and evicts."""
+        fake_l1 = _FakeL1Manager()
+        controller = L1EvictionController(
+            l1_manager=fake_l1,
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+        )
+        assert fake_l1.listener is not None
+        fake_l1.listener.on_l1_keys_write_finished([_make_key(i) for i in range(10)])
+
+        # Make the policy raise exactly once, then behave normally.
+        policy = controller._eviction_policy
+        real_get_actions = policy.get_eviction_actions
+        fail_once = {"pending": True}
+
+        def flaky_get_actions(*args, **kwargs):
+            if fail_once["pending"]:
+                fail_once["pending"] = False
+                raise RuntimeError("injected transient failure")
+            return real_get_actions(*args, **kwargs)
+
+        policy.get_eviction_actions = flaky_get_actions
+
+        with _ThreadExceptionCapture() as capture:
+            controller.start()
+            evicted = _wait_for(lambda: len(fake_l1.deleted_keys) > 0, _LOOP_TIMEOUT_S)
+            assert evicted, "eviction should recover after a transient failure"
+            assert controller._thread.is_alive()
+            assert controller.report_status()["is_healthy"] is True
+        controller.stop()
+
+        # The injected failure was contained — no uncaught thread exception.
+        assert capture.exceptions == []
+        assert fail_once["pending"] is False  # the failure actually fired
+
+
+class TestLRURegression:
+    def test_lru_still_evicts(self):
+        fake_l1 = _FakeL1Manager()
+        controller = L1EvictionController(
+            l1_manager=fake_l1,
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+        )
+        assert fake_l1.listener is not None
+        fake_l1.listener.on_l1_keys_write_finished([_make_key(i) for i in range(10)])
+        controller.start()
+        evicted = _wait_for(lambda: len(fake_l1.deleted_keys) > 0, _LOOP_TIMEOUT_S)
+        controller.stop()
+        assert evicted


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4817.

`--eviction-policy IsolatedLRU` reaches the L1 eviction controller, which calls `get_eviction_actions()` without `cache_salt`; `IsolatedLRUEvictionPolicy` raises `ValueError`, and the unprotected daemon eviction thread dies permanently on the first over-watermark cycle. L1 then freezes at its cap and all new stores fail with `OUT_OF_MEMORY` (details and repro in the issue).

Three changes, all in `lmcache/v1/distributed/storage_controllers/eviction_controller.py`:

1. **Startup guard** — `L1EvictionController.__init__` raises `ValueError` when the created policy has `support_isolation=True`. Isolation-only policies need the per-`cache_salt` scoping that only the L2 controller (via `QuotaManager`) provides, so the misconfiguration now fails fast at boot with an actionable message instead of a runtime thread death. Keyed on the `support_isolation` property, not the policy name.
2. **L1 loop hardening** — the eviction cycle body is extracted to `_eviction_cycle()` and wrapped in `try/except Exception` + `logger.exception`. A per-cycle failure logs and retries next cycle instead of permanently killing the only mechanism that frees L1 (allocation does not evict).
3. **L2 loop hardening** — `L2EvictionController._eviction_loop` wraps the per-adapter `_check_and_evict` call the same way, so one adapter's failure (network, fs, backend) cannot kill the shared eviction thread for all adapters.

**Special notes for your reviewers**:

- The guard intentionally rejects by capability (`support_isolation`) rather than name, so any future isolation-only policy is covered. No existing code, test, or doc constructs `L1EvictionController` with an isolated policy.
- Behavior for `LRU`/`noop` is unchanged; `time.sleep(1)` stays outside the `try`, so a persistently failing cycle cannot busy-spin.
- Open question: with a persistent failure the hardened loops log once per second. Happy to add rate-limiting (e.g. log-once-then-suppress with a periodic reminder) if preferred — kept the first cut simple.
- Alternative considered: making L1 quota-aware (wiring `QuotaManager` + salt-scoped eviction into `L1EvictionController`). That is a feature with real design questions (L1 salt-usage accounting, watermark semantics per salt) and deserves its own issue; this PR just removes the landmine.

**If applicable**:

- [ ] this PR contains user facing changes - docs added (help text for `--eviction-policy` could note IsolatedLRU is L2-only — happy to add if wanted)
- [x] this PR contains unit tests

Tests added (`tests/v1/distributed/test_isolated_lru_l1_guard.py`):

- `IsolatedLRU` on L1 now raises `ValueError` at construction.
- `LRU` and `noop` still construct and behave as before.
- The L1 eviction thread survives an injected one-shot policy exception and successfully evicts on the next cycle (`is_healthy` stays `true`).
- Regression: existing IsolatedLRU/LRU policy suites and the L2 per-`cache_salt` eviction controller suite pass unchanged.
