### PR TITLE
[Feat] report hidden-state coverage through the lookup path

### DIFF
--- a/docs/design/v1/hidden_state_store.md
+++ b/docs/design/v1/hidden_state_store.md
@@ -63,6 +63,11 @@ caching is disabled).
   either KV is missing (lazy coupled-eviction cleanup) or HS is missing
   (prefix-strict). Returns the contiguous prefix tensor or `None` for a
   full miss.
+- `coverage(chunks, layer_idxs=(0,)) -> int`
+  Walks the `(start, end, key)` chunks a token database produced for a request
+  and stops at the first one missing any layer in `layer_idxs`. The result is a
+  prefix length in tokens, directly comparable with what `engine.lookup`
+  reports for KV.
 - `close()`
   Frees the pinned pool.
 
@@ -71,6 +76,28 @@ distinct `layer_idx` (and `retrieve_hidden_states` per layer on restore).
 
 When `enable_hidden_state_cache` is `False`, `engine.hidden_state_store` is
 `None`; callers must omit HS APIs on that worker.
+
+## Reporting coverage to the scheduler
+
+`get_num_new_matched_tokens()` runs in the scheduler process, where there is no
+engine and therefore no `hidden_state_store`. A caller that wants to commit only
+to what both tiers can supply asks for it through the lookup:
+
+- put the layer indices it needs under `lmcache.hidden_state_layer_idxs` in
+  `request_configs`
+- the lookup server appends a second 4-byte field to its reply, and
+  `LookupClientInterface.lookup_hidden_state_coverage(lookup_id)` returns it
+
+The field is appended rather than substituted, so the ends stay compatible: an
+older server ignores the key and answers 4 bytes, in which case the client
+reports `None` and the caller falls back to the KV hit length alone; an older
+client never sends the key and sees the reply unchanged.
+
+This matters because the two tiers drift. They evict independently, hidden
+states are stored per layer, and the defaults size the HS pool under the KV
+pool, so KV routinely covers more tokens than hidden states do. Committing to
+the KV number alone means skipping a prefill whose hidden states nobody can
+supply, which nothing detects until the worker.
 
 ## Eviction (lazy coupled-check)
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    cast,
 )
 
 if TYPE_CHECKING:
@@ -1541,6 +1542,32 @@ class LMCacheEngine:
         return num_tokens
 
     @_lmcache_nvtx_annotate
+    def lookup_hidden_states(
+        self,
+        tokens: Optional[Union[torch.Tensor, List[int]]] = None,
+        hashes: Optional[List[int]] = None,
+        offsets: Optional[List[int]] = None,
+        layer_idxs: Sequence[int] = (0,),
+        request_configs: Optional[dict] = None,
+    ) -> int:
+        """How many prefix tokens have hidden states for every requested layer.
+
+        Same chunking and prefix semantics as :meth:`lookup`, so a caller can
+        compare the two directly and only commit to the smaller.
+        """
+        if self.hidden_state_store is None:
+            return 0
+        chunk_info_iterator = self.token_database.process_tokens(
+            tokens=tokens,
+            hashes=hashes,
+            offsets=offsets,
+            request_configs=request_configs,
+        )
+        return self.hidden_state_store.coverage(
+            cast("Iterable[tuple[int, int, CacheEngineKey]]", chunk_info_iterator),
+            layer_idxs,
+        )
+
     def lookup_unpin(self, lookup_id: str) -> None:
         if lookup_id in self.lookup_pins:
             assert self.storage_manager is not None

--- a/lmcache/v1/hidden_state_store.py
+++ b/lmcache/v1/hidden_state_store.py
@@ -9,6 +9,7 @@ when ``config.enable_hidden_state_cache`` is True and exposed as
 
 # Standard
 from collections import OrderedDict
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 
 # Third Party
@@ -289,6 +290,23 @@ class HiddenStateStore:
         """Return True if a chunk is cached for ``(key, layer_idx)``."""
         layer_map = self._chunks.get(key)
         return layer_map is not None and layer_idx in layer_map
