### PR TITLE
[Bugfix][MP][NIXL] Isolate dynamic store paths by cache_salt

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/nixl_store.md
+++ b/docs/design/v1/distributed/l2_adapters/nixl_store.md
@@ -141,7 +141,7 @@ and using deterministic file names derived from `ObjectKey`.
 | Aspect | Static | Dynamic |
 |---|---|---|
 | File lifecycle | All opened at init, closed at shutdown | Opened per store/load, closed after each transfer |
-| File naming | Random UUID (`obj_{i}_{uuid}.bin`) | Deterministic from the complete ObjectKey |
+| File naming | Random UUID (`obj_{i}_{uuid}.bin`) | Readable fields (`{model}_{rank}_{group}_{hash}[@{cache_salt}].bin`) |
 | Nixl registration | Single prepped dlist for all storage | Per-operation register → transfer → deregister |
 | Pool / page indices | `NixlObjPool` manages fixed slots | No pool; `NixlStoreObj.page_indices` unused (`[]`) |
 | Capacity control | Pool size (slot count) | `max_capacity_gb` (byte-based) |

--- a/docs/design/v1/distributed/l2_adapters/nixl_store.md
+++ b/docs/design/v1/distributed/l2_adapters/nixl_store.md
@@ -149,11 +149,10 @@ and using deterministic file names derived from `ObjectKey`.
 | Batching | One DMA transfer per batch of keys | One DMA transfer per key (each key = separate file) |
 
 For compatibility, keys with an empty `cache_salt` retain the legacy filename
-and chunk-hash shard. Keys with a non-empty salt use
-`salted-v1_<sha256>.bin`, where the digest covers every `ObjectKey` field using
-a domain-separated, length-delimited encoding. This keeps filenames bounded,
-does not expose the raw salt, and gives flat and sharded layouts the same key
-identity.
+and chunk-hash shard. Keys with a non-empty salt append `@<cache_salt>` before
+the `.bin` extension, matching the trailing-salt representation used by the S3
+and filesystem L2 adapters. Sharded layouts continue to use the chunk hash for
+the directory levels; the filename provides the salt isolation.
 
 ### Key Components
 

--- a/docs/design/v1/distributed/l2_adapters/nixl_store.md
+++ b/docs/design/v1/distributed/l2_adapters/nixl_store.md
@@ -141,12 +141,19 @@ and using deterministic file names derived from `ObjectKey`.
 | Aspect | Static | Dynamic |
 |---|---|---|
 | File lifecycle | All opened at init, closed at shutdown | Opened per store/load, closed after each transfer |
-| File naming | Random UUID (`obj_{i}_{uuid}.bin`) | Deterministic from ObjectKey (`{model}_{rank}_{hash}.bin`) |
+| File naming | Random UUID (`obj_{i}_{uuid}.bin`) | Deterministic from the complete ObjectKey |
 | Nixl registration | Single prepped dlist for all storage | Per-operation register → transfer → deregister |
 | Pool / page indices | `NixlObjPool` manages fixed slots | No pool; `NixlStoreObj.page_indices` unused (`[]`) |
 | Capacity control | Pool size (slot count) | `max_capacity_gb` (byte-based) |
 | Persist/recover | Not supported | Supported |
 | Batching | One DMA transfer per batch of keys | One DMA transfer per key (each key = separate file) |
+
+For compatibility, keys with an empty `cache_salt` retain the legacy filename
+and chunk-hash shard. Keys with a non-empty salt use
+`salted-v1_<sha256>.bin`, where the digest covers every `ObjectKey` field using
+a domain-separated, length-delimited encoding. This keeps filenames bounded,
+does not expose the raw salt, and gives flat and sharded layouts the same key
+identity.
 
 ### Key Components
 
@@ -252,6 +259,12 @@ In `close()`, after the event loop has stopped:
 
 No metadata JSON is written — the deterministic `ObjectKey → filename`
 mapping is sufficient to rediscover each file on restart.
+
+Files created by older releases for non-empty salts are ambiguous because the
+legacy filename did not record the salt. Salted lookup does not fall back to
+that path. Clear or quarantine the old cache directory before upgrading a
+deployment that previously used salted dynamic-NIXL traffic; unsalted paths
+remain compatible.
 
 #### Secondary Lookup (lazy disk recovery)
 

--- a/docs/source/mp/l2_storage/nixl.rst
+++ b/docs/source/mp/l2_storage/nixl.rst
@@ -112,11 +112,10 @@ per-operation instead of pre-allocating them at init. This enables:
   controller to compute usage.
 - ``shard_dirs``: ``"true"`` or ``"false"`` (default ``"false"``). When
   ``"true"``, data files are spread across a two-level subdirectory tree
-  under ``file_path`` instead of all living in one flat directory. Unsalted
-  keys use the first four hex characters of the chunk hash. Salted keys use
-  the first four characters of the versioned full-key digest also embedded in
-  ``salted-v1_<digest>.bin``. Both layouts provide up to 256 × 256
-  subdirectories. Leaving ``shard_dirs`` unset preserves the flat layout.
+  under ``file_path`` instead of all living in one flat directory. The two
+  levels use the first four hex characters of the chunk hash for both salted
+  and unsalted keys, providing up to 256 × 256 subdirectories. Leaving
+  ``shard_dirs`` unset preserves the flat layout.
 
   Large flat directories slow down metadata operations on many filesystems,
   so sharding helps once a single cache directory holds a large number of
@@ -135,6 +134,10 @@ per-operation instead of pre-allocating them at init. This enables:
      to salt-blind legacy paths. Those files cannot be safely attributed to a
      salt and are not used as a fallback. Clear or quarantine that cache
      directory when upgrading a deployment that used non-empty salts.
+
+For both flat and sharded layouts, a non-empty ``cache_salt`` is appended to
+the filename as ``@<cache_salt>`` before ``.bin``. An empty salt retains the
+legacy filename.
 
 **Optional fields (for persist):**
 

--- a/docs/source/mp/l2_storage/nixl.rst
+++ b/docs/source/mp/l2_storage/nixl.rst
@@ -112,12 +112,11 @@ per-operation instead of pre-allocating them at init. This enables:
   controller to compute usage.
 - ``shard_dirs``: ``"true"`` or ``"false"`` (default ``"false"``). When
   ``"true"``, data files are spread across a two-level subdirectory tree
-  under ``file_path`` instead of all living in one flat directory. The two
-  levels are the first four hex characters of the chunk hash, matching the
-  hash prefix already embedded in the filename
-  (for example ``834ebc79...`` is stored as ``83/4e/<filename>``), giving a
-  fanout of up to 256 × 256 subdirectories. Leaving it unset preserves the
-  original flat layout.
+  under ``file_path`` instead of all living in one flat directory. Unsalted
+  keys use the first four hex characters of the chunk hash. Salted keys use
+  the first four characters of the versioned full-key digest also embedded in
+  ``salted-v1_<digest>.bin``. Both layouts provide up to 256 × 256
+  subdirectories. Leaving ``shard_dirs`` unset preserves the flat layout.
 
   Large flat directories slow down metadata operations on many filesystems,
   so sharding helps once a single cache directory holds a large number of
@@ -131,6 +130,11 @@ per-operation instead of pre-allocating them at init. This enables:
      directory makes previously written files unreachable (they are not
      deleted, just no longer found). Choose the layout when the cache
      directory is first created, or clear it when changing the setting.
+
+     Releases that predate salted dynamic-NIXL filenames wrote salted traffic
+     to salt-blind legacy paths. Those files cannot be safely attributed to a
+     salt and are not used as a fallback. Clear or quarantine that cache
+     directory when upgrading a deployment that used non-empty salts.
 
 **Optional fields (for persist):**
 

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_agents/dynamic_nixl_store_agent.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_agents/dynamic_nixl_store_agent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 import asyncio
+import hashlib
 import os
 import uuid
 
@@ -21,6 +22,41 @@ from nixl._api import nixlBind
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.internal_api import L1MemoryDesc
 
+_SALTED_KEY_DOMAIN = b"lmcache.dynamic-nixl.object-key.v1\x00"
+_SALTED_FILENAME_PREFIX = "salted-v1_"
+_FILE_EXTENSION = ".bin"
+
+
+def _salted_object_key_digest(key: ObjectKey) -> str:
+    """Return a stable SHA-256 digest covering every ``ObjectKey`` field."""
+    digest = hashlib.sha256(_SALTED_KEY_DOMAIN)
+    fields = (
+        key.model_name.encode("utf-8"),
+        str(key.kv_rank).encode("ascii"),
+        str(key.object_group_id).encode("ascii"),
+        key.chunk_hash,
+        key.cache_salt.encode("utf-8"),
+    )
+    for field in fields:
+        digest.update(len(field).to_bytes(8, byteorder="big"))
+        digest.update(field)
+    return digest.hexdigest()
+
+
+def _object_key_storage_components(key: ObjectKey) -> tuple[str, str]:
+    """Return the sharding token and deterministic filename for ``key``."""
+    if key.cache_salt:
+        digest = _salted_object_key_digest(key)
+        return digest, f"{_SALTED_FILENAME_PREFIX}{digest}{_FILE_EXTENSION}"
+
+    safe_model_name = key.model_name.replace("/", "--")
+    chunk_hex = key.chunk_hash.hex()
+    filename = (
+        f"{safe_model_name}_{key.kv_rank:08x}_"
+        f"{key.object_group_id:x}_{chunk_hex}{_FILE_EXTENSION}"
+    )
+    return chunk_hex, filename
+
 
 def _object_key_to_filename(key: ObjectKey) -> str:
     """Derive a deterministic storage object name from an object key.
@@ -31,24 +67,17 @@ def _object_key_to_filename(key: ObjectKey) -> str:
     Returns:
         A deterministic object name that is safe to use as a file name.
     """
-    safe_model_name = key.model_name.replace("/", "--")
-    chunk_hex = key.chunk_hash.hex()
-    return (
-        f"{safe_model_name}_{key.kv_rank:08x}_{key.object_group_id:x}_{chunk_hex}.bin"
-    )
+    return _object_key_storage_components(key)[1]
 
 
 def _object_key_to_relpath(key: ObjectKey) -> str:
-    """Relative path ``<hex[:2]>/<hex[2:4]>/filename`` — a 2-level hash-prefix
-    subdir tree (GDS-style) keyed on the chunk-hash hex.
+    """Return a two-level sharded path for ``key``.
 
