### PR TITLE
[MP][Coordinator] Track per-key ACCESS counts in the key directory

### DIFF
--- a/docs/design/v1/mp_coordinator/cache_events.md
+++ b/docs/design/v1/mp_coordinator/cache_events.md
@@ -126,10 +126,11 @@ listener plumbing or a dedicated flush task:
   trade for a self-contained protocol (see
   [key_directory.md](key_directory.md) — Token index).
   `ACCESS` batches carry an **empty backend**: the directory only
-  refreshes key-level recency on access, so there is no placement
-  identity to name — the vocabulary requires a non-empty backend for
-  `store`/`delete` only. The subscriber is single-threaded by design —
-  everything runs on the bus's drain thread, so it needs no locking.
+  refreshes key-level recency and access count on access, so there is
+  no placement identity to name. The vocabulary requires a non-empty
+  backend for `store`/`delete` only. The subscriber is single-threaded
+  by design - everything runs on the bus's drain thread, so it needs no
+  locking.
 - **Threading.** The bus dispatches on one drain thread, which is
   exactly the per-instance FIFO the directory needs. The subscriber
   self-paces delivery: recording flushes when `flush_interval` has

--- a/docs/design/v1/mp_coordinator/views/key_directory.md
+++ b/docs/design/v1/mp_coordinator/views/key_directory.md
@@ -46,10 +46,11 @@ the binding's tokens (see below).
 deletes too). Removing an absent placement/key is a no-op. A key with no
 remaining placements is dropped from the directory (leaving its chunk's
 token binding).
-- `ACCESS` — refresh the key's `last_access` recency (max of batch `ts`);
-never creates records, and carries no placement identity — its
-`backend` may be empty (`tier`/`backend` are ignored on apply). `ts` is
-emitter wall-clock and is never compared across instances.
+- `ACCESS` — refresh the key's `last_access` recency (max of batch `ts`)
+and increment its `access_count`; never creates records, and carries no
+placement identity — its `backend` may be empty (`tier`/`backend` are
+ignored on apply). `ts` is emitter wall-clock and is never compared
+across instances.
 
 Plus one non-batch hook, `fence_instance(instance_id)`: the gate calls
 it when an emitter restarts (a higher incarnation) or leaves the fleet,
