### PR TITLE
fix: comply with vLLM KVConnector contract in request_finished / finished_sending

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -578,6 +578,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+            # Request IDs for which the scheduler created STORE metadata.
+            # Used by request_finished to decide delay_free: only requests
+            # with an async store should delay block freeing.
+            self._stored_requests: set[str] = set()
 
             # GPU block pool reference
             self._gpu_block_pool: "BlockPool | None" = None
@@ -1195,6 +1199,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         metadata = LMCacheMPConnectorMetadata()
         metadata.need_flush_before_forward = _has_preemption_reqs(scheduler_output)
 
+        # Clean up _stored_requests for requests that finished in the
+        # previous step (request_finished was already called for them).
+        for finished_req_id in scheduler_output.finished_req_ids:
+            self._stored_requests.discard(finished_req_id)
+
         self._process_retrieve_requests(metadata)
         self._process_new_requests(scheduler_output, metadata)
         self._process_cached_requests(scheduler_output, metadata)
@@ -1278,7 +1287,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if self.lazy_offload:
             self._pending_store.mark_req_finished(request.request_id)
             return False, (return_params or None)
-        return True, (return_params or None)
+        has_store = request.request_id in self._stored_requests
+        return has_store, (return_params or None)
 
     def request_finished_all_groups(
         self,
@@ -1392,6 +1402,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                     self._pending_store.add(r_meta)
                 else:
                     metadata.add_request_metadata(r_meta)
+                self._stored_requests.add(new_request.req_id)
         # if scheduler_output.total_num_scheduled_tokens is 0,
         # vllm `gpu_model_runner` will call `kv_connector_no_forward`
         # in `execute_model`, which will result in lose some store ops.
@@ -1433,6 +1444,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                     self._pending_store.add(r_meta)
                 else:
                     metadata.add_request_metadata(r_meta)
+                self._stored_requests.add(request_id)
         # if scheduler_output.total_num_scheduled_tokens is 0,
         # vllm `gpu_model_runner` will call `kv_connector_no_forward`
         # in `execute_model`, which will result in lose some store ops.

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1174,6 +1174,11 @@ class LMCacheMPWorkerAdapter:
         # Request IDs already returned as finished_sending to the scheduler.
         # Prevents re-reporting the same ID after drain clears tracking sets.
         self._returned_finished: set[str] = set()
+        # Request IDs whose STORE metadata was seen by this worker
+        # (submit_store_request was called).  Used to distinguish between
+        # kv_writer=False workers (called but no future) and requests with
+        # no STORE metadata at all (never called, e.g. MultiConnector).
+        self._submitted_stores: set[str] = set()
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
@@ -1486,6 +1491,7 @@ class LMCacheMPWorkerAdapter:
                 the IPC key.
         """
         self._ensure_heartbeat_started()
+        self._submitted_stores.add(request_id)
 
         if not self.is_kv_writer:
             return
@@ -1691,10 +1697,11 @@ class LMCacheMPWorkerAdapter:
                 continue
             if req_id in self.finished_stores or req_id in self.store_futures:
                 self.previously_finished.add(req_id)
-            else:
+            elif req_id in self._submitted_stores:
                 ret_stores.add(req_id)
         ret_stores.update(self._update_and_get_finished_store())
         self._returned_finished.update(ret_stores)
+        self._submitted_stores -= self._returned_finished
         return ret_stores
 
     @_lmcache_nvtx_annotate


### PR DESCRIPTION
**What this PR does / why we need it**:

Align LMCacheMP's `request_finished()` return value with `get_finished()` `finished_sending` reporting to comply with the vLLM KVConnector contract.

### The contract

vLLM `KVConnectorBase_V1` defines a strict pairing between two methods:

- **`request_finished()` returning `True`** signals the connector has async save/send in flight. The scheduler delay-frees the blocks and waits for `finished_sending` before releasing them.
- **`get_finished()` reporting `finished_sending`** must only include requests that previously returned `True` from `request_finished()`.

```
request_finished == True   <->  scheduler delay-frees  <->  must report finished_sending
request_finished == False  <->  scheduler frees now    <->  must NOT report finished_sending
```

If the two sides disagree, the scheduler's `assert req_id in self.requests` can fire (reported but already freed) or blocks leak (delay-freed but never reported).

### How LMCacheMP violated the contract

**Violation 1 — `request_finished` returns True with no async store**

`return True` unconditionally delay-frees blocks, even for requests that never submitted a store (e.g. aborted before decode, or `GetStoreMetadata` returned None, or MultiConnector where another connector owns the store). This makes the scheduler wait for a `finished_sending` that corresponds to no real async operation.

**Violation 2 — `finished_sending` reported for requests with no store**

`_process_finished_stores` unconditionally added requests to `finished_sending` via an `else` branch, even for requests that never submitted a store and were not delay-freed.

### Fix

Make both sides honor the contract.

**Scheduler side** — track actual store submissions via `_stored_requests`; only delay-free when there is a real async store:

```python
has_store = request.request_id in self._stored_requests
return has_store, (return_params or None)
```

**Worker side** — report `finished_sending` only for requests that were delay-freed. Replace the unconditional `else` with a three-branch check using `_submitted_stores`:

```python
if req_id in self.finished_stores or req_id in self.store_futures:
    self.previously_finished.add(req_id)   # store in flight, wait for it
elif req_id in self._submitted_stores:
    ret_stores.add(req_id)                  # store metadata seen, no future
                                            # (kv_writer=False), report now
# else: no store metadata -> do not report
```

This makes the pairing exact:

| request has store?          | request_finished | finished_sending            |
|-----------------------------|------------------|-----------------------------|
| No (MultiConnector / abort) | False            | not reported                |
| Yes, kv_writer=True         | True             | reported after future done  |
| Yes, kv_writer=False (MLA)  | True             | reported immediately        |

**Special notes for your reviewers**:

- The `_submitted_stores` branch (immediate report) is required for MLA-only models: with TP=8 only rank 0 is `kv_writer=True`, ranks 1-7 receive STORE metadata (so the scheduler delay-frees) but create no future. Without this branch they never report `finished_sending`, the aggregator never reaches 8/8, and blocks leak.
- The SKIP branch (no report) is required for MultiConnector deployments where LMCacheMP has no store for a request — reporting a no-op `finished_sending` prematurely frees a request that another connector (e.g. Mooncake) may still be protecting under `WAITING_FOR_REMOTE_KVS`, causing `assert req_id in self.requests` to crash when Mooncake's `finished_recving` arrives.
- `_stored_requests` (scheduler side) and `_submitted_stores` (worker side) are kept in sync via STORE metadata flowing through `build_connector_meta` -> `submit_store_request`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests