### PR TITLE
fix: two logging calls that raise and drop their message

### DIFF
--- a/lmcache/v1/storage_backend/connector/mock_connector.py
+++ b/lmcache/v1/storage_backend/connector/mock_connector.py
@@ -276,8 +276,10 @@ class MockConnector(RemoteConnector):
             )
             if memory_obj is None:
                 logger.warning(
-                    "Failed to allocate memory even with",
-                    f" busy loop on {i} out of {len(mock_objs)} objects",
+                    "Failed to allocate memory even with busy loop on %s out of %s"
+                    " objects",
+                    i,
+                    len(mock_objs),
                 )
                 break
             memory_objs.append(memory_obj)

--- a/lmcache/v1/storage_backend/p2p_backend.py
+++ b/lmcache/v1/storage_backend/p2p_backend.py
@@ -152,7 +152,9 @@ class PeerInfo:
         try:
             self.lookup_socket.close(linger=0)
         except Exception as e:
-            logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
+            logger.error(
+                "Failed to close peer %s lookup socket: %s", self.peer_init_url, e
+            )
         self.lookup_socket = new_lookup_socket
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ select = [
     #"G",
     # flake8-self (private member access)
     "SLF",
+    # pylint: logging call has more arguments than format placeholders
+    "PLE1205",
 ]
 ignore = [
     # star imports


### PR DESCRIPTION
**What this PR does / why we need it**:

Two `logger` calls pass more arguments than their format string has placeholders. `record.getMessage()` then raises `TypeError: not all arguments converted during string formatting`; the logging module catches it, writes `--- Logging error ---` to stderr, and **the intended message is never emitted**.

| site | shape | consequence |
|---|---|---|
| `lmcache/v1/storage_backend/p2p_backend.py:155` | one `%s`, two args | the exception `e` is lost |
| `lmcache/v1/storage_backend/connector/mock_connector.py:278` | no placeholders, one arg | a `,` where the author meant string concatenation |

The p2p one is the one that costs something. It is the error path for closing a peer lookup socket:

```python
except Exception as e:
    logger.error("Failed to close peer %s lookup socket", self.peer_init_url, e)
```

so the diagnostic disappears at exactly the moment it is wanted.

Reproduced standalone on CPython 3.12 (same call shapes, no LMCache imports):

```
--- Logging error ---
TypeError: not all arguments converted during string formatting
Message: 'Failed to allocate memory even with'
Arguments: (' busy loop on 3 out of 8 objects',)
```

and after the fix:

```
ERROR:repro:Failed to close peer tcp://10.0.0.4:5555 lookup socket: socket already closed
```

Both rewrites keep lazy `%s` formatting, consistent with the direction of #4779 / #4737.

**Special notes for your reviewers**:

- I enabled ruff `PLE1205` rather than adding a unit test. Per `docs/coding_standards.md` §5.2 a bug fix wants a regression test, but a meaningful test here would have to stand up a `P2PBackend` peer with live zmq sockets just to assert that a log record renders — the lint rule prevents recurrence tree-wide for one line of config. These two were the **only** `PLE1205` hits in the repo, so `ruff check .` with your existing config plus this rule is green as of this commit. Happy to split the `pyproject.toml` hunk into its own PR if you would rather keep this one to the two source lines (§1.1).
- `ruff format --check` and `ruff check` pass on the touched files. I did not run `pre-commit run --all-files` or the pytest suites — I do not have the full toolchain or a GPU on this machine.
- AI-assisted.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
