### PR TITLE
fix(vllm): recompute mixed recurrent cache tails

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -145,6 +145,44 @@ def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
     return False
 
 
+def _iter_kv_cache_specs(kv_cache_config: "KVCacheConfig | None") -> Iterable[Any]:
+    """Yield leaf KV cache specs without depending on a vLLM helper API."""
+    if kv_cache_config is None:
+        return
+    for group in kv_cache_config.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
+        if isinstance(per_layer_specs, dict):
+            yield from per_layer_specs.values()
+        else:
+            yield group_spec
+
+
+def _has_recurrent_cache(kv_cache_config: "KVCacheConfig | None") -> bool:
+    """Return whether the resolved cache contains recurrent-state pages."""
+    if kv_cache_config is None:
+        return False
+    if bool(getattr(kv_cache_config, "has_mamba_layers", False)):
+        return True
+    return any(
+        any(cls.__name__ == "MambaSpec" for cls in type(spec).__mro__)
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+    )
+
+
+def _should_suppress_mixed_recurrent_retrieve(
+    has_recurrent_cache: bool,
+    num_computed_tokens: int,
+    num_lmcache_hit_tokens: int,
+) -> bool:
+    """Reject an external tail spliced onto existing local recurrent state."""
+    return (
+        has_recurrent_cache
+        and num_computed_tokens > 0
+        and num_lmcache_hit_tokens > num_computed_tokens
+    )
+
+
 def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
     """Reject scheduler configs whose steps cannot advance a whole Mamba block.
 
@@ -300,8 +338,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         super().__init__(vllm_config, role, kv_cache_config)
 
         # Fail fast, before the server handshake below.
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
         validate_mamba_step_alignment(vllm_config)
-        validate_kv_cache_groups(getattr(self, "_kv_cache_config", None))
+        validate_kv_cache_groups(kv_cache_config)
+        self._has_recurrent_cache = _has_recurrent_cache(kv_cache_config)
 
         assert vllm_config.kv_transfer_config is not None
 
@@ -821,6 +861,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if tracker.state == LMCacheMPRequestState.BYPASS_LMCACHE:
             return 0, False
 
+        # Once this request has selected the recurrent-safe local-recompute
+        # path, scheduler polling must be idempotent. Reprocessing the same
+        # completed lookup would double-count num_stored_tokens and retain a
+        # second logical ownership of the same lookup result.
+        if tracker.suppress_mixed_recurrent_retrieve:
+            return 0, False
+
         # A completed async load normally leaves num_computed_tokens > 0, so
         # the scheduler does not call this method again.  If vLLM reset the
         # request to zero after the worker reported invalid blocks, however,
@@ -876,6 +923,25 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             * self._hit_alignment_tokens
         )
         tracker.num_lmcache_hit_tokens = ret
+
+        # A local APC prefix and a deeper external tail are not composable for
+        # recurrent groups in this connector. Keep the completed lookup and
+        # its locks until update_state_after_alloc releases the full range,
+        # then recompute the tail from trusted local state.
+        if _should_suppress_mixed_recurrent_retrieve(
+            self._has_recurrent_cache,
+            num_computed_tokens,
+            ret,
+        ):
+            tracker.suppress_mixed_recurrent_retrieve = True
+            logger.warning(
+                "Suppressing mixed recurrent LMCache retrieve for request %s: "
+                "local_tokens=%d, external_tokens=%d; recomputing the tail",
+                request.request_id,
+                num_computed_tokens,
+                ret,
+            )
+            return 0, False
 
         need_to_load = max(0, ret - num_computed_tokens)
 
@@ -1395,9 +1461,30 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         Clean up request tracker and associated lookup future for a request.
         This should be called when a request is finished to prevent memory leak.
         """
