### PR TITLE
feat: Add AWS Trainium device support

### DIFF
--- a/benchmarks/gpu_connector/neuron_kv_staging_benchmark.py
+++ b/benchmarks/gpu_connector/neuron_kv_staging_benchmark.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Microbenchmark for the Neuron KV staging path.
+
+Times ``NeuronKVBlockStager`` against synthetic paged-KV tensors shaped like a
+real vllm-neuron deployment (HND layout, ``NL_X_TWO_NB_NH_BS_HS``).
+
+The benchmark mirrors how the cache engine actually drives the stager, because
+an earlier version of this file did not and reported a throughput two orders of
+magnitude better than serving:
+
+* **Chunked calls.** The engine calls ``from_gpu`` once per chunk of
+  ``chunk_size`` tokens, not once per request, so a request is
+  ``ceil(num_tokens / chunk_size)`` staging calls. Timing one whole-sequence
+  call amortizes all per-call fixed cost exactly once and hides it.
+* **Scattered blocks.** Slot mappings come from vLLM's block allocator, so the
+  gathered block ids are non-contiguous. A dense ``arange`` slot mapping lets
+  ``index_select`` degenerate into a strided slice and measures the best case.
+* **No warm-only reporting.** Per-request cost is reported in full. A
+  ``warm mean (2..N)`` over a repeated identical shape discards precisely the
+  first-touch and per-shape device tracing cost that dominates serving.
+
+Both directions are measured: ``transfer_into_key_value`` (D2H, the store path)
+and ``transfer_from_key_value`` (H2D, the retrieve path).
+
+``--verify`` checks correctness instead of speed: it drives a full store/retrieve
+round trip on device and asserts the selected blocks come back bit-exact while
+every other block is left alone. A throughput number from a path that moves the
+wrong bytes is worthless, so run ``--verify`` first at the shapes you intend to
+measure.
+
+Must run on Neuron hardware (import ``libtorch_neuronx_lite`` registers the
+``neuron`` device); off-hardware it runs on CPU tensors as a functional check.
+
+Example:
+
+    python benchmarks/gpu_connector/neuron_kv_staging_benchmark.py \
+        --requests 5 \
+        --num-layers 16 \
+        --num-tokens 1202 \
+        --chunk-size 32 \
+        --num-heads 4 \
+        --head-size 64 \
+        --block-size 16 \
+        --device neuron
+"""
+
+# Standard
+from dataclasses import dataclass
+import argparse
+import json
+import random
+import time
+
+# Third Party
+import torch
+
+# Registering the Neuron privateuse1 backend (renamed to "neuron") is a side
+# effect of importing libtorch_neuronx_lite. It must happen before any
+# ``device="neuron..."`` tensor is allocated, so the import is unconditional
+# but tolerated as absent off-hardware.
+try:
+    # Third Party
+    import libtorch_neuronx_lite  # noqa: F401
+except ImportError:
+    pass
+
+# First Party
+from lmcache.v1.gpu_connector.neuron_kv_staging import NeuronKVBlockStager
+import lmcache.lmcache_native as lmcache_native
+
+
+@dataclass(frozen=True)
+class BenchConfig:
+    """Shape and run parameters for the staging benchmark."""
+
+    requests: int
+    num_layers: int
+    num_tokens: int
+    chunk_size: int
+    num_heads: int
+    head_size: int
+    block_size: int
+    cache_blocks: int
+    device: str
+    dtype: torch.dtype
+    seed: int
+    skip_prefix_tokens: int
+
+
+@dataclass(frozen=True)
+class DirectionStats:
+    """Timing results for one transfer direction."""
+
+    calls_per_request: int
+    request_secs: list[float]
+    mean_request_sec: float
+    mean_call_sec: float
+    gib_per_sec: float
+
+
+def _build_layer_tensors(config: BenchConfig) -> list[torch.Tensor]:
+    """Allocate per-layer paged KV tensors in ``NL_X_TWO_NB_NH_BS_HS`` layout.
+
+    The cache is sized to ``cache_blocks`` rather than to the request, so the
+    gathered blocks are a sparse subset of a realistically large cache.
+
+    :param config: Benchmark configuration.
+    :returns: One tensor per layer of shape
+        ``[2, cache_blocks, num_heads, block_size, head_size]`` on the target
+        device.
+    """
+    shape = (
+        2,
+        config.cache_blocks,
+        config.num_heads,
+        config.block_size,
+        config.head_size,
+    )
+    return [
+        torch.randn(shape, dtype=config.dtype, device=config.device)
+        for _ in range(config.num_layers)
+    ]
+
+
+def _build_scattered_slot_mapping(
+    config: BenchConfig, rng: random.Random
+) -> torch.Tensor:
+    """Build a slot mapping over randomly scattered cache blocks.
+
+    Models vLLM's block allocator: the request's tokens occupy whichever blocks
+    happen to be free, in allocation order, not a contiguous run.
+
+    :param config: Benchmark configuration.
+    :param rng: Seeded source of randomness for block selection.
+    :returns: A CPU int64 tensor of length ``num_tokens`` mapping each token to
+        a slot in a scattered set of blocks.
+    :raises ValueError: If the request needs more blocks than the cache holds.
+    """
+    blocks_needed = -(-config.num_tokens // config.block_size)  # ceil
+    if blocks_needed > config.cache_blocks:
+        raise ValueError(
+            f"num_tokens={config.num_tokens} needs {blocks_needed} blocks, "
+            f"cache_blocks={config.cache_blocks}"
+        )
+    chosen = rng.sample(range(config.cache_blocks), blocks_needed)
+    slots = [
+        block_id * config.block_size + offset
+        for block_id in chosen
+        for offset in range(config.block_size)
+    ]
+    return torch.tensor(slots[: config.num_tokens], dtype=torch.long, device="cpu")
+
+
+def _build_key_value(config: BenchConfig, num_tokens: int) -> torch.Tensor:
+    """Allocate the CPU staging tensor in ``[2, NL, NT, HS]`` layout.
+
+    :param config: Benchmark configuration.
+    :param num_tokens: Number of token slots this chunk covers.
+    :returns: A CPU tensor of shape ``[2, num_layers, num_tokens, hidden]``.
+    """
+    hidden = config.num_heads * config.head_size
+    return torch.empty(
+        (2, config.num_layers, num_tokens, hidden), dtype=config.dtype, device="cpu"
+    )
+
+
+def _staged_gib(config: BenchConfig) -> float:
+    """Return the payload size moved per request, in GiB.
+
+    :param config: Benchmark configuration.
+    :returns: Bytes of KV staged per request (both K and V, all layers, valid
+        tokens only), expressed in GiB.
+    """
+    elt = torch.tensor([], dtype=config.dtype).element_size()
+    hidden = config.num_heads * config.head_size
+    total_bytes = 2 * config.num_layers * config.num_tokens * hidden * elt
+    return total_bytes / (1024**3)
+
+
+def _chunk_bounds(config: BenchConfig) -> list[tuple[int, int]]:
+    """Split a request's tokens into the chunks the cache engine would use.
+
+    :param config: Benchmark configuration.
+    :returns: A list of ``(start, end)`` token offsets per chunk.
+    """
+    return [
+        (start, min(start + config.chunk_size, config.num_tokens))
+        for start in range(0, config.num_tokens, config.chunk_size)
+    ]
+
+
+def _time_direction(
+    config: BenchConfig,
+    layer_tensors: list[torch.Tensor],
+    store: bool,
+) -> DirectionStats:
+    """Time one transfer direction across whole requests.
+
+    A fresh stager is built per direction so cache state is not carried in from
+    the other direction's run.
+
+    :param config: Benchmark configuration.
+    :param layer_tensors: Per-layer paged KV tensors on the target device.
+    :param store: Time the D2H store path when true, the H2D retrieve path when
+        false.
+    :returns: Timing statistics for the direction.
+    """
+    rng = random.Random(config.seed)
+    stager = NeuronKVBlockStager()
+    fmt = lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
+    bounds = _chunk_bounds(config)
+    gib = _staged_gib(config)
+
+    request_secs: list[float] = []
+    for _ in range(config.requests):
+        # A new slot mapping per request: block ids differ every time in
+        # serving, so any per-selection caching must not be handed a
+        # artificially stable input.
+        slot_mapping = _build_scattered_slot_mapping(config, rng)
+        chunks = [
+            (_build_key_value(config, end - start), slot_mapping[start:end])
+            for start, end in bounds
+        ]
+
+        start_time = time.perf_counter()
+        for key_value, chunk_slots in chunks:
+            if store:
+                stager.transfer_into_key_value(
+                    key_value=key_value,
+                    layer_tensors=layer_tensors,
+                    slot_mapping=chunk_slots,
+                    engine_kv_format=fmt,
+                    block_size=config.block_size,
+                    head_size=config.head_size,
+                )
+            else:
+                stager.transfer_from_key_value(
+                    key_value=key_value,
+                    layer_tensors=layer_tensors,
+                    slot_mapping=chunk_slots,
+                    engine_kv_format=fmt,
+                    block_size=config.block_size,
+                    head_size=config.head_size,
+                    skip_prefix_n_tokens=0,
+                )
+        request_secs.append(time.perf_counter() - start_time)
+
+    mean_request = sum(request_secs) / len(request_secs)
+    return DirectionStats(
+        calls_per_request=len(bounds),
+        request_secs=request_secs,
+        mean_request_sec=mean_request,
+        mean_call_sec=mean_request / len(bounds) if bounds else 0.0,
+        gib_per_sec=gib / mean_request if mean_request > 0 else 0.0,
+    )
+
+
+def verify_round_trip(config: BenchConfig) -> None:
+    """Assert a store/retrieve round trip restores KV exactly, on device.
+
+    The staging path only moves bytes -- there is no arithmetic in it -- so a
+    correct round trip is bit-exact even in bfloat16, and any mismatch is a real
+    indexing or layout bug rather than tolerable drift.
+
+    The whole cache is overwritten with unrelated data between the store and the
+    retrieve. Without that, a retrieve that silently wrote nothing would still
+    compare equal and the check would pass on a completely broken scatter. The
+    overwrite also gives the untouched-blocks assertion something to detect: it
+    catches a scatter that writes outside the blocks it was asked for, which is
+    the failure mode that corrupts another request's KV rather than erroring.
+
+    Both the store and the retrieve are driven chunk by chunk with a scattered
+    slot mapping, matching how the cache engine calls the connector.
+
+    :param config: Benchmark configuration; shapes and device come from it.
+    :raises AssertionError: If any selected block fails to round trip, or if any
+        block outside the selection was modified.
+    """
+    rng = random.Random(config.seed)
+    stager = NeuronKVBlockStager()
+    fmt = lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
+
+    layer_tensors = _build_layer_tensors(config)
+    original = [layer.to("cpu") for layer in layer_tensors]
+
+    slot_mapping = _build_scattered_slot_mapping(config, rng)
+    chunks = [
+        (_build_key_value(config, end - start), slot_mapping[start:end])
+        for start, end in _chunk_bounds(config)
+    ]
+
+    for key_value, chunk_slots in chunks:
+        stager.transfer_into_key_value(
+            key_value=key_value,
+            layer_tensors=layer_tensors,
+            slot_mapping=chunk_slots,
+            engine_kv_format=fmt,
+            block_size=config.block_size,
+            head_size=config.head_size,
+        )
+
+    # Overwrite the cache so the retrieve has to actually put the data back.
+    poison = [torch.randn_like(reference) for reference in original]
+    for layer, poisoned in zip(layer_tensors, poison, strict=True):
+        layer.copy_(poisoned.to(layer.device))
+
+    # The first chunk carries a prefix skip, as it does whenever vLLM's own
+    # prefix cache already holds the head of the request. Those slots must come
+    # back untouched: their blocks can be shared with another running request,
+    # so writing them corrupts KV that is not ours.
+    skip = config.skip_prefix_tokens
+    skipped_slots = (
+        chunks[0][1][:skip] if chunks else torch.tensor([], dtype=torch.long)
+    )
+
+    for index, (key_value, chunk_slots) in enumerate(chunks):
+        stager.transfer_from_key_value(
+            key_value=key_value,
+            layer_tensors=layer_tensors,
+            slot_mapping=chunk_slots,
+            engine_kv_format=fmt,
+            block_size=config.block_size,
+            head_size=config.head_size,
+            skip_prefix_n_tokens=skip if index == 0 else 0,
+        )
+
+    # Which token slots the retrieve was expected to write, at slot granularity
+    # rather than block granularity: a partially covered tail block must keep its
+    # unmapped slots and a skipped prefix slot must keep its old value, so
+    # checking whole blocks would miss both failures.
+    covered = torch.zeros(
+        config.cache_blocks * config.block_size, dtype=torch.bool, device="cpu"
+    )
+    covered[slot_mapping] = True
+    covered[skipped_slots] = False
+    covered_blocks = covered.view(config.cache_blocks, config.block_size)
+
+    # One layer is pulled back at a time. Holding every layer at once costs
+    # num_layers * cache size on the host, which at serving shapes is tens of
+    # GiB and turns a correctness check into an OOM.
+    for layer_index, layer in enumerate(layer_tensors):
+        actual = layer.to("cpu")
+        reference = original[layer_index]
+        poisoned = poison[layer_index]
+
+        # Broadcast the slot mask over [2, NB, NH, BS, HS].
+        mask = covered_blocks[None, :, None, :, None]
+        expected = torch.where(mask, reference, poisoned)
+        if not torch.equal(actual, expected):
+            wrong = (actual != expected).any(dim=(0, 2, 4))  # -> [NB, BS]
+            bad_blocks = wrong.any(dim=1).nonzero().flatten().tolist()
+            block = bad_blocks[0]
+            bad_slots = wrong[block].nonzero().flatten().tolist()
+            raise AssertionError(
+                f"layer {layer_index}: {len(bad_blocks)} block(s) wrong after "
+                f"round trip, first is block {block} at within-block slots "
+                f"{bad_slots} (mapped slots there: "
+                f"{covered_blocks[block].nonzero().flatten().tolist()}); "
+                f"{(actual != expected).sum().item()} elements differ in total"
+            )
+
+    num_selected = int(covered_blocks.any(dim=1).sum())
+    num_partial = int((covered_blocks.any(dim=1) & ~covered_blocks.all(dim=1)).sum())
+    print(
+        f"verify: OK -- {int(covered.sum())} token slots across {num_selected} "
+        f"blocks round tripped exactly on {config.num_layers} layers "
+        f"({num_partial} partially covered block(s) kept their unmapped slots); "
+        f"{config.cache_blocks - num_selected} blocks untouched; "
+        f"{len(chunks)} chunks each direction"
+    )
+
+
+def run_benchmark(config: BenchConfig) -> dict[str, object]:
+    """Run the staging benchmark in both directions.
+
+    :param config: Benchmark configuration.
+    :returns: A dict of per-direction timing statistics plus the payload size.
+    """
+    layer_tensors = _build_layer_tensors(config)
+    return {
+        "staged_gib": _staged_gib(config),
+        "store_d2h": _time_direction(config, layer_tensors, store=True),
+        "retrieve_h2d": _time_direction(config, layer_tensors, store=False),
+    }
+
+
+def _format_direction(name: str, stats: DirectionStats) -> str:
+    """Render one direction's statistics as an indented block.
+
+    :param name: Human-readable direction label.
+    :param stats: Timing statistics to render.
+    :returns: A multi-line string.
+    """
+    per_request = ", ".join(f"{sec:.4f}" for sec in stats.request_secs)
+    return (
+        f"  {name}:\n"
+        f"    calls/request:    {stats.calls_per_request}\n"
+        f"    mean/request:     {stats.mean_request_sec:.4f}s "
+        f"({stats.gib_per_sec:.4f} GiB/s)\n"
+        f"    mean/call:        {stats.mean_call_sec * 1e3:.2f}ms\n"
+        f"    per-request secs: [{per_request}]"
+    )
+
+
+def _parse_args() -> tuple[BenchConfig, str, bool]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", type=int, default=5)
+    parser.add_argument("--num-layers", type=int, default=16)
+    parser.add_argument("--num-tokens", type=int, default=1202)
+    parser.add_argument("--chunk-size", type=int, default=32)
+    parser.add_argument("--num-heads", type=int, default=4)
+    parser.add_argument("--head-size", type=int, default=64)
+    parser.add_argument("--block-size", type=int, default=16)
+    parser.add_argument(
+        "--cache-blocks",
+        type=int,
+        default=2048,
+        help="Total blocks in the paged cache; blocks are scattered within it.",
+    )
+    parser.add_argument("--device", type=str, default="neuron:0")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--skip-prefix-tokens",
+        type=int,
+        default=3,
+        help="Leading tokens of the first chunk to treat as already held by "
+        "vLLM's prefix cache during --verify. Those slots must come back "
+        "unmodified. Only used by --verify.",
+    )
+    parser.add_argument("--output-json", type=str, default="")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Check a store/retrieve round trip is bit-exact, then exit without "
+        "timing. Run this before trusting any throughput number.",
+    )
+    args = parser.parse_args()
+    config = BenchConfig(
+        requests=args.requests,
+        num_layers=args.num_layers,
+        num_tokens=args.num_tokens,
+        chunk_size=args.chunk_size,
+        num_heads=args.num_heads,
+        head_size=args.head_size,
+        block_size=args.block_size,
+        cache_blocks=args.cache_blocks,
+        device=args.device,
+        dtype=torch.bfloat16,
+        seed=args.seed,
+        skip_prefix_tokens=args.skip_prefix_tokens,
+    )
+    return config, args.output_json, args.verify
+
+
+def main() -> None:
+    config, output_json, verify = _parse_args()
+    if verify:
+        verify_round_trip(config)
+        return
+    stats = run_benchmark(config)
+    store = stats["store_d2h"]
+    retrieve = stats["retrieve_h2d"]
+    assert isinstance(store, DirectionStats)
+    assert isinstance(retrieve, DirectionStats)
+    print(
+        f"neuron_kv_staging: device={config.device} "
+        f"layers={config.num_layers} tokens={config.num_tokens} "
+        f"chunk_size={config.chunk_size} "
+        f"staged={stats['staged_gib']:.4f}GiB/request\n"
+        f"{_format_direction('store (D2H)', store)}\n"
+        f"{_format_direction('retrieve (H2D)', retrieve)}"
+    )
+    if output_json:
+        payload = {
+            "staged_gib": stats["staged_gib"],
+            "store_d2h": vars(store),
+            "retrieve_h2d": vars(retrieve),
+        }
+        with open(output_json, "w") as f:
+            json.dump(payload, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -41,9 +41,26 @@ def is_false(value: str) -> bool:
 
 
 def vllm_layout_hints(vllm_config: "VllmConfig | None" = None) -> "LayoutHints":
-    """Build layout_hints dict by querying vLLM at runtime."""
+    """Build layout_hints dict by querying vLLM at runtime.
+
+    On Neuron the layout is forced to ``"HND"``. vllm-neuron allocates its
+    paged KV cache heads-before-block-size (``[2, NB, NH, BS, HS]``) but
+    reports vLLM's generic ``NHD`` default. Trusting that report makes format
+    detection read ``NH`` as ``BS``, yielding ``NL_X_TWO_NB_BS_NH_HS`` and a
+    ``block_size`` of ``num_kv_heads`` instead of ``NL_X_TWO_NB_NH_BS_HS``.
+    The mis-detected format then reaches the transfer kernels as a layout they
+    do not recognise, so KV stores fail with a shape mismatch.
+    """
     hints: dict[str, str] = {}
     kv_layout = try_get_vllm_kv_cache_layout(vllm_config)
+    if torch_device_type == "neuron":
+        if kv_layout is not None and kv_layout != "HND":
+            logger.info(
+                "Overriding the vLLM-reported KV cache layout %r with 'HND': "
+                "vllm-neuron allocates heads before block-size.",
+                kv_layout,
+            )
+        kv_layout = "HND"
     if kv_layout is not None:
         hints["kv_layout"] = kv_layout
     return hints  # type: ignore[return-value]

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -46,6 +46,12 @@ from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import validate_and_set_config_value
 from lmcache.v1.manager import LMCacheManager
+from lmcache.v1.platform import torch_device_type
+
+# Platforms whose runner builds attention state itself and calls
+# set_forward_context with attn_metadata=None on a real forward pass. On these,
+# a None attn_metadata carries no information about whether a load should run.
+_NO_ATTN_METADATA_DEVICES = frozenset({"neuron"})
 
 if TYPE_CHECKING:
     # Third Party
@@ -776,8 +782,19 @@ class LMCacheConnectorV1Impl:
         assert len(self.kv_caches) > 0
         kvcaches = list(self.kv_caches.values())
 
+        # Platforms that build their own attention state run a real forward pass
+        # with attn_metadata set to None -- vllm-neuron does -- so on those this
+        # check silently disabled every load while stores kept running. It was
+        # never a real precondition anywhere: this path reads only token ids and
+        # slot mappings, both from the connector metadata, and wait_for_save (the
+        # store path) has always driven off that metadata alone. Requests that
+        # must not be loaded are filtered per request below, via load_spec.
+        #
+        # The check is nonetheless kept for every other platform, so CUDA
+        # behaviour is unchanged. Only the platforms that cannot supply
+        # attn_metadata opt out.
         attn_metadata = forward_context.attn_metadata
-        if attn_metadata is None:
+        if attn_metadata is None and torch_device_type not in _NO_ATTN_METADATA_DEVICES:
             logger.debug("In connector.start_load_kv, but the attn_metadata is None")
             return
 

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -16,7 +16,11 @@ from lmcache.v1.metadata import LMCacheMetadata
 # supported_devices)``; the human label is what appears in the error message.
 _DEVICE_SCOPED_VLLM_BOOL_FEATURES: tuple[tuple[str, str, frozenset[str]], ...] = (
     ("enable_blending", "config.enable_blending", frozenset({"cuda", "xpu"})),
-    ("use_gpu_connector_v3", "config.use_gpu_connector_v3", frozenset({"cuda", "xpu"})),
+    (
+        "use_gpu_connector_v3",
+        "config.use_gpu_connector_v3",
+        frozenset({"cuda", "xpu", "neuron"}),
+    ),
 )
 
 
@@ -158,19 +162,14 @@ def CreateGPUConnector(
     elif engine == EngineType.VLLM:
         _validate_vllm_device_features(config)
 
-        # First Party
-        from lmcache.v1.gpu_connector.gpu_connectors import (
-            VLLMBufferLayerwiseGPUConnector,
-            VLLMPagedMemGPUConnectorV2,
-            VLLMPagedMemGPUConnectorV3,
-            VLLMPagedMemLayerwiseGPUConnector,
-        )
-
         local_worker_id = metadata.local_worker_id
         torch_dev.set_device(local_worker_id)
         device = torch.device(f"{torch_device_type}:{local_worker_id}")
+        enable_neuron_kv_staging = torch_device_type == "neuron" and bool(
+            config.get_extra_config_value("neuron_use_kv_staging", True)
+        )
 
-        if torch_device_type == "cuda":
+        if torch_device_type in ("cuda", "neuron"):
             # First Party
             from lmcache.v1.gpu_connector.gpu_connectors import (
                 VLLMBufferLayerwiseGPUConnector,
@@ -178,6 +177,14 @@ def CreateGPUConnector(
                 VLLMPagedMemGPUConnectorV3,
                 VLLMPagedMemLayerwiseGPUConnector,
             )
+
+            if config.use_layerwise and torch_device_type == "neuron":
+                raise ValueError(
+                    "config.use_layerwise is not supported on Neuron. The "
+                    "layerwise connectors transfer paged KV directly, which "
+                    "Neuron cannot do -- its blocks must be staged through a "
+                    "contiguous host buffer first. Unset use_layerwise."
+                )
 
             if config.use_layerwise:
                 if config.enable_blending:
@@ -189,14 +196,24 @@ def CreateGPUConnector(
                         metadata, use_gpu, device, layout_hints=layout_hints
                     )
 
+            connector: VLLMPagedMemGPUConnectorV2 | VLLMPagedMemGPUConnectorV3
             if config.use_gpu_connector_v3:
-                return VLLMPagedMemGPUConnectorV3.from_metadata(
-                    metadata, use_gpu, device, layout_hints=layout_hints
+                connector = VLLMPagedMemGPUConnectorV3.from_metadata(
+                    metadata,
+                    use_gpu,
+                    device,
+                    layout_hints=layout_hints,
                 )
             else:
-                return VLLMPagedMemGPUConnectorV2.from_metadata(
-                    metadata, use_gpu, device, layout_hints=layout_hints
+                connector = VLLMPagedMemGPUConnectorV2.from_metadata(
+                    metadata,
+                    use_gpu,
+                    device,
+                    layout_hints=layout_hints,
                 )
+            if enable_neuron_kv_staging:
+                connector.configure_neuron_kv_staging()
+            return connector
         elif torch_device_type == "xpu":
             # First Party
             from lmcache.v1.gpu_connector.xpu_connectors import (

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import List, Optional, Tuple, Union
+from contextlib import nullcontext
+from typing import List, Optional, Protocol, Tuple, Union, cast
 import abc
 
 # Third Party
@@ -40,6 +41,86 @@ from lmcache.v1.platform.ops_types import PageBufferShapeDesc
 import lmcache.lmcache_native as lmcache_native
 
 logger = init_logger(__name__)
+
+
+class _NoOpStream:
+    """Synchronous fallback for non-CUDA devices."""
+
+    def synchronize(self) -> None:
+        pass
+
+    def wait_stream(self, other: object) -> None:
+        pass
+
+
+def _create_device_stream(
+    device: torch.device | None,
+) -> "torch.cuda.Stream | _NoOpStream":
+    """Create a stream for the given device, or a no-op stub.
+
+    On CUDA this is exactly ``torch.cuda.Stream(device=device)``, so callers keep
+    the stream they had before; ``device`` is forwarded rather than dropped
+    because TRTLLM builds its streams for a specific device.
+
+    Args:
+        device: Device the stream belongs to, or None.
+
+    Returns:
+        A CUDA stream on CUDA, else a synchronous no-op stand-in.
+    """
+    device_type = str(device).split(":")[0] if device is not None else "cpu"
+    if device_type == "cuda":
+        return torch.cuda.Stream(device=device)
+    return _NoOpStream()
+
+
+def _device_stream_context(
+    stream: "torch.cuda.Stream | _NoOpStream",
+) -> "torch.cuda.StreamContext | nullcontext":
+    """Return a context manager that routes ops to the given stream."""
+    if isinstance(stream, torch.cuda.Stream):
+        return torch.cuda.stream(stream)
+    return nullcontext()
+
+
+class _NeuronKVStager(Protocol):
+    def transfer_into_key_value(
+        self,
+        key_value: torch.Tensor,
+        layer_tensors: list[torch.Tensor],
+        slot_mapping: torch.Tensor,
+        engine_kv_format: "lmcache_native.EngineKVFormat",
+        block_size: int,
+        head_size: int,
+    ) -> None: ...
+
+    def transfer_from_key_value(
+        self,
+        key_value: torch.Tensor,
+        layer_tensors: list[torch.Tensor],
+        slot_mapping: torch.Tensor,
+        engine_kv_format: "lmcache_native.EngineKVFormat",
+        block_size: int,
+        head_size: int,
+        skip_prefix_n_tokens: int,
+    ) -> None: ...
+
+
+# Device types with no pointer-based transfer kernel. These consume the
+# normalized per-layer tensor list directly, via the torch fallback or the
+# Neuron stager, instead of an array of base pointers.
+_TENSOR_LIST_DEVICES = frozenset({"neuron"})
+
+
+def _build_neuron_kv_stager() -> "_NeuronKVStager":
+    """Import and construct the Neuron KV stager lazily.
+
+    The import is deferred so non-Neuron builds never load the module.
+    """
+    # First Party
+    from lmcache.v1.gpu_connector.neuron_kv_staging import NeuronKVBlockStager
+
+    return NeuronKVBlockStager()
 
 
 class GPUConnectorInterface(metaclass=abc.ABCMeta):
@@ -188,6 +269,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             )
             or {}
         )
+        self._neuron_kv_stager: _NeuronKVStager | None = None
+        self._normalized_kv_caches: dict[str, List[torch.Tensor]] = {}
         if use_gpu:
             assert "chunk_size" in kwargs, (
                 "chunk_size should be provided to create a GPU buffer."
@@ -201,8 +284,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                 shape, dtype=kwargs["dtype"], device=kwargs["device"]
             )
 
-        self.store_stream = torch.cuda.Stream()
-        self.load_stream = torch.cuda.Stream()
+        self.store_stream = _create_device_stream(kwargs.get("device"))
+        self.load_stream = _create_device_stream(kwargs.get("device"))
 
     @classmethod
     def from_metadata(
@@ -243,8 +326,77 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             layout_hints=layout_hints,
         )
 
-    def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
+    def _resolve_layout(self, kv_caches: List[torch.Tensor]) -> List[torch.Tensor]:
+        """Discover the KV layout for a device without a pointer kernel.
+
+        Only reached for :data:`_TENSOR_LIST_DEVICES`; the pointer path in
+        :meth:`_initialize_pointers` is untouched. The KV caches are registered
+        once at engine start and never replaced, so detection runs on the first
+        call per device and later calls reuse it -- re-running it would add
+        layout discovery to every chunk.
+
+        Args:
+            kv_caches: Per-layer paged KV tensors as registered by the engine.
+
+        Returns:
+            The normalized per-layer KV tensors for the discovered layout.
+        """
+        cached = self._normalized_kv_caches.get(str(kv_caches[0].device))
+        if cached is not None:
+            return cached
+
+        discoverable_kv_caches = cast(DiscoverableKVCache, kv_caches)
+        self.engine_kv_format, normalized_kv_caches = normalize_kv_and_discover_format(
+            discoverable_kv_caches,
+            EngineType.VLLM,
+            layout_hints=self.layout_hints,
+        )  # type: ignore[arg-type]
+        normalized = cast(List[torch.Tensor], normalized_kv_caches)
+        discoverable_normalized = cast(DiscoverableKVCache, normalized)
+        self.num_blocks = get_num_blocks(  # type: ignore[arg-type]
+            discoverable_normalized, self.engine_kv_format
+        )
+        self.block_size = get_block_size(discoverable_normalized, self.engine_kv_format)  # type: ignore[arg-type]
+        self.page_buffer_size = self.num_blocks * self.block_size
+        self.head_size = get_head_size(  # type: ignore[arg-type]
+            discoverable_normalized, self.engine_kv_format
+        )
+        self.block_stride_elems = (
+            resolve_block_stride_and_log_layout(
+                discoverable_normalized,
+                self.engine_kv_format,
+                layer_idx=0,
+                group_idx=0,
+            )  # type: ignore[arg-type]
+            or 0
+        )
+        self._normalized_kv_caches[str(kv_caches[0].device)] = normalized
+        return normalized
+
+    def _initialize_pointers(
+        self, kv_caches: List[torch.Tensor]
+    ) -> torch.Tensor | List[torch.Tensor]:
+        """Return the transfer handle for the registered KV caches.
+
+        Devices with a fused pointer-based kernel get a device tensor of
+        per-layer base pointers, built once per device. Devices without one
+        (Neuron) get the normalized per-layer tensor list, which the torch
+        fallback and the Neuron stager consume directly.
+
+        Args:
+            kv_caches: Per-layer paged KV tensors as registered by the engine.
+
+        Returns:
+            A device tensor of per-layer base pointers, or the per-layer
+            tensor list for devices that transfer by tensor.
+        """
         self.device = kv_caches[0].device
+
+        # Devices without a pointer-based kernel branch out here, before the
+        # pointer path, so everything below stays exactly as it is on dev.
+        if self.device.type in _TENSOR_LIST_DEVICES:
+            return self._resolve_layout(kv_caches)
+
         assert self.device.type == "cuda", "The device should be CUDA."
         idx = self.device.index
         if idx in self.kv_cache_pointers_on_gpu:
@@ -271,6 +423,14 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         )
 
         return self.kv_cache_pointers_on_gpu[idx]
+
+    def configure_neuron_kv_staging(self) -> None:
+        """Enable Neuron block staging for paged-KV transfers.
+
+        Called post-construction so the Neuron-only staging path stays out of
+        the shared connector constructors.
+        """
+        self._neuron_kv_stager = _build_neuron_kv_stager()
 
     @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
@@ -324,6 +484,23 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         vllm_cached = kwargs.get("vllm_cached_tokens", 0)
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
+        if (
+            self._neuron_kv_stager is not None
+            and isinstance(kv_cache_pointers, list)
+            and str(self.kvcaches[0].device).split(":")[0] == "neuron"
+        ):
+            layer_tensors = cast(List[torch.Tensor], kv_cache_pointers)
+            self._neuron_kv_stager.transfer_from_key_value(
+                key_value=memory_obj.tensor,
+                layer_tensors=layer_tensors,
+                slot_mapping=slot_mapping[start:end],
+                engine_kv_format=self.engine_kv_format,
+                block_size=self.block_size,
+                head_size=self.head_size,
+                skip_prefix_n_tokens=skip_prefix_n_tokens,
+            )
+            return
+
         device_ops.multi_layer_kv_transfer(
             memory_obj.tensor,
             kv_cache_pointers,
@@ -371,7 +548,25 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 
         kv_cache_pointers = self._initialize_pointers(self.kvcaches)
 
-        with torch.cuda.stream(self.store_stream):
+        if (
+            self._neuron_kv_stager is not None
+            and isinstance(kv_cache_pointers, list)
+            and str(self.kvcaches[0].device).split(":")[0] == "neuron"
+        ):
+            layer_tensors = cast(List[torch.Tensor], kv_cache_pointers)
+            self._neuron_kv_stager.transfer_into_key_value(
+                key_value=memory_obj.tensor,
+                layer_tensors=layer_tensors,
+                slot_mapping=slot_mapping[start:end],
+                engine_kv_format=self.engine_kv_format,
+                block_size=self.block_size,
+                head_size=self.head_size,
+            )
+            if self.use_mla:
+                memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
+            return
+
+        with _device_stream_context(self.store_stream):
             if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
                 device_ops.multi_layer_kv_transfer(
                     memory_obj.tensor,
@@ -414,7 +609,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
 
     # TODO(Jiayi): need to optimize to enable real batching
     def batched_to_gpu(self, memory_objs, starts, ends, **kwargs):
-        with torch.cuda.stream(self.load_stream):
+        with _device_stream_context(self.load_stream):
             for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
                 self.to_gpu(memory_obj, start, end, **kwargs)
         self.load_stream.synchronize()
@@ -437,7 +632,9 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         use_gpu: bool = False,
         layout_hints: Optional[LayoutHints] = None,
     ):
-        assert device.type == "cuda", "The device should be CUDA."
+        assert device.type in ("cuda", "neuron"), (
+            f"Unsupported device type: {device.type}"
+        )
         self.metadata = metadata
         self.device = device
         self.use_mla = metadata.use_mla
@@ -445,13 +642,16 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.use_gpu = use_gpu
         self.layout_hints: LayoutHints = layout_hints or {}
         self.kvcaches: Optional[List[torch.Tensor]] = None
+        self._neuron_kv_stager: _NeuronKVStager | None = None
 
         self.init = False
-        self.group_kv_cache_pointers_on_gpu: Optional[list[torch.Tensor]] = None
+        self.group_kv_cache_pointers_on_gpu: Optional[
+            list[torch.Tensor | list[torch.Tensor]]
+        ] = None
         self.group_tmp_buffer: Optional[list[torch.Tensor]] = None
 
-        self.store_stream = torch.cuda.Stream()
-        self.load_stream = torch.cuda.Stream()
+        self.store_stream = _create_device_stream(self.device)
+        self.load_stream = _create_device_stream(self.device)
 
     @classmethod
     def from_metadata(
@@ -532,19 +732,34 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 for shape, dtype in zip(tmp_buf_shapes, tmp_buf_dtypes, strict=True)
             ]
 
+        device_type = str(self.device).split(":")[0]
         self.group_kv_cache_pointers_on_gpu = []
+        self._group_kv_cache_tensor_lists: list[list[torch.Tensor]] = []
         for group in klg_manager.kernel_groups:
-            ptrs = get_group_data_ptrs(
-                self.kvcaches, self.engine_kv_format, group.layer_indices
-            )
-            cpu = torch.empty(len(ptrs), dtype=torch.int64, device="cpu")
-            cpu.numpy()[:] = ptrs
-            gpu = torch.empty(len(ptrs), dtype=torch.int64, device=self.device)
-            gpu.copy_(cpu)
-            self.group_kv_cache_pointers_on_gpu.append(gpu)
+            if device_type not in ("cuda", "xpu", "musa"):
+                layer_tensors = [self.kvcaches[i] for i in group.layer_indices]
+                self._group_kv_cache_tensor_lists.append(layer_tensors)
+                self.group_kv_cache_pointers_on_gpu.append(layer_tensors)
+            else:
+                ptrs = get_group_data_ptrs(
+                    self.kvcaches, self.engine_kv_format, group.layer_indices
+                )
+                cpu = torch.empty(len(ptrs), dtype=torch.int64, device="cpu")
+                cpu.numpy()[:] = ptrs
+                gpu = torch.empty(len(ptrs), dtype=torch.int64, device=self.device)
+                gpu.copy_(cpu)
+                self.group_kv_cache_pointers_on_gpu.append(gpu)
 
         self.init = True
         logger.info("init kv cache pointers success in VLLMPagedMemGPUConnectorV3")
+
+    def configure_neuron_kv_staging(self) -> None:
+        """Enable Neuron block staging for paged-KV transfers.
+
+        Called post-construction so the Neuron-only staging path stays out of
+        the shared connector constructors.
+        """
+        self._neuron_kv_stager = _build_neuron_kv_stager()
 
     @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
@@ -567,6 +782,25 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         # block lmcache is transferring back
         vllm_cached = kwargs.get("vllm_cached_tokens", 0)
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
+
+        if (
+            self._neuron_kv_stager is not None
+            and str(self.kvcaches[0].device).split(":")[0] == "neuron"
+        ):
+            for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
+                assert isinstance(kv_cache_pointer, list)
+                memory_obj_tensor = memory_obj.get_tensor(i)
+                assert memory_obj_tensor is not None
+                self._neuron_kv_stager.transfer_from_key_value(
+                    key_value=memory_obj_tensor,
+                    layer_tensors=kv_cache_pointer,
+                    slot_mapping=slot_mapping[start:end],
+                    engine_kv_format=self.engine_kv_format,
+                    block_size=self.block_size,
+                    head_size=self.head_size,
+                    skip_prefix_n_tokens=skip_prefix_n_tokens,
+                )
+            return
 
         for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
             memory_obj_tensor = memory_obj.get_tensor(i)
@@ -596,7 +830,28 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         assert self.kvcaches[0].device == self.device
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
-        with torch.cuda.stream(self.store_stream):
+
+        if (
+            self._neuron_kv_stager is not None
+            and str(self.kvcaches[0].device).split(":")[0] == "neuron"
+        ):
+            for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
+                assert isinstance(kv_cache_pointer, list)
+                memory_obj_tensor = memory_obj.get_tensor(i)
+                assert memory_obj_tensor is not None
+                self._neuron_kv_stager.transfer_into_key_value(
+                    key_value=memory_obj_tensor,
+                    layer_tensors=kv_cache_pointer,
+                    slot_mapping=slot_mapping[start:end],
+                    engine_kv_format=self.engine_kv_format,
+                    block_size=self.block_size,
+                    head_size=self.head_size,
+                )
+            if self.use_mla:
+                memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
+            return
+
+        with _device_stream_context(self.store_stream):
             if not self.use_gpu or end - start != self.chunk_size:
                 for i, kv_cache_pointer in enumerate(
                     self.group_kv_cache_pointers_on_gpu
@@ -648,7 +903,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
 
     def batched_to_gpu(self, memory_objs, starts, ends, **kwargs):
-        with torch.cuda.stream(self.load_stream):
+        with _device_stream_context(self.load_stream):
             for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
                 self.to_gpu(memory_obj, start, end, **kwargs)
         self.load_stream.synchronize()
@@ -693,8 +948,8 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         self.dtype = kwargs["dtype"]
         self.device = kwargs["device"]
 
-        self.load_stream = torch.cuda.Stream()
-        self.store_stream = torch.cuda.Stream()
+        self.load_stream = _create_device_stream(self.device)
+        self.store_stream = _create_device_stream(self.device)
 
         self.buffer_mapping: dict[int, MemoryObj] = {}
 
@@ -895,7 +1150,8 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
 
             if layer_id > 0 and layer_id <= self.num_layers:
                 # NOTE: wait until both compute and load streams are done
-                torch.cuda.synchronize()
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
 
                 # ping-pong the buffers
                 compute_gpu_buffer_obj, load_gpu_buffer_obj = (
@@ -924,7 +1180,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                 memory_objs_layer = yield
 
                 # memobj -> gpu_buffer
-                with torch.cuda.stream(self.load_stream):
+                with _device_stream_context(self.load_stream):
                     for start, end, memory_obj in zip(
                         starts, ends, memory_objs_layer, strict=False
                     ):
@@ -1034,13 +1290,16 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
         )
         assert tmp_gpu_buffer_obj.tensor is not None
 
-        current_stream = torch.cuda.current_stream()
+        current_stream = (
+            torch.cuda.current_stream() if torch.cuda.is_available() else None
+        )
 
         for layer_id in range(self.num_layers):
             memory_objs_layer = memory_objs[layer_id]
             # kvcaches -> gpu_buffer -> memobj
-            with torch.cuda.stream(self.store_stream):
-                self.store_stream.wait_stream(current_stream)
+            with _device_stream_context(self.store_stream):
+                if current_stream is not None:
+                    self.store_stream.wait_stream(current_stream)
                 device_ops.single_layer_kv_transfer(
                     tmp_gpu_buffer_obj.tensor,
                     self.kvcaches[layer_id],
@@ -1115,8 +1374,8 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
         # All sizes are in bytes
         self.element_size = torch.tensor([], dtype=self.dtype).element_size()
 
-        self.load_stream = torch.cuda.Stream()
-        self.store_stream = torch.cuda.Stream()
+        self.load_stream = _create_device_stream(self.device)
+        self.store_stream = _create_device_stream(self.device)
 
         self.use_mla = "use_mla" in kwargs and kwargs["use_mla"]
 
@@ -1264,17 +1523,22 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
             assert tmp_gpu_buffer_obj.tensor is not None
 
         offset = starts[0]
-        current_stream = torch.cuda.current_stream()
+        current_stream = (
+            torch.cuda.current_stream() if torch.cuda.is_available() else None
+        )
 
         for layer_id in range(self.num_layers):
             memory_objs_layer = yield
             if sync:
-                current_stream.wait_stream(self.load_stream)
+                if current_stream is not None and isinstance(
+                    self.load_stream, torch.cuda.Stream
+                ):
+                    current_stream.wait_stream(self.load_stream)
             if layer_id > 0:
                 logger.debug("Finished loading layer %s", layer_id - 1)
 
             # memobj -> gpu_buffer -> kvcaches
-            with torch.cuda.stream(self.load_stream):
+            with _device_stream_context(self.load_stream):
                 for start, end, memory_obj in zip(
                     starts, ends, memory_objs_layer, strict=False
                 ):
@@ -1315,7 +1579,11 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
         yield
 
         # synchronize the last layer
-        if sync:
+        if (
+            sync
+            and current_stream is not None
+            and isinstance(self.load_stream, torch.cuda.Stream)
+        ):
             current_stream.wait_stream(self.load_stream)
 
         # free the buffer memory
@@ -1396,13 +1664,16 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
             assert tmp_gpu_buffer_obj.tensor is not None
 
         offset = starts[0]
-        current_stream = torch.cuda.current_stream()
+        current_stream = (
+            torch.cuda.current_stream() if torch.cuda.is_available() else None
+        )
 
         for layer_id in range(self.num_layers):
             memory_objs_layer = memory_objs[layer_id]
             # kvcaches -> gpu_buffer -> memobj
-            with torch.cuda.stream(self.store_stream):
-                self.store_stream.wait_stream(current_stream)
+            with _device_stream_context(self.store_stream):
+                if current_stream is not None:
+                    self.store_stream.wait_stream(current_stream)
                 if self.use_gpu:
                     device_ops.single_layer_kv_transfer(
                         tmp_gpu_buffer_obj.tensor,
@@ -1641,7 +1912,8 @@ class SGLangGPUConnector(GPUConnectorInterface):
             # Force a synchronize if the target buffer is NOT CUDA device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
-            torch.cuda.synchronize()
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
 
         if self.use_mla:
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
@@ -2004,8 +2276,8 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         self.dtype = dtype
         self.device = device
         self._batch_size = _TRTLLM_KERNEL_BATCH_SIZE
-        self.load_stream = torch.cuda.Stream(device=device)
-        self.store_stream = torch.cuda.Stream(device=device)
+        self.load_stream = _create_device_stream(device)
+        self.store_stream = _create_device_stream(device)
 
         self.kv_cache_tensor: Optional[torch.Tensor] = None
         self.paged_buffer_ptrs: Optional[torch.Tensor] = None
@@ -2126,11 +2398,11 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         tensor_ptr: int,
         block_ids: List[int],
         direction: "lmcache_native.TransferDirection",
-        stream: torch.cuda.Stream,
+        stream: "torch.cuda.Stream | _NoOpStream",
     ) -> None:
         if self.shape_desc is None or self._kv_format is None:
             raise RuntimeError("register_kv_caches must be called before transfer")
-        with torch.cuda.stream(stream):
+        with _device_stream_context(stream):
             block_ids_gpu = self._stage_block_ids(block_ids)
             device_ops.multi_layer_block_kv_transfer(
                 self.paged_buffer_ptrs,
@@ -2176,7 +2448,7 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         starts: List[int],
         block_ids: List[int],
         direction: "lmcache_native.TransferDirection",
-        stream: torch.cuda.Stream,
+        stream: "torch.cuda.Stream | _NoOpStream",
     ) -> None:
         if self.shape_desc is None or self._kv_format is None:
             raise RuntimeError("register_kv_caches must be called before transfer")
@@ -2188,7 +2460,7 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
             if chunk_blocks is not None:
                 valid.append((memory_obj, chunk_blocks))
 
-        with torch.cuda.stream(stream):
+        with _device_stream_context(stream):
             for i in range(0, len(valid), self._batch_size):
                 batch = valid[i : i + self._batch_size]
                 all_block_ids: List[int] = []

--- a/lmcache/v1/gpu_connector/neuron_kv_staging.py
+++ b/lmcache/v1/gpu_connector/neuron_kv_staging.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Neuron-specific KV staging for LMCache GPU connectors.
+
+This path stages selected paged-KV blocks between Neuron device memory and
+temporary CPU tensors, then reuses the existing CPU-side pack/unpack logic in
+``device_ops.multi_layer_kv_transfer``. It exists because Neuron device-to-host
+copy (``tensor.to("cpu")``) only succeeds on fully-contiguous tensors: slicing
+out individual KV blocks yields a non-contiguous view, and ``.contiguous()`` is
+a no-op on Neuron shared-storage tensors, so a naive block-slice copy raises
+``Expected self.is_contiguous() to be true``.
+
+The staging therefore moves each selected region directly between the paged KV
+tensor and a host staging buffer, one ``narrow`` + ``copy_`` per contiguous run
+per layer.
+
+Three properties of Neuron copies, measured on a trn2.3xlarge (SDK 2.31, native
+``torch.neuron`` backend), determine that shape. They are recorded here because
+they are not obvious and they rule out the designs one would otherwise reach for:
+
+1. **A device-to-device copy between views of differently-sized parent tensors
+   fails** with ``nrt_tensor_copy status=2``. So the selected blocks *cannot* be
+   gathered into a compact device-side buffer and shipped to the host in one
+   transfer -- that buffer is necessarily smaller than the paged cache. Only
+   same-sized parents work device-to-device.
+2. **A direct device-to-host (or host-to-device) copy between views of
+   differently-sized parents works and is correct.** No intermediate
+   ``.to("cpu")`` temporary is needed, so none is allocated.
+3. **Per-copy overhead is small.** A single block-slice transfer costs about
+   0.017 ms, and a whole 32-copy chunk of a 16-layer model about 0.7 ms
+   (~1.35 GiB/s store, ~1.67 GiB/s retrieve). Issuing one copy per run per layer
+   is therefore cheap; minimising the *number* of transfers is not worth
+   contorting the design for.
+
+The gather/scatter deliberately avoids ``torch.index_select`` and
+``torch.Tensor.index_copy_``: on Neuron those cost time proportional to the
+*whole* paged cache rather than to the selected rows, so a 0.02 GiB request
+against a 27k-block cache took over a minute. Instead the selected indices are
+collapsed into maximal runs of consecutive values and each run is moved with
+``torch.Tensor.narrow`` plus ``copy_``, which touches only the selected region.
+Both primitives are device-agnostic, so the same code runs on CPU tensors for
+tests.
+
+Staging buffers are host-side, cached, and reused across chunks. Chunk geometry
+is fixed by ``chunk_size`` and the layer layout, so steady-state serving
+reallocates nothing; a differently-shaped request (the final short chunk)
+replaces the cache entry.
+"""
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import device_ops
+from lmcache.logging import init_logger
+import lmcache.lmcache_native as lmcache_native
+
+logger = init_logger(__name__)
+
+
+class NeuronKVBlockStager:
+    """Stage selected KV blocks between Neuron memory and CPU paged tensors.
+
+    One instance backs one connector and is reused for every chunk, which is
+    what lets the staging buffers persist across transfers. It is not safe to
+    share an instance across threads: the buffers are mutated in place.
+    """
+
+    def __init__(self) -> None:
+        """Create a stager with empty staging-buffer caches."""
+        self._store_stage: dict[tuple[object, ...], torch.Tensor] = {}
+        self._retrieve_stage: dict[tuple[object, ...], torch.Tensor] = {}
+
+    def transfer_into_key_value(
+        self,
+        key_value: torch.Tensor,
+        layer_tensors: list[torch.Tensor],
+        slot_mapping: torch.Tensor,
+        engine_kv_format: "lmcache_native.EngineKVFormat",
+        block_size: int,
+        head_size: int,
+    ) -> None:
+        """Stage selected KV blocks from device memory into a CPU tensor (D2H).
+
+        :param key_value: CPU destination tensor packed by
+            ``device_ops.multi_layer_kv_transfer``.
+        :param layer_tensors: Per-layer paged KV tensors on the source device.
+        :param slot_mapping: Token-to-slot mapping for the request.
+        :param engine_kv_format: Layout of the per-layer KV tensors.
+        :param block_size: Number of token slots per KV block.
+        :param head_size: Size of each attention head.
+        :raises ValueError: If ``key_value`` is not a CPU tensor.
+        """
+        if key_value.device.type != "cpu":
+            raise ValueError("Neuron staging requires a CPU destination tensor")
+        if not layer_tensors:
+            return
+        if slot_mapping.numel() == 0:
+            return
+
+        selected_blocks, compact_slot_mapping = self._compact_slot_mapping(
+            slot_mapping, block_size
+        )
+        if not selected_blocks:
+            return
+
+        compact_num_blocks = len(selected_blocks)
+        dim, indices = self._selection_indices(
+            selected_blocks, engine_kv_format, block_size
+        )
+        runs = self._contiguous_runs(indices)
+
+        # Copies land straight in the host buffer: device-to-host is legal
+        # between differently-sized parents, so no device-side gather buffer and
+        # no per-run temporary is needed.
+        staged_host = self._stage_buffer(
+            self._store_stage, layer_tensors, dim, len(indices)
+        )
+        self._gather_runs(layer_tensors, staged_host, dim, runs)
+        staged_layers = [staged_host[index] for index in range(len(layer_tensors))]
+
+        compact_page_buffer_size = compact_num_blocks * block_size
+        device_ops.multi_layer_kv_transfer(
+            key_value,
+            staged_layers,
+            compact_slot_mapping,
+            torch.device("cpu"),
+            compact_page_buffer_size,
+            lmcache_native.TransferDirection.D2H,
+            engine_kv_format,
+            block_size=block_size,
+            head_size=head_size,
+        )
+
+    def transfer_from_key_value(
+        self,
+        key_value: torch.Tensor,
+        layer_tensors: list[torch.Tensor],
+        slot_mapping: torch.Tensor,
+        engine_kv_format: "lmcache_native.EngineKVFormat",
+        block_size: int,
+        head_size: int,
+        skip_prefix_n_tokens: int,
+    ) -> None:
+        """Scatter staged CPU KV blocks back into device memory (H2D).
+
+        :param key_value: CPU source tensor unpacked by
+            ``device_ops.multi_layer_kv_transfer``.
+        :param layer_tensors: Per-layer paged KV tensors on the destination
+            device; updated in place at the selected block positions.
+        :param slot_mapping: Token-to-slot mapping for the request.
+        :param engine_kv_format: Layout of the per-layer KV tensors.
+        :param block_size: Number of token slots per KV block.
+        :param head_size: Size of each attention head.
+        :param skip_prefix_n_tokens: Number of leading tokens of this chunk that
+            vLLM already holds via prefix caching and must not be written. Their
+            blocks can be shared with other running requests, so writing them
+            races with live readers. Required rather than defaulted: it was
+            silently omitted here once already, and nothing failed until loads
+            started running.
+        :raises ValueError: If ``key_value`` is not a CPU tensor, or if
+            ``skip_prefix_n_tokens`` is negative.
+        """
+        if key_value.device.type != "cpu":
+            raise ValueError("Neuron staging requires a CPU source tensor")
+        if skip_prefix_n_tokens < 0:
+            raise ValueError(
+                f"skip_prefix_n_tokens must be non-negative, got {skip_prefix_n_tokens}"
+            )
+        if not layer_tensors:
+            return
+        if slot_mapping.numel() == 0:
+            return
+
+        selected_blocks, compact_slot_mapping = self._compact_slot_mapping(
+            slot_mapping, block_size
+        )
+        if not selected_blocks:
+            return
+
+        compact_num_blocks = len(selected_blocks)
+        dim, indices = self._selection_indices(
+            selected_blocks, engine_kv_format, block_size
+        )
+        runs = self._contiguous_runs(indices)
+
+        staged_host = self._stage_buffer(
+            self._retrieve_stage, layer_tensors, dim, len(indices)
+        )
+
+        # Transfers are block-granular but the unpack below fills only the token
+        # slots it is asked to. Any staged position it leaves alone would be
+        # scattered back as-is, overwriting live device KV with whatever the
+        # buffer last held. Seeding the buffer from the device first makes those
+        # positions write back what is already there. Two cases leave gaps:
+        #
+        #  * A partially covered block -- the tail block of any request whose
+        #    length is not a multiple of block_size. Its remaining slots hold KV
+        #    for tokens vLLM has not generated yet.
+        #  * A non-zero skip_prefix_n_tokens. Those leading slots are already
+        #    populated by vLLM's prefix cache and their blocks may be shared with
+        #    other running requests.
+        #
+        # The extra host crossing is skipped when neither applies, which is the
+        # common case.
+        if skip_prefix_n_tokens > 0 or self._has_partial_block(
+            slot_mapping, block_size
+        ):
+            self._gather_runs(layer_tensors, staged_host, dim, runs)
+
+        staged_layers = [staged_host[index] for index in range(len(layer_tensors))]
+        compact_page_buffer_size = compact_num_blocks * block_size
+
+        device_ops.multi_layer_kv_transfer(
+            key_value,
+            staged_layers,
+            compact_slot_mapping,
+            torch.device("cpu"),
+            compact_page_buffer_size,
+            lmcache_native.TransferDirection.H2D,
+            engine_kv_format,
+            block_size=block_size,
+            head_size=head_size,
+            skip_prefix_n_tokens=skip_prefix_n_tokens,
+        )
+
+        self._scatter_runs(layer_tensors, staged_host, dim, runs)
+
+    @staticmethod
+    def _has_partial_block(slot_mapping: torch.Tensor, block_size: int) -> bool:
+        """Report whether any selected block is only partially covered.
+
+        A block is partially covered when the slot mapping names fewer than
+        ``block_size`` of its slots, which happens for the tail block of any
+        request whose token count is not a multiple of ``block_size``.
+
+        :param slot_mapping: Token-to-slot mapping for the request; negative
+            entries are unused and ignored.
+        :param block_size: Number of token slots per KV block.
+        :returns: True if at least one selected block is partially covered.
+        """
+        slots = slot_mapping.to(dtype=torch.long, device="cpu")
+        valid = slots[slots >= 0]
+        if valid.numel() == 0:
+            return False
+        blocks = torch.div(valid, block_size, rounding_mode="floor")
+        _, counts = torch.unique(blocks, return_counts=True)
+        return bool((counts < block_size).any())
+
+    @staticmethod
+    def _gather_runs(
+        layer_tensors: list[torch.Tensor],
+        staged: torch.Tensor,
+        dim: int,
+        runs: list[tuple[int, int]],
+    ) -> None:
+        """Copy the selected runs of every layer into the staging buffer.
+
+        :param layer_tensors: Per-layer paged KV tensors to read from.
+        :param staged: All-layer staging buffer to fill, indexed by layer on its
+            leading dimension.
+        :param dim: Transfer axis within a single layer's shape.
+        :param runs: ``(start, length)`` pairs along ``dim``, in staging order.
+        """
+        for layer_index, layer_tensor in enumerate(layer_tensors):
+            offset = 0
+            for start, length in runs:
+                for source, destination in NeuronKVBlockStager._run_slice_pairs(
+                    layer_tensor, staged[layer_index], dim, start, offset, length
+                ):
+                    destination.copy_(source)
+                offset += length
+
+    @staticmethod
+    def _scatter_runs(
+        layer_tensors: list[torch.Tensor],
+        staged: torch.Tensor,
+        dim: int,
+        runs: list[tuple[int, int]],
+    ) -> None:
+        """Copy the staging buffer back into the selected runs of every layer.
+
+        :param layer_tensors: Per-layer paged KV tensors to write into, updated
+            in place.
+        :param staged: All-layer staging buffer to read from, indexed by layer on
+            its leading dimension.
+        :param dim: Transfer axis within a single layer's shape.
+        :param runs: ``(start, length)`` pairs along ``dim``, in staging order.
+        """
+        for layer_index, layer_tensor in enumerate(layer_tensors):
+            offset = 0
+            for start, length in runs:
+                for destination, source in NeuronKVBlockStager._run_slice_pairs(
+                    layer_tensor, staged[layer_index], dim, start, offset, length
+                ):
+                    destination.copy_(source)
+                offset += length
+
+    @staticmethod
+    def _stage_buffer(
+        cache: dict[tuple[object, ...], torch.Tensor],
+        layer_tensors: list[torch.Tensor],
+        dim: int,
+        selected_count: int,
+    ) -> torch.Tensor:
+        """Return a reusable all-layer host staging buffer, allocated on demand.
+
+        The buffer holds every layer's selected region in one contiguous host
+        allocation, shaped ``(num_layers, *layer_shape)`` with the transfer axis
+        narrowed to ``selected_count``. It is always on CPU: the paged KV tensor
+        is the only device-side participant, because a device-to-device copy
+        between differently-sized parents is rejected by the runtime.
+
+        Every position is written before it is read -- by the unpack, by the
+        gather, or by the seeding gather for partially covered regions -- so
+        returning a buffer still holding a previous chunk's data is safe, and the
+        allocation is skipped for every chunk of the same geometry.
+
+        :param cache: Per-direction buffer cache to look in and populate.
+        :param layer_tensors: Per-layer paged KV tensors, used for dtype and the
+            non-transfer dimensions.
+        :param dim: Transfer axis within a single layer's shape.
+        :param selected_count: Extent of the transfer axis in the staged buffer.
+        :returns: A contiguous CPU tensor of shape ``(num_layers, *layer_shape)``
+            with ``layer_shape[dim] == selected_count``.
+        """
+        layer_shape = list(layer_tensors[0].shape)
+        layer_shape[dim] = selected_count
+        shape = (len(layer_tensors), *layer_shape)
+        dtype = layer_tensors[0].dtype
+
+        key = (dtype, shape)
+        buffer = cache.get(key)
+        if buffer is None:
+            buffer = torch.empty(shape, dtype=dtype, device="cpu")
+            cache[key] = buffer
+        return buffer
+
+    def _selection(
+        self,
+        device: torch.device,
+        selected_blocks: list[int],
+        engine_kv_format: "lmcache_native.EngineKVFormat",
+        block_size: int,
+    ) -> tuple[int, torch.Tensor]:
+        """Compute the gather/scatter dimension and index tensor for a layout.
+
+        Retained for callers that need an explicit index tensor. The transfer
+        paths deliberately do not use it; see :meth:`_selection_indices`.
+
+        :param device: Device the returned index tensor must live on.
+        :param selected_blocks: Sorted, de-duplicated KV block ids.
+        :param engine_kv_format: Layout of the per-layer KV tensor.
+        :param block_size: Number of token slots per KV block.
+        :returns: A tuple of the tensor dimension to gather/scatter along and a
+            ``torch.long`` index tensor on ``device``.
+        """
+        dim, indices = self._selection_indices(
+            selected_blocks, engine_kv_format, block_size
+        )
+        return dim, torch.tensor(indices, dtype=torch.long, device=device)
+
+    def _selection_indices(
+        self,
+        selected_blocks: list[int],
+        engine_kv_format: "lmcache_native.EngineKVFormat",
+        block_size: int,
+    ) -> tuple[int, list[int]]:
+        """Compute the transfer dimension and the indices to move along it.
+
+        Block-structured layouts index the block axis directly; token-structured
+        layouts (where blocks map to ``block_size`` consecutive token slots)
+        index the token axis.
+
+        :param selected_blocks: Sorted, de-duplicated KV block ids.
+        :param engine_kv_format: Layout of the per-layer KV tensor.
+        :param block_size: Number of token slots per KV block.
+        :returns: A tuple of the tensor dimension and the sorted indices along
+            it, as plain Python ints.
+        """
+        fmt = int(engine_kv_format)
+        block_axis = {
+            int(lmcache_native.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS): 0,
+            int(lmcache_native.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS): 0,
+            int(lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS): 1,
+        }
+        if fmt in block_axis:
+            return block_axis[fmt], list(selected_blocks)
+        dim = 0 if fmt == int(lmcache_native.EngineKVFormat.NL_X_NB_BS_HS) else 1
+        return dim, [
+            block_id * block_size + offset
+            for block_id in selected_blocks
+            for offset in range(block_size)
+        ]
+
+    @staticmethod
+    def _run_slice_pairs(
+        device_tensor: torch.Tensor,
+        host_tensor: torch.Tensor,
+        dim: int,
+        device_start: int,
+        host_start: int,
+        length: int,
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Pair up matching device and host slices for one contiguous run.
+
+        Every returned *device* slice is contiguous, which Neuron requires for
+        any host transfer. A run along dimension 0 is already a contiguous
+        block; a run along dimension 1 is not, so it is split into one slice per
+        leading (key/value) index, each of which is contiguous.
+
+        :param device_tensor: The paged KV tensor on the source/destination
+            device.
+        :param host_tensor: The CPU staging tensor.
+        :param dim: Transfer axis, either 0 or 1.
+        :param device_start: Start index of the run in ``device_tensor``.
+        :param host_start: Start index of the run in ``host_tensor``.
+        :param length: Number of indices in the run.
+        :returns: A list of ``(device_slice, host_slice)`` pairs of equal shape.
+        :raises ValueError: If ``dim`` is neither 0 nor 1.
+        """
+        if dim == 0:
+            return [
+                (
+                    device_tensor.narrow(0, device_start, length),
+                    host_tensor.narrow(0, host_start, length),
+                )
+            ]
+        if dim != 1:
+            raise ValueError(f"Unsupported transfer dimension {dim}")
+        return [
+            (
+                device_tensor[leading].narrow(0, device_start, length),
+                host_tensor[leading].narrow(0, host_start, length),
+            )
+            for leading in range(device_tensor.shape[0])
+        ]
+
+    @staticmethod
+    def _contiguous_runs(indices: list[int]) -> list[tuple[int, int]]:
+        """Collapse sorted indices into maximal runs of consecutive values.
+
+        Transfers are issued per run so each one reads a single narrow slice of
+        the paged cache rather than indexing across the whole tensor.
+
+        :param indices: Sorted, de-duplicated indices along the transfer axis.
+        :returns: A list of ``(start, length)`` pairs covering ``indices`` in
+            order.
+        """
+        runs: list[tuple[int, int]] = []
+        for index in indices:
+            if runs and index == runs[-1][0] + runs[-1][1]:
+                start, length = runs[-1]
+                runs[-1] = (start, length + 1)
+            else:
+                runs.append((index, 1))
+        return runs
+
+    def _compact_slot_mapping(
+        self, slot_mapping: torch.Tensor, block_size: int
+    ) -> tuple[list[int], torch.Tensor]:
+        """Remap a slot mapping onto a compacted, gap-free block range.
+
+        :param slot_mapping: Token-to-slot mapping; negative entries are unused
+            (e.g. prefix-cache padding) and skipped.
+        :param block_size: Number of token slots per KV block.
+        :returns: A tuple of the sorted, de-duplicated source block ids and a
+            CPU ``torch.long`` slot mapping rewritten against the compacted
+            block layout.
+        """
+        slots_cpu = slot_mapping.to(dtype=torch.long, device="cpu")
+        valid_mask = slots_cpu >= 0
+        if not bool(valid_mask.any()):
+            return [], slots_cpu
+
+        valid_slots = slots_cpu[valid_mask]
+        source_blocks = torch.div(valid_slots, block_size, rounding_mode="floor")
+        # ``torch.unique`` returns sorted values, so a block's position in
+        # ``selected`` is exactly its index in the compacted range and
+        # ``searchsorted`` recovers that mapping without a Python-level loop.
+        selected = torch.unique(source_blocks)
+        compact_blocks = torch.searchsorted(selected, source_blocks)
+
+        compact = slots_cpu.clone()
+        compact[valid_mask] = compact_blocks * block_size + valid_slots % block_size
+        return [int(block_id) for block_id in selected.tolist()], compact

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -244,6 +244,7 @@ def _detect_device() -> "tuple[Any, str, str | None]":
     env_backend_name = _get_env_choice(DEVICE_BACKEND_ENV_VAR)
     if env_backend_name is not None:
         torch_module, spec = _resolve_explicit_backend(torch, env_backend_name)
+        torch_module = spec.adapt_torch_module(torch_module)
         return torch_module, spec.device_type, spec.backend_name
 
     env_device_type = _get_env_choice("DEVICE_TYPE")
@@ -251,6 +252,7 @@ def _detect_device() -> "tuple[Any, str, str | None]":
         resolved = _resolve_device_type_candidates(torch, env_device_type)
         if resolved is not None:
             torch_module, spec = resolved
+            torch_module = spec.adapt_torch_module(torch_module)
             return torch_module, spec.device_type, spec.backend_name
         logger.warning(
             "DEVICE_TYPE=%r is not available or not registered, "
@@ -262,6 +264,7 @@ def _detect_device() -> "tuple[Any, str, str | None]":
         resolved = _resolve_device_type_candidates(torch, device_type)
         if resolved is not None:
             torch_module, spec = resolved
+            torch_module = spec.adapt_torch_module(torch_module)
             return torch_module, spec.device_type, spec.backend_name
 
     # No accelerator found -- fall back to CPU stub

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -96,6 +96,25 @@ class DeviceSpec:
         """
         return ""
 
+    def adapt_torch_module(self, torch_module: Any) -> Any:
+        """Return the device module LMCache should use for this backend.
+
+        Called once during detection with ``getattr(torch, torch_module_name)``.
+        The base returns it unchanged. Backends whose torch device module does
+        not expose the full surface LMCache calls (``set_device``,
+        ``device_count``, ``Stream``, ``current_stream``) override this to
+        return an adapter, rather than mutating the module in place -- that
+        module belongs to the accelerator vendor and is shared with every other
+        library in the process.
+
+        Args:
+            torch_module: The resolved ``torch.<torch_module_name>`` module.
+
+        Returns:
+            The module to publish as ``lmcache.torch_dev``.
+        """
+        return torch_module
+
     @property
     def ops_cls(self) -> type[DeviceOps]:
         """DeviceOps subclass providing this platform's operation surface.

--- a/lmcache/v1/platform/neuron/__init__.py
+++ b/lmcache/v1/platform/neuron/__init__.py
@@ -12,9 +12,131 @@ spec.
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import Any
+import os
+
 # First Party
 from lmcache.v1.platform.base.device_ops import DeviceOps
 from lmcache.v1.platform.base.device_spec import DeviceSpec
+
+
+def parse_visible_devices(value: str) -> int:
+    """Count the NeuronCores named by a ``NEURON_VISIBLE_DEVICES`` value.
+
+    The variable accepts comma-separated ids, inclusive ranges, or a mix of
+    both -- vllm-neuron uses range form (``"0-7"`` for two replicas of four
+    cores). Counting commas alone reports ``1`` for a range spanning a whole
+    node.
+
+    Args:
+        value: Raw ``NEURON_VISIBLE_DEVICES`` value, e.g. ``"0-3,8"``.
+
+    Returns:
+        Number of cores named, or ``1`` when the value is empty or malformed.
+    """
+    if not value.strip():
+        return 1
+    total = 0
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            low, _, high = part.partition("-")
+            try:
+                start, stop = int(low), int(high)
+            except ValueError:
+                return 1
+            if stop < start:
+                return 1
+            total += stop - start + 1
+        else:
+            try:
+                int(part)
+            except ValueError:
+                return 1
+            total += 1
+    return total or 1
+
+
+class _NoOpStream:
+    """Synchronous stand-in for a CUDA stream on a device without them."""
+
+    def synchronize(self) -> None:
+        """Return immediately; work on this device is already complete."""
+
+    def wait_stream(self, other: object) -> None:
+        """Return immediately; there is no stream ordering to enforce.
+
+        Args:
+            other: Accepted for signature compatibility and ignored.
+        """
+
+
+class _NeuronTorchModule:
+    """Adapter over ``torch.neuron`` supplying the calls LMCache makes.
+
+    ``torch.neuron`` does not expose ``set_device``, ``device_count``,
+    ``Stream`` or ``current_stream``. Rather than adding them to the vendor's
+    module -- which is process-global and shared with every other library --
+    this proxies every real attribute through and answers only for the missing
+    ones. Core selection on Neuron is external, via ``NEURON_VISIBLE_DEVICES``,
+    so ``set_device`` is a no-op by design.
+    """
+
+    def __init__(self, module: Any) -> None:
+        """Wrap a torch device module.
+
+        Args:
+            module: The real ``torch.neuron`` module.
+        """
+        self._module = module
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward any attribute LMCache asks for to the wrapped module.
+
+        Args:
+            name: Attribute name.
+
+        Returns:
+            The wrapped module's attribute.
+
+        Raises:
+            AttributeError: If the wrapped module does not define it.
+        """
+        return getattr(self._module, name)
+
+    def __repr__(self) -> str:
+        """Return a representation naming the wrapped module."""
+        return f"_NeuronTorchModule({self._module!r})"
+
+    def set_device(self, device: object = None) -> None:
+        """Accept and ignore a device selection.
+
+        Neuron core visibility is set by ``NEURON_VISIBLE_DEVICES`` before the
+        process starts; there is no in-process equivalent to switch to.
+
+        Args:
+            device: Accepted for signature compatibility and ignored.
+        """
+
+    def device_count(self) -> int:
+        """Return the number of NeuronCores visible to this process.
+
+        Returns:
+            The count named by ``NEURON_VISIBLE_DEVICES``, or ``1``.
+        """
+        return parse_visible_devices(os.environ.get("NEURON_VISIBLE_DEVICES", ""))
+
+    @property
+    def Stream(self) -> type[_NoOpStream]:  # noqa: N802 -- mirrors torch.cuda.Stream
+        """Return the no-op stream type used in place of CUDA streams."""
+        return _NoOpStream
+
+    def current_stream(self) -> _NoOpStream:
+        """Return a no-op stream standing in for the current device stream."""
+        return _NoOpStream()
 
 
 class NeuronDeviceSpec(DeviceSpec):
@@ -35,23 +157,36 @@ class NeuronDeviceSpec(DeviceSpec):
     def is_available(self) -> bool:
         """Check Neuron availability.
 
-        Imports ``torch_neuronx`` to trigger
-        ``rename_privateuse1_backend("neuron")``, which registers
-        ``torch.neuron``.  Without this import the device module does
-        not exist on ``torch`` and detection silently fails.
+        Supports both the legacy ``torch_neuronx`` XLA shim (which calls
+        ``rename_privateuse1_backend("neuron")``) and the native PyTorch
+        Neuron backend (SDK >= 2.27) where ``torch.neuron`` is registered
+        by ``vllm_neuron`` or the runtime itself.
         """
         try:
             # Third Party
             import torch
 
+            if hasattr(torch, "neuron") and torch.neuron.is_available():  # type: ignore[attr-defined]
+                return True
             try:
                 # Third Party
-                import torch_neuronx  # noqa: F401 — side-effect: registers torch.neuron
+                import torch_neuronx  # noqa: F401
             except ImportError:
                 return False
             return hasattr(torch, "neuron") and torch.neuron.is_available()  # type: ignore[attr-defined]
         except Exception:
             return False
+
+    def adapt_torch_module(self, torch_module: Any) -> Any:
+        """Wrap ``torch.neuron`` so the calls LMCache makes all resolve.
+
+        Args:
+            torch_module: The real ``torch.neuron`` module.
+
+        Returns:
+            A :class:`_NeuronTorchModule` proxying it.
+        """
+        return _NeuronTorchModule(torch_module)
 
     def is_handle_transfer_available(self) -> bool:
         return False

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -575,17 +575,10 @@ def multi_layer_kv_transfer(
             f"Expected torch.Tensor or list, but got {type(key_value_ptrs).__name__}"
         )
 
-    # TODO: Implement head_size support for HND layouts (NL_X_TWO_NB_NH_BS_HS,
-    # NL_X_NB_TWO_NH_BS_HS) as next step.
-    if int(engine_kv_format) in (
+    is_hnd_split_kv = int(engine_kv_format) in (
         int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS),
         int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS),
-    ):
-        raise NotImplementedError(
-            "HND layouts (NL_X_TWO_NB_NH_BS_HS, NL_X_NB_TWO_NH_BS_HS) "
-            "are not supported in the non-CUDA fallback. "
-            "head_size parameter is required but not implemented in this path."
-        )
+    )
     # 1. Filter out invalid slots.
     #    valid_mask_kv:  on key_value.device, used to index key_value
     #    valid_slots:    on paged_memory_device, used to index paged_tensor
