### PR TITLE
feat(prefetch): identify keys that fail after lookup

### DIFF
--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -1373,6 +1373,14 @@ class PrefetchController(StorageControllerInterface):
         # added once the serde PR lands and adapters can distinguish
         # deserialization errors from missing objects.
         if failed_keys:
+            logger.warning(
+                "Prefetch request %d: %d/%d plan keys failed to load from "
+                "L2 (lookup hit, load empty); sample: %s",
+                request.request_id,
+                len(failed_keys),
+                len(request.write_reserved_keys),
+                [str(key)[:160] for key in failed_keys[:3]],
+            )
             self._event_bus.publish(
                 Event(
                     event_type=EventType.L2_PREFETCH_FAILED,

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -38,6 +38,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
     MockL2Adapter,
     MockL2AdapterConfig,
 )
+from lmcache.v1.distributed.storage_controllers import (
+    prefetch_controller as prefetch_controller_module,
+)
 from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
     PrefetchController,
     build_trim_mask,
@@ -367,7 +370,7 @@ class TestSingleAdapterPrefetch:
         ctrl.stop()
         adapter.close()
 
-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
+    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
         """fault_inject (load fails at index 2) drives the segmented path.
 
         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
@@ -375,6 +378,14 @@ class TestSingleAdapterPrefetch:
         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
         key ranges per policy keep the shared L1 from serving the second pass.
         """
+        warning_messages: list[str] = []
+
+        def capture_warning(message, *args, **_kwargs):
+            warning_messages.append(message % args)
+
+        monkeypatch.setattr(
+            prefetch_controller_module.logger, "warning", capture_warning
+        )
         layout = make_layout()
         for base, trim, expected in (
             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
@@ -407,6 +418,11 @@ class TestSingleAdapterPrefetch:
                 l1_manager.finish_read(held)
             ctrl.stop()
             fault.close()
+
+        assert any(
+            "1/5 plan keys failed to load from L2" in message and "sample:" in message
+            for message in warning_messages
+        )
 
     def test_key0_missing(self, l1_manager):
         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""


### PR DESCRIPTION
## Summary

Log a bounded, actionable warning when an L2 lookup reports keys present but
the subsequent prefetch load returns no object for some of them.

The existing structured `L2_PREFETCH_FAILED` event is preserved. This adds the
failed/planned ratio and at most three shortened key strings to the normal log,
which makes lookup/load gaps visible without enabling trace-level telemetry or
emitting an unbounded list.

Background and the wider community integration series:
https://github.com/LMCache/LMCache/issues/4831

## Change

- Emit one warning only on the existing failed-load branch.
- Report failed keys relative to the complete reserved prefetch plan.
- Bound the sample to three keys and each rendered key to 160 characters.
- Cover both segmented-prefix trimming and strict-prefix truncation.

Successful loads, lookup behavior, trimming decisions, structured events,
storage state, and non-prefetch paths are unchanged.

## Validation

Current official base: `LMCache/LMCache:dev@117a0b88`.

The exact patch passed the complete prefetch-controller module on CN4 with a
real CUDA runtime: **49/49** tests across prefix, segmented, sparse, warm,
sliding-window, lock-release, multi-adapter, and concurrent-eviction paths.
The injected lookup/load-gap regression proves both unchanged trimming results
(`{0,1,3,4}` segmented and `{0,1}` prefix) and the bounded `1/5` warning.

The focused current-`dev` source rebuilt successfully in a clean Python 3.12
`NO_GPU_EXT=1` environment. Its CPU-only rerun skipped the module at the
repository's existing no-device-runtime gate; it did not fail a test. The
intervening official change from the previously tested base to `117a0b88`
touches only the independent MetaX/MACA build profile, and this patch is
byte-identical to the 49/49-tested integration change.

The exact changed-file pre-commit gate passed SPDX/policy checks, isort, Ruff,
Ruff format, codespell, and mypy. Native/Rust formatting hooks had no matching
files.

No serving configuration or KV allocation is changed by this log-only unit.
The supporting integrated CN4 run used GLM-5.3-Flash NVFP4, FP8 KV, TP4/DCP4,
MTP3, APC, CKV gather, and GMU 0.90, with 35,060,805,120 bytes
(32.652919292 GiB) of KV per rank and 140,243,220,480 bytes
(130.611677170 GiB) aggregate.

## Provenance

- Historical source: `660f18ad`, `2cee5a2c`.
- LIL integration commit: `f5e37731`.
- Focused current-`dev` commit: `4acd6c99`.
- Co-authored-by: Florian Bernd `<git@flobernd.de>`.
- Co-authored-by: Martin Vit `<martin@voipmonitor.org>`.
- Reconciliation and tests: Derek Yates.
