### PR TITLE
[Fix][CB] Key the applied-range skip on the blocks each range actually writes

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Protocol
 import threading
 import time
 import weakref
-import zlib
 
 if TYPE_CHECKING:
     # First Party
@@ -756,7 +755,7 @@ class BlendModule(InstanceLivenessTarget):
         # Bounded LRU keyed by (request id, WORKER id) -- at TP>1 each worker
         # issues its own retrieve and scatters into its own KV buffers, so the
         # key must include the worker or later ranks skip work they never did.
-        self._cb_applied_match_ranges: "OrderedDict[tuple[str, int | None], set[tuple[bytes, int, int, int]]]" = OrderedDict()  # noqa: E501
+        self._cb_applied_match_ranges: "OrderedDict[tuple[str, int | None], set[tuple[bytes, int, int, tuple]]]" = OrderedDict()  # noqa: E501
 
         # Request-invariant retrieve-plan specs per GPU context (entries die
         # with the context). The cached tuple holds the rope_state it was
@@ -2717,13 +2716,35 @@ class BlendModule(InstanceLivenessTarget):
         cb_match_result = sorted(cb_match_result, key=lambda r: r.cur_st)
         # vLLM may call retrieve twice (partial- then full-block alloc). KV
         # blocks never move mid-prefill, but connector-injected aux pages can
-        # be reassigned on the repeat, so qualify the applied set with a
-        # fingerprint of the full destination table.
-        dest_fp = zlib.crc32(
-            np.asarray(
-                [b for grp in gpu_block_ids for b in grp], dtype=np.int64
-            ).tobytes()
-        )
+        # be reassigned on the repeat, so qualify the applied set with the
+        # destination blocks each range actually writes into. Hashing the WHOLE
+        # table instead also changed the key on plain allocation growth -- the
+        # very reason vLLM re-calls -- so the skip never matched and every
+        # repeat re-scattered work already done.
+        _staged_kgs = [
+            gpu_context.kv_layer_groups_manager.kernel_groups[i] for i in staged_kernel
+        ]
+
+        def _dest(r: "CBMatchResult") -> tuple:
+            """The destination blocks this range writes into.
+
+            Empty when the geometry is unavailable, which never matches a prior
+            applied entry, so the range re-scatters. Conservative by design:
+            wrongly SKIPPING a needed scatter would leave unpopulated KV, while
+            a redundant re-scatter only costs work.
+            """
+            out: list[int] = []
+            try:
+                for kg in _staged_kgs:
+                    tpb = kg.tokens_per_block
+                    if not tpb:
+                        return ()
+                    blocks = gpu_block_ids[kg.engine_group_idx]
+                    out.extend(blocks[r.cur_st // tpb : (r.cur_ed - 1) // tpb + 1])
+            except (IndexError, TypeError, AttributeError):
+                return ()
+            return tuple(out)
+
         applied_ranges = self._cb_applied_match_ranges
         applied_key = (key.request_id, key.worker_id)
         prior_applied = applied_ranges.get(applied_key)
@@ -2731,11 +2752,11 @@ class BlendModule(InstanceLivenessTarget):
             cb_match_result = [
                 r
                 for r in cb_match_result
-                if (r.hash, r.cur_st, r.cur_ed, dest_fp) not in prior_applied
+                if (r.hash, r.cur_st, r.cur_ed, _dest(r)) not in prior_applied
             ]
             if not cb_match_result:
                 return _noop_success("already_applied")
-        applied_now: "set[tuple[bytes, int, int, int]]" = set()
+        applied_now: "set[tuple[bytes, int, int, tuple]]" = set()
         # Partial-alloc first call: every match can be beyond the allocated
         # slots -> return before the obj-key machinery. Read locks stay held
         # for the full-alloc follow-up, as the in-loop drop path leaves them.
@@ -3094,7 +3115,7 @@ class BlendModule(InstanceLivenessTarget):
                             )
 
                     applied_now = {
-                        (r.hash, r.cur_st, r.cur_ed, dest_fp) for r, _ in pairs
+                        (r.hash, r.cur_st, r.cur_ed, _dest(r)) for r, _ in pairs
                     }
 
                     # Release read locks of the scattered matches (stream-ordered).


### PR DESCRIPTION
`cb_retrieve_pre_computed` keeps an applied-range set so vLLM's repeat call
(partial- then full-block alloc) skips ranges it already scattered. That set was
keyed on `crc32` of the **entire** destination block table — which also changes when
the allocation merely **grows**, and growth is precisely why the repeat call happens.
So the guard mistook *"more blocks allocated"* for *"my destination moved"*, never
matched, and every repeat re-scattered work already done.

Measured on minimax_m3 `bench_quality`: **1** `already_applied` hit against **3,328**
failed reads.

## The change

The key now carries the destination blocks **that range** actually writes into. A tuple
of block ids is hashable, so no fingerprint is needed at all — which drops the `crc32`
and its (remote) collision risk, and lets the `zlib` import go:

```python
def _dest(r: "CBMatchResult") -> tuple:
    out: list[int] = []
    try:
        for kg in _staged_kgs:
            tpb = kg.tokens_per_block
            if not tpb:
                return ()
            blocks = gpu_block_ids[kg.engine_group_idx]
            out.extend(blocks[r.cur_st // tpb : (r.cur_ed - 1) // tpb + 1])
    except (IndexError, TypeError, AttributeError):
        return ()
    return tuple(out)
```

This is strictly more precise than the whole-table hash: unrelated growth no longer
perturbs it, while a genuine reassignment of *that range's own* blocks still changes it
and re-scatters. It can only remove false negatives, never add a false positive — which
matters, because wrongly skipping a needed scatter would leave **unpopulated KV** rather
than merely costing work. Unavailable geometry yields the empty tuple, which never
matches a prior entry, so the fallback is "always re-scatter" — the old conservative
behaviour.

Net diff: one file, **+33/−12**.

## Side effect — and explicitly *not* the fix for it

The repeat call also re-reads object keys whose read locks the first call already
released after its scatter (`KEY_NOT_READABLE` → `scatter_ran=False` → the client
full-recomputes). Suppressing the redundant re-scatter should remove that read too.

**The underlying defect is a lock-lifecycle bug, not a dedup bug, and this PR does not
fix it.** The lookup reserves read locks for the *request*; the retrieve releases them
per *scatter*. So the storage manager — the single source of truth for object lifecycle —
stops recording a live reader while the request is still reading. CB compensates with
module-local state (`_cb_applied_match_ranges`, a **bounded LRU**) instead of the Session
lock model its own prefix leg already publishes via `record_prefetch_result`.

This PR makes that local state correct. It does **not** restore the invariant, and
specifically does not help:

* an **LRU eviction** of the applied-range entry, which silently reopens the gap;
* the **other two readers** of the same prefetched objects, which never consult CB's side
  table — `lmcache_driven_transfer.py:1450` (aux plane) and `server_transfer.py:247`.

The lifecycle fix belongs with the Session lock model (**#4852**): record the sparse
leg's locked keys on the Session, have the retrieve read-and-remove what it releases, and
release the remainder at session destroy with `read_locks=num_kv_readers`. Please don't
read this PR as closing that.

## Verification

The argument for this change is structural and needs no measurement: a hash over the
whole block table cannot answer *"did **this range's** destination move"*, because it also
changes when unrelated blocks are allocated. `1` skip hit against `3,328` failed reads is
the observable consequence.

An end-to-end run on minimax_m3 `bench_quality` (8xH200, TP=8, 20 samples) showed read
failures `1568 → 0` and degraded scatter calls `104/392 → 0/392`. **That comparison was
not single-variable** — the two images also differed in two unrelated lock changes — so it
is reported here as corroboration, not attribution. A controlled A/B differing only in
this commit is in progress and I will post it when it lands.

Full LMCache suite: **1849 passed, 41 skipped**. Lint clean.

No unit test: the computation is a few lines inside `cb_retrieve_pre_computed` and is not
reachable without standing up a GPU context, rope state and transfer module.
