### PR TITLE
fix(l1): order eviction by prefix position

### DIFF
--- a/lmcache/v1/distributed/eviction.py
+++ b/lmcache/v1/distributed/eviction.py
@@ -203,6 +203,12 @@ class L1EvictionPolicy(L1ManagerListener):
     def on_l1_keys_finish_write_and_reserve_read(self, keys: list[ObjectKey]):
         self._policy.on_keys_created(keys)
 
+    def note_key_positions(self, keys: list[ObjectKey], positions: list[int]) -> None:
+        """Forward prefix positions to the policy, if it consumes them."""
+        fn = getattr(self._policy, "note_key_positions", None)
+        if fn is not None:
+            fn(keys, positions)
+
     def on_l1_keys_accessed(self, keys: list[ObjectKey]):
         self._policy.on_keys_touched(keys)
 

--- a/lmcache/v1/distributed/eviction_policy/lru.py
+++ b/lmcache/v1/distributed/eviction_policy/lru.py
@@ -16,6 +16,15 @@ from lmcache.v1.distributed.internal_api import (
     EvictionDestination,
 )
 
+# Upper bound on staged chunk positions. Positions are reported by the key
+# resolver, which runs on retrieve as well as store, so a lookup that misses
+# stages positions for keys that are never created and never reach
+# `on_keys_removed`. The map is therefore capped rather than left to grow with
+# every chunk ever looked up. Overflow is harmless: the resolver re-reports
+# positions before each create and each touch, so a dropped entry costs at most
+# one batch its position ordering, and only until that key is next accessed.
+MAX_TRACKED_POSITIONS = 1 << 16
+
 
 class LRUEvictionPolicy(EvictionPolicy):
     """
@@ -33,7 +42,17 @@ class LRUEvictionPolicy(EvictionPolicy):
         _order: OrderedDict maintaining LRU order (most recent at end)
         _destinations: List of registered eviction destinations
         _default_destination: The default destination for eviction actions
+        _key_positions: Staged chunk positions, bounded by MAX_TRACKED_POSITIONS
+        _prefix_run: Keys of the prefix run currently being ordered
+        _prefix_run_hwm: Highest position the run has reached
     """