-    ``hex`` is ``chunk_hash.hex()``, the same value embedded in the filename, so
-    the two subdir levels are the first four hex chars of the hash and match the
-    filename's hash prefix (e.g. ``834e...`` -> ``83/4e/``). Spreads files
-    across up to 256*256 subdirectories instead of one flat directory.
+    Unsalted keys retain the legacy chunk-hash shard. Salted keys use the
+    complete-key digest for both the shard and filename.
     """
-    h = key.chunk_hash.hex()
-    return os.path.join(h[:2], h[2:4], _object_key_to_filename(key))
+    shard, filename = _object_key_storage_components(key)
+    return os.path.join(shard[:2], shard[2:4], filename)
 
 
 class DynamicNixlStorageAgent(ABC):

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_agents/dynamic_nixl_store_agent.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_agents/dynamic_nixl_store_agent.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 import asyncio
-import hashlib
 import os
 import uuid
 
@@ -22,44 +21,13 @@ from nixl._api import nixlBind
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.internal_api import L1MemoryDesc
 
-_SALTED_KEY_DOMAIN = b"lmcache.dynamic-nixl.object-key.v1\x00"
-_SALTED_FILENAME_PREFIX = "salted-v1_"
-_FILE_EXTENSION = ".bin"
-
-
-def _salted_object_key_digest(key: ObjectKey) -> str:
-    """Return a stable SHA-256 digest covering every ``ObjectKey`` field."""
-    digest = hashlib.sha256(_SALTED_KEY_DOMAIN)
-    fields = (
-        key.model_name.encode("utf-8"),
-        str(key.kv_rank).encode("ascii"),
-        str(key.object_group_id).encode("ascii"),
-        key.chunk_hash,
-        key.cache_salt.encode("utf-8"),
-    )
-    for field in fields:
-        digest.update(len(field).to_bytes(8, byteorder="big"))
-        digest.update(field)
-    return digest.hexdigest()
-
-
-def _object_key_storage_components(key: ObjectKey) -> tuple[str, str]:
-    """Return the sharding token and deterministic filename for ``key``."""
-    if key.cache_salt:
-        digest = _salted_object_key_digest(key)
-        return digest, f"{_SALTED_FILENAME_PREFIX}{digest}{_FILE_EXTENSION}"
-
-    safe_model_name = key.model_name.replace("/", "--")
-    chunk_hex = key.chunk_hash.hex()
-    filename = (
-        f"{safe_model_name}_{key.kv_rank:08x}_"
-        f"{key.object_group_id:x}_{chunk_hex}{_FILE_EXTENSION}"
-    )
-    return chunk_hex, filename
-
 
 def _object_key_to_filename(key: ObjectKey) -> str:
     """Derive a deterministic storage object name from an object key.
+
+    A non-empty ``cache_salt`` is appended as a trailing ``@``-delimited
+    field, matching the S3 and filesystem L2 adapters. An empty salt retains
+    the exact legacy filename.
 
     Args:
         key: Key identifying the stored cache object.
@@ -67,17 +35,23 @@ def _object_key_to_filename(key: ObjectKey) -> str:
     Returns:
         A deterministic object name that is safe to use as a file name.
     """
-    return _object_key_storage_components(key)[1]
+    safe_model_name = key.model_name.replace("/", "--")
+    chunk_hex = key.chunk_hash.hex()
+    salt_suffix = f"@{key.cache_salt}" if key.cache_salt else ""
+    return (
+        f"{safe_model_name}_{key.kv_rank:08x}_"
+        f"{key.object_group_id:x}_{chunk_hex}{salt_suffix}.bin"
+    )
 
 
 def _object_key_to_relpath(key: ObjectKey) -> str:
-    """Return a two-level sharded path for ``key``.
+    """Return a two-level chunk-hash-sharded path for ``key``.
 
-    Unsalted keys retain the legacy chunk-hash shard. Salted keys use the
-    complete-key digest for both the shard and filename.
+    The shard remains independent of ``cache_salt``; salted keys with the same
+    chunk hash have distinct filenames inside the same shard.
     """
-    shard, filename = _object_key_storage_components(key)
-    return os.path.join(shard[:2], shard[2:4], filename)
+    chunk_hex = key.chunk_hash.hex()
+    return os.path.join(chunk_hex[:2], chunk_hex[2:4], _object_key_to_filename(key))
 
 
 class DynamicNixlStorageAgent(ABC):

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -7,11 +7,13 @@ persist, secondary lookup, and capacity management.
 """
 
 # Standard
+from pathlib import Path
 import inspect
 import os
 import select
 import shutil
 import tempfile
+import time
 
 # Third Party
 import pytest
@@ -41,6 +43,7 @@ from lmcache.v1.distributed.l2_adapters.nixl_store_dynamic_l2_adapter import (  
 )
 from lmcache.v1.memory_management import (  # noqa: E402
     MemoryFormat,
+    MemoryObj,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
@@ -74,6 +77,9 @@ class _RecordingListener(L2AdapterListener):
 PAGE_SIZE = 4096  # 4 KB per page
 NUM_BUFFER_PAGES = 20  # pages in the registered memory buffer
 MAX_CAPACITY_GB = 0.001  # ~1 MB
+SALTED_GOLDEN_FILENAME = (
+    "salted-v1_0d1618328728b71e944064dbc9c98bdfa6e268e35e4d6c9c54619ee0090baccb.bin"
+)
 
 if torch_device_type == "xpu":
     pytest.skip(
@@ -135,12 +141,17 @@ def test_file_agent_creates_directory_before_nixl_initialization(
 # =============================================================================
 
 
-def create_object_key(chunk_id: int, model_name: str = "test_model") -> ObjectKey:
+def create_object_key(
+    chunk_id: int,
+    model_name: str = "test_model",
+    cache_salt: str = "",
+) -> ObjectKey:
     """Create a test ObjectKey with the given chunk ID."""
     return ObjectKey(
         chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
         model_name=model_name,
         kv_rank=0,
+        cache_salt=cache_salt,
     )
 
 
@@ -182,6 +193,57 @@ def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
             pass
         return True
     return False
+
+
+def create_adapter_for_path(
+    file_path: Path,
+    buffer: torch.Tensor,
+    *,
+    persist_enabled: bool = False,
+    shard_dirs: bool = False,
+) -> tuple[
+    DynamicNixlStoreL2Adapter,
+    L1MemoryDesc,
+    DynamicNixlStoreL2AdapterConfig,
+]:
+    """Create a POSIX dynamic adapter using ``file_path``."""
+    l1_memory = L1MemoryDesc(
+        ptr=buffer.data_ptr(),
+        size=buffer.numel(),
+        align_bytes=PAGE_SIZE,
+    )
+    config = DynamicNixlStoreL2AdapterConfig(
+        backend="POSIX",
+        backend_params={
+            "file_path": str(file_path),
+            "use_direct_io": "false",
+            "max_capacity_gb": str(MAX_CAPACITY_GB),
+            "shard_dirs": str(shard_dirs).lower(),
+        },
+    )
+    config.persist_config = PersistConfig(persist_enabled=persist_enabled)
+    return DynamicNixlStoreL2Adapter(config, l1_memory), l1_memory, config
+
+
+def store_and_wait(
+    adapter: DynamicNixlStoreL2Adapter,
+    keys: list[ObjectKey],
+    objects: list[MemoryObj],
+) -> None:
+    """Store objects and assert successful asynchronous completion."""
+    task_id = adapter.submit_store_task(keys, objects)
+    assert wait_for_event_fd(adapter.get_store_event_fd())
+    result = adapter.pop_completed_store_tasks()[task_id]
+    assert result.is_successful()
+
+
+def list_data_files(file_path: Path) -> list[str]:
+    """Return sorted data-file paths relative to ``file_path``."""
+    return sorted(
+        str(path.relative_to(file_path))
+        for path in file_path.rglob("*.bin")
+        if path.is_file()
+    )
 
 
 # =============================================================================
@@ -608,6 +670,296 @@ class TestEndToEnd:
 
         # Unlock
         adpt.submit_unlock([key])
+
+
+# =============================================================================
+# Cache Salt Isolation Tests
+# =============================================================================
+
+
+class TestCacheSaltIsolation:
+    @pytest.mark.parametrize("shard_dirs", [False, True], ids=["flat", "sharded"])
+    def test_store_and_delete_are_isolated_by_salt(
+        self, tmp_path: Path, shard_dirs: bool
+    ) -> None:
+        """Deleting one salted key must leave the other key loadable."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=shard_dirs)
+        key_a = create_object_key(1, cache_salt="tenant-a")
+        key_b = create_object_key(1, cache_salt="tenant-b")
+
+        try:
+            store_and_wait(
+                adpt,
+                [key_a, key_b],
+                [
+                    create_memory_obj(buffer, page_index=0, fill_value=11.0),
+                    create_memory_obj(buffer, page_index=1, fill_value=22.0),
+                ],
+            )
+
+            assert len(list_data_files(tmp_path)) == 2
+            assert dict(adpt.get_usage().bytes_by_cache_salt) == {
+                "tenant-a": PAGE_SIZE,
+                "tenant-b": PAGE_SIZE,
+            }
+
+            adpt.delete([key_a])
+            assert dict(adpt.get_usage().bytes_by_cache_salt) == {"tenant-b": PAGE_SIZE}
+
+            lookup_task = adpt.submit_lookup_and_lock_task(
+                [key_a, key_b], {0: _EMPTY_LAYOUT}
+            )
+            assert wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
+            bitmap = adpt.query_lookup_and_lock_result(lookup_task)
+            assert bitmap is not None
+            assert not bitmap.test(0)
+            assert bitmap.test(1)
+
+            load_obj = create_memory_obj(buffer, page_index=2, fill_value=0.0)
+            load_task = adpt.submit_load_task([key_b], [load_obj])
+            assert wait_for_event_fd(adpt.get_load_event_fd())
+            bitmap = adpt.query_load_result(load_task)
+            assert bitmap is not None and bitmap.test(0)
+            loaded = buffer[2 * PAGE_SIZE : 3 * PAGE_SIZE].view(torch.float32)
+            assert torch.all(loaded == 22.0)
+            adpt.submit_unlock([key_b])
+        finally:
+            adpt.close()
+
+    @pytest.mark.parametrize("shard_dirs", [False, True], ids=["flat", "sharded"])
+    def test_salted_objects_recover_independently_after_restart(
+        self, tmp_path: Path, shard_dirs: bool
+    ) -> None:
+        """Persisted salted keys must recover with their original payloads."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, l1_memory, config = create_adapter_for_path(
+            tmp_path,
+            buffer,
+            persist_enabled=True,
+            shard_dirs=shard_dirs,
+        )
+        key_a = create_object_key(1, cache_salt="tenant-a")
+        key_b = create_object_key(1, cache_salt="tenant-b")
+        key_c = create_object_key(1, cache_salt="tenant-c")
+
+        try:
+            store_and_wait(
+                adpt,
+                [key_a, key_b],
+                [
+                    create_memory_obj(buffer, page_index=0, fill_value=31.0),
+                    create_memory_obj(buffer, page_index=1, fill_value=47.0),
+                ],
+            )
+        finally:
+            adpt.close()
+
+        recovered = DynamicNixlStoreL2Adapter(config, l1_memory)
+        try:
+            lookup_task = recovered.submit_lookup_and_lock_task(
+                [key_a, key_b, key_c], {0: _EMPTY_LAYOUT}
+            )
+            assert wait_for_event_fd(recovered.get_lookup_and_lock_event_fd())
+            bitmap = recovered.query_lookup_and_lock_result(lookup_task)
+            assert bitmap is not None
+            assert bitmap.test(0)
+            assert bitmap.test(1)
+            assert not bitmap.test(2)
+
+            load_objects: list[MemoryObj] = [
+                create_memory_obj(buffer, page_index=2, fill_value=0.0),
+                create_memory_obj(buffer, page_index=3, fill_value=0.0),
+            ]
+            load_task = recovered.submit_load_task([key_a, key_b], load_objects)
+            assert wait_for_event_fd(recovered.get_load_event_fd())
+            bitmap = recovered.query_load_result(load_task)
+            assert bitmap is not None
+            assert bitmap.test(0) and bitmap.test(1)
+            assert torch.all(
+                buffer[2 * PAGE_SIZE : 3 * PAGE_SIZE].view(torch.float32) == 31.0
+            )
+            assert torch.all(
+                buffer[3 * PAGE_SIZE : 4 * PAGE_SIZE].view(torch.float32) == 47.0
+            )
+            assert dict(recovered.get_usage().bytes_by_cache_salt) == {
+                "tenant-a": PAGE_SIZE,
+                "tenant-b": PAGE_SIZE,
+            }
+            recovered.submit_unlock([key_a, key_b])
+        finally:
+            recovered.close()
+
+    def test_salted_lookup_does_not_fall_back_to_legacy_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A salted key must not discover an unsalted legacy file."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, l1_memory, config = create_adapter_for_path(
+            tmp_path, buffer, persist_enabled=True
+        )
+        legacy_key = create_object_key(1)
+        salted_key = create_object_key(1, cache_salt="tenant-a")
+
+        try:
+            store_and_wait(
+                adpt,
+                [legacy_key],
+                [create_memory_obj(buffer, page_index=0, fill_value=19.0)],
+            )
+        finally:
+            adpt.close()
+
+        recovered = DynamicNixlStoreL2Adapter(config, l1_memory)
+        try:
+            lookup_task = recovered.submit_lookup_and_lock_task(
+                [salted_key], {0: _EMPTY_LAYOUT}
+            )
+            assert wait_for_event_fd(recovered.get_lookup_and_lock_event_fd())
+            bitmap = recovered.query_lookup_and_lock_result(lookup_task)
+            assert bitmap is not None
+            assert not bitmap.test(0)
+        finally:
+            recovered.close()
+
+    def test_concurrent_stores_with_same_hash_do_not_alias(
+        self, tmp_path: Path
+    ) -> None:
+        """Concurrent salted store tasks must publish distinct files."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=True)
+        keys = [create_object_key(1, cache_salt=f"tenant-{i}") for i in range(8)]
+        try:
+            task_ids = {
+                adpt.submit_store_task(
+                    [key],
+                    [create_memory_obj(buffer, page_index=i, fill_value=float(i + 1))],
+                )
+                for i, key in enumerate(keys)
+            }
+            completed = adpt.pop_completed_store_tasks()
+            deadline = time.monotonic() + 10.0
+            while task_ids - completed.keys():
+                remaining = deadline - time.monotonic()
+                assert remaining > 0
+                assert wait_for_event_fd(adpt.get_store_event_fd(), remaining)
+                completed.update(adpt.pop_completed_store_tasks())
+
+            assert all(completed[task_id].is_successful() for task_id in task_ids)
+            assert len(list_data_files(tmp_path)) == len(keys)
+            assert dict(adpt.get_usage().bytes_by_cache_salt) == {
+                key.cache_salt: PAGE_SIZE for key in keys
+            }
+
+            lookup_task = adpt.submit_lookup_and_lock_task(keys, {0: _EMPTY_LAYOUT})
+            assert wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
+            bitmap = adpt.query_lookup_and_lock_result(lookup_task)
+            assert bitmap is not None
+            assert all(bitmap.test(i) for i in range(len(keys)))
+
+            load_objects: list[MemoryObj] = [
+                create_memory_obj(buffer, page_index=8 + i, fill_value=0.0)
+                for i in range(len(keys))
+            ]
+            load_task = adpt.submit_load_task(keys, load_objects)
+            assert wait_for_event_fd(adpt.get_load_event_fd())
+            bitmap = adpt.query_load_result(load_task)
+            assert bitmap is not None
+            for i in range(len(keys)):
+                assert bitmap.test(i)
+                page = 8 + i
+                loaded = buffer[page * PAGE_SIZE : (page + 1) * PAGE_SIZE].view(
+                    torch.float32
+                )
+                assert torch.all(loaded == float(i + 1))
+            adpt.submit_unlock(keys)
+        finally:
+            adpt.close()
+
+    @pytest.mark.parametrize(
+        ("shard_dirs", "expected_path"),
+        [
+            (False, "test_model_00000000_0_00000001.bin"),
+            (True, os.path.join("00", "00", "test_model_00000000_0_00000001.bin")),
+        ],
+        ids=["flat", "sharded"],
+    )
+    def test_empty_salt_preserves_legacy_path(
+        self, tmp_path: Path, shard_dirs: bool, expected_path: str
+    ) -> None:
+        """Unsalted stores must keep their exact pre-change path."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=shard_dirs)
+        try:
+            store_and_wait(
+                adpt,
+                [create_object_key(1)],
+                [create_memory_obj(buffer, page_index=0)],
+            )
+            assert list_data_files(tmp_path) == [expected_path]
+        finally:
+            adpt.close()
+
+    @pytest.mark.parametrize(
+        ("shard_dirs", "expected_path"),
+        [
+            (False, SALTED_GOLDEN_FILENAME),
+            (
+                True,
+                os.path.join("0d", "16", SALTED_GOLDEN_FILENAME),
+            ),
+        ],
+        ids=["flat", "sharded"],
+    )
+    def test_salted_path_matches_versioned_golden(
+        self, tmp_path: Path, shard_dirs: bool, expected_path: str
+    ) -> None:
+        """The versioned salted-path encoding must remain stable."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=shard_dirs)
+        try:
+            store_and_wait(
+                adpt,
+                [create_object_key(1, cache_salt="tenant-a")],
+                [create_memory_obj(buffer, page_index=0)],
+            )
+            assert list_data_files(tmp_path) == [expected_path]
+        finally:
+            adpt.close()
+
+    def test_salted_filename_is_bounded(self, tmp_path: Path) -> None:
+        """Maximum legal salt and long model names must fit one filename."""
+        buffer = torch.empty(
+            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
+        )
+        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=True)
+        cache_salt = "租" * 128
+        key = create_object_key(1, model_name="m" * 300, cache_salt=cache_salt)
+        try:
+            store_and_wait(
+                adpt,
+                [key],
+                [create_memory_obj(buffer, page_index=0)],
+            )
+            [relative_path] = list_data_files(tmp_path)
+            filename = os.path.basename(relative_path)
+            assert filename.startswith("salted-v1_")
+            assert len(os.fsencode(filename)) == 78
+            assert cache_salt not in relative_path
+        finally:
+            adpt.close()
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -13,7 +13,6 @@ import os
 import select
 import shutil
 import tempfile
-import time
 
 # Third Party
 import pytest
@@ -77,9 +76,6 @@ class _RecordingListener(L2AdapterListener):
 PAGE_SIZE = 4096  # 4 KB per page
 NUM_BUFFER_PAGES = 20  # pages in the registered memory buffer
 MAX_CAPACITY_GB = 0.001  # ~1 MB
-SALTED_GOLDEN_FILENAME = (
-    "salted-v1_0d1618328728b71e944064dbc9c98bdfa6e268e35e4d6c9c54619ee0090baccb.bin"
-)
 
 if torch_device_type == "xpu":
     pytest.skip(
@@ -679,10 +675,10 @@ class TestEndToEnd:
 
 class TestCacheSaltIsolation:
     @pytest.mark.parametrize("shard_dirs", [False, True], ids=["flat", "sharded"])
-    def test_store_and_delete_are_isolated_by_salt(
+    def test_store_load_and_delete_are_isolated_by_salt(
         self, tmp_path: Path, shard_dirs: bool
     ) -> None:
-        """Deleting one salted key must leave the other key loadable."""
+        """Store, load, and delete must preserve salt isolation."""
         buffer = torch.empty(
             PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
         )
@@ -705,6 +701,22 @@ class TestCacheSaltIsolation:
                 "tenant-a": PAGE_SIZE,
                 "tenant-b": PAGE_SIZE,
             }
+
+            load_objects: list[MemoryObj] = [
+                create_memory_obj(buffer, page_index=2, fill_value=0.0),
+                create_memory_obj(buffer, page_index=3, fill_value=0.0),
+            ]
+            load_task = adpt.submit_load_task([key_a, key_b], load_objects)
+            assert wait_for_event_fd(adpt.get_load_event_fd())
+            bitmap = adpt.query_load_result(load_task)
+            assert bitmap is not None
+            assert bitmap.test(0) and bitmap.test(1)
+            assert torch.all(
+                buffer[2 * PAGE_SIZE : 3 * PAGE_SIZE].view(torch.float32) == 11.0
+            )
+            assert torch.all(
+                buffer[3 * PAGE_SIZE : 4 * PAGE_SIZE].view(torch.float32) == 22.0
+            )
 
             adpt.delete([key_a])
             assert dict(adpt.get_usage().bytes_by_cache_salt) == {"tenant-b": PAGE_SIZE}
@@ -794,170 +806,51 @@ class TestCacheSaltIsolation:
         finally:
             recovered.close()
 
-    def test_salted_lookup_does_not_fall_back_to_legacy_path(
-        self, tmp_path: Path
+    @pytest.mark.parametrize(
+        ("shard_dirs", "path_prefix"),
+        [
+            (False, ""),
+            (True, os.path.join("83", "4e")),
+        ],
+        ids=["flat", "sharded"],
+    )
+    def test_filename_contract_preserves_legacy_and_appends_raw_salt(
+        self, tmp_path: Path, shard_dirs: bool, path_prefix: str
     ) -> None:
-        """A salted key must not discover an unsalted legacy file."""
+        """Filenames must preserve legacy keys and append raw salts."""
         buffer = torch.empty(
             PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
         )
-        adpt, l1_memory, config = create_adapter_for_path(
-            tmp_path, buffer, persist_enabled=True
-        )
-        legacy_key = create_object_key(1)
-        salted_key = create_object_key(1, cache_salt="tenant-a")
+        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=shard_dirs)
+        legacy_key = create_object_key(0x834EBC79)
+        salted_key = create_object_key(0x834EBC79, cache_salt="tenant-a")
+        missing_key = create_object_key(0x834EBC79, cache_salt="tenant-b")
+        legacy_filename = "test_model_00000000_0_834ebc79.bin"
+        salted_filename = "test_model_00000000_0_834ebc79@tenant-a.bin"
 
         try:
             store_and_wait(
                 adpt,
-                [legacy_key],
-                [create_memory_obj(buffer, page_index=0, fill_value=19.0)],
+                [legacy_key, salted_key],
+                [
+                    create_memory_obj(buffer, page_index=0, fill_value=17.0),
+                    create_memory_obj(buffer, page_index=1, fill_value=23.0),
+                ],
             )
-        finally:
-            adpt.close()
-
-        recovered = DynamicNixlStoreL2Adapter(config, l1_memory)
-        try:
-            lookup_task = recovered.submit_lookup_and_lock_task(
-                [salted_key], {0: _EMPTY_LAYOUT}
+            assert list_data_files(tmp_path) == sorted(
+                [
+                    os.path.join(path_prefix, legacy_filename),
+                    os.path.join(path_prefix, salted_filename),
+                ]
             )
-            assert wait_for_event_fd(recovered.get_lookup_and_lock_event_fd())
-            bitmap = recovered.query_lookup_and_lock_result(lookup_task)
-            assert bitmap is not None
-            assert not bitmap.test(0)
-        finally:
-            recovered.close()
 
-    def test_concurrent_stores_with_same_hash_do_not_alias(
-        self, tmp_path: Path
-    ) -> None:
-        """Concurrent salted store tasks must publish distinct files."""
-        buffer = torch.empty(
-            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
-        )
-        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=True)
-        keys = [create_object_key(1, cache_salt=f"tenant-{i}") for i in range(8)]
-        try:
-            task_ids = {
-                adpt.submit_store_task(
-                    [key],
-                    [create_memory_obj(buffer, page_index=i, fill_value=float(i + 1))],
-                )
-                for i, key in enumerate(keys)
-            }
-            completed = adpt.pop_completed_store_tasks()
-            deadline = time.monotonic() + 10.0
-            while task_ids - completed.keys():
-                remaining = deadline - time.monotonic()
-                assert remaining > 0
-                assert wait_for_event_fd(adpt.get_store_event_fd(), remaining)
-                completed.update(adpt.pop_completed_store_tasks())
-
-            assert all(completed[task_id].is_successful() for task_id in task_ids)
-            assert len(list_data_files(tmp_path)) == len(keys)
-            assert dict(adpt.get_usage().bytes_by_cache_salt) == {
-                key.cache_salt: PAGE_SIZE for key in keys
-            }
-
-            lookup_task = adpt.submit_lookup_and_lock_task(keys, {0: _EMPTY_LAYOUT})
+            lookup_task = adpt.submit_lookup_and_lock_task(
+                [missing_key], {0: _EMPTY_LAYOUT}
+            )
             assert wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
             bitmap = adpt.query_lookup_and_lock_result(lookup_task)
             assert bitmap is not None
-            assert all(bitmap.test(i) for i in range(len(keys)))
-
-            load_objects: list[MemoryObj] = [
-                create_memory_obj(buffer, page_index=8 + i, fill_value=0.0)
-                for i in range(len(keys))
-            ]
-            load_task = adpt.submit_load_task(keys, load_objects)
-            assert wait_for_event_fd(adpt.get_load_event_fd())
-            bitmap = adpt.query_load_result(load_task)
-            assert bitmap is not None
-            for i in range(len(keys)):
-                assert bitmap.test(i)
-                page = 8 + i
-                loaded = buffer[page * PAGE_SIZE : (page + 1) * PAGE_SIZE].view(
-                    torch.float32
-                )
-                assert torch.all(loaded == float(i + 1))
-            adpt.submit_unlock(keys)
-        finally:
-            adpt.close()
-
-    @pytest.mark.parametrize(
-        ("shard_dirs", "expected_path"),
-        [
-            (False, "test_model_00000000_0_00000001.bin"),
-            (True, os.path.join("00", "00", "test_model_00000000_0_00000001.bin")),
-        ],
-        ids=["flat", "sharded"],
-    )
-    def test_empty_salt_preserves_legacy_path(
-        self, tmp_path: Path, shard_dirs: bool, expected_path: str
-    ) -> None:
-        """Unsalted stores must keep their exact pre-change path."""
-        buffer = torch.empty(
-            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
-        )
-        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=shard_dirs)
-        try:
-            store_and_wait(
-                adpt,
-                [create_object_key(1)],
-                [create_memory_obj(buffer, page_index=0)],
-            )
-            assert list_data_files(tmp_path) == [expected_path]
-        finally:
-            adpt.close()
-
-    @pytest.mark.parametrize(
-        ("shard_dirs", "expected_path"),
-        [
-            (False, SALTED_GOLDEN_FILENAME),
-            (
-                True,
-                os.path.join("0d", "16", SALTED_GOLDEN_FILENAME),
-            ),
-        ],
-        ids=["flat", "sharded"],
-    )
-    def test_salted_path_matches_versioned_golden(
-        self, tmp_path: Path, shard_dirs: bool, expected_path: str
-    ) -> None:
-        """The versioned salted-path encoding must remain stable."""
-        buffer = torch.empty(
-            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
-        )
-        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=shard_dirs)
-        try:
-            store_and_wait(
-                adpt,
-                [create_object_key(1, cache_salt="tenant-a")],
-                [create_memory_obj(buffer, page_index=0)],
-            )
-            assert list_data_files(tmp_path) == [expected_path]
-        finally:
-            adpt.close()
-
-    def test_salted_filename_is_bounded(self, tmp_path: Path) -> None:
-        """Maximum legal salt and long model names must fit one filename."""
-        buffer = torch.empty(
-            PAGE_SIZE * NUM_BUFFER_PAGES, dtype=torch.uint8, device="cpu"
-        )
-        adpt, _, _ = create_adapter_for_path(tmp_path, buffer, shard_dirs=True)
-        cache_salt = "租" * 128
-        key = create_object_key(1, model_name="m" * 300, cache_salt=cache_salt)
-        try:
-            store_and_wait(
-                adpt,
-                [key],
-                [create_memory_obj(buffer, page_index=0)],
-            )
-            [relative_path] = list_data_files(tmp_path)
-            filename = os.path.basename(relative_path)
-            assert filename.startswith("salted-v1_")
-            assert len(os.fsencode(filename)) == 78
-            assert cache_salt not in relative_path
+            assert not bitmap.test(0)
         finally:
             adpt.close()
 


### PR DESCRIPTION
Fixes #4856

**What this PR does / why we need it**:

`nixl_store_dynamic` mapped keys that differed only by `cache_salt` to the same file, so store, load, secondary lookup, delete, and eviction did not preserve `ObjectKey` isolation.

This change:

- preserves the exact legacy filename for an empty salt;
- appends non-empty salts as `@<cache_salt>` before `.bin`, matching the S3/filesystem convention;
- keeps chunk-hash sharding unchanged;
- adds flat and sharded store/load/delete/restart/no-fallback regression coverage;
- documents upgrade behavior.

The shared mapping covers POSIX, GDS, GDS_MT, and HF3FS. No transfer or eviction algorithm changes. Filename-length handling remains out of scope and is tracked in #4827.

**Special notes for your reviewers**:

Salted lookup intentionally does not fall back to the legacy salt-blind path. Files written by previously salted traffic contain no salt provenance and cannot be migrated safely; clear or quarantine that cache directory when upgrading. Unsalted paths remain compatible.

**Validation**:

- `SKIP=rust-fmt,rust-clippy uvx pre-commit run --all-files`: all 10 applicable hooks passed. Rust hooks were skipped per repository macOS guidance; this PR does not touch Rust.
- `python3 -m py_compile` for both changed Python files: passed.
- `git diff --check`: passed.
- Local macOS could not run the POSIX/NIXL pytest module because pytest, Torch, and NIXL test dependencies are unavailable. Linux/NIXL CI is running on this revision.
- Sphinx parsed and rendered the modified NIXL page without a warning. The repository-wide `sphinx-build -W --keep-going` remains blocked by 31 warnings/errors in unchanged files, including `production/observability/chunk_statistics.rst:291`.

Dev GPU end-to-end validation used LMCache 0.5.4 with an equivalent backport of the final trailing-salt mapping:

- Qwen/Qwen3.8-27B, vLLM `0.26.1rc1.dev994+gd626108b1`, 1x RTX PRO 6000;
- the same 1,792-token chunk under salts A and B produced disjoint readable `@<cache_salt>.bin` paths, and B remained a cold miss;
- eight simultaneous cold salted writes completed with disjoint paths;
- IsolatedLRU pressure evicted A only while B remained intact;
- after a same-Pod process restart, nine simultaneous salted requests each completed one L2 load and zero stores; all 10 physical paths and sizes were unchanged.

The test canary was scaled back to zero and removed; the original Qwen3.8 deployment was restored to 1/1 Ready on the pre-existing GPU node.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests