### PR TITLE
[SGLang][MP] Preserve cache_salt across external KV operations

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -403,6 +403,9 @@ class LMCacheMPConnector:
         Returns:
             The chunk-aligned matched-token count, or zero if no aligned hit
             exists, the connector is unhealthy, or ``request_id`` is empty.
+
+        Raises:
+            ValueError: If ``cache_salt`` violates the cache-key constraints.
         """
         if not self.is_healthy or not request_id:
             return 0
@@ -674,6 +677,10 @@ class LMCacheMPConnector:
             A future resolving to ``True`` when the store completes
             successfully (or there was nothing to store), or ``False``
             on daemon-side failure or an unhealthy connector.
+
+        Raises:
+            ValueError: If ``store_metadata.cache_salt`` violates the
+                cache-key constraints.
         """
         if not self.is_healthy:
             return _completed_future(False)
@@ -723,6 +730,8 @@ class LMCacheMPConnector:
                 indices for the finished request.
 
         Raises:
+            ValueError: If ``store_metadata.cache_salt`` violates the
+                cache-key constraints.
             RuntimeError: If the daemon reports that the store failed.
         """
         if not self.is_healthy:

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -142,11 +142,14 @@ class _PendingLookup:
         locks_held: True iff the daemon still holds the read locks
             reserved by this LOOKUP. RETRIEVE consumes them; explicit
             FREE_LOOKUP_LOCKS releases them.
+        cache_salt: Per-tenant isolation salt captured by LOOKUP and reused by
+            RETRIEVE and every lock-release path for this request.
     """
 
     token_ids: list[int]
     matched_token_num: int
     locks_held: bool
+    cache_salt: str
 
 
 class LMCacheMPConnector:
@@ -166,7 +169,12 @@ class LMCacheMPConnector:
     - ``end_session``: per-request cleanup. Frees any still-held
       locks then sends END_SESSION so the daemon doesn't leak
       read-lock reservations.
+
+    ``supports_cache_salt`` is a connector capability flag for integrations
+    that must fail closed rather than silently use unsalted external keys.
     """
+
+    supports_cache_salt: bool = True
 
     def __init__(
         self,
@@ -269,8 +277,22 @@ class LMCacheMPConnector:
         start: int,
         end: int,
         request_id: str,
+        cache_salt: str = "",
         no_worker_id: bool = False,
     ) -> IPCCacheServerKey:
+        """Build an IPC cache key for an SGLang MP request.
+
+        Args:
+            token_ids: Complete token sequence used to hash cache chunks.
+            start: Inclusive token offset for this operation.
+            end: Exclusive token offset for this operation.
+            request_id: Request identifier used for session tracking.
+            cache_salt: Per-tenant isolation salt included in cache identity.
+            no_worker_id: Whether the key represents all tensor-parallel workers.
+
+        Returns:
+            The cache-server key sent over the multi-process protocol.
+        """
         return IPCCacheServerKey(
             model_name=self.model_name,
             world_size=self.tp_size,
@@ -282,6 +304,7 @@ class LMCacheMPConnector:
             start=start,
             end=end,
             request_id=request_id,
+            cache_salt=cache_salt,
         )
 
     def _slot_mapping_to_block_ids(self, slot_mapping: torch.Tensor) -> list[int]:
@@ -334,6 +357,7 @@ class LMCacheMPConnector:
         start: int,
         end: int,
         request_id: str,
+        cache_salt: str,
     ) -> None:
         if start >= end or not self.is_healthy:
             return
@@ -346,13 +370,19 @@ class LMCacheMPConnector:
                     start=start,
                     end=end,
                     request_id=request_id,
+                    cache_salt=cache_salt,
                     no_worker_id=True,
                 ),
                 self.tp_size,
             ],
         )
 
-    def lookup_kv(self, token_ids: list[int], request_id: str) -> int:
+    def lookup_kv(
+        self,
+        token_ids: list[int],
+        request_id: str,
+        cache_salt: str = "",
+    ) -> int:
         """Phase 1 of the two-phase load — fires LOOKUP only.
 
         The daemon prefetches missing chunks L2 → L1 (DRAM), creates a
@@ -365,9 +395,14 @@ class LMCacheMPConnector:
         its read locks released before the new LOOKUP fires, so locks
         don't accumulate.
 
