### PR TITLE
[Bugfix][MP] Complete async copies before their buffers are reused

### DIFF
--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -664,6 +664,9 @@ def scatter_cpu_to_paged_kv(
     if not selected_block_ids:
         return
 
+    # Only the ptr-only branch below pins temporaries; the tensor branch
+    # hands torch the chunks directly and keeps them alive itself.
+    dynamically_pinned = False
     if _LMC_OPS_BLOCK_TRANSFER_ACCEPTS_TENSOR:
         # Python fallback: accepts tensor list directly for all params.
         paged_arg = normalized
@@ -687,7 +690,8 @@ def scatter_cpu_to_paged_kv(
         # Defensive check: Ensure all incoming CPU chunks are pinned memory.
         # Otherwise, the underlying CUDA kernel may throw an Illegal
         # Memory Access error during H2D transfer.
-        if not all(chunk.is_pinned() for chunk in chunks):
+        dynamically_pinned = not all(chunk.is_pinned() for chunk in chunks)
+        if dynamically_pinned:
             logger.warning(
                 "Received unpinned CPU tensors in scatter_cpu_to_paged_kv. "
                 "Dynamically pinning memory now, which may incur additional"
@@ -742,3 +746,15 @@ def scatter_cpu_to_paged_kv(
     # We intentionally omit synchronization here for performance.
     # WARNING: The caller MUST explicitly call `torch_dev.synchronize()`
     # before consuming these chunks to ensure data validity.
+
+    if dynamically_pinned:
+        # The temporaries pinned above are read by the async H2D launches
+        # through raw pointers, which torch's stream tracking cannot see.
+        # Returning drops the last reference to them, and the caching host
+        # allocator then hands that memory to the next caller while the
+        # copies are still in flight -- the next pin_memory() overwrites the
+        # bytes mid-transfer. The caller-side synchronize documented above
+        # cannot cover this: by then the temporaries are already gone.
+        # Only the dynamically pinned case pays this; caller-owned pinned
+        # chunks keep the fast path.
+        torch_dev.synchronize()

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -781,9 +781,12 @@ class EngineDrivenTransferContext(TransferContext):
             out=out_buffers,
             chunk_indices=chunk_indices,
         )
-        if out_buffers is not None:
-            # SHM path uses async device->CPU copies; complete them before commit.
-            torch_dev.synchronize()
+        # Gather issues async device->CPU copies on BOTH transports: into the
+        # SHM slots when out_buffers is given, otherwise into fresh buffers that
+        # commit_store serializes immediately. Either way the copies must be
+        # complete first, so this is unconditional -- guarding it on out_buffers
+        # left the pickle path serializing a buffer still being written.
+        torch_dev.synchronize()
         ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
 
         future = MessagingFuture()

--- a/tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py
+++ b/tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py
@@ -12,6 +12,7 @@ CPU-only unit CI. The hardware reproductions live alongside them in
 """
 
 # Standard
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 # Third Party
@@ -53,7 +54,10 @@ def test_scatter_syncs_before_releasing_dynamically_pinned_chunks() -> None:
         patch.object(base, "torch_dev") as dev,
         patch("lmcache.device_ops") as ops,
     ):
-        base.scatter_cpu_to_paged_kv(kv, list(range(4)), chunks, 4)
+        # cast: the mocks stand in for tensors on purpose (see above).
+        base.scatter_cpu_to_paged_kv(
+            kv, list(range(4)), cast(list[torch.Tensor], chunks), 4
+        )
         assert ops.multi_layer_block_kv_transfer.called, (
             "fixture must reach the async H2D launches"
         )
@@ -78,9 +82,12 @@ def test_pickle_store_syncs_before_commit_serializes() -> None:
     ctx = worker_transfer.EngineDrivenTransferContext()
     ctx._engine_driven_context = MagicMock()
     ctx._engine_driven_context.prepare_store.return_value = None  # pickle mode
-    ctx._engine_driven_context.commit_store.side_effect = lambda *a, **k: (
-        order.append("commit") or True
-    )
+
+    def _commit(*_a: object, **_k: object) -> bool:
+        order.append("commit")
+        return True
+
+    ctx._engine_driven_context.commit_store.side_effect = _commit
     ctx._layout_hints = None
     ctx._engine_kv_format = None
 

--- a/tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py
+++ b/tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Async device<->CPU copies must complete before their buffers are reused.
+
+Both engine-driven paths launch async copies and then hand the buffers to
+something that reads them. Two places got this wrong, and both failed
+silently: the KV was already committed or already scattered, so the only
+symptom was corrupted content much later.
+
+These tests assert the ordering contract without a GPU, so they run in the
+CPU-only unit CI. The hardware reproductions live alongside them in
+``test_engine_driven_transfer.py`` and skip without CUDA.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import torch
+
+
+def test_scatter_syncs_before_releasing_dynamically_pinned_chunks() -> None:
+    """Unpinned input must be synced before scatter returns.
+
+    ``scatter_cpu_to_paged_kv`` pins unpinned chunks into temporaries and
+    launches async H2D reads on them through raw pointers, which torch's
+    stream tracking cannot see. Returning drops the last reference, so the
+    caching host allocator can hand that memory to the next caller while the
+    copies are in flight. The documented caller-side synchronize cannot cover
+    it -- by then the temporaries are gone -- so scatter must sync itself.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import base
+
+    kv = {f"layer_{i}": torch.zeros(2, 4, 4, 2, 8) for i in range(2)}
+
+    # Mock chunks, not real tensors: pin_memory() needs an accelerator, so the
+    # ptr-only branch cannot execute for real on the CPU-only unit CI. What we
+    # are pinning down is the ordering contract, not the copy itself.
+    def _unpinned_chunk() -> MagicMock:
+        c = MagicMock()
+        c.is_pinned.return_value = False
+        c.pin_memory.return_value = c
+        c.data_ptr.return_value = 0
+        return c
+
+    chunks = [_unpinned_chunk()]
+
+    # Pin the ptr-only path: only that branch pins temporaries, and whether the
+    # compiled op takes tensors varies by build. scatter imports device_ops
+    # inside the function, so patch it at source.
+    with (
+        patch.object(base, "_LMC_OPS_BLOCK_TRANSFER_ACCEPTS_TENSOR", False),
+        patch.object(base, "torch_dev") as dev,
+        patch("lmcache.device_ops") as ops,
+    ):
+        base.scatter_cpu_to_paged_kv(kv, list(range(4)), chunks, 4)
+        assert ops.multi_layer_block_kv_transfer.called, (
+            "fixture must reach the async H2D launches"
+        )
+        assert dev.synchronize.called, (
+            "scatter must complete async H2D before releasing the temporaries "
+            "it pinned; otherwise the host allocator reuses them mid-copy"
+        )
+
+
+def test_pickle_store_syncs_before_commit_serializes() -> None:
+    """The pickle path must sync before commit_store reads the buffers.
+
+    Gather issues async device->CPU copies into fresh buffers, and the pickle
+    transport serializes them immediately in ``commit_store``. Syncing only
+    when ``out_buffers`` is given (the SHM path) leaves pickle serializing a
+    buffer that is still being written.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import worker_transfer
+
+    order: list[str] = []
+    ctx = worker_transfer.EngineDrivenTransferContext()
+    ctx._engine_driven_context = MagicMock()
+    ctx._engine_driven_context.prepare_store.return_value = None  # pickle mode
+    ctx._engine_driven_context.commit_store.side_effect = lambda *a, **k: (
+        order.append("commit") or True
+    )
+    ctx._layout_hints = None
+    ctx._engine_kv_format = None
+
+    def _gather(*_a: object, **_k: object) -> list[torch.Tensor]:
+        order.append("gather")
+        return [torch.zeros(1)]
+
+    with (
+        patch.object(worker_transfer, "torch_dev") as dev,
+        patch.object(worker_transfer, "gather_paged_kv_to_cpu", side_effect=_gather),
+    ):
+        dev.synchronize.side_effect = lambda *a, **k: order.append("sync")
+        ctx.submit_store(
+            "req",
+            MagicMock(),  # key
+            1,  # instance_id
+            {"layer_0": torch.zeros(2, 4, 4, 2, 8)},
+            [[0, 1, 2, 3]],
+            MagicMock(),  # event (unused on this transport)
+            4,  # blocks_in_chunk
+        )
+
+    # A sync must fall BETWEEN gather and commit. submit_store also syncs
+    # before prepare_store, so merely finding a "sync" proves nothing -- that
+    # earlier one is why guarding this on out_buffers went unnoticed.
+    gathered, committed = order.index("gather"), order.index("commit")
+    assert any(
+        i for i, step in enumerate(order) if step == "sync" and gathered < i < committed
+    ), (
+        "pickle store must synchronize after gather and before commit_store "
+        f"serializes the buffers, got {order}"
+    )


### PR DESCRIPTION
Two places in the engine-driven transfer path launch async copies and then hand the buffers to something that reads them, without waiting. Both fail silently, because the KV is already committed or already scattered by the time anything is wrong. Found while running the engine-driven pickle transport on 8xH100: a gsm8k score dropped from 0.80 to 0.00 with no error anywhere, and a targeted repro showed 4000 corrupted blocks going to 0 with these fixes.

Split out of #4410 at @hlin99's suggestion, since neither fix depends on that PR's design.

### 1. `scatter_cpu_to_paged_kv` releases pinned temporaries mid-copy

The ptr-only branch pins unpinned chunks into temporaries and launches async H2D reads on them through raw pointers, which torch's stream tracking cannot see. Returning drops the last reference, so the caching host allocator can hand that memory to the next caller while the copies are still in flight, and the next `pin_memory()` overwrites the bytes mid-transfer. The engine-driven pickle retrieve path scatters one group after another and hit exactly this; unpinned input is the contract there, since the payload arrives unpickled and unpinned.

The caller-side `synchronize()` the function documents cannot cover it: by then the temporaries are already gone. So sync before returning, but only when we pinned them. Caller-owned pinned chunks keep the existing fast path.

### 2. `submit_store` synchronized only on the SHM path

The sync was guarded on `out_buffers is not None`. Gather issues async device->CPU copies on both transports, and the pickle transport serializes the buffers immediately in `commit_store`, so the pickle path was serializing a buffer still being written. Made unconditional.

### Tests

Both run without a GPU, so they hold in the CPU-only unit CI, and both fail without the corresponding fix (verified by reverting each).

The pickle test asserts that a sync falls *between* gather and commit rather than merely occurring. `submit_store` also syncs before `prepare_store`, and that earlier call is precisely why guarding the second one on `out_buffers` went unnoticed. An assertion that only checked "a sync happened" passes on the broken code.

`tests/v1/multiprocess/` shows no new failures against `dev`, and `ruff` / `isort` are clean. `mypy` reports the same 7 pre-existing errors in `base.py` on this branch and on `dev`, none added.