+
+    def coverage(
+        self,
+        chunks: Iterable["tuple[int, int, CacheEngineKey]"],
+        layer_idxs: Sequence[int] = (0,),
+    ) -> int:
+        """Return how many leading tokens have every layer in ``layer_idxs`` cached.
+
+        The walk stops at the first gap, so the result is a prefix length
+        directly comparable with the token count ``lookup`` reports for KV.
+        """
+        covered = 0
+        for _start, end, key in chunks:
+            if not all(self.has_chunk(key, layer_idx) for layer_idx in layer_idxs):
+                break
+            covered = end
+        return covered
 
     def drop_key(self, key: CacheEngineKey) -> bool:
         """Manually drop all HS layers for ``key``. Test/admin use."""

--- a/lmcache/v1/hidden_state_store.py
+++ b/lmcache/v1/hidden_state_store.py
@@ -296,11 +296,7 @@ class HiddenStateStore:
         chunks: Iterable["tuple[int, int, CacheEngineKey]"],
         layer_idxs: Sequence[int] = (0,),
     ) -> int:
-        """Return how many leading tokens have every layer in ``layer_idxs`` cached.
-
-        The walk stops at the first gap, so the result is a prefix length
-        directly comparable with the token count ``lookup`` reports for KV.
-        """
+        """Return how many leading tokens have every layer in ``layer_idxs`` cached."""
         covered = 0
         for _start, end, key in chunks:
             if not all(self.has_chunk(key, layer_idx) for layer_idx in layer_idxs):

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -67,6 +67,15 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
         """
         return False
 
+    def lookup_hidden_state_coverage(self, lookup_id: str) -> Optional[int]:
+        """How many prefix tokens have hidden states cached, if known.
+
+        ``None`` means the client cannot answer -- either it does not implement
+        the query or the server did not report it -- and callers should fall
+        back to the KV hit length alone.
+        """
+        return None
+
     def clear_lookup_status(self, lookup_id: str) -> None:
         """
         Clear temporary lookup status for a given lookup ID.

--- a/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
+++ b/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
@@ -69,6 +69,9 @@ class ChunkStatisticsLookupClient(LookupClientInterface):
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
         return self.actual_lookup_client.lookup_cache(lookup_id)
 
+    def lookup_hidden_state_coverage(self, lookup_id: str) -> Optional[int]:
+        return self.actual_lookup_client.lookup_hidden_state_coverage(lookup_id)
+
     def start_statistics(self) -> None:
         with self.lock:
             self.enabled = True

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -40,6 +40,9 @@ class HitLimitLookupClient(LookupClientInterface):
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
         return self.actual_lookup_client.lookup_cache(lookup_id)
 
+    def lookup_hidden_state_coverage(self, lookup_id: str) -> Optional[int]:
+        return self.actual_lookup_client.lookup_hidden_state_coverage(lookup_id)
+
     def lookup(
         self,
         token_ids: Union["torch.Tensor", list[int]],

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -23,6 +23,10 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# request_configs key carrying the layer indices whose hidden-state coverage
+# the caller wants reported alongside the KV hit length.
+HS_LAYER_IDXS_CONFIG = "lmcache.hidden_state_layer_idxs"
+
 
 class LMCacheLookupClient(LookupClientInterface):
     """
@@ -63,6 +67,10 @@ class LMCacheLookupClient(LookupClientInterface):
         # looked up, the following lookups of the same
         # request must have the same result.
         self.reqs_status: dict[str, int] = {}
+
+        # Only populated when the request asked for hidden-state coverage and
+        # the server was new enough to answer.
+        self.hs_status: dict[str, int] = {}
 
         # First Party
         from lmcache.v1.token_database import (
@@ -143,7 +151,12 @@ class LMCacheLookupClient(LookupClientInterface):
         if not responses:
             return 0
 
-        results = [int.from_bytes(resp, "big") for resp in responses]
+        results = [int.from_bytes(resp[:4], "big") for resp in responses]
+        hs_results = [
+            int.from_bytes(resp[4:8], "big") for resp in responses if len(resp) >= 8
+        ]
+        if len(hs_results) == len(responses):
+            self.hs_status[lookup_id] = min(hs_results)
 
         assert len(results) == self.transport.world_size
         if len(set(results)) > 1:
@@ -160,8 +173,12 @@ class LMCacheLookupClient(LookupClientInterface):
 
         return num_hit_toks
 
+    def lookup_hidden_state_coverage(self, lookup_id: str) -> Optional[int]:
+        return self.hs_status.get(lookup_id)
+
     def clear_lookup_status(self, lookup_id: str) -> None:
         self.reqs_status.pop(lookup_id, None)
+        self.hs_status.pop(lookup_id, None)
 
     def supports_producer_reuse(self) -> bool:
         """Return True as LMCacheLookupClient supports
@@ -240,6 +257,7 @@ class LMCacheLookupServer:
                         json.loads(request_configs_str) if request_configs_str else None
                     )
 
+                    hashes = offsets = tokens = None
                     if not self.enable_blending:
                         hashes = data_frames[0]
                         offsets = data_frames[1]
@@ -259,6 +277,20 @@ class LMCacheLookupServer:
                             request_configs=request_configs,
                         )
                     response = lookup_result.to_bytes(4, "big")
+                    # Appended, not substituted: a client that does not ask for
+                    # hidden-state coverage still gets the 4-byte reply it
+                    # expects, and one that asks an older server gets 4 bytes
+                    # back and treats the coverage as unknown.
+                    layer_idxs = (request_configs or {}).get(HS_LAYER_IDXS_CONFIG)
+                    if layer_idxs:
+                        hs_result = self.lmcache_engine.lookup_hidden_states(
+                            tokens=tokens,
+                            hashes=hashes,
+                            offsets=offsets,
+                            layer_idxs=layer_idxs,
+                            request_configs=request_configs,
+                        )
+                        response += hs_result.to_bytes(4, "big")
                     self.transport.send_response(identity, response)
                 except json.JSONDecodeError as e:
                     logger.error("Error decoding JSON in lookup request: %s", e)

--- a/tests/v1/lookup_client/test_lookup_hidden_state_coverage.py
+++ b/tests/v1/lookup_client/test_lookup_hidden_state_coverage.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wire compatibility for the optional hidden-state coverage field.
+
+The reply grew a second 4-byte field, appended rather than substituted, so a
+client and a server on different versions still understand each other. These
+build the client without an engine and feed it replies directly.
+"""
+
+# First Party
+from lmcache.v1.lookup_client.lmcache_lookup_client import (
+    HS_LAYER_IDXS_CONFIG,
+    LMCacheLookupClient,
+)
+
+
+class _FakeTransport:
+    def __init__(self, responses):
+        self._responses = responses
+        self.world_size = len(responses)
+        self.sent = []
+
+    def send_and_recv_all(self, msg_buf):
+        self.sent.append(msg_buf)
+        return self._responses
+
+
+class _FakeTokenDatabase:
+    def process_tokens(self, token_ids, make_key=True):
+        yield (0, 256, 1111)
+        yield (256, 512, 2222)
+
+
+def _client(responses):
+    client = object.__new__(LMCacheLookupClient)
+    client.transport = _FakeTransport(responses)
+    client.enable_blending = False
+    client.token_database = _FakeTokenDatabase()
+    client.reqs_status = {}
+    client.hs_status = {}
+    return client
+
+
+def test_four_byte_reply_leaves_coverage_unknown():
+    """An older server answers KV only; the caller must fall back, not read zero."""
+    client = _client([(512).to_bytes(4, "big")])
+
+    assert client.lookup([1, 2, 3], "req") == 512
+    assert client.lookup_hidden_state_coverage("req") is None
+
+
+def test_eight_byte_reply_carries_coverage():
+    client = _client([(512).to_bytes(4, "big") + (256).to_bytes(4, "big")])
+
+    assert client.lookup([1, 2, 3], "req") == 512
+    assert client.lookup_hidden_state_coverage("req") == 256
+
+
+def test_coverage_takes_the_minimum_across_ranks():
+    client = _client(
+        [
+            (512).to_bytes(4, "big") + (512).to_bytes(4, "big"),
+            (512).to_bytes(4, "big") + (256).to_bytes(4, "big"),
+        ]
+    )
+
+    assert client.lookup([1, 2, 3], "req") == 512
+    assert client.lookup_hidden_state_coverage("req") == 256
+
+
+def test_the_layer_request_rides_in_request_configs():
+    """No frame-format change, so an older server just ignores the key."""
+    client = _client([(512).to_bytes(4, "big")])
+
+    client.lookup([1, 2, 3], "req", request_configs={HS_LAYER_IDXS_CONFIG: [0, -1]})
+
+    sent = client.transport.sent[0]
+    assert len(sent) == 4
+    assert HS_LAYER_IDXS_CONFIG in sent[-1]
+
+
+def test_clearing_status_drops_the_coverage_too():
+    client = _client([(512).to_bytes(4, "big") + (256).to_bytes(4, "big")])
+    client.lookup([1, 2, 3], "req")
+
+    client.clear_lookup_status("req")
+
+    assert client.lookup_hidden_state_coverage("req") is None
+    assert client.lookup_cache("req") == -1

--- a/tests/v1/test_hidden_state_store.py
+++ b/tests/v1/test_hidden_state_store.py
@@ -432,3 +432,58 @@ def test_store_token_offset_rejects_bad_args():
             token_offset=2,
         )
     fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Coverage reporting
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_reports_the_stored_prefix():
+    fix = _Fixture()
+    token_ids = list(range(3 * CHUNK_SIZE))
+    fix.mark_kv_present(fix.keys_for(token_ids))
+    fix.store.store_hidden_states(token_ids, torch.randn(len(token_ids), HIDDEN_DIM))
+
+    chunks = list(fix.db.process_tokens(tokens=token_ids))
+    assert fix.store.coverage(chunks) == 3 * CHUNK_SIZE
+    fix.close()
+
+
+def test_coverage_stops_at_the_first_gap():
+    """A hole partway through truncates, so the result stays a usable prefix."""
+    fix = _Fixture()
+    token_ids = list(range(3 * CHUNK_SIZE))
+    keys = fix.keys_for(token_ids)
+    fix.mark_kv_present(keys)
+    fix.store.store_hidden_states(token_ids, torch.randn(len(token_ids), HIDDEN_DIM))
+
+    fix.store.drop_key(keys[1])
+    chunks = list(fix.db.process_tokens(tokens=token_ids))
+    assert fix.store.coverage(chunks) == CHUNK_SIZE
+    fix.close()
+
+
+def test_coverage_requires_every_requested_layer():
+    fix = _Fixture(layers=[0, 1])
+    token_ids = list(range(2 * CHUNK_SIZE))
+    fix.mark_kv_present(fix.keys_for(token_ids))
+    rows = torch.randn(len(token_ids), HIDDEN_DIM)
+    fix.store.store_hidden_states(token_ids, rows, layer_idx=0)
+    # Layer 1 only covers the first chunk.
+    fix.store.store_hidden_states(
+        token_ids[:CHUNK_SIZE], rows[:CHUNK_SIZE], layer_idx=1
+    )
+
+    chunks = list(fix.db.process_tokens(tokens=token_ids))
+    assert fix.store.coverage(chunks, layer_idxs=(0,)) == 2 * CHUNK_SIZE
+    assert fix.store.coverage(chunks, layer_idxs=(0, 1)) == CHUNK_SIZE
+    fix.close()
+
+
+def test_coverage_is_zero_without_any_stored_chunk():
+    fix = _Fixture()
+    token_ids = list(range(2 * CHUNK_SIZE))
+    chunks = list(fix.db.process_tokens(tokens=token_ids))
+    assert fix.store.coverage(chunks) == 0
+    fix.close()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Problem

`get_num_new_matched_tokens()` is where vLLM decides how much prefill to skip, and it only ever learns how many tokens LMCache holds KV for. Hidden states live in a separate pool with its own capacity, its own LRU and its own per-layer contents, so the two quantities drift: the pools evict independently, and the shipped defaults size hidden states at `max_hidden_state_cpu_size=2.0` against `max_local_cpu_size=5.0`, so hidden states go first while their KV survives. A store is also per layer, so a caller that needs hidden states from more than one layer loses the whole prefix when any one of them is missing.

When KV covers more than hidden states do, the engine skips a prefill whose hidden states nobody can supply. Nothing detects that at schedule time — the consumer only finds out in the worker, after the KV is committed and the recompute it would have needed is gone.

Not hypothetical for consumers that condition a downstream stage on hidden states. In vLLM-Omni the talker stage is conditioned on the thinker's hidden states, and a short restore leaves it with a truncated prefix; the audio degrades with no error anywhere. The two tiers there also align on different multiples — vLLM's prefix cache reports block multiples (16) while LMCache's coverage is chunk-aligned (256) — so agreeing is the coincidence, not the rule.

## Approach

Report hidden-state coverage alongside the KV hit length, so a caller can commit to `min(KV, HS)` instead of to KV alone.

`request_configs` already travels end to end and is free-form, so the request side needs no format change: a caller names the layers it cares about under `lmcache.hidden_state_layer_idxs`. When that key is present the lookup server appends a second 4-byte field to its reply.

That keeps both directions working. A new client against an old server gets its key ignored and a 4-byte reply, reports coverage as unknown, and the caller falls back to the KV count. An old client against a new server never sends the key, so the reply is unchanged.

Four small additions:

- `HiddenStateStore.coverage(chunks, layer_idxs)` walks the request's `(start, end, key)` chunks and stops at the first gap, so the result is a prefix length directly comparable with what `lookup` reports for KV.
- `LMCacheEngine.lookup_hidden_states(...)` uses the same chunking and prefix semantics as `lookup`, and returns 0 when no hidden-state store is configured.
- `LookupClientInterface.lookup_hidden_state_coverage(lookup_id)` defaults to `None`, meaning "cannot answer". `LMCacheLookupClient` fills it in when the server reported it.
- The other clients that can answer do. `LMCacheBypassLookupClient` holds the engine, so it queries it directly. `HitLimitLookupClient` and `ChunkStatisticsLookupClient` wrap an inner client and forward to it. Leaving any of them on the default would have made coverage unreadable under a supported configuration, which is the silent degradation this query exists to prevent. `LMCacheAsyncLookupClient` and `MooncakeLookupClient` keep the default: the first speaks its own protocol to a separate server and would need that extended too, and the second fronts an external store with no hidden-state pool.

## Tests

`tests/v1/test_hidden_state_store.py` covers the coverage walk: full prefix covered, a gap partway through truncates to the prefix before it, every requested layer is required, and an empty store reports 0.

`tests/v1/lookup_client/test_lookup_hidden_state_coverage.py` covers the wire: a 4-byte reply leaves coverage unknown rather than reading as zero, an 8-byte one carries it, coverage takes the minimum across ranks the way the KV count does, the request rides in `request_configs` so the frame layout is unchanged, and clearing a lookup drops both fields. Two more cover the bypass client answering from its engine and leaving the engine alone when the caller did not ask.

The server-side branch that appends the field is a two-line conditional inside `LMCacheLookupServer.__init__`'s closure; I checked that by reading rather than by test, since making it callable would mean restructuring for testability.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