-        Returns the chunk-aligned matched-token count (0 if no
-        chunk-aligned hit, including the ``aligned_end == 0`` short-
-        prompt case).
+        Args:
+            token_ids: Complete token sequence to look up.
+            request_id: Request identifier used for session tracking.
+            cache_salt: Per-tenant isolation salt included in cache identity.
+
+        Returns:
+            The chunk-aligned matched-token count, or zero if no aligned hit
+            exists, the connector is unhealthy, or ``request_id`` is empty.
         """
         if not self.is_healthy or not request_id:
             return 0
@@ -379,7 +414,11 @@ class LMCacheMPConnector:
             stale = self._pending_lookups.pop(request_id, None)
         if stale is not None and stale.locks_held:
             self._free_lookup_locks(
-                stale.token_ids, 0, stale.matched_token_num, request_id
+                stale.token_ids,
+                0,
+                stale.matched_token_num,
+                request_id,
+                stale.cache_salt,
             )
 
         aligned_end = (len(token_ids) // self._lmcache_chunk_size) * (
@@ -393,6 +432,7 @@ class LMCacheMPConnector:
             start=0,
             end=aligned_end,
             request_id=request_id,
+            cache_salt=cache_salt,
             no_worker_id=True,
         )
         send_lmcache_request(
@@ -411,6 +451,7 @@ class LMCacheMPConnector:
                 token_ids=list(token_ids),
                 matched_token_num=matched,
                 locks_held=matched > 0,
+                cache_salt=cache_salt,
             )
         return matched
 
@@ -426,8 +467,15 @@ class LMCacheMPConnector:
             pending.locks_held = False
             token_ids = pending.token_ids
             matched = pending.matched_token_num
+            cache_salt = pending.cache_salt
         if matched > 0:
-            self._free_lookup_locks(token_ids, 0, matched, request_id)
+            self._free_lookup_locks(
+                token_ids,
+                0,
+                matched,
+                request_id,
+                cache_salt,
+            )
 
     def end_session(self, request_id: str) -> None:
         """Tell the daemon we're done with this request_id.
@@ -449,7 +497,11 @@ class LMCacheMPConnector:
             return
         if pending.locks_held and pending.matched_token_num > 0:
             self._free_lookup_locks(
-                pending.token_ids, 0, pending.matched_token_num, request_id
+                pending.token_ids,
+                0,
+                pending.matched_token_num,
+                request_id,
+                pending.cache_salt,
             )
         send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
 
@@ -461,6 +513,7 @@ class LMCacheMPConnector:
         matched_end: int,
         block_ids: list[int],
         skip_prefix_n_blocks: int = 0,
+        cache_salt: str = "",
     ) -> tuple[
         MessagingFuture[tuple[bytes, bool]],
         MessagingFuture[bool],
@@ -476,6 +529,7 @@ class LMCacheMPConnector:
                     start=offset,
                     end=matched_end,
                     request_id=request_id,
+                    cache_salt=cache_salt,
                 ),
                 self.instance_id,
                 # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
@@ -524,6 +578,7 @@ class LMCacheMPConnector:
 
         retrieve_token_num = pending.matched_token_num
         token_ids = pending.token_ids
+        cache_salt = pending.cache_salt
         offset = load_metadata.offset
 
         # ``slot_mapping[offset : offset + prefix_pad)`` is sentinel ``-1`` —
@@ -537,7 +592,13 @@ class LMCacheMPConnector:
         fresh_start = offset + prefix_pad
         prefix_pad_pages = prefix_pad // self.page_size
 
-        self._free_lookup_locks(token_ids, 0, offset, request_id)
+        self._free_lookup_locks(
+            token_ids,
+            0,
+            offset,
+            request_id,
+            cache_salt,
+        )
         fresh_block_ids = self._slot_mapping_to_block_ids(
             load_metadata.slot_mapping[fresh_start:retrieve_token_num]
         )
@@ -558,6 +619,7 @@ class LMCacheMPConnector:
                 matched_end=retrieve_token_num,
                 block_ids=block_ids,
                 skip_prefix_n_blocks=prefix_pad_pages,
+                cache_salt=cache_salt,
             )
             if not future.result(timeout=self._mq_timeout):
                 event_handle, _ = raw_future.result(timeout=0)
