### PR TITLE
[Refactor] extract server-bench data models

### DIFF
--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -43,6 +43,10 @@ import time
 
 # First Party
 from lmcache import torch_dev
+from lmcache.cli.commands.bench.server_bench.config import (
+    WorkerSpec,
+    parse_args_to_config,
+)
 
 # Heavy imports reused by the orchestrator. ``DTYPE_MAP`` is required
 # for the ``--kvcache-shape-spec`` help string at parser-registration
@@ -389,14 +393,15 @@ def run_server_bench(
     from lmcache.v1.multiprocess.group_view import EngineGroupInfo
     from lmcache.v1.multiprocess.mq import MessageQueueClient
 
-    quiet = getattr(args, "quiet", False)
+    config = parse_args_to_config(args)
+    quiet = config.quiet
 
     def log(msg: str) -> None:
         """Print progress messages; suppressed by --quiet."""
         if not quiet:
             print(msg)
 
-    use_gpu = args.mode == "gpu"
+    use_gpu = config.is_gpu
     if use_gpu and not torch_dev.is_available():
         print("ERROR: --mode gpu requires CUDA")
         sys.exit(1)
@@ -404,13 +409,7 @@ def run_server_bench(
     # Resolve transfer mode. ``auto`` reproduces the historical
     # behaviour: gpu -> lmcache_driven path, cpu -> engine_driven path.
     # ``lmcache_driven`` / ``engine_driven`` are explicit overrides.
-    transfer_mode = getattr(args, "transfer_mode", "auto")
-    if transfer_mode == "auto":
-        use_handle = use_gpu
-    elif transfer_mode == "lmcache_driven":
-        use_handle = True
-    else:
-        use_handle = False
+    use_handle = config.uses_handle_transfer
     if use_handle and not use_gpu:
         log(
             "  [info] --transfer-mode=lmcache_driven on cpu mode: "
@@ -434,9 +433,9 @@ def run_server_bench(
     warm_lookup_ms: list[float] = []
     warm_retrieve_ms: list[float] = []
 
-    url = args.rpc_url
+    url = config.rpc_url
     log(
-        "Connecting to LMCache MP Server at %s (mode=%s) ..." % (url, args.mode),
+        "Connecting to LMCache MP Server at %s (mode=%s) ..." % (url, config.mode),
     )
 
     ctx = zmq.Context()
@@ -452,7 +451,7 @@ def run_server_bench(
         log("Server chunk_size = %d" % chunk_size)
 
         # Parse KV shape spec
-        layer_groups = parse_kvcache_shape_spec(args.kvcache_shape_spec)
+        layer_groups = parse_kvcache_shape_spec(config.kvcache_shape_spec)
         # One block-id list is sent per LMCache KV group; each shape-spec
         # group becomes its own group server-side.
         num_engine_group_infos = len(layer_groups) or 1
@@ -479,17 +478,17 @@ def run_server_bench(
         num_layers = sum(g.num_layers for g in layer_groups)
         spec_nb = getattr(first.shape_desc, "nb", 0) or 0
         spec_bs = getattr(first.shape_desc, "bs", 0) or 0
-        num_blocks = spec_nb if spec_nb > 0 else args.num_blocks
-        block_size = spec_bs if spec_bs > 0 else args.block_size
-        if spec_nb and spec_nb != args.num_blocks:
+        num_blocks = spec_nb if spec_nb > 0 else config.num_blocks
+        block_size = spec_bs if spec_bs > 0 else config.block_size
+        if spec_nb and spec_nb != config.num_blocks:
             log(
                 "  [info] spec nb=%d overrides --num-blocks=%d"
-                % (spec_nb, args.num_blocks)
+                % (spec_nb, config.num_blocks)
             )
-        if spec_bs and spec_bs != args.block_size:
+        if spec_bs and spec_bs != config.block_size:
             log(
                 "  [info] spec bs=%d overrides --block-size=%d"
-                % (spec_bs, args.block_size)
+                % (spec_bs, config.block_size)
             )
         # For display / legacy hint fields only: collapse to the first
         # group when homogeneous, otherwise report "mixed".
@@ -549,7 +548,7 @@ def run_server_bench(
             for group_idx, group in enumerate(layer_groups)
         ]
 
-        num_tokens = args.num_tokens
+        num_tokens = config.num_tokens
         log(
             "Each request: %d tokens (%d full chunks)"
             % (
@@ -577,13 +576,13 @@ def run_server_bench(
         # multi-process worker layout in vLLM. shm_names aggregates every
         # rank's per-layer SHM segments for a best-effort cleanup on
         # shutdown.
-        tp_size = max(1, int(getattr(args, "tp_size", 1)))
+        tp_size = config.tp_size
         # Explicit --use-mla wins; otherwise infer MLA from the shape
         # spec via ``_is_mla_kv_size`` (kv_size == 1 marks an MLA
         # single-plane group). Routing all shape-derived MLA checks
         # through ``_is_mla_kv_size`` keeps this file, the helpers
         # module, and the server detector agreeing on one contract.
-        use_mla = bool(getattr(args, "use_mla", False)) or (
+        use_mla = config.use_mla or (
             isinstance(kv_size_disp, int) and _is_mla_kv_size(kv_size_disp)
         )
         # Fail fast when --use-mla is set but the shape spec still
@@ -687,13 +686,16 @@ def run_server_bench(
 
             workers.append(
                 WorkerContext(
-                    kv_worker_id=kv_worker_id,
-                    kv_world_size=kv_world_size,
-                    instance_id=instance_id,
+                    spec=WorkerSpec(
+                        rank=rank,
+                        kv_worker_id=kv_worker_id,
+                        kv_world_size=kv_world_size,
+                        instance_id=instance_id,
+                        store_enabled=(rank == 0) if use_mla else True,
+                        retrieve_enabled=True,
+                    ),
                     client_tensors=None if use_handle else client_kv_tensors,
                     server_pool=rank_server_pool,
-                    # MLA: only rank 0 stores; non-MLA: every rank stores.
-                    is_kv_writer=(rank == 0) if use_mla else True,
                 )
             )
         log("")
@@ -702,12 +704,12 @@ def run_server_bench(
         # concrete instance-id list to send matching UNREGISTERs.
         registered = bool(registered_instance_ids)
 
-        if args.end is not None:
-            seq_iter: itertools.count | range = range(args.start, args.end)
+        if config.end is not None:
+            seq_iter: itertools.count | range = range(config.start, config.end)
         else:
-            seq_iter = itertools.count(args.start)
+            seq_iter = itertools.count(config.start)
 
-        http_base = args.url.rstrip("/")
+        http_base = config.http_url.rstrip("/")
 
         # Record only the steady-state load, not the one-time registration.
         if profiler is not None:
@@ -733,10 +735,9 @@ def run_server_bench(
                 world_size=kv_world_size,
             )
             if cold_result is not None:
-                if cold_result.lookup_ms is not None:
-                    cold_lookup_ms.append(cold_result.lookup_ms)
-                if cold_result.store_ms is not None:
-                    cold_store_ms.append(cold_result.store_ms)
+                cold_lookup_ms.append(cold_result.lookup.latency_ms)
+                if cold_result.store is not None:
+                    cold_store_ms.append(cold_result.store.latency_ms)
 
             time.sleep(args.interval)
 
@@ -757,10 +758,9 @@ def run_server_bench(
                 world_size=kv_world_size,
             )
             if warm_result is not None:
-                if warm_result.lookup_ms is not None:
-                    warm_lookup_ms.append(warm_result.lookup_ms)
-                if warm_result.retrieve_ms is not None:
-                    warm_retrieve_ms.append(warm_result.retrieve_ms)
+                warm_lookup_ms.append(warm_result.lookup.latency_ms)
+                if warm_result.retrieve is not None:
+                    warm_retrieve_ms.append(warm_result.retrieve.latency_ms)
 
             # Compare checksums
             total_requests += 1

--- a/lmcache/cli/commands/bench/server_bench/config.py
+++ b/lmcache/cli/commands/bench/server_bench/config.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration and logical worker models for ``lmcache bench server``."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+import argparse
+
+
+@dataclass(frozen=True)
+class BenchConfig:
+    """Immutable configuration for one server benchmark run.
+
+    CLI-only concerns such as profiling stay with the command layer.
+
+    Attributes:
+        rpc_url: ZMQ endpoint of the LMCache Server.
+        http_url: HTTP endpoint used by management and checksum APIs.
+        mode: ``"cpu"`` or ``"gpu"`` for mock Worker resources.
+        transfer_mode: ``"auto"``, ``"engine_driven"``, or
+            ``"lmcache_driven"``.
+        tp_size: Number of simulated tensor-parallel Workers.
+        use_mla: Whether the CLI explicitly requested MLA routing.
+        num_tokens: Synthetic payload tokens per request, excluding the
+            sequence token prepended by the benchmark.
+        kvcache_shape_spec: LMCache KV shape specification string.
+        num_blocks: Fallback number of paged KV blocks.
+        block_size: Fallback number of tokens per paged KV block.
+        start: First synthetic sequence number.
+        end: Exclusive final sequence number, or ``None`` to run forever.
+        quiet: Whether progress output is disabled.
+    """
+
+    rpc_url: str
+    http_url: str
+    mode: str
+    transfer_mode: str
+    tp_size: int
+    use_mla: bool
+    num_tokens: int
+    kvcache_shape_spec: str
+    num_blocks: int
+    block_size: int
+    start: int
+    end: int | None
+    quiet: bool
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("cpu", "gpu"):
+            raise ValueError(f"unsupported device mode: {self.mode}")
+        if self.transfer_mode not in (
+            "auto",
+            "engine_driven",
+            "lmcache_driven",
+        ):
+            raise ValueError(f"unsupported transfer mode: {self.transfer_mode}")
+        if self.tp_size < 1:
+            raise ValueError(f"tp_size must be positive, got {self.tp_size}")
+
+    @property
+    def is_gpu(self) -> bool:
+        """Return whether mock Workers use GPU memory."""
+        return self.mode == "gpu"
+
+    @property
+    def uses_handle_transfer(self) -> bool:
+        """Return whether this run uses REGISTER plus STORE/RETRIEVE.
+
+        ``auto`` preserves the existing mapping: GPU uses the handle path,
+        while CPU uses the engine-driven PREPARE/COMMIT path.
+        """
+        if self.transfer_mode == "auto":
+            return self.is_gpu
+        return self.transfer_mode == "lmcache_driven"
+
+
+@dataclass(frozen=True)
+class WorkerSpec:
+    """Logical identity and routing roles of one simulated Worker.
+
+    Attributes:
+        rank: Simulated tensor-parallel rank.
+        instance_id: Server registration context identifier.
+        kv_worker_id: Worker identifier stored in cache keys.
+        kv_world_size: KV world size stored in cache keys.
+        store_enabled: Whether STORE operations target this Worker.
+        retrieve_enabled: Whether RETRIEVE operations target this Worker.
+    """
+
+    rank: int
+    instance_id: int
+    kv_worker_id: int
+    kv_world_size: int
+    store_enabled: bool
+    retrieve_enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if self.rank < 0:
+            raise ValueError(f"rank must be non-negative, got {self.rank}")
+        if self.instance_id < 0:
+            raise ValueError(
+                f"instance_id must be non-negative, got {self.instance_id}"
+            )
+        if self.kv_worker_id < 0:
+            raise ValueError(
+                f"kv_worker_id must be non-negative, got {self.kv_worker_id}"
+            )
+        if self.kv_world_size < 1:
+            raise ValueError(
+                f"kv_world_size must be positive, got {self.kv_world_size}"
+            )
+
+
+def parse_args_to_config(args: argparse.Namespace) -> BenchConfig:
+    """Convert server-bench CLI arguments into an immutable config.
+
+    Args:
+        args: Parsed arguments for ``lmcache bench server``.
+
+    Returns:
+        A ``BenchConfig`` with the same defaults and TP clamping used by the
+        existing command path.
+    """
+    return BenchConfig(
+        rpc_url=args.rpc_url,
+        http_url=args.url,
+        mode=args.mode,
+        transfer_mode=getattr(args, "transfer_mode", "auto"),
+        tp_size=max(1, int(getattr(args, "tp_size", 1))),
+        use_mla=bool(getattr(args, "use_mla", False)),
+        num_tokens=args.num_tokens,
+        kvcache_shape_spec=args.kvcache_shape_spec,
+        num_blocks=args.num_blocks,
+        block_size=args.block_size,
+        start=args.start,
+        end=args.end,
+        quiet=bool(getattr(args, "quiet", False)),
+    )

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -30,6 +30,11 @@ import urllib.request
 
 # First Party
 from lmcache import torch_dev, torch_device_type
+from lmcache.cli.commands.bench.server_bench.config import WorkerSpec
+from lmcache.cli.commands.bench.server_bench.runtime import (
+    LookupResult,
+    TransferResult,
+)
 
 # ``lmcache bench server`` allocates real CUDA tensors and talks to
 # the MP server via ZMQ, both of which are absent from the thin
@@ -132,47 +137,39 @@ _DEFAULT_SHAPE_SPEC = "(2,1024,16,8,128):float16:32"
 
 @dataclass
 class WorkerContext:
-    """Per-rank state for a single simulated TP worker.
+    """Live resources for a single simulated TP Worker.
 
-    Mirrors what ``LMCacheMPWorkerAdapter`` holds per vLLM worker in a
-    real deployment. Two identifiers matter here and they are *not* the
-    same as the vLLM rank:
+    ``WorkerSpec`` owns the logical identity and routing roles. This temporary
+    context keeps the existing tensor and SHM resources together until
+    ``WorkerRuntime`` is introduced in the next refactor step.
 
-    * ``kv_worker_id`` is the identifier used in ``IPCCacheServerKey``.
+    Two identifiers in ``spec`` matter and are not the same as the vLLM rank:
+
+    * ``spec.kv_worker_id`` is the identifier used in ``IPCCacheServerKey``.
       In vLLM this is ``ParallelStrategy.kv_worker_id`` --
       ``vllm_worker_id // tp_size`` under MLA (all TP ranks fold into
       one kv_worker) and ``vllm_worker_id`` otherwise.
-    * ``kv_world_size`` is the world_size the server uses to index
+    * ``spec.kv_world_size`` is the world_size the server uses to index
       cache entries. Also from ``ParallelStrategy``: for MLA it is
       ``vllm_world_size // tp_size`` (typically 1 for pure TP-MLA)
       and ``vllm_world_size`` otherwise.
 
-    ``instance_id`` stays per-simulated-rank so each vLLM process still
+    ``spec.instance_id`` stays per simulated rank so each vLLM process still
     gets its own ``REGISTER_KV_CACHE`` context; multiple TP ranks
     inside the same MLA kv_worker share the same ``kv_worker_id`` but
     keep distinct ``instance_id`` values.
 
     Attributes:
-        kv_worker_id: The KV worker id (``ParallelStrategy.kv_worker_id``).
-        kv_world_size: The KV world size (``ParallelStrategy.kv_world_size``).
-        instance_id: Unique server-side context id for this simulated
-            vLLM rank; matches what would be ``os.getpid()`` in a real
-            deployment.
+        spec: Immutable logical Worker identity and routing roles.
         client_tensors: Paged KV tensors owned by this worker (data-mode
             self-check source/sink). ``None`` in handle mode.
         server_pool: mmap of the server's SHM pool for this worker's
             engine-driven context. ``None`` outside data mode.
-        is_kv_writer: Whether this worker participates in STORE. For MLA
-            only ranks with ``vllm_worker_id % tp_size == 0`` write; non-
-            MLA writes on every rank. RETRIEVE runs on every rank.
     """
 
-    kv_worker_id: int
-    kv_world_size: int
-    instance_id: int
+    spec: WorkerSpec
     client_tensors: "list[torch.Tensor] | None" = None
     server_pool: "mmap.mmap | None" = None
-    is_kv_writer: bool = True
 
 
 # ------------------------------------------------------------------ #
@@ -1056,14 +1053,10 @@ class RequestResult:
     per-operation latency measurements (for metrics aggregation).
     """
 
+    lookup: LookupResult
     checksums: list[str] | None = None
-    lookup_ms: float | None = None
-    retrieve_ms: float | None = None
-    store_ms: float | None = None
-    hit_chunks: int = 0
-    total_chunks: int = 0
-    store_tokens: int = 0
-    retrieve_tokens: int = 0
+    retrieve: TransferResult | None = None
+    store: TransferResult | None = None
 
 
 def _process_request(
@@ -1101,9 +1094,10 @@ def _process_request(
 
     ``workers`` (optional) drives multi-rank TP simulation: LOOKUP
     stays scheduler-scoped (single call, worker_id=None) while
-    STORE fans out to every ``is_kv_writer`` rank and RETRIEVE fans
-    out to every rank -- mirroring how ``LMCacheMPWorkerAdapter``
-    routes requests in a real vLLM deployment. When ``None`` the
+    STORE fans out to every Worker with ``spec.store_enabled`` and
+    RETRIEVE fans out to every Worker with ``spec.retrieve_enabled`` --
+    mirroring how ``LMCacheMPWorkerAdapter`` routes requests in a real
+    vLLM deployment. When ``None`` the
     bench synthesises a single worker from ``client_tensors`` /
     ``server_pool`` so single-rank runs stay unchanged.
     """
@@ -1113,12 +1107,16 @@ def _process_request(
     if workers is None:
         workers = [
             WorkerContext(
-                kv_worker_id=0,
-                kv_world_size=world_size,
-                instance_id=_INSTANCE_ID,
+                spec=WorkerSpec(
+                    rank=0,
+                    kv_worker_id=0,
+                    kv_world_size=world_size,
+                    instance_id=_INSTANCE_ID,
+                    store_enabled=True,
+                    retrieve_enabled=True,
+                ),
                 client_tensors=client_tensors,
                 server_pool=server_pool,
-                is_kv_writer=True,
             )
         ]
     # ``client_tensors is not None`` gates client-side self-check (data
@@ -1198,7 +1196,7 @@ def _process_request(
             store_num_blocks = (num_full_tokens - hit_tokens) // block_size
             cold_parts: list[str] = []
             for w in workers:
-                if not w.is_kv_writer or w.client_tensors is None:
+                if not w.spec.store_enabled or w.client_tensors is None:
                     continue
                 cold_parts.extend(
                     _compute_client_checksums(
@@ -1213,7 +1211,7 @@ def _process_request(
         if pass_label == "warm" and hit_chunks > 0:
             retr_num_blocks = hit_tokens // block_size
             for w in workers:
-                if w.client_tensors is not None:
+                if w.spec.retrieve_enabled and w.client_tensors is not None:
                     _zero_fill_client_blocks(
                         w.client_tensors,
                         block_offset,
@@ -1221,18 +1219,24 @@ def _process_request(
                     )
 
     # 3. RETRIEVE hit portion — every rank retrieves its own KV shard.
-    retrieve_ms: float = 0.0
-    store_ms: float = 0.0
+    retrieve_result: TransferResult | None = None
+    store_result: TransferResult | None = None
     if hit_chunks > 0:
         t1 = time.monotonic()
         status = "retrieved"
+        attempted_ranks: list[int] = []
+        successful_ranks: list[int] = []
+        failed_ranks: list[int] = []
         for w in workers:
+            if not w.spec.retrieve_enabled:
+                continue
+            attempted_ranks.append(w.spec.rank)
             retrieve_key = _make_key(
                 token_ids,
                 request_id,
                 start=0,
                 end=hit_tokens,
-                worker_id=w.kv_worker_id,
+                worker_id=w.spec.kv_worker_id,
                 world_size=world_size,
             )
             w_status = _send_retrieve(
@@ -1247,11 +1251,22 @@ def _process_request(
                 use_handle=use_handle,
                 client_tensors=w.client_tensors,
                 server_pool=w.server_pool,
-                instance_id=w.instance_id,
+                instance_id=w.spec.instance_id,
             )
-            if w_status != "retrieved":
+            if w_status == "retrieved":
+                successful_ranks.append(w.spec.rank)
+            else:
+                failed_ranks.append(w.spec.rank)
                 status = w_status
         retrieve_ms = (time.monotonic() - t1) * 1000
+        retrieve_result = TransferResult(
+            operation="retrieve",
+            token_count=hit_tokens,
+            latency_ms=retrieve_ms,
+            attempted_worker_ranks=tuple(attempted_ranks),
+            successful_worker_ranks=tuple(successful_ranks),
+            failed_worker_ranks=tuple(failed_ranks),
+        )
         print(
             "  [seq %d/%s] RETRIEVE: %s "
             "(%d tokens, %.1f ms, %d workers)"
@@ -1261,7 +1276,7 @@ def _process_request(
                 status,
                 hit_tokens,
                 retrieve_ms,
-                len(workers),
+                len(attempted_ranks),
             )
         )
 
@@ -1273,17 +1288,19 @@ def _process_request(
         t2 = time.monotonic()
         store_block_off = block_offset + (hit_tokens // block_size)
         status = "stored"
-        n_store_workers = 0
+        attempted_ranks = []
+        successful_ranks = []
+        failed_ranks = []
         for w in workers:
-            if not w.is_kv_writer:
+            if not w.spec.store_enabled:
                 continue
-            n_store_workers += 1
+            attempted_ranks.append(w.spec.rank)
             store_key = _make_key(
                 token_ids,
                 request_id,
                 start=store_start,
                 end=store_end,
-                worker_id=w.kv_worker_id,
+                worker_id=w.spec.kv_worker_id,
                 world_size=world_size,
             )
             w_status = _send_store(
@@ -1297,11 +1314,22 @@ def _process_request(
                 client_tensors=w.client_tensors,
                 chunk_size=chunk_size,
                 server_pool=w.server_pool,
-                instance_id=w.instance_id,
+                instance_id=w.spec.instance_id,
             )
-            if w_status != "stored":
+            if w_status == "stored":
+                successful_ranks.append(w.spec.rank)
+            else:
+                failed_ranks.append(w.spec.rank)
                 status = w_status
         store_ms = (time.monotonic() - t2) * 1000
+        store_result = TransferResult(
+            operation="store",
+            token_count=store_end - store_start,
+            latency_ms=store_ms,
+            attempted_worker_ranks=tuple(attempted_ranks),
+            successful_worker_ranks=tuple(successful_ranks),
+            failed_worker_ranks=tuple(failed_ranks),
+        )
         print(
             "  [seq %d/%s] STORE: %s "
             "(%d tokens, %.1f ms, %d writers)"
@@ -1311,7 +1339,7 @@ def _process_request(
                 status,
                 store_end - store_start,
                 store_ms,
-                n_store_workers,
+                len(attempted_ranks),
             )
         )
 
@@ -1331,7 +1359,7 @@ def _process_request(
             retr_num_blocks = hit_tokens // block_size
             warm_parts: list[str] = []
             for w in workers:
-                if not w.is_kv_writer or w.client_tensors is None:
+                if not w.spec.store_enabled or w.client_tensors is None:
                     continue
                 warm_parts.extend(
                     _compute_client_checksums(
@@ -1354,7 +1382,7 @@ def _process_request(
             num_blocks,
             block_size,
             chunk_size,
-            instance_id=workers[0].instance_id,
+            instance_id=workers[0].spec.instance_id,
         )
     if checksums:
         digest = hashlib.md5("".join(checksums).encode()).hexdigest()[:16]
@@ -1371,14 +1399,14 @@ def _process_request(
     # 6. END_SESSION
     _send_end_session(client, request_id)
     return RequestResult(
+        lookup=LookupResult(
+            hit_chunks=hit_chunks,
+            total_chunks=total_chunks,
+            latency_ms=lookup_ms,
+        ),
         checksums=checksums,
-        lookup_ms=lookup_ms,
-        retrieve_ms=retrieve_ms if hit_chunks > 0 else None,
-        store_ms=store_ms if miss_chunks > 0 else None,
-        hit_chunks=hit_chunks,
-        total_chunks=total_chunks,
-        store_tokens=(num_full_tokens - hit_tokens) if miss_chunks > 0 else 0,
-        retrieve_tokens=hit_tokens if hit_chunks > 0 else 0,
+        retrieve=retrieve_result,
+        store=store_result,
     )
 
 

--- a/lmcache/cli/commands/bench/server_bench/runtime.py
+++ b/lmcache/cli/commands/bench/server_bench/runtime.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Operation result models for the server benchmark runtime."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LookupResult:
+    """Result of one LOOKUP, including its hit range and latency."""
+
+    hit_chunks: int
+    total_chunks: int
+    latency_ms: float
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.total_chunks < 0:
+            raise ValueError(
+                f"total_chunks must be non-negative, got {self.total_chunks}"
+            )
+        if not 0 <= self.hit_chunks <= self.total_chunks:
+            raise ValueError(
+                "hit_chunks must be between zero and total_chunks, got "
+                f"{self.hit_chunks}/{self.total_chunks}"
+            )
+        if self.latency_ms < 0:
+            raise ValueError(f"latency_ms must be non-negative, got {self.latency_ms}")
+
+    @property
+    def succeeded(self) -> bool:
+        """Return whether LOOKUP completed without an error."""
+        return self.error is None
+
+    @property
+    def is_full_hit(self) -> bool:
+        """Return whether every requested chunk was found."""
+        return (
+            self.succeeded
+            and self.total_chunks > 0
+            and (self.hit_chunks == self.total_chunks)
+        )
+
+    @property
+    def is_full_miss(self) -> bool:
+        """Return whether no requested chunk was found."""
+        return self.succeeded and self.total_chunks > 0 and self.hit_chunks == 0
+
+    @property
+    def is_partial_hit(self) -> bool:
+        """Return whether LOOKUP found some but not all requested chunks."""
+        return self.succeeded and 0 < self.hit_chunks < self.total_chunks
+
+
+@dataclass(frozen=True)
+class TransferResult:
+    """Aggregate STORE or RETRIEVE result for its target Worker ranks."""
+
+    operation: str
+    token_count: int
+    latency_ms: float
+    attempted_worker_ranks: tuple[int, ...]
+    successful_worker_ranks: tuple[int, ...]
+    failed_worker_ranks: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if self.token_count < 0:
+            raise ValueError(
+                f"token_count must be non-negative, got {self.token_count}"
+            )
+        if self.latency_ms < 0:
+            raise ValueError(f"latency_ms must be non-negative, got {self.latency_ms}")
+
+        attempted = set(self.attempted_worker_ranks)
+        successful = set(self.successful_worker_ranks)
+        failed = set(self.failed_worker_ranks)
+        if len(attempted) != len(self.attempted_worker_ranks):
+            raise ValueError("attempted_worker_ranks must not contain duplicates")
+        if len(successful) != len(self.successful_worker_ranks):
+            raise ValueError("successful_worker_ranks must not contain duplicates")
+        if len(failed) != len(self.failed_worker_ranks):
+            raise ValueError("failed_worker_ranks must not contain duplicates")
+        if successful & failed:
+            raise ValueError("successful and failed Worker ranks must be disjoint")
+        if attempted != successful | failed:
+            raise ValueError(
+                "successful and failed Worker ranks must exactly partition "
+                "attempted_worker_ranks"
+            )
+
+    @property
+    def succeeded(self) -> bool:
+        """Return whether every attempted Worker completed successfully."""
+        return not self.failed_worker_ranks

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -22,6 +22,7 @@ import zmq
 
 # First Party
 from lmcache.cli.commands.bench import BenchCommand
+from lmcache.cli.commands.bench.server_bench.config import WorkerSpec
 from lmcache.cli.commands.bench.server_bench.helpers import (
     _allocate_kv_cache,
     _build_token_ids,
@@ -1037,13 +1038,16 @@ class TestProcessRequestMultiWorker:
         for rank in range(tp_size):
             workers.append(
                 WorkerContext(
-                    kv_worker_id=0 if is_mla else rank,
-                    kv_world_size=kv_world_size,
-                    instance_id=_INSTANCE_ID_BASE + rank,
+                    spec=WorkerSpec(
+                        rank=rank,
+                        kv_worker_id=0 if is_mla else rank,
+                        kv_world_size=kv_world_size,
+                        instance_id=_INSTANCE_ID_BASE + rank,
+                        store_enabled=(rank == 0) if is_mla else True,
+                        retrieve_enabled=True,
+                    ),
                     client_tensors=None,
                     server_pool=None,
-                    # MLA: only rank 0 stores; non-MLA: every rank stores.
-                    is_kv_writer=(rank == 0) if is_mla else True,
                 )
             )
 
@@ -1059,7 +1063,7 @@ class TestProcessRequestMultiWorker:
             patch.object(sv_helpers, "_call", side_effect=fake_call),
             patch.object(sv_helpers, "_make_event_handle", return_value=b""),
         ):
-            _process_request(
+            result = _process_request(
                 client=None,  # type: ignore[arg-type]  # unused: _call mocked
                 seq_no=0,
                 num_tokens=32,
@@ -1075,10 +1079,11 @@ class TestProcessRequestMultiWorker:
                 world_size=kv_world_size,
             )
 
-        return calls
+        assert result is not None
+        return calls, result
 
     def test_mla_tp2_store_only_from_rank0(self) -> None:
-        calls = self._run(is_mla=True, tp_size=2)
+        calls, result = self._run(is_mla=True, tp_size=2)
         # Extract STORE + RETRIEVE calls with their instance_id argument.
         stores = [c for c in calls if c[0].name == "STORE"]
         retrieves = [c for c in calls if c[0].name == "RETRIEVE"]
@@ -1101,9 +1106,14 @@ class TestProcessRequestMultiWorker:
         )
         # No hits in the fake -> RETRIEVE is skipped entirely.
         assert retrieves == []
+        assert result.lookup.is_full_miss
+        assert result.store is not None
+        assert result.store.attempted_worker_ranks == (0,)
+        assert result.store.successful_worker_ranks == (0,)
+        assert result.store.succeeded
 
     def test_non_mla_tp2_store_on_every_rank(self) -> None:
-        calls = self._run(is_mla=False, tp_size=2)
+        calls, result = self._run(is_mla=False, tp_size=2)
         stores = [c for c in calls if c[0].name == "STORE"]
         # Non-MLA: every rank stores.
         assert len(stores) == 2
@@ -1120,11 +1130,15 @@ class TestProcessRequestMultiWorker:
             )
         worker_ids = sorted(c[1][0].worker_id for c in stores)
         assert worker_ids == [0, 1]
+        assert result.store is not None
+        assert result.store.attempted_worker_ranks == (0, 1)
+        assert result.store.successful_worker_ranks == (0, 1)
+        assert result.store.succeeded
 
     def test_lookup_called_once_regardless_of_tp(self) -> None:
         for is_mla in (True, False):
             for tp in (1, 2, 4):
-                calls = self._run(is_mla=is_mla, tp_size=tp)
+                calls, _result = self._run(is_mla=is_mla, tp_size=tp)
                 lookups = [c for c in calls if c[0].name == "LOOKUP"]
                 assert len(lookups) == 1, (
                     "LOOKUP should fire exactly once regardless of tp_size "

--- a/tests/cli/commands/bench/test_server_bench_models.py
+++ b/tests/cli/commands/bench/test_server_bench_models.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for server-bench data models."""
+
+# Standard
+from dataclasses import FrozenInstanceError
+import argparse
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.bench.server_bench.config import (
+    WorkerSpec,
+    parse_args_to_config,
+)
+from lmcache.cli.commands.bench.server_bench.runtime import (
+    LookupResult,
+    TransferResult,
+)
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "rpc_url": "tcp://localhost:5555",
+        "url": "http://localhost:8080",
+        "mode": "gpu",
+        "transfer_mode": "auto",
+        "tp_size": 1,
+        "use_mla": False,
+        "num_tokens": 512,
+        "kvcache_shape_spec": "(2,1024,16,8,128):float16:32",
+        "num_blocks": 1024,
+        "block_size": 16,
+        "start": 0,
+        "end": 3,
+        "quiet": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+@pytest.mark.parametrize(
+    ("mode", "transfer_mode", "uses_handle"),
+    [
+        ("gpu", "auto", True),
+        ("cpu", "auto", False),
+        ("cpu", "lmcache_driven", True),
+        ("gpu", "engine_driven", False),
+    ],
+)
+def test_bench_config_preserves_cli_routing(
+    mode: str,
+    transfer_mode: str,
+    uses_handle: bool,
+) -> None:
+    config = parse_args_to_config(
+        _args(mode=mode, transfer_mode=transfer_mode, tp_size=0)
+    )
+
+    assert config.mode == mode
+    assert config.transfer_mode == transfer_mode
+    assert config.tp_size == 1
+    assert config.uses_handle_transfer is uses_handle
+
+
+def test_worker_spec_is_immutable_and_validated() -> None:
+    spec = WorkerSpec(0, 1000, 0, 1, True)
+    with pytest.raises(FrozenInstanceError):
+        spec.rank = 1  # type: ignore[misc]
+    with pytest.raises(ValueError, match="kv_world_size must be positive"):
+        WorkerSpec(0, 1000, 0, 0, True)
+
+
+@pytest.mark.parametrize(
+    ("hit_chunks", "expected"),
+    [(0, "is_full_miss"), (1, "is_partial_hit"), (2, "is_full_hit")],
+)
+def test_lookup_result_classifies_hit_ranges(
+    hit_chunks: int,
+    expected: str,
+) -> None:
+    result = LookupResult(hit_chunks, total_chunks=2, latency_ms=1.5)
+
+    assert result.succeeded
+    assert getattr(result, expected)
+
+
+def test_lookup_result_rejects_invalid_range() -> None:
+    with pytest.raises(ValueError, match="between zero and total_chunks"):
+        LookupResult(hit_chunks=3, total_chunks=2, latency_ms=1.0)
+
+
+def test_transfer_result_reports_partial_failure() -> None:
+    result = TransferResult(
+        operation="retrieve",
+        token_count=256,
+        latency_ms=3.0,
+        attempted_worker_ranks=(0, 1),
+        successful_worker_ranks=(0,),
+        failed_worker_ranks=(1,),
+    )
+
+    assert not result.succeeded
+
+
+def test_transfer_result_requires_exact_worker_partition() -> None:
+    with pytest.raises(ValueError, match="exactly partition"):
+        TransferResult("store", 256, 2.5, (0, 1), (0,), ())


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #4815.

Extract the first server-bench data models:

- `BenchConfig` and `WorkerSpec`
- structured LOOKUP / STORE / RETRIEVE results

`run_server_bench()` remains the driver. The existing CLI, protocol flow, and cold/warm baseline behavior are unchanged.

**Special notes for your reviewers**:

`BenchRuntime` and Scenario support will follow in later PRs.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Tests:
- server-bench unit tests
- CPU `engine_driven` baseline
- CPU `lmcache_driven` baseline