### PR TITLE
[CI]: scope the vLLM 0.27.1 workaround to dsv4_flash_tp

### DIFF
--- a/.buildkite/k3_harness/resolve-pinned-vllm.sh
+++ b/.buildkite/k3_harness/resolve-pinned-vllm.sh
@@ -81,20 +81,6 @@ if [[ -z "${PINNED_VLLM_VERSION}" && "${USE_PINNED_VLLM}" == "true" ]]; then
     fi
 fi
 
-# The 0.28.1rc1 nightlies break DeepSeek-V4-Flash sparse decode on SM120
-# ("eidx must be contiguous", flashinfer _sparse_mla_sm120) at engine start.
-# The canary verifies nightlies with vllm_bench only, so it green-lit that
-# range and dsv4_flash_tp went red from the re-pin onward -- it was green on
-# 0.27.1 the same morning with everything else equal, and the same stack
-# passes on SM90. Clamp back to the last good release until a nightly passes
-# dsv4 again. TODO: drop the clamp and have the canary verify dsv4_flash_tp.
-if [[ "${PINNED_VLLM_VERSION}" == 0.28.1rc1.* ]]; then
-    echo "[resolve-pinned-vllm] pin ${PINNED_VLLM_VERSION} is in the"          "known-bad 0.28.1rc1 range for dsv4_flash_tp; clamping to 0.27.1" >&2
-    PINNED_VLLM_VERSION="0.27.1"
-    PINNED_VLLM_ARCHIVE_INDEX_URL=""
-    PINNED_VLLM_FULL_SHA=""
-fi
-
 export PINNED_VLLM_VERSION
 export PINNED_VLLM_ARCHIVE_INDEX_URL
 export PINNED_VLLM_FULL_SHA

--- a/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
@@ -220,18 +220,89 @@ count_retrieves() {
     grep -c "Retrieved" "$LMCACHE_LOG" 2>/dev/null || true
 }
 
-# ── 0a. Pin vLLM for this test only ─────────────────────────
+# ── 0a. Probe the ambient vLLM, downgrade only if it is broken ──
 # The 0.28.1rc1 nightlies break DeepSeek-V4-Flash sparse decode on SM120
-# ("eidx must be contiguous", flashinfer _sparse_mla_sm120) at engine start;
-# 0.27.1 is the last release that passes, and every other k3 test is green
-# on the nightlies, so the downgrade is scoped to this test. Same torch
-# (2.13.0+cu130), so the LMCache native build stays valid. Set
-# DSV4_VLLM_VERSION="" to run the ambient vLLM instead.
-# TODO: drop once a nightly passes this test again.
-DSV4_VLLM_VERSION="${DSV4_VLLM_VERSION-0.27.1}"
-if [ -n "$DSV4_VLLM_VERSION" ]; then
-    echo "=== Pinning vLLM ${DSV4_VLLM_VERSION} for dsv4_flash_tp ==="
-    uv pip install "vllm[runai,tensorizer,flashinfer]==${DSV4_VLLM_VERSION}" \
+# ("eidx must be contiguous", flashinfer _sparse_mla_sm120) during engine
+# start. That is a pure-vLLM fault -- it reproduces with no connector
+# configured -- so probe for it instead of hardcoding "nightlies are bad":
+# boot vLLM alone with dummy weights and see whether the engine comes up.
+# Healthy keeps the ambient (nightly) vLLM, so this test returns to nightly
+# coverage on its own once upstream fixes the kernel, with no code change.
+# Broken installs the last release that passes. Same torch (2.13.0+cu130)
+# either way, so the LMCache native build stays valid.
+#
+# Dummy weights keep the probe cheap: the crash is a stride/contiguity check
+# in the warmup decode, which runs regardless of weight *values*. Every
+# ambiguous outcome (timeout, launch failure) is treated as broken, since
+# falling back to the pinned version still produces a valid test run.
+DSV4_FALLBACK_VLLM_VERSION="${DSV4_FALLBACK_VLLM_VERSION-0.27.1}"
+DSV4_PROBE_PORT="${DSV4_PROBE_PORT:-8971}"
+DSV4_PROBE_TIMEOUT="${DSV4_PROBE_TIMEOUT:-900}"
+
+# Wait for every process in $1's process group to disappear, so the probe
+# cannot leave workers holding GPU memory when the real run starts.
+wait_for_pgid_exit() {
+    local pgid="$1" deadline=$((SECONDS + 120))
+    [ -n "$pgid" ] || return 0
+    kill -TERM -"$pgid" 2>/dev/null || true
+    while kill -0 -"$pgid" 2>/dev/null; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            kill -KILL -"$pgid" 2>/dev/null || true
+            break
+        fi
+        sleep 2
+    done
+    sleep 10  # let the driver release device memory
+}
+
+# Boot vLLM alone (no LMCache connector) on dummy weights.
+# Returns 0 if the engine serves, 1 if it crashes / never comes up.
+probe_ambient_vllm() {
+    local probe_log="$TP_DIR/vllm_probe.log"
+    echo "=== Probing ambient vLLM $(python3 -c 'import vllm; print(vllm.__version__)') ==="
+    echo "Probe log: $probe_log"
+    # Model-shaping flags mirror the real launch below (they select the
+    # kernels); the connector, prefix caching and dev mode are omitted.
+    setsid env -u VLLM_PORT vllm serve "$MODEL" \
+        --tensor-parallel-size "$TENSOR_PARALLEL_SIZE" \
+        --enable-expert-parallel \
+        --kv-cache-dtype fp8_ds_mla \
+        --tokenizer-mode deepseek_v4 \
+        --trust-remote-code \
+        --enforce-eager \
+        --load-format dummy \
+        --max-model-len auto \
+        --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
+        --port "$DSV4_PROBE_PORT" \
+        > "$probe_log" 2>&1 &
+    local probe_pid=$! probe_pgid rc=1 verdict="timed out after ${DSV4_PROBE_TIMEOUT}s"
+    probe_pgid="$(ps -o pgid= -p "$probe_pid" | tr -d ' ')"
+    echo "$probe_pid" >> "$PID_FILE"
+
+    local deadline=$((SECONDS + DSV4_PROBE_TIMEOUT))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if curl -sf "http://localhost:${DSV4_PROBE_PORT}/v1/models" >/dev/null 2>&1; then
+            rc=0 verdict="serves"
+            break
+        fi
+        if ! kill -0 "$probe_pid" 2>/dev/null; then
+            verdict="died during startup"
+            tail -n 25 "$probe_log"
+            break
+        fi
+        sleep 5
+    done
+    echo "Probe verdict: ambient vLLM ${verdict}."
+
+    wait_for_pgid_exit "$probe_pgid"
+    return "$rc"
+}
+
+if [ -z "$DSV4_FALLBACK_VLLM_VERSION" ]; then
+    echo "=== DSV4_FALLBACK_VLLM_VERSION empty: using ambient vLLM unprobed ==="
+elif ! probe_ambient_vllm; then
+    echo "=== Installing vLLM ${DSV4_FALLBACK_VLLM_VERSION} for this test ==="
+    uv pip install "vllm[runai,tensorizer,flashinfer]==${DSV4_FALLBACK_VLLM_VERSION}" \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --index-strategy unsafe-best-match
     python3 -c "import vllm; print('vLLM for this test:', vllm.__version__)"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
@@ -220,7 +220,24 @@ count_retrieves() {
     grep -c "Retrieved" "$LMCACHE_LOG" 2>/dev/null || true
 }
 
-# ── 0. Provision DeepGEMM (SM120 only) ──────────────────────
+# ── 0a. Pin vLLM for this test only ─────────────────────────
+# The 0.28.1rc1 nightlies break DeepSeek-V4-Flash sparse decode on SM120
+# ("eidx must be contiguous", flashinfer _sparse_mla_sm120) at engine start;
+# 0.27.1 is the last release that passes, and every other k3 test is green
+# on the nightlies, so the downgrade is scoped to this test. Same torch
+# (2.13.0+cu130), so the LMCache native build stays valid. Set
+# DSV4_VLLM_VERSION="" to run the ambient vLLM instead.
+# TODO: drop once a nightly passes this test again.
+DSV4_VLLM_VERSION="${DSV4_VLLM_VERSION-0.27.1}"
+if [ -n "$DSV4_VLLM_VERSION" ]; then
+    echo "=== Pinning vLLM ${DSV4_VLLM_VERSION} for dsv4_flash_tp ==="
+    uv pip install "vllm[runai,tensorizer,flashinfer]==${DSV4_VLLM_VERSION}" \
+        --extra-index-url https://download.pytorch.org/whl/cu130 \
+        --index-strategy unsafe-best-match
+    python3 -c "import vllm; print('vLLM for this test:', vllm.__version__)"
+fi
+
+# ── 0b. Provision DeepGEMM (SM120 only) ──────────────────────
 # vLLM's _import_deep_gemm() prefers a `deep_gemm` in site-packages over the
 # copy bundled in the wheel, so installing one overrides the arch-incomplete
 # bundled build without rebuilding vLLM. Build steps mirror vLLM's own

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -184,10 +184,14 @@ stop_vllm() {
     fi
     # Free the serving port in case a child socket lingers.
     fuser -k "${VLLM_PORT}/tcp" 2>/dev/null || true
-    # GPU 1 is used exclusively by vLLM (the LMCache server pins its CUDA
-    # context on GPU 0), so its memory dropping to near-idle is a clean signal
-    # that the old vLLM (and its TP workers) are fully gone.
+    # TP=2 puts a vLLM rank on GPU 0 and GPU 1, so both have to come back
+    # before the relaunch sizes its KV cache -- waiting on GPU 1 alone let a
+    # rank-0 allocation that outlived the process shrink the relaunch's budget
+    # ("Free memory on device cuda:0 ... less than desired GPU memory
+    # utilization"). GPU 1 is vLLM's alone; GPU 0 also carries the LMCache
+    # server, so it is measured against the pre-vLLM baseline.
     wait_for_gpu_release 1 2000
+    wait_for_gpu_release 0 $(( GPU0_BASELINE_MIB + 2000 ))
 }
 
 # Send one greedy completion request and write the generated text to a file.
@@ -250,6 +254,13 @@ LMCACHE_PID=$!
 echo "$LMCACHE_PID" >> "$PID_FILE"
 echo "LMCache MP server started (PID=$LMCACHE_PID)"
 sleep 10
+
+# Everything on GPU 0 that is not vLLM (the LMCache server's CUDA context and
+# its buffers). stop_vllm waits for GPU 0 to come back to this, so the wait
+# does not depend on guessing the server's footprint.
+GPU0_BASELINE_MIB=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits \
+    -i 0 2>/dev/null | tr -d ' ' || echo 0)
+echo "GPU 0 baseline before vLLM: ${GPU0_BASELINE_MIB} MiB"
 
 # ── 2. Build a long, deterministic prompt, then ask for a summary ──
 # A ~7-8k word document (well over the several-thousand-token span needed for


### PR DESCRIPTION
Follow-up to #4801: the clamp held the whole k3 suite on vLLM 0.27.1, but only `dsv4_flash_tp` needs it -- every other job is empirically green on the 0.28.1rc1 nightlies (k3-mp build 4570 ran them all on `dev91` with only dsv4 red).

This removes the clamp so the canary pin / latest nightly applies as normal, and `run-dsv4-flash-tp.sh` installs `vllm==0.27.1` for itself before launching (next to its existing arch-specific DeepGEMM provisioning). Same torch (2.13.0+cu130), so the LMCache native build stays valid. `DSV4_VLLM_VERSION=""` runs the ambient vLLM instead; drop the block once a nightly passes the test (upstream SM120 regression: `eidx must be contiguous`, flashinfer `_sparse_mla_sm120`, 0.27.1 -> 0.28.1rc1 window).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Buildkite test scripts (vLLM version selection and GPU teardown timing); no application runtime or data paths are touched.
> 
> **Overview**
> **Removes the k3-wide vLLM pin** that forced `0.28.1rc1` nightlies back to `0.27.1` in `resolve-pinned-vllm.sh`, so the canary/nightly pin applies to the rest of the multiprocess suite again.
> 
> **`dsv4_flash_tp` now decides vLLM at test time:** it boots ambient vLLM with dummy weights and the same kernel-shaping flags as the real run; if startup fails or times out, it installs `DSV4_FALLBACK_VLLM_VERSION` (default `0.27.1`) for that job only. A healthy nightly is kept automatically once the SM120 sparse-decode regression is fixed. Probe teardown waits on the process group so GPUs are free before the main run.
> 
> **`run-kimi-linear-tp.sh`** records GPU 0 memory before vLLM and, on restart, waits for **both** TP GPUs to release memory (GPU 0 vs LMCache baseline + slack, GPU 1 vs idle), avoiding relaunch KV-cache sizing failures when rank-0 allocations linger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6fee49f46e77ca2b4d9ce361601dc160c54ff6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->