### PR TITLE
fix(mp): make remote transfer results authoritative

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -20,7 +20,10 @@ from lmcache.integration.vllm.utils import (
     extract_request_configs_from_request,
 )
 from lmcache.integration.vllm.vllm_multi_process_adapter import LoadStoreOp
+from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
+
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     # Third Party
@@ -319,6 +322,25 @@ class LMCacheMPRequestMetadata:
             "number of LMCache hit tokens. "
         )
         if end_token_idx > start_token_idx:
+            short_groups = [
+                group_idx
+                for group_idx, tokens_per_block in enumerate(group_tokens_per_block)
+                if len(tracker.allocated_block_ids.get(group_idx, []))
+                * tokens_per_block
+                < end_token_idx
+            ]
+            if short_groups:
+                # Slicing a short Python list truncates silently. Emitting a
+                # partial retrieve would acknowledge a load vLLM expects to
+                # cover the full range, so suppress it and recompute instead.
+                logger.warning(
+                    "LMCache retrieve suppressed for request_id=%s: engine "
+                    "group(s) %s do not cover end_token_idx=%d",
+                    tracker.request_id,
+                    short_groups,
+                    end_token_idx,
+                )
+                return None
             block_ids = slice_block_ids_per_group(
                 tracker.allocated_block_ids,
                 group_tokens_per_block,

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -15,7 +15,6 @@ import torch
 import zmq
 
 # First Party
-from lmcache import torch_dev
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
 from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.utils import vllm_layout_hints
@@ -1978,8 +1977,6 @@ class LMCacheMPWorkerAdapter:
         if not self.is_healthy or self.transfer_ctx is None:
             return
         self.transfer_ctx.flush_inflight_stores()
-        # Force device sync here, compare to preemption, perf panelty is trivial
-        torch_dev.synchronize()
 
     def shutdown(self) -> None:
         """

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1201,8 +1201,10 @@ class LMCacheMPWorkerAdapter:
         self.store_events: dict[str, _IpcEvent] = {}
         self.retrieve_events: dict[str, _IpcEvent] = {}
 
-        # Block IDs that failed due to retrieve timeout
+        # Block IDs whose retrieve failed, consumed by the scheduler's
+        # invalid-block recompute path.
         self.error_block_ids: set[int] = set()
+        self.retrieve_failure_count = 0
 
         # Retrieve request ids dropped by the unhealthy early-return of
         # submit_retrieve_request. get_finished must still report each id
@@ -1805,37 +1807,8 @@ class LMCacheMPWorkerAdapter:
             ret_stores -= finished_retrieves
             return ret_stores, finished_retrieves
 
-        finished_stores = set()
-        finished_retrieves = set()
-        for request_id, s_future in self.store_futures.items():
-            if not s_future.query():
-                continue
-
-            s_result = s_future.result(timeout=60)
-            finished_stores.add(request_id)
-
-            if not s_result:
-                logger.error(
-                    "Something went wrong when processing the "
-                    "store request for request_id=%s",
-                    request_id,
-                )
-
-        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
-            if not r_future.query():
-                continue
-
-            r_result = r_future.result(timeout=60)
-            finished_retrieves.add(request_id)
-
-            if not r_result:
-                self.error_block_ids.update(r_block_ids)
-                logger.error(
-                    "Something went wrong when processing the "
-                    "retrieve request for request_id=%s, result=%s",
-                    request_id,
-                    r_result,
-                )
+        finished_stores = self._poll_store_futures()
+        finished_retrieves = self._poll_retrieve_futures()
 
         # Remove the finished requests from the tracking dicts
         for request_id in finished_stores:
@@ -1926,37 +1899,8 @@ class LMCacheMPWorkerAdapter:
                 self._completed_store_requests[req_id] = 1
             return None, finished_retrieves
 
-        finished_stores = set()
-        finished_retrieves = set()
-        for request_id, s_future in self.store_futures.items():
-            if not s_future.query():
-                continue
-
-            s_result = s_future.result(timeout=60)
-            finished_stores.add(request_id)
-
-            if not s_result:
-                logger.error(
-                    "Something went wrong when processing the "
-                    "store request for request_id=%s",
-                    request_id,
-                )
-
-        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
-            if not r_future.query():
-                continue
-
-            r_result = r_future.result(timeout=60)
-            finished_retrieves.add(request_id)
-
-            if not r_result:
-                self.error_block_ids.update(r_block_ids)
-                logger.error(
-                    "Something went wrong when processing the "
-                    "retrieve request for request_id=%s, result=%s",
-                    request_id,
-                    r_result,
-                )
+        finished_stores = self._poll_store_futures()
+        finished_retrieves = self._poll_retrieve_futures()
 
         # Remove the finished requests from the tracking dicts
         for request_id in finished_stores:
@@ -2008,8 +1952,11 @@ class LMCacheMPWorkerAdapter:
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         """
-        Returns the block IDs that failed due to retrieve timeout,
-        then clears the internal set.
+        Return block IDs from failed retrieves, then clear the internal set.
+
+        Server-reported failures and future exceptions use the same path as
+        timeouts so vLLM recomputes the affected span instead of decoding over
+        blocks LMCache did not populate.
         """
         errors = self.error_block_ids.copy()
         self.error_block_ids.clear()
@@ -2076,6 +2023,54 @@ class LMCacheMPWorkerAdapter:
         self.request_telemetry.close()
 
     # Helper functions
+    def _poll_store_futures(self) -> set[str]:
+        """Return terminal store request IDs and log unsuccessful stores."""
+        finished: set[str] = set()
+        for request_id, future in self.store_futures.items():
+            if not future.query():
+                continue
+            result = future.result(timeout=60)
+            finished.add(request_id)
+            if not result:
+                logger.error("LMCache store failed for request_id=%s", request_id)
+        return finished
+
+    def _poll_retrieve_futures(self) -> set[str]:
+        """Return terminal retrieves and mark every failed span invalid."""
+        finished: set[str] = set()
+        for request_id, (future, block_ids) in self.retrieve_futures.items():
+            try:
+                if not future.query():
+                    continue
+                result = future.result(timeout=60)
+            except Exception:
+                finished.add(request_id)
+                self.error_block_ids.update(block_ids)
+                self.retrieve_failure_count += 1
+                logger.exception(
+                    "LMCache retrieve raised for request_id=%s; marking %d "
+                    "block(s) invalid for scheduler recompute "
+                    "(worker failure count=%d)",
+                    request_id,
+                    len(block_ids),
+                    self.retrieve_failure_count,
+                )
+                continue
+
+            finished.add(request_id)
+            if not result:
+                self.error_block_ids.update(block_ids)
+                self.retrieve_failure_count += 1
+                logger.error(
+                    "LMCache retrieve failed for request_id=%s; marked %d "
+                    "block(s) invalid for scheduler recompute "
+                    "(worker failure count=%d)",
+                    request_id,
+                    len(block_ids),
+                    self.retrieve_failure_count,
+                )
+        return finished
+
     def _update_and_get_finished_store(
         self,
     ) -> set[str]:

--- a/lmcache/v1/multiprocess/futures.py
+++ b/lmcache/v1/multiprocess/futures.py
@@ -16,6 +16,7 @@ class MessagingFuture(Generic[T]):
     def __init__(self) -> None:
         self.is_done_ = threading.Event()
         self.result_: T | None = None
+        self.exception_: BaseException | None = None
         self._retained_references: list[object] = []
 
     def query(self) -> bool:
@@ -57,6 +58,8 @@ class MessagingFuture(Generic[T]):
         flag = self.wait(timeout)
         if not flag:
             raise LMCacheTimeoutError("Future result not available within timeout")
+        if self.exception_ is not None:
+            raise self.exception_
         return cast(T, self.result_)
 
     def set_result(self, result: T) -> None:
@@ -69,6 +72,20 @@ class MessagingFuture(Generic[T]):
             result (T): The result to set.
         """
         self.result_ = result
+        self.is_done_.set()
+
+    def set_exception(self, exception: BaseException) -> None:
+        """Complete this future with an exception.
+
+        Args:
+            exception: Failure to raise from :meth:`result`.
+
+        Raises:
+            TypeError: If ``exception`` is not a ``BaseException`` instance.
+        """
+        if not isinstance(exception, BaseException):
+            raise TypeError("exception must derive from BaseException")
+        self.exception_ = exception
         self.is_done_.set()
 
     def retain_reference(self, value: object) -> None:
@@ -146,7 +163,15 @@ class DeviceMessagingFuture(MessagingFuture[T]):
         if self._raw_response_processed:
             return
 
-        event_bytes, result = self.raw_future_.result()
+        try:
+            event_bytes, result = self.raw_future_.result()
+        except BaseException as exc:
+            # ``query`` follows the standard Future contract and reports a
+            # terminal failure as done. Preserve the exception for result()
+            # instead of raising from a non-blocking readiness check.
+            self.exception_ = exc
+            self._raw_response_processed = True
+            return
         event = None
         if event_bytes:
             event = self._event_backend.import_event(event_bytes, self.device_)
@@ -208,6 +233,9 @@ class DeviceMessagingFuture(MessagingFuture[T]):
             raise LMCacheTimeoutError(
                 "DeviceMessagingFuture result not available within timeout"
             )
+
+        if self.exception_ is not None:
+            raise self.exception_
 
         assert self.result_ is not None
         return self.result_

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -40,6 +40,37 @@ T = TypeVar("T")
 # Internal type used for the client-server communication
 RequestUID = int
 
+_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
+_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
+
+
+class RemoteHandlerError(RuntimeError):
+    """A request handler failed in the remote LMCache process.
+
+    Args:
+        request_type: Request whose remote handler failed.
+        error_type: Remote exception class name.
+        message: Bounded remote exception message.
+    """
+
+    def __init__(
+        self,
+        request_type: RequestType,
+        error_type: str,
+        message: str,
+    ) -> None:
+        self.request_type = request_type
+        self.error_type = error_type
+        self.remote_message = message
+        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
+
+
+class _RemoteErrorPayload(msgspec.Struct, frozen=True):
+    """Version-one bounded handler-error payload."""
+
+    error_type: str
+    message: str
+
 
 # Helper functions
 def encode_request_uid(uid: RequestUID) -> bytes:
@@ -360,11 +391,33 @@ class MessageQueueClient:
 
         if request_uid in self.pending_futures:
             future = self.pending_futures.pop(request_uid)
-            if b_response:
-                response = msgspec_decode(b_response[0], cls=response_cls)
-                future.set_result(response)
-            else:
-                future.set_result(None)
+            try:
+                if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
+                    if len(b_response) != 2:
+                        raise RuntimeError(
+                            "Malformed LMCache RPC error response: expected "
+                            "marker and one payload frame"
+                        )
+                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
+                    future.set_exception(
+                        RemoteHandlerError(
+                            request_type=request_type,
+                            error_type=error.error_type,
+                            message=error.message,
+                        )
+                    )
+                elif b_response:
+                    response = msgspec_decode(b_response[0], cls=response_cls)
+                    future.set_result(response)
+                else:
+                    future.set_result(None)
+            except Exception as exc:
+                # A matching response owns this future. Never leave it pending
+                # after malformed wire data or a response-decoding failure.
+                future.set_exception(exc)
+                logger.exception(
+                    "Failed to decode response for request type %s", request_type
+                )
 
     def submit_request(
         self,
@@ -530,6 +583,26 @@ class MessageQueueServer:
         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
 
+    def _queue_error_response(
+        self,
+        prefix_frames: list[bytes],
+        exception: BaseException,
+    ) -> None:
+        """Queue a bounded handler error without touching ZMQ off-thread."""
+        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
+        payload = _RemoteErrorPayload(
+            error_type=type(exception).__name__,
+            message=message.decode("utf-8", errors="replace"),
+        )
+        self.output_queue.put(
+            prefix_frames
+            + [
+                _ERROR_RESPONSE_MARKER,
+                msgspec_encode(payload, cls=_RemoteErrorPayload),
+            ]
+        )
+        self._output_efd.notify()
+
     def _call_sync_handler(
         self,
         handler_entry: SyncRequestHandler[Any],
@@ -585,8 +658,9 @@ class MessageQueueServer:
                 self.output_queue.put(frames_to_send)
                 self._output_efd.notify()
 
-            except Exception:
+            except Exception as exc:
                 logger.exception("Error in blocking handler")
+                self._queue_error_response(prefix_frames, exc)
 
         future.add_done_callback(_notify_response)
 
@@ -633,13 +707,23 @@ class MessageQueueServer:
                             payloads=payloads,
                             prefix_frames=[identity, b_request_uid, b_request_type],
                         )
-                    except Exception:
+                    except Exception as exc:
                         logger.exception("Error handling request %s", request_type)
+                        self._queue_error_response(
+                            [identity, b_request_uid, b_request_type], exc
+                        )
                 else:
                     logger.error(
                         "No handler registered for request type %s", request_type
                     )
                     logger.error("Available handlers: %s", list(self.handlers.keys()))
+                    self._queue_error_response(
+                        [identity, b_request_uid, b_request_type],
+                        RuntimeError(
+                            "No handler registered for request type "
+                            f"{request_type.name}"
+                        ),
+                    )
 
             # Send the responses
             if outbound_state and outbound_state & zmq.POLLIN:

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -427,6 +427,13 @@ class LMCacheDrivenTransferContext(TransferContext):
         self._send_request: SendRequest | None = None
         self._device: torch.device | None = None
         self._event_backend: EventIPCBackend | None = None
+        self._mq_timeout: float | None = None
+        # The server reads paged KV asynchronously through exported device
+        # handles. Keep outstanding stores alive here so preemption can wait
+        # for the actual remote reads before vLLM reuses their blocks. This
+        # cannot rely on the adapter's per-request map: a later chunk may
+        # replace that entry while the earlier store is still in flight.
+        self._inflight_store_futures: set[MessagingFuture[Any]] = set()
 
     def register(
         self,
@@ -483,6 +490,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         future.result(timeout=mq_timeout)
         self._device = device
         self._event_backend = event_backend
+        self._mq_timeout = mq_timeout
 
     def create_recorded_event(self) -> IPCEvent:
         """Create and record an exportable event for handle-based transfer.
@@ -574,11 +582,16 @@ class LMCacheDrivenTransferContext(TransferContext):
         if event is None:
             raise RuntimeError("LMCache-driven transfer requires an IPC event.")
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._send_request(
+        self._inflight_store_futures = {
+            future for future in self._inflight_store_futures if not future.query()
+        }
+        future = self._send_request(
             self._mq_client,
             RequestType.STORE,
             [key, instance_id, block_ids, event_ipc_handle],
         ).to_device_future(device=self._device)
+        self._inflight_store_futures.add(future)
+        return future
 
     def submit_q_store(
         self,
@@ -663,9 +676,22 @@ class LMCacheDrivenTransferContext(TransferContext):
         self._send_request = None
         self._device = None
         self._event_backend = None
+        self._mq_timeout = None
+        self._inflight_store_futures.clear()
 
     def flush_inflight_stores(self) -> None:
-        pass
+        """Wait for server-side device reads that preemption could overwrite.
+
+        LMCache-driven stores execute in the server process, so synchronizing
+        the worker's device does not order or complete them. Their device-aware
+        futures do: each resolves only after the server response and imported
+        completion event. Usually this set is empty, making preemption handling
+        a true no-op instead of a device-wide barrier.
+        """
+        timeout = self._mq_timeout
+        for future in list(self._inflight_store_futures):
+            future.result(timeout=timeout)
+            self._inflight_store_futures.discard(future)
 
 
 class EngineDrivenTransferContext(TransferContext):

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -590,6 +590,7 @@ class LMCacheDrivenTransferContext(TransferContext):
             RequestType.STORE,
             [key, instance_id, block_ids, event_ipc_handle],
         ).to_device_future(device=self._device)
+        future.retain_reference(event)
         self._inflight_store_futures.add(future)
         return future
 

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -393,6 +393,69 @@ def test_create_transfer_context_force_lmcache_driven_mode() -> None:
     assert isinstance(context, LMCacheDrivenTransferContext)
 
 
+def test_lmcache_driven_preemption_waits_for_remote_store_futures() -> None:
+    """Handle-path flush waits on remote completion, not the worker device."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        LMCacheDrivenTransferContext,
+        worker_transfer,
+    )
+
+    context = LMCacheDrivenTransferContext()
+    registration_future = MagicMock(name="registration_future")
+    raw_store_future = MagicMock(name="raw_store_future")
+    pending = MagicMock(name="pending_store_future")
+    raw_store_future.to_device_future.return_value = pending
+    send_request = MagicMock(
+        name="send_request", side_effect=[registration_future, raw_store_future]
+    )
+    event_backend = MagicMock(name="event_backend")
+    event_backend.export_event.return_value = b"event"
+
+    with (
+        patch.object(
+            worker_transfer,
+            "get_event_ipc_backend",
+            return_value=event_backend,
+        ),
+        patch.object(worker_transfer, "wrap_kv_caches", return_value=[]),
+    ):
+        context.register(
+            instance_id=1,
+            kv_caches={"layer_0": torch.zeros(1)},
+            model_name="model",
+            world_size=1,
+            _blocks_in_chunk=1,
+            mq_client=MagicMock(name="mq_client"),
+            mq_timeout=2.5,
+            send_request=send_request,
+        )
+        context.submit_store(
+            _request_id="request",
+            key="key",
+            instance_id=1,
+            kv_caches={},
+            block_ids=[[0]],
+            event=MagicMock(name="event"),
+            _blocks_in_chunk=1,
+        )
+
+    context.flush_inflight_stores()
+
+    pending.result.assert_called_once_with(timeout=2.5)
+    context.flush_inflight_stores()
+    pending.result.assert_called_once()
+
+
+def test_lmcache_driven_preemption_without_stores_is_noop() -> None:
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import LMCacheDrivenTransferContext
+
+    context = LMCacheDrivenTransferContext()
+
+    context.flush_inflight_stores()
+
+
 def test_create_transfer_context_force_engine_driven_mode_on_cpu() -> None:
     """``mode='engine_driven'`` on CPU returns EngineDrivenTransferContext
     (data path; no wrapper-factory capability check is performed)."""

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -393,8 +393,8 @@ def test_create_transfer_context_force_lmcache_driven_mode() -> None:
     assert isinstance(context, LMCacheDrivenTransferContext)
 
 
-def test_lmcache_driven_preemption_waits_for_remote_store_futures() -> None:
-    """Handle-path flush waits on remote completion, not the worker device."""
+def test_lmcache_driven_preemption_retains_each_store_event_and_waits() -> None:
+    """Two stores for one request retain both events until remote completion."""
     # First Party
     from lmcache.v1.multiprocess.transfer_context import (
         LMCacheDrivenTransferContext,
@@ -403,14 +403,24 @@ def test_lmcache_driven_preemption_waits_for_remote_store_futures() -> None:
 
     context = LMCacheDrivenTransferContext()
     registration_future = MagicMock(name="registration_future")
-    raw_store_future = MagicMock(name="raw_store_future")
-    pending = MagicMock(name="pending_store_future")
-    raw_store_future.to_device_future.return_value = pending
+    raw_store_futures = [
+        MagicMock(name="raw_store_future_1"),
+        MagicMock(name="raw_store_future_2"),
+    ]
+    pending = [
+        MagicMock(name="pending_store_future_1"),
+        MagicMock(name="pending_store_future_2"),
+    ]
+    for pending_future in pending:
+        pending_future.query.return_value = False
+    for raw_future, pending_future in zip(raw_store_futures, pending, strict=True):
+        raw_future.to_device_future.return_value = pending_future
     send_request = MagicMock(
-        name="send_request", side_effect=[registration_future, raw_store_future]
+        name="send_request", side_effect=[registration_future, *raw_store_futures]
     )
     event_backend = MagicMock(name="event_backend")
-    event_backend.export_event.return_value = b"event"
+    event_backend.export_event.side_effect = [b"event-1", b"event-2"]
+    events = [MagicMock(name="event_1"), MagicMock(name="event_2")]
 
     with (
         patch.object(
@@ -430,21 +440,27 @@ def test_lmcache_driven_preemption_waits_for_remote_store_futures() -> None:
             mq_timeout=2.5,
             send_request=send_request,
         )
-        context.submit_store(
-            _request_id="request",
-            key="key",
-            instance_id=1,
-            kv_caches={},
-            block_ids=[[0]],
-            event=MagicMock(name="event"),
-            _blocks_in_chunk=1,
-        )
+        for index, event in enumerate(events):
+            context.submit_store(
+                _request_id="request",
+                key=f"key-{index}",
+                instance_id=1,
+                kv_caches={},
+                block_ids=[[index]],
+                event=event,
+                _blocks_in_chunk=1,
+            )
+
+    pending[0].retain_reference.assert_called_once_with(events[0])
+    pending[1].retain_reference.assert_called_once_with(events[1])
 
     context.flush_inflight_stores()
 
-    pending.result.assert_called_once_with(timeout=2.5)
+    for pending_future in pending:
+        pending_future.result.assert_called_once_with(timeout=2.5)
     context.flush_inflight_stores()
-    pending.result.assert_called_once()
+    for pending_future in pending:
+        pending_future.result.assert_called_once()
 
 
 def test_lmcache_driven_preemption_without_stores_is_noop() -> None:

--- a/tests/v1/multiprocess/test_futures.py
+++ b/tests/v1/multiprocess/test_futures.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from unittest.mock import MagicMock
 import gc
 import multiprocessing as mp
 import threading
@@ -221,6 +222,50 @@ def test_messaging_future_complex_type():
     assert result == complex_data, "Complex types should be preserved"
 
     thread.join()
+
+
+def test_messaging_future_exception_is_terminal_and_re_raised() -> None:
+    """A messaging failure completes the future without becoming a timeout."""
+    future = MessagingFuture[int]()
+    error = RuntimeError("remote operation failed")
+
+    future.set_exception(error)
+
+    assert future.query()
+    assert future.wait(timeout=0.1)
+    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
+        future.result(timeout=0.1)
+    assert exc_info.value is error
+
+
+def test_messaging_future_rejects_non_exception() -> None:
+    future = MessagingFuture[int]()
+
+    with pytest.raises(TypeError, match="must derive from BaseException"):
+        future.set_exception("not an exception")  # type: ignore[arg-type]
+
+
+def test_device_future_query_reports_remote_exception_as_done(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readiness checks stay non-raising; result preserves the root failure."""
+    # First Party
+    from lmcache.v1.multiprocess import futures as futures_mod
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    backend = MagicMock(name="event_backend")
+    monkeypatch.setattr(futures_mod, "get_event_ipc_backend", lambda _device: backend)
+    raw = MessagingFuture[tuple[bytes, bool]]()
+    wrapped = DeviceMessagingFuture.FromMessagingFuture(raw, device="cpu")
+    error = RuntimeError("remote handler failed")
+
+    raw.set_exception(error)
+
+    assert wrapped.query()
+    assert wrapped.wait(timeout=0.1)
+    with pytest.raises(RuntimeError, match="remote handler failed") as exc_info:
+        wrapped.result(timeout=0.1)
+    assert exc_info.value is error
 
 
 def test_messaging_future_retains_reference_for_its_lifetime() -> None:

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -25,6 +25,7 @@ from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,
     MessageQueueServer,
+    RemoteHandlerError,
 )
 from lmcache.v1.multiprocess.protocol import (
     RequestType,
@@ -687,6 +688,127 @@ def test_shared_loop_dispatch():
         client_b.close()
         assert ClientPollingLoop._instance is None
     finally:
+        server.close()
+
+
+def test_sync_handler_failure_completes_future_and_loop_recovers() -> None:
+    """A synchronous handler error is terminal and does not poison the loop."""
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
+    add_handler_helper(
+        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
+    )
+    server.start()
+    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
+
+    try:
+        failed: MessagingFuture[str] = client.submit_request(RequestType.NOOP, [])
+        with pytest.raises(
+            RemoteHandlerError, match="intentional sync handler failure"
+        ) as exc_info:
+            failed.result(timeout=2)
+        assert exc_info.value.request_type is RequestType.NOOP
+        assert exc_info.value.error_type == "ValueError"
+
+        server.add_sync_handler(
+            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
+        )
+        assert (
+            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
+        )
+    finally:
+        client.close()
+        server.close()
+
+
+def test_blocking_handler_failure_completes_future() -> None:
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
+    add_handler_helper(
+        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
+    )
+    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
+    server.start()
+    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
+
+    try:
+        future: MessagingFuture[None] = client.submit_request(
+            RequestType.LOOKUP, [create_cache_key(1), 1]
+        )
+        with pytest.raises(
+            RemoteHandlerError, match="intentional blocking handler failure"
+        ) as exc_info:
+            future.result(timeout=2)
+        assert exc_info.value.request_type is RequestType.LOOKUP
+        assert exc_info.value.error_type == "OSError"
+    finally:
+        client.close()
+        server.close()
+
+
+def test_missing_handler_completes_future_with_remote_error() -> None:
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:16023", context)
+    server.start()
+    client = MessageQueueClient("tcp://127.0.0.1:16023", context)
+
+    try:
+        with pytest.raises(RemoteHandlerError, match="No handler registered"):
+            client.submit_request(RequestType.NOOP, []).result(timeout=2)
+    finally:
+        client.close()
+        server.close()
+
+
+def test_malformed_error_frame_completes_future_and_loop_recovers() -> None:
+    """A matched malformed response fails its future instead of stranding it."""
+    # First Party
+    from lmcache.v1.multiprocess.mq import _ERROR_RESPONSE_MARKER
+
+    server_url = "tcp://127.0.0.1:16024"
+    context = zmq.Context.instance()
+    router = context.socket(zmq.ROUTER)
+    router.bind(server_url)
+
+    def serve() -> None:
+        identity, b_uid, b_type, *_ = router.recv_multipart()
+        router.send_multipart([identity, b_uid, b_type, _ERROR_RESPONSE_MARKER])
+        identity, b_uid, b_type, *_ = router.recv_multipart()
+        router.send_multipart(
+            [identity, b_uid, b_type, msgspec.msgpack.encode("NOOP_OK")]
+        )
+
+    threading.Thread(target=serve, daemon=True).start()
+    client = MessageQueueClient(server_url, context)
+    try:
+        malformed: MessagingFuture[str] = client.submit_request(RequestType.NOOP, [])
+        with pytest.raises(RuntimeError, match="Malformed LMCache RPC error"):
+            malformed.result(timeout=2)
+        assert (
+            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
+        )
+    finally:
+        client.close()
+        router.close()
+
+
+def test_remote_error_message_is_bounded() -> None:
+    context = zmq.Context.instance()
+    server = MessageQueueServer("tcp://127.0.0.1:16025", context)
+    add_handler_helper(
+        server,
+        RequestType.NOOP,
+        test_mq_handler_helpers.oversized_noop_failure_handler,
+    )
+    server.start()
+    client = MessageQueueClient("tcp://127.0.0.1:16025", context)
+
+    try:
+        with pytest.raises(RemoteHandlerError) as exc_info:
+            client.submit_request(RequestType.NOOP, []).result(timeout=2)
+        assert len(exc_info.value.remote_message.encode("utf-8")) <= 4096
+    finally:
+        client.close()
         server.close()
 
 

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -29,6 +29,16 @@ def noop_handler() -> str:
     return "NOOP_OK"
 
 
+def failing_noop_handler() -> str:
+    """Raise a deterministic synchronous-handler failure."""
+    raise ValueError("intentional sync handler failure")
+
+
+def oversized_noop_failure_handler() -> str:
+    """Raise a handler failure whose message must be bounded on the wire."""
+    raise ValueError("x" * 8192)
+
+
 # ==============================================================================
 # REGISTER_KV_CACHE Request Handlers
 # ==============================================================================
@@ -201,6 +211,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
     # For testing, we just validate the input
     assert isinstance(key, KeyType), f"Expected key to be KeyType, got {type(key)}"
     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+
+
+def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
+    """Raise a deterministic blocking-handler failure."""
+    del key, tp_size
+    raise OSError("intentional blocking handler failure")
 
 
 # ==============================================================================

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -559,6 +559,38 @@ def test_failed_retrieve_marks_blocks_for_recompute(
 
     assert finished_retrieves == {"req-1"}
     assert adapter.get_block_ids_with_load_errors() == {7, 8}
+    assert adapter.retrieve_failure_count == 1
+    assert "req-1" not in adapter.retrieve_futures
+
+
+@pytest.mark.parametrize("lazy_offload", [False, True])
+@pytest.mark.parametrize("failure_site", ["query", "result"])
+def test_raising_retrieve_marks_blocks_for_recompute(
+    fake_adapter,
+    lazy_offload: bool,
+    failure_site: str,
+) -> None:
+    """Remote exceptions are contained on both readiness and result paths."""
+    adapter, _send_mock, _future = fake_adapter
+    adapter.lazy_offload = lazy_offload
+    retrieve_future = MagicMock(name="retrieve_future")
+    retrieve_future.query.return_value = True
+    if failure_site == "query":
+        retrieve_future.query.side_effect = RuntimeError("query failed")
+    else:
+        retrieve_future.result.side_effect = RuntimeError("result failed")
+    adapter.retrieve_futures["req-1"] = (retrieve_future, [7, 8])
+
+    if lazy_offload:
+        finished_stores, finished_retrieves = adapter.get_finished_with_lazy_offload()
+        assert finished_stores is None
+    else:
+        finished_stores, finished_retrieves = adapter.get_finished(set())
+        assert finished_stores == set()
+
+    assert finished_retrieves == {"req-1"}
+    assert adapter.get_block_ids_with_load_errors() == {7, 8}
+    assert adapter.retrieve_failure_count == 1
     assert "req-1" not in adapter.retrieve_futures
 
 

--- a/tests/v1/test_vllm_mp_connector_metadata.py
+++ b/tests/v1/test_vllm_mp_connector_metadata.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Allocation coverage tests for vLLM MP retrieve metadata."""
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP metadata imports vLLM at module load")
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
+    LMCacheMPRequestMetadata,
+    LMCacheMPRequestState,
+    LMCacheMPRequestTracker,
+)
+
+CHUNK_TOKENS = 64
+
+
+def _tracker(
+    *,
+    lmcache_hit_tokens: int = CHUNK_TOKENS,
+    vllm_hit_tokens: int = 0,
+    allocated_block_ids: dict[int, list[int]],
+) -> LMCacheMPRequestTracker:
+    """Build a tracker ready to retrieve one aligned chunk."""
+    token_ids = list(range(CHUNK_TOKENS))
+    request = SimpleNamespace(
+        request_id="req-1",
+        cache_salt="",
+        prompt_token_ids=token_ids,
+        all_token_ids=token_ids,
+        mm_features=[],
+    )
+    tracker = LMCacheMPRequestTracker(request)
+    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
+    tracker.num_vllm_hit_tokens = vllm_hit_tokens
+    tracker.allocated_block_ids = allocated_block_ids
+    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
+    return tracker
+
+
+@pytest.mark.parametrize(
+    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
+    [
+        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
+        ([64], {0: [5]}, [[5]]),
+        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
+        ([16], {0: [0, 1, 2, 3, 4]}, [[0, 1, 2, 3]]),
+    ],
+)
+def test_retrieve_emitted_when_every_group_covers_range(
+    group_tokens_per_block: list[int],
+    allocated_block_ids: dict[int, list[int]],
+    expected_block_ids: list[list[int]],
+) -> None:
+    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        _tracker(allocated_block_ids=allocated_block_ids),
+        CHUNK_TOKENS,
+        group_tokens_per_block,
+    )
+
+    assert metadata is not None
+    assert metadata.direction == "RETRIEVE"
+    assert metadata.op.start == 0
+    assert metadata.op.end == CHUNK_TOKENS
+    assert metadata.op.block_ids == expected_block_ids
+
+
+@pytest.mark.parametrize(
+    ("group_tokens_per_block", "allocated_block_ids"),
+    [
+        ([16], {0: [0, 1, 2]}),
+        ([64], {0: []}),
+        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
+        ([16, 16], {0: [0, 1, 2, 3]}),
+    ],
+)
+def test_retrieve_suppressed_when_any_group_is_short(
+    group_tokens_per_block: list[int],
+    allocated_block_ids: dict[int, list[int]],
+) -> None:
+    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        _tracker(allocated_block_ids=allocated_block_ids),
+        CHUNK_TOKENS,
+        group_tokens_per_block,
+    )
+
+    assert metadata is None
+
+
+def test_retrieve_preserves_skip_inside_first_chunk() -> None:
+    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        _tracker(
+            vllm_hit_tokens=16,
+            allocated_block_ids={0: [0, 1, 2, 3]},
+        ),
+        CHUNK_TOKENS,
+        [16],
+    )
+
+    assert metadata is not None
+    assert metadata.op.start == 0
+    assert metadata.op.end == CHUNK_TOKENS
+    assert metadata.op.skip_first_n_tokens == 16

--- a/tests/v1/test_vllm_mp_preemption.py
+++ b/tests/v1/test_vllm_mp_preemption.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Preemption synchronization tests for the vLLM multiprocess adapter."""
+
+# Standard
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
+from lmcache.integration.vllm.vllm_multi_process_adapter import (
+    LMCacheMPWorkerAdapter,
+)
+
+
+def _healthy_adapter() -> tuple[LMCacheMPWorkerAdapter, MagicMock]:
+    transfer_ctx = MagicMock(name="transfer_ctx")
+    adapter = cast(
+        LMCacheMPWorkerAdapter,
+        SimpleNamespace(is_healthy=True, transfer_ctx=transfer_ctx),
+    )
+    return adapter, transfer_ctx
+
+
+def test_handle_preemptions_delegates_without_device_wide_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The transport owns its completion primitive during preemption.
+
+    A worker-side device synchronize cannot complete server-process CUDA work
+    and serializes unrelated inference work when preemptions are frequent.
+    """
+    adapter, transfer_ctx = _healthy_adapter()
+    synchronize = MagicMock(name="synchronize")
+    monkeypatch.setattr(adapter_mod.torch_dev, "synchronize", synchronize)
+
+    LMCacheMPWorkerAdapter.handle_preemptions(adapter, True)
+
+    transfer_ctx.flush_inflight_stores.assert_called_once_with()
+    synchronize.assert_not_called()
+
+
+def test_handle_preemptions_false_is_noop() -> None:
+    adapter, transfer_ctx = _healthy_adapter()
+
+    LMCacheMPWorkerAdapter.handle_preemptions(adapter, False)
+
+    transfer_ctx.flush_inflight_stores.assert_not_called()

--- a/tests/v1/test_vllm_mp_preemption.py
+++ b/tests/v1/test_vllm_mp_preemption.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # First Party
-from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
+from lmcache import torch_dev
 from lmcache.integration.vllm.vllm_multi_process_adapter import (
     LMCacheMPWorkerAdapter,
 )
@@ -35,7 +35,7 @@ def test_handle_preemptions_delegates_without_device_wide_sync(
     """
     adapter, transfer_ctx = _healthy_adapter()
     synchronize = MagicMock(name="synchronize")
-    monkeypatch.setattr(adapter_mod.torch_dev, "synchronize", synchronize)
+    monkeypatch.setattr(torch_dev, "synchronize", synchronize)
 
     LMCacheMPWorkerAdapter.handle_preemptions(adapter, True)
 


### PR DESCRIPTION
Part of #4888. Supersedes #4835.

## Summary

Make multiprocess transfer results authoritative: return remote handler failures
to the requesting future, recompute failed retrieves, and wait for actual
server-side store completion before vLLM reuses preempted blocks.

## Problem

LMCache-driven stores read exported device pages asynchronously in the server
process. A worker-local device synchronization does not order those reads. At
the same time, a server handler failure can currently surface only as a timeout,
and a failed retrieve can remain classified as a cache hit even though its pages
were not populated.

The combination can reuse source blocks too early, decode over an incomplete
retrieve, or obscure the original remote failure.

## Change

- Return bounded, typed error responses for synchronous, blocking, missing, and
  malformed handler failures.
- Complete the matched future with the remote failure while keeping readiness
  polling non-raising.
- Invalidate the complete affected span and hand failed retrieves to the normal
  recompute path.
- Reject advertised hybrid retrieves when any group lacks allocation coverage.
- Retain every outstanding store future and its transfer event through remote
  completion, including earlier chunks displaced from per-request tracking.
- Drain those futures on actual preemption; keep no-store and no-preemption paths
  as no-ops instead of device-wide barriers.

Store failures remain fatal because their sources may already be in use by a
remote reader. This PR does not select recurrent boundaries or source blocks;
that is tracked separately in #4888.

## Compatibility

The changes are confined to multiprocess request/future handling and the vLLM MP
adapter. Successful responses, non-MP connectors, cache keys, serialization, and
dense geometry are unchanged. The implementation is based on current `dev` and
#4854's context-aware event API.

## Validation

- Focused coverage includes real MQ failure responses, terminal future
  semantics, normal and lazy-offload retrieve failures, short hybrid-group
  allocation, all outstanding store chunks, event retention, preemption drain,
  and no-op controls.
- The previously separate revisions passed their focused suites; the preemption
  revision also passed the full upstream Buildkite matrix.
- The consolidated current-`dev` branch passes Ruff lint/format and
  `git diff --check`; upstream CI should rerun for this combined revision.