@@ -572,7 +634,11 @@ class LMCacheMPConnector:
         finally:
             if not retrieve_succeeded and not server_released_locks:
                 self._free_lookup_locks(
-                    token_ids, offset, retrieve_token_num, request_id
+                    token_ids,
+                    offset,
+                    retrieve_token_num,
+                    request_id,
+                    cache_salt,
                 )
             with self._pending_lookups_lock:
                 if request_id in self._pending_lookups:
@@ -601,8 +667,8 @@ class LMCacheMPConnector:
         (see :meth:`end_session`); it is not fired here.
 
         Args:
-            store_metadata: tokens, request id, and KV slot indices for
-                the finished request.
+            store_metadata: Tokens, request id, tenant salt, and KV slot
+                indices for the finished request.
 
         Returns:
             A future resolving to ``True`` when the store completes
@@ -633,6 +699,7 @@ class LMCacheMPConnector:
                     start=0,
                     end=aligned_end,
                     request_id=request_id,
+                    cache_salt=store_metadata.cache_salt,
                 ),
                 self.instance_id,
                 # STORE takes per-group block IDs (list[list[int]]); SGLang is
@@ -649,6 +716,15 @@ class LMCacheMPConnector:
         return future
 
     def store_kv(self, store_metadata: StoreMetadata) -> None:
+        """Store a chunk-aligned SGLang KV prefix and wait for completion.
+
+        Args:
+            store_metadata: Tokens, request id, tenant salt, and KV slot
+                indices for the finished request.
+
+        Raises:
+            RuntimeError: If the daemon reports that the store failed.
+        """
         if not self.is_healthy:
             return
 
@@ -674,6 +750,7 @@ class LMCacheMPConnector:
                         start=0,
                         end=aligned_end,
                         request_id=request_id,
+                        cache_salt=store_metadata.cache_salt,
                     ),
                     self.instance_id,
                     # STORE takes per-group block IDs (list[list[int]]); SGLang is

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -57,7 +57,8 @@ class StoreMetadata:
         offset: First token index eligible for storage.
         request_id: Request identifier used for LMCache session tracking.
         cache_salt: Per-tenant isolation salt. The empty string preserves the
-            historical unsalted key behavior.
+            historical unsalted key behavior. Non-empty values must be at most
+            128 characters and must not contain ``@``, ``/``, ``\\``, or NUL.
     """
 
     last_node: object

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -48,11 +48,24 @@ def _model_uses_mla(model_config: ModelConfig) -> bool:
 
 @dataclass
 class StoreMetadata:
+    """Describe an SGLang request whose KV cache should be stored.
+
+    Attributes:
+        last_node: Last radix-tree node associated with the request.
+        token_ids: Complete token sequence used to build the cache key.
+        kv_indices: GPU KV slot indices corresponding to ``token_ids``.
+        offset: First token index eligible for storage.
+        request_id: Request identifier used for LMCache session tracking.
+        cache_salt: Per-tenant isolation salt. The empty string preserves the
+            historical unsalted key behavior.
+    """
+
     last_node: object
     token_ids: List[int]
     kv_indices: torch.Tensor
     offset: int
     request_id: str = ""
+    cache_salt: str = ""
 
 
 @dataclass

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Public-API unit tests for ``LMCacheMPConnector.store_kv_async``. The MQ and
-GPU boundaries are stubbed; no live daemon or CUDA device needed. Covers the
-async store contract added for SGLang MP mode: ``store_kv_async`` always
-returns a pollable future -- an already-completed one on the no-op paths
-(unhealthy connector / no chunk-aligned range), and the daemon's real
-completion future on the happy path -- and never blocks on the result."""
+"""Public-API unit tests for the SGLang multi-process connector.
+
+The MQ and GPU boundaries are stubbed; no live daemon or CUDA device is needed.
+The suite covers the async store contract and per-request cache-salt isolation
+across lookup, retrieve, lock cleanup, and store operations.
+"""
 
 # Standard
 from collections.abc import Callable
@@ -127,6 +127,113 @@ class _FakeTorchDev:
     @staticmethod
     def current_stream():
         return object()
+
+
+class _WireResponse:
+    """Minimal response supporting synchronous and device-future consumers."""
+
+    def __init__(
+        self,
+        raw_result: object = None,
+        device_result: bool = True,
+    ) -> None:
+        self.raw_result = raw_result
+        self.device_result = device_result
+
+    def result(self, timeout: float | None = None) -> object:
+        return self.raw_result
+
+    def to_device_future(self, device: object = None) -> MessagingFuture[bool]:
+        future: MessagingFuture[bool] = MessagingFuture()
+        future.set_result(self.device_result)
+        return future
+
+
+class _FakeMQClient:
+    """Message queue stand-in used by public connector tests."""
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeHeartbeatThread:
+    """Heartbeat stand-in that avoids starting a background thread."""
+
+    def __init__(
+        self,
+        mq_client: object,
+        health_event: threading.Event,
+        interval: float,
+        instance_id: int | None,
+    ) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+def _make_public_connector(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    retrieve_succeeds: bool = True,
+) -> tuple[Any, list[tuple[object, list[object]]]]:
+    """Create a connector through its public constructor with stubbed I/O."""
+    adapter_mod, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
+    requests: list[tuple[object, list[object]]] = []
+    mq_client = _FakeMQClient()
+
+    def send_request(
+        _client: object,
+        request_type: object,
+        payload: list[object],
+    ) -> _WireResponse:
+        requests.append((request_type, payload))
+        if request_type is adapter_mod.RequestType.WAIT_PREFETCH_STATUS:
+            return _WireResponse(raw_result=1)
+        if request_type is adapter_mod.RequestType.RETRIEVE:
+            return _WireResponse(
+                raw_result=(b"completion-event", retrieve_succeeds),
+                device_result=retrieve_succeeds,
+            )
+        return _WireResponse()
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "zmq",
+        SimpleNamespace(Context=SimpleNamespace(instance=lambda: object())),
+    )
+    monkeypatch.setattr(
+        adapter_mod,
+        "MessageQueueClient",
+        lambda _endpoint, _context: mq_client,
+    )
+    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
+    monkeypatch.setattr(adapter_mod, "HeartbeatThread", _FakeHeartbeatThread)
+    monkeypatch.setattr(
+        adapter_mod,
+        "get_device_spec",
+        lambda _device_type: SimpleNamespace(
+            is_handle_transfer_available=lambda: True
+        ),
+    )
+    monkeypatch.setattr(adapter_mod, "wrap_one_kv_cache", lambda tensor: tensor)
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_request)
+    monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
+
+    connector = LMCacheMPConnector(
+        sgl_config=SimpleNamespace(model_path="test-model"),
+        tp_size=1,
+        rank=0,
+        page_size=2,
+        host="127.0.0.1",
+        port=5556,
+        k_pool=[torch.empty(4, 1, 8)],
+        v_pool=[torch.empty(4, 1, 8)],
+    )
+    return connector, requests
 
 
 def test_completed_future_resolves_to_given_result() -> None:
@@ -488,3 +595,160 @@ def test_layerwise_load_forwards_partial_slot_mapping_offset() -> None:
         retrieve_kwargs["slot_mapping"].cpu(),
         metadata.slot_mapping.cpu(),
     )
+
+
+def test_mp_connector_advertises_cache_salt_capability() -> None:
+    """Callers can detect salt-aware connectors before sending salted keys."""
+    _, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
+
+    assert LMCacheMPConnector.supports_cache_salt is True
+
+
+@pytest.mark.parametrize("cleanup_method", ["release_pending", "end_session"])
+def test_lookup_cleanup_preserves_cache_salt(
+    cleanup_method: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lock cleanup uses the same tenant salt as the originating lookup."""
+    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    connector, requests = _make_public_connector(monkeypatch)
+    token_ids = list(range(8))
+
+    assert connector.lookup_kv(token_ids, "request-1", cache_salt="tenant-a") == 4
+    getattr(connector, cleanup_method)("request-1")
+
+    lookup_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.LOOKUP
+    ]
+    free_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.FREE_LOOKUP_LOCKS
+    ]
+    assert [key.cache_salt for key in lookup_keys] == ["tenant-a"]
+    assert [key.cache_salt for key in free_keys] == ["tenant-a"]
+
+
+def test_rescheduled_lookup_releases_locks_with_original_cache_salt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replacing pending state cannot free old locks under the new salt."""
+    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    connector, requests = _make_public_connector(monkeypatch)
+    token_ids = list(range(8))
+
+    assert connector.lookup_kv(token_ids, "request-1", cache_salt="tenant-a") == 4
+    assert connector.lookup_kv(token_ids, "request-1", cache_salt="tenant-b") == 4
+
+    lookup_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.LOOKUP
+    ]
+    free_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.FREE_LOOKUP_LOCKS
+    ]
+    assert [key.cache_salt for key in lookup_keys] == ["tenant-a", "tenant-b"]
+    assert [key.cache_salt for key in free_keys] == ["tenant-a"]
+
+
+def test_retrieve_and_failure_cleanup_preserve_lookup_cache_salt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retrieve and its failure cleanup share lookup's saved tenant salt."""
+    adapter_mod, _, _, _, LoadMetadata, _ = _import_adapter_symbols()
+    connector, requests = _make_public_connector(
+        monkeypatch,
+        retrieve_succeeds=False,
+    )
+    token_ids = list(range(8))
+    connector.lookup_kv(token_ids, "request-1", cache_salt="tenant-a")
+
+    with pytest.raises(RuntimeError, match="LMCache MP retrieve failed"):
+        connector.retrieve_kv(
+            LoadMetadata(
+                token_ids=token_ids,
+                slot_mapping=torch.arange(4),
+                offset=0,
+                request_id="request-1",
+            )
+        )
+
+    retrieve_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.RETRIEVE
+    ]
+    free_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.FREE_LOOKUP_LOCKS
+    ]
+    assert [key.cache_salt for key in retrieve_keys] == ["tenant-a"]
+    assert [key.cache_salt for key in free_keys] == ["tenant-a"]
+
+
+@pytest.mark.parametrize("store_method", ["store_kv", "store_kv_async"])
+def test_store_key_uses_metadata_cache_salt(
+    store_method: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both synchronous and asynchronous stores isolate keys by metadata salt."""
+    adapter_mod, _, _, _, _, StoreMetadata = _import_adapter_symbols()
+    connector, requests = _make_public_connector(monkeypatch)
+    metadata = StoreMetadata(
+        last_node=None,
+        token_ids=list(range(8)),
+        kv_indices=torch.arange(8),
+        offset=0,
+        request_id="request-1",
+        cache_salt="tenant-a",
+    )
+
+    result = getattr(connector, store_method)(metadata)
+    if isinstance(result, MessagingFuture):
+        assert result.result(timeout=0) is True
+
+    store_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.STORE
+    ]
+    assert [key.cache_salt for key in store_keys] == ["tenant-a"]
+
+
+def test_cache_salt_defaults_preserve_unsalted_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing callers that omit cache_salt continue using the empty salt."""
+    adapter_mod, _, _, _, _, StoreMetadata = _import_adapter_symbols()
+    connector, requests = _make_public_connector(monkeypatch)
+    token_ids = list(range(8))
+
+    connector.lookup_kv(token_ids, "request-1")
+    connector.release_pending("request-1")
+    connector.store_kv_async(
+        StoreMetadata(
+            last_node=None,
+            token_ids=token_ids,
+            kv_indices=torch.arange(8),
+            offset=0,
+            request_id="request-1",
+        )
+    ).result(timeout=0)
+
+    keyed_request_types = {
+        adapter_mod.RequestType.LOOKUP,
+        adapter_mod.RequestType.FREE_LOOKUP_LOCKS,
+        adapter_mod.RequestType.STORE,
+    }
+    keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type in keyed_request_types
+    ]
+    assert [key.cache_salt for key in keys] == ["", "", ""]

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -179,6 +179,7 @@ def _make_public_connector(
     monkeypatch: pytest.MonkeyPatch,
     *,
     retrieve_succeeds: bool = True,
+    matched_chunks: int = 1,
 ) -> tuple[Any, list[tuple[object, list[object]]]]:
     """Create a connector through its public constructor with stubbed I/O."""
     adapter_mod, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
@@ -192,7 +193,7 @@ def _make_public_connector(
     ) -> _WireResponse:
         requests.append((request_type, payload))
         if request_type is adapter_mod.RequestType.WAIT_PREFETCH_STATUS:
-            return _WireResponse(raw_result=1)
+            return _WireResponse(raw_result=matched_chunks)
         if request_type is adapter_mod.RequestType.RETRIEVE:
             return _WireResponse(
                 raw_result=(b"completion-event", retrieve_succeeds),
@@ -689,6 +690,45 @@ def test_retrieve_and_failure_cleanup_preserve_lookup_cache_salt(
     ]
     assert [key.cache_salt for key in retrieve_keys] == ["tenant-a"]
     assert [key.cache_salt for key in free_keys] == ["tenant-a"]
+
+
+def test_retrieve_prefix_cleanup_preserves_lookup_cache_salt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prefix lock release and retrieve share lookup's saved tenant salt."""
+    adapter_mod, _, _, _, LoadMetadata, _ = _import_adapter_symbols()
+    connector, requests = _make_public_connector(monkeypatch, matched_chunks=2)
+    token_ids = list(range(8))
+
+    assert connector.lookup_kv(token_ids, "request-1", cache_salt="tenant-a") == 8
+    assert (
+        connector.retrieve_kv(
+            LoadMetadata(
+                token_ids=token_ids,
+                slot_mapping=torch.arange(8),
+                offset=4,
+                request_id="request-1",
+            )
+        )
+        == 4
+    )
+
+    free_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.FREE_LOOKUP_LOCKS
+    ]
+    retrieve_keys = [
+        payload[0]
+        for request_type, payload in requests
+        if request_type is adapter_mod.RequestType.RETRIEVE
+    ]
+    assert [(key.start, key.end, key.cache_salt) for key in free_keys] == [
+        (0, 4, "tenant-a")
+    ]
+    assert [(key.start, key.end, key.cache_salt) for key in retrieve_keys] == [
+        (4, 8, "tenant-a")
+    ]
 
 
 @pytest.mark.parametrize("store_method", ["store_kv", "store_kv_async"])

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -215,9 +215,7 @@ def _make_public_connector(
     monkeypatch.setattr(
         adapter_mod,
         "get_device_spec",
-        lambda _device_type: SimpleNamespace(
-            is_handle_transfer_available=lambda: True
-        ),
+        lambda _device_type: SimpleNamespace(is_handle_transfer_available=lambda: True),
     )
     monkeypatch.setattr(adapter_mod, "wrap_one_kv_cache", lambda tensor: tensor)
     monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_request)
@@ -528,6 +526,7 @@ def test_retrieve_failure_uses_single_cleanup_owner(
             token_ids=list(range(2 * _CHUNK_SIZE)),
             matched_token_num=2 * _CHUNK_SIZE,
             locks_held=True,
+            cache_salt="",
         )
     }
     connector._pending_lookups_lock = threading.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4825. Companion issue: sgl-project/sglang#37160. Companion draft PR: sgl-project/sglang#37229.

The existing SGLang multi-process connector builds LMCache IPC keys without the request's `cache_salt`. Different tenants using identical token sequences can therefore resolve to the same external `ObjectKey`, even though the multiprocess key and storage layers already support salted identities.

This change:

- adds a backwards-compatible `cache_salt: str = ""` field to SGLang store metadata and argument to `lookup_kv`;
- captures the lookup salt once in `_PendingLookup`;
- reuses that salt for RETRIEVE, rescheduling cleanup, `release_pending`, `end_session`, and failure cleanup;
- includes metadata salt in synchronous and asynchronous STORE keys;
- advertises `supports_cache_salt = True` so SGLang can avoid silently using token-only keys with older connectors; and
- documents the existing IPC salt constraints.

Empty defaults preserve existing unsalted SGLang callers and serialized key behavior.

**Special notes for your reviewers**:

This PR targets the currently shipped SGLang MP connector. Draft #4828 already models salt in its new unified connector. If that connector is intended to replace the existing path rather than coexist with it, I can adjust the scope accordingly.

Validation:

```text
pytest -q --confcutdir=tests/v1 tests/v1/test_sglang_mp_adapter.py
24 passed

pytest -q --confcutdir=tests/v1 tests/v1/test_sglang_adapter.py
5 passed
```

Ruff, format, isort, codespell, and `git diff --check` pass for the changed files.

The initial scope is MP mode only. IP mode and `extra_key` / LoRA execution namespacing require separate designs and remain follow-ups.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
