### PR TITLE
[Fix][CB] Reserve one sparse-leg read lock per KV reader, not one per key

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -1233,6 +1233,7 @@ class BlendModule(InstanceLivenessTarget):
             PrefetchRequestSpec(
                 keys=uniq_keys,
                 group_layout_descs=layouts,
+                num_kv_readers=key.require_num_kv_readers(),
                 policy=TrimPolicy.SPARSE,
                 attn_desc=_narrow_attn_desc(attn_desc, read.gids),
             ),


### PR DESCRIPTION
## What this PR does  
The sparse leg omitted `num_kv_readers`, so the spec defaulted to **1** read lock per key.
The prefix leg passes it.

This is harmless with sharded KV — one key per rank, each releasing its own. Under **MLA
the KV is stored once**, so every rank resolves to the same object key, dedup collapses
them to one, and that single lock goes to whichever rank retrieves first. The other
`tp-1` releases underflow and unpin the object while those ranks still need it.
 