### PR TITLE
fix(vllm): wait for remote stores before preemption

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1967,8 +1967,6 @@ class LMCacheMPWorkerAdapter:
         if not self.is_healthy or self.transfer_ctx is None:
             return
         self.transfer_ctx.flush_inflight_stores()
-        # Force device sync here, compare to preemption, perf panelty is trivial
-        torch_dev.synchronize()
 
     def shutdown(self) -> None:
         """

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -411,6 +411,13 @@ class LMCacheDrivenTransferContext(TransferContext):
         self._send_request: SendRequest | None = None
         self._device: torch.device | None = None
         self._event_backend: EventIPCBackend | None = None
+        self._mq_timeout: float | None = None
+        # The server reads paged KV asynchronously through exported device
+        # handles. Keep outstanding stores alive here so preemption can wait
+        # for the actual remote reads before vLLM reuses their blocks. This
+        # cannot rely on the adapter's per-request map: a later chunk may
+        # replace that entry while the earlier store is still in flight.
+        self._inflight_store_futures: set[MessagingFuture[Any]] = set()
 
     def register(
         self,
@@ -467,6 +474,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         future.result(timeout=mq_timeout)
         self._device = device
         self._event_backend = event_backend
+        self._mq_timeout = mq_timeout
 
     def register_q(
         self,
@@ -538,11 +546,16 @@ class LMCacheDrivenTransferContext(TransferContext):
                 "Call register() before submit_store()."
             )
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._send_request(
+        self._inflight_store_futures = {
+            future for future in self._inflight_store_futures if not future.query()
+        }
+        future = self._send_request(
             self._mq_client,
             RequestType.STORE,
             [key, instance_id, block_ids, event_ipc_handle],
         ).to_device_future(device=self._device)
+        self._inflight_store_futures.add(future)
+        return future
 
     def submit_q_store(
         self,
@@ -625,9 +638,22 @@ class LMCacheDrivenTransferContext(TransferContext):
         self._send_request = None
         self._device = None
         self._event_backend = None
+        self._mq_timeout = None
+        self._inflight_store_futures.clear()
 
     def flush_inflight_stores(self) -> None:
-        pass
+        """Wait for server-side device reads that preemption could overwrite.
+
+        LMCache-driven stores execute in the server process, so synchronizing
+        the worker's device does not order or complete them. Their device-aware
+        futures do: each resolves only after the server response and imported
+        completion event. Usually this set is empty, making preemption handling
+        a true no-op instead of a device-wide barrier.
+        """
+        timeout = self._mq_timeout
+        for future in list(self._inflight_store_futures):
+            future.result(timeout=timeout)
+            self._inflight_store_futures.discard(future)
 
 
 class EngineDrivenTransferContext(TransferContext):

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -389,6 +389,31 @@ def test_create_transfer_context_force_lmcache_driven_mode() -> None:
     assert isinstance(context, LMCacheDrivenTransferContext)
 
 
+def test_lmcache_driven_preemption_waits_for_remote_store_futures() -> None:
+    """Handle-path flush waits on remote completion, not the worker device."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import LMCacheDrivenTransferContext
+
+    context = LMCacheDrivenTransferContext()
+    context._mq_timeout = 2.5
+    pending = MagicMock(name="pending_store_future")
+    context._inflight_store_futures.add(pending)
+
+    context.flush_inflight_stores()
+
+    pending.result.assert_called_once_with(timeout=2.5)
+    assert not context._inflight_store_futures
+
+
+def test_lmcache_driven_preemption_without_stores_is_noop() -> None:
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import LMCacheDrivenTransferContext
+
+    context = LMCacheDrivenTransferContext()
+
+    context.flush_inflight_stores()
+
+
 def test_create_transfer_context_force_engine_driven_mode_on_cpu() -> None:
     """``mode='engine_driven'`` on CPU returns EngineDrivenTransferContext
     (data path; no wrapper-factory capability check is performed)."""

