### PR TITLE
fix(native): acknowledge durable stores per key

### DIFF
--- a/csrc/storage_backends/connector_base.h
+++ b/csrc/storage_backends/connector_base.h
@@ -111,6 +111,10 @@ class ConnectorBase : public IStorageConnector {
     auto [batch_future_id, batch_state, num_tiles, tile_size] =
         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
 
+    // RESULT_UNKNOWN preserves compatibility with derived connectors that
+    // override do_batch_set() but predate per-key completion results.
+    batch_state->per_key_results.assign(num_items, BatchState::RESULT_UNKNOWN);
+
     // fan out work to threads
     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
       auto tile_req = create_tile_request(
@@ -327,9 +331,25 @@ class ConnectorBase : public IStorageConnector {
     }
   }
   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
+    bool any_failed = false;
+    std::string first_error;
     for (size_t i = 0; i < req.keys.size(); ++i) {
-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
-                    req.batch_chunk_num_bytes);
+      try {
+        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+                      req.batch_chunk_num_bytes);
+        req.batch->per_key_results[req.start_idx + i] = 1;
+      } catch (const std::exception& e) {
+        req.batch->per_key_results[req.start_idx + i] = 0;
+        if (!any_failed) {
+          any_failed = true;
+          first_error = e.what();
+        }
+        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
+                req.keys[i].c_str(), e.what());
+      }
+    }
+    if (any_failed) {
+      throw std::runtime_error("batch set partially failed: " + first_error);
     }
   }
   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
