### PR TITLE
[Fix][CB] Decide fused-KV packing per group, not per registration

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -580,9 +580,13 @@ def _cb_group_rope_geometry(
     # Use the spec fact, not a format list: a missed fused format is treated
     # as split K/V and the V half of every head gets re-RoPE'd.
     engine_kv_format = getattr(group, "engine_kv_format", None)
-    fused_packed = (
+    fused_format = (
         engine_kv_format is not None
         and get_spec_class(engine_kv_format).is_fused_packed
+    )
+    declared_hs = getattr(getattr(group, "shape_desc", None), "hs", None)
+    fused_packed = fused_format and (
+        declared_hs is None or declared_hs == 2 * head_size
     )
     per_head = head_size * (2 if fused_packed else 1)
     n_heads = hidden_dim // per_head

--- a/tests/v1/multiprocess/test_cb_fused_geometry.py
+++ b/tests/v1/multiprocess/test_cb_fused_geometry.py
@@ -7,7 +7,16 @@ as split K/V it halves ``per_head``, doubles ``n_heads``, and the rope kernel
 then rotates the V half of every head. The helper used to decide this from a
 hardcoded format list, so any fused format added later silently took the
 split path; these tests pin the decision to the spec fact for every
-``EngineKVFormat`` so a new format cannot regress it. CPU only.
+``EngineKVFormat`` so a new format cannot regress it.
+
+The spec fact alone is not sufficient, though: it is recorded once per
+registration, and a registration may MIX a fused main K/V group with a
+key-only side cache. MiniMax-M3 does exactly that (60 fused ``2 * head_size``
+layers plus 57 key-only ``head_size`` lightning-indexer layers, all rank 4 and
+all ``kv_size == 1``), so the shared format labelled the index group fused,
+``per_head`` became ``2 * head_size``, and it did not divide that group's row --
+every CB retrieve raised and the blend degraded on every rank. The mixed-
+registration tests below pin the per-group rule. CPU only.
 """
 
 # Standard
@@ -31,6 +40,23 @@ def _group(engine_kv_format, tokens_per_block: int = 4) -> SimpleNamespace:
         tokens_per_block=tokens_per_block,
         slots_per_block=tokens_per_block,
         engine_kv_format=engine_kv_format,
+    )
+
+
+def _group_with_shape(
+    engine_kv_format, nh: int, hs: int, tokens_per_block: int = 128
+) -> SimpleNamespace:
+    """Kernel-group stand-in that also declares its allocated shape.
+
+    ``shape_desc.hs`` is the per-head width vLLM allocated for THIS group --
+    ``2 * head_size`` when K/V are packed together, ``head_size`` when the group
+    is key-only or split.
+    """
+    return SimpleNamespace(
+        tokens_per_block=tokens_per_block,
+        slots_per_block=tokens_per_block,
+        engine_kv_format=engine_kv_format,
+        shape_desc=SimpleNamespace(nh=nh, hs=hs),
     )
 
 
@@ -68,3 +94,77 @@ def test_untagged_group_infers_split_kv():
         _group(None), 2, NH * HS, HS, 0
     )
     assert (fused, per_head, n_heads, rot_offset) == (False, HS, NH, 0)
+
+
+# MiniMax-M3 as measured on an 8-way H200 run (head_size 128): kernel group 0 is
+# 60 fused layers of one 256-wide row, kernel group 1 is 57 key-only
+# lightning-indexer layers of one 128-wide row. Both are rank 4 and both report
+# kv_size == 1, so both carry the same fused engine_kv_format.
+M3_HEAD_SIZE = 128
+M3_FUSED_FORMAT = F.NL_X_NB_BS_NH_CS
+
+
+def test_mixed_registration_key_only_group_is_not_fused():
+    """Regression: the index side cache must not inherit the fused claim.
+
+    Before the per-group rule this raised
+    "hidden_dim (128) not a multiple of per-head width (256; fused=True)",
+    which the blend server answered as scatter_ran=False -- so every scatter
+    degraded TP-collectively and blend_rate was 0.0 with correct output.
+    """
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group_with_shape(M3_FUSED_FORMAT, nh=1, hs=M3_HEAD_SIZE),
+        1,
+        M3_HEAD_SIZE,
+        M3_HEAD_SIZE,
+        1,
+    )
+    # One 128-wide K plane, rotated whole: the indexer's keys ARE RoPE'd (the
+    # M3 write kernel ropes index-K at the token's absolute position), so this
+    # group must be rotated, just not as a fused pair.
+    assert (fused, per_head, n_heads, rot_offset) == (False, M3_HEAD_SIZE, 1, 0)
+
+
+def test_mixed_registration_main_group_stays_fused():
+    """The fused main K/V group in the same registration is unaffected."""
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group_with_shape(M3_FUSED_FORMAT, nh=1, hs=2 * M3_HEAD_SIZE),
+        1,
+        2 * M3_HEAD_SIZE,
+        M3_HEAD_SIZE,
+        0,
+    )
+    assert (fused, per_head, n_heads, rot_offset) == (
+        True,
+        2 * M3_HEAD_SIZE,
+        1,
+        0,
+    )
+
+
+def test_multi_head_fused_group_with_shape_desc_stays_fused():
+    """The ordinary fused case keeps working when a shape is declared."""
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group_with_shape(F.NL_X_NB_NH_BS_CS, nh=NH, hs=2 * HS),
+        1,
+        NH * 2 * HS,
+        HS,
+        0,
+    )
+    assert (fused, per_head, n_heads, rot_offset) == (True, 2 * HS, NH, 0)
+
+
+def test_declared_shape_never_promotes_a_non_fused_format():
+    """The per-group width only ever NARROWS a fused claim, never widens one.
+
+    A split-K/V registration whose row happens to be ``2 * head_size`` wide is
+    two heads, not one fused head; the format is authoritative for that.
+    """
+    fused, per_head, n_heads, rot_offset = _cb_group_rope_geometry(
+        _group_with_shape(F.NL_X_TWO_NB_NH_BS_HS, nh=2, hs=HS),
+        2,
+        2 * HS,
+        HS,
+        0,
+    )
+    assert (fused, per_head, n_heads, rot_offset) == (False, HS, 2, 0)


### PR DESCRIPTION
`engine_kv_format` is chosen once per **registration**, while fused-ness is a property
of the **group**. MiniMax-M3's lightning-indexer group is key-only (`hs=128`) but
inherited a fused-packed format, so the re-RoPE geometry computed `128 // 256 == 0`
and raised.

Measured on `bench_quality`/minimax_m3 before the fix: `blend_degraded=408`
(8 ranks x 51 calls), `blend_loads=0`, `cb_f1=0.9632` -- a full-recompute F1 with
CacheBlend contributing nothing. The gate reported `blend_rate 0.0`.

Fused-ness is now decided from the group's own `shape_desc.hs` when it declares one,
falling back to the registration format only when it does not.

## Verification

E2E on 8xH200, TP=8, vLLM 0.28.1rc1.dev136, comprehensive-tier args:

| workload | model | result |
|---|---|---|
| `bench_quality` | minimax_m3 | **PASS** cb_f1 0.9669 / std_f1 0.9632, regression **-0.0038** |
| `bench_quality` | glm_5_2 | **PASS** regression **-0.0017** |

Unit tests: `tests/v1/multiprocess/test_cb_fused_geometry.py` gains 4 mixed-registration
cases (a key-only group alongside a fused one, and the reverse) that fail against the
unfixed code. Full suite 1912 passed, 41 skipped. Lint clean.

## Split out of this PR

Two read-lock fixes that were briefly on this branch now live in their own PR -- they
are a different subsystem (L1 read-lock accounting, not KV geometry) and want separate
review.