--- a/tests/v1/test_vllm_mp_preemption.py
+++ b/tests/v1/test_vllm_mp_preemption.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Preemption synchronization tests for the vLLM multiprocess adapter."""
+
+# Standard
+from unittest.mock import MagicMock
+import threading
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
+from lmcache.integration.vllm.vllm_multi_process_adapter import (
+    LMCacheMPWorkerAdapter,
+)
+
+
+def _healthy_adapter() -> tuple[LMCacheMPWorkerAdapter, MagicMock]:
+    adapter = object.__new__(LMCacheMPWorkerAdapter)
+    adapter._health_event = threading.Event()
+    adapter._health_event.set()
+    transfer_ctx = MagicMock(name="transfer_ctx")
+    adapter.transfer_ctx = transfer_ctx
+    return adapter, transfer_ctx
+
+
+def test_handle_preemptions_delegates_without_device_wide_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The transport owns its completion primitive during preemption.
+
+    A worker-side device synchronize cannot complete server-process CUDA work
+    and serializes unrelated inference work when preemptions are frequent.
+    """
+    adapter, transfer_ctx = _healthy_adapter()
+    synchronize = MagicMock(name="synchronize")
+    monkeypatch.setattr(adapter_mod.torch_dev, "synchronize", synchronize)
+
+    adapter.handle_preemptions(True)
+
+    transfer_ctx.flush_inflight_stores.assert_called_once_with()
+    synchronize.assert_not_called()
+
+
+def test_handle_preemptions_false_is_noop() -> None:
+    adapter, transfer_ctx = _healthy_adapter()
+
+    adapter.handle_preemptions(False)
+
+    transfer_ctx.flush_inflight_stores.assert_not_called()


### PR DESCRIPTION
## Summary

Wait for the CUDA transfer primitive that actually covers remote LMCache server reads before vLLM reuses preempted KV blocks.

`LMCacheMPWorkerAdapter.handle_preemptions()` currently flushes the transfer context and then performs an unconditional worker-local `torch.cuda.synchronize()`. In LMCache-driven mode, the server process asynchronously reads pages through exported CUDA handles. Synchronizing the worker device neither orders nor completes that server-process work, while it does serialize unrelated inference work.

This PR:

- strongly tracks every outstanding LMCache-driven store future in the CUDA transfer context;
- retains earlier stores even if a later chunk replaces the adapter's per-request future entry;
- prunes completed futures during subsequent submissions;
- waits for the remote/device-aware completion future during a preemption flush;
- clears tracked futures during shutdown; and
- removes the unconditional device-wide synchronization from the adapter.

An empty preemption flush is now a true no-op. Active stores wait on the completion event and server response that protect the blocks being reclaimed.

## Correctness contract

The server imports the exported device page and completion event, performs the remote read, and resolves the `DeviceMessagingFuture` only after that operation is complete. Holding and awaiting those futures is therefore the transport-aware ordering boundary. A local device-wide barrier is not.

Strong references are intentional: a weak collection could drop an unfinished future, and the adapter's request map is insufficient because later stores can replace its entry while an older server read remains in flight.

## Validation

- Focused preemption tests: **4 passed**
  - adapter delegates to the transfer context without a device-wide sync;
  - `preempted=False` is a no-op;
  - remote store futures are awaited with the configured messaging timeout; and
  - an empty outstanding-store set is a no-op.
- Broader Linux multiprocess/connector selection: **58 passed**
- Initial combined Linux validation selection: **94 passed**
- `pre-commit run --files` over all changed files: **all hooks passed**
- `git diff --check`: **passed**
- DCO: author-matching `Signed-off-by` trailer present
- Every changed file at the signed PR tip was byte-compared with the corresponding runtime-tested implementation: **identical**

## cn4 runtime evidence

The exact implementation was built into a current-Jovian GLM-5.3 candidate and exercised with NVFP4, FP8 KV cache, TP4/DCP4, DFlash2, vision support, and LMCache MP.

Actual KV allocation for the run:

```text
23.08 GiB/rank
92.32 GiB aggregate
171,416-token pool
```

A sustained C16/ctx0 run produced 22,415 output tokens over 59.737 seconds, encountered 23 logged preemption events, and completed with zero request errors. The fix did not recover the broader LMCache-enabled throughput gap (375.23 output tok/s versus 384.88 before this fix), which demonstrates that removing the invalid global barrier is a correctness/lifecycle repair rather than the complete performance solution.

No ordinary connector-off vLLM path is changed by this PR. Remaining LMCache feature-path performance work is being investigated separately.

Base: `LMCache/LMCache:dev` at `df002c21cfab03106546bfd29f5c622431b9e0dd`.

AI-assisted implementation and validation.
