### PR TITLE
fix(fs): publish objects atomically under concurrent writers

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -1,11 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "connector.h"
+#include <atomic>
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <stdexcept>
 #include <string>
+
+namespace {
+std::atomic<uint64_t> next_temp_file_id{0};
+
+void remove_temp_file(const std::filesystem::path& tmp_path) {
+  std::error_code remove_ec;
+  std::filesystem::remove(tmp_path, remove_ec);
+  if (remove_ec) {
+    fprintf(stderr, "[LMCache SET] temporary file cleanup failed: %s: %s\n",
+            tmp_path.c_str(), remove_ec.message().c_str());
+  }
+}
+}  // namespace
 
 namespace lmcache {
 namespace connector {
@@ -246,46 +260,60 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
     return;
   }
 
-  // Determine temp file path
+  const auto tmp_dir =
+      conn.tmp_dir.empty() ? file_path.parent_path() : conn.tmp_dir;
   std::filesystem::path tmp_path;
-  if (!conn.tmp_dir.empty()) {
-    tmp_path = conn.tmp_dir / filename;
-  } else {
-    tmp_path = file_path;
-    tmp_path.replace_extension(TMP_EXT);
-  }
-
-  int flags = O_CREAT | O_WRONLY | O_TRUNC;
+  int flags = O_CREAT | O_EXCL | O_WRONLY;
   if (conn.use_odirect) {
     try_enable_odirect(flags, buf, len, conn.disk_block_size);
   }
 
-  int fd = ::open(tmp_path.c_str(), flags, 0644);
+  int fd = -1;
+  for (size_t attempt = 0; attempt < 1024; ++attempt) {
+    const uint64_t id =
+        next_temp_file_id.fetch_add(1, std::memory_order_relaxed);
+    tmp_path = tmp_dir / (filename + TMP_EXT + "." +
+                          std::to_string(static_cast<uint64_t>(::getpid())) +
+                          "." + std::to_string(id));
+    fd = ::open(tmp_path.c_str(), flags, 0644);
+    if (fd >= 0) break;
+    if (errno != EEXIST) {
+      throw std::runtime_error("open for write failed: " + tmp_path.string() +
+                               ": " + strerror(errno));
+    }
+  }
   if (fd < 0) {
-    throw std::runtime_error("open for write failed: " + tmp_path.string() +
-                             ": " + strerror(errno));
+    throw std::runtime_error("failed to allocate a unique temporary file for " +
+                             file_path.string());
   }
 
   try {
     write_all(fd, buf, len);
+    if (::close(fd) != 0) {
+      const int close_errno = errno;
+      fd = -1;
+      throw std::runtime_error("close after write failed: " +
+                               std::string(strerror(close_errno)));
+    }
+    fd = -1;
   } catch (...) {
-    ::close(fd);
-    // Clean up temp file on failure
-    std::filesystem::remove(tmp_path);
+    if (fd >= 0) ::close(fd);
+    remove_temp_file(tmp_path);
     throw;
   }
-  ::close(fd);
 
-  // Atomic rename: tmp -> final
-  std::error_code ec;
-  std::filesystem::rename(tmp_path, file_path, ec);
-  if (ec) {
-    // Try to clean up, but prioritize reporting the original error.
-    std::error_code remove_ec;
-    std::filesystem::remove(tmp_path, remove_ec);
-    throw std::runtime_error("rename failed: " + tmp_path.string() + " -> " +
-                             file_path.string() + ": " + ec.message());
+  // Publish the completed writer-owned inode without replacing an established
+  // value. Concurrent and cross-process duplicate writers therefore never
+  // share writable storage, and readers only observe a complete object.
+  if (::link(tmp_path.c_str(), file_path.c_str()) != 0) {
+    const int link_errno = errno;
+    remove_temp_file(tmp_path);
+    if (link_errno == EEXIST) return;
+    throw std::runtime_error("publish failed: " + tmp_path.string() + " -> " +
+                             file_path.string() + ": " + strerror(link_errno));
   }
+
+  remove_temp_file(tmp_path);
 }
 
 bool FSConnector::do_single_exists(WorkerFSConn& conn, const std::string& key) {

--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -128,8 +128,7 @@ static bool try_enable_odirect(int& flags, const void* buf, size_t len,
   }
   auto addr = reinterpret_cast<std::uintptr_t>(buf);
   if (addr % disk_block_size != 0) {
-    throw std::runtime_error(
-        "O_DIRECT buffer address is not aligned to filesystem block size");
+    return false;
   }
   flags |= O_DIRECT;
   return true;

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -20,8 +20,9 @@ static constexpr const char* PATH_SLASH_REPLACEMENT = "-SEP-";
 static constexpr const char* FILE_EXT = ".data";
 static constexpr const char* TMP_EXT = ".tmp";
 
-// Per-worker connection state for the FS connector.
-// Each worker maintains its own I/O buffer for O_DIRECT.
+// Per-worker connection state for the FS connector. O_DIRECT is enabled per
+// request only when both the transfer length and caller-owned buffer address
+// meet the filesystem block-alignment requirement; otherwise I/O is buffered.
 struct WorkerFSConn {
   std::filesystem::path base_path;
   std::filesystem::path tmp_dir;  // empty if not configured

--- a/docs/source/mp/l2_storage/fs_native.rst
+++ b/docs/source/mp/l2_storage/fs_native.rst
@@ -27,6 +27,18 @@ I/O queue depth on a single Python thread.
 - ``max_capacity_gb`` (float, default ``0``): Maximum L2 capacity in GB
   for client-side usage tracking.  Default ``0`` disables tracking.
 
+Atomic publication
+------------------
+
+Both filesystem adapters write each store into a writer-owned temporary inode
+opened with create-exclusive semantics. After the write is closed, a hard link
+publishes that complete inode only if the final key does not already exist.
+Concurrent or cross-process duplicate stores therefore succeed without sharing
+writable storage or replacing an established value; readers see either no key
+or one complete value. Temporary files live under ``base_path`` (or its
+``relative_tmp_dir`` child) so publication remains on one filesystem, and each
+writer removes its temporary link after winning or losing the publish race.
+
 .. important::
 
    ``O_DIRECT`` has two independent alignment requirements:

--- a/docs/source/mp/l2_storage/fs_native.rst
+++ b/docs/source/mp/l2_storage/fs_native.rst
@@ -47,10 +47,10 @@ I/O queue depth on a single Python thread.
       also be aligned (typically to 4096 bytes on local disks, or to the
       FS block size on parallel filesystems).  This is controlled by
       ``--l1-align-bytes`` (default ``4096``) -- raise it to match the
-      FS block size when running on a filesystem with larger blocks.  If
-      the buffer is misaligned, the connector reports a runtime error instead
-      of silently falling back to buffered I/O.  This protects real-disk
-      benchmark runs from accidentally measuring the page cache.
+      FS block size when running on a filesystem with larger blocks. If the
+      buffer is misaligned, the connector falls back to buffered I/O for that
+      operation. Correctness is preserved, but a real-disk benchmark must
+      align both length and address to guarantee direct I/O.
 
    If unsure, start with ``use_odirect: false`` and confirm correctness
    before enabling ``O_DIRECT``.

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Optional, Union
 import asyncio
 import os
 import threading
+import uuid
 
 if TYPE_CHECKING:
     # First Party
@@ -55,6 +56,38 @@ _KEY_SEP = "@"
 # csrc/storage_backends/fs/connector.cpp.
 _PATH_SLASH_REPLACEMENT = "-SEP-"
 _FILE_EXT = ".data"
+
+
+def _write_all(fd: int, buf: bytes | bytearray | memoryview) -> None:
+    """Write all bytes to ``fd``, retrying short writes."""
+    view = memoryview(buf)
+    written = 0
+    while written < len(view):
+        count = os.write(fd, view[written:])
+        if count <= 0:
+            raise OSError("write returned 0 before the buffer was complete")
+        written += count
+
+
+def _publish_temp_file(tmp_path: Path, file_path: Path) -> bool:
+    """Publish a complete inode without replacing an established value.
+
+    Returns ``True`` when this writer created ``file_path`` and ``False`` when
+    another writer already published the same key. The writer-owned temporary
+    link is removed in both cases.
+    """
+    try:
+        os.link(tmp_path, file_path)
+        return True
+    except FileExistsError:
+        return False
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.warning("Failed to remove temporary cache file %s", tmp_path)
 
 
 def _readinto_full(
@@ -526,9 +559,10 @@ class FSL2Adapter(L2AdapterInterface):
         fname = _object_key_to_filename(key)
         final = self._base_path / fname
         if self._relative_tmp_dir is not None:
-            tmp = self._base_path / self._relative_tmp_dir / fname
+            tmp_dir = self._base_path / self._relative_tmp_dir
         else:
-            tmp = final.with_suffix(".tmp")
+            tmp_dir = self._base_path
+        tmp = tmp_dir / f"{fname}.tmp"
         return final, tmp
 
     # ---- O_DIRECT helpers -----------------------------------------------
@@ -572,7 +606,9 @@ class FSL2Adapter(L2AdapterInterface):
                 except OSError:
                     pass
 
-    def _write_with_odirect(self, file_path: Path, buf: bytes) -> None:
+    def _write_with_odirect(
+        self, file_path: Path, buf: Union[bytearray, memoryview, bytes]
+    ) -> None:
         """Synchronous O_DIRECT write of *buf*.
 
         Runs in an executor (not on the event loop).
@@ -581,10 +617,12 @@ class FSL2Adapter(L2AdapterInterface):
         try:
             fd = os.open(
                 str(file_path),
-                os.O_CREAT | os.O_WRONLY | getattr(os, "O_DIRECT", 0),
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_DIRECT", 0),
                 0o644,
             )
-            os.write(fd, buf)
+            _write_all(fd, buf)
+            os.close(fd)
+            fd = -1
         except Exception:
             logger.exception("Failed to O_DIRECT write %s", file_path)
             raise
@@ -609,13 +647,16 @@ class FSL2Adapter(L2AdapterInterface):
         stored_sizes: list[int] = []
         try:
             for key, obj in zip(keys, objects, strict=True):
-                file_path, tmp_path = self._key_to_file_and_tmp_path(key)
+                file_path, tmp_template = self._key_to_file_and_tmp_path(key)
 
                 # Skip if already stored on disk
                 if await aiofiles.os.path.exists(file_path):
                     continue
                 buf = obj.byte_array
                 size = len(buf)
+                tmp_path = tmp_template.with_name(
+                    f"{tmp_template.name}.{os.getpid()}.{uuid.uuid4().hex}"
+                )
 
                 try:
                     # Decide whether O_DIRECT is usable
@@ -641,18 +682,26 @@ class FSL2Adapter(L2AdapterInterface):
                             buf,
                         )
                     else:
-                        async with aiofiles.open(tmp_path, "wb") as f:
+                        async with aiofiles.open(tmp_path, "xb") as f:
                             await f.write(buf)
 
-                    await aiofiles.os.replace(tmp_path, file_path)
-                    bytes_written += size
-                    stored_keys.append(key)
-                    stored_sizes.append(size)
-                    logger.debug(
-                        "FSL2Adapter stored key %s (%d bytes)",
-                        file_path.name,
-                        size,
+                    published = await self._loop.run_in_executor(
+                        None, _publish_temp_file, tmp_path, file_path
                     )
+                    if published:
+                        bytes_written += size
+                        stored_keys.append(key)
+                        stored_sizes.append(size)
+                        logger.debug(
+                            "FSL2Adapter stored key %s (%d bytes)",
+                            file_path.name,
+                            size,
+                        )
+                    else:
+                        logger.debug(
+                            "FSL2Adapter duplicate store kept existing key %s",
+                            file_path.name,
+                        )
                 except Exception:
                     logger.exception(
                         "FSL2Adapter failed to store %s",

--- a/tests/v1/distributed/test_fs_atomic_publish.py
+++ b/tests/v1/distributed/test_fs_atomic_publish.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Atomic publication tests for filesystem L2 cache objects."""
+
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+import multiprocessing
+import select
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+    _object_key_to_filename,
+    _publish_temp_file,
+    _write_all,
+)
+
+
+class _BufferObj:
+    def __init__(self, payload: bytes) -> None:
+        self._buffer = bytearray(payload)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._buffer)
+
+    def get_size(self) -> int:
+        return len(self._buffer)
+
+
+def _key() -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=bytes.fromhex("aabbccdd"),
+        model_name="atomic/model",
+        kv_rank=0,
+        object_group_id=3,
+    )
+
+
+def _wait_for_adapter_stores(
+    adapter: FSL2Adapter, expected: int, timeout: float = 10.0
+) -> dict:
+    completed: dict[int, Any] = {}
+    deadline = time.monotonic() + timeout
+    while len(completed) < expected and time.monotonic() < deadline:
+        completed.update(adapter.pop_completed_store_tasks())
+        if len(completed) < expected:
+            time.sleep(0.01)
+    assert len(completed) == expected
+    return completed
+
+
+def _wait_for_native_completion(client, timeout: float = 20.0):
+    poller = select.poll()
+    poller.register(client.event_fd(), select.POLLIN)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if poller.poll(50):
+            completions = client.drain_completions()
+            if completions:
+                return completions[0]
+    raise AssertionError("native connector completion timed out")
+
+
+def _native_store_process(
+    base_path: str,
+    value: int,
+    payload_size: int,
+    ready_queue: Any,
+    start_event: Any,
+    result_queue: Any,
+) -> None:
+    try:
+        # First Party
+        from lmcache.lmcache_fs import LMCacheFSClient
+
+        client = LMCacheFSClient(base_path, 1, "pending", False, 0)
+        try:
+            ready_queue.put(True)
+            if not start_event.wait(timeout=20.0):
+                raise RuntimeError("cross-process start barrier timed out")
+            payload = memoryview(bytearray(bytes([value]) * payload_size))
+            future_id = client.submit_batch_set(
+                ["atomic/model@00000000@3@aabbccdd"], [payload]
+            )
+            completed_id, ok, error, _results = _wait_for_native_completion(client)
+            result_queue.put((completed_id == future_id, ok, error))
+        finally:
+            client.close()
+    except BaseException as exc:
+        result_queue.put((False, False, repr(exc), None))
+
+
+def test_publish_keeps_existing_complete_inode(tmp_path) -> None:
+    final_path = tmp_path / "shared.data"
+    temp_path = tmp_path / "shared.data.tmp.writer"
+    final_path.write_bytes(b"established")
+    temp_path.write_bytes(b"replacement")
+
+    assert _publish_temp_file(temp_path, final_path) is False
+    assert final_path.read_bytes() == b"established"
+    assert not temp_path.exists()
+
+
+def test_concurrent_publish_selects_one_complete_inode(tmp_path) -> None:
+    final_path = tmp_path / "shared.data"
+    payloads = [bytes([value]) * (1024 * 1024) for value in range(8)]
+    temp_paths = []
+    for index, payload in enumerate(payloads):
+        temp_path = tmp_path / f"shared.data.tmp.{index}"
+        temp_path.write_bytes(payload)
+        temp_paths.append(temp_path)
+
+    with ThreadPoolExecutor(max_workers=len(temp_paths)) as executor:
+        published = list(
+            executor.map(lambda path: _publish_temp_file(path, final_path), temp_paths)
+        )
+
+    assert published.count(True) == 1
+    assert final_path.read_bytes() in payloads
+    assert all(not path.exists() for path in temp_paths)
+
+
+def test_write_all_retries_short_writes(monkeypatch) -> None:
+    written = bytearray()
+
+    def short_write(_fd: int, data: memoryview) -> int:
+        count = min(3, len(data))
+        written.extend(data[:count])
+        return count
+
+    monkeypatch.setattr("os.write", short_write)
+    _write_all(7, memoryview(b"complete-payload"))
+    assert written == b"complete-payload"
+
+
+def test_python_adapter_duplicate_stores_publish_one_value(tmp_path) -> None:
+    pending = tmp_path / "pending"
+    adapter = FSL2Adapter(
+        FSL2AdapterConfig(base_path=str(tmp_path), relative_tmp_dir="pending")
+    )
+    payloads = [bytes([value]) * (4 * 1024 * 1024) for value in range(4)]
+    try:
+        task_ids = []
+        for payload in payloads:
+            objects: Any = [_BufferObj(payload)]
+            task_ids.append(adapter.submit_store_task([_key()], objects))
+        completed = _wait_for_adapter_stores(adapter, len(task_ids))
+
+        assert all(completed[task_id].is_successful() for task_id in task_ids)
+        assert sum(
+            completed[task_id].bytes_transferred() for task_id in task_ids
+        ) == len(payloads[0])
+        assert (tmp_path / _object_key_to_filename(_key())).read_bytes() in payloads
+        assert list(pending.iterdir()) == []
+    finally:
+        adapter.close()
+
+
+def test_native_duplicate_workers_publish_one_value(tmp_path) -> None:
+    lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
+    pending = tmp_path / "pending"
+    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 4, "pending", False, 0)
+    payloads = [bytearray(bytes([value]) * (4 * 1024 * 1024)) for value in range(4)]
+    try:
+        future_id = client.submit_batch_set(
+            ["atomic/model@00000000@3@aabbccdd"] * len(payloads),
+            [memoryview(payload) for payload in payloads],
+        )
+        completed_id, ok, error, _results = _wait_for_native_completion(client)
+
+        assert completed_id == future_id
+        assert ok, error
+        assert (tmp_path / _object_key_to_filename(_key())).read_bytes() in payloads
+        assert list(pending.iterdir()) == []
+    finally:
+        client.close()
+
+
+def test_native_cross_process_writers_publish_one_value(tmp_path) -> None:
+    pytest.importorskip("lmcache.lmcache_fs")
+    ctx = multiprocessing.get_context("spawn")
+    ready_queue = ctx.Queue()
+    result_queue = ctx.Queue()
+    start_event = ctx.Event()
+    payload_size = 16 * 1024 * 1024
+    values = [ord("a"), ord("b")]
+    processes = [
+        ctx.Process(
+            target=_native_store_process,
+            args=(
+                str(tmp_path),
+                value,
+                payload_size,
+                ready_queue,
+                start_event,
+                result_queue,
+            ),
+        )
+        for value in values
+    ]
+    for process in processes:
+        process.start()
+    try:
+        for _ in processes:
+            assert ready_queue.get(timeout=20.0) is True
+        start_event.set()
+        results = [result_queue.get(timeout=30.0) for _ in processes]
+        assert all(submitted and ok for submitted, ok, _error in results), results
+    finally:
+        start_event.set()
+        for process in processes:
+            process.join(timeout=30.0)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5.0)
+        ready_queue.close()
+        result_queue.close()
+
+    published = (tmp_path / _object_key_to_filename(_key())).read_bytes()
+    assert published in [bytes([value]) * payload_size for value in values]
+    assert list((tmp_path / "pending").iterdir()) == []

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -111,8 +111,8 @@ def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:
         client.close()
 
 
