### PR TITLE
[Bugfix] ATOM: set multiprocess key reader count

### DIFF
--- a/lmcache/integration/atom/multi_process_adapter.py
+++ b/lmcache/integration/atom/multi_process_adapter.py
@@ -319,6 +319,8 @@ class AtomMPSchedulerAdapter:
         return IPCCacheServerKey(
             model_name=self._model_name,
             world_size=self._parallel.world_size,
+            # Each ATOM TP rank retrieves only its own rank-local object.
+            num_kv_readers=1,
             worker_id=worker_id,
             token_ids=tuple(token_ids),
             start=start,
@@ -846,6 +848,8 @@ class AtomMPWorkerAdapter:
         return IPCCacheServerKey(
             model_name=self._model_name,
             world_size=self._parallel.world_size,
+            # Each ATOM TP rank retrieves only its own rank-local object.
+            num_kv_readers=1,
             worker_id=self._parallel.worker_id,
             token_ids=tuple(spec.token_ids),
             start=spec.start,

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -163,6 +163,33 @@ def _mock_client(worker: AtomMPWorkerAdapter) -> MagicMock:
     return cast(MagicMock, worker._client)
 
 
+def test_atom_lookup_submits_valid_reader_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduler lookups declare one reader for each rank-local object."""
+    client = MagicMock(name="mq_client")
+    future: MessagingFuture[None] = MessagingFuture()
+    future.set_result(None)
+    client.submit_request.return_value = future
+    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
+    scheduler = AtomMPSchedulerAdapter(
+        server_url="tcp://127.0.0.1:5555",
+        context=MagicMock(name="zmq_context"),
+        model_name="atom-test-model",
+        block_size=64,
+        parallel_config=AtomMPParallelConfig(2, 1, 2),
+    )
+
+    scheduler.maybe_submit_lookup_request("request-1", list(range(300)))
+
+    lookup_call = client.submit_request.call_args
+    assert lookup_call.args[0] is RequestType.LOOKUP
+    key = lookup_call.args[1][0]
+    assert key.require_num_kv_readers() == 1
+    assert lookup_call.args[1][1] == 2
+
+
 def test_atom_worker_registers_native_engine_type(
     worker_with_transfer_context: tuple[
         AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]
@@ -216,6 +243,7 @@ def test_atom_submit_returns_future_and_expands_physical_groups(
     assert returned is future
     assert event in returned._retained_references
     submit_call = getattr(transfer_context, submit_name).call_args
+    assert submit_call.args[1].require_num_kv_readers() == 1
     assert submit_call.args[4] == [[7, 8, 9, 10], [7, 8, 9, 10]]
 
     future.set_result(True)


### PR DESCRIPTION
**What this PR does / why we need it**:

ATOM multiprocess keys currently leave `num_kv_readers` at its default value of 0. The lookup path now validates this field through `require_num_kv_readers()`, so ATOM lookups are rejected before cache matching and warm requests fall back to recomputation.

This PR sets `num_kv_readers=1` on both scheduler-side lookup keys and worker-side store/retrieve keys. Each ATOM TP rank stores and retrieves its own rank-local object, so each object has one reader; the scheduler already sends `tp_size` separately to fan the lookup out across ranks.

It also adds regression coverage over the actual LOOKUP and transfer payloads, including the server-side reader-count validation method.

This aligns the ATOM adapter with the mandatory reader-count contract introduced in #4679 and is relevant to the LMCache integration added by #4662. The issue was found while validating https://github.com/ROCm/ATOM/pull/1953.

**Special notes for your reviewers**:

Reproduced with the `v0.5.5rc2-rocm-torch210` wheel and ATOM TP=8: cold store completed, but both cold and warm lookups were rejected with `num_kv_readers=0`; consequently, the warm request did not retrieve cached KV data.

Validation:

- `pytest -q tests/v1/test_atom_mp_adapter.py` — 30 passed
- `SKIP=rust-fmt,rust-clippy pre-commit run --files lmcache/integration/atom/multi_process_adapter.py tests/v1/test_atom_mp_adapter.py` — all applicable checks passed

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