@@ -590,6 +610,20 @@ class ConnectorBase : public IStorageConnector {
   }
 
   void handle_tile_completion(const Request& req, const Completion& comp) {
+    // Preserve existing batch semantics for external derived connectors that
+    // override do_batch_set() without populating per-key results. A successful
+    // tile means every unreported key succeeded; a failed tile is
+    // conservatively reported as failed. In-tree implementations replace every
+    // sentinel.
+    if (req.batch->batch_op == Op::BATCH_TILE_SET) {
+      for (size_t i = 0; i < req.keys.size(); ++i) {
+        uint8_t& result = req.batch->per_key_results[req.start_idx + i];
+        if (result == BatchState::RESULT_UNKNOWN) {
+          result = comp.ok ? 1 : 0;
+        }
+      }
+    }
+
     // record failure if any
     if (!comp.ok) {
       req.batch->any_failed.store(true, std::memory_order_relaxed);
@@ -612,9 +646,10 @@ class ConnectorBase : public IStorageConnector {
         std::lock_guard<std::mutex> lk(req.batch->err_mu);
         batch_comp.error = req.batch->first_error;
       }
-      // for batch exists and batch get, move per-key results
+      // Move per-key results for every operation that records them.
       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
           req.batch->batch_op == Op::BATCH_TILE_GET ||
+          req.batch->batch_op == Op::BATCH_TILE_SET ||
           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
         batch_comp.result_bytes = std::move(req.batch->per_key_results);
       }

--- a/csrc/storage_backends/connector_interface.h
+++ b/csrc/storage_backends/connector_interface.h
@@ -57,6 +57,8 @@ class IStorageConnector {
 
   returns:
     uint64_t: future id for tracking this batch operation
+    completion will contain result_bytes vector with 0/1 for each key
+    (1 = stored, 0 = failed)
   */
   virtual uint64_t submit_batch_set(const std::vector<std::string>& keys,
                                     const std::vector<void*>& bufs,

--- a/csrc/storage_backends/connector_types.h
+++ b/csrc/storage_backends/connector_types.h
@@ -38,16 +38,20 @@ tiling refers to dividing work for batched operations between threads
 beforehand.
 */
 struct BatchState {
+  static constexpr uint8_t RESULT_UNKNOWN = 2;
+
   std::atomic<uint32_t> remaining_tiles{0};
   std::atomic<bool> any_failed{false};
 
   std::mutex err_mu;
   std::string first_error;
 
-  // Per-key success/failure results used by both EXISTS and GET.
+  // Per-key success/failure results used by EXISTS, GET, SET, and DELETE.
   // For EXISTS: 1 = key found, 0 = not found.
-  // For GET: 1 = read succeeded, 0 = read failed (e.g. file
-  //   not found).  This enables per-key error tolerance on loads.
+  // For GET/SET: 1 = transfer succeeded, 0 = transfer failed.
+  // RESULT_UNKNOWN is used only while a SET tile is in flight so an older
+  // derived connector that overrides do_batch_set() without recording
+  // per-key results can retain its batch-level behavior.
   // IMPORTANT: not vector<bool> due to concurrent write data race
   std::vector<uint8_t> per_key_results;
 
@@ -92,9 +96,8 @@ struct Completion {
 
   bool ok = true;
 
-  // for EXISTS operations, store boolean results as
-  // bytes (0/1). Single EXISTS will have 1 element, batch EXISTS will have N
-  // elements. No result in the completion for SET and GET.
+  // Per-key boolean results as bytes (0/1) for EXISTS, GET, SET, and DELETE.
+  // A batch operation returns one element per requested key.
   std::vector<uint8_t> result_bytes;
 
   std::string error;

--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -173,11 +173,20 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
 
+  size_t first_failed = results.size();
   for (size_t i = 0; i < results.size(); ++i) {
-    if (results[i] != 0) {
-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
-                               req.keys[i]);
+    if (results[i] == 0) {
+      req.batch->per_key_results[req.start_idx + i] = 1;
+    } else {
+      req.batch->per_key_results[req.start_idx + i] = 0;
+      if (first_failed == results.size()) {
+        first_failed = i;
+      }
     }
+  }
+  if (first_failed != results.size()) {
+    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+                             req.keys[first_failed]);
   }
 }
 

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -140,6 +140,7 @@ class L2AdapterInterface(ABC):
         # every adapter exposes the same shape via ``get_usage()``.
         self._max_capacity_bytes: int = max_capacity_bytes
         self._total_bytes_used: int = 0
+        self._reserved_store_bytes: int = 0
         self._bytes_by_cache_salt: dict[str, int] = {}
         self._usage_lock = threading.Lock()
 
@@ -380,13 +381,11 @@ class L2AdapterInterface(ABC):
         self._backend_name = name
         self._shared = shared
 
-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
-        """Update byte accounting and notify listeners that ``keys`` were
-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
-
-        Accounting is held under ``_usage_lock``; listener callbacks fire
-        outside the lock so a slow listener cannot stall further notifies.
-        """
+    @staticmethod
+    def _stored_byte_deltas(
+        keys: list[ObjectKey], sizes: list[int]
+    ) -> tuple[int, dict[str, int]]:
+        """Aggregate stored bytes globally and by cache salt."""
         # Aggregate per-salt deltas before touching
         # ``_bytes_by_cache_salt`` — one dict read/write per unique
         # salt instead of one per key. This matters when the registry is
@@ -396,13 +395,29 @@ class L2AdapterInterface(ABC):
         for key, size in zip(keys, sizes, strict=True):
             delta[key.cache_salt] = delta.get(key.cache_salt, 0) + size
             total_delta += size
+        return total_delta, delta
+
+    def _apply_stored_byte_deltas(
+        self, total_delta: int, delta: dict[str, int]
+    ) -> None:
+        """Apply pre-aggregated stored-byte deltas under ``_usage_lock``."""
+        self._total_bytes_used += total_delta
+        for salt, size in delta.items():
+            self._bytes_by_cache_salt[salt] = (
+                self._bytes_by_cache_salt.get(salt, 0) + size
+            )
+
+    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+        """Apply stored-key byte accounting without notifying observers."""
+        total_delta, delta = self._stored_byte_deltas(keys, sizes)
 
         with self._usage_lock:
-            self._total_bytes_used += total_delta
-            for salt, d in delta.items():
-                self._bytes_by_cache_salt[salt] = (
-                    self._bytes_by_cache_salt.get(salt, 0) + d
-                )
+            self._apply_stored_byte_deltas(total_delta, delta)
+
+    def _notify_keys_stored_observers(
+        self, keys: list[ObjectKey], sizes: list[int]
+    ) -> None:
+        """Notify stored-key listeners and observability subscribers."""
         for listener in self._listeners:
             listener.on_l2_keys_stored(keys, sizes)
         self._event_bus.publish(
@@ -416,6 +431,66 @@ class L2AdapterInterface(ABC):
                 },
             )
         )
+
+    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+        """Update byte accounting and notify observers that ``keys`` stored.
+
+        Accounting is committed under ``_usage_lock`` before callbacks fire.
+        Splitting these phases lets durability-sensitive adapters release a
+        synchronous caller after persistence and accounting without making a
+        slow listener part of the caller's storage deadline.
+        """
+        self._account_keys_stored(keys, sizes)
+        self._notify_keys_stored_observers(keys, sizes)
+
+    def _try_reserve_store_bytes(self, size: int) -> bool:
+        """Reserve capacity before an asynchronous L2 store is submitted."""
+        if size < 0:
+            raise ValueError("store reservation size must be non-negative")
+        with self._usage_lock:
+            projected = self._total_bytes_used + self._reserved_store_bytes + size
+            if self._max_capacity_bytes > 0 and projected > self._max_capacity_bytes:
+                return False
+            self._reserved_store_bytes += size
+            return True
+
+    def _settle_store_reservation(
+        self,
+        reserved_bytes: int,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        """Atomically release a reservation and account successfully stored keys."""
+        if reserved_bytes < 0:
+            raise ValueError("reserved_bytes must be non-negative")
+        total_delta, delta = self._stored_byte_deltas(keys, sizes)
+        with self._usage_lock:
+            if reserved_bytes > self._reserved_store_bytes:
+                raise RuntimeError(
+                    "store reservation accounting underflow: "
+                    f"settling {reserved_bytes} bytes with only "
+                    f"{self._reserved_store_bytes} reserved"
+                )
+            self._reserved_store_bytes -= reserved_bytes
+            self._apply_stored_byte_deltas(total_delta, delta)
+
+    def _release_store_reservation(self, reserved_bytes: int) -> None:
+        """Release capacity for a store that cannot produce a completion."""
+        if reserved_bytes < 0:
+            raise ValueError("reserved_bytes must be non-negative")
+        with self._usage_lock:
+            if reserved_bytes > self._reserved_store_bytes:
+                raise RuntimeError(
+                    "store reservation accounting underflow: "
+                    f"releasing {reserved_bytes} bytes with only "
+                    f"{self._reserved_store_bytes} reserved"
+                )
+            self._reserved_store_bytes -= reserved_bytes
+
+    def get_reserved_store_bytes(self) -> int:
+        """Return bytes reserved by stores awaiting native completion."""
+        with self._usage_lock:
+            return self._reserved_store_bytes
 
     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
         # ``_notify_keys_accessed`` carries no byte impact — only LRU

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 # Standard
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any
 import select
 import threading
@@ -81,6 +82,21 @@ def _obj_to_memoryview(
     return obj.byte_array  # type: ignore[return-value]
 
 
+@dataclass
+class _PendingStore:
+    """State retained until a native SET completion is drained.
+
+    ``buffer_owners`` is deliberately retained even after a synchronous caller
+    times out: the C++ connector owns raw pointers, not the Python objects that
+    keep those buffers alive.
+    """
+
+    keys: list[ObjectKey]
+    sizes: list[int]
+    reserved_bytes: int
+    buffer_owners: list[MemoryObj]
+
+
 class NativeConnectorL2Adapter(L2AdapterInterface):
     """
     Wraps a pybind-wrapped C++ IStorageConnector to
@@ -98,6 +114,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
     # Operation type tags for the pending-ops map
     _OP_STORE = "store"
+    _OP_SYNC_STORE = "sync_store"
     _OP_LOOKUP = "lookup"
     _OP_LOAD = "load"
     _OP_DELETE = "delete"
@@ -144,15 +161,20 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         # Pending delete events for synchronous delete() calls
         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
 
+        # Synchronous stores use private completions so StoreController cannot
+        # consume another thread's result from ``_completed_stores``.
+        self._pending_sync_store_events: dict[
+            L2TaskId, tuple[threading.Event, dict[str, Any]]
+        ] = {}
+
         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
         # at delete time (the native completion only carries booleans, not
         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
         # and per-user totals live in the base class — see ``get_usage``.
         self._key_sizes: dict[ObjectKey, int] = {}
-        # Pending store sizes: native future_id -> (keys, per_key_sizes).
-        # Bridges the async store submit → demux completion gap so the
-        # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
-        self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
+        # Bridges store submission to demux completion for capacity settlement,
+        # durable accounting, and native buffer lifetime ownership.
+        self._pending_store_sizes: dict[int, _PendingStore] = {}
 
         # Task ID counter
         self._next_task_id: L2TaskId = 0
@@ -194,20 +216,40 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         key_strings = [_object_key_to_string(k) for k in keys]
         memviews = [_obj_to_memoryview(obj) for obj in objects]
         per_key_sizes = [obj.get_size() for obj in objects]
+        reserved_bytes = sum(per_key_sizes)
 
         # Register pending op BEFORE submit to avoid race
         # with demux thread. The native submit is
         # non-blocking so holding the lock is brief.
         with self._lock:
             task_id = self._get_next_task_id()
-            future_id = int(self._client.submit_batch_set(key_strings, memviews))
+            if not self._try_reserve_store_bytes(reserved_bytes):
+                self._completed_stores[task_id] = L2StoreResult(False, 0)
+                self._store_efd.notify()
+                logger.warning(
+                    "Rejected native L2 store of %d bytes: capacity would "
+                    "exceed %d bytes",
+                    reserved_bytes,
+                    self._max_capacity_bytes,
+                )
+                return task_id
+            try:
+                future_id = int(self._client.submit_batch_set(key_strings, memviews))
+            except Exception:
+                self._release_store_reservation(reserved_bytes)
+                raise
             self._pending_ops[future_id] = (
                 self._OP_STORE,
                 task_id,
                 len(keys),
                 None,
             )
-            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
+            self._pending_store_sizes[future_id] = _PendingStore(
+                keys=list(keys),
+                sizes=per_key_sizes,
+                reserved_bytes=reserved_bytes,
+                buffer_owners=list(objects),
+            )
 
         return task_id
 
@@ -218,6 +260,86 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             completed = self._completed_stores
             self._completed_stores = {}
         return completed
+
+    def store_objects_sync(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        timeout: float | None = None,
+    ) -> tuple[bool, int, int]:
+        """Persist objects and wait for native backend completion.
+
+        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
+        true only when every key persists; the count and byte fields describe
+        successful keys in a partially failed batch. A timeout detaches only
+        the caller: in-flight state, capacity, and buffer owners remain until
+        the native completion arrives or the adapter closes.
+        """
+        if len(keys) != len(objects):
+            raise ValueError("keys and objects length mismatch")
+        if not keys:
+            return True, 0, 0
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        key_strings = [_object_key_to_string(key) for key in keys]
+        memviews = [_obj_to_memoryview(obj) for obj in objects]
+        per_key_sizes = [obj.get_size() for obj in objects]
+        reserved_bytes = sum(per_key_sizes)
+        done_event = threading.Event()
+        result: dict[str, Any] = {
+            "ok": False,
+            "persisted_count": 0,
+            "bytes_written": 0,
+        }
+
+        with self._lock:
+            task_id = self._get_next_task_id()
+            if not self._try_reserve_store_bytes(reserved_bytes):
+                logger.warning(
+                    "Rejected synchronous native L2 store of %d bytes: "
+                    "capacity would exceed %d bytes",
+                    reserved_bytes,
+                    self._max_capacity_bytes,
+                )
+                return False, 0, 0
+            try:
+                future_id = int(self._client.submit_batch_set(key_strings, memviews))
+            except Exception:
+                self._release_store_reservation(reserved_bytes)
+                raise
+            self._pending_ops[future_id] = (
+                self._OP_SYNC_STORE,
+                task_id,
+                len(keys),
+                None,
+            )
+            self._pending_store_sizes[future_id] = _PendingStore(
+                keys=list(keys),
+                sizes=per_key_sizes,
+                reserved_bytes=reserved_bytes,
+                buffer_owners=list(objects),
+            )
+            self._pending_sync_store_events[task_id] = (done_event, result)
+
+        wait_timeout = (
+            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
+        )
+        if not done_event.wait(timeout=wait_timeout):
+            with self._lock:
+                self._pending_sync_store_events.pop(task_id, None)
+            logger.warning(
+                "store_objects_sync() timed out after %.1fs for %d keys",
+                wait_timeout,
+                len(keys),
+            )
+            return False, 0, 0
+
+        return (
+            bool(result["ok"]),
+            int(result["persisted_count"]),
+            int(result["bytes_written"]),
+        )
 
     # ---------------------------------------------------------------
     # Lookup and Lock Interface
@@ -360,6 +482,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         status: dict[str, Any] = {
             "is_healthy": (self._demux_thread.is_alive() and not self._stop.is_set()),
             "type": self._type_name,
+            "reserved_store_bytes": self.get_reserved_store_bytes(),
         }
         status.update(self._extra_status)
         return status
@@ -372,7 +495,24 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         self._stop.set()
         self._demux_thread.join(timeout=5)
 
+        with self._lock:
+            sync_events = [
+                event for event, _result in self._pending_sync_store_events.values()
+            ]
+            self._pending_sync_store_events.clear()
+            abandoned_stores = list(self._pending_store_sizes.values())
+            self._pending_store_sizes.clear()
+            self._pending_ops.clear()
+        # Keep ``abandoned_stores`` (and therefore every buffer owner) alive
+        # until the native client has stopped its worker threads.
         self._client.close()
+        abandoned_reservations = sum(
+            pending.reserved_bytes for pending in abandoned_stores
+        )
+        if abandoned_reservations:
+            self._release_store_reservation(abandoned_reservations)
+        for event in sync_events:
+            event.set()
 
         self._store_efd.close()
         self._lookup_efd.close()
@@ -420,11 +560,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             keys_accessed: list[ObjectKey] = []
             keys_deleted: list[ObjectKey] = []
             sizes_deleted: list[int] = []
+            settled_store_reservations = 0
+            async_store_completed = False
             # Events for synchronous ``delete()`` callers. We set these
             # AFTER firing ``_notify_keys_deleted`` below so that when
             # the caller unblocks and calls ``get_usage()``, the base
             # class's byte counters already reflect the deletion.
             delete_done_events: list[threading.Event] = []
+            sync_store_done_events: list[threading.Event] = []
 
             with self._lock:
                 for (
@@ -449,12 +592,15 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         lookup_keys,
                     ) = entry
 
-                    if op_type == self._OP_STORE:
+                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
                         store_info = self._pending_store_sizes.pop(fid, None)
                         task_bytes = 0
+                        persisted_count = 0
                         completion_ok = False
                         if store_info is not None:
-                            store_keys, sizes = store_info
+                            store_keys = store_info.keys
+                            sizes = store_info.sizes
+                            settled_store_reservations += store_info.reserved_bytes
                             if result_bools is None:
                                 stored_flags = [bool(ok)] * len(store_keys)
                             else:
@@ -471,6 +617,8 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                             ):
                                 if not stored:
                                     continue
+                                persisted_count += 1
+                                task_bytes += size
                                 # First-store wins for byte accounting:
                                 # a re-store of an existing key adds 0
                                 # bytes (the backend already holds it).
@@ -482,14 +630,24 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                     self._key_sizes[key] = size
                                     keys_stored.append(key)
                                     sizes_stored.append(size)
-                                    task_bytes += size
                                 else:
                                     keys_stored.append(key)
                                     sizes_stored.append(0)
-                        self._completed_stores[task_id] = L2StoreResult(
-                            completion_ok, task_bytes
-                        )
-                        self._store_efd.notify()
+                        if op_type == self._OP_STORE:
+                            self._completed_stores[task_id] = L2StoreResult(
+                                completion_ok, task_bytes
+                            )
+                            async_store_completed = True
+                        else:
+                            sync_entry = self._pending_sync_store_events.pop(
+                                task_id, None
+                            )
+                            if sync_entry is not None:
+                                sync_event, sync_result = sync_entry
+                                sync_result["ok"] = completion_ok
+                                sync_result["persisted_count"] = persisted_count
+                                sync_result["bytes_written"] = task_bytes
+                                sync_store_done_events.append(sync_event)
 
                     elif op_type == self._OP_LOOKUP:
                         bitmap = Bitmap(num_keys)
@@ -537,10 +695,24 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                         if evt is not None:
                             delete_done_events.append(evt)
 
-            # Fire listener notifications outside the lock so a slow
-            # listener cannot stall further demux iterations.
+            # Release in-flight reservations and commit durable-byte
+            # accounting before exposing either completion path.
+            if settled_store_reservations or keys_stored:
+                self._settle_store_reservation(
+                    settled_store_reservations,
+                    keys_stored,
+                    sizes_stored,
+                )
+            if async_store_completed:
+                self._store_efd.notify()
+            for event in sync_store_done_events:
+                event.set()
+
+            # Observer callbacks remain outside the lock and after synchronous
+            # durability completion. A slow observer must not consume a
+            # caller's bounded store deadline.
             if keys_stored:
-                self._notify_keys_stored(keys_stored, sizes_stored)
+                self._notify_keys_stored_observers(keys_stored, sizes_stored)
             if keys_accessed:
                 self._notify_keys_accessed(keys_accessed)
             if keys_deleted:

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -452,9 +452,25 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                     if op_type == self._OP_STORE:
                         store_info = self._pending_store_sizes.pop(fid, None)
                         task_bytes = 0
-                        if ok and store_info is not None:
+                        completion_ok = False
+                        if store_info is not None:
                             store_keys, sizes = store_info
-                            for key, size in zip(store_keys, sizes, strict=True):
+                            if result_bools is None:
+                                stored_flags = [bool(ok)] * len(store_keys)
+                            else:
+                                stored_flags = [bool(value) for value in result_bools]
+                                if len(stored_flags) < len(store_keys):
+                                    stored_flags.extend(
+                                        [False] * (len(store_keys) - len(stored_flags))
+                                    )
+                                elif len(stored_flags) > len(store_keys):
+                                    stored_flags = stored_flags[: len(store_keys)]
+                            completion_ok = bool(ok) and all(stored_flags)
+                            for key, size, stored in zip(
+                                store_keys, sizes, stored_flags, strict=True
+                            ):
+                                if not stored:
+                                    continue
                                 # First-store wins for byte accounting:
                                 # a re-store of an existing key adds 0
                                 # bytes (the backend already holds it).
@@ -470,7 +486,9 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                 else:
                                     keys_stored.append(key)
                                     sizes_stored.append(0)
-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+                        self._completed_stores[task_id] = L2StoreResult(
+                            completion_ok, task_bytes
+                        )
                         self._store_efd.notify()
 
                     elif op_type == self._OP_LOOKUP:

--- a/tests/v1/distributed/test_l2_adapter_base.py
+++ b/tests/v1/distributed/test_l2_adapter_base.py
@@ -8,6 +8,7 @@ exposes them through ``get_usage()``. Adapters drive accounting by passing
 """
 
 # Standard
+from unittest.mock import Mock
 import threading
 
 # Third Party
@@ -272,6 +273,48 @@ class TestBaseAccounting:
         assert a.get_usage().total_bytes_used == n_threads * per_thread * 10
 
 
+class TestStoreReservations:
+    def test_reservation_includes_used_and_inflight_bytes(self):
+        adapter = _StubAdapter(max_capacity_bytes=300)
+        key = _make_key(1, salt="alice")
+        adapter._notify_keys_stored([key], [100])
+
+        assert adapter._try_reserve_store_bytes(200) is True
+        assert adapter._try_reserve_store_bytes(1) is False
+        assert adapter.get_reserved_store_bytes() == 200
+
+    def test_settle_atomically_releases_and_accounts_partial_result(self):
+        adapter = _StubAdapter(max_capacity_bytes=300)
+        key = _make_key(1, salt="alice")
+        assert adapter._try_reserve_store_bytes(300) is True
+
+        adapter._settle_store_reservation(300, [key], [100])
+
+        assert adapter.get_reserved_store_bytes() == 0
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == 100
+        assert usage.bytes_by_cache_salt == {"alice": 100}
+
+    def test_release_returns_capacity_without_accounting(self):
+        adapter = _StubAdapter(max_capacity_bytes=100)
+        assert adapter._try_reserve_store_bytes(100) is True
+
+        adapter._release_store_reservation(100)
+
+        assert adapter.get_reserved_store_bytes() == 0
+        assert adapter.get_usage().total_bytes_used == 0
+        assert adapter._try_reserve_store_bytes(100) is True
+
+    def test_invalid_reservations_fail_closed(self):
+        adapter = _StubAdapter(max_capacity_bytes=100)
+        with pytest.raises(ValueError, match="non-negative"):
+            adapter._try_reserve_store_bytes(-1)
+        with pytest.raises(ValueError, match="non-negative"):
+            adapter._release_store_reservation(-1)
+        with pytest.raises(RuntimeError, match="underflow"):
+            adapter._release_store_reservation(1)
+
+
 # ---------------------------------------------------------------------------
 # Listener notifications still fire (regression guard for the refactor)
 # ---------------------------------------------------------------------------
@@ -304,6 +347,15 @@ class TestListenersStillFire:
         k = _make_key(1, salt="alice")
         a._notify_keys_stored([k], [100])
         assert lst.stored == [[k]]
+
+    def test_store_notify_still_publishes_observability_event(self):
+        adapter = _StubAdapter(max_capacity_bytes=1000)
+        adapter._event_bus = Mock()
+        key = _make_key(1, salt="alice")
+
+        adapter._notify_keys_stored([key], [100])
+
+        adapter._event_bus.publish.assert_called_once()
 
     def test_delete_notify_fires_listener(self):
         a = _StubAdapter(max_capacity_bytes=1000)

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -56,6 +56,8 @@ class MockNativeConnector:
         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
         self._lock = threading.Lock()
         self._closed = False
+        self.fail_set_keys: set[str] = set()
+        self.report_set_per_key_results = False
 
     def event_fd(self) -> int:
         return self._efd.fileno()
@@ -66,9 +68,20 @@ class MockNativeConnector:
             self._next_id += 1
 
         try:
+            results: list[bool] = []
             for key, mv in zip(keys, memoryviews, strict=False):
+                if key in self.fail_set_keys:
+                    results.append(False)
+                    continue
                 self._store[key] = bytes(mv)
-            self._push_completion(fid, True, "", None)
+                results.append(True)
+            ok = all(results)
+            self._push_completion(
+                fid,
+                ok,
+                "" if ok else "injected set failure",
+                results if self.report_set_per_key_results else None,
+            )
         except Exception as e:
             self._push_completion(fid, False, str(e), None)
 
@@ -1358,3 +1371,22 @@ class TestUsageTracking:
         usage = adp.get_usage()
         assert usage.usage_fraction == pytest.approx(0.2)
         assert usage.total_bytes_used == 400
+
+    def test_partial_store_accounts_only_successful_keys(self, adapter_with_capacity):
+        adp = adapter_with_capacity
+        mock_client = adp._client
+        mock_client.report_set_per_key_results = True
+        keys = [create_object_key(i) for i in range(3)]
+        objects = [create_memory_obj(size=100, fill_value=float(i)) for i in range(3)]
+        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
+
+        task_id = adp.submit_store_task(keys, objects)
+        assert wait_for_event_fd(adp.get_store_event_fd(), timeout=5.0)
+
+        result = adp.pop_completed_store_tasks()[task_id]
+        assert result.is_successful() is False
+        assert adp.get_usage().total_bytes_used == 800
+        assert set(mock_client._store) == {
+            _object_key_to_string(keys[0]),
+            _object_key_to_string(keys[2]),
+        }

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
 import ctypes
 import select
 import threading
+import time
 
 # Third Party
 import pytest
@@ -58,11 +59,18 @@ class MockNativeConnector:
         self._closed = False
         self.fail_set_keys: set[str] = set()
         self.report_set_per_key_results = False
+        self.suppress_set_completion = False
+        self.raise_set_submit = False
+        self._suppressed_set_completions: list[
+            tuple[int, bool, str, list[bool] | None]
+        ] = []
 
     def event_fd(self) -> int:
         return self._efd.fileno()
 
     def submit_batch_set(self, keys: list[str], memoryviews: list) -> int:
+        if self.raise_set_submit:
+            raise RuntimeError("injected submit failure")
         with self._lock:
             fid = self._next_id
             self._next_id += 1
@@ -76,16 +84,26 @@ class MockNativeConnector:
                 self._store[key] = bytes(mv)
                 results.append(True)
             ok = all(results)
-            self._push_completion(
+            completion = (
                 fid,
                 ok,
                 "" if ok else "injected set failure",
                 results if self.report_set_per_key_results else None,
             )
+            if self.suppress_set_completion:
+                self._suppressed_set_completions.append(completion)
+            else:
+                self._push_completion(*completion)
         except Exception as e:
             self._push_completion(fid, False, str(e), None)
 
         return fid
+
+    def complete_suppressed_sets(self) -> None:
+        completions = self._suppressed_set_completions
+        self._suppressed_set_completions = []
+        for completion in completions:
+            self._push_completion(*completion)
 
     def submit_batch_get(self, keys: list[str], memoryviews: list) -> int:
         with self._lock:
@@ -213,6 +231,14 @@ def adapter():
     mock_client = MockNativeConnector()
     adp = NativeConnectorL2Adapter(mock_client)
     yield adp
+    adp.close()
+
+
+@pytest.fixture
+def adapter_and_mock():
+    mock_client = MockNativeConnector()
+    adp = NativeConnectorL2Adapter(mock_client)
+    yield adp, mock_client
     adp.close()
 
 
@@ -1390,3 +1416,237 @@ class TestUsageTracking:
             _object_key_to_string(keys[0]),
             _object_key_to_string(keys[2]),
         }
+
+
+class _BlockingStoreListener:
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def on_l2_keys_stored(self, keys, sizes) -> None:
+        self.entered.set()
+        assert self.release.wait(timeout=5.0)
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class TestStoreObjectsSync:
+    def test_success_uses_private_completion(self, adapter):
+        keys = [create_object_key(i) for i in range(2)]
+        objects = [create_memory_obj(fill_value=float(i)) for i in range(2)]
+
+        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objects)
+
+        assert ok is True
+        assert persisted == 2
+        assert bytes_written == sum(obj.get_size() for obj in objects)
+        assert adapter.get_usage().total_bytes_used == bytes_written
+        assert adapter.pop_completed_store_tasks() == {}
+
+    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
+        adapter, mock_client = adapter_and_mock
+        mock_client.report_set_per_key_results = True
+        keys = [create_object_key(i) for i in range(2)]
+        objects = [create_memory_obj(fill_value=float(i)) for i in range(2)]
+        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
+
+        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objects)
+
+        assert ok is False
+        assert persisted == 1
+        assert bytes_written == objects[0].get_size()
+        assert adapter.get_usage().total_bytes_used == objects[0].get_size()
+
+    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
+        adapter, mock_client = adapter_and_mock
+        mock_client.report_set_per_key_results = False
+        keys = [create_object_key(i) for i in range(2)]
+        objects = [create_memory_obj(fill_value=float(i)) for i in range(2)]
+
+        assert adapter.store_objects_sync(keys, objects) == (
+            True,
+            2,
+            sum(obj.get_size() for obj in objects),
+        )
+
+    def test_restore_reports_transferred_bytes_without_double_accounting(self, adapter):
+        key = create_object_key(1)
+        obj = create_memory_obj(size=100)
+        assert adapter.store_objects_sync([key], [obj]) == (True, 1, obj.get_size())
+
+        assert adapter.store_objects_sync([key], [obj]) == (True, 1, obj.get_size())
+        assert adapter.get_usage().total_bytes_used == obj.get_size()
+
+    def test_validates_inputs(self, adapter):
+        with pytest.raises(ValueError, match="length mismatch"):
+            adapter.store_objects_sync([create_object_key(1)], [])
+        with pytest.raises(ValueError, match="timeout must be positive"):
+            adapter.store_objects_sync(
+                [create_object_key(1)], [create_memory_obj()], timeout=0
+            )
+        assert adapter.store_objects_sync([], []) == (True, 0, 0)
+
+    def test_timeout_retains_buffers_and_reservation_until_late_completion(self):
+        mock_client = MockNativeConnector()
+        mock_client.suppress_set_completion = True
+        obj = create_memory_obj(size=100)
+        adapter = NativeConnectorL2Adapter(
+            mock_client,
+            max_capacity_gb=obj.get_size() / (1024**3),
+        )
+        try:
+            result = adapter.store_objects_sync(
+                [create_object_key(1)], [obj], timeout=0.02
+            )
+
+            assert result == (False, 0, 0)
+            assert adapter.get_reserved_store_bytes() == obj.get_size()
+            with adapter._lock:
+                pending = next(iter(adapter._pending_store_sizes.values()))
+                assert pending.buffer_owners == [obj]
+
+            mock_client.complete_suppressed_sets()
+            assert _wait_until(lambda: adapter.get_reserved_store_bytes() == 0)
+            assert adapter.get_usage().total_bytes_used == obj.get_size()
+            assert adapter._pending_store_sizes == {}
+        finally:
+            adapter.close()
+
+    def test_completion_does_not_wait_for_observer(self, adapter):
+        listener = _BlockingStoreListener()
+        adapter.register_listener(listener)
+        result = []
+        worker = threading.Thread(
+            target=lambda: result.append(
+                adapter.store_objects_sync(
+                    [create_object_key(1)],
+                    [create_memory_obj()],
+                    timeout=0.05,
+                )
+            )
+        )
+        worker.start()
+        assert listener.entered.wait(timeout=5.0)
+        worker.join(timeout=0.5)
+        assert not worker.is_alive()
+        assert result[0][0] is True
+        assert adapter.get_usage().total_bytes_used == result[0][2]
+
+        listener.release.set()
+
+    def test_close_unblocks_waiter_and_releases_reservation(self):
+        mock_client = MockNativeConnector()
+        mock_client.suppress_set_completion = True
+        adapter = NativeConnectorL2Adapter(mock_client, max_capacity_gb=1)
+        result = []
+        worker = threading.Thread(
+            target=lambda: result.append(
+                adapter.store_objects_sync(
+                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
+                )
+            )
+        )
+        worker.start()
+        assert _wait_until(lambda: adapter.get_reserved_store_bytes() > 0)
+
+        adapter.close()
+        worker.join(timeout=5.0)
+
+        assert not worker.is_alive()
+        assert result == [(False, 0, 0)]
+        assert adapter.get_reserved_store_bytes() == 0
+
+
+class TestStoreCapacityReservation:
+    def test_inflight_stores_cannot_exceed_capacity(self):
+        mock_client = MockNativeConnector()
+        mock_client.suppress_set_completion = True
+        capacity = 800
+        adapter = NativeConnectorL2Adapter(
+            mock_client,
+            max_capacity_gb=capacity / (1024**3),
+        )
+        try:
+            obj = create_memory_obj(size=100)  # 400 bytes
+            first = adapter.submit_store_task([create_object_key(1)], [obj])
+            second = adapter.submit_store_task([create_object_key(2)], [obj])
+            rejected = adapter.submit_store_task([create_object_key(3)], [obj])
+
+            assert first != second != rejected
+            assert adapter.get_reserved_store_bytes() == capacity
+            assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=1.0)
+            result = adapter.pop_completed_store_tasks()[rejected]
+            assert result.is_successful() is False
+            assert result.bytes_transferred() == 0
+        finally:
+            adapter.close()
+
+    def test_failed_store_releases_capacity_reservation(self):
+        mock_client = MockNativeConnector()
+        mock_client.report_set_per_key_results = True
+        capacity = 400
+        adapter = NativeConnectorL2Adapter(
+            mock_client,
+            max_capacity_gb=capacity / (1024**3),
+        )
+        try:
+            first_key = create_object_key(1)
+            mock_client.fail_set_keys = {_object_key_to_string(first_key)}
+            first = adapter.submit_store_task(
+                [first_key], [create_memory_obj(size=100)]
+            )
+            assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=1.0)
+            assert adapter.pop_completed_store_tasks()[first].is_successful() is False
+            assert adapter.get_reserved_store_bytes() == 0
+
+            mock_client.fail_set_keys.clear()
+            second = adapter.submit_store_task(
+                [create_object_key(2)], [create_memory_obj(size=100)]
+            )
+            assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=1.0)
+            assert adapter.pop_completed_store_tasks()[second].is_successful() is True
+            assert adapter.get_usage().total_bytes_used == capacity
+        finally:
+            adapter.close()
+
+    def test_submit_exception_releases_capacity_reservation(self):
+        mock_client = MockNativeConnector()
+        mock_client.raise_set_submit = True
+        adapter = NativeConnectorL2Adapter(mock_client, max_capacity_gb=1)
+        try:
+            with pytest.raises(RuntimeError, match="injected submit failure"):
+                adapter.submit_store_task(
+                    [create_object_key(1)], [create_memory_obj(size=100)]
+                )
+            assert adapter.get_reserved_store_bytes() == 0
+        finally:
+            adapter.close()
+
+    def test_synchronous_store_respects_capacity(self):
+        mock_client = MockNativeConnector()
+        capacity = 400
+        adapter = NativeConnectorL2Adapter(
+            mock_client,
+            max_capacity_gb=capacity / (1024**3),
+        )
+        try:
+            first = adapter.store_objects_sync(
+                [create_object_key(1)], [create_memory_obj(size=100)]
+            )
+            rejected = adapter.store_objects_sync(
+                [create_object_key(2)], [create_memory_obj(size=100)]
+            )
+
+            assert first == (True, 1, capacity)
+            assert rejected == (False, 0, 0)
+            assert len(mock_client._store) == 1
+            assert adapter.get_usage().total_bytes_used == capacity
+        finally:
+            adapter.close()

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -82,6 +82,31 @@ def _submit_and_wait(
     return _wait_for_completion(client, future_id)
 
 
+def test_batch_set_reports_partial_results_and_continues(tmp_path) -> None:
+    """A failed key must not hide or prevent successful siblings."""
+    LMCacheFSClient = _import_fs_client()
+    keys = [
+        "model@00000000@01",
+        "malformed-key",
+        "model@00000000@03",
+    ]
+    payloads = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
+    client = LMCacheFSClient(str(tmp_path), 1)
+    try:
+        future_id = client.submit_batch_set(
+            keys, [memoryview(payload) for payload in payloads]
+        )
+        completed_id, ok, error, results = _wait_for_completion(client, future_id)
+
+        assert completed_id == future_id
+        assert ok is False
+        assert "partially failed" in error
+        assert results == [True, False, True]
+        assert (tmp_path / "model@0x00000000@01.data").read_bytes() == b"first"
+        assert (tmp_path / "model@0x00000000@03.data").read_bytes() == b"last"
+    finally:
+        client.close()
+
 def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:
     """O_DIRECT reads should ignore read_ahead_size and use one aligned read."""
     if not hasattr(os, "O_DIRECT"):

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -11,6 +11,15 @@ import time
 # Third Party
 import pytest
 
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    _object_key_to_filename,
+)
+from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+    NativeConnectorL2Adapter,
+)
+
 
 def _import_fs_client() -> type:
     try:
