### PR TITLE
[Bugfix][vLLM] Parse LMCACHE_FORCE_SKIP_SAVE false values correctly

### DIFF
--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -35,7 +35,13 @@ _config_lock = threading.Lock()
 
 def is_false(value: str) -> bool:
     """Check if the given string value is equivalent to 'false'."""
-    return value.lower() in ("false", "0", "no", "n", "off")
+    return value.strip().lower() in ("false", "0", "no", "n", "off")
+
+
+def is_env_var_enabled(name: str) -> bool:
+    """Return whether a boolean-like environment variable is enabled."""
+    value = os.environ.get(name)
+    return bool(value and value.strip() and not is_false(value))
 
 
 def vllm_layout_hints(vllm_config: "VllmConfig | None" = None) -> "LayoutHints":

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
 import math
-import os
 import sys
 
 # Third Party
@@ -34,6 +33,7 @@ from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
     apply_mm_hashes_to_token_ids,
     extract_mm_features,
+    is_env_var_enabled,
     lmcache_get_or_create_config,
 )
 from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
@@ -577,7 +577,7 @@ class LMCacheConnectorV1Impl:
         )
         self.current_layer = 0
 
-        self.force_skip_save = bool(os.environ.get("LMCACHE_FORCE_SKIP_SAVE", False))
+        self.force_skip_save = is_env_var_enabled("LMCACHE_FORCE_SKIP_SAVE")
         self._requests_priority: dict[str, int] = {}
 
         # Chunked KV loading: cap the number of external tokens

--- a/tests/v1/test_vllm_env_utils.py
+++ b/tests/v1/test_vllm_env_utils.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for environment flags used by vLLM integrations."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.integration.vllm.utils import is_env_var_enabled
+
+
+@pytest.mark.parametrize(
+    "value", ["0", "false", "FALSE", " false ", "no", "off", "", " "]
+)
+def test_env_var_false_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("LMCACHE_TEST_FLAG", value)
+
+    assert is_env_var_enabled("LMCACHE_TEST_FLAG") is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_env_var_true_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("LMCACHE_TEST_FLAG", value)
+
+    assert is_env_var_enabled("LMCACHE_TEST_FLAG") is True
+
+
+def test_unset_env_var_defaults_to_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LMCACHE_TEST_FLAG", raising=False)
+
+    assert is_env_var_enabled("LMCACHE_TEST_FLAG") is False


### PR DESCRIPTION
**What this PR does / why we need it**:

`LMCACHE_FORCE_SKIP_SAVE` was parsed with `bool(<string>)`, so explicit false values such as `false`, `0`, `no`, and `off` all evaluated to `True` and unexpectedly disabled KV cache writes.

This change adds a shared vLLM environment-flag helper based on the integration's existing false-value convention and uses it for `LMCACHE_FORCE_SKIP_SAVE`. It also trims surrounding whitespace and keeps unset/empty values disabled.

Regression tests cover false, true, empty, whitespace-only, and unset values.

Fixes #4862

**Special notes for your reviewers**:

Verification completed on commit `208dd6e0`:

- Fork Ubuntu workflow: Python 3.10, 3.11, 3.12, and 3.13 full CPU unit-test suites passed; raw-block Rust tests passed — https://github.com/devinhuang2001/LMCache/actions/runs/33512406713
- Fork Ubuntu full pre-commit (`--all-files`) passed, including lint, format, spelling, and mypy — https://github.com/devinhuang2001/LMCache/actions/runs/33514241427
- Local focused tests: `tests/v1/test_vllm_env_utils.py` and `tests/v1/test_vllm_kv_layout_discovery.py` — 32 passed
- Local Ruff check and format check on all changed files — passed

The temporary workflow-only commit used to dispatch full pre-commit lives on a separate `ci/4862-code-quality` branch and is not part of this PR.

**If applicable**:

- [ ] this PR contains user facing changes - README updated
- [x] this PR contains unit tests