@@ -172,7 +173,7 @@ reporter:
 ```
 ObjectKey → _KeyRecord {
     placements: list[Placement],   # ≤1 per placement identity (see STORE)
-    content_hash_hex, last_access
+    content_hash_hex, last_access, access_count
 }
 chunk_hash → _TokenBinding { token_ids: uint32[], token_offset, keys }
 instance_id → set[ObjectKey]       # L1 reverse index
@@ -201,15 +202,17 @@ Supply exactly one of: `keys` (resolve keys directly) or `token_ids`
 as the pin APIs do; requires `model_name` / `world_size` / `cache_salt`
 since key identity includes them — and the sequence must be the
 request's whole prefix, since chunk hashes are prefix-chained). One
-result per resolved key, request order, both fields empty for unknown
-keys. Position-independent token matching arrives with the content
-index (M2).
+result per resolved key, request order, with placements, token ids,
+and `access_count`. Unknown keys get empty lists and `0`.
+Position-independent token matching arrives with the content index
+(M2).
 - `GET /directory/keys` — paginated listing (`offset`/`limit`) with
 `tier`/`instance_id`/`backend` filters; each row carries the key, its
-matching placements, recency, and `num_tokens` — a cheap indicator of
-whether the chunk's tokens are known. Full token ids are deliberately
-not inlined (a page repeats each chunk across its ranks/groups; fetch
-content via `/directory/lookup` for exactly the keys that need it).
+matching placements, recency, `access_count`, and `num_tokens` — a
+cheap indicator of whether the chunk's tokens are known. Full token ids
+are deliberately not inlined (a page repeats each chunk across its
+ranks/groups; fetch content via `/directory/lookup` for exactly the keys
+that need it).
 - `GET /directory/stats` — key/placement counts, per-instance L1 key
 counts (the fencing index), and the blend-index counts; per-key L2
 detail lives on the keys listing endpoint. Directory contents only —

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -814,7 +814,8 @@ List cached keys and their placements, one page at a time.
               "shared": false
             }
           ],
-          "num_tokens": 256
+          "num_tokens": 256,
+          "access_count": 7
         }
       ]
     }
@@ -824,8 +825,9 @@ List cached keys and their placements, one page at a time.
 placements**. ``num_tokens`` reports how many token ids the directory knows for
 the key's chunk (``0`` = unknown) -- fetch the actual tokens via
 ``POST /directory/lookup``, which exists precisely so listing pages stay
-small. Pages of a changing directory may skip or repeat keys (snapshot
-semantics).
+small. ``access_count`` is the number of ``access`` events applied to the key
+since the directory first saw it. Pages of a changing directory may skip or
+repeat keys (snapshot semantics).
 
 **HTTP status codes:**
 
@@ -901,7 +903,8 @@ forms -- supply exactly one:
             {"instance_id": "server-1", "incarnation": 1770000000, "tier": "l1",
              "backend": "dram", "size_bytes": 8388608, "shared": false}
           ],
-          "token_ids": [15496, 11, 995]
+          "token_ids": [15496, 11, 995],
+          "access_count": 7
         }
       ]
     }
@@ -911,7 +914,8 @@ the number of keys requested); ``results`` has one entry per resolved key, in
 request order (tokens form: ``chunks`` x the per-rank fan-out). ``placements``
 is empty for keys the directory does not know; ``token_ids`` is empty when the
 directory has no tokens for the key's chunk (never stored with token reporting
-on, or not yet re-reported after an event gap).
+on, or not yet re-reported after an event gap). ``access_count`` is the number
+of ``access`` events applied to the key, ``0`` for unknown keys.
 
 **HTTP status codes:**
 

--- a/lmcache/v1/mp_coordinator/api.py
+++ b/lmcache/v1/mp_coordinator/api.py
@@ -29,10 +29,10 @@ class CacheEventType(str, Enum):
     """The kind of cache-state change a :class:`CacheEventBatch` reports.
 
     ``STORE`` commits placements; ``DELETE`` removes them (owners report
-    evictions as deletes); ``ACCESS`` refreshes recency without changing
-    placement state. ``CONFIG`` carries no placement at all: it declares
-    one compartment's configured capacity, so the fleet view has a
-    denominator for the bytes the other three report.
+    evictions as deletes); ``ACCESS`` refreshes recency and counts a use
+    without changing placement state. ``CONFIG`` carries no placement at
+    all: it declares one compartment's configured capacity, so the fleet
+    view has a denominator for the bytes the other three report.
     """
 
     STORE = "store"

--- a/lmcache/v1/mp_coordinator/cache_events.py
+++ b/lmcache/v1/mp_coordinator/cache_events.py
@@ -324,8 +324,8 @@ class CacheEventSubscriber(EventSubscriber):
 
     def _on_l1_access(self, event: Event) -> None:
         keys: list[ObjectKey] = event.metadata["keys"]
-        # ACCESS refreshes key-level recency only; it carries no
-        # placement identity, so the backend is empty by contract.
+        # ACCESS updates key-level recency and access count only; it
+        # carries no placement identity, so the backend is empty by contract.
         self._record(
             CacheEventType.ACCESS,
             Tier.L1,

--- a/lmcache/v1/mp_coordinator/http_apis/directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/directory_api.py
@@ -53,8 +53,8 @@ async def lookup_placements(
 
     Returns:
         Chunk count plus one result per resolved key, in request order,
-        each with its known placements and the chunk's token ids
-        (both empty when the directory knows nothing about the key).
+        each with its known placements, the chunk's token ids, and the
+        key's access count. Unknown keys get empty lists and ``0``.
 
     Raises:
         HTTPException: 400 when the token sequence exceeds the
@@ -80,14 +80,18 @@ async def lookup_placements(
     directory = ctx.views.get(KeyDirectory)
     placements = directory.lookup(obj_keys)
     token_ids = directory.get_token_ids([key.chunk_hash for key in obj_keys])
+    access_counts = directory.get_access_counts(obj_keys)
     return DirectoryLookupResponse(
         chunks=chunks,
         results=[
             DirectoryKeyPlacements(
-                key=encoded, placements=key_placements, token_ids=list(tokens)
+                key=encoded,
+                placements=key_placements,
+                token_ids=list(tokens),
+                access_count=access_count,
             )
-            for encoded, key_placements, tokens in zip(
-                encoded_keys, placements, token_ids, strict=True
+            for encoded, key_placements, tokens, access_count in zip(
+                encoded_keys, placements, token_ids, access_counts, strict=True
             )
         ],
     )
@@ -156,8 +160,8 @@ async def list_directory_keys(
 
     Returns:
         The number of keys matching the filters plus the requested page,
-        each key with its matching placements and the number of token
-        ids known for its chunk.
+        each key with its matching placements, the number of token ids
+        known for its chunk, and its access count.
     """
     directory = get_context(request).views.get(KeyDirectory)
 
@@ -165,6 +169,7 @@ async def list_directory_keys(
         """Page the directory and shape the rows for the wire."""
         total, page = directory.list_keys(tier, instance_id, backend, offset, limit)
         token_ids = directory.get_token_ids([key.chunk_hash for key in page])
+        access_counts = directory.get_access_counts(list(page))
         return DirectoryListResponse(
             total=total,
             keys=[
@@ -172,9 +177,10 @@ async def list_directory_keys(
                     key=key.to_encoded_object_key(),
                     placements=placements,
                     num_tokens=len(tokens),
+                    access_count=access_count,
                 )
-                for (key, placements), tokens in zip(
-                    page.items(), token_ids, strict=True
+                for (key, placements), tokens, access_count in zip(
+                    page.items(), token_ids, access_counts, strict=True
                 )
             ],
         )

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -392,18 +392,21 @@ class DirectoryLookupRequest(BaseModel):
 
 
 class DirectoryKeyPlacements(BaseModel):
-    """Placements and token ids for one resolved key.
+    """Placements, token ids, and access count for one resolved key.
 
     Attributes:
         key: The resolved key, echoed back.
         placements: Known placements; empty when the directory knows
             nothing about the key.
         token_ids: The chunk's token ids; empty when unknown.
+        access_count: ``ACCESS`` entries applied to the key since its
+            creation.
     """
 
     key: EncodedObjectKey
     placements: list[Placement] = Field(default_factory=list)
     token_ids: list[int] = Field(default_factory=list)
+    access_count: int = 0
 
 
 class DirectoryLookupResponse(BaseModel):
@@ -428,11 +431,14 @@ class DirectoryKeyInfo(BaseModel):
         key: The listed key.
         placements: The key's placements that matched the listing filters.
         num_tokens: Token ids known for the key's chunk (``0`` = unknown).
+        access_count: ``ACCESS`` entries applied to the key since its
+            creation.
     """
 
     key: EncodedObjectKey
     placements: list[Placement] = Field(default_factory=list)
     num_tokens: int = 0
+    access_count: int = 0
 
 
 class DirectoryListResponse(BaseModel):

--- a/lmcache/v1/mp_coordinator/views/key_directory.py
+++ b/lmcache/v1/mp_coordinator/views/key_directory.py
@@ -104,10 +104,12 @@ class DirectoryStats:
 
 @dataclass
 class _KeyRecord:
-    """Directory value for one key: its placements plus recency."""
+    """Directory value for one key: its placements, recency, and
+    number of accesses applied to it."""
 
     placements: list[Placement] = field(default_factory=list)
     last_access: float = 0.0
+    access_count: int = 0
 
 
 @dataclass
@@ -251,6 +253,23 @@ class KeyDirectory(View):
                 for chunk_hash in chunk_hashes
             ]
 
+    def get_access_counts(self, keys: list[ObjectKey]) -> list[int]:
+        """Return the number of ``ACCESS`` entries applied to each key.
+
+        Args:
+            keys: The keys to look up.
+
+        Returns:
+            One count per requested key, in request order.
+        """
+        with self._lock:
+            return [
+                record.access_count
+                if (record := self._directory.get(key)) is not None
+                else 0
+                for key in keys
+            ]
+
     def blend_match(self, tokens: np.ndarray) -> list[BlendMatch]:
         """Find cached chunks contained anywhere in ``tokens``.
 
@@ -368,7 +387,7 @@ class KeyDirectory(View):
         """Return the directory's contents.
 
         Returns:
-            ``{"keys": [(key, last_access, [placement, ...]), ...],
+            ``{"keys": [(key, last_access, access_count, [placement, ...]), ...],
             "bindings": [(chunk_hash, token_offset, token bytes), ...],
             "l1_keys_by_instance": {instance_id: [key index, ...]}}``.
             The blend index is derived, so it is absent.
@@ -378,6 +397,7 @@ class KeyDirectory(View):
                 (
                     encode_key(key),
                     record.last_access,
+                    record.access_count,
                     [_encode_placement(p) for p in record.placements],
                 )
                 for key, record in self._directory.items()
@@ -415,7 +435,9 @@ class KeyDirectory(View):
             ValueError: If the directory already holds keys, or the
                 reverse index cites a key position that does not exist.
         """
-        captured_keys = cast("list[tuple[object, float, list[object]]]", state["keys"])
+        captured_keys = cast(
+            "list[tuple[object, float, int, list[object]]]", state["keys"]
+        )
         bindings = cast("list[tuple[bytes, int, bytes]]", state["bindings"])
         l1_by_instance = cast("Mapping[str, list[int]]", state["l1_keys_by_instance"])
         with self._lock:
@@ -426,12 +448,13 @@ class KeyDirectory(View):
                     f"{len(self._l1_keys_by_instance)} instances)"
                 )
             key_table = []
-            for encoded_key, last_access, placements in captured_keys:
+            for encoded_key, last_access, access_count, placements in captured_keys:
                 key = decode_key(encoded_key)
                 key_table.append(key)
                 self._directory[key] = _KeyRecord(
                     placements=[_decode_placement(p) for p in placements],
                     last_access=last_access,
+                    access_count=access_count,
                 )
                 self._add_token_binding(key)
             for chunk_hash, token_offset, raw_tokens in bindings:
@@ -529,6 +552,7 @@ class KeyDirectory(View):
             record = self._directory.get(key)
             if record is not None:
                 record.last_access = max(record.last_access, batch.ts)
+                record.access_count += 1
 
     @staticmethod
     def _find_placement(

--- a/tests/v1/mp_coordinator/test_directory_api.py
+++ b/tests/v1/mp_coordinator/test_directory_api.py
@@ -343,6 +343,36 @@ def test_lookup_keys_form_returns_placements_and_tokens():
         assert results[1]["placements"] == []
 
 
+def test_lookup_and_listing_report_access_counts():
+    def _access(seq: int) -> dict:
+        return _batch(
+            seq=seq, event_type="access", backend="", entries=[{"key": _key(h="aa")}]
+        )
+
+    with _client() as client:
+        _post_events(
+            client,
+            [
+                _batch(
+                    seq=1,
+                    entries=[
+                        {"key": _key(h="aa"), "size_bytes": 1},
+                        {"key": _key(h="bb"), "size_bytes": 1},
+                    ],
+                ),
+                _access(seq=2),
+                _access(seq=3),
+            ],
+        )
+
+        results = _lookup(client, [_key(h="aa"), _key(h="bb"), _key(h="ff")])["results"]
+        assert [r["access_count"] for r in results] == [2, 0, 0]
+
+        listed = client.get("/directory/keys").json()["keys"]
+        by_hash = {row["key"]["chunk_hash_hex"]: row["access_count"] for row in listed}
+        assert by_hash == {"aa": 2, "bb": 0}
+
+
 def test_lookup_malformed_key_is_rejected():
     with _client() as client:
         resp = client.post("/directory/lookup", json={"keys": [_key(h="zz")]})

--- a/tests/v1/mp_coordinator/test_key_directory.py
+++ b/tests/v1/mp_coordinator/test_key_directory.py
@@ -178,6 +178,67 @@ def test_access_batch_allows_empty_backend():
     assert len(placements) == 1  # placement identity untouched
 
 
+def _access(directory: KeyDirectory, seq: int, *keys: ObjectKey) -> None:
+    directory.consume(
+        _batch(seq=seq, event_type=CacheEventType.ACCESS, keys=list(keys), backend="")
+    )
+
+
+def test_access_counts_every_admitted_entry():
+    """Each ACCESS entry counts once whatever tier reported it. STORE
+    never counts, and neither does a re-store."""
+    directory = KeyDirectory()
+    directory.consume(_batch(seq=1, keys=[_key(1), _key(2)]))
+    assert directory.get_access_counts([_key(1), _key(2)]) == [0, 0]
+
+    _access(directory, 2, _key(1))
+    directory.consume(
+        _batch(seq=3, event_type=CacheEventType.ACCESS, keys=[_key(1)], tier=Tier.L2)
+    )
+    directory.consume(_batch(seq=4, keys=[_key(1)], size_bytes=2048))  # re-store
+
+    assert directory.get_access_counts([_key(1), _key(2), _key(3)]) == [2, 0, 0]
+
+
+def test_access_count_of_unknown_key_is_zero_and_creates_nothing():
+    directory = KeyDirectory()
+    _access(directory, 1, _key(1))
+    assert directory.get_access_counts([_key(1)]) == [0]
+    assert directory.stats().num_keys == 0
+
+
+def test_access_count_dies_with_the_record():
+    """A re-stored key starts over. The count belongs to the record, not
+    the content."""
+    directory = KeyDirectory()
+    directory.consume(_batch(seq=1, keys=[_key(1)]))
+    _access(directory, 2, _key(1))
+    directory.consume(_batch(seq=3, event_type=CacheEventType.DELETE, keys=[_key(1)]))
+    assert directory.get_access_counts([_key(1)]) == [0]
+
+    directory.consume(_batch(seq=4, keys=[_key(1)]))
+    assert directory.get_access_counts([_key(1)]) == [0]
+
+
+def test_fencing_drops_access_counts_with_the_l1_record():
+    directory = KeyDirectory()
+    directory.consume(_batch(seq=1, keys=[_key(1)]))
+    _access(directory, 2, _key(1))
+    directory.fence_instance("node-a")
+    assert directory.get_access_counts([_key(1)]) == [0]
+
+
+def test_access_count_survives_capture_and_restore():
+    live = KeyDirectory()
+    live.consume(_batch(seq=1, keys=[_key(1)]))
+    _access(live, 2, _key(1))
+    _access(live, 3, _key(1))
+
+    restored = KeyDirectory()
+    restored.restore(live.capture())
+    assert restored.get_access_counts([_key(1)]) == [2]
+
+
 def test_placement_bearing_batches_require_backend():
     with pytest.raises(ValueError):
         _batch(event_type=CacheEventType.STORE, keys=[_key(1)], backend="")


### PR DESCRIPTION
**What this PR does / why we need it:**

Adds a per-key `access_count` to the MP coordinator's fleet-wide key directory. 
This provides a direct measure of how often each directory record has been accessed.

- Each admitted `ACCESS` entry increments the matching key's count once, regardless of which cache tier reported it.
- An `ACCESS` event for an unknown key does not create a directory record.
- The count follows the directory record's lifetime.
- `POST /directory/lookup` now returns `access_count` for every requested key.
- `GET /directory/keys` now returns `access_count` for every listed key.
- Unknown and unaccessed keys report `access_count: 0`.
- The OpenAPI response schemas and coordinator documentation describe the new field and its lifecycle semantics.

**Special notes for reviewers:**

- The API change is additive. Both response models default `access_count` to `0`.
- Unit coverage includes incrementing, unknown keys, delete/re-store, instance fencing, and checkpoint restoration.
- API coverage verifies accessed, unaccessed, and unknown keys through both directory endpoints.

**If applicable:**

- [x] This PR contains user-facing changes — docs added.
- [x] This PR contains unit tests.