### PR TITLE
fix(vllm): preserve exact recurrent cache ownership

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -145,6 +145,44 @@ def _has_preemption_reqs(scheduler_output: SchedulerOutput) -> bool:
     return False
 
 
+def _iter_kv_cache_specs(kv_cache_config: "KVCacheConfig | None") -> Iterable[Any]:
+    """Yield leaf KV cache specs without depending on a vLLM helper API."""
+    if kv_cache_config is None:
+        return
+    for group in kv_cache_config.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
+        if isinstance(per_layer_specs, dict):
+            yield from per_layer_specs.values()
+        else:
+            yield group_spec
+
+
+def _has_recurrent_cache(kv_cache_config: "KVCacheConfig | None") -> bool:
+    """Return whether the resolved cache contains recurrent-state pages."""
+    if kv_cache_config is None:
+        return False
+    if bool(getattr(kv_cache_config, "has_mamba_layers", False)):
+        return True
+    return any(
+        any(cls.__name__ == "MambaSpec" for cls in type(spec).__mro__)
+        for spec in _iter_kv_cache_specs(kv_cache_config)
+    )
+
+
+def _should_suppress_mixed_recurrent_retrieve(
+    has_recurrent_cache: bool,
+    num_computed_tokens: int,
+    num_lmcache_hit_tokens: int,
+) -> bool:
+    """Reject an external tail spliced onto existing local recurrent state."""
+    return (
+        has_recurrent_cache
+        and num_computed_tokens > 0
+        and num_lmcache_hit_tokens > num_computed_tokens
+    )
+
+
 def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
     """Reject scheduler configs whose steps cannot advance a whole Mamba block.
 
@@ -300,8 +338,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         super().__init__(vllm_config, role, kv_cache_config)
 
         # Fail fast, before the server handshake below.
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
         validate_mamba_step_alignment(vllm_config)
-        validate_kv_cache_groups(getattr(self, "_kv_cache_config", None))
+        validate_kv_cache_groups(kv_cache_config)
+        self._has_recurrent_cache = _has_recurrent_cache(kv_cache_config)
 
         assert vllm_config.kv_transfer_config is not None
 
@@ -821,6 +861,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         if tracker.state == LMCacheMPRequestState.BYPASS_LMCACHE:
             return 0, False
 
+        # Once this request has selected the recurrent-safe local-recompute
+        # path, scheduler polling must be idempotent. Reprocessing the same
+        # completed lookup would double-count num_stored_tokens and retain a
+        # second logical ownership of the same lookup result.
+        if tracker.suppress_mixed_recurrent_retrieve:
+            return 0, False
+
         # A completed async load normally leaves num_computed_tokens > 0, so
         # the scheduler does not call this method again.  If vLLM reset the
         # request to zero after the worker reported invalid blocks, however,
@@ -876,6 +923,25 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             * self._hit_alignment_tokens
         )
         tracker.num_lmcache_hit_tokens = ret
+
+        # A local APC prefix and a deeper external tail are not composable for
+        # recurrent groups in this connector. Keep the completed lookup and
+        # its locks until update_state_after_alloc releases the full range,
+        # then recompute the tail from trusted local state.
+        if _should_suppress_mixed_recurrent_retrieve(
+            self._has_recurrent_cache,
+            num_computed_tokens,
+            ret,
+        ):
+            tracker.suppress_mixed_recurrent_retrieve = True
+            logger.warning(
+                "Suppressing mixed recurrent LMCache retrieve for request %s: "
+                "local_tokens=%d, external_tokens=%d; recomputing the tail",
+                request.request_id,
+                num_computed_tokens,
+                ret,
+            )
+            return 0, False
 
         need_to_load = max(0, ret - num_computed_tokens)
 
@@ -1395,9 +1461,30 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         Clean up request tracker and associated lookup future for a request.
         This should be called when a request is finished to prevent memory leak.
         """
-        # Clean up request tracker
-        if self.request_trackers.pop(request_id, None):
-            logger.debug(
-                "[KVConnector] Cleaned up request_tracker for request %s",
-                request_id,
-            )
+        tracker = self.request_trackers.get(request_id)
+        if tracker is None:
+            return
+
+        # The normal allocation callback owns lookup cleanup. A request can be
+        # cancelled after the scheduler accepted the recurrent-safe fallback
+        # but before allocation; release the retained result and every lock in
+        # that exceptional window. READY means allocation already did so.
+        if (
+            tracker.suppress_mixed_recurrent_retrieve
+            and tracker.state == LMCacheMPRequestState.PREFETCHING
+        ):
+            self.scheduler_adapter.cleanup_lookup_result(request_id)
+            if tracker.num_lmcache_hit_tokens > 0:
+                self.scheduler_adapter.free_lookup_locks(
+                    token_ids=tracker.get_token_ids(),
+                    start=0,
+                    end=tracker.num_lmcache_hit_tokens,
+                    request_id=request_id,
+                    cache_salt=tracker.cache_salt,
+                )
+
+        self.request_trackers.pop(request_id)
+        logger.debug(
+            "[KVConnector] Cleaned up request_tracker for request %s",
+            request_id,
+        )

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -67,6 +67,7 @@ class LMCacheMPRequestTracker:
     # Staging load operation -- save vllm and lmcache hit tokens during lookup
     num_vllm_hit_tokens: int = 0
     num_lmcache_hit_tokens: int = 0
+    suppress_mixed_recurrent_retrieve: bool = False
 
     # Main state
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
@@ -83,6 +84,7 @@ class LMCacheMPRequestTracker:
         self.num_stored_tokens = 0
         self.num_vllm_hit_tokens = 0
         self.num_lmcache_hit_tokens = 0
+        self.suppress_mixed_recurrent_retrieve = False
         self.state = LMCacheMPRequestState.PREFETCHING
         self.mm_adjusted_prompt_ids = []
         mm_hashes, mm_positions = extract_mm_features(request)