-        # Clean up request tracker
-        if self.request_trackers.pop(request_id, None):
-            logger.debug(
-                "[KVConnector] Cleaned up request_tracker for request %s",
-                request_id,
-            )
+        tracker = self.request_trackers.get(request_id)
+        if tracker is None:
+            return
+
+        # The normal allocation callback owns lookup cleanup. A request can be
+        # cancelled after the scheduler accepted the recurrent-safe fallback
+        # but before allocation; release the retained result and every lock in
+        # that exceptional window. READY means allocation already did so.
+        if (
+            tracker.suppress_mixed_recurrent_retrieve
+            and tracker.state == LMCacheMPRequestState.PREFETCHING
+        ):
+            self.scheduler_adapter.cleanup_lookup_result(request_id)
+            if tracker.num_lmcache_hit_tokens > 0:
+                self.scheduler_adapter.free_lookup_locks(
+                    token_ids=tracker.get_token_ids(),
+                    start=0,
+                    end=tracker.num_lmcache_hit_tokens,
+                    request_id=request_id,
+                    cache_salt=tracker.cache_salt,
+                )
+
+        self.request_trackers.pop(request_id)
+        logger.debug(
+            "[KVConnector] Cleaned up request_tracker for request %s",
+            request_id,
+        )

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -67,6 +67,7 @@ class LMCacheMPRequestTracker:
     # Staging load operation -- save vllm and lmcache hit tokens during lookup
     num_vllm_hit_tokens: int = 0
     num_lmcache_hit_tokens: int = 0
+    suppress_mixed_recurrent_retrieve: bool = False
 
     # Main state
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
@@ -83,6 +84,7 @@ class LMCacheMPRequestTracker:
         self.num_stored_tokens = 0
         self.num_vllm_hit_tokens = 0
         self.num_lmcache_hit_tokens = 0
+        self.suppress_mixed_recurrent_retrieve = False
         self.state = LMCacheMPRequestState.PREFETCHING
         self.mm_adjusted_prompt_ids = []
         mm_hashes, mm_positions = extract_mm_features(request)