@@ -51,6 +60,20 @@ def _misaligned_memoryview(
 
 def _fill(view: memoryview) -> None:
     view[:] = bytes(i % 251 for i in range(len(view)))
+
+
+class _BufferObj:
+    """Minimal MemoryObj-compatible owner for native adapter integration."""
+
+    def __init__(self, payload: bytes):
+        self._buffer = bytearray(payload)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._buffer)
+
+    def get_size(self) -> int:
+        return len(self._buffer)
 
 
 def _wait_for_completion(
@@ -106,6 +129,34 @@ def test_batch_set_reports_partial_results_and_continues(tmp_path) -> None:
         assert (tmp_path / "model@0x00000000@03.data").read_bytes() == b"last"
     finally:
         client.close()
+
+
+def test_sync_adapter_waits_for_compiled_fs_completion(tmp_path) -> None:
+    """The Python durability API consumes real native SET completions."""
+    LMCacheFSClient = _import_fs_client()
+    keys = [
+        ObjectKey(
+            chunk_hash=ObjectKey.IntHash2Bytes(i),
+            model_name="compiled-sync",
+            kv_rank=0,
+        )
+        for i in range(2)
+    ]
+    objects: Any = [_BufferObj(b"first"), _BufferObj(b"other")]
+    adapter = NativeConnectorL2Adapter(LMCacheFSClient(str(tmp_path), 1))
+    try:
+        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objects)
+
+        assert ok is True
+        assert persisted == 2
+        assert bytes_written == 10
+        assert adapter.get_usage().total_bytes_used == 10
+        assert adapter.get_reserved_store_bytes() == 0
+        assert (tmp_path / _object_key_to_filename(keys[0])).read_bytes() == b"first"
+        assert (tmp_path / _object_key_to_filename(keys[1])).read_bytes() == b"other"
+    finally:
+        adapter.close()
+
 
 def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:
     """O_DIRECT reads should ignore read_ahead_size and use one aligned read."""