@@ -98,7 +100,8 @@ class LMCacheMPRequestTracker:
         """Check whether the current request needs retrieve, will be used
         update_stage_after_alloc"""
         return (
-            self.num_lmcache_hit_tokens > self.num_vllm_hit_tokens
+            not self.suppress_mixed_recurrent_retrieve
+            and self.num_lmcache_hit_tokens > self.num_vllm_hit_tokens
             and self.state
             not in (
                 LMCacheMPRequestState.READY,

--- a/tests/v1/test_vllm_mp_mixed_recurrent.py
+++ b/tests/v1/test_vllm_mp_mixed_recurrent.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed mixed-prefix tests for the vLLM MP connector."""
+
+# Standard
+from types import SimpleNamespace
+from typing import Any
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module load")
+
+# Third Party
+from vllm.v1.utils import ConstantList  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+    LMCacheMPRequestState,
+    _has_recurrent_cache,
+)
+
+
+class _Request:
+    """Duck-typed text request carrying the fields the connector reads."""
+
+    def __init__(self, request_id: str, num_tokens: int) -> None:
+        self.request_id = request_id
+        self.cache_salt = ""
+        self.prompt_token_ids = list(range(num_tokens))
+        self.all_token_ids = ConstantList(self.prompt_token_ids)
+        self.mm_features: list[object] = []
+        self.status = object()
+        self.kv_transfer_params = None
+
+
+class _SchedulerAdapter:
+    """Minimal scheduler adapter with observable lookup lifecycle calls."""
+
+    lmcache_tokens_per_chunk = 3072
+
+    def __init__(self, lookup_tokens: int) -> None:
+        self.lookup_tokens = lookup_tokens
+        self.submit_count = 0
+        self.check_count = 0
+        self.cleaned_request_ids: list[str] = []
+        self.freed_ranges: list[tuple[int, int, str]] = []
+        self.ended_request_ids: list[str] = []
+
+    def maybe_submit_lookup_request(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        cache_salt: str,
+    ) -> None:
+        del request_id, token_ids, cache_salt
+        self.submit_count += 1
+
+    def check_lookup_result(self, request_id: str) -> int:
+        del request_id
+        self.check_count += 1
+        return self.lookup_tokens
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        self.cleaned_request_ids.append(request_id)
+
+    def free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str,
+    ) -> None:
+        del token_ids, cache_salt
+        self.freed_ranges.append((start, end, request_id))
+
+    def end_session(self, request_id: str) -> None:
+        self.ended_request_ids.append(request_id)
+
+
+class _NoBlocks:
+    """Empty allocation returned when the external tail is recomputed."""
+
+    @staticmethod
+    def get_block_ids() -> tuple[list[int], ...]:
+        return ()
+
+
+class MambaSpec:
+    """Compatibility stand-in detected by the helper's public class name."""
+
+
+class AttentionSpec:
+    """Ordinary attention control for recurrent-cache detection."""
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (None, False),
+        (SimpleNamespace(has_mamba_layers=True, kv_cache_groups=[]), True),
+        (
+            SimpleNamespace(
+                has_mamba_layers=False,
+                kv_cache_groups=[SimpleNamespace(kv_cache_spec=MambaSpec())],
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                has_mamba_layers=False,
+                kv_cache_groups=[SimpleNamespace(kv_cache_spec=AttentionSpec())],
+            ),
+            False,
+        ),
+    ],
+)
+def test_recurrent_cache_detection_supports_old_and_new_vllm_configs(
+    config: object,
+    expected: bool,
+) -> None:
+    assert _has_recurrent_cache(config) is expected  # type: ignore[arg-type]
+
+
+def _scheduler_connector(
+    *, has_recurrent_cache: bool, lookup_tokens: int
+) -> LMCacheMPConnector:
+    connector: Any = object.__new__(LMCacheMPConnector)
+    connector.request_trackers = {}
+    connector._has_recurrent_cache = has_recurrent_cache
+    connector._hit_alignment_tokens = 3072
+    connector.scheduler_adapter = _SchedulerAdapter(lookup_tokens)
+    connector.lazy_offload = False
+    return connector
+
+
+def test_recurrent_mixed_local_and_external_prefix_recomputes_tail() -> None:
+    """A deeper external tail must not be spliced onto local recurrent state."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=True,
+        lookup_tokens=46080,
+    )
+    request = _Request("mixed-recurrent", 47963)
+
+    matched = connector.get_num_new_matched_tokens(
+        request,
+        num_computed_tokens=36864,
+    )
+
+    assert matched == (0, False)
+    tracker = connector.request_trackers[request.request_id]
+    assert tracker.num_vllm_hit_tokens == 36864
+    assert tracker.num_lmcache_hit_tokens == 46080
+    assert tracker.num_stored_tokens == 46080
+
+    connector.update_state_after_alloc(request, _NoBlocks(), 0)
+
+    assert tracker.state == LMCacheMPRequestState.READY
+    adapter = connector.scheduler_adapter
+    assert isinstance(adapter, _SchedulerAdapter)
+    assert adapter.cleaned_request_ids == [request.request_id]
+    assert adapter.freed_ranges == [(0, 46080, request.request_id)]
+
+    connector.request_finished(request, [])
+    assert adapter.cleaned_request_ids == [request.request_id]
+    assert adapter.freed_ranges == [(0, 46080, request.request_id)]
+
+
+def test_suppressed_retrieve_is_idempotent_under_repeated_polling() -> None:
+    """Repeated scheduler polling must not re-lookup or double-count a hit."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=True,
+        lookup_tokens=46080,
+    )
+    request = _Request("repeated-mixed-recurrent", 47963)
+
+    assert connector.get_num_new_matched_tokens(request, 36864) == (0, False)
+    assert connector.get_num_new_matched_tokens(request, 36864) == (0, False)
+
+    tracker = connector.request_trackers[request.request_id]
+    adapter = connector.scheduler_adapter
+    assert isinstance(adapter, _SchedulerAdapter)
+    assert tracker.num_stored_tokens == 46080
+    assert adapter.submit_count == 1
+    assert adapter.check_count == 1
+
+
+def test_cancelled_suppressed_retrieve_releases_lookup_locks() -> None:
+    """Cancellation before allocation must not strand the retained locks."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=True,
+        lookup_tokens=46080,
+    )
+    request = _Request("cancelled-mixed-recurrent", 47963)
+
+    assert connector.get_num_new_matched_tokens(request, 36864) == (0, False)
+    connector.request_finished(request, [])
+
+    adapter = connector.scheduler_adapter
+    assert isinstance(adapter, _SchedulerAdapter)
+    assert adapter.cleaned_request_ids == [request.request_id]
+    assert adapter.freed_ranges == [(0, 46080, request.request_id)]
+    assert adapter.ended_request_ids == [request.request_id]
+    assert request.request_id not in connector.request_trackers
+
+
+@pytest.mark.parametrize(
+    ("has_recurrent_cache", "num_computed_tokens", "expected"),
+    [
+        (True, 0, (46080, True)),
+        (False, 36864, (9216, True)),
+        (True, 46080, (0, False)),
+    ],
+)
+def test_mixed_recurrent_guard_preserves_qualified_retrievals(
+    has_recurrent_cache: bool,
+    num_computed_tokens: int,
+    expected: tuple[int, bool],
+) -> None:
+    """Full external, non-recurrent, and non-deeper hits retain behavior."""
+    connector = _scheduler_connector(
+        has_recurrent_cache=has_recurrent_cache,
+        lookup_tokens=46080,
+    )
+    request = _Request("qualified-retrieve", 47963)
+
+    matched = connector.get_num_new_matched_tokens(
+        request,
+        num_computed_tokens=num_computed_tokens,
+    )
+
+    assert matched == expected
+    tracker = connector.request_trackers[request.request_id]
+    assert tracker.needs_retrieve() is (expected[0] > 0)


### PR DESCRIPTION
Part of #4888.

> **Dependency status:** this PR is deliberately draft. Its current remote head
> contains only the mixed-tail fail-closed guard. The complete local patch is
> ready, but it depends on the authoritative MP completion change in #4836 and
> the opaque hybrid geometry PR tracked by #4888. The stacked dependency commits
> will not be presented as part of this PR's `dev` diff. This branch will be
> rebased to the final six-commit recurrent series after those prerequisites
> land.

## Intended summary

Preserve exact recurrent cache ownership: use, advertise, and store recurrent
prefixes only at boundaries for which LMCache has authoritative state and source
blocks.

## Intended change

- Recompute a deeper external-only tail when local recurrent APC stops earlier.
- Restore exact recurrent lookup and store boundaries, including final prompt
  token exclusion.
- Retain new-request handoff blocks and store only handoff-ready prefixes.
- Require serialized producer prefill where concurrent production would make
  the state boundary ambiguous.
- Snapshot authoritative block tables for each store job.
- Retain those source blocks until every remote worker has completed its read.
- Release lookup locks, sessions, and retained sources on success, cancellation,
  and failure.

Attention-only and equal/full-prefix cases retain their existing behavior.
Missing or ambiguous recurrent ownership fails closed to recomputation.

## Validation plan

The local series contains focused coverage for mixed local/external prefixes,
exact boundaries, new-request handoffs, final-token exclusion, source snapshots,
multiple remote consumers, preemption, cancellation, and ordinary attention
controls. Ruff lint/format and `git diff --check` pass on the stacked review
range. Upstream CI will run after the dependencies land and the final clean diff
is pushed.