@@ -98,7 +100,8 @@ class LMCacheMPRequestTracker:
         """Check whether the current request needs retrieve, will be used
         update_stage_after_alloc"""
         return (
-            self.num_lmcache_hit_tokens > self.num_vllm_hit_tokens
+            not self.suppress_mixed_recurrent_retrieve
+            and self.num_lmcache_hit_tokens > self.num_vllm_hit_tokens
             and self.state
             not in (
                 LMCacheMPRequestState.READY,

--- a/tests/v1/test_vllm_mp_mixed_recurrent.py
+++ b/tests/v1/test_vllm_mp_mixed_recurrent.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed mixed-prefix tests for the vLLM MP connector."""
+
+# Standard
+from types import SimpleNamespace
+from typing import Any
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module load")
+
+# Third Party
+from vllm.v1.utils import ConstantList  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+    LMCacheMPRequestState,
+    _has_recurrent_cache,
+)
+
+
+class _Request:
+    """Duck-typed text request carrying the fields the connector reads."""
+
+    def __init__(self, request_id: str, num_tokens: int) -> None:
+        self.request_id = request_id
+        self.cache_salt = ""
+        self.prompt_token_ids = list(range(num_tokens))
+        self.all_token_ids = ConstantList(self.prompt_token_ids)
+        self.mm_features: list[object] = []
+        self.status = object()
+        self.kv_transfer_params = None
+
+
+class _SchedulerAdapter:
+    """Minimal scheduler adapter with observable lookup lifecycle calls."""
+
+    lmcache_tokens_per_chunk = 3072
+
+    def __init__(self, lookup_tokens: int) -> None:
+        self.lookup_tokens = lookup_tokens
+        self.submit_count = 0
+        self.check_count = 0
+        self.cleaned_request_ids: list[str] = []
+        self.freed_ranges: list[tuple[int, int, str]] = []
+        self.ended_request_ids: list[str] = []
+
+    def maybe_submit_lookup_request(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        cache_salt: str,
+    ) -> None:
+        del request_id, token_ids, cache_salt
+        self.submit_count += 1
+
+    def check_lookup_result(self, request_id: str) -> int:
+        del request_id
+        self.check_count += 1
+        return self.lookup_tokens
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        self.cleaned_request_ids.append(request_id)
+
+    def free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str,
+    ) -> None:
+        del token_ids, cache_salt
+        self.freed_ranges.append((start, end, request_id))
+
+    def end_session(self, request_id: str) -> None:
+        self.ended_request_ids.append(request_id)
+
+
+class _NoBlocks:
+    """Empty allocation returned when the external tail is recomputed."""
+
+    @staticmethod
+    def get_block_ids() -> tuple[list[int], ...]:
+        return ()
+
+
+class MambaSpec:
+    """Compatibility stand-in detected by the helper's public class name."""
+
+
+class AttentionSpec:
+    """Ordinary attention control for recurrent-cache detection."""
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (None, False),
+        (SimpleNamespace(has_mamba_layers=True, kv_cache_groups=[]), True),
+        (
+            SimpleNamespace(
+                has_mamba_layers=False,
+                kv_cache_groups=[SimpleNamespace(kv_cache_spec=MambaSpec())],
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                has_mamba_layers=False,
+                kv_cache_groups=[SimpleNamespace(kv_cache_spec=AttentionSpec())],
+            ),
+            False,
+        ),
+    ],
+)
+def test_recurrent_cache_detection_supports_old_and_new_vllm_configs(
+    config: object,
+    expected: bool,
+) -> None:
+    assert _has_recurrent_cache(config) is expected  # type: ignore[arg-type]
+
+
+def _scheduler_connector(
+    *, has_recurrent_cache: bool, lookup_tokens: int
+) -> LMCacheMPConnector:
+    connector: Any = object.__new__(LMCacheMPConnector)
+    connector.request_trackers = {}
+    connector._has_recurrent_cache = has_recurrent_cache
+    connector._hit_alignment_tokens = 3072
+    connector.scheduler_adapter = _SchedulerAdapter(lookup_tokens)
+    connector.lazy_offload = False
+    return connector
+
+
+def test_recurrent_mixed_local_and_external_prefix_recomputes_tail() -> None:
+    """A deeper external tail must not be spliced onto local recurrent state."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=True,
+        lookup_tokens=46080,
+    )
+    request = _Request("mixed-recurrent", 47963)
+
+    matched = connector.get_num_new_matched_tokens(
+        request,
+        num_computed_tokens=36864,
+    )
+
+    assert matched == (0, False)
+    tracker = connector.request_trackers[request.request_id]
+    assert tracker.num_vllm_hit_tokens == 36864
+    assert tracker.num_lmcache_hit_tokens == 46080
+    assert tracker.num_stored_tokens == 46080
+
+    connector.update_state_after_alloc(request, _NoBlocks(), 0)
+
+    assert tracker.state == LMCacheMPRequestState.READY
+    adapter = connector.scheduler_adapter
+    assert isinstance(adapter, _SchedulerAdapter)
+    assert adapter.cleaned_request_ids == [request.request_id]
+    assert adapter.freed_ranges == [(0, 46080, request.request_id)]
+
+    connector.request_finished(request, [])
+    assert adapter.cleaned_request_ids == [request.request_id]
+    assert adapter.freed_ranges == [(0, 46080, request.request_id)]
+
+
+def test_suppressed_retrieve_is_idempotent_under_repeated_polling() -> None:
+    """Repeated scheduler polling must not re-lookup or double-count a hit."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=True,
+        lookup_tokens=46080,
+    )
+    request = _Request("repeated-mixed-recurrent", 47963)
+
+    assert connector.get_num_new_matched_tokens(request, 36864) == (0, False)
+    assert connector.get_num_new_matched_tokens(request, 36864) == (0, False)
+
+    tracker = connector.request_trackers[request.request_id]
+    adapter = connector.scheduler_adapter
+    assert isinstance(adapter, _SchedulerAdapter)
+    assert tracker.num_stored_tokens == 46080
+    assert adapter.submit_count == 1
+    assert adapter.check_count == 1
+
+
+def test_cancelled_suppressed_retrieve_releases_lookup_locks() -> None:
+    """Cancellation before allocation must not strand the retained locks."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=True,
+        lookup_tokens=46080,
+    )
+    request = _Request("cancelled-mixed-recurrent", 47963)
+
+    assert connector.get_num_new_matched_tokens(request, 36864) == (0, False)
+    connector.request_finished(request, [])
+
+    adapter = connector.scheduler_adapter
+    assert isinstance(adapter, _SchedulerAdapter)
+    assert adapter.cleaned_request_ids == [request.request_id]
+    assert adapter.freed_ranges == [(0, 46080, request.request_id)]
+    assert adapter.ended_request_ids == [request.request_id]
+    assert request.request_id not in connector.request_trackers
+
+
+@pytest.mark.parametrize(
+    ("has_recurrent_cache", "num_computed_tokens", "expected"),
+    [
+        (True, 0, (46080, True)),
+        (False, 36864, (9216, True)),
+        (True, 46080, (0, False)),
+    ],
+)
+def test_mixed_recurrent_guard_preserves_qualified_retrievals(
+    has_recurrent_cache: bool,
+    num_computed_tokens: int,
+    expected: tuple[int, bool],
+) -> None:
+    """Full external, non-recurrent, and non-deeper hits retain behavior."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=has_recurrent_cache,
+        lookup_tokens=46080,
+    )
+    request = _Request("qualified-retrieve", 47963)
+
+    matched = connector.get_num_new_matched_tokens(
+        request,
+        num_computed_tokens=num_computed_tokens,
+    )
+
+    assert matched == expected
+    tracker = connector.request_trackers[request.request_id]
+    assert tracker.needs_retrieve() is (expected[0] > 0)