+
+    # Created on first use, so a policy that never receives positions behaves
+    # exactly as before. Declared here for typing only -- an annotation without
+    # an assignment does not create the attribute.
+    _key_positions: OrderedDict[ObjectKey, int]
+    _prefix_run: dict[ObjectKey, int]
+    _prefix_run_hwm: int
 
     def __init__(
         self,
@@ -69,6 +88,103 @@ class LRUEvictionPolicy(EvictionPolicy):
             if destination not in self._destinations:
                 self._destinations.append(destination)
 
+    def note_key_positions(self, keys: list[ObjectKey], positions: list[int]) -> None:
+        """Record each key's chunk position within its prefix.
+
+        Reported by the key resolver, which is the only component that still knows
+        the position. Entries for cached keys are dropped in
+        :meth:`on_keys_removed`; entries for keys that are never created -- a
+        lookup that missed -- are bounded by `MAX_TRACKED_POSITIONS` instead.
+        """
+        if not keys:
+            return
+        with self._lock:
+            pm = getattr(self, "_key_positions", None)
+            if pm is None:
+                pm = self._key_positions = OrderedDict()
+            for k, p in zip(keys, positions, strict=False):
+                pm[k] = p
+                pm.move_to_end(k)
+            while len(pm) > MAX_TRACKED_POSITIONS:
+                pm.popitem(last=False)
+
+    def _prefix_positions(self, keys):
+        """Positions for these keys, or None if any is unknown.
+
+        Caller holds the lock.
+        """
+        pm = getattr(self, "_key_positions", None)
+        if not pm:
+            return None
+        pos = [pm.get(k) for k in keys]
+        return pos if all(p is not None for p in pos) else None
+
+    def _prefix_ordered_insert(
+        self, keys: list[ObjectKey], *, insert_missing: bool = True
+    ) -> None:
+        """Order a batch within its prefix run, or fall back to arrival order.
+
+        `reversed(keys)` only orders within one call, but a prefix arrives across
+        several: a serving engine stores one batch per
+        `max_num_batched_tokens / chunk_size` chunks, and a cache hit touches the
+        matched head as a separate call. Ordering those independently leaves the
+        boundary between them least-recently-used, so eviction opens a hole in the
+        middle of the prefix -- and a prefix is only usable contiguously from chunk 0.
+
+        Batches are therefore folded into one run and ordered by position. A batch
+        continues the run if it SHARES A KEY with it (a touch always does; an
+        overlapping store does) or begins exactly at run_max + 1 (a clean extension).
+        A different prefix restarting at position 0 does neither, so it correctly
+        starts a new run and ordinary cross-request LRU is preserved.
+
+        With `insert_missing=False` an unknown key is dropped instead of admitted,
+        for callers that report access rather than storage.
+
+        Caller holds the lock.
+        """
+        if not insert_missing:
+            # A touch reports access, not admission: a key absent from `_order`
+            # was evicted (or never stored) and must not be resurrected. Both
+            # paths below admit unknown keys unconditionally, so filter here --
+            # which also keeps those keys out of the run and its high-water mark.
+            keys = [k for k in keys if k in self._order]
+        if not keys:
+            return
+        pos = self._prefix_positions(keys)
+        if pos is None:
+            for key in reversed(keys):
+                if key in self._order:
+                    self._order.move_to_end(key)
+                else:
+                    self._order[key] = None
+            return
+
+        run = getattr(self, "_prefix_run", None) or {}
+        # High-water mark of the run, tracked separately: eviction removes entries
+        # from `run`, and if the extension check used max(run.values()) it would
+        # regress every time the tail was trimmed -- so the next batch would look
+        # like a new prefix, become most-recently-used, and push eviction back into
+        # the middle. The mark only advances, and only resets with the run.
+        run_hwm = getattr(self, "_prefix_run_hwm", -1)
+        if run or run_hwm >= 0:
+            shares_key = any(k in run for k in keys)
+            extends = min(pos) <= run_hwm + 1
+            if not (shares_key or extends):
+                run, run_hwm = {}, -1
+        for k, p in zip(keys, pos, strict=True):
+            run[k] = p
+            if k not in self._order:
+                self._order[k] = None
+        # Entries evicted out from under us are no longer orderable.
+        for k in [k for k in run if k not in self._order]:
+            del run[k]
+        # Descending position => position 0 ends most-recently-used, so eviction
+        # trims the TAIL and the retained set stays a contiguous prefix.
+        for k in sorted(run, key=lambda k: -run[k]):
+            self._order.move_to_end(k)
+        self._prefix_run = run
+        self._prefix_run_hwm = max(run_hwm, max(pos))
+
     def on_keys_created(self, keys: list[ObjectKey]):
         """
         Notify the eviction policy that new keys have been created.
@@ -80,16 +196,7 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
-            # NOTE: for the request, the later keys should be evicted first.
-            # For example, the request has (key1, key2, key3), if we first
-            # evict key1, due to prefix match, key2 and key3 will not be hit.
-            for key in reversed(keys):
-                # If key already exists, move it to the end (most recently used)
-                if key in self._order:
-                    self._order.move_to_end(key)
-                else:
-                    # Add new key at the end (most recently used)
-                    self._order[key] = None
+            self._prefix_ordered_insert(keys)
 
     def on_keys_touched(self, keys: list[ObjectKey]):
         """
@@ -102,12 +209,7 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
-            # NOTE: for the request, the later keys should be evicted first.
-            # The example is the same as `on_keys_created`.
-            for key in reversed(keys):
-                if key in self._order:
-                    # Move to end (most recently used)
-                    self._order.move_to_end(key)
+            self._prefix_ordered_insert(keys, insert_missing=False)
 
     def on_keys_removed(self, keys: list[ObjectKey]):
         """
@@ -120,10 +222,17 @@ class LRUEvictionPolicy(EvictionPolicy):
         if not keys:
             return
         with self._lock:
+            posmap = getattr(self, "_key_positions", None)
+            run = getattr(self, "_prefix_run", None)
             for key in keys:
                 # Remove from LRU order tracking
                 if key in self._order:
                     del self._order[key]
+                # Positions track live cache contents only.
+                if posmap is not None:
+                    posmap.pop(key, None)
+                if run is not None:
+                    run.pop(key, None)
 
     def get_eviction_actions(
         self,

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -304,7 +304,28 @@ class MPCacheServerContext:
         ]
         if key.worker_id is None:
             raise ValueError("Must resolve keys with worker_id != None")
-        return ipc_key_to_object_keys(key, chunk_hashes, object_group_ids)
+        _res = ipc_key_to_object_keys(key, chunk_hashes, object_group_ids)
+        # report chunk positions to the eviction policy. This is the last point
+        # that knows them; downstream only sees an unordered key list.
+        try:
+            _base = key.start // self.token_hasher.chunk_size
+            # Each group's list is chunk-major / rank-minor: one key per
+            # (chunk, kv_rank). Divide out the rank factor or positions are
+            # inflated by world_size and run detection breaks at TP > 1.
+            # The rank-minor layout is read off ipc_key_to_object_keys; this
+            # has only been exercised at world_size 1, not on a live TP > 1
+            # engine.
+            _nranks = max(1, len(_res[0]) // max(1, len(chunk_hashes))) if _res else 1
+            _l1 = self.storage_manager._l1_manager
+            for _lst in _l1._registered_listeners:
+                _fn = getattr(_lst, "note_key_positions", None)
+                if _fn is None:
+                    continue
+                for _gk in _res:
+                    _fn(list(_gk), [_base + _i // _nranks for _i in range(len(_gk))])
+        except Exception:
+            pass
+        return _res
 
     @staticmethod
     def _compute_shm_pool_info(

--- a/tests/v1/distributed/test_prefix_aware_eviction.py
+++ b/tests/v1/distributed/test_prefix_aware_eviction.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: a prefix stored across several batches must evict tail-first.
+
+`on_keys_created` reverses within a single call so that "the later keys should be
+evicted first" (its own comment). But a serving engine stores a long prefix in
+several calls -- vLLM's chunked prefill emits one store per
+`max_num_batched_tokens / chunk_size` chunks -- and across calls the earliest
+batch stays oldest, so eviction sheds the prefix HEAD.
+
+That is the one thing a prefix cache cannot lose: a match always starts at chunk 0,
+so losing the head invalidates every chunk still resident.
+"""
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.eviction_policy import LRUEvictionPolicy
+from lmcache.v1.distributed.eviction_policy.lru import MAX_TRACKED_POSITIONS
+
+
+def make_key(chunk_hash: int, model: str = "model", kv_rank: int = 0) -> ObjectKey:
+    """Create an ObjectKey for testing."""
+    hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+    return ObjectKey(chunk_hash=hash_bytes, model_name=model, kv_rank=kv_rank)
+
+
+class TestPrefixOrderingAcrossStoreBatches:
+    """A prefix stored in batches must still evict from its tail."""
+
+    def test_single_batch_evicts_tail_first(self):
+        """Baseline: within one call the existing reversal already does this."""
+        policy = LRUEvictionPolicy()
+        keys = [make_key(i) for i in range(6)]
+        policy.note_key_positions(keys, list(range(6)))
+        policy.on_keys_created(keys)
+
+        candidates = policy.get_eviction_candidates(6)
+        assert ObjectKey.Bytes2IntHash(candidates[0].chunk_hash) == 5
+
+    def test_multi_batch_evicts_tail_first(self):
+        """A prefix split across two stores must evict position 5, not position 0."""
+        policy = LRUEvictionPolicy()
+        first = [make_key(i) for i in range(3)]  # chunks 0,1,2
+        second = [make_key(i) for i in range(3, 6)]  # chunks 3,4,5
+
+        policy.note_key_positions(first, [0, 1, 2])
+        policy.on_keys_created(first)
+        policy.note_key_positions(second, [3, 4, 5])
+        policy.on_keys_created(second)
+
+        candidates = policy.get_eviction_candidates(6)
+        evicted = [ObjectKey.Bytes2IntHash(c.chunk_hash) for c in candidates]
+        assert evicted[0] == 5, (
+            "eviction must start at the prefix TAIL; got %r. Starting at 0 means the "
+            "head was shed, which invalidates the whole cached prefix." % evicted
+        )
+        # the head must be the very last thing to go
+        assert evicted[-1] == 0, evicted
+
+    def test_head_survives_partial_eviction(self):
+        """After evicting half a batched prefix, the survivors must start at chunk 0."""
+        policy = LRUEvictionPolicy()
+        for start in (0, 3, 6):
+            batch = [make_key(i) for i in range(start, start + 3)]
+            policy.note_key_positions(batch, list(range(start, start + 3)))
+            policy.on_keys_created(batch)
+
+        actions = policy.get_eviction_actions(0.5)
+        evicted = {
+            ObjectKey.Bytes2IntHash(k.chunk_hash) for a in actions for k in a.keys
+        }
+        survivors = sorted(set(range(9)) - evicted)
+        assert survivors, "eviction removed everything"
+        assert survivors[0] == 0, (
+            "surviving prefix must start at chunk 0; got %r" % survivors
+        )
+        assert survivors == list(range(len(survivors))), (
+            "surviving prefix must be contiguous from 0; got %r" % survivors
+        )
+
+    def test_unrelated_prefix_does_not_disturb_lru(self):
+        """A second prefix restarting at position 0 must not be treated as a
+        continuation of the first, or ordinary cross-request LRU breaks."""
+        policy = LRUEvictionPolicy()
+        first = [make_key(i) for i in range(3)]
+        policy.note_key_positions(first, [0, 1, 2])
+        policy.on_keys_created(first)
+
+        second = [make_key(100 + i) for i in range(3)]
+        policy.note_key_positions(second, [0, 1, 2])
+        policy.on_keys_created(second)
+
+        assert policy.get_num_tracked_keys() == 6
+
+    def test_multi_rank_keys_evict_tail_first(self):
+        """Tensor parallel: each chunk expands to one key per kv_rank, and the
+        expansion is chunk-major / rank-minor. Positions must be per CHUNK, not per
+        key, or a batched prefix is mis-ordered on any world_size > 1."""
+        policy = LRUEvictionPolicy()
+        ranks = (0, 1)
+
+        def batch(chunks):
+            keys, pos = [], []
+            for c in chunks:
+                for r in ranks:
+                    keys.append(make_key(c, kv_rank=r))
+                    pos.append(c)
+            return keys, pos
+
+        first_keys, first_pos = batch([0, 1, 2])
+        policy.note_key_positions(first_keys, first_pos)
+        policy.on_keys_created(first_keys)
+        second_keys, second_pos = batch([3, 4, 5])
+        policy.note_key_positions(second_keys, second_pos)
+        policy.on_keys_created(second_keys)
+
+        candidates = policy.get_eviction_candidates(len(ranks) * 6)
+        evicted = [ObjectKey.Bytes2IntHash(c.chunk_hash) for c in candidates]
+        assert evicted[0] == 5, (
+            "eviction must start at the prefix TAIL even with per-rank keys; "
+            "got %r" % evicted
+        )
+        assert evicted[-1] == 0, evicted
+
+    def test_full_attention_single_group_prefix_survives(self):
+        """A model with no sliding window has one object group needing the WHOLE
+        prefix, so head loss is total loss. Same ordering requirement."""
+        policy = LRUEvictionPolicy()
+        for start in (0, 4, 8):
+            keys = [make_key(i) for i in range(start, start + 4)]
+            policy.note_key_positions(keys, list(range(start, start + 4)))
+            policy.on_keys_created(keys)
+
+        actions = policy.get_eviction_actions(0.5)
+        evicted = {
+            ObjectKey.Bytes2IntHash(k.chunk_hash) for a in actions for k in a.keys
+        }
+        survivors = sorted(set(range(12)) - evicted)
+        assert survivors[0] == 0, survivors
+        assert survivors == list(range(len(survivors))), survivors
+
+    def test_touch_of_absent_key_neither_admits_nor_raises(self):
+        """`on_keys_touched` reports access, not storage.
+
+        A key can be evicted between the lookup that matched it and the touch
+        that reports the hit. Admitting it would resurrect an entry with no
+        backing data; and with every key of the batch absent the positions list
+        is empty, which used to reach `min(pos)` and raise.
+        """
+        policy = LRUEvictionPolicy()
+        resident = [make_key(i) for i in range(3)]
+        policy.note_key_positions(resident, [0, 1, 2])
+        policy.on_keys_created(resident)
+
+        gone = [make_key(i) for i in range(7, 10)]
+        policy.note_key_positions(gone, [7, 8, 9])
+        policy.on_keys_touched(gone)
+
+        assert len(policy.get_eviction_candidates(10)) == 3, (
+            "touching absent keys must not admit them"
+        )
+
+        policy.on_keys_touched(gone + [resident[0]])
+        candidates = policy.get_eviction_candidates(10)
+        assert len(candidates) == 3
+        assert ObjectKey.Bytes2IntHash(candidates[-1].chunk_hash) == 0, (
+            "the resident key in a mixed batch must still be ordered"
+        )
+
+
+class TestPositionMapIsBounded:
+    """Positions are staged for keys that may never be created."""
+
+    def test_lookup_misses_do_not_grow_the_map_without_bound(self):
+        """`resolve_obj_keys` runs on retrieve as well as store, so a lookup that
+        misses stages positions for keys that are never created and therefore
+        never reach `on_keys_removed`. Left unbounded that is one entry per unique
+        chunk ever looked up on the server.
+        """
+        policy = LRUEvictionPolicy()
+        cap = MAX_TRACKED_POSITIONS
+        for base in range(0, cap * 2, 256):
+            keys = [make_key(i) for i in range(base, base + 256)]
+            policy.note_key_positions(keys, list(range(base, base + 256)))
+
+        assert not policy._order, "nothing was ever created"
+        assert len(policy._key_positions) <= cap, (
+            "staged positions for never-created keys must be bounded; got %d"
+            % len(policy._key_positions)
+        )
+
+    def test_ordering_still_correct_after_the_map_overflows(self):
+        """Dropping a staged entry costs at most one batch its ordering: the
+        resolver re-reports positions before every create and every touch.
+        """
+        policy = LRUEvictionPolicy()
+        for base in range(0, MAX_TRACKED_POSITIONS * 2, 256):
+            keys = [make_key(i) for i in range(base, base + 256)]
+            policy.note_key_positions(keys, list(range(base, base + 256)))
+
+        off = 10_000_000
+        for start in (0, 3):
+            batch = [make_key(off + i) for i in range(start, start + 3)]
+            policy.note_key_positions(batch, list(range(start, start + 3)))
+            policy.on_keys_created(batch)
+
+        candidates = policy.get_eviction_candidates(6)
+        evicted = [ObjectKey.Bytes2IntHash(c.chunk_hash) - off for c in candidates]
+        assert evicted[0] == 5, evicted
+        assert evicted[-1] == 0, evicted


### PR DESCRIPTION
**What this PR does / why we need it**:

L1 eviction can shed the *head* of a prefix while keeping its tail, which makes
the surviving chunks unusable — a prefix match always starts at chunk 0.

`on_keys_created` reverses the keys of a single call so later chunks are evicted
first. That works within one call, but a serving engine stores a long prefix
across several: vLLM's chunked prefill emits one store per
`max_num_batched_tokens / chunk_size` chunks, and a cache hit touches the matched
head as a separate call. Ordered independently, the earliest batch stays
least-recently-used, so eviction starts at the head and walks forward.

The symptom is a cache that fills normally and then serves nothing. On a two-node
deployment (gemma-4-31b-it fp8-block, H200, `chunk_size=256`, 56 GiB L1 per
node) the usable prefix sat at **0 chunks** with thousands resident. With this
patch:

| | before | after |
|---|---|---|
| usable prefix | 0 chunks | 128 chunks |
| first repeat of a 59k-token prompt | 0 hits, 21.9 s | 179 chunks, 7.9 s |

Batches are now folded into one run ordered by chunk position. A batch continues
the run if it shares a key with it (a touch always does; an overlapping store
does) or begins at `run_max + 1`. A different prefix starting at position 0 does
neither, so it opens a new run and ordinary cross-request LRU is preserved
between prefixes. The run's high-water mark is tracked separately from its
members, because eviction removes entries and a mark derived from the survivors
would regress every time the tail was trimmed — which would make the next batch
look like a new prefix and push eviction back into the middle.

Chunk positions are recorded in `MPCacheServerContext.resolve_obj_keys`, the last
point that knows them; downstream only sees an unordered key list.

**Related work**:

- **#4832 (`fix(eviction): keep distributed chunk families coherent`)** solves the
  orthogonal half of the same class of problem and touches this file. That PR keeps
  the rank/object-group members of *one* logical chunk on the same side of the
  boundary; this one orders *different* chunks so the boundary falls at the prefix
  tail. Both produce "partial presence that cannot be loaded", one vertically and
  one horizontally, and both are needed. They compose:
  `select_chunk_coherent_victims` consumes `self._order`, which is precisely what
  this change reorders, so its coherence guarantee is unaffected — only which
  families sit at the boundary changes. Expect a textual conflict in
  `on_keys_created` and in the import block; happy to rebase onto whichever lands
  first.
- **#4137** reports a similar *symptom* (a resident entry measuring as a full miss)
  from an unrelated cause — the shared `keys_in_request` list in
  `LocalCPUBackend` under `LMCacheConnectorV1`. Different backend, different code
  path, already being worked. Noting it only so the two aren't conflated.
- **Scope: `IsolatedLRUEvictionPolicy` is not fixed here.** It is a sibling of
  `EvictionPolicy` rather than a subclass of `LRUEvictionPolicy`, so it keeps its
  own `_order` and has the same head-eviction behaviour. The duck-typed position
  reporting means it is simply unaffected rather than broken. I left it out because
  #4818 proposes rejecting `IsolatedLRU` on L1 at startup, which would make L1
  head-eviction moot for it — but if that PR does not land, this fix should be
  ported across, and I'm glad to do it here instead.

**Special notes for your reviewers**:

Deliberate choices:

1. **`except Exception: pass` around the position reporting** (`engine_context.py`).
   Position reporting is a best-effort hint: if it fails, ordering degrades to the
   existing arrival-order fallback, and it cannot break the store path. It
   swallows silently.

2. **Lazy `getattr`/`hasattr` init** of `_key_positions`, `_prefix_run`, and
   `_prefix_run_hwm` rather than `__init__`, so a policy that never receives
   positions constructs and behaves exactly as before. Their types are declared as
   class-level annotations, which do not create the attributes, so this stays
   type-checked despite the lazy creation.

3. **Duck-typed listener call.** `L1EvictionPolicy.note_key_positions` forwards via
   `getattr(self._policy, "note_key_positions", None)`, and `engine_context` probes
   listeners the same way, so policies that don't consume positions are unaffected
   and the `EvictionPolicy` interface is unchanged.

4. **Private access** — `self.storage_manager._l1_manager` and
   `_l1._registered_listeners`. I did not find a public accessor for the listener
   list.

5. **Bound on staged positions.** `on_keys_removed` purges positions for evicted
   keys, but `resolve_obj_keys` runs on `retrieve` as well as `store`, so a lookup
   that misses stages a position for a key that is never created and therefore
   never removed -- one entry per unique chunk ever looked up on that server. The
   map is capped at `MAX_TRACKED_POSITIONS` (65536 entries; 16.8 MiB measured at
   full occupancy) and evicts oldest-first. Overflow is safe rather than merely
   tolerable: the resolver re-reports positions before every create and every
   touch, so a dropped entry costs at most one batch its ordering, and only until
   that key is next accessed. The cap is a module constant.

6. **TP > 1 is untested.** The per-rank arithmetic (`_base + _i // _nranks`) is
   derived from the expansion order of `ipc_key_to_object_keys` — one key per
   `(chunk, kv_rank)`, chunk-major — and the world_size factor must be divided out
   or positions are inflated and run detection breaks. It is covered by a unit test
   at multiple ranks, but has only ever *run* on a `world_size 1` deployment. If
   that expansion order ever changes, positions silently degrade rather than fail.

7. **Sort cost.** Each store/touch re-sorts the whole run under the policy lock,
   so it is O(n log n) in run length per batch rather than O(batch). At realistic
   prefix lengths this is a few hundred entries and did not show up in TTFT
   measurements, but it is a real change in the hot path.

Tests: 9 new cases in `tests/v1/distributed/test_prefix_aware_eviction.py` covering
single- and multi-batch ordering, head survival under partial eviction, unrelated
prefixes not disturbing LRU, multi-rank keys, full-attention (single object group)
models, touches of absent keys, and the position-map bound.
`tests/v1/distributed/` with the patch: 786 passed, 78 skipped, plus 3
pre-existing errors in `test_bigtable_l2_adapter_integration` that need a
Bigtable emulator I don't have running locally and are untouched by this diff.
No behaviour change for policies that never receive positions.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
