### PR TITLE
fix(fs): accept salted object group keys

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -28,13 +28,13 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Legacy  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+  //   Current : <model_name>@<kv_rank_hex>@<object_group_id_hex>
+  //             @<chunk_hash_hex>[@<cache_salt>]
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
-  //   Salted  :
-  //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+  // The output preserves every field after kv_rank, replaces '/' in the model
+  // name, prefixes kv_rank with "0x", and appends ".data".
   //
   // The unsalted 3-field shape is bit-identical to the pre-cache_salt
   // format, so existing cache directories remain valid.
@@ -43,7 +43,7 @@ std::string FSConnector::key_to_filename(const std::string& key) {
   // '@' (invariant enforced on the Python side), so splitting on '@'
   // is unambiguous — no marker, no rsplit.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Split on '@' — accept the legacy shape and current unsalted/salted shapes.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -52,34 +52,27 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() < 3 || parts.size() > 5) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
-  // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
   std::string result;
-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
-                 cache_salt.size() + 32);
+  result.reserve(key.size() + 16);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
-  result += KEY_SEP;
-  result += chunk_hash;
-  if (!cache_salt.empty()) {
+  for (size_t i = 2; i < parts.size(); ++i) {
     result += KEY_SEP;
-    result += cache_salt;
+    result += parts[i];
   }
   result += FILE_EXT;
   return result;

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -52,12 +52,13 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   // Build the filesystem-safe filename from a serialized key string.
   //
   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
+  //   Legacy : "{model}@{kv_rank:08x}@{hash.hex()}"
+  //   Current: "{model}@{kv_rank:08x}@{object_group_id:x}@{hash.hex()}"
+  //            optionally followed by "@{cache_salt}"
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
+  //   Every field is preserved, with a safe model name, 0x-prefixed kv_rank,
+  //   and a .data suffix.
   //
   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
   // gains a '0x' prefix, and '.data' is appended. Both model_name and

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -130,3 +130,24 @@ def test_odirect_fails_for_misaligned_buffer(tmp_path) -> None:
         assert "O_DIRECT buffer address is not aligned" in store[2]
     finally:
         client.close()
+
+
+def test_salted_object_group_key_roundtrip(tmp_path) -> None:
+    """Native FS must accept the distributed adapter's five-field key."""
+    LMCacheFSClient = _import_fs_client()
+    key = "test_model@00000000@2@0123456789abcdef@tenant"
+    source = memoryview(bytearray(b"checkpoint"))
+    dest = memoryview(bytearray(len(source)))
+
+    client = LMCacheFSClient(str(tmp_path), 1, "", False, 0)
+    try:
+        store = _submit_and_wait(client, "submit_batch_set", key, source)
+        assert store[1], store[2]
+        load = _submit_and_wait(client, "submit_batch_get", key, dest)
+        assert load[1], load[2]
+        assert bytes(dest) == bytes(source)
+        assert (
+            tmp_path / "test_model@0x00000000@2@0123456789abcdef@tenant.data"
+        ).is_file()
+    finally:
+        client.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

`NativeConnectorL2Adapter` serializes current object keys with an `object_group_id` and optional `cache_salt`. The native filesystem connector only accepts three or four fields, so salted five-field keys fail with `malformed key`.

Preserve every serialized field after `kv_rank` while retaining the legacy three-field filename shape. The regression test covers a native filesystem store/load round trip with a salted object-group key.

**Special notes for your reviewers**:

Validation:
- 120 focused and related tests passed
- changed-file pre-commit hooks passed

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests