### PR TITLE
fix(vllm): support DCP-interleaved hybrid cache geometry

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -604,12 +604,22 @@ Decode context parallelism (DCP)
 ``--decode-context-parallel-size`` is supported. Under DCP, vLLM shards the
 attention KV cache across ranks along the token axis, so each rank holds only
 a strided ``1/dcp`` slice and one block ID spans ``block_size * dcp`` tokens.
-LMCache stores each rank's slice as its own object and a chunk counts as a hit
-only when every rank's slice is present.
+LMCache stores each rank's opaque page as its own object and a chunk counts as
+a hit only when every rank's slice is present. Non-trivial
+``--cp-kv-cache-interleave-size`` values are supported when they evenly divide
+every resolved attention cache block size. Because interleave changes the
+token-to-slot byte layout, the connector automatically adds the DCP size and
+interleave value to its internal cache namespace. This prevents pages written
+by one interleave layout from being loaded by another. It does not change the
+model name served by vLLM, but the decorated cache model name is visible in MP
+metric labels so operators can distinguish incompatible cache layouts.
 
 One configuration change is required: the LMCache chunk size must be a
-multiple of ``block_size * decode_context_parallel_size``, not just
-``block_size``. If it is smaller, vLLM fails at connector startup with the
+multiple of vLLM's resolved scheduler block size. For a single attention
+group, that is ``block_size * decode_context_parallel_size``. For a hybrid
+model, it is the least common multiple of every attention group's DCP-scaled
+block span and every recurrent-state group's unscaled physical block span. If
+the chunk size is incompatible, vLLM fails at connector startup with the
 required multiple in the message (the LMCache server itself starts fine).
 
 The example model also needs a vLLM build that can run it under DCP:
@@ -640,11 +650,13 @@ DCP. These combinations are rejected at startup:
      - Reason
    * - ``--prefill-context-parallel-size > 1``
      - Adds a second KV shard axis this connector does not map.
-   * - ``--cp-kv-cache-interleave-size != 1``
-     - Changes the token-to-rank mapping, which would store the wrong KV.
    * - Fewer than ``dcp_size`` ranks per LMCache server
      - No server holds a complete set of shards, and lookup takes the
        minimum hit count across servers, so it reports no hits.
+
+An interleave value that is non-positive, larger than a resolved attention
+cache block, or does not evenly divide every resolved attention block is
+rejected at connector startup.
 
 ``decode_context_parallel_size > tensor_parallel_size`` is rejected by vLLM
 itself, so this connector does not re-check it.

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -404,10 +404,12 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         padding, and any sibling layers on a shared pool, live between
         row and S).
 
-        Output for NHD: [num_blocks, block_size, 1, head_size] with
-        strides (S, head_size, head_size, 1). HND swaps dims 1 and 2:
-        [num_blocks, 1, block_size, head_size] with strides
-        (S, block_size * head_size, head_size, 1).
+        Output for NHD/BLNHC: [num_blocks, block_size, 1, head_size]
+        with strides (S, head_size, head_size, 1). HND/BLHNC swaps dims
+        1 and 2: [num_blocks, 1, block_size, head_size] with strides
+        (S, block_size * head_size, head_size, 1). Blocks-first layouts
+        preserve the input's block stride so it can continue spanning
+        sibling layers and object groups in the shared pool.
 
         head_size = ceil(row / block_size), rounded up to the kernels'
         vector alignment, and block_size * head_size may exceed the row
@@ -418,9 +420,10 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
             "single-layer KV cache must be a torch.Tensor"
         )
         kv_layout = layout_hints.get("kv_layout", "none")
-        if kv_layout not in ("NHD", "HND"):
+        if kv_layout not in ("NHD", "HND", "BLHNC", "BLNHC"):
             raise ValueError(
-                f"Unsupported kv_layout: {kv_layout}. Only NHD and HND are supported."
+                f"Unsupported kv_layout: {kv_layout}. Expected NHD, HND, "
+                "BLHNC, or BLNHC."
             )
         num_blocks = kv_cache.shape[0]
         row = kv_cache[0].numel()
@@ -447,7 +450,7 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
                 f"cannot tile a {row}-element state row into {block_size} "
                 f"aligned tokens within the {page_bytes}-byte page"
             )
-        if kv_layout == "NHD":
+        if kv_layout in ("NHD", "BLNHC"):
             inner = (block_size, 1, head_size)
             inner_strides = (head_size, head_size, 1)
         else:

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -374,9 +374,14 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
 
 
 class _MambaUnifiedViewEdit(KVCacheGroupEdit):
-    """Re-view mamba's unified state as a per-token paged tensor.
+    """Re-view Mamba's unified state as an opaque rank-3 page tensor.
 
     For vLLM >= 0.26.0, where the unified KV cache layout is implemented.
+
+    Rank 3 deliberately selects LMCache's ``NL_X_NB_BS_HS`` format: it is the
+    block-axis format whose transfer path carries the authoritative dim-0
+    stride. This is required for vLLM's blocks-first HMA pools, where sibling
+    layer pages pad the gap between consecutive blocks.
     """
 
     name = "mamba-unified-view"
@@ -395,7 +400,7 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         self,
         spec: KVCacheSpec,
         kv_cache: RegisteredKVCache,
-        layout_hints: LayoutHints,
+        _layout_hints: LayoutHints,
     ) -> torch.Tensor:
         """Re-view the per-block state row as block_size tokens.
 
@@ -404,12 +409,10 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         padding, and any sibling layers on a shared pool, live between
         row and S).
 
-        Output for NHD/BLNHC: [num_blocks, block_size, 1, head_size]
-        with strides (S, head_size, head_size, 1). HND/BLHNC swaps dims
-        1 and 2: [num_blocks, 1, block_size, head_size] with strides
-        (S, block_size * head_size, head_size, 1). Blocks-first layouts
-        preserve the input's block stride so it can continue spanning
-        sibling layers and object groups in the shared pool.
+        Output: [num_blocks, block_size, head_size] with strides
+        (S, head_size, 1). The rank-3 opaque format preserves the input's
+        block stride so it can continue spanning sibling layers and object
+        groups in the shared pool.
 
         head_size = ceil(row / block_size), rounded up to the kernels'
         vector alignment, and block_size * head_size may exceed the row
@@ -419,11 +422,10 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         assert isinstance(kv_cache, torch.Tensor), (
             "single-layer KV cache must be a torch.Tensor"
         )
-        kv_layout = layout_hints.get("kv_layout", "none")
-        if kv_layout not in ("NHD", "HND", "BLHNC", "BLNHC"):
+        if tuple(kv_cache.shape[1:3]) != (1, 1):
             raise ValueError(
-                f"Unsupported kv_layout: {kv_layout}. Expected NHD, HND, "
-                "BLHNC, or BLNHC."
+                "unified Mamba cache must have singleton head and token axes, "
+                f"got shape {tuple(kv_cache.shape)}"
             )
         num_blocks = kv_cache.shape[0]
         row = kv_cache[0].numel()
@@ -450,14 +452,63 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
                 f"cannot tile a {row}-element state row into {block_size} "
                 f"aligned tokens within the {page_bytes}-byte page"
             )
-        if kv_layout in ("NHD", "BLNHC"):
-            inner = (block_size, 1, head_size)
-            inner_strides = (head_size, head_size, 1)
-        else:
-            inner = (1, block_size, head_size)
-            inner_strides = (block_size * head_size, head_size, 1)
         return kv_cache.as_strided(
-            (num_blocks, *inner), (kv_cache.stride(0), *inner_strides)
+            (num_blocks, block_size, head_size),
+            (kv_cache.stride(0), head_size, 1),
+        )
+
+
+class _PaddedAttentionPageViewEdit(KVCacheGroupEdit):
+    """Canonicalize a padded attention layer as an opaque rank-3 page.
+
+    Current vLLM HMA layouts expose MLA as ``[B, H=1, N, C]`` and a replicated
+    DFlash page as e.g. ``[B, H=2, N=16, C=256]``. In both cases the inner page
+    is tightly packed, while sibling pages create a gap between dim-0 rows.
+    LMCache's opaque ``[B, N, C]`` format supports that authoritative padded
+    block stride. Re-factoring all inner page elements over the engine's
+    logical block size is a zero-copy view and preserves every payload byte;
+    the resulting dimensions are addressing metadata, not semantic K/V axes.
+    """
+
+    name = "padded-attention-page-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        kind = get_kv_cache_spec_kind(spec)
+        return (
+            (
+                kind == KVCacheSpecKind.MLA_ATTENTION
+                or kind in _SUBPAGEABLE_ATTENTION_KINDS
+            )
+            and not _declares_slot_compression(spec)
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 4
+            and kv_cache[0].is_contiguous()
+            and kv_cache.stride(0) > kv_cache.shape[1:].numel()
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """Return a padded-stride-preserving opaque ``[B, BS, HS]`` view.
+
+        Raises:
+            ValueError: If one physical page cannot be factored evenly over
+                the engine's logical block size.
+        """
+        assert isinstance(kv_cache, torch.Tensor)
+        page_elems = kv_cache.shape[1:].numel()
+        if page_elems % spec.block_size:
+            raise ValueError(
+                f"a {page_elems}-element attention page cannot be factored "
+                f"over block_size={spec.block_size}"
+            )
+        hidden_size = page_elems // spec.block_size
+        return kv_cache.as_strided(
+            (kv_cache.shape[0], spec.block_size, hidden_size),
+            (kv_cache.stride(0), hidden_size, 1),
         )
 
 
@@ -536,6 +587,7 @@ class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
 _EDITS: tuple[KVCacheGroupEdit, ...] = (
     _MambaUnifiedViewEdit(),
     _MambaPageViewEdit(),
+    _PaddedAttentionPageViewEdit(),
     _SubpagedMLAAttentionViewEdit(),
     _SubpagedAttentionViewEdit(),
 )

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -32,17 +32,32 @@ def _is_attention_spec(spec: Any) -> bool:
     return any(cls.__name__ == "AttentionSpec" for cls in type(spec).__mro__)
 
 
+def _is_dcp_replicated_spec(spec: Any) -> bool:
+    """Return whether every layer represented by ``spec`` is DCP-replicated.
+
+    DFlash draft attention marks its cache spec ``dcp_replicated=True``: every
+    DCP rank stores the complete sequence, so one block ID still covers only
+    ``block_size`` tokens. ``UniformTypeKVCacheSpecs`` may wrap those leaf
+    specs; inspect the leaves directly instead of relying on a vLLM-version-
+    specific convenience property on the wrapper.
+    """
+    inner = getattr(spec, "kv_cache_specs", None)
+    specs = list(inner.values()) if isinstance(inner, dict) else [spec]
+    return bool(specs) and all(getattr(leaf, "dcp_replicated", False) for leaf in specs)
+
+
 def get_tokens_per_block(kv_cache_spec: Any, dcp_size: int) -> int:
     """Global tokens covered by one block id of ``kv_cache_spec``.
 
     Attention blocks span ``block_size * dcp_size`` tokens under DCP
-    (vLLM's ``resolve_kv_cache_block_sizes`` rule); recurrent state is
-    replicated, not sharded, and stays at ``block_size``.
+    (vLLM's ``resolve_kv_cache_block_sizes`` rule), except attention specs
+    explicitly marked ``dcp_replicated`` (e.g. DFlash draft KV). Replicated
+    attention and recurrent state both stay at ``block_size``.
     """
     block_size = kv_cache_spec.block_size
     if dcp_size <= 1:
         return block_size
-    if _is_attention_spec(kv_cache_spec):
+    if _is_attention_spec(kv_cache_spec) and not _is_dcp_replicated_spec(kv_cache_spec):
         return block_size * dcp_size
     return block_size
 

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -81,7 +81,7 @@ try:
         )
 except ImportError:
     # Third Party
-    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (  # type: ignore[no-redef]
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (  # type: ignore[assignment,no-redef]
         LMCacheMPSchedulerAdapter,
         LMCacheMPWorkerAdapter,
         ParallelStrategy,
@@ -108,6 +108,9 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = lmcache_init_logger(__name__)
+
+_DCP_LAYOUT_NAMESPACE = "##lmcache-dcp-layout-v1-"
+_MAX_LCM_EXPANSION_FACTOR = 4
 
 
 # Helper functions
@@ -145,7 +148,124 @@ def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
     return False
 
 
-def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
+def _iter_kv_cache_specs(kv_cache_config: "KVCacheConfig | None") -> Iterable[Any]:
+    """Yield leaf KV cache specs without depending on a vLLM helper API."""
+    if kv_cache_config is None:
+        return
+    for group in kv_cache_config.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
+        if isinstance(per_layer_specs, dict):
+            yield from per_layer_specs.values()
+        else:
+            yield group_spec
+
+
+def get_group_tokens_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> list[int]:
+    """Return each engine group's block span in scheduler token coordinates.
+
+    Attention pages are local DCP shards and therefore cover
+    ``spec.block_size * dcp_size`` global tokens. Recurrent-state pages are
+    replicated and retain their physical ``spec.block_size`` span. When vLLM
+    does not provide group metadata, preserve the legacy single-group rule.
+    """
+    dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
+    groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    return [
+        get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in groups
+    ] or [vllm_config.cache_config.block_size * dcp_size]
+
+
+def get_lmcache_scheduler_block_size(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> int:
+    """Resolve the scheduling block shared by every engine KV cache group."""
+    group_spans = get_group_tokens_per_block(vllm_config, kv_cache_config)
+    scheduler_block_size = math.lcm(*group_spans)
+    largest_group_span = max(group_spans)
+    if scheduler_block_size > largest_group_span * _MAX_LCM_EXPANSION_FACTOR:
+        logger.warning(
+            "LMCache resolved a scheduler block of %d tokens from group spans "
+            "%s (%0.1fx the largest span). Near-coprime group geometry can "
+            "make cache chunks too coarse to be useful.",
+            scheduler_block_size,
+            group_spans,
+            scheduler_block_size / largest_group_span,
+        )
+    return scheduler_block_size
+
+
+def get_lmcache_model_name(vllm_config: VllmConfig) -> str:
+    """Return a cache key namespace that isolates DCP interleave layouts.
+
+    A DCP rank's page is an opaque byte image whose token-to-slot mapping
+    changes with ``cp_kv_cache_interleave_size``. The existing ``kv_rank``
+    identity distinguishes DCP shard counts but not interleave values, so a
+    deployment changing only interleave could otherwise retrieve incompatible
+    pages left by the earlier deployment. ``model_name`` is also exposed as a
+    label by MP observability subscribers, so metrics use this decorated value;
+    callers can recover the served model name with
+    :func:`get_lmcache_base_model_name`. Keep legacy keys unchanged unless a
+    non-trivial DCP interleave is active. The ``##`` separator follows the SDK
+    cache-kind namespace convention.
+    """
+    model_name = vllm_config.model_config.model
+    parallel_config = vllm_config.parallel_config
+    dcp_size = getattr(parallel_config, "decode_context_parallel_size", 1)
+    interleave = getattr(parallel_config, "cp_kv_cache_interleave_size", 1)
+    if dcp_size <= 1 or interleave == 1:
+        return model_name
+    return f"{model_name}{_DCP_LAYOUT_NAMESPACE}d{dcp_size}-interleave{interleave}"
+
+
+def get_lmcache_base_model_name(model_name: str) -> str:
+    """Remove the connector's DCP layout namespace from a cache model name.
+
+    Args:
+        model_name: A served model name or an LMCache-decorated model name.
+
+    Returns:
+        The undecorated model name used by the serving API and model config.
+    """
+    return model_name.partition(_DCP_LAYOUT_NAMESPACE)[0]
+
+
+def get_resolved_attention_block_sizes(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> set[int]:
+    """Return physical block sizes for resolved attention cache groups.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        The resolved attention block sizes. Falls back to vLLM's cache block
+        size when group metadata is unavailable.
+    """
+    block_sizes = {
+        spec.block_size
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if any(cls.__name__ == "AttentionSpec" for cls in type(spec).__mro__)
+    }
+    if block_sizes:
+        return block_sizes
+    return {vllm_config.cache_config.block_size}
+
+
+def validate_mamba_step_alignment(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> None:
     """Reject scheduler configs whose steps cannot advance a whole Mamba block.
 
     In ``mamba_cache_mode="align"`` vLLM snapshots the recurrent state only at
@@ -169,7 +289,21 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
     """
     if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
         return
-    block_size = vllm_config.cache_config.block_size
+    mamba_block_sizes = {
+        spec.block_size
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if any(cls.__name__ == "MambaSpec" for cls in type(spec).__mro__)
+    }
+    if len(mamba_block_sizes) > 1:
+        raise ValueError(
+            "All Mamba KV cache groups must use one physical block size; got "
+            f"{sorted(mamba_block_sizes)}."
+        )
+    block_size = (
+        next(iter(mamba_block_sizes))
+        if mamba_block_sizes
+        else vllm_config.cache_config.block_size
+    )
     max_batched = vllm_config.scheduler_config.max_num_batched_tokens
     if max_batched < block_size:
         raise ValueError(
@@ -181,7 +315,11 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
         )
 
 
-def validate_dcp_support(vllm_config: VllmConfig, n_servers: int) -> None:
+def validate_dcp_support(
+    vllm_config: VllmConfig,
+    n_servers: int,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> None:
     """Reject decode-context-parallel topologies this connector cannot serve.
 
     These would silently store wrong or incomplete KV, so fail at startup
@@ -204,13 +342,25 @@ def validate_dcp_support(vllm_config: VllmConfig, n_servers: int) -> None:
             f"together with DCP (got pcp={pcp_size}, dcp={dcp_size})."
         )
 
-    # Fail-closed, not fundamental: the interleave sets each object's byte
-    # layout but is absent from cache identity, and k != 1 is unvalidated.
     interleave = getattr(pc, "cp_kv_cache_interleave_size", 1)
-    if interleave != 1:
+    if interleave < 1:
         raise ValueError(
-            "LMCacheMPConnector requires cp_kv_cache_interleave_size == 1 "
+            "LMCacheMPConnector requires cp_kv_cache_interleave_size >= 1 "
             f"under DCP (got {interleave})."
+        )
+    attention_block_sizes = get_resolved_attention_block_sizes(
+        vllm_config, kv_cache_config
+    )
+    incompatible_block_sizes = sorted(
+        block_size
+        for block_size in attention_block_sizes
+        if interleave > block_size or block_size % interleave != 0
+    )
+    if incompatible_block_sizes:
+        raise ValueError(
+            f"cp_kv_cache_interleave_size ({interleave}) must be no greater "
+            "than and evenly divide every resolved attention block size; "
+            f"incompatible sizes: {incompatible_block_sizes}."
         )
 
     ranks_per_server = pc.world_size // n_servers
@@ -297,11 +447,22 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig | None" = None,
     ):
-        super().__init__(vllm_config, role, kv_cache_config)
+        # Older supported vLLM releases allow connectors to omit this value,
+        # while current vLLM's type declaration requires it.
+        super().__init__(vllm_config, role, kv_cache_config)  # type: ignore[arg-type]
 
         # Fail fast, before the server handshake below.
-        validate_mamba_step_alignment(vllm_config)
-        validate_kv_cache_groups(getattr(self, "_kv_cache_config", None))
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        validate_mamba_step_alignment(vllm_config, kv_cache_config)
+        validate_kv_cache_groups(kv_cache_config)
+
+        group_tokens_per_block = get_group_tokens_per_block(
+            vllm_config, kv_cache_config
+        )
+        scheduler_block_size = get_lmcache_scheduler_block_size(
+            vllm_config, kv_cache_config
+        )
+        cache_model_name = get_lmcache_model_name(vllm_config)
 
         assert vllm_config.kv_transfer_config is not None
 
@@ -340,7 +501,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # The server count is derived from lmcache.mp.server_urls.
         n_servers = len(server_urls)
 
-        validate_dcp_support(vllm_config, n_servers)
+        validate_dcp_support(vllm_config, n_servers, kv_cache_config)
+
+        logger.info(
+            "Resolved LMCache MP geometry: group_tokens_per_block=%s, "
+            "scheduler_block_size=%d, cache_model_name=%s",
+            group_tokens_per_block,
+            scheduler_block_size,
+            cache_model_name,
+        )
 
         assert vllm_config.parallel_config.world_size % n_servers == 0, (
             f"world_size ({vllm_config.parallel_config.world_size}) must be "
@@ -394,8 +563,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.scheduler_adapter = LMCacheMPSchedulerAdapter(
                 server_urls=server_urls,
                 context=zmq_context,
-                model_name=vllm_config.model_config.model,
-                vllm_block_size=vllm_config.cache_config.block_size * dcp_size,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
@@ -421,8 +590,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.worker_adapter = LMCacheMPWorkerAdapter(
                 server_url=local_server_url,
                 context=zmq_context,
-                model_name=vllm_config.model_config.model,
-                vllm_block_size=vllm_config.cache_config.block_size * dcp_size,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
@@ -446,21 +615,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         else:
             raise ValueError(f"Unknown KVConnectorRole: {self.role}")
 
-        kv_cache_config = getattr(self, "_kv_cache_config", None)
-        vllm_groups = (
-            getattr(kv_cache_config, "kv_cache_groups", ()) or ()
-            if kv_cache_config is not None
-            else ()
-        )
         # Tokens covered by one paged chunk (one block ID) of each engine
         # group, from the group's KV cache spec. Hybrid models can mix
         # different values (e.g. gemma-4: sliding-window groups 32,
         # full-attention groups 16; DeepSeek V4: 256/64/8/4). Falls back to
         # the engine's base block size when no group metadata is available
         # (single non-hybrid group).
-        self._group_tokens_per_block: list[int] = [
-            get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in vllm_groups
-        ] or [vllm_config.cache_config.block_size * dcp_size]
+        self._group_tokens_per_block = group_tokens_per_block
         for engine_group_idx, tokens_per_block in enumerate(
             self._group_tokens_per_block
         ):

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -6,10 +6,12 @@ and ``get_tokens_per_block`` (attention-only block scaling). No GPU needed."""
 # Standard
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from typing import Literal
 import importlib.util
 
 # Third Party
 import pytest
+import torch
 
 # First Party
 from lmcache.integration.vllm.kv_cache_groups import get_tokens_per_block
@@ -248,6 +250,14 @@ class _FakeMambaSpec:
 
 
 @dataclass
+class MambaSpec:
+    """Mamba spec double detected by its public class name."""
+
+    block_size: int
+    mamba_cache_mode: str = "align"
+
+
+@dataclass
 class AttentionSpec:
     """Double for vLLM's AttentionSpec base; detection is by class name."""
 
@@ -304,6 +314,160 @@ def test_hybrid_layout_produces_mixed_spans():
     assert math.lcm(*spans) == 2048  # scheduler commit granularity
 
 
+def _import_connector_geometry_helpers():
+    """Import helpers lazily because their module imports vLLM."""
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_group_tokens_per_block,
+        get_lmcache_model_name,
+        get_lmcache_scheduler_block_size,
+        validate_mamba_step_alignment,
+    )
+
+    return (
+        get_group_tokens_per_block,
+        get_lmcache_model_name,
+        get_lmcache_scheduler_block_size,
+        validate_mamba_step_alignment,
+    )
+
+
+def _hybrid_kv_cache_config(
+    attention_block_size: int = 2304,
+    mamba_block_size: int = 2304,
+) -> SimpleNamespace:
+    """Resolved GLM-like groups after platform page-size equalization."""
+    return SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=_attention_spec(attention_block_size)),
+            SimpleNamespace(kv_cache_spec=MambaSpec(mamba_block_size)),
+        ]
+    )
+
+
+def _geometry_config(
+    *,
+    dcp_size: int = 4,
+    interleave: int = 4,
+    base_block_size: int = 256,
+    max_num_batched_tokens: int = 4096,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model="org/glm-5.3-flash"),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+            cp_kv_cache_interleave_size=interleave,
+        ),
+        cache_config=SimpleNamespace(
+            block_size=base_block_size,
+            mamba_cache_mode="align",
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=max_num_batched_tokens),
+    )
+
+
+@requires_vllm
+def test_glm_dcp4_geometry_resolves_physical_mamba_block():
+    (
+        get_group_tokens_per_block,
+        _,
+        get_lmcache_scheduler_block_size,
+        _,
+    ) = _import_connector_geometry_helpers()
+    config = _geometry_config()
+    kv_config = _hybrid_kv_cache_config()
+
+    assert get_group_tokens_per_block(config, kv_config) == [9216, 2304]
+    assert get_lmcache_scheduler_block_size(config, kv_config) == 9216
+
+
+@requires_vllm
+def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
+    *_, validate_mamba_step_alignment = _import_connector_geometry_helpers()
+    kv_config = _hybrid_kv_cache_config()
+
+    with pytest.raises(ValueError, match=r"block_size=2304"):
+        validate_mamba_step_alignment(
+            _geometry_config(max_num_batched_tokens=2048), kv_config
+        )
+
+    validate_mamba_step_alignment(
+        _geometry_config(max_num_batched_tokens=4096), kv_config
+    )
+
+
+@requires_vllm
+@pytest.mark.parametrize(
+    ("kv_layout", "expected_shape"),
+    [
+        ("BLHNC", (3, 1, 4, 4)),
+        ("BLNHC", (3, 4, 1, 4)),
+    ],
+)
+def test_mamba_unified_view_preserves_blocks_first_pool_stride(
+    kv_layout: Literal["BLHNC", "BLNHC"], expected_shape: tuple[int, ...]
+):
+    """Jovian's shared blocks-first pool remains a zero-copy strided view."""
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        _MambaUnifiedViewEdit,
+    )
+
+    num_blocks, num_layers, row, page_elems = 3, 2, 13, 16
+    pool = torch.arange(num_blocks * num_layers * page_elems, dtype=torch.float32)
+    layer = pool.as_strided(
+        (num_blocks, 1, 1, row),
+        (num_layers * page_elems, row, row, 1),
+        storage_offset=page_elems,
+    )
+    spec = SimpleNamespace(block_size=4, page_size_bytes=64)
+
+    edited = _MambaUnifiedViewEdit().apply(spec, layer, {"kv_layout": kv_layout})
+
+    assert edited.shape == expected_shape
+    assert edited.stride(0) == num_layers * page_elems
+    assert edited.data_ptr() == layer.data_ptr()
+
+
+@requires_vllm
+def test_dcp_interleave_participates_in_cache_identity():
+    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_lmcache_base_model_name,
+    )
+
+    interleave4 = get_lmcache_model_name(_geometry_config(interleave=4))
+    interleave8 = get_lmcache_model_name(_geometry_config(interleave=8))
+    assert interleave4 != interleave8
+    assert interleave4.endswith("##lmcache-dcp-layout-v1-d4-interleave4")
+    assert get_lmcache_base_model_name(interleave4) == "org/glm-5.3-flash"
+
+
+@requires_vllm
+def test_base_model_name_preserves_undecorated_names():
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_lmcache_base_model_name,
+    )
+
+    assert get_lmcache_base_model_name("org/glm-5.3-flash") == ("org/glm-5.3-flash")
+
+
+@requires_vllm
+def test_trivial_interleave_preserves_legacy_cache_identity():
+    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+
+    assert (
+        get_lmcache_model_name(_geometry_config(dcp_size=4, interleave=1))
+        == "org/glm-5.3-flash"
+    )
+    assert (
+        get_lmcache_model_name(_geometry_config(dcp_size=1, interleave=4))
+        == "org/glm-5.3-flash"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # validate_dcp_support: fail closed on unproven topologies                     #
 # --------------------------------------------------------------------------- #
@@ -324,6 +488,7 @@ def _config(
     pp_size: int = 1,
     interleave: int = 1,
     tp_size: int = 8,
+    cache_block_size: int = 256,
 ) -> SimpleNamespace:
     """Minimal stand-in exposing only the parallel_config fields read."""
     return SimpleNamespace(
@@ -334,7 +499,8 @@ def _config(
             cp_kv_cache_interleave_size=interleave,
             tensor_parallel_size=tp_size,
             world_size=tp_size * pp_size,
-        )
+        ),
+        cache_config=SimpleNamespace(block_size=cache_block_size),
     )
 
 
@@ -365,10 +531,36 @@ def test_validate_rejects_pcp_with_dcp():
 
 
 @requires_vllm
-def test_validate_rejects_nontrivial_interleave():
-    """The silent-corruption guard: wrong KV stored, no crash, without it."""
-    with pytest.raises(ValueError, match="cp_kv_cache_interleave_size"):
-        _import_validate_dcp_support()(_config(dcp_size=2, interleave=64), 1)
+def test_validate_accepts_interleave_when_layout_is_namespaced():
+    """Opaque per-rank pages round-trip when their key namespace is isolated."""
+    _import_validate_dcp_support()(
+        _config(dcp_size=4, interleave=4), 1, _hybrid_kv_cache_config()
+    )
+
+
+@requires_vllm
+def test_validate_uses_resolved_attention_block_for_interleave():
+    """The resolved 2304 page, rather than the CLI 256 page, is authoritative."""
+    validate = _import_validate_dcp_support()
+    kv_config = _hybrid_kv_cache_config(attention_block_size=2304)
+
+    validate(_config(dcp_size=4, interleave=768), 1, kv_config)
+
+
+@requires_vllm
+def test_validate_rejects_interleave_not_dividing_resolved_attention_block():
+    with pytest.raises(ValueError, match="evenly divide"):
+        _import_validate_dcp_support()(
+            _config(dcp_size=4, interleave=1000),
+            1,
+            _hybrid_kv_cache_config(attention_block_size=2304),
+        )
+
+
+@requires_vllm
+def test_validate_rejects_nonpositive_interleave():
+    with pytest.raises(ValueError, match=">= 1"):
+        _import_validate_dcp_support()(_config(dcp_size=4, interleave=0), 1)
 
 
 @requires_vllm

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -262,6 +262,7 @@ class AttentionSpec:
     """Double for vLLM's AttentionSpec base; detection is by class name."""
 
     block_size: int
+    dcp_replicated: bool = False
 
 
 @dataclass
@@ -295,6 +296,12 @@ def test_mamba_group_never_scaled():
     spec = _FakeMambaSpec(block_size=1024)
     assert get_tokens_per_block(spec, 2) == 1024
     assert get_tokens_per_block(spec, 8) == 1024
+
+
+def test_dcp_replicated_attention_group_never_scaled():
+    """Replicated DFlash draft KV keeps ordinary DCP1 block coordinates."""
+    spec = FullAttentionSpec(block_size=16, dcp_replicated=True)
+    assert get_tokens_per_block(spec, 4) == 16
 
 
 def test_dcp_one_is_identity_for_every_spec_type():
@@ -398,20 +405,25 @@ def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
 
 @requires_vllm
 @pytest.mark.parametrize(
-    ("kv_layout", "expected_shape"),
-    [
-        ("BLHNC", (3, 1, 4, 4)),
-        ("BLNHC", (3, 4, 1, 4)),
-    ],
+    "kv_layout",
+    ["BLHNC", "BLNHC"],
 )
 def test_mamba_unified_view_preserves_blocks_first_pool_stride(
-    kv_layout: Literal["BLHNC", "BLNHC"], expected_shape: tuple[int, ...]
+    kv_layout: Literal["BLHNC", "BLNHC"],
 ):
-    """Jovian's shared blocks-first pool remains a zero-copy strided view."""
+    """Jovian Mamba pages use the padded-stride-capable opaque format."""
+    # Third Party
+    from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
+    from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+
     # First Party
     from lmcache.integration.vllm.kv_cache_group_edits import (
-        _MambaUnifiedViewEdit,
+        apply_kv_cache_group_edits,
     )
+    from lmcache.v1.gpu_connector.utils import (
+        resolve_block_stride_and_log_layout,
+    )
+    import lmcache.lmcache_native as lmcache_native
 
     num_blocks, num_layers, row, page_elems = 3, 2, 13, 16
     pool = torch.arange(num_blocks * num_layers * page_elems, dtype=torch.float32)
@@ -420,13 +432,194 @@ def test_mamba_unified_view_preserves_blocks_first_pool_stride(
         (num_layers * page_elems, row, row, 1),
         storage_offset=page_elems,
     )
-    spec = SimpleNamespace(block_size=4, page_size_bytes=64)
+    spec = VllmMambaSpec(
+        block_size=4,
+        shapes=((row,),),
+        dtypes=(torch.float32,),
+        page_size_padded=page_elems * torch.float32.itemsize,
+        mamba_cache_mode="align",
+    )
+    kv_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["mamba"], spec)],
+        kv_cache_layout=kv_layout,
+    )
 
-    edited = _MambaUnifiedViewEdit().apply(spec, layer, {"kv_layout": kv_layout})
+    edited = apply_kv_cache_group_edits(
+        kv_config,
+        {"mamba": layer},
+        {"kv_layout": kv_layout},
+    )["mamba"]
 
-    assert edited.shape == expected_shape
+    assert isinstance(edited, torch.Tensor)
+    assert edited.shape == (3, 4, 4)
+    assert edited.stride() == (num_layers * page_elems, 4, 1)
     assert edited.stride(0) == num_layers * page_elems
     assert edited.data_ptr() == layer.data_ptr()
+    assert (
+        resolve_block_stride_and_log_layout(
+            [edited],
+            lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+            layer_idx=0,
+            group_idx=0,
+        )
+        == num_layers * page_elems
+    )
+
+
+@requires_vllm
+@pytest.mark.parametrize(
+    ("kv_layout", "target_shape", "target_strides"),
+    [
+        ("BLHNC", (3, 1, 4, 8), (80, 32, 8, 1)),
+        ("BLNHC", (3, 4, 1, 8), (80, 8, 32, 1)),
+    ],
+)
+def test_padded_attention_page_views_preserve_hma_block_padding(
+    kv_layout: Literal["BLHNC", "BLNHC"],
+    target_shape: tuple[int, ...],
+    target_strides: tuple[int, ...],
+):
+    """Jovian HMA MLA and DFlash pages become padded rank-3 tensors."""
+    # Third Party
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+    from vllm.v1.kv_cache_interface import (
+        MLAAttentionSpec,
+    )
+
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        apply_kv_cache_group_edits,
+    )
+    from lmcache.v1.gpu_connector.utils import (
+        resolve_block_stride_and_log_layout,
+    )
+    import lmcache.lmcache_native as lmcache_native
+
+    target_pool = torch.arange(3 * 80, dtype=torch.uint8)
+    target = target_pool.as_strided(target_shape, target_strides)
+    draft_shape = (*target_shape[:-1], 16)
+    if kv_layout == "BLHNC":
+        draft_strides = (96, 64, 16, 1)
+    else:
+        draft_strides = (96, 16, 64, 1)
+    draft_pool = torch.arange(3 * 96, dtype=torch.uint8)
+    draft = draft_pool.as_strided(draft_shape, draft_strides)
+    if kv_layout == "BLHNC":
+        dflash_shape = (3, 2, 4, 16)
+        dflash_strides = (160, 64, 16, 1)
+    else:
+        dflash_shape = (3, 4, 2, 16)
+        dflash_strides = (160, 32, 16, 1)
+    dflash_pool = torch.arange(3 * 160, dtype=torch.uint8)
+    dflash = dflash_pool.as_strided(dflash_shape, dflash_strides)
+    plain_strides = (64, 64, 16, 1) if kv_layout == "BLHNC" else (64, 16, 64, 1)
+    plain_pool = torch.arange(3 * 64, dtype=torch.uint8)
+    plain = plain_pool.as_strided(draft_shape, plain_strides)
+    mamba_pool = torch.arange(3 * 32, dtype=torch.float32)
+    mamba = mamba_pool.as_strided((3, 1, 1, 13), (32, 13, 13, 1))
+    mla_spec = MLAAttentionSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.uint8,
+    )
+    mamba_spec = VllmMambaSpec(
+        block_size=4,
+        shapes=((13,),),
+        dtypes=(torch.float32,),
+        page_size_padded=64,
+        mamba_cache_mode="align",
+    )
+    draft_spec = FullAttentionSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.uint8,
+    )
+    dflash_spec = FullAttentionSpec(
+        block_size=8,
+        num_kv_heads=2,
+        head_size=4,
+        dtype=torch.uint8,
+    )
+    kv_config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["target"], mla_spec),
+            KVCacheGroupSpec(["draft"], draft_spec),
+            KVCacheGroupSpec(["dflash"], dflash_spec),
+            KVCacheGroupSpec(["plain"], draft_spec),
+            KVCacheGroupSpec(["mamba"], mamba_spec),
+        ],
+        kv_cache_layout=kv_layout,
+    )
+
+    edited_caches = apply_kv_cache_group_edits(
+        kv_config,
+        {
+            "target": target,
+            "draft": draft,
+            "dflash": dflash,
+            "plain": plain,
+            "mamba": mamba,
+        },
+        {"kv_layout": kv_layout},
+    )
+    edited = edited_caches["target"]
+    edited_draft = edited_caches["draft"]
+    edited_dflash = edited_caches["dflash"]
+
+    assert isinstance(edited, torch.Tensor)
+    assert edited.shape == (3, 4, 8)
+    assert edited.stride() == (80, 8, 1)
+    assert edited.data_ptr() == target.data_ptr()
+    assert torch.equal(edited[1].reshape(-1), target[1].reshape(-1))
+    assert isinstance(edited_draft, torch.Tensor)
+    assert edited_draft.shape == (3, 4, 16)
+    assert edited_draft.stride() == (96, 16, 1)
+    assert edited_draft.data_ptr() == draft.data_ptr()
+    assert torch.equal(edited_draft[1].reshape(-1), draft[1].reshape(-1))
+    assert isinstance(edited_dflash, torch.Tensor)
+    assert edited_dflash.shape == (3, 8, 16)
+    assert edited_dflash.stride() == (160, 16, 1)
+    assert edited_dflash.data_ptr() == dflash.data_ptr()
+    assert torch.equal(edited_dflash[1].reshape(-1), dflash[1].reshape(-1))
+    assert edited_caches["plain"] is plain
+    assert (
+        resolve_block_stride_and_log_layout(
+            [edited],
+            lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+            layer_idx=0,
+            group_idx=0,
+        )
+        == 80
+    )
+    assert (
+        resolve_block_stride_and_log_layout(
+            [edited_draft],
+            lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+            layer_idx=0,
+            group_idx=1,
+        )
+        == 96
+    )
+    assert (
+        resolve_block_stride_and_log_layout(
+            [edited_dflash],
+            lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+            layer_idx=0,
+            group_idx=2,
+        )
+        == 160
+    )
 
 
 @requires_vllm
@@ -622,6 +815,16 @@ def test_uniform_type_wrapper_still_scales_under_dcp():
     )
     assert get_tokens_per_block(wrapped, 2) == 2048
     assert get_tokens_per_block(wrapped, 1) == 1024
+
+
+def test_uniform_type_wrapper_of_replicated_attention_is_not_scaled():
+    """Wrapped DFlash leaves retain replicated block coordinates."""
+    inner = FullAttentionSpec(block_size=16, dcp_replicated=True)
+    wrapped = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={"draft.0": inner, "draft.1": inner},
+    )
+    assert get_tokens_per_block(wrapped, 4) == 16
 
 
 def test_uniform_type_wrapper_of_mamba_is_not_scaled():