-def test_odirect_fails_for_misaligned_buffer(tmp_path) -> None:
-    """Misaligned buffers should fail instead of hiding O_DIRECT misuse."""
+def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path) -> None:
+    """Address misalignment uses buffered I/O without losing correctness."""
     LMCacheFSClient = _import_fs_client()
     block_size = os.statvfs(tmp_path).f_bsize
     if block_size <= 0:
@@ -121,12 +121,17 @@ def test_odirect_fails_for_misaligned_buffer(tmp_path) -> None:
     size = block_size * 2
     key = "test_model@00000000@fedcba9876543210"
     _source_raw, source = _misaligned_memoryview(size, block_size)
+    _dest_raw, dest = _misaligned_memoryview(size, block_size)
     _fill(source)
 
     client = LMCacheFSClient(str(tmp_path), 1, "", True, 1)
     try:
         store = _submit_and_wait(client, "submit_batch_set", key, source)
-        assert not store[1]
-        assert "O_DIRECT buffer address is not aligned" in store[2]
+        assert store[1], store[2]
+
+        load = _submit_and_wait(client, "submit_batch_get", key, dest)
+        assert load[1], load[2]
+        assert load[3] == [True]
+        assert bytes(dest) == bytes(source)
     finally:
         client.close()


### PR DESCRIPTION
Part of #4888.