### PR DESCRIPTION
## Summary

Fail closed when a recurrent/hybrid request combines a local vLLM APC prefix with a deeper external LMCache prefix.

- Detect recurrent cache groups across current and older vLLM cache-config shapes.
- Recompute the external-only tail instead of splicing it onto incompatible local recurrent state.
- Make scheduler polling idempotent after suppression.
- Release lookup results, locks, and sessions on both allocation and cancellation paths.
- Preserve full-external-prefix, attention-only, and equal-prefix retrieval behavior.

## Problem

For attention KV, a local prefix and a deeper external prefix can be combined by retrieving only the missing suffix. A recurrent-state page is different: it is a state snapshot at a token boundary. If vLLM already has a shorter local APC prefix, loading only a later external recurrent snapshot skips the intervening state transitions and can make recurrent state diverge from the token stream.

The unsafe shape is:

```text
0 < local APC tokens < external LMCache hit tokens
```

for a cache containing recurrent/Mamba pages.

This change retains the completed lookup long enough to release its full lock range, returns no external matched tokens to the scheduler, and recomputes the tail from trusted local state. Cache use remains an optimization: this safety fallback does not fail serving.

## Lifecycle details

- Suppression is sticky in the request tracker, so repeated scheduler polls do not re-run the lookup or double-count stored tokens.
- The normal allocation callback cleans the completed lookup and releases all externally locked keys.
- Cancellation before allocation performs the same cleanup and ends the session.
- The tracker reports that no retrieve is needed once suppression is selected.

## Compatibility and performance

The new path is selected only when all three conditions hold: the resolved cache contains recurrent pages, local APC has already computed a nonzero prefix, and the external hit is deeper than that local prefix.

Focused controls prove unchanged behavior for:

- a full external recurrent hit with no local prefix;
- an attention-only cache with a mixed prefix;
- an external hit equal to the local prefix;
- old and current vLLM recurrent-cache config representations.

The normal decision adds only constant-time boolean checks. It does not change cache geometry, keys, transfer format, allocation, or the ordinary attention path. The intentionally affected mixed-recurrent case recomputes for correctness instead of serving potentially invalid state.

## Validation

Current official base: `LMCache/LMCache:dev@117a0b8809728cd604e41ed4906cebc0e98d3504`.

Focused commit: `56fa3c7f`.

- Exact current-base overlay in the pinned GLM-5.3 runtime: 10/10 tests passed.
- Changed-file pre-commit: SPDX/policy checks, isort, Ruff, Ruff format, codespell, and mypy all pass.
- `git diff --check` passes.

Live CN4 proof used GLM-5.3-Flash NVFP4, FP8 KV, TP4/DCP4, MTP3, APC, GMU 0.90, 2,602 KV blocks per rank, 32.652919292 GiB KV per rank / 130.611677170 GiB aggregate, and 4,671,908 useful KV tokens.

The decisive 52,309-token request had a 34,816-token local APC prefix and a 49,152-token external LMCache prefix. The connector logged:

```text
Suppressing mixed recurrent LMCache retrieve ... local_tokens=34816,
external_tokens=49152; recomputing the tail
```

The external-served counter increased by zero. A replay returned the fixture label correctly and again served zero external tokens. The fixture used an atomic native-FS directory swap to create a real load-failure/local-compute prefix while preserving the live server inventory; the original L2 was restored before the decisive request, the model was not restarted, and production remained healthy.

Structured evidence: `evidence-lmcache-consolidation/mixed-recurrent-tail/20260831T101900/live-guard-proof.json` in the local-inference-lab validation record.

## Provenance

The failure mode and initial guard direction were developed with myshytf; attribution is retained in the commit trailer.

Community background and integration tracker: https://github.com/LMCache/LMCache/issues/4831