### PR DESCRIPTION
## Summary

Make the vLLM multiprocess connector use the resolved per-group KV-cache geometry for DCP-interleaved hybrid models instead of assuming the CLI/base block size is the transfer span.

This change:

- derives attention and recurrent token spans from `KVCacheConfig`;
- uses their LCM for scheduler/chunk alignment and warns on pathological expansion;
- validates Mamba step and DCP interleave against the resolved attention page size;
- namespaces cache identity by DCP size and interleave using the existing `##` convention, with an inverse helper for observability;
- preserves legacy cache keys for DCP-disabled and interleave-1 deployments; and
- canonicalizes padded blocks-first Mamba, MLA, and DFlash pages as opaque rank-3 views so transfers retain the authoritative block stride and never cross into adjacent HMA pages.

## Why interleave is safe here

Each DCP rank is stored as an opaque, separately keyed byte page. LMCache does not gather, deinterleave, or reinterpret the page contents. A round trip is therefore safe while topology is fixed, provided pages from different token-to-slot layouts cannot collide. The versioned DCP/interleave cache namespace supplies that isolation.

## Failure mode fixed

For the validated GLM-5.3 Flash DCP4 layout, the engine's base block is 256 tokens while resolved attention pages span 2,304 tokens and the hybrid-group LCM is 9,216 tokens. Using the base block for validation or scheduling either rejects valid interleaves or transfers the wrong page geometry. Padded physical pages can additionally expose a larger first-axis stride than their logical block count; flattening those pages can cross into a sibling cache page.

## Unit and static validation

- `pytest -q tests/v1/test_vllm_dcp_support.py`: **65 passed**
- Broader Linux connector/layout selection: **94 passed**
- `pre-commit run --files` over every changed source, test, and documentation file: **all hooks passed**
- `git diff --check`: **passed**
- DCO: both commits contain author-matching `Signed-off-by` trailers
- Every changed file at the signed PR tip was byte-compared with the corresponding runtime-tested source: **identical**
- `cd docs && make clean && make html`: **exit 0**, 179 documents built; the repository emitted 36 warnings in unrelated pages and none from the modified `mp/configuration.rst`

The tests cover:

- resolved attention pages differing from the base block size;
- legal and illegal DCP interleaves;
- DCP rank ownership and cache namespace isolation;
- legacy-key compatibility and namespace decoding;
- hybrid group LCM geometry and pathological-LCM warning;
- BLHNC and BLNHC views;
- padded, wrapped, and zero-copy Mamba/MLA/DFlash page layouts;
- byte payload and stride preservation; and
- multi-server reader accounting.

## cn4 end-to-end correctness evidence

Validated with these exact changed files on 4x RTX PRO 6000 Blackwell Workstation Edition using current Jovian vLLM, GLM-5.3-Flash-NVFP4, TP4/DCP4, FP8 DS-MLA KV cache, DFlash2 (7 draft tokens), vision, and LMCache MP DRAM + `fs_native` NVMe tiers.

Observed runtime geometry on every rank:

```text
group_tokens_per_block=[2304, 2304, 2304, 2304, 9216, 16]
scheduler_block_size=9216
cache_model_name=/model##lmcache-dcp-layout-v1-d4-interleave4
```

Actual vLLM KV allocation:

```text
23.08 GiB/rank
92.32 GiB aggregate
171,416-token pool
1.31x maximum concurrency at a 131,072-token request length
```

Offload/recovery results:

| Gate | Result |
|---|---:|
| Initial store | 39,400 prompt tokens; 48 rank objects stored |
| DRAM full-prefix recovery | 36,864 external-hit tokens; 48 L1 read chunks |
| NVMe full-prefix recovery after L1/APC clear | 36,864 tokens; 4 L2 chunks |
| NVMe partial-prefix recovery | 18,432 tokens; 2 L2 chunks from a 22,400-token common prefix |
| Eviction pressure | 22 fill fixtures; 1,260 L1 chunks evicted |
| Bounded L2 eviction | largest observed usage drop 4,351,451,136 bytes |
| Post-eviction newest-fixture recovery | 46,080 tokens; 5 L2 chunks |
| Cross-process restart recovery | 50,700-token fixture recovered 46,080 tokens / 5 L2 chunks |
| Vision smoke | image text transcribed exactly as `Hello, AI world!` |
| Text/DFlash2+DCP4 smoke | passed with zero request errors |

The 9,216-token cache chunk is derived from the resolved hybrid geometry, not a tuning constant. Prompts shorter than 9,216 tokens receive no external-cache benefit, and hits occur on 9,216-token boundaries; for example, a 22,352-token common prefix retrieves 18,432 tokens and recomputes the remainder.

## Quality and performance scope

FP8/NVFP4 KLD qualification produced mean KLD `0.1349859522` and `0.1320639380`, both inside the established `0.13037–0.14133` acceptance window.

There is no meaningful pre-fix LMCache+DCP4 performance baseline because the base path cannot serve this geometry correctly. In a matched C16/ctx0 DFlash2 diagnostic, connector-off serving measured 580.93 output tok/s and the added LMCache-enabled path measured 375.23 tok/s with zero request errors. Connector-off serving is outside this connector-only change surface. LMCache feature-path performance tuning is continuing separately and no speculative performance experiment is included in this PR.

## Integration

The corresponding vLLM DFlash2+DCP4 correctness work is tracked in [local-inference-lab/vllm#513](https://github.com/local-inference-lab/vllm/pull/513).

Base: `LMCache/LMCache:dev` at `df002c21cfab03106546bfd29f5c622431b9e0dd`.

AI-assisted implementation and validation.
