### PR TITLE
fix(eviction): keep distributed chunk families coherent

### DIFF
--- a/lmcache/v1/distributed/eviction_policy/_selection.py
+++ b/lmcache/v1/distributed/eviction_policy/_selection.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for selecting coherent distributed-cache eviction victims."""
+
+# Standard
+from collections.abc import Callable, Collection, Iterable
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+
+KVTopology = tuple[int, int] | None
+TopologyNamespace = tuple[str, KVTopology]
+
+
+def _kv_topology(kv_rank: int) -> KVTopology:
+    """Decode the stable world/local-world topology from a packed KV rank."""
+    world_size = (kv_rank >> 24) & 0xFF
+    global_rank = (kv_rank >> 16) & 0xFF
+    local_world_size = (kv_rank >> 8) & 0xFF
+    local_rank = kv_rank & 0xFF
+    if (
+        world_size > 0
+        and local_world_size > 0
+        and global_rank < world_size
+        and local_rank < local_world_size
+        and global_rank % local_world_size == local_rank
+    ):
+        return world_size, local_world_size
+    # Tests and legacy callers may use an unpacked integer rank. Preserve
+    # their observed-coordinate behavior rather than guessing a topology.
+    return None
+
+
+def _topology_namespace(key: ObjectKey) -> TopologyNamespace:
+    """Return the cache-model and parallel-layout namespace for ``key``."""
+    return key.model_name, _kv_topology(key.kv_rank)
+
+
+def _logical_chunk_family(
+    key: ObjectKey,
+) -> tuple[bytes, str, str, KVTopology]:
+    """Return the identity shared by every rank/group object for one chunk."""
+    return (
+        key.chunk_hash,
+        key.model_name,
+        key.cache_salt,
+        _kv_topology(key.kv_rank),
+    )
+
+
+class ChunkFamilyTopology:
+    """Track the observed rank/group coordinates of logical chunk families.
+
+    Eviction policies already serialize key lifecycle notifications and victim
+    selection under their own lock. Recording only the small topology keeps
+    selection proportional to the number of victim families without either
+    rebuilding or retaining a second full-cache map.
+    """
+
+    def __init__(self) -> None:
+        self._coordinates: dict[TopologyNamespace, set[tuple[int, int]]] = {}
+        self._ordered_coordinates: dict[
+            TopologyNamespace,
+            tuple[tuple[int, int], ...],
+        ] = {}
+
+    def observe(self, keys: Iterable[ObjectKey]) -> None:
+        """Record rank/group coordinates present for each cache namespace."""
+        changed_namespaces = set()
+        for key in keys:
+            namespace = _topology_namespace(key)
+            coordinates = self._coordinates.setdefault(namespace, set())
+            previous_count = len(coordinates)
+            coordinates.add((key.kv_rank, key.object_group_id))
+            if len(coordinates) != previous_count:
+                changed_namespaces.add(namespace)
+        for namespace in changed_namespaces:
+            observed = self._coordinates[namespace]
+            topology = namespace[1]
+            if topology is None:
+                expected = observed
+            else:
+                world_size, local_world_size = topology
+                group_ids = {object_group_id for _, object_group_id in observed}
+                expected = {
+                    (
+                        ObjectKey.ComputeKVRank(
+                            world_size=world_size,
+                            global_rank=global_rank,
+                            local_world_size=local_world_size,
+                            local_rank=global_rank % local_world_size,
+                        ),
+                        object_group_id,
+                    )
+                    for global_rank in range(world_size)
+                    for object_group_id in group_ids
+                }
+            self._ordered_coordinates[namespace] = tuple(sorted(expected))
+
+    def members(
+        self,
+        key: ObjectKey,
+        tracked_keys: Collection[ObjectKey],
+    ) -> tuple[ObjectKey, ...]:
+        """Return a complete family, or empty while any sibling is absent."""
+        coordinates = self._ordered_coordinates.get(_topology_namespace(key), ())
+        if coordinates == ((key.kv_rank, key.object_group_id),):
+            return (key,)
+
+        members = []
+        for kv_rank, object_group_id in coordinates:
+            candidate = ObjectKey(
+                chunk_hash=key.chunk_hash,
+                model_name=key.model_name,
+                kv_rank=kv_rank,
+                object_group_id=object_group_id,
+                cache_salt=key.cache_salt,
+            )
+            if candidate not in tracked_keys:
+                # Stores complete asynchronously across rank/group batches.
+                # Evicting the currently visible subset lets late siblings
+                # publish a permanently incomplete family after this pass.
+                return ()
+            members.append(candidate)
+        return tuple(members)
+
+
+def select_chunk_coherent_victims(
+    ordered_keys: Collection[ObjectKey],
+    target_count: int,
+    family_topology: ChunkFamilyTopology,
+    key_eligible_filter: Callable[[ObjectKey], bool] | None = None,
+) -> list[ObjectKey]:
+    """Select LRU victims without splitting a logical chunk family.
+
+    A distributed or hybrid chunk is persisted as multiple ``ObjectKey``
+    instances that differ only by ``kv_rank`` and ``object_group_id``. Deleting
+    an arbitrary subset makes a later lookup appear promising while the load
+    cannot reconstruct any tokens. Once the LRU boundary selects one member,
+    return every tracked member of that logical family.
+
+    When an eligibility filter is present, a family is selected only if every
+    member is eligible. This prevents eviction from splitting a family around
+    a read/write-locked object. The returned count may exceed ``target_count``
+    by at most one family; eviction ratios are approximate by contract.
+
+    Args:
+        ordered_keys: Keys in least-to-most-recently-used order.
+        target_count: Approximate number of object keys to select.
+        family_topology: Rank/group coordinates observed by the calling
+            eviction policy.
+        key_eligible_filter: Optional per-key eligibility predicate.
+
+    Returns:
+        Selected keys in family/LRU order, or an empty list when no complete
+        eligible family can be selected. A family remains ineligible while an
+        expected rank/group sibling has not completed its store.
+    """
+    if target_count <= 0:
+        return []
+
+    selected: list[ObjectKey] = []
+    visited: set[tuple[bytes, str, str, KVTopology]] = set()
+    for key in ordered_keys:
+        family_id = _logical_chunk_family(key)
+        if family_id in visited:
+            continue
+        visited.add(family_id)
+        members = family_topology.members(key, ordered_keys)
+        if not members:
+            continue
+        if key_eligible_filter is not None and any(
+            not key_eligible_filter(member) for member in members
+        ):
+            continue
+        selected.extend(members)
+        if len(selected) >= target_count:
+            break
+    return selected

--- a/lmcache/v1/distributed/eviction_policy/isolated_lru.py
+++ b/lmcache/v1/distributed/eviction_policy/isolated_lru.py
@@ -32,6 +32,9 @@ from lmcache.v1.distributed.internal_api import (
 from lmcache.v1.mp_coordinator.persistence.durable_component import PersistenceType
 from lmcache.v1.mp_coordinator.utils.encoding import decode_key, encode_key
 
+# Local
+from ._selection import ChunkFamilyTopology, select_chunk_coherent_victims
+
 
 class IsolatedLRUEvictionPolicy(EvictionPolicy):
     """Per-``cache_salt`` LRU eviction policy.
@@ -56,6 +59,7 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
         self._lock = threading.Lock()
         # cache_salt -> ordered {ObjectKey: None} (oldest first).
         self._per_salt_order: dict[str, OrderedDict[ObjectKey, None]] = {}
+        self._family_topology = ChunkFamilyTopology()
         # Registered destinations (first one wins if any are registered,
         # matching LRUEvictionPolicy semantics).
         self._destinations: list[EvictionDestination] = []
@@ -82,6 +86,7 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
                     order.move_to_end(key)
                 else:
                     order[key] = None
+            self._family_topology.observe(keys)
 
     def on_keys_touched(self, keys: list[ObjectKey]) -> None:
         if not keys:
@@ -146,25 +151,22 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
             )
         with self._lock:
             order = self._per_salt_order.get(cache_salt)
-            pool = list(order.keys()) if order else []
-
-            if not pool:
+            if not order:
                 return []
 
             expected_ratio = max(0.0, min(1.0, expected_ratio))
-            target_count = int(len(pool) * expected_ratio)
+            target_count = int(len(order) * expected_ratio)
             if expected_ratio > 0 and target_count == 0:
                 target_count = 1
             if target_count == 0:
                 return []
 
-            keys_to_evict: list[ObjectKey] = []
-            for key in pool:
-                if key_eligible_filter is not None and not key_eligible_filter(key):
-                    continue
-                keys_to_evict.append(key)
-                if len(keys_to_evict) >= target_count:
-                    break
+            keys_to_evict = select_chunk_coherent_victims(
+                order,
+                target_count,
+                self._family_topology,
+                key_eligible_filter,
+            )
 
             if not keys_to_evict:
                 return []
@@ -240,6 +242,9 @@ class IsolatedLRUEvictionPolicy(EvictionPolicy):
                 )
                 for cache_salt, ordered in buckets.items()
             }
+            self._family_topology = ChunkFamilyTopology()
+            for order in self._per_salt_order.values():
+                self._family_topology.observe(order)
 
 
 # -- Internals ----------------------------------------------------------------

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -16,6 +16,9 @@ from lmcache.v1.distributed.internal_api import (
     EvictionDestination,
 )
 
+# Local
+from ._selection import ChunkFamilyTopology, select_chunk_coherent_victims
+
 
 class LRUEvictionPolicy(EvictionPolicy):
     """
@@ -51,6 +54,7 @@ class LRUEvictionPolicy(EvictionPolicy):
 
         # OrderedDict to maintain LRU order - keys at the beginning are oldest
         self._order: OrderedDict[ObjectKey, None] = OrderedDict()
+        self._family_topology = ChunkFamilyTopology()
 
         # List of registered eviction destinations
         self._destinations: list[EvictionDestination] = []
@@ -90,6 +94,7 @@ class LRUEvictionPolicy(EvictionPolicy):
                 else:
                     # Add new key at the end (most recently used)
                     self._order[key] = None
+            self._family_topology.observe(keys)
 
     def on_keys_touched(self, keys: list[ObjectKey]):
         """
@@ -174,18 +179,16 @@ class LRUEvictionPolicy(EvictionPolicy):
             if target_count == 0:
                 return []
 
-            # Get keys in LRU order (from beginning - least recently used),
-            # skipping keys that fail the filter (e.g. locked keys).
-            keys_to_evict: list[ObjectKey] = []
-
-            for key in self._order:
-                if key_eligible_filter is not None and not key_eligible_filter(key):
-                    # Skip keys that are not eligible for eviction
-                    # (e.g. currently locked by read/write operations)
-                    continue
-                keys_to_evict.append(key)
-                if len(keys_to_evict) >= target_count:
-                    break
+            # Keep every distributed rank/object-group member of a logical
+            # chunk on the same side of the eviction boundary. Otherwise an
+            # L2 lookup can find only part of a hybrid chunk and the load must
+            # discard the entire apparent hit.
+            keys_to_evict = select_chunk_coherent_victims(
+                self._order,
+                target_count,
+                self._family_topology,
+                key_eligible_filter,
+            )
 
             if not keys_to_evict:
                 return []

--- a/tests/v1/distributed/test_chunk_coherent_lru_eviction.py
+++ b/tests/v1/distributed/test_chunk_coherent_lru_eviction.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for chunk-coherent distributed LRU eviction."""
+
+# Standard
+from collections.abc import Iterable
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction_policy import (
+    IsolatedLRUEvictionPolicy,
+    LRUEvictionPolicy,
+)
+
+
+def _key(
+    chunk_id: int,
+    kv_rank: int,
+    object_group_id: int,
+    cache_salt: str = "",
+) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="hybrid-model",
+        kv_rank=kv_rank,
+        object_group_id=object_group_id,
+        cache_salt=cache_salt,
+    )
+
+
+def _family(
+    chunk_id: int,
+    cache_salt: str = "",
+) -> set[ObjectKey]:
+    return {
+        _key(chunk_id, kv_rank, object_group_id, cache_salt)
+        for kv_rank in range(2)
+        for object_group_id in range(2)
+    }
+
+
+def _register_rank_group_batches(
+    policy: LRUEvictionPolicy | IsolatedLRUEvictionPolicy,
+    chunk_ids: Iterable[int],
+    cache_salt: str = "",
+) -> None:
+    """Mimic asynchronously completed per-rank/object-group store batches."""
+    for kv_rank in range(2):
+        for object_group_id in range(2):
+            policy.on_keys_created(
+                [
+                    _key(chunk_id, kv_rank, object_group_id, cache_salt)
+                    for chunk_id in chunk_ids
+                ]
+            )
+
+
+def test_global_lru_does_not_split_rank_or_object_group_family() -> None:
+    policy = LRUEvictionPolicy()
+    _register_rank_group_batches(policy, range(3))
+
+    actions = policy.get_eviction_actions(0.25)
+
+    assert len(actions) == 1
+    selected = set(actions[0].keys)
+    assert len(selected) == 4
+    assert selected in (_family(0), _family(1), _family(2))
+
+
+def test_locked_family_is_skipped_as_a_unit() -> None:
+    policy = LRUEvictionPolicy()
+    _register_rank_group_batches(policy, range(2))
+    locked = _key(1, kv_rank=0, object_group_id=0)
+
+    actions = policy.get_eviction_actions(
+        1.0,
+        key_eligible_filter=lambda key: key != locked,
+    )
+
+    assert len(actions) == 1
+    selected = set(actions[0].keys)
+    assert selected == _family(0)
+    assert selected.isdisjoint(_family(1))
+
+
+def test_removed_family_members_are_not_returned_as_stale_siblings() -> None:
+    policy = LRUEvictionPolicy()
+    _register_rank_group_batches(policy, range(2))
+    removed = _family(0)
+    policy.on_keys_removed(list(removed))
+
+    actions = policy.get_eviction_actions(1.0)
+
+    assert len(actions) == 1
+    assert set(actions[0].keys) == _family(1)
+
+
+def test_incomplete_family_is_skipped_until_late_sibling_arrives() -> None:
+    policy = LRUEvictionPolicy()
+    family = _family(0)
+    policy.on_keys_created(list(family))
+    late_sibling = _key(0, kv_rank=1, object_group_id=1)
+    policy.on_keys_removed([late_sibling])
+
+    assert policy.get_eviction_actions(1.0) == []
+
+    policy.on_keys_created([late_sibling])
+    actions = policy.get_eviction_actions(1.0)
+    assert len(actions) == 1
+    assert set(actions[0].keys) == family
+
+
+def test_family_topology_is_scoped_to_cache_model_namespace() -> None:
+    policy = LRUEvictionPolicy()
+    hybrid_family = _family(0)
+    policy.on_keys_created(list(hybrid_family))
+    policy.on_keys_removed(list(hybrid_family))
+    ordinary_key = ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(1),
+        model_name="ordinary-model",
+        kv_rank=0,
+    )
+    policy.on_keys_created([ordinary_key])
+
+    actions = policy.get_eviction_actions(1.0)
+
+    assert len(actions) == 1
+    assert actions[0].keys == [ordinary_key]
+
+
+def test_packed_rank_topology_skips_family_before_other_rank_completes() -> None:
+    policy = LRUEvictionPolicy()
+    ranks = [
+        ObjectKey.ComputeKVRank(
+            world_size=2,
+            global_rank=rank,
+            local_world_size=2,
+            local_rank=rank,
+        )
+        for rank in range(2)
+    ]
+    rank_zero_batch = {
+        _key(0, kv_rank=ranks[0], object_group_id=object_group_id)
+        for object_group_id in range(2)
+    }
+    rank_one_batch = {
+        _key(0, kv_rank=ranks[1], object_group_id=object_group_id)
+        for object_group_id in range(2)
+    }
+
+    policy.on_keys_created(list(rank_zero_batch))
+    assert policy.get_eviction_actions(1.0) == []
+
+    policy.on_keys_created(list(rank_one_batch))
+    actions = policy.get_eviction_actions(1.0)
+    assert len(actions) == 1
+    assert set(actions[0].keys) == rank_zero_batch | rank_one_batch
+
+
+def test_parallel_topologies_do_not_require_each_others_ranks() -> None:
+    policy = LRUEvictionPolicy()
+    keys = []
+    for world_size in (2, 4):
+        for rank in range(world_size):
+            keys.append(
+                _key(
+                    chunk_id=world_size,
+                    kv_rank=ObjectKey.ComputeKVRank(
+                        world_size=world_size,
+                        global_rank=rank,
+                        local_world_size=world_size,
+                        local_rank=rank,
+                    ),
+                    object_group_id=0,
+                )
+            )
+    policy.on_keys_created(keys)
+
+    actions = policy.get_eviction_actions(0.1)
+
+    assert len(actions) == 1
+    selected = actions[0].keys
+    selected_topologies = {
+        ((key.kv_rank >> 24) & 0xFF, key.chunk_hash) for key in selected
+    }
+    assert len(selected_topologies) == 1
+    assert len(selected) in (2, 4)
+
+
+@pytest.mark.parametrize("cache_salt", ["tenant-a", "tenant-b"])
+def test_isolated_lru_keeps_each_salt_chunk_coherent(cache_salt: str) -> None:
+    policy = IsolatedLRUEvictionPolicy()
+    _register_rank_group_batches(policy, range(3), cache_salt)
+
+    actions = policy.get_eviction_actions(0.25, cache_salt=cache_salt)
+
+    assert len(actions) == 1
+    selected = set(actions[0].keys)
+    assert len(selected) == 4
+    assert selected in (
+        _family(0, cache_salt),
+        _family(1, cache_salt),
+        _family(2, cache_salt),
+    )
+
+
+def test_isolated_lru_never_crosses_salt_boundaries() -> None:
+    policy = IsolatedLRUEvictionPolicy()
+    _register_rank_group_batches(policy, range(2), "tenant-a")
+    _register_rank_group_batches(policy, range(2), "tenant-b")
+
+    actions = policy.get_eviction_actions(1.0, cache_salt="tenant-a")
+
+    assert len(actions) == 1
+    assert set(actions[0].keys) == _family(0, "tenant-a") | _family(1, "tenant-a")


### PR DESCRIPTION
Part of #4888.

## Summary

Keep every `kv_rank` and `object_group_id` member of one logical chunk on the
same side of an LRU eviction boundary.

## Problem

Distributed and grouped stores complete asynchronously, so their notifications
interleave the key LRU. Evicting an arbitrary number of individual keys can
leave many apparent chunks with one or more required objects missing. Lookup
then finds partial presence, but none of those chunks is restorable.

## Change

- Define a logical family by chunk hash, model, salt, and parallel topology;
  rank and object-group coordinates are its siblings.
- Select every expected and resident sibling when an eviction boundary reaches
  one family member.
- Skip the family when an expected sibling has not completed or any member is
  ineligible, rather than splitting it.
- Learn topology per cache/model/parallel namespace so different TP layouts do
  not contaminate each other.
- Apply the same contract to global and salt-isolated LRU.
- Preserve the direct single-rank/single-group path and existing ordering.

Eviction ratios remain approximate and can overshoot by at most one logical
family. Serving, transfer, serialization, and LMCache-disabled paths are
unchanged.

## Validation

Focused coverage exercises global and isolated LRU, late sibling completion,
mixed topologies, locks, and the ordinary single-key path. The equivalent prior
revision passed 57 focused/existing tests; this branch is rebased onto current
`dev` and passes Ruff lint/format and `git diff --check` pending upstream CI.