@@ -612,10 +605,15 @@ def multi_layer_kv_transfer(
     num_layers = key_value.size(1)
     hidden_size = key_value.size(3)
 
-    # For the flash_infer interleaved layout, pre-compute block-level indices.
-    if is_flash_infer:
+    # For block-indexed layouts, pre-compute block-level indices.
+    if is_flash_infer or is_hnd_split_kv:
         block_indices = valid_slots // block_size
         block_offsets = valid_slots % block_size
+
+    # For HND layouts, derive num_heads from hidden_size and head_size.
+    if is_hnd_split_kv:
+        assert head_size > 0, "head_size is required for HND layouts"
+        num_heads = hidden_size // head_size
 
     # Determine the physical shape of the underlying paged tensor
     # (used when wrapping a raw pointer).
@@ -626,6 +624,12 @@ def multi_layer_kv_transfer(
     elif is_flash_infer:
         num_blocks = page_buffer_size // block_size
         layer_shape = (num_blocks, 2, block_size, hidden_size)
+    elif is_hnd_split_kv:
+        num_blocks = page_buffer_size // block_size
+        if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
+            layer_shape = (2, num_blocks, num_heads, block_size, head_size)
+        else:
+            layer_shape = (num_blocks, 2, num_heads, block_size, head_size)
     else:
         layer_shape = (2, page_buffer_size, hidden_size)
 
@@ -669,6 +673,73 @@ def multi_layer_kv_transfer(
                 key_value[:, layer_id, valid_mask_kv, :] = gathered.to(
                     kv_device, non_blocking=False
                 ).transpose(0, 1)
+        elif is_hnd_split_kv:
+            # NL_X_TWO_NB_NH_BS_HS: [2, NB, NH, BS, HS]
+            # NL_X_NB_TWO_NH_BS_HS: [NB, 2, NH, BS, HS]
+            # key_value layout:      [2, NL, num_tokens, hidden_size]
+            is_two_first = int(engine_kv_format) == int(
+                EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
+            )
+            # Positions of the valid tokens, as indices rather than a boolean
+            # mask, for index_select/index_copy_ below. Derived here rather than
+            # alongside valid_slots so the shared prologue stays byte-identical
+            # to the non-HND path.
+            token_indices = valid_mask_kv.nonzero(as_tuple=False).flatten()
+            # This fallback uses fancy indexing, which is unsupported on some
+            # accelerators (e.g. Neuron). Those devices must stage their blocks
+            # to CPU first (see NeuronKVBlockStager) rather than pay a silent
+            # full-tensor device-to-host copy here.
+            if paged_tensor.device.type != "cpu":
+                raise RuntimeError(
+                    "HND fallback requires CPU paged tensors; got device "
+                    f"'{paged_tensor.device}'. Stage the KV blocks to CPU "
+                    "before calling multi_layer_kv_transfer."
+                )
+            paged_cpu = paged_tensor
+            bi_cpu = block_indices.cpu()
+            bo_cpu = block_offsets.cpu()
+            if int(direction) == int(TransferDirection.H2D):
+                parts = []
+                for kv_idx in range(2):
+                    parts.append(
+                        key_value[kv_idx, layer_id].index_select(0, token_indices)
+                    )
+                lmc_valid = torch.stack(parts, dim=0)
+                # lmc_valid: [2, num_valid, hidden_size]
+                src = lmc_valid.contiguous().view(2, -1, num_heads, head_size)
+                # src: [2, num_valid, NH, HS]
+                if is_two_first:
+                    # paged: [2, NB, NH, BS, HS]
+                    # Advanced indexing on dims 1,3 puts indexed dim first:
+                    # need [num_valid, NH, HS] per KV, write via loop
+                    for kv_idx in range(2):
+                        paged_cpu[kv_idx, bi_cpu, :, bo_cpu, :] = src[kv_idx]
+                else:
+                    # paged: [NB, 2, NH, BS, HS]
+                    for kv_idx in range(2):
+                        paged_cpu[bi_cpu, kv_idx, :, bo_cpu, :] = src[kv_idx]
+                paged_tensor.copy_(paged_cpu)
+            else:
+                if is_two_first:
+                    # paged: [2, NB, NH, BS, HS]
+                    parts = []
+                    for kv_idx in range(2):
+                        g = paged_cpu[kv_idx, bi_cpu, :, bo_cpu, :]
+                        # g: [num_valid, NH, HS]
+                        parts.append(g.reshape(-1, hidden_size))
+                    flat = torch.stack(parts, dim=0)
+                    # flat: [2, num_valid, hidden_size]
+                else:
+                    parts = []
+                    for kv_idx in range(2):
+                        g = paged_cpu[bi_cpu, kv_idx, :, bo_cpu, :]
+                        parts.append(g.reshape(-1, hidden_size))
+                    flat = torch.stack(parts, dim=0)
+                flat_c = flat.to(kv_device, non_blocking=False)
+                for kv_idx2 in range(2):
+                    key_value[kv_idx2, layer_id].index_copy_(
+                        0, token_indices, flat_c[kv_idx2]
+                    )
         else:
             # Paged layout : [2, page_buffer_size, hidden_size]
             # key_value layout: [2, num_layers, num_tokens, hidden_size]

--- a/tests/v1/platform/neuron/test_neuron_backend.py
+++ b/tests/v1/platform/neuron/test_neuron_backend.py
@@ -125,3 +125,87 @@ def test_neuron_device_type_matches_torch_neuronx() -> None:
         f"NeuronDeviceSpec assumes device_type='neuron' but "
         f"torch_neuronx reports '{actual}'. Update NeuronDeviceSpec."
     )
+
+
+# -- Visible-device parsing ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", 1),
+        ("   ", 1),
+        ("5", 1),
+        ("0,1,2", 3),
+        ("0-7", 8),
+        ("0-3,8-11", 8),
+        ("0-3,8", 5),
+        ("0-0", 1),
+        ("3-1", 1),
+        ("garbage", 1),
+    ],
+)
+def test_parse_visible_devices(value: str, expected: int) -> None:
+    """NEURON_VISIBLE_DEVICES ranges are counted, not just comma-separated ids.
+
+    vllm-neuron sets this in range form (e.g. "0-7" for two replicas of four
+    cores), so counting commas alone under-reports a whole-node allocation.
+    """
+    # First Party
+    from lmcache.v1.platform.neuron import parse_visible_devices
+
+    assert parse_visible_devices(value) == expected
+
+
+# -- torch module adapter --------------------------------------------------
+
+
+def test_adapt_torch_module_supplies_missing_methods(
+    neuron_spec: NeuronDeviceSpec, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The adapter answers the calls torch.neuron does not define."""
+    monkeypatch.setenv("NEURON_VISIBLE_DEVICES", "0-7")
+
+    class BareModule:
+        """Stands in for a torch.neuron without the CUDA-shaped surface."""
+
+        def is_available(self) -> bool:
+            return True
+
+    adapted = neuron_spec.adapt_torch_module(BareModule())
+
+    assert adapted.device_count() == 8
+    assert adapted.set_device(0) is None
+    assert adapted.current_stream().synchronize() is None
+    assert adapted.Stream is not None
+
+
+def test_adapt_torch_module_does_not_mutate_the_module(
+    neuron_spec: NeuronDeviceSpec,
+) -> None:
+    """Adapting leaves the vendor's module untouched."""
+
+    class BareModule:
+        """Stands in for a torch.neuron without the CUDA-shaped surface."""
+
+    module = BareModule()
+    neuron_spec.adapt_torch_module(module)
+
+    assert not hasattr(module, "set_device")
+    assert not hasattr(module, "device_count")
+    assert not hasattr(module, "Stream")
+
+
+def test_adapt_torch_module_forwards_real_attributes(
+    neuron_spec: NeuronDeviceSpec,
+) -> None:
+    """Attributes the real module defines are passed straight through."""
+
+    class BareModule:
+        """Stands in for a torch.neuron exposing its own attribute."""
+
+        sentinel = "from-the-real-module"
+
+    adapted = neuron_spec.adapt_torch_module(BareModule())
+
+    assert adapted.sentinel == "from-the-real-module"

--- a/tests/v1/test_gpu_connector_layout_cache.py
+++ b/tests/v1/test_gpu_connector_layout_cache.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for KV layout discovery on devices without a pointer kernel.
+
+Layout discovery is a start-up concern: the engine registers its KV caches once
+and never replaces them. These tests pin that discovery to a single run per
+device so it cannot drift back into the per-transfer path, where it would cost
+every chunk.
+
+The path under test is reached only for ``_TENSOR_LIST_DEVICES``; the CUDA
+pointer path in ``_initialize_pointers`` is deliberately left as it is on dev.
+CPU tensors stand in for such a device -- the fixture adds ``"cpu"`` to that set
+-- because the concern is device-agnostic and Neuron is not available in CI.
+"""
+
+# Standard
+from typing import Any
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.gpu_connector.gpu_connectors import VLLMPagedMemGPUConnectorV2
+import lmcache.lmcache_native as lmcache_native
+import lmcache.v1.gpu_connector.gpu_connectors as connectors_mod
+
+
+@pytest.fixture
+def kv_caches() -> list[torch.Tensor]:
+    """Two CPU layers in ``[2, NB, NH, BS, HS]`` (HND) layout."""
+    return [torch.zeros((2, 4, 2, 8, 16)) for _ in range(2)]
+
+
+@pytest.fixture
+def connector(monkeypatch: pytest.MonkeyPatch) -> VLLMPagedMemGPUConnectorV2:
+    """A connector with layout-discovery state initialized, no GPU buffer.
+
+    ``"cpu"`` is added to the tensor-list device set so CPU tensors take the same
+    branch a Neuron device would.
+    """
+    monkeypatch.setattr(
+        connectors_mod, "_TENSOR_LIST_DEVICES", frozenset({"neuron", "cpu"})
+    )
+    instance = object.__new__(VLLMPagedMemGPUConnectorV2)
+    instance.layout_hints = {"kv_layout": "HND"}
+    instance.kv_cache_pointers_on_gpu = {}
+    instance._normalized_kv_caches = {}
+    return instance
+
+
+def _count_detection_calls(
+    monkeypatch: pytest.MonkeyPatch, counter: dict[str, int]
+) -> None:
+    """Patch layout detection and geometry helpers to count and stub them.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param counter: Dict incremented under ``"detect"`` on each detection call.
+    """
+    fmt = lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
+
+    def fake_detect(kv_caches: Any, engine: Any, layout_hints: Any = None) -> Any:
+        counter["detect"] = counter.get("detect", 0) + 1
+        return fmt, kv_caches
+
+    monkeypatch.setattr(connectors_mod, "normalize_kv_and_discover_format", fake_detect)
+    monkeypatch.setattr(connectors_mod, "get_num_blocks", lambda *a, **k: 4)
+    monkeypatch.setattr(connectors_mod, "get_block_size", lambda *a, **k: 8)
+    monkeypatch.setattr(connectors_mod, "get_head_size", lambda *a, **k: 16)
+    monkeypatch.setattr(
+        connectors_mod, "resolve_block_stride_and_log_layout", lambda *a, **k: 0
+    )
+
+
+def test_layout_discovery_runs_once_across_transfers(
+    connector: VLLMPagedMemGPUConnectorV2,
+    kv_caches: list[torch.Tensor],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated transfers reuse the layout discovered on the first call."""
+    counter: dict[str, int] = {}
+    _count_detection_calls(monkeypatch, counter)
+
+    for _ in range(5):
+        connector._initialize_pointers(kv_caches)
+
+    assert counter["detect"] == 1
+
+
+def test_layout_geometry_is_populated(
+    connector: VLLMPagedMemGPUConnectorV2,
+    kv_caches: list[torch.Tensor],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cached geometry is derived on the first call and stays available."""
+    counter: dict[str, int] = {}
+    _count_detection_calls(monkeypatch, counter)
+
+    connector._initialize_pointers(kv_caches)
+    connector._initialize_pointers(kv_caches)
+
+    assert connector.block_size == 8
+    assert connector.num_blocks == 4
+    assert connector.head_size == 16
+    assert connector.page_buffer_size == 32
+    assert (
+        connector.engine_kv_format == lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
+    )
+
+
+def test_non_pointer_device_returns_tensor_list(
+    connector: VLLMPagedMemGPUConnectorV2,
+    kv_caches: list[torch.Tensor],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Devices without a fused pointer kernel get the per-layer tensor list."""
+    counter: dict[str, int] = {}
+    _count_detection_calls(monkeypatch, counter)
+
+    result = connector._initialize_pointers(kv_caches)
+
+    assert isinstance(result, list)
+    assert len(result) == len(kv_caches)
+
+
+def test_layout_is_cached_per_device_not_per_connector(
+    connector: VLLMPagedMemGPUConnectorV2,
+    kv_caches: list[torch.Tensor],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second device gets its own discovery, not the first device's result.
+
+    The normalized tensors are what callers read geometry and pointers from, so
+    caching them once per connector rather than once per device would hand the
+    second device the first device's tensors.
+    """
+    counter: dict[str, int] = {}
+    _count_detection_calls(monkeypatch, counter)
+
+    connector._initialize_pointers(kv_caches)
+    first = connector._normalized_kv_caches[str(kv_caches[0].device)]
+    assert counter["detect"] == 1
+
+    # Distinct tensor objects standing in for a second device's caches. They are
+    # still CPU tensors; what matters is that reusing the first entry would be
+    # detectable. Key them under a different device string to force the miss.
+    other = [tensor.clone() for tensor in kv_caches]
+    connector._normalized_kv_caches.pop(str(other[0].device))
+    connector._initialize_pointers(other)
+
+    assert counter["detect"] == 2, "detection must re-run for a second device"
+    assert connector._normalized_kv_caches[str(other[0].device)] is not first

--- a/tests/v1/test_neuron_kv_staging.py
+++ b/tests/v1/test_neuron_kv_staging.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Any
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+import lmcache.lmcache_native as lmcache_native
+import lmcache.v1.gpu_connector.neuron_kv_staging as staging_mod
+
+
+def _capture_multi_layer(monkeypatch, recorded: dict[str, Any]):
+    """Patch ``multi_layer_kv_transfer`` to record staged tensors.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param recorded: Dict populated with the captured call arguments; the
+        staged layer tensors are stored under ``"staged"`` (as clones) so the
+        gather output can be inspected, and the same list object under
+        ``"staged_ref"`` so a test can mutate it to simulate an H2D unpack.
+    """
+
+    def fake_multi_layer_kv_transfer(
+        key_value,
+        key_value_ptrs,
+        slot_mapping,
+        paged_memory_device,
+        page_buffer_size,
+        direction,
+        engine_kv_format,
+        block_size=0,
+        head_size=0,
+        skip_prefix_n_tokens=0,
+        block_stride_elems=0,
+    ):
+        recorded["staged"] = [t.clone() for t in key_value_ptrs]
+        recorded["staged_ref"] = key_value_ptrs
+        recorded["slot_mapping"] = slot_mapping.tolist()
+        recorded["page_buffer_size"] = page_buffer_size
+        recorded["direction"] = int(direction)
+        recorded["fmt"] = int(engine_kv_format)
+        recorded["block_size"] = block_size
+        recorded["head_size"] = head_size
+
+    monkeypatch.setattr(
+        staging_mod.device_ops, "multi_layer_kv_transfer", fake_multi_layer_kv_transfer
+    )
+
+
+def test_compact_slot_mapping_remaps_blocks_and_preserves_invalid_slots():
+    stager = staging_mod.NeuronKVBlockStager()
+    slots = torch.tensor([-1, 4, 5, 12, 13], dtype=torch.long)
+
+    selected_blocks, compact = stager._compact_slot_mapping(slots, block_size=4)
+
+    assert selected_blocks == [1, 3]
+    assert compact.tolist() == [-1, 0, 1, 4, 5]
+
+
+def test_compact_slot_mapping_handles_scattered_unsorted_blocks():
+    """Real slot mappings come from the block allocator, not a dense range."""
+    stager = staging_mod.NeuronKVBlockStager()
+    # Blocks 9, 2 and 5, visited out of order, with a prefix-cache gap.
+    slots = torch.tensor([-1, -1, 37, 36, 11, 22, 8], dtype=torch.long)
+
+    selected_blocks, compact = stager._compact_slot_mapping(slots, block_size=4)
+
+    assert selected_blocks == [2, 5, 9]
+    # 37 -> block 9 off 1 -> compact block 2; 36 -> block 9 off 0;
+    # 11 -> block 2 off 3 -> compact block 0; 22 -> block 5 off 2 -> compact 1;
+    # 8 -> block 2 off 0 -> compact block 0.
+    assert compact.tolist() == [-1, -1, 9, 8, 3, 6, 0]
+
+
+def test_compact_slot_mapping_all_invalid_returns_no_blocks():
+    stager = staging_mod.NeuronKVBlockStager()
+    slots = torch.tensor([-1, -1], dtype=torch.long)
+
+    selected_blocks, compact = stager._compact_slot_mapping(slots, block_size=4)
+
+    assert selected_blocks == []
+    assert compact.tolist() == [-1, -1]
+
+
+def test_contiguous_runs_collapses_adjacent_indices():
+    """Runs are what keep a transfer from touching the whole paged cache."""
+    runs = staging_mod.NeuronKVBlockStager._contiguous_runs([0, 1, 2, 7, 9, 10])
+
+    assert runs == [(0, 3), (7, 1), (9, 2)]
+
+
+def test_contiguous_runs_empty_selection():
+    assert staging_mod.NeuronKVBlockStager._contiguous_runs([]) == []
+
+
+def test_contiguous_runs_fully_scattered_indices():
+    runs = staging_mod.NeuronKVBlockStager._contiguous_runs([1, 3, 5])
+
+    assert runs == [(1, 1), (3, 1), (5, 1)]
+
+
+def test_selection_block_indexed_hnd_two_major_uses_block_axis():
+    stager = staging_mod.NeuronKVBlockStager()
+
+    dim, indices = stager._selection(
+        torch.device("cpu"),
+        [1, 3],
+        lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+    )
+
+    assert dim == 1
+    assert indices.tolist() == [1, 3]
+
+
+def test_selection_token_indexed_expands_blocks_to_token_slots():
+    stager = staging_mod.NeuronKVBlockStager()
+
+    dim, indices = stager._selection(
+        torch.device("cpu"),
+        [1, 3],
+        lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+        block_size=2,
+    )
+
+    assert dim == 0
+    assert indices.tolist() == [2, 3, 6, 7]
+
+
+def test_transfer_into_key_value_gathers_only_selected_blocks(monkeypatch):
+    recorded: dict[str, Any] = {}
+    _capture_multi_layer(monkeypatch, recorded)
+
+    stager = staging_mod.NeuronKVBlockStager()
+    key_value = torch.empty((2, 1, 4, 6), dtype=torch.float32)
+    # [2, num_blocks, num_heads, block_size, head_size]; unique per block.
+    layer = torch.arange(2 * 4 * 3 * 2 * 2, dtype=torch.float32).reshape(2, 4, 3, 2, 2)
+    slots = torch.tensor([2, 3, 6, 7], dtype=torch.long)  # blocks 1 and 3
+
+    stager.transfer_into_key_value(
+        key_value=key_value,
+        layer_tensors=[layer],
+        slot_mapping=slots,
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+        head_size=2,
+    )
+
+    assert recorded["slot_mapping"] == [0, 1, 2, 3]
+    assert recorded["page_buffer_size"] == 4
+    assert recorded["direction"] == int(lmcache_native.TransferDirection.D2H)
+    staged = recorded["staged"]
+    assert len(staged) == 1
+    assert tuple(staged[0].shape) == (2, 2, 3, 2, 2)
+    # Staged data must equal the source layer's blocks 1 and 3.
+    expected = layer.index_select(1, torch.tensor([1, 3]))
+    assert torch.equal(staged[0], expected)
+
+
+def test_transfer_from_key_value_scatters_into_selected_blocks(monkeypatch):
+    stager = staging_mod.NeuronKVBlockStager()
+    key_value = torch.empty((2, 1, 4, 6), dtype=torch.float32)
+    layer = torch.zeros((2, 4, 3, 2, 2), dtype=torch.float32)
+    slots = torch.tensor([2, 3, 6, 7], dtype=torch.long)  # blocks 1 and 3
+
+    # Simulate the CPU unpack filling each staged buffer with known values.
+    def fill_staged(key_value, key_value_ptrs, *_args, **_kwargs):
+        for staged in key_value_ptrs:
+            staged.copy_(torch.ones_like(staged))
+
+    monkeypatch.setattr(staging_mod.device_ops, "multi_layer_kv_transfer", fill_staged)
+
+    stager.transfer_from_key_value(
+        key_value=key_value,
+        layer_tensors=[layer],
+        slot_mapping=slots,
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+        head_size=2,
+        skip_prefix_n_tokens=0,
+    )
+
+    # Blocks 1 and 3 must now be ones; blocks 0 and 2 untouched (zeros).
+    assert torch.equal(layer[:, 1], torch.ones_like(layer[:, 1]))
+    assert torch.equal(layer[:, 3], torch.ones_like(layer[:, 3]))
+    assert torch.equal(layer[:, 0], torch.zeros_like(layer[:, 0]))
+    assert torch.equal(layer[:, 2], torch.zeros_like(layer[:, 2]))
+
+
+def _multi_layer_args(num_layers: int) -> dict[str, Any]:
+    """Build a call for ``num_layers`` identical layers in an HND-two-major cache.
+
+    :param num_layers: Number of per-layer KV tensors to generate.
+    :returns: Keyword arguments for either transfer method.
+    """
+    return {
+        "key_value": torch.empty((2, num_layers, 4, 6), dtype=torch.float32),
+        "layer_tensors": [
+            torch.arange(2 * 4 * 3 * 2 * 2, dtype=torch.float32).reshape(2, 4, 3, 2, 2)
+            for _ in range(num_layers)
+        ],
+        "slot_mapping": torch.tensor([2, 3, 6, 7], dtype=torch.long),
+        "engine_kv_format": lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        "block_size": 2,
+        "head_size": 2,
+    }
+
+
+def test_all_layers_stage_through_a_single_buffer(monkeypatch):
+    """Every layer must land in one allocation, so one host copy covers them all.
+
+    This is the property the staging exists for: host transfer count on Neuron
+    is a fixed cost per copy, so staging per layer reintroduces the overhead the
+    gather was meant to remove.
+    """
+    recorded: dict[str, Any] = {}
+    _capture_multi_layer(monkeypatch, recorded)
+
+    stager = staging_mod.NeuronKVBlockStager()
+    stager.transfer_into_key_value(**_multi_layer_args(num_layers=8))
+
+    staged = recorded["staged_ref"]
+    assert len(staged) == 8
+    storages = {tensor.untyped_storage().data_ptr() for tensor in staged}
+    assert len(storages) == 1, "staged layers must be views of one buffer"
+
+
+def test_staging_buffers_are_reused_across_chunks_of_equal_geometry(monkeypatch):
+    """Steady-state serving must not reallocate; only new geometry may."""
+    recorded: dict[str, Any] = {}
+    _capture_multi_layer(monkeypatch, recorded)
+    stager = staging_mod.NeuronKVBlockStager()
+
+    stager.transfer_into_key_value(**_multi_layer_args(num_layers=4))
+    first = recorded["staged_ref"][0].untyped_storage().data_ptr()
+
+    stager.transfer_into_key_value(**_multi_layer_args(num_layers=4))
+    second = recorded["staged_ref"][0].untyped_storage().data_ptr()
+    assert first == second
+
+    # A different layer count is different geometry and gets its own buffer.
+    stager.transfer_into_key_value(**_multi_layer_args(num_layers=5))
+    assert recorded["staged_ref"][0].untyped_storage().data_ptr() != first
+
+
+def test_reused_buffer_does_not_leak_the_previous_chunk(monkeypatch):
+    """A reused buffer is fully overwritten, so no stale KV can be stored."""
+    recorded: dict[str, Any] = {}
+    _capture_multi_layer(monkeypatch, recorded)
+    stager = staging_mod.NeuronKVBlockStager()
+
+    args = _multi_layer_args(num_layers=2)
+    stager.transfer_into_key_value(**args)
+
+    # Second chunk selects different blocks from a different source tensor.
+    args["layer_tensors"] = [torch.full((2, 4, 3, 2, 2), 7.0) for _ in range(2)]
+    args["slot_mapping"] = torch.tensor([0, 1, 4, 5], dtype=torch.long)  # blocks 0, 2
+    stager.transfer_into_key_value(**args)
+
+    for staged in recorded["staged"]:
+        assert torch.equal(staged, torch.full_like(staged, 7.0))
+
+
+def test_partially_covered_block_keeps_its_uncovered_slots(monkeypatch):
+    """A partial tail block must not have its unmapped slots overwritten.
+
+    Transfers are block-granular but the unpack only fills the token slots named
+    in the slot mapping. The tail block of any request whose length is not a
+    multiple of ``block_size`` is partially covered, and its remaining slots hold
+    live KV for tokens vLLM has not generated yet. Scattering the staging buffer
+    over them wholesale corrupts the cache with whatever that buffer last held --
+    a previous chunk's KV, which is plausible enough to produce bad output rather
+    than an error.
+    """
+    stager = staging_mod.NeuronKVBlockStager()
+    # [2, num_blocks, num_heads, block_size, head_size] with block_size 2.
+    layer = torch.arange(2 * 4 * 3 * 2 * 2, dtype=torch.float32).reshape(2, 4, 3, 2, 2)
+    original = layer.clone()
+    # Slot 2 only: block 1, offset 0. Offset 1 of block 1 is not mapped.
+    slots = torch.tensor([2], dtype=torch.long)
+
+    def fill_covered_slot_only(key_value, key_value_ptrs, *_args, **_kwargs):
+        """Mimic the native unpack: write only the mapped slot, leave the rest."""
+        for staged in key_value_ptrs:
+            # staged is [2, 1 block, num_heads, block_size, head_size].
+            staged[:, :, :, 0, :] = 1.0
+
+    monkeypatch.setattr(
+        staging_mod.device_ops, "multi_layer_kv_transfer", fill_covered_slot_only
+    )
+
+    stager.transfer_from_key_value(
+        key_value=torch.empty((2, 1, 1, 6), dtype=torch.float32),
+        layer_tensors=[layer],
+        slot_mapping=slots,
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+        head_size=2,
+        skip_prefix_n_tokens=0,
+    )
+
+    # The mapped slot took the retrieved value.
+    assert torch.equal(layer[:, 1, :, 0, :], torch.ones_like(layer[:, 1, :, 0, :]))
+    # The unmapped slot of the same block is unchanged.
+    assert torch.equal(layer[:, 1, :, 1, :], original[:, 1, :, 1, :])
+    # Other blocks are untouched.
+    for block in (0, 2, 3):
+        assert torch.equal(layer[:, block], original[:, block])
+
+
+def test_skipped_prefix_tokens_are_not_written(monkeypatch):
+    """Prefix-cached leading tokens must survive a retrieve untouched.
+
+    ``skip_prefix_n_tokens`` names tokens vLLM already holds. Their blocks can be
+    shared with other running requests via prefix caching, so writing them races
+    with live readers and corrupts KV that belongs to a different request. The
+    connector computed this value and the Neuron path dropped it on the floor.
+    """
+    stager = staging_mod.NeuronKVBlockStager()
+    layer = torch.arange(2 * 4 * 3 * 2 * 2, dtype=torch.float32).reshape(2, 4, 3, 2, 2)
+    original = layer.clone()
+    # Blocks 1 and 3. The first two tokens (block 1) are prefix-cached.
+    slots = torch.tensor([2, 3, 6, 7], dtype=torch.long)
+
+    def fill_after_skip(
+        key_value, key_value_ptrs, *_args, skip_prefix_n_tokens=0, **_kwargs
+    ):
+        """Mimic the native unpack honouring the skip: leave the first N slots."""
+        for staged in key_value_ptrs:
+            # staged is [2, 2 blocks, num_heads, block_size, head_size]; flatten
+            # the block and within-block axes to index tokens of the chunk.
+            flat = staged.permute(0, 2, 1, 3, 4).reshape(2, 3, 4, 2)
+            flat[:, :, skip_prefix_n_tokens:, :] = 1.0
+            staged.copy_(flat.reshape(2, 3, 2, 2, 2).permute(0, 2, 1, 3, 4))
+
+    monkeypatch.setattr(
+        staging_mod.device_ops, "multi_layer_kv_transfer", fill_after_skip
+    )
+
+    stager.transfer_from_key_value(
+        key_value=torch.empty((2, 1, 4, 6), dtype=torch.float32),
+        layer_tensors=[layer],
+        slot_mapping=slots,
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+        head_size=2,
+        skip_prefix_n_tokens=2,
+    )
+
+    # Block 1 holds the two skipped tokens and must be exactly as it was.
+    assert torch.equal(layer[:, 1], original[:, 1])
+    # Block 3 holds the retrieved tokens.
+    assert torch.equal(layer[:, 3], torch.ones_like(layer[:, 3]))
+    # Unselected blocks untouched.
+    assert torch.equal(layer[:, 0], original[:, 0])
+    assert torch.equal(layer[:, 2], original[:, 2])
+
+
+def test_skip_prefix_n_tokens_is_forwarded_to_the_unpack(monkeypatch):
+    """The value must reach the unpack, not just gate the seeding."""
+    seen: dict[str, Any] = {}
+
+    def record(key_value, key_value_ptrs, *_args, skip_prefix_n_tokens=0, **_kwargs):
+        seen["skip"] = skip_prefix_n_tokens
+
+    monkeypatch.setattr(staging_mod.device_ops, "multi_layer_kv_transfer", record)
+
+    staging_mod.NeuronKVBlockStager().transfer_from_key_value(
+        key_value=torch.empty((2, 1, 4, 6), dtype=torch.float32),
+        layer_tensors=[torch.zeros((2, 4, 3, 2, 2), dtype=torch.float32)],
+        slot_mapping=torch.tensor([2, 3, 6, 7], dtype=torch.long),
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+        head_size=2,
+        skip_prefix_n_tokens=3,
+    )
+
+    assert seen["skip"] == 3
+
+
+def test_negative_skip_prefix_n_tokens_is_rejected():
+    with pytest.raises(ValueError, match="non-negative"):
+        staging_mod.NeuronKVBlockStager().transfer_from_key_value(
+            key_value=torch.empty((2, 1, 4, 6), dtype=torch.float32),
+            layer_tensors=[torch.zeros((2, 4, 3, 2, 2), dtype=torch.float32)],
+            slot_mapping=torch.tensor([2, 3], dtype=torch.long),
+            engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+            block_size=2,
+            head_size=2,
+            skip_prefix_n_tokens=-1,
+        )
+
+
+def test_transfer_from_key_value_scatters_token_indexed_layout(monkeypatch):
+    """The scatter must also be correct for a layout indexed on the token axis."""
+    stager = staging_mod.NeuronKVBlockStager()
+    # NL_X_NB_BS_HS: [num_blocks * block_size, num_heads, head_size], dim 0.
+    layer = torch.zeros((8, 3, 2), dtype=torch.float32)
+
+    def fill_staged(key_value, key_value_ptrs, *_args, **_kwargs):
+        for staged in key_value_ptrs:
+            staged.copy_(torch.ones_like(staged))
+
+    monkeypatch.setattr(staging_mod.device_ops, "multi_layer_kv_transfer", fill_staged)
+
+    stager.transfer_from_key_value(
+        key_value=torch.empty((2, 1, 4, 6), dtype=torch.float32),
+        layer_tensors=[layer],
+        slot_mapping=torch.tensor([2, 3, 6, 7], dtype=torch.long),  # blocks 1 and 3
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_NB_BS_HS,
+        block_size=2,
+        head_size=2,
+        skip_prefix_n_tokens=0,
+    )
+
+    # Token slots 2,3 and 6,7 written; 0,1 and 4,5 untouched.
+    assert torch.equal(layer[2:4], torch.ones_like(layer[2:4]))
+    assert torch.equal(layer[6:8], torch.ones_like(layer[6:8]))
+    assert torch.equal(layer[0:2], torch.zeros_like(layer[0:2]))
+    assert torch.equal(layer[4:6], torch.zeros_like(layer[4:6]))
+
+
+def test_transfer_into_key_value_requires_cpu_destination():
+    stager = staging_mod.NeuronKVBlockStager()
+    with pytest.raises(ValueError):
+        stager.transfer_into_key_value(
+            key_value=torch.empty((2, 1, 4, 6), device="meta"),
+            layer_tensors=[torch.empty((2, 4, 3, 2, 2))],
+            slot_mapping=torch.tensor([0], dtype=torch.long),
+            engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+            block_size=2,
+            head_size=2,
+        )
+
+
+def test_transfer_into_key_value_empty_inputs_are_noops(monkeypatch):
+    recorded: dict[str, Any] = {}
+    _capture_multi_layer(monkeypatch, recorded)
+
+    stager = staging_mod.NeuronKVBlockStager()
+    key_value = torch.empty((2, 1, 4, 6), dtype=torch.float32)
+
+    stager.transfer_into_key_value(
+        key_value=key_value,
+        layer_tensors=[],
+        slot_mapping=torch.tensor([], dtype=torch.long),
+        engine_kv_format=lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        block_size=2,
+        head_size=2,
+    )
+
+    assert "staged" not in recorded

--- a/tests/v1/test_torch_ops.py
+++ b/tests/v1/test_torch_ops.py
@@ -3017,6 +3017,167 @@ class TestScenarios:
                         )
 
 
+@pytest.mark.parametrize(
+    ("engine_kv_format", "is_two_first"),
+    [
+        (lmcache_native.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS, True),
+        (lmcache_native.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS, False),
+    ],
+)
+@pytest.mark.parametrize("use_tensor_list", [False, True])
+def test_multi_layer_kv_transfer_hnd_round_trip(
+    engine_kv_format: lmcache_native.EngineKVFormat,
+    is_two_first: bool,
+    use_tensor_list: bool,
+) -> None:
+    """Exercise the Python fallback HND transfer path on CPU."""
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+    num_layers = 2
+    num_tokens = 5
+    num_heads = 2
+    head_size = 8
+    hidden_size = num_heads * head_size
+    page_buffer_size = 10
+    block_size = 5
+    slot_mapping = torch.tensor([0, -1, 5, 9, 3], dtype=torch.int64, device=device)
+    valid_token_ids = [
+        idx for idx, slot in enumerate(slot_mapping.tolist()) if slot >= 0
+    ]
+    unused_slot = 1
+
+    def _hnd_value(base: int) -> torch.Tensor:
+        return (base + torch.arange(hidden_size, dtype=dtype)).reshape(
+            num_heads, head_size
+        )
+
+    def _paged_slice(
+        paged_layer: torch.Tensor,
+        kv_idx: int,
+        slot_idx: int,
+    ) -> torch.Tensor:
+        block_idx, block_offset = divmod(slot_idx, block_size)
+        if is_two_first:
+            return paged_layer[kv_idx, block_idx, :, block_offset, :]
+        return paged_layer[block_idx, kv_idx, :, block_offset, :]
+
+    paged_in = [
+        torch.zeros(
+            (2, page_buffer_size // block_size, num_heads, block_size, head_size),
+            dtype=dtype,
+            device=device,
+        )
+        if is_two_first
+        else torch.zeros(
+            (page_buffer_size // block_size, 2, num_heads, block_size, head_size),
+            dtype=dtype,
+            device=device,
+        )
+        for _ in range(num_layers)
+    ]
+    for layer_id, paged_layer in enumerate(paged_in):
+        for slot_idx in range(page_buffer_size):
+            for kv_idx in range(2):
+                value = _hnd_value(kv_idx * 5000 + layer_id * 1000 + slot_idx * 10)
+                _paged_slice(paged_layer, kv_idx, slot_idx).copy_(value)
+
+    key_value = torch.zeros((2, num_layers, num_tokens, hidden_size), dtype=dtype)
+    paged_in_ptrs: Union[list[torch.Tensor], torch.Tensor]
+    if use_tensor_list:
+        paged_in_ptrs = paged_in
+    else:
+        paged_in_ptrs = torch.tensor(
+            [layer.data_ptr() for layer in paged_in],
+            dtype=torch.uint64,
+            device=device,
+        )
+
+    _py_ops.multi_layer_kv_transfer(
+        key_value,
+        paged_in_ptrs,
+        slot_mapping,
+        device,
+        page_buffer_size,
+        lmcache_native.TransferDirection.D2H,
+        engine_kv_format,
+        block_size,
+        head_size,
+    )
+
+    for layer_id in range(num_layers):
+        for token_id in valid_token_ids:
+            slot_idx = int(slot_mapping[token_id].item())
+            for kv_idx in range(2):
+                expected = _hnd_value(kv_idx * 5000 + layer_id * 1000 + slot_idx * 10)
+                torch.testing.assert_close(
+                    key_value[kv_idx, layer_id, token_id],
+                    expected.reshape(-1),
+                )
+
+    for layer_id in range(num_layers):
+        for kv_idx in range(2):
+            torch.testing.assert_close(
+                key_value[kv_idx, layer_id, 1],
+                torch.zeros(hidden_size, dtype=dtype),
+            )
+
+    key_value_h2d = torch.zeros((2, num_layers, num_tokens, hidden_size), dtype=dtype)
+    for layer_id in range(num_layers):
+        for token_id in valid_token_ids:
+            for kv_idx in range(2):
+                key_value_h2d[kv_idx, layer_id, token_id] = (
+                    kv_idx * 7000
+                    + layer_id * 2000
+                    + token_id * 10
+                    + torch.arange(hidden_size, dtype=dtype)
+                )
+
+    paged_out = [torch.zeros_like(layer) for layer in paged_in]
+    paged_out_ptrs: Union[list[torch.Tensor], torch.Tensor]
+    if use_tensor_list:
+        paged_out_ptrs = paged_out
+    else:
+        paged_out_ptrs = torch.tensor(
+            [layer.data_ptr() for layer in paged_out],
+            dtype=torch.uint64,
+            device=device,
+        )
+
+    _py_ops.multi_layer_kv_transfer(
+        key_value_h2d,
+        paged_out_ptrs,
+        slot_mapping,
+        device,
+        page_buffer_size,
+        lmcache_native.TransferDirection.H2D,
+        engine_kv_format,
+        block_size,
+        head_size,
+    )
+
+    for layer_id, paged_layer in enumerate(paged_out):
+        for token_id in valid_token_ids:
+            slot_idx = int(slot_mapping[token_id].item())
+            for kv_idx in range(2):
+                expected = (
+                    kv_idx * 7000
+                    + layer_id * 2000
+                    + token_id * 10
+                    + torch.arange(hidden_size, dtype=dtype)
+                )
+                torch.testing.assert_close(
+                    _paged_slice(paged_layer, kv_idx, slot_idx).reshape(-1),
+                    expected,
+                )
+
+        for kv_idx in range(2):
+            torch.testing.assert_close(
+                _paged_slice(paged_layer, kv_idx, unused_slot),
+                torch.zeros((num_heads, head_size), dtype=dtype),
+            )
+
+
 # ==========================================
 # Allocation page alignment
 # ==========================================

--- a/tests/v1/test_vllm_kv_layout_discovery.py
+++ b/tests/v1/test_vllm_kv_layout_discovery.py
@@ -20,6 +20,7 @@ from lmcache.integration.vllm.utils import (
     try_get_vllm_kv_cache_layout,
     vllm_layout_hints,
 )
+import lmcache.integration.vllm.utils as vllm_utils
 
 UNSUPPORTED_LAYOUTS = ("LHBNC", "BHLNC")
 
@@ -142,6 +143,18 @@ class TestVllmLayoutHints:
     def test_unresolved_layout_raises_through_hints(self):
         with pytest.raises(ValueError, match="resolved"):
             vllm_layout_hints(make_unresolved_vllm_config())
+
+    def test_neuron_overrides_reported_nhd_with_hnd(self, monkeypatch):
+        """vllm-neuron reports NHD but allocates [2, NB, NH, BS, HS] (HND).
+
+        Trusting the report makes format detection read ``NH`` as ``BS``.
+        """
+        monkeypatch.setattr(vllm_utils, "torch_device_type", "neuron")
+        assert vllm_layout_hints(make_vllm_config("LBNHC")) == {"kv_layout": "HND"}
+
+    def test_non_neuron_keeps_reported_layout(self, monkeypatch):
+        monkeypatch.setattr(vllm_utils, "torch_device_type", "cuda")
+        assert vllm_layout_hints(make_vllm_config("LBNHC")) == {"kv_layout": "NHD"}
 
 
 class TestResolveVllmKVLayout:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds LMCache support for AWS Trainium via the Neuron SDK, enabling KV cache CPU
offload on Neuron hardware, including alongside Dynamo disaggregated inference in a
MultiConnector setup where NeuronNixlConnector handles prefill-to-decode KV
transfer over NIXL/EFA.

GPU code paths are unchanged from `dev`; everything Neuron-specific is in its own
module or behind a device check.

**Changes:**

- `platform/neuron/__init__.py`: Detect Neuron via native `torch.neuron`
  (SDK >= 2.27) or the legacy `torch_neuronx` shim. Adds a wrapper supplying the
  `set_device` / `device_count` / `Stream` / `current_stream` that `torch.neuron`
  lacks.
- `platform/base/device_spec.py`: New `adapt_torch_module()` hook, returning the
  module unchanged for every other backend. Neuron wraps rather than monkey-patches
  `torch.neuron`, which is process-global and shared with other libraries.
- `gpu_connector/neuron_kv_staging.py`: New. Stages selected paged-KV blocks
  between device memory and a reusable host buffer, one `narrow` + `copy_` per
  contiguous run per layer, reusing the existing CPU pack/unpack. Neuron rejects
  device→device copies between differently-sized parents
  (`nrt_tensor_copy status=2`), so the blocks cannot be gathered into a compact
  device buffer; `index_select` is avoided because it costs time proportional to
  the whole cache.
- `platform/torch_ops.py`: HND layout support (`NL_X_TWO_NB_NH_BS_HS`,
  `NL_X_NB_TWO_NH_BS_HS`), replacing a `NotImplementedError`.
- `integration/vllm/utils.py`: Force the HND layout hint on Neuron. vllm-neuron
  allocates heads-before-block-size but reports vLLM's generic NHD default, so
  detection read `NH` as `BS` and every store died on a shape mismatch.
- `integration/vllm/vllm_v1_adapter.py`: `start_load_kv` returned early whenever
  `attn_metadata` was None, which it always is on vllm-neuron — so loads were
  silently dead while stores ran. The value was never actually read. The check is
  kept for all other platforms, so CUDA is unchanged.
- `gpu_connector/{__init__,gpu_connectors}.py`: Route `"neuron"` to the paged-mem
  connectors; stream helpers that return the original `torch.cuda.Stream` /
  `torch.cuda.stream` on CUDA; devices without a pointer kernel branch out of
  `_initialize_pointers` before the pointer path, which is unchanged. Staging is
  enabled post-construction to keep it out of the shared constructors.
  `use_layerwise` and blending are rejected on Neuron.

**Two correctness fixes found on hardware:**

- Transfers are block-granular but the unpack fills only the slots it is asked to,
  so the tail block of any request not a multiple of `block_size` was scattered
  back with stale buffer contents over live KV. Unfilled staged regions are now
  seeded from the device first.
- `skip_prefix_n_tokens` was computed at both call sites and dropped on the Neuron
  path. Those tokens live in blocks prefix caching shares between requests, so
  writing them races with other requests' reads. Now a required argument.

**Special notes for your reviewers**:

Validated on trn2.3xlarge (single node) and 2x trn2.48xlarge (1P1D), vllm-neuron
0.24 + Dynamo, SDK 2.31, Llama-3.2-1B-Instruct. 1P1D needs EFA — trn2.3xlarge has
no `/dev/infiniband` and NeuronNixlConnector fails there at `agent.registerMem`.
Requires the Dynamo protocol registration from
https://github.com/ai-dynamo/dynamo/pull/13771.

### Verified results

Staging round trip on device, compared at slot granularity
(`neuron_kv_staging_benchmark.py --verify`):

```
verify: OK -- 1199 token slots across 38 blocks round tripped exactly on 16 layers
(2 partially covered block(s) kept their unmapped slots); 474 blocks untouched
```

End to end, repeated prompt, vLLM prefix caching **off** so only LMCache can serve
the hit:

| | single node, 312 tok | 1P1D, 148 tok |
|---|---|---|
| req 1 | `computed 0, hit 0`; stored 312/312 in 187 ms | `computed 0, hit 0`; stored 148/148 in 228 ms |
| req 2 | `computed 0, hit 312`; retrieved 312/312 in 11.6 ms | `computed 0, hit 148`; retrieved 148/148 in 9.5 ms |
| TTFT | — | 0.623 s → 0.287 s (2.2x) |

`Inference Engine computed tokens: 0` is the load actually happening — vLLM
contributed nothing. Warm requests are byte-identical across repeats.

In the 1P1D column each worker stores and hits its **own** `local_cpu` cache;
prefill→decode KV transfer is NeuronNixlConnector's job, not LMCache's. Sharing a
cache *between* engines needs a shared tier (`remote_url` / the LMCache server),
which is untested here — `local_cpu` and `local_disk` both index in memory and so
are per-process.

**Three caveats worth knowing:**

1. `usage.prompt_tokens_details.cached_tokens` is `null` on some vLLM paths even
   when LMCache served the whole prefix. Use the `LMCache hit tokens` /
   `Retrieved N out of N` log lines instead.
2. With `--enable-prefix-caching` on, vLLM's block cache serves the repeat and
   LMCache's contribution is not separable (measured: `computed 144` of 148, with
   LMCache asked for 3). Turn it off to attribute anything to LMCache.
3. vllm-neuron pads prefill into fixed graph buckets, so loading KV does not shrink
   the prefill graph. Against pure recompute on a 1B model, offload is slower below
   ~2.5k tokens and 1.12x faster above, where the load drops into a smaller bucket.
   The retrieve is ~11 ms of a ~0.45 s request, so the limit is bucketing, not
   transfer speed.

### Reproducible configuration

Prerequisites: [vllm-neuron 0.24](https://github.com/vllm-project/vllm-neuron/blob/release-0.24.0.1.1.0/docs/getting-started/setup-guide.md),
[Dynamo with NeuronNixlConnector](https://github.com/ai-dynamo/dynamo/pull/13771),
2x trn2.48xlarge with EFA for 1P1D.

`/tmp/lmcache.yaml`:
```yaml
chunk_size: 32
local_cpu: true
max_local_cpu_size: 4.0
save_unfull_chunk: true
```

Single node (`NEURON_RT_VISIBLE_CORES` must be left unset — vLLM rejects it under
its multiprocess executor, though raw torch scripts require it):

```bash
export LMCACHE_CONFIG_FILE=/tmp/lmcache.yaml
export FI_EFA_ENABLE_SHM_TRANSFER=0 NEURON_SKIP_EFA_AFFINITY=1
export NEURON_VISIBLE_DEVICES=0

python3 -m vllm.entrypoints.openai.api_server \
  --model meta-llama/Llama-3.2-1B-Instruct \
  --tensor-parallel-size 1 --max-model-len 4096 --max-num-seqs 4 \
  --max-num-batched-tokens 2048 --no-enable-prefix-caching --port 8000 \
  --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1Dynamic","kv_connector_module_path":"lmcache.integration.vllm.lmcache_connector_v1","kv_role":"kv_both"}'
```

1P1D: as above per node with `python3 -m dynamo.vllm`,
`--disaggregation-mode prefill|decode`, `--tensor-parallel-size 2`,
`NEURON_VISIBLE_DEVICES=0,1`, `--block-size 16`, etcd/nats on the prefill node,
and a `MultiConnector` wrapping `NeuronNixlConnector` (`kv_producer` /
`kv_consumer`, `backends: ["LIBFABRIC"]`) plus `LMCacheConnectorV1Dynamic`
(`kv_both`). Frontend: `python3 -m dynamo.frontend --http-port 8000`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
