### PR TITLE
fix(l1): allocate the largest fitting reserve prefix

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -463,7 +463,9 @@ class L1Manager:
 
         Errors:
             KEY_NOT_WRITABLE: The key exists but is not writable.
-            OUT_OF_MEMORY: Not enough memory to allocate for the object.
+            OUT_OF_MEMORY: Not enough memory to allocate for the object. When a
+                multi-key batch only partially fits, the longest allocatable
+                prefix succeeds and the remaining keys return this error.
         """
         need_to_allocate: list[tuple[ObjectKey, bool]] = []
         ret: dict[ObjectKey, L1OperationResult] = {}
@@ -501,6 +503,24 @@ class L1Manager:
             layout_desc, len(need_to_allocate)
         )
 
+        # A full-batch failure should not collapse a large L2-to-L1 restore to
+        # zero hits when most of its contiguous prefix still fits. Memory
+        # managers provide all-or-nothing batch allocation, so under the L1
+        # lock feasibility is monotonic and can be probed safely.
+        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
+            if allocated_objs:
+                self._memory_manager.free(allocated_objs)
+                allocated_objs = []
+            err, allocated_objs = self._allocate_largest_prefix(
+                layout_desc, len(need_to_allocate)
+            )
+            if err == L1Error.SUCCESS:
+                logger.warning(
+                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
+                    len(allocated_objs),
+                    len(need_to_allocate),
+                )
+
         if err != L1Error.SUCCESS:
             for key, _ in need_to_allocate:
                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
@@ -510,6 +530,8 @@ class L1Manager:
                 self._memory_manager.free(allocated_objs)
 
         else:
+            for key, _ in need_to_allocate[len(allocated_objs) :]:
+                ret[key] = (L1Error.OUT_OF_MEMORY, None)
             for (key, is_temp), mem_obj in zip(
                 need_to_allocate, allocated_objs, strict=False
             ):
@@ -532,6 +554,43 @@ class L1Manager:
             )
         )
         return ret
+
+    def _allocate_largest_prefix(
+        self, layout_desc: MemoryLayoutDesc, want: int
+    ) -> tuple[L1Error, list[MemoryObj]]:
+        """Allocate the largest prefix below a failed full-batch request.
+
+        Successful probes are released before the final allocation. This is
+        called only while the L1 manager lock is held, after ``want`` objects
+        failed to allocate, so fixed-layout batch feasibility is monotonic.
+
+        Args:
+            layout_desc: Memory layout shared by every requested object.
+            want: Size of the already-failed full batch.
+
+        Returns:
+            The final allocation result for the largest fitting prefix, or
+            ``OUT_OF_MEMORY`` with an empty list when no object fits.
+        """
+        low = 1
+        high = want - 1
+        largest = 0
+
+        while low <= high:
+            candidate = (low + high) // 2
+            err, objects = self._memory_manager.allocate(layout_desc, candidate)
+            if err == L1Error.SUCCESS:
+                largest = candidate
+                self._memory_manager.free(objects)
+                low = candidate + 1
+            else:
+                if objects:
+                    self._memory_manager.free(objects)
+                high = candidate - 1
+
+        if largest == 0:
+            return L1Error.OUT_OF_MEMORY, []
+        return self._memory_manager.allocate(layout_desc, largest)
 
     @l1_mgr_synchronized
     def finish_write(

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -875,8 +875,8 @@ class TestReserveWrite:
 
         manager.close()
 
-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
+    def test_reserve_write_uses_available_prefix(self, small_l1_config, large_layout):
+        """Test that a partial prefix is retained after batch allocation fails."""
         manager = L1Manager(small_l1_config)
         keys = [make_object_key(i) for i in range(10)]
         is_temporary = [False] * 10
@@ -884,10 +884,12 @@ class TestReserveWrite:
         # Request more memory than available (8MB * 10 = 80MB > 64MB)
         result = manager.reserve_write(keys, is_temporary, large_layout)
 
-        # All keys should return OUT_OF_MEMORY
-        for key in keys:
-            assert result[key][0] == L1Error.OUT_OF_MEMORY
-            assert result[key][1] is None
+        statuses = [result[key][0] for key in keys]
+        num_success = statuses.count(L1Error.SUCCESS)
+        assert 0 < num_success < len(keys)
+        assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
+            len(keys) - num_success
+        )
 
         manager.close()
 

--- a/tests/v1/distributed/test_l1_manager_partial_alloc.py
+++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Partial-prefix allocation behavior for ``L1Manager.reserve_write``."""
+
+# Standard
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any, cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.internal_api import L1ManagerListener
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.mp_observability.event_bus import EventType
+
+POOL_BYTES = 64 * 1024 * 1024
+OBJECT_LAYOUT = MemoryLayoutDesc(
+    shapes=[torch.Size([2048, 1024])],
+    dtypes=[torch.float32],
+)
+OVERSIZED_LAYOUT = MemoryLayoutDesc(
+    shapes=[torch.Size([2048 * 16, 1024])],
+    dtypes=[torch.float32],
+)
+
+
+class _RecordingListener:
+    def __init__(self) -> None:
+        self.reserved_write: list[ObjectKey] = []
+
+    def on_l1_keys_reserved_read(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_read_finished(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_reserved_write(self, keys: list[ObjectKey]) -> None:
+        self.reserved_write.extend(keys)
+
+    def on_l1_keys_write_finished(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_deleted_by_manager(self, keys: list[ObjectKey]) -> None:
+        pass
+
+    def on_l1_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        pass
+
+
+class _RecordingEventBus:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def publish(self, event: Any) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture
+def manager() -> Iterator[L1Manager]:
+    config = L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(
+            size_in_bytes=POOL_BYTES,
+            use_lazy=False,
+            init_size_in_bytes=POOL_BYTES,
+            align_bytes=0x1000,
+        ),
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+    instance = L1Manager(config)
+    yield instance
+    instance.close()
+
+
+def _make_keys(count: int) -> list[ObjectKey]:
+    return [
+        ObjectKey(
+            chunk_hash=ObjectKey.IntHash2Bytes(index),
+            model_name="partial-allocation-test",
+            kv_rank=0,
+        )
+        for index in range(count)
+    ]
+
+
+def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
+    """Only the unallocatable tail fails, and observers see the prefix."""
+    keys = _make_keys(10)
+    listener = _RecordingListener()
+    event_bus = _RecordingEventBus()
+    manager.register_listener(cast(L1ManagerListener, listener))
+    manager._event_bus = cast(Any, event_bus)
+
+    result = manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
+
+    assert set(result) == set(keys)
+    statuses = [result[key][0] for key in keys]
+    num_success = statuses.count(L1Error.SUCCESS)
+    assert 0 < num_success < len(keys)
+    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
+        len(keys) - num_success
+    )
+
+    successful_keys = keys[:num_success]
+    assert all(result[key][1] is not None for key in successful_keys)
+    assert all(result[key][1] is None for key in keys[num_success:])
+    assert listener.reserved_write == successful_keys
+    assert event_bus.events[-1].event_type == EventType.L1_WRITE_RESERVED
+    assert event_bus.events[-1].metadata["keys"] == successful_keys
+
+
+def test_partial_prefix_remains_committable(manager: L1Manager) -> None:
+    keys = _make_keys(10)
+    result = manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
+    successful_keys = [key for key in keys if result[key][0] == L1Error.SUCCESS]
+
+    assert successful_keys
+    assert manager.finish_write(successful_keys) == {
+        key: L1Error.SUCCESS for key in successful_keys
+    }
+
+
+@pytest.mark.parametrize("count", [1, 3])
+def test_reserve_write_reports_all_oom_when_no_object_fits(
+    manager: L1Manager, count: int
+) -> None:
+    keys = _make_keys(count)
+
+    result = manager.reserve_write(keys, [False] * count, OVERSIZED_LAYOUT)
+
+    assert result == {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
+
+
+def test_largest_prefix_probe_finds_the_maximum_fit() -> None:
+    """Probe allocation instead of relying on an inaccurate byte estimate."""
+
+    class BoundedMemoryManager:
+        def __init__(self, capacity: int) -> None:
+            self.capacity = capacity
+            self.allocate_counts: list[int] = []
+            self.freed_counts: list[int] = []
+
+        def allocate(
+            self, _layout: MemoryLayoutDesc, count: int
+        ) -> tuple[L1Error, list[Any]]:
+            self.allocate_counts.append(count)
+            if count > self.capacity:
+                return L1Error.OUT_OF_MEMORY, []
+            return L1Error.SUCCESS, [object() for _ in range(count)]
+
+        def free(self, objects: list[Any]) -> L1Error:
+            self.freed_counts.append(len(objects))
+            return L1Error.SUCCESS
+
+    memory_manager = BoundedMemoryManager(capacity=7)
+    manager = SimpleNamespace(_memory_manager=memory_manager)
+
+    err, objects = L1Manager._allocate_largest_prefix(
+        manager,  # type: ignore[arg-type]
+        OBJECT_LAYOUT,
+        10,
+    )
+
+    assert err == L1Error.SUCCESS
+    assert len(objects) == 7
+    assert memory_manager.allocate_counts[-1] == 7
+    assert 8 in memory_manager.allocate_counts
+    assert memory_manager.freed_counts == [5, 7]


### PR DESCRIPTION
## Summary

Preserve the largest fitting prefix of an L1 multi-object reservation when the
complete batch does not fit.

LMCache restores and grouped stores reserve contiguous object lists. The L1
memory managers expose all-or-nothing batch allocation, so one object beyond
available capacity currently turns every otherwise usable object in the batch
into `OUT_OF_MEMORY`. This can collapse a large L2 restore to zero L1 objects
even when most of its prefix fits.

## Change

- After a failed multi-object allocation, probe under the existing L1 manager
  lock for the largest fitting prefix and perform one final allocation at that
  size.
- Return `SUCCESS` and writable objects for that prefix and explicit
  `OUT_OF_MEMORY` results for the remaining tail.
- Publish only successfully reserved keys to listeners and the event bus.
- Preserve single-object, complete-allocation, no-object-fits, update-only, and
  existing-key behavior.

The memory-manager contract is all-or-nothing and every object in one call has
the same layout, making feasibility monotonic while the L1 lock is held. Probe
allocations are released before the final reservation. The search is
logarithmic in the requested object count.

This is independently useful for ordinary multi-object L1 reservations and is
a prerequisite for capacity-aware grouped prefetch. It does not make an
incomplete hybrid object group serveable: higher-level grouped admission still
fails closed when any required member is unavailable.

Background and the wider community integration series:
https://github.com/LMCache/LMCache/issues/4831

## Validation

Current official base: `LMCache/LMCache:dev@117a0b88`.

Exact current-`dev` source was exercised in CN4's compiled Python 3.12 test
environment:

```text
python -m pytest -q \
  tests/v1/distributed/test_l1_manager.py \
  tests/v1/distributed/test_l1_manager_partial_alloc.py

5 passed, 1 skipped in 1.02s
```

The skip is the pre-existing `test_l1_manager.py` module guard: the CPU-only
container does not expose an available Torch CPU runtime. The new tests use
the same public `L1Manager` API without that accelerator-only guard and cover:

- longest-prefix selection with ordered success/OOM results;
- listener and event-bus publication of successful keys only;
- committing the returned prefix through `finish_write`;
- one- and multi-object cases where no object fits;
- exact maximum selection by the binary probe rather than an estimated byte
  calculation.

Applicable pre-commit hooks pass for all three changed files: SPDX/policy,
isort, Ruff, Ruff format, codespell, and mypy. Rust hooks were explicitly
skipped because this Python-only change was validated on macOS, where the
repository's Linux `io-uring` clippy dependency is unsupported.

### Integrated pressure controls

The wider consolidated stack ran on GLM-5.3-Flash NVFP4, FP8 KV, TP4/DCP4,
MTP3, APC, CKV gather, and GMU 0.90. Actual KV allocation was
35,060,805,120 bytes (32.652919292 GiB) per rank and 140,243,220,480 bytes
(130.611677170 GiB) aggregate, with 4,671,908 useful tokens.

With 64 GiB DRAM L1 and 512 GiB native-FS L2, the system crossed both capacity
watermarks, evicted 1,488 L1 objects, dropped 85,899,673,600 L2 bytes, restored
49,152 external-prefix tokens / 12 L2 chunks from the retained newest fixture,
and restored the same prefix after a fresh-container restart. This proves the
integrated L1/L2 pressure and serving paths; the deterministic five-test suite
above is the isolation evidence for this PR's partial-allocation branch. The
archived production logs did not happen to emit a partial-allocation warning,
so no claim is made that the exact fallback branch triggered in that workload.

## Provenance

- LIL integration source commit: `229b7ff2`.
- Focused current-`dev` commit: `d222dfbd`.
- Co-authored-by: Florian Bernd `<git@flobernd.de>`.
- Co-authored-by: Martin Vit `<martin@voipmonitor.org>`.
- Reconciliation and tests: Derek Yates.