### PR DESCRIPTION
Part of #4888.

## Summary

Report native stores per key and settle persistence, bytes, capacity, and source
memory only after backend completion.

## Problem

A native batch can partially fail, complete after a caller timeout, or still be
using raw pointers after the submitting coroutine returns. Batch-level success
and submission-time accounting can therefore advertise keys that were not
persisted, leak reserved capacity, or release source memory before completion.

## Change

- Return one SET result per requested key and continue a batch after individual
  failures while preserving the batch-level failure result.
- Record Mooncake results through the same completion interface.
- Account and notify only successfully persisted keys.
- Add a synchronous durability boundary for callers that must know which keys
  completed.
- Retain `MemoryObj` owners through native completion, including late completion
  after caller timeout.
- Reserve configured capacity before submission and atomically settle successful
  new keys; release reservations on submission failure, backend failure, or
  shutdown.
- Keep observer callbacks outside the caller durability deadline and expose
  in-flight reserved bytes in status.

Native object-group filename handling has moved to the geometry PR tracked by
#4888. GET, EXISTS, DELETE, non-native adapters, and the existing asynchronous
task interface are unchanged. Capacity `0` remains unlimited.

## Validation

Focused tests cover partial first/bad/last results, older connector compatibility,
synchronous completion, blocking observers, caller timeout with late completion,
submission failure, capacity saturation, shutdown release, re-store accounting,
and a compiled filesystem adapter path. The narrowed current-`dev` branch passes
Ruff lint/format and `git diff --check`; native/C++ CI should rerun upstream.