## Summary

Make filesystem publication safe under concurrent same-key writers and fall
back to buffered I/O when a caller buffer cannot satisfy `O_DIRECT` alignment.

## Problem

The native and Python filesystem paths use a deterministic temporary pathname
per key. Concurrent writers can therefore truncate and write the same inode,
then replace an already complete destination. Native short writes and an
unaligned direct-I/O buffer add separate paths to partial or failed publication.

## Change

- Give each C++ and Python writer an exclusive temporary pathname.
- Fully write and close the writer-owned inode before publication.
- Publish with a same-filesystem create-if-absent hard link so one complete
  inode wins without replacing an established object.
- Remove losing temporary links on success and error paths.
- Retry native short writes until the requested buffer is complete.
- Account Python bytes only for the publication winner.
- Fall back to buffered I/O when address, length, or offset alignment makes
  `O_DIRECT` ineligible.

GET, EXISTS, DELETE, key derivation, non-filesystem adapters, and the public
native completion API are unchanged.

## Validation

Focused coverage includes aligned direct reads, unaligned-address fallback,
existing destinations, concurrent helper/native/process writers, deliberately
short writes, duplicate adapter stores, complete winner contents, and temporary
cleanup. The rebased branch passes Ruff lint/format and `git diff --check`; the
compiled filesystem suite should rerun upstream.
