### PR TITLE
fix(vllm): support DCP-interleaved hybrid geometry

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -604,12 +604,22 @@ Decode context parallelism (DCP)
 ``--decode-context-parallel-size`` is supported. Under DCP, vLLM shards the
 attention KV cache across ranks along the token axis, so each rank holds only
 a strided ``1/dcp`` slice and one block ID spans ``block_size * dcp`` tokens.
-LMCache stores each rank's slice as its own object and a chunk counts as a hit
-only when every rank's slice is present.
+LMCache stores each rank's opaque page as its own object and a chunk counts as
+a hit only when every rank's slice is present. Non-trivial
+``--cp-kv-cache-interleave-size`` values are supported when they evenly divide
+every resolved attention cache block size. Because interleave changes the
+token-to-slot byte layout, the connector automatically adds the DCP size and
+interleave value to its internal cache namespace. This prevents pages written
+by one interleave layout from being loaded by another. It does not change the
+model name served by vLLM, but the decorated cache model name is visible in MP
+metric labels so operators can distinguish incompatible cache layouts.
 
 One configuration change is required: the LMCache chunk size must be a
-multiple of ``block_size * decode_context_parallel_size``, not just
-``block_size``. If it is smaller, vLLM fails at connector startup with the
+multiple of vLLM's resolved scheduler block size. For a single attention
+group, that is ``block_size * decode_context_parallel_size``. For a hybrid
+model, it is the least common multiple of every attention group's DCP-scaled
+block span and every recurrent-state group's unscaled physical block span. If
+the chunk size is incompatible, vLLM fails at connector startup with the
 required multiple in the message (the LMCache server itself starts fine).
 
 The example model also needs a vLLM build that can run it under DCP:
@@ -640,11 +650,13 @@ DCP. These combinations are rejected at startup:
      - Reason
    * - ``--prefill-context-parallel-size > 1``
      - Adds a second KV shard axis this connector does not map.
-   * - ``--cp-kv-cache-interleave-size != 1``
-     - Changes the token-to-rank mapping, which would store the wrong KV.
    * - Fewer than ``dcp_size`` ranks per LMCache server
      - No server holds a complete set of shards, and lookup takes the
        minimum hit count across servers, so it reports no hits.
+
+An interleave value that is non-positive, larger than a resolved attention
+cache block, or does not evenly divide every resolved attention block is
+rejected at connector startup.
 
 ``decode_context_parallel_size > tensor_parallel_size`` is rejected by vLLM
 itself, so this connector does not re-check it.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -81,7 +81,7 @@ try:
         )
 except ImportError:
     # Third Party
-    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (  # type: ignore[no-redef]
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration import (  # type: ignore[assignment,no-redef]
         LMCacheMPSchedulerAdapter,
         LMCacheMPWorkerAdapter,
         ParallelStrategy,
@@ -108,6 +108,9 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = lmcache_init_logger(__name__)
+
+_DCP_LAYOUT_NAMESPACE = "##lmcache-dcp-layout-v1-"
+_MAX_LCM_EXPANSION_FACTOR = 4
 
 
 # Helper functions
@@ -145,7 +148,124 @@ def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
     return False
 
 
-def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
+def _iter_kv_cache_specs(kv_cache_config: "KVCacheConfig | None") -> Iterable[Any]:
+    """Yield leaf KV cache specs without depending on a vLLM helper API."""
+    if kv_cache_config is None:
+        return
+    for group in kv_cache_config.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
+        if isinstance(per_layer_specs, dict):
+            yield from per_layer_specs.values()
+        else:
+            yield group_spec
+
+
+def get_group_tokens_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> list[int]:
+    """Return each engine group's block span in scheduler token coordinates.
+
+    Attention pages are local DCP shards and therefore cover
+    ``spec.block_size * dcp_size`` global tokens. Recurrent-state pages are
+    replicated and retain their physical ``spec.block_size`` span. When vLLM
+    does not provide group metadata, preserve the legacy single-group rule.
+    """
+    dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
+    groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    return [
+        get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in groups
+    ] or [vllm_config.cache_config.block_size * dcp_size]
+
+
+def get_lmcache_scheduler_block_size(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> int:
+    """Resolve the scheduling block shared by every engine KV cache group."""
+    group_spans = get_group_tokens_per_block(vllm_config, kv_cache_config)
+    scheduler_block_size = math.lcm(*group_spans)
+    largest_group_span = max(group_spans)
+    if scheduler_block_size > largest_group_span * _MAX_LCM_EXPANSION_FACTOR:
+        logger.warning(
+            "LMCache resolved a scheduler block of %d tokens from group spans "
+            "%s (%0.1fx the largest span). Near-coprime group geometry can "
+            "make cache chunks too coarse to be useful.",
+            scheduler_block_size,
+            group_spans,
+            scheduler_block_size / largest_group_span,
+        )
+    return scheduler_block_size
+
+
+def get_lmcache_model_name(vllm_config: VllmConfig) -> str:
+    """Return a cache key namespace that isolates DCP interleave layouts.
+
+    A DCP rank's page is an opaque byte image whose token-to-slot mapping
+    changes with ``cp_kv_cache_interleave_size``. The existing ``kv_rank``
+    identity distinguishes DCP shard counts but not interleave values, so a
+    deployment changing only interleave could otherwise retrieve incompatible
+    pages left by the earlier deployment. ``model_name`` is also exposed as a
+    label by MP observability subscribers, so metrics use this decorated value;
+    callers can recover the served model name with
+    :func:`get_lmcache_base_model_name`. Keep legacy keys unchanged unless a
+    non-trivial DCP interleave is active. The ``##`` separator follows the SDK
+    cache-kind namespace convention.
+    """
+    model_name = vllm_config.model_config.model
+    parallel_config = vllm_config.parallel_config
+    dcp_size = getattr(parallel_config, "decode_context_parallel_size", 1)
+    interleave = getattr(parallel_config, "cp_kv_cache_interleave_size", 1)
+    if dcp_size <= 1 or interleave == 1:
+        return model_name
+    return f"{model_name}{_DCP_LAYOUT_NAMESPACE}d{dcp_size}-interleave{interleave}"
+
+
+def get_lmcache_base_model_name(model_name: str) -> str:
+    """Remove the connector's DCP layout namespace from a cache model name.
+
+    Args:
+        model_name: A served model name or an LMCache-decorated model name.
+
+    Returns:
+        The undecorated model name used by the serving API and model config.
+    """
+    return model_name.partition(_DCP_LAYOUT_NAMESPACE)[0]
+
+
+def get_resolved_attention_block_sizes(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None",
+) -> set[int]:
+    """Return physical block sizes for resolved attention cache groups.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        The resolved attention block sizes. Falls back to vLLM's cache block
+        size when group metadata is unavailable.
+    """
+    block_sizes = {
+        spec.block_size
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if any(cls.__name__ == "AttentionSpec" for cls in type(spec).__mro__)
+    }
+    if block_sizes:
+        return block_sizes
+    return {vllm_config.cache_config.block_size}
+
+
+def validate_mamba_step_alignment(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> None:
     """Reject scheduler configs whose steps cannot advance a whole Mamba block.
 
     In ``mamba_cache_mode="align"`` vLLM snapshots the recurrent state only at
@@ -169,7 +289,21 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
     """
     if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
         return
-    block_size = vllm_config.cache_config.block_size
+    mamba_block_sizes = {
+        spec.block_size
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+        if any(cls.__name__ == "MambaSpec" for cls in type(spec).__mro__)
+    }
+    if len(mamba_block_sizes) > 1:
+        raise ValueError(
+            "All Mamba KV cache groups must use one physical block size; got "
+            f"{sorted(mamba_block_sizes)}."
+        )
+    block_size = (
+        next(iter(mamba_block_sizes))
+        if mamba_block_sizes
+        else vllm_config.cache_config.block_size
+    )
     max_batched = vllm_config.scheduler_config.max_num_batched_tokens
     if max_batched < block_size:
         raise ValueError(
@@ -181,7 +315,11 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
         )
 
 
-def validate_dcp_support(vllm_config: VllmConfig, n_servers: int) -> None:
+def validate_dcp_support(
+    vllm_config: VllmConfig,
+    n_servers: int,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> None:
     """Reject decode-context-parallel topologies this connector cannot serve.
 
     These would silently store wrong or incomplete KV, so fail at startup
@@ -204,13 +342,25 @@ def validate_dcp_support(vllm_config: VllmConfig, n_servers: int) -> None:
             f"together with DCP (got pcp={pcp_size}, dcp={dcp_size})."
         )
 
-    # Fail-closed, not fundamental: the interleave sets each object's byte
-    # layout but is absent from cache identity, and k != 1 is unvalidated.
     interleave = getattr(pc, "cp_kv_cache_interleave_size", 1)
-    if interleave != 1:
+    if interleave < 1:
         raise ValueError(
-            "LMCacheMPConnector requires cp_kv_cache_interleave_size == 1 "
+            "LMCacheMPConnector requires cp_kv_cache_interleave_size >= 1 "
             f"under DCP (got {interleave})."
+        )
+    attention_block_sizes = get_resolved_attention_block_sizes(
+        vllm_config, kv_cache_config
+    )
+    incompatible_block_sizes = sorted(
+        block_size
+        for block_size in attention_block_sizes
+        if interleave > block_size or block_size % interleave != 0
+    )
+    if incompatible_block_sizes:
+        raise ValueError(
+            f"cp_kv_cache_interleave_size ({interleave}) must be no greater "
+            "than and evenly divide every resolved attention block size; "
+            f"incompatible sizes: {incompatible_block_sizes}."
         )
 
     ranks_per_server = pc.world_size // n_servers
@@ -297,11 +447,22 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig | None" = None,
     ):
-        super().__init__(vllm_config, role, kv_cache_config)
+        # Older supported vLLM releases allow connectors to omit this value,
+        # while current vLLM's type declaration requires it.
+        super().__init__(vllm_config, role, kv_cache_config)  # type: ignore[arg-type]
 
         # Fail fast, before the server handshake below.
-        validate_mamba_step_alignment(vllm_config)
-        validate_kv_cache_groups(getattr(self, "_kv_cache_config", None))
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        validate_mamba_step_alignment(vllm_config, kv_cache_config)
+        validate_kv_cache_groups(kv_cache_config)
+
+        group_tokens_per_block = get_group_tokens_per_block(
+            vllm_config, kv_cache_config
+        )
+        scheduler_block_size = get_lmcache_scheduler_block_size(
+            vllm_config, kv_cache_config
+        )
+        cache_model_name = get_lmcache_model_name(vllm_config)
 
         assert vllm_config.kv_transfer_config is not None
 
@@ -340,7 +501,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # The server count is derived from lmcache.mp.server_urls.
         n_servers = len(server_urls)
 
-        validate_dcp_support(vllm_config, n_servers)
+        validate_dcp_support(vllm_config, n_servers, kv_cache_config)
+
+        logger.info(
+            "Resolved LMCache MP geometry: group_tokens_per_block=%s, "
+            "scheduler_block_size=%d, cache_model_name=%s",
+            group_tokens_per_block,
+            scheduler_block_size,
+            cache_model_name,
+        )
 
         assert vllm_config.parallel_config.world_size % n_servers == 0, (
             f"world_size ({vllm_config.parallel_config.world_size}) must be "
@@ -394,8 +563,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.scheduler_adapter = LMCacheMPSchedulerAdapter(
                 server_urls=server_urls,
                 context=zmq_context,
-                model_name=vllm_config.model_config.model,
-                vllm_block_size=vllm_config.cache_config.block_size * dcp_size,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
@@ -421,8 +590,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             self.worker_adapter = LMCacheMPWorkerAdapter(
                 server_url=local_server_url,
                 context=zmq_context,
-                model_name=vllm_config.model_config.model,
-                vllm_block_size=vllm_config.cache_config.block_size * dcp_size,
+                model_name=cache_model_name,
+                vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
@@ -446,21 +615,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         else:
             raise ValueError(f"Unknown KVConnectorRole: {self.role}")
 
-        kv_cache_config = getattr(self, "_kv_cache_config", None)
-        vllm_groups = (
-            getattr(kv_cache_config, "kv_cache_groups", ()) or ()
-            if kv_cache_config is not None
-            else ()
-        )
         # Tokens covered by one paged chunk (one block ID) of each engine
         # group, from the group's KV cache spec. Hybrid models can mix
         # different values (e.g. gemma-4: sliding-window groups 32,
         # full-attention groups 16; DeepSeek V4: 256/64/8/4). Falls back to
         # the engine's base block size when no group metadata is available
         # (single non-hybrid group).
-        self._group_tokens_per_block: list[int] = [
-            get_tokens_per_block(group.kv_cache_spec, dcp_size) for group in vllm_groups
-        ] or [vllm_config.cache_config.block_size * dcp_size]
+        self._group_tokens_per_block = group_tokens_per_block
         for engine_group_idx, tokens_per_block in enumerate(
             self._group_tokens_per_block
         ):

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -165,12 +165,19 @@ def get_group_tokens_per_block(
     vllm_config: VllmConfig,
     kv_cache_config: "KVCacheConfig | None",
 ) -> list[int]:
-    """Return each engine group's block span in scheduler token coordinates.
+    """Return each KV cache group's effective block span in tokens.
 
     Attention pages are local DCP shards and therefore cover
     ``spec.block_size * dcp_size`` global tokens. Recurrent-state pages are
     replicated and retain their physical ``spec.block_size`` span. When vLLM
     does not provide group metadata, preserve the legacy single-group rule.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        The effective token span of each KV cache group.
     """
     dcp_size = getattr(vllm_config.parallel_config, "decode_context_parallel_size", 1)
     groups = (
@@ -183,11 +190,22 @@ def get_group_tokens_per_block(
     ] or [vllm_config.cache_config.block_size * dcp_size]
 
 
-def get_lmcache_scheduler_block_size(
+def get_vllm_scheduler_block_size(
     vllm_config: VllmConfig,
     kv_cache_config: "KVCacheConfig | None",
 ) -> int:
-    """Resolve the scheduling block shared by every engine KV cache group."""
+    """Return vLLM's scheduler block size for the resolved cache groups.
+
+    The scheduler boundary must align with every cache group, so vLLM uses the
+    least common multiple of their effective block spans.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        The scheduler block size in tokens.
+    """
     group_spans = get_group_tokens_per_block(vllm_config, kv_cache_config)
     scheduler_block_size = math.lcm(*group_spans)
     largest_group_span = max(group_spans)
@@ -203,19 +221,18 @@ def get_lmcache_scheduler_block_size(
     return scheduler_block_size
 
 
-def get_lmcache_model_name(vllm_config: VllmConfig) -> str:
-    """Return a cache key namespace that isolates DCP interleave layouts.
+def get_dcp_decorated_model_name(vllm_config: VllmConfig) -> str:
+    """Decorate the model name with its non-trivial DCP interleave layout.
 
-    A DCP rank's page is an opaque byte image whose token-to-slot mapping
-    changes with ``cp_kv_cache_interleave_size``. The existing ``kv_rank``
-    identity distinguishes DCP shard counts but not interleave values, so a
-    deployment changing only interleave could otherwise retrieve incompatible
-    pages left by the earlier deployment. ``model_name`` is also exposed as a
-    label by MP observability subscribers, so metrics use this decorated value;
-    callers can recover the served model name with
-    :func:`get_lmcache_base_model_name`. Keep legacy keys unchanged unless a
-    non-trivial DCP interleave is active. The ``##`` separator follows the SDK
-    cache-kind namespace convention.
+    Embedding the DCP interleave size in the LMCache model name prevents a
+    changed interleave from hitting objects with an incompatible byte layout.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+
+    Returns:
+        The decorated cache model name, or the original model name when DCP or
+        interleaving is inactive.
     """
     model_name = vllm_config.model_config.model
     parallel_config = vllm_config.parallel_config
@@ -224,18 +241,6 @@ def get_lmcache_model_name(vllm_config: VllmConfig) -> str:
     if dcp_size <= 1 or interleave == 1:
         return model_name
     return f"{model_name}{_DCP_LAYOUT_NAMESPACE}d{dcp_size}-interleave{interleave}"
-
-
-def get_lmcache_base_model_name(model_name: str) -> str:
-    """Remove the connector's DCP layout namespace from a cache model name.
-
-    Args:
-        model_name: A served model name or an LMCache-decorated model name.
-
-    Returns:
-        The undecorated model name used by the serving API and model config.
-    """
-    return model_name.partition(_DCP_LAYOUT_NAMESPACE)[0]
 
 
 def get_resolved_attention_block_sizes(
@@ -283,9 +288,14 @@ def validate_mamba_step_alignment(
     Args:
         vllm_config: The vLLM config; only Mamba-hybrid models in ``align``
             cache mode are constrained, others pass.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        None.
 
     Raises:
-        ValueError: If ``max_num_batched_tokens < block_size``.
+        ValueError: If Mamba groups have inconsistent block sizes or
+            ``max_num_batched_tokens < block_size``.
     """
     if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
         return
@@ -325,6 +335,14 @@ def validate_dcp_support(
     These would silently store wrong or incomplete KV, so fail at startup
     instead. ``dcp > tp`` is not re-checked; vLLM's ``ParallelConfig``
     already rejects it.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+        n_servers: The number of LMCache servers backing the deployment.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
+
+    Returns:
+        None.
 
     Raises:
         ValueError: On an unsupported DCP topology (``dcp_size == 1``
@@ -459,10 +477,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         group_tokens_per_block = get_group_tokens_per_block(
             vllm_config, kv_cache_config
         )
-        scheduler_block_size = get_lmcache_scheduler_block_size(
+        scheduler_block_size = get_vllm_scheduler_block_size(
             vllm_config, kv_cache_config
         )
-        cache_model_name = get_lmcache_model_name(vllm_config)
+        cache_model_name = get_dcp_decorated_model_name(vllm_config)
 
         assert vllm_config.kv_transfer_config is not None
 

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -361,11 +361,6 @@ def validate_dcp_support(
         )
 
     interleave = getattr(pc, "cp_kv_cache_interleave_size", 1)
-    if interleave < 1:
-        raise ValueError(
-            "LMCacheMPConnector requires cp_kv_cache_interleave_size >= 1 "
-            f"under DCP (got {interleave})."
-        )
     attention_block_sizes = get_resolved_attention_block_sizes(
         vllm_config, kv_cache_config
     )

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -526,12 +526,6 @@ def test_validate_rejects_interleave_not_dividing_resolved_attention_block():
 
 
 @requires_vllm
-def test_validate_rejects_nonpositive_interleave():
-    with pytest.raises(ValueError, match=">= 1"):
-        _import_validate_dcp_support()(_config(dcp_size=4, interleave=0), 1)
-
-
-@requires_vllm
 def test_validate_accepts_multi_server_when_each_holds_a_full_shard_set():
     """Ranks split into contiguous per-server blocks; a block of >= dcp_size
     consecutive ranks covers every shard exactly once, so each server is

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -248,6 +248,14 @@ class _FakeMambaSpec:
 
 
 @dataclass
+class MambaSpec:
+    """Mamba spec double detected by its public class name."""
+
+    block_size: int
+    mamba_cache_mode: str = "align"
+
+
+@dataclass
 class AttentionSpec:
     """Double for vLLM's AttentionSpec base; detection is by class name."""
 
@@ -304,6 +312,127 @@ def test_hybrid_layout_produces_mixed_spans():
     assert math.lcm(*spans) == 2048  # scheduler commit granularity
 
 
+def _import_connector_geometry_helpers():
+    """Import helpers lazily because their module imports vLLM."""
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_group_tokens_per_block,
+        get_lmcache_model_name,
+        get_lmcache_scheduler_block_size,
+        validate_mamba_step_alignment,
+    )
+
+    return (
+        get_group_tokens_per_block,
+        get_lmcache_model_name,
+        get_lmcache_scheduler_block_size,
+        validate_mamba_step_alignment,
+    )
+
+
+def _hybrid_kv_cache_config(
+    attention_block_size: int = 2304,
+    mamba_block_size: int = 2304,
+) -> SimpleNamespace:
+    """Resolved GLM-like groups after platform page-size equalization."""
+    return SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=_attention_spec(attention_block_size)),
+            SimpleNamespace(kv_cache_spec=MambaSpec(mamba_block_size)),
+        ]
+    )
+
+
+def _geometry_config(
+    *,
+    dcp_size: int = 4,
+    interleave: int = 4,
+    base_block_size: int = 256,
+    max_num_batched_tokens: int = 4096,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model="org/glm-5.3-flash"),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+            cp_kv_cache_interleave_size=interleave,
+        ),
+        cache_config=SimpleNamespace(
+            block_size=base_block_size,
+            mamba_cache_mode="align",
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=max_num_batched_tokens),
+    )
+
+
+@requires_vllm
+def test_glm_dcp4_geometry_resolves_physical_mamba_block():
+    (
+        get_group_tokens_per_block,
+        _,
+        get_lmcache_scheduler_block_size,
+        _,
+    ) = _import_connector_geometry_helpers()
+    config = _geometry_config()
+    kv_config = _hybrid_kv_cache_config()
+
+    assert get_group_tokens_per_block(config, kv_config) == [9216, 2304]
+    assert get_lmcache_scheduler_block_size(config, kv_config) == 9216
+
+
+@requires_vllm
+def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
+    *_, validate_mamba_step_alignment = _import_connector_geometry_helpers()
+    kv_config = _hybrid_kv_cache_config()
+
+    with pytest.raises(ValueError, match=r"block_size=2304"):
+        validate_mamba_step_alignment(
+            _geometry_config(max_num_batched_tokens=2048), kv_config
+        )
+
+    validate_mamba_step_alignment(
+        _geometry_config(max_num_batched_tokens=4096), kv_config
+    )
+
+
+@requires_vllm
+def test_dcp_interleave_participates_in_cache_identity():
+    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_lmcache_base_model_name,
+    )
+
+    interleave4 = get_lmcache_model_name(_geometry_config(interleave=4))
+    interleave8 = get_lmcache_model_name(_geometry_config(interleave=8))
+    assert interleave4 != interleave8
+    assert interleave4.endswith("##lmcache-dcp-layout-v1-d4-interleave4")
+    assert get_lmcache_base_model_name(interleave4) == "org/glm-5.3-flash"
+
+
+@requires_vllm
+def test_base_model_name_preserves_undecorated_names():
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_lmcache_base_model_name,
+    )
+
+    assert get_lmcache_base_model_name("org/glm-5.3-flash") == ("org/glm-5.3-flash")
+
+
+@requires_vllm
+def test_trivial_interleave_preserves_legacy_cache_identity():
+    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+
+    assert (
+        get_lmcache_model_name(_geometry_config(dcp_size=4, interleave=1))
+        == "org/glm-5.3-flash"
+    )
+    assert (
+        get_lmcache_model_name(_geometry_config(dcp_size=1, interleave=4))
+        == "org/glm-5.3-flash"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # validate_dcp_support: fail closed on unproven topologies                     #
 # --------------------------------------------------------------------------- #
@@ -324,6 +453,7 @@ def _config(
     pp_size: int = 1,
     interleave: int = 1,
     tp_size: int = 8,
+    cache_block_size: int = 256,
 ) -> SimpleNamespace:
     """Minimal stand-in exposing only the parallel_config fields read."""
     return SimpleNamespace(
@@ -334,7 +464,8 @@ def _config(
             cp_kv_cache_interleave_size=interleave,
             tensor_parallel_size=tp_size,
             world_size=tp_size * pp_size,
-        )
+        ),
+        cache_config=SimpleNamespace(block_size=cache_block_size),
     )
 
 
@@ -365,10 +496,36 @@ def test_validate_rejects_pcp_with_dcp():
 
 
 @requires_vllm
-def test_validate_rejects_nontrivial_interleave():
-    """The silent-corruption guard: wrong KV stored, no crash, without it."""
-    with pytest.raises(ValueError, match="cp_kv_cache_interleave_size"):
-        _import_validate_dcp_support()(_config(dcp_size=2, interleave=64), 1)
+def test_validate_accepts_interleave_when_layout_is_namespaced():
+    """Opaque per-rank pages round-trip when their key namespace is isolated."""
+    _import_validate_dcp_support()(
+        _config(dcp_size=4, interleave=4), 1, _hybrid_kv_cache_config()
+    )
+
+
+@requires_vllm
+def test_validate_uses_resolved_attention_block_for_interleave():
+    """The resolved 2304 page, rather than the CLI 256 page, is authoritative."""
+    validate = _import_validate_dcp_support()
+    kv_config = _hybrid_kv_cache_config(attention_block_size=2304)
+
+    validate(_config(dcp_size=4, interleave=768), 1, kv_config)
+
+
+@requires_vllm
+def test_validate_rejects_interleave_not_dividing_resolved_attention_block():
+    with pytest.raises(ValueError, match="evenly divide"):
+        _import_validate_dcp_support()(
+            _config(dcp_size=4, interleave=1000),
+            1,
+            _hybrid_kv_cache_config(attention_block_size=2304),
+        )
+
+
+@requires_vllm
+def test_validate_rejects_nonpositive_interleave():
+    with pytest.raises(ValueError, match=">= 1"):
+        _import_validate_dcp_support()(_config(dcp_size=4, interleave=0), 1)
 
 
 @requires_vllm

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -316,16 +316,16 @@ def _import_connector_geometry_helpers():
     """Import helpers lazily because their module imports vLLM."""
     # First Party
     from lmcache.integration.vllm.lmcache_mp_connector import (
+        get_dcp_decorated_model_name,
         get_group_tokens_per_block,
-        get_lmcache_model_name,
-        get_lmcache_scheduler_block_size,
+        get_vllm_scheduler_block_size,
         validate_mamba_step_alignment,
     )
 
     return (
         get_group_tokens_per_block,
-        get_lmcache_model_name,
-        get_lmcache_scheduler_block_size,
+        get_dcp_decorated_model_name,
+        get_vllm_scheduler_block_size,
         validate_mamba_step_alignment,
     )
 
@@ -369,14 +369,32 @@ def test_glm_dcp4_geometry_resolves_physical_mamba_block():
     (
         get_group_tokens_per_block,
         _,
-        get_lmcache_scheduler_block_size,
+        get_vllm_scheduler_block_size,
         _,
     ) = _import_connector_geometry_helpers()
     config = _geometry_config()
     kv_config = _hybrid_kv_cache_config()
 
     assert get_group_tokens_per_block(config, kv_config) == [9216, 2304]
-    assert get_lmcache_scheduler_block_size(config, kv_config) == 9216
+    assert get_vllm_scheduler_block_size(config, kv_config) == 9216
+
+
+@requires_vllm
+def test_scheduler_block_size_is_group_span_lcm():
+    (
+        get_group_tokens_per_block,
+        _,
+        get_vllm_scheduler_block_size,
+        _,
+    ) = _import_connector_geometry_helpers()
+    config = _geometry_config(dcp_size=2)
+    kv_config = _hybrid_kv_cache_config(
+        attention_block_size=6,
+        mamba_block_size=18,
+    )
+
+    assert get_group_tokens_per_block(config, kv_config) == [12, 18]
+    assert get_vllm_scheduler_block_size(config, kv_config) == 36
 
 
 @requires_vllm
@@ -396,39 +414,24 @@ def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
 
 @requires_vllm
 def test_dcp_interleave_participates_in_cache_identity():
-    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
-    # First Party
-    from lmcache.integration.vllm.lmcache_mp_connector import (
-        get_lmcache_base_model_name,
-    )
+    _, get_dcp_decorated_model_name, _, _ = _import_connector_geometry_helpers()
 
-    interleave4 = get_lmcache_model_name(_geometry_config(interleave=4))
-    interleave8 = get_lmcache_model_name(_geometry_config(interleave=8))
+    interleave4 = get_dcp_decorated_model_name(_geometry_config(interleave=4))
+    interleave8 = get_dcp_decorated_model_name(_geometry_config(interleave=8))
     assert interleave4 != interleave8
     assert interleave4.endswith("##lmcache-dcp-layout-v1-d4-interleave4")
-    assert get_lmcache_base_model_name(interleave4) == "org/glm-5.3-flash"
-
-
-@requires_vllm
-def test_base_model_name_preserves_undecorated_names():
-    # First Party
-    from lmcache.integration.vllm.lmcache_mp_connector import (
-        get_lmcache_base_model_name,
-    )
-
-    assert get_lmcache_base_model_name("org/glm-5.3-flash") == ("org/glm-5.3-flash")
 
 
 @requires_vllm
 def test_trivial_interleave_preserves_legacy_cache_identity():
-    _, get_lmcache_model_name, _, _ = _import_connector_geometry_helpers()
+    _, get_dcp_decorated_model_name, _, _ = _import_connector_geometry_helpers()
 
     assert (
-        get_lmcache_model_name(_geometry_config(dcp_size=4, interleave=1))
+        get_dcp_decorated_model_name(_geometry_config(dcp_size=4, interleave=1))
         == "org/glm-5.3-flash"
     )
     assert (
-        get_lmcache_model_name(_geometry_config(dcp_size=1, interleave=4))
+        get_dcp_decorated_model_name(_geometry_config(dcp_size=1, interleave=4))
         == "org/glm-5.3-flash"
     )
 


### PR DESCRIPTION
## Summary

Resolve LMCache MP scheduling geometry from vLLM's actual KV-cache groups and
allow namespaced, non-trivial DCP interleave layouts.

Hybrid engines may expose attention and recurrent groups whose physical page
spans differ from the CLI `--block-size`. Scaling every group by DCP, or
validating against only the CLI value, produces the wrong chunk boundary and
can either reject a valid deployment or transfer incomplete state.

## Change

- Derive each resolved group's scheduler-token span. Attention pages cover
  `physical_block_size * dcp_size`; recurrent pages retain their replicated
  physical span.
- Use the least common multiple of those spans as the scheduler block passed
  to the MP adapters, and validate chunk/recurrent-step alignment against the
  resolved groups.
- Validate interleave against every resolved attention block rather than the
  CLI cache block size.
- Allow non-trivial interleave for opaque per-rank pages and include DCP size
  plus interleave in a versioned internal cache namespace. This prevents pages
  with incompatible token-to-slot layouts from colliding.
- Preserve legacy cache keys for DCP-disabled and interleave-1 deployments,
  provide an inverse namespace helper, log the resolved geometry, and warn on
  pathologically coarse near-coprime LCMs.
- Document the chunk-alignment and metrics-label behavior.

The connector never gathers or deinterleaves a rank's page: every rank remains
an opaque, independently keyed byte image. Interleave is therefore safe once
the key namespace identifies the layout and all required rank objects are
present.

This focused PR intentionally does not change cache tensor views or packed
subpage handling. Official PR #4731 remains complementary and is not
duplicated here.

Background and the wider community integration series:
https://github.com/LMCache/LMCache/issues/4831

## Validation

Current official base: `LMCache/LMCache:dev@1af78035`.

Standalone affected/control suite using the exact current-`dev` connector,
group geometry, and group-edit files over the compiled test environment:

```text
python -m pytest -q test_vllm_dcp_support.py

65 passed in 9.39s
```

The suite covers DCP1/DCP2/DCP4 validation, TP/DCP rank ownership,
multi-server reader accounting, hybrid attention/recurrent spans, resolved
attention-block interleave validation, cache-namespace isolation and inverse
decoding, recurrent-step alignment, legacy-key compatibility, and existing
failure guards.

Applicable pre-commit hooks pass for all three changed files: SPDX/policy,
isort, Ruff, Ruff format, codespell, and mypy. Rust hooks were explicitly
skipped because this Python/documentation-only change was validated on macOS,
where the repository's Linux `io-uring` clippy dependency is unsupported.

### CN4 full-system evidence

- Image:
  `ghcr.io/yatesdr/jovian-judgement-glm53-lmcache@sha256:bdb5bdc2dca4e196b5f9239c08d543635ca6f5ed4b0a435635fedc92e937f58a`.
- Model: GLM-5.3-Flash NVFP4; FP8 KV; TP4/DCP4; interleave 4; MTP3;
  APC/CKV gather/vision enabled; GMU 0.90.
- Runtime-resolved group spans: `[512, 512, 512, 2048]` tokens; scheduler
  block: 2,048 tokens; configured LMCache chunk: 4,096 tokens.
- Actual KV pool: 35,060,805,120 bytes (32.652919292 GiB) per rank and
  140,243,220,480 bytes (130.611677170 GiB) aggregate; 4,671,908 useful
  tokens at a configured 262,144-token model maximum.
- Text and exact-answer vision passed. Full and partial DRAM/NVMe recovery,
  capacity eviction, and fresh-container restart recovery passed. The final
  restart restored 49,152 external-prefix tokens / 12 chunks.
- KLD over 2,047 positions did not regress: unchanged r7 mean
  `0.13809181884582677`; integrated candidate `0.12785119915669524`
  (`-7.42%`, lower is better).
- Matched MTP3 performance versus unchanged r7 DFlash2 was +9.7% at 32K
  prefill and +22.3%/+26.4%/+37.8%/+38.0% at C1/C4/C8/C16 decode.

The full-system image contains the wider integration series, so the focused
65-test suite is the isolation evidence for this PR's exact surface. This PR
does not modify LMCache-disabled inference, cache contents, serialization, or
transport payloads.

## Provenance

- LIL integration commit: `33354010`.
- Focused current-`dev` commit: `347b0c8a`.
- Historical community testing and reconciliation are tracked in #4831.
