### PR TITLE
refactor(multiprocess): add ZMQ RPC client facade

### DIFF
--- a/lmcache/cli/commands/bench/server_bench/client.py
+++ b/lmcache/cli/commands/bench/server_bench/client.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     import torch
 
     # First Party
-    from lmcache.v1.multiprocess.mq import MessageQueueClient
+    from lmcache.v1.multiprocess.client import RequestClient
 
 
 @dataclass(frozen=True)
@@ -160,7 +160,7 @@ class ServerBenchClient:
         self._config = config
         self._log = log
         self._zmq_context: Any | None = None
-        self._mq_client: "MessageQueueClient | None" = None
+        self._mq_client: "RequestClient | None" = None
         self._workers: list[WorkerContext] = []
         self._registered_instance_ids: list[int] = []
         self._shm_names: list[str] = []
@@ -704,6 +704,7 @@ class ServerBenchClient:
             format_kvcache_shape_spec,
             parse_kvcache_shape_spec,
         )
+        from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
         from lmcache.v1.multiprocess.group_view import EngineGroupInfo
         from lmcache.v1.multiprocess.mq import MessageQueueClient
 
@@ -723,7 +724,9 @@ class ServerBenchClient:
             % (config.rpc_url, config.mode)
         )
         self._zmq_context = zmq.Context()
-        self._mq_client = MessageQueueClient(config.rpc_url, self._zmq_context)
+        self._mq_client = ZmqMultiprocessClient(
+            MessageQueueClient(config.rpc_url, self._zmq_context)
+        )
 
         self._chunk_size = _get_chunk_size(self._mq_client)
         self._log("Server chunk_size = %d" % self._chunk_size)
@@ -926,8 +929,8 @@ class ServerBenchClient:
 
         self._log("")
 
-    def _require_started(self) -> "MessageQueueClient":
-        """Return the live MessageQueueClient or raise before startup."""
+    def _require_started(self) -> "RequestClient":
+        """Return the live multiprocess client or raise before startup."""
         if not self._started or self._mq_client is None:
             raise RuntimeError("ServerBenchClient must be started before use")
         return self._mq_client

--- a/lmcache/cli/commands/bench/server_bench/client.py
+++ b/lmcache/cli/commands/bench/server_bench/client.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     import torch
 
     # First Party
-    from lmcache.v1.multiprocess.client import RequestClient
+    from lmcache.v1.multiprocess.transport.base import RequestClient
 
 
 @dataclass(frozen=True)
@@ -160,7 +160,7 @@ class ServerBenchClient:
         self._config = config
         self._log = log
         self._zmq_context: Any | None = None
-        self._mq_client: "RequestClient | None" = None
+        self._req_client: "RequestClient | None" = None
         self._workers: list[WorkerContext] = []
         self._registered_instance_ids: list[int] = []
         self._shm_names: list[str] = []
@@ -249,7 +249,7 @@ class ServerBenchClient:
         Raises:
             RuntimeError: If the client is not started.
         """
-        mq_client = self._require_started()
+        req_client = self._require_started()
 
         # First Party
         from lmcache.cli.commands.bench.server_bench.helpers import (
@@ -266,7 +266,7 @@ class ServerBenchClient:
             world_size=self._kv_world_size,
         )
         started_at = time.monotonic()
-        if not _send_lookup(mq_client, lookup_key, tp_size=len(self._workers)):
+        if not _send_lookup(req_client, lookup_key, tp_size=len(self._workers)):
             latency_ms = (time.monotonic() - started_at) * 1000
             self._log("  [seq %d/%s] LOOKUP timeout" % (request.seq_no, request.label))
             return LookupResult(
@@ -276,7 +276,7 @@ class ServerBenchClient:
                 error="timeout",
             )
 
-        hit_chunks = _poll_prefetch_status(mq_client, lookup_key.request_id)
+        hit_chunks = _poll_prefetch_status(req_client, lookup_key.request_id)
         if hit_chunks is None:
             hit_chunks = 0
         latency_ms = (time.monotonic() - started_at) * 1000
@@ -316,7 +316,7 @@ class ServerBenchClient:
             RuntimeError: If the client is not started.
             ValueError: If a non-empty range is invalid or not chunk-aligned.
         """
-        mq_client = self._require_started()
+        req_client = self._require_started()
         if token_count == 0:
             return None
         self._validate_token_range(request, start_token, token_count)
@@ -346,7 +346,7 @@ class ServerBenchClient:
                 world_size=self._kv_world_size,
             )
             worker_status = _send_store(
-                mq_client,
+                req_client,
                 key,
                 block_offset=block_offset,
                 block_size=self._block_size,
@@ -406,7 +406,7 @@ class ServerBenchClient:
             RuntimeError: If the client is not started.
             ValueError: If a non-empty range is invalid or not chunk-aligned.
         """
-        mq_client = self._require_started()
+        req_client = self._require_started()
         if token_count == 0:
             return None
         self._validate_token_range(request, start_token, token_count)
@@ -437,7 +437,7 @@ class ServerBenchClient:
                 world_size=self._kv_world_size,
             )
             worker_status = _send_retrieve(
-                mq_client,
+                req_client,
                 key,
                 self._chunk_size,
                 hit_chunks,
@@ -597,12 +597,12 @@ class ServerBenchClient:
         Raises:
             RuntimeError: If the client is not started.
         """
-        mq_client = self._require_started()
+        req_client = self._require_started()
 
         # First Party
         from lmcache.cli.commands.bench.server_bench.helpers import _send_end_session
 
-        _send_end_session(mq_client, request.request_id)
+        _send_end_session(req_client, request.request_id)
 
     def close(self) -> None:
         """Idempotently release resources, including after partial startup."""
@@ -611,11 +611,11 @@ class ServerBenchClient:
             _send_unregister_kv_cache,
         )
 
-        if self._mq_client is not None:
+        if self._req_client is not None:
             for instance_id in self._registered_instance_ids:
                 try:
                     ok = _send_unregister_kv_cache(
-                        self._mq_client,
+                        self._req_client,
                         instance_id=instance_id,
                         use_handle=self._config.uses_handle_transfer,
                     )
@@ -652,13 +652,13 @@ class ServerBenchClient:
                     except OSError:
                         pass
 
-        if self._mq_client is not None:
+        if self._req_client is not None:
             try:
-                self._mq_client.close()
+                self._req_client.close()
             except Exception as exc:
                 self._log("  [warning] MessageQueueClient close failed: %s" % exc)
             finally:
-                self._mq_client = None
+                self._req_client = None
         if self._zmq_context is not None:
             try:
                 self._zmq_context.term()
@@ -704,9 +704,9 @@ class ServerBenchClient:
             format_kvcache_shape_spec,
             parse_kvcache_shape_spec,
         )
-        from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
         from lmcache.v1.multiprocess.group_view import EngineGroupInfo
         from lmcache.v1.multiprocess.mq import MessageQueueClient
+        from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 
         config = self._config
         use_gpu = config.is_gpu
@@ -724,11 +724,11 @@ class ServerBenchClient:
             % (config.rpc_url, config.mode)
         )
         self._zmq_context = zmq.Context()
-        self._mq_client = ZmqMultiprocessClient(
+        self._req_client = ZmqMultiprocessClient(
             MessageQueueClient(config.rpc_url, self._zmq_context)
         )
 
-        self._chunk_size = _get_chunk_size(self._mq_client)
+        self._chunk_size = _get_chunk_size(self._req_client)
         self._log("Server chunk_size = %d" % self._chunk_size)
 
         layer_groups = parse_kvcache_shape_spec(config.kvcache_shape_spec)
@@ -898,7 +898,7 @@ class ServerBenchClient:
             self._workers.append(worker)
 
             register_result = _send_register_kv_cache(
-                self._mq_client,
+                self._req_client,
                 instance_id=instance_id,
                 world_size=self._kv_world_size,
                 layout_hints=layout_hints,
@@ -931,9 +931,9 @@ class ServerBenchClient:
 
     def _require_started(self) -> "RequestClient":
         """Return the live multiprocess client or raise before startup."""
-        if not self._started or self._mq_client is None:
+        if not self._started or self._req_client is None:
             raise RuntimeError("ServerBenchClient must be started before use")
-        return self._mq_client
+        return self._req_client
 
     def _validate_token_range(
         self,

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -52,6 +52,7 @@ try:
         DTYPE_MAP,
         KVLayerGroupInfo,
     )
+    from lmcache.v1.multiprocess.client import RequestClient
     from lmcache.v1.multiprocess.custom_types import (
         IPCCacheServerKey,
         KVCache,
@@ -59,9 +60,7 @@ try:
     )
     from lmcache.v1.multiprocess.futures import MessagingFuture
     from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-    from lmcache.v1.multiprocess.mq import MessageQueueClient
     from lmcache.v1.multiprocess.posix_shm import shm_open_pool_as_mmap
-    from lmcache.v1.multiprocess.protocols.base import RequestType
     from lmcache.v1.multiprocess.protocols.engine import (
         RegisterEngineDrivenContextResponse,
     )
@@ -142,18 +141,15 @@ _DEFAULT_RPC_TIMEOUT_S = 10.0
 _TIMEOUT = object()
 
 
-def _call(
-    client: MessageQueueClient,
-    request_type: RequestType,
-    payloads: list,
+def _wait_for_result(
+    future: MessagingFuture[Any],
     timeout_s: float = _DEFAULT_RPC_TIMEOUT_S,
 ) -> Any:
-    """Submit a request through ``MessageQueueClient`` and block.
+    """Wait for an RPC future and convert a timeout to ``_TIMEOUT``.
 
     Returns the decoded response (possibly ``None`` for void replies)
     on success, or the sentinel ``_TIMEOUT`` on RPC timeout.
     """
-    future: MessagingFuture[Any] = client.submit_request(request_type, payloads)
     try:
         return future.result(timeout=timeout_s)
     except TimeoutError:
@@ -384,7 +380,7 @@ def _allocate_cpu_shm_kv_cache(
 
 
 def _send_register_kv_cache(
-    client: MessageQueueClient,
+    client: RequestClient,
     instance_id: int = 0,
     model_name: str = _MODEL_NAME,
     world_size: int = _WORLD_SIZE,
@@ -429,16 +425,17 @@ def _send_register_kv_cache(
         if layout_hints:
             hints.update(layout_hints)
         # TODO(maobaolong): Make the engine type configurable
-        payloads = [
-            instance_id,
-            kv_caches,
-            model_name,
-            world_size,
-            EngineType.VLLM,
-            hints,
-            list(engine_group_infos or ()),
-        ]
-        result = _call(client, RequestType.REGISTER_KV_CACHE, payloads)
+        result = _wait_for_result(
+            client.register_kv_cache(
+                instance_id,
+                kv_caches,
+                model_name,
+                world_size,
+                EngineType.VLLM,
+                hints,
+                list(engine_group_infos or ()),
+            )
+        )
         return result is not _TIMEOUT
 
     # CPU mode: use the non-GPU context registration protocol.
@@ -477,9 +474,7 @@ def _send_register_kv_cache(
         use_mla=use_mla,
         num_physical_slots=num_physical_slots,
     )
-    result = _call(
-        client, RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT, [payload]
-    )
+    result = _wait_for_result(client.register_kv_cache_engine_driven_context(payload))
     if result is _TIMEOUT:
         return False
     # The data-mode register reply carries the server's SHM pool name
@@ -490,7 +485,7 @@ def _send_register_kv_cache(
 
 
 def _send_unregister_kv_cache(
-    client: MessageQueueClient,
+    client: RequestClient,
     instance_id: int = 0,
     use_handle: bool = True,
 ) -> bool:
@@ -521,17 +516,17 @@ def _send_unregister_kv_cache(
         ``True`` if the server acknowledged the call, ``False`` on RPC
         timeout.
     """
-    request_type = (
-        RequestType.UNREGISTER_KV_CACHE
+    future = (
+        client.unregister_kv_cache(instance_id)
         if use_handle
-        else RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+        else client.unregister_kv_cache_engine_driven_context(instance_id)
     )
-    result = _call(client, request_type, [instance_id])
+    result = _wait_for_result(future)
     return result is not _TIMEOUT
 
 
 def _send_lookup(
-    client: MessageQueueClient,
+    client: RequestClient,
     key: IPCCacheServerKey,
     tp_size: int = 1,
 ) -> bool:
@@ -545,12 +540,12 @@ def _send_lookup(
     The server-side handler returns ``None`` (void) on success, so
     we only distinguish RPC timeout from a completed call.
     """
-    result = _call(client, RequestType.LOOKUP, [key, tp_size])
+    result = _wait_for_result(client.lookup(key, tp_size))
     return result is not _TIMEOUT
 
 
 def _poll_prefetch_status(
-    client: MessageQueueClient,
+    client: RequestClient,
     request_id: str,
     max_polls: int = 50,
     poll_interval: float = 0.05,
@@ -562,11 +557,7 @@ def _poll_prefetch_status(
     (str), not an integer job handle.
     """
     for _ in range(max_polls):
-        result = _call(
-            client,
-            RequestType.QUERY_PREFETCH_STATUS,
-            [request_id],
-        )
+        result = _wait_for_result(client.query_prefetch_status(request_id))
         if result is _TIMEOUT:
             # RPC timeout — treat as giving up on this poll cycle.
             return None
@@ -788,7 +779,7 @@ def _zero_fill_client_blocks(
 
 
 def _send_store(
-    client: MessageQueueClient,
+    client: RequestClient,
     key: IPCCacheServerKey,
     block_offset: int = 0,
     block_size: int = 16,
@@ -818,19 +809,20 @@ def _send_store(
         num_tokens = key.end - key.start
         num_blocks = num_tokens // block_size
         block_ids = list(range(block_offset, block_offset + num_blocks))
-        payloads = [
-            key,
-            instance_id,
-            [block_ids] * num_engine_group_infos,
-            _make_event_handle(),
-        ]
-        result = _call(client, RequestType.STORE, payloads)
+        result = _wait_for_result(
+            client.store(
+                key,
+                instance_id,
+                [block_ids] * num_engine_group_infos,
+                _make_event_handle(),
+            )
+        )
         if result is _TIMEOUT:
             return "timeout"
         return "stored" if result[1] else "store_failed"
 
     # CPU mode: PREPARE_STORE -> COMMIT_STORE
-    prep = _call(client, RequestType.PREPARE_STORE, [key, instance_id])
+    prep = _wait_for_result(client.prepare_store(key, instance_id))
     if prep is _TIMEOUT:
         return "timeout"
     if server_pool is not None and client_tensors is not None and chunk_size > 0:
@@ -850,14 +842,14 @@ def _send_store(
             for slot_view, chunk_idx in zip(slot_views, chunk_indices, strict=False):
                 if 0 <= chunk_idx < len(full_chunks):
                     slot_view.copy_(full_chunks[chunk_idx].view(slot_view.shape))
-    commit = _call(client, RequestType.COMMIT_STORE, [key, instance_id, b""])
+    commit = _wait_for_result(client.commit_store(key, instance_id, b""))
     if commit is _TIMEOUT:
         return "timeout"
     return "stored" if commit else "store_failed"
 
 
 def _send_retrieve(
-    client: MessageQueueClient,
+    client: RequestClient,
     key: IPCCacheServerKey,
     chunk_size: int,
     hit_chunks: int,
@@ -888,20 +880,21 @@ def _send_retrieve(
         hit_tokens = hit_chunks * chunk_size
         num_blocks = hit_tokens // block_size
         block_ids = list(range(block_offset, block_offset + num_blocks))
-        payloads = [
-            key,
-            instance_id,
-            [block_ids] * num_engine_group_infos,
-            _make_event_handle(),
-            0,  # skip_first_n_tokens
-        ]
-        result = _call(client, RequestType.RETRIEVE, payloads)
+        result = _wait_for_result(
+            client.retrieve(
+                key,
+                instance_id,
+                [block_ids] * num_engine_group_infos,
+                _make_event_handle(),
+                0,  # skip_first_n_tokens
+            )
+        )
         if result is _TIMEOUT:
             return "timeout"
         return "retrieved" if result[1] else "retrieve_failed"
 
     # CPU mode: PREPARE_RETRIEVE -> COMMIT_RETRIEVE
-    prep = _call(client, RequestType.PREPARE_RETRIEVE, [key, instance_id])
+    prep = _wait_for_result(client.prepare_retrieve(key, instance_id))
     if prep is _TIMEOUT:
         return "timeout"
     if not prep.success:
@@ -921,18 +914,18 @@ def _send_retrieve(
                 )
             except (RuntimeError, ValueError) as exc:
                 print("  [WARNING] retrieve scatter failed: %s" % exc)
-    commit = _call(client, RequestType.COMMIT_RETRIEVE, [key, instance_id])
+    commit = _wait_for_result(client.commit_retrieve(key, instance_id))
     if commit is _TIMEOUT:
         return "timeout"
     return "retrieved" if commit else "retrieve_failed"
 
 
 def _send_end_session(
-    client: MessageQueueClient,
+    client: RequestClient,
     request_id: str,
 ) -> None:
     """END_SESSION — clean up server-side session state."""
-    _call(client, RequestType.END_SESSION, [request_id])
+    _wait_for_result(client.end_session(request_id))
 
 
 # ------------------------------------------------------------------ #
@@ -1015,9 +1008,9 @@ def _query_checksum(
 # ------------------------------------------------------------------ #
 
 
-def _get_chunk_size(client: MessageQueueClient) -> int:
+def _get_chunk_size(client: RequestClient) -> int:
     """Query the server's chunk size."""
-    result = _call(client, RequestType.GET_CHUNK_SIZE, [])
+    result = _wait_for_result(client.get_chunk_size())
     if result is _TIMEOUT or result is None:
         return 256  # fallback
     return int(result)

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -52,7 +52,6 @@ try:
         DTYPE_MAP,
         KVLayerGroupInfo,
     )
-    from lmcache.v1.multiprocess.client import RequestClient
     from lmcache.v1.multiprocess.custom_types import (
         IPCCacheServerKey,
         KVCache,
@@ -65,6 +64,7 @@ try:
         RegisterEngineDrivenContextResponse,
     )
     from lmcache.v1.multiprocess.transfer_context.shm import ShmSlotDescriptor
+    from lmcache.v1.multiprocess.transport.base import RequestClient
     from lmcache.v1.platform.cpu.shm import (
         CpuShmTensorWrapper,
         shm_create_readwrite,
@@ -506,7 +506,7 @@ def _send_unregister_kv_cache(
     reply, so success is distinguished from an RPC timeout only.
 
     Args:
-        client: The MP message-queue client.
+        client: The MP request client.
         instance_id: The instance ID used at registration time. Must match
             the ``instance_id`` passed to :func:`_send_register_kv_cache`.
         use_handle: ``True`` for the handle path (GPU CUDA-IPC / CPU SHM),

--- a/lmcache/integration/atom/multi_process_adapter.py
+++ b/lmcache/integration/atom/multi_process_adapter.py
@@ -20,7 +20,6 @@ import zmq
 
 # First Party
 from lmcache.utils import EngineType, init_logger
-from lmcache.v1.multiprocess.client import RequestClient, ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import (
@@ -32,6 +31,8 @@ from lmcache.v1.multiprocess.transfer_context import (
     TransferContext,
     create_transfer_context,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
 
 logger = init_logger(__name__)

--- a/lmcache/integration/atom/multi_process_adapter.py
+++ b/lmcache/integration/atom/multi_process_adapter.py
@@ -20,6 +20,7 @@ import zmq
 
 # First Party
 from lmcache.utils import EngineType, init_logger
+from lmcache.v1.multiprocess.client import RequestClient, ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import (
@@ -27,7 +28,6 @@ from lmcache.v1.multiprocess.group_view import (
     expand_engine_block_ids,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context import (
     TransferContext,
     create_transfer_context,
@@ -48,22 +48,9 @@ class _IpcEvent(Protocol):
     def wait(self, stream: object | None = None) -> None: ...
 
 
-def _send_request(
-    client: MessageQueueClient,
-    request_type: RequestType,
-    payloads: list[Any],
-) -> MessagingFuture[Any]:
-    """Submit one typed request to an LMCache multiprocess server."""
-    return client.submit_request(
-        request_type,
-        payloads,
-        get_response_class(request_type),
-    )
-
-
-def _get_chunk_size(client: MessageQueueClient, timeout: float) -> int:
+def _get_chunk_size(client: RequestClient, timeout: float) -> int:
     """Read the server's configured token chunk size."""
-    return int(_send_request(client, RequestType.GET_CHUNK_SIZE, []).result(timeout))
+    return int(client.get_chunk_size().result(timeout))
 
 
 class _HeartbeatThread(PeriodicThread):
@@ -71,7 +58,7 @@ class _HeartbeatThread(PeriodicThread):
 
     def __init__(
         self,
-        client: MessageQueueClient,
+        client: RequestClient,
         health_event: threading.Event,
         instance_id: int,
         interval: float,
@@ -125,11 +112,7 @@ class _HeartbeatThread(PeriodicThread):
         was_healthy = self._health_event.is_set()
         try:
             healthy = bool(
-                _send_request(
-                    self._client,
-                    RequestType.PING,
-                    [self._instance_id],
-                ).result(timeout=self._timeout)
+                self._client.ping(self._instance_id).result(timeout=self._timeout)
             )
         except Exception:
             healthy = False
@@ -191,7 +174,7 @@ class AtomMPSchedulerAdapter:
         *,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
     ) -> None:
-        client = MessageQueueClient(server_url, context)
+        client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
         self._model_name = model_name
         self._parallel = parallel_config
         self._mq_timeout = mq_timeout
@@ -242,11 +225,9 @@ class AtomMPSchedulerAdapter:
             request_id=request_id,
             worker_id=None,
         )
-        _send_request(
-            self._client,
-            RequestType.LOOKUP,
-            [key, self._parallel.tp_size],
-        ).result(timeout=self._mq_timeout)
+        self._client.lookup(key, self._parallel.tp_size).result(
+            timeout=self._mq_timeout
+        )
         self._pending_lookups.add(request_id)
 
     def check_lookup_result(self, request_id: str) -> int | None:
@@ -255,11 +236,9 @@ class AtomMPSchedulerAdapter:
             return self._lookup_results[request_id]
         if request_id not in self._pending_lookups:
             return 0
-        result = _send_request(
-            self._client,
-            RequestType.QUERY_PREFETCH_STATUS,
-            [request_id],
-        ).result(timeout=self._mq_timeout)
+        result = self._client.query_prefetch_status(request_id).result(
+            timeout=self._mq_timeout
+        )
         if result is None:
             return None
         matched_tokens = int(result) * self.lmcache_tokens_per_chunk
@@ -283,11 +262,7 @@ class AtomMPSchedulerAdapter:
             request_id=request_id,
             worker_id=None,
         )
-        _send_request(
-            self._client,
-            RequestType.FREE_LOOKUP_LOCKS,
-            [key, self._parallel.tp_size],
-        )
+        self._client.free_lookup_locks(key, self._parallel.tp_size)
 
     def cleanup_lookup_result(self, request_id: str) -> None:
         """Discard client-side lookup state after handoff or cleanup."""
@@ -296,7 +271,7 @@ class AtomMPSchedulerAdapter:
 
     def end_session(self, request_id: str) -> None:
         """Ask the LMCache server to release request-scoped state."""
-        _send_request(self._client, RequestType.END_SESSION, [request_id])
+        self._client.end_session(request_id)
 
     def shutdown(self) -> None:
         """Close the scheduler-side message queue client."""
@@ -344,7 +319,7 @@ class AtomMPWorkerAdapter:
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         transfer_mode: str | None = None,
     ) -> None:
-        client = MessageQueueClient(server_url, context)
+        client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
         self._model_name = model_name
         self._block_size = block_size
         self._parallel = parallel_config
@@ -563,11 +538,9 @@ class AtomMPWorkerAdapter:
 
             if registered and transfer_context is not None:
                 try:
-                    _send_request(
-                        self._client,
-                        RequestType.UNREGISTER_KV_CACHE,
-                        [self.instance_id],
-                    ).result(timeout=self._mq_timeout)
+                    self._client.unregister_kv_cache(self.instance_id).result(
+                        timeout=self._mq_timeout
+                    )
                 except Exception:
                     logger.warning(
                         "ATOM LMCache unregister failed during shutdown",
@@ -615,7 +588,6 @@ class AtomMPWorkerAdapter:
                 self.blocks_in_chunk,
                 self._client,
                 self._mq_timeout,
-                _send_request,
                 layout_hints={},
                 engine_group_infos=engine_group_infos,
                 engine_type=EngineType.ATOM,
@@ -681,11 +653,9 @@ class AtomMPWorkerAdapter:
         # late server registration and never publish its local context.
         try:
             try:
-                _send_request(
-                    self._client,
-                    RequestType.UNREGISTER_KV_CACHE,
-                    [self.instance_id],
-                ).result(timeout=self._mq_timeout)
+                self._client.unregister_kv_cache(self.instance_id).result(
+                    timeout=self._mq_timeout
+                )
             except Exception:
                 logger.warning(
                     "Failed to remove late ATOM LMCache registration",
@@ -807,11 +777,9 @@ class AtomMPWorkerAdapter:
     ) -> None:
         """Best-effort removal of an ambiguously registered candidate."""
         try:
-            _send_request(
-                self._client,
-                RequestType.UNREGISTER_KV_CACHE,
-                [self.instance_id],
-            ).result(timeout=self._mq_timeout)
+            self._client.unregister_kv_cache(self.instance_id).result(
+                timeout=self._mq_timeout
+            )
         except Exception:
             logger.warning(
                 "Failed to roll back rejected ATOM LMCache registration",

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -28,13 +28,14 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.kv_wrap import wrap_one_kv_cache
 
@@ -200,11 +201,11 @@ class LMCacheMPConnector:
         self._pending_lookups_lock = threading.Lock()
 
         self.context = zmq.Context.instance()
-        self.mq_client = ZmqMultiprocessClient(
+        self.req_client: RequestClient = ZmqMultiprocessClient(
             MessageQueueClient(f"tcp://{host}:{port}", self.context)
         )
 
-        self._lmcache_chunk_size = get_lmcache_chunk_size(self.mq_client)
+        self._lmcache_chunk_size = get_lmcache_chunk_size(self.req_client)
         if self._lmcache_chunk_size % self.page_size != 0:
             raise ValueError(
                 "LMCache chunk size must be a multiple of SGLang page size, got "
@@ -222,7 +223,7 @@ class LMCacheMPConnector:
         # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the
         # empty list -- which the server treats as one group spanning all layers
         # (matching the vLLM non-hybrid and TensorRT-LLM register paths).
-        self.mq_client.register_kv_cache(
+        self.req_client.register_kv_cache(
             self.instance_id,
             _wrap_sglang_kv_caches(k_pool, v_pool),
             self.model_name,
@@ -238,7 +239,7 @@ class LMCacheMPConnector:
         if self._heartbeat is not None:
             return
         self._heartbeat = HeartbeatThread(
-            mq_client=self.mq_client,
+            req_client=self.req_client,
             health_event=self._health_event,
             interval=self._heartbeat_interval,
             instance_id=self.instance_id,
@@ -313,7 +314,7 @@ class LMCacheMPConnector:
         """
         # The daemon blocks up to ``self._mq_timeout`` for the result, so give
         # the response itself a little longer than that to cover the round trip.
-        matched_chunks = self.mq_client.wait_prefetch_status(
+        matched_chunks = self.req_client.wait_prefetch_status(
             request_id, self._mq_timeout
         ).result(timeout=self._mq_timeout + _WAIT_LOOKUP_RESPONSE_BUFFER_S)
         if matched_chunks is None:
@@ -332,7 +333,7 @@ class LMCacheMPConnector:
     ) -> None:
         if start >= end or not self.is_healthy:
             return
-        self.mq_client.free_lookup_locks(
+        self.req_client.free_lookup_locks(
             self._create_key(
                 token_ids,
                 start=start,
@@ -386,7 +387,9 @@ class LMCacheMPConnector:
             request_id=request_id,
             no_worker_id=True,
         )
-        self.mq_client.lookup(lookup_key, self.tp_size).result(timeout=self._mq_timeout)
+        self.req_client.lookup(lookup_key, self.tp_size).result(
+            timeout=self._mq_timeout
+        )
         matched = self._wait_for_lookup(request_id)
         matched = self._global_min_tokens(matched)
 
@@ -438,7 +441,7 @@ class LMCacheMPConnector:
             self._free_lookup_locks(
                 pending.token_ids, 0, pending.matched_token_num, request_id
             )
-        self.mq_client.end_session(request_id)
+        self.req_client.end_session(request_id)
 
     def _submit_retrieve(
         self,
@@ -454,7 +457,7 @@ class LMCacheMPConnector:
     ]:
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        raw_future: MessagingFuture[tuple[bytes, bool]] = self.mq_client.retrieve(
+        raw_future: MessagingFuture[tuple[bytes, bool]] = self.req_client.retrieve(
             self._create_key(
                 token_ids,
                 start=offset,
@@ -607,7 +610,7 @@ class LMCacheMPConnector:
         )
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        future = self.mq_client.store(
+        future = self.req_client.store(
             self._create_key(
                 store_metadata.token_ids,
                 start=0,
@@ -644,7 +647,7 @@ class LMCacheMPConnector:
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
         success = (
-            self.mq_client.store(
+            self.req_client.store(
                 self._create_key(
                     store_metadata.token_ids,
                     start=0,
@@ -676,10 +679,10 @@ class LMCacheMPConnector:
             self._heartbeat = None
         if self._registered:
             try:
-                self.mq_client.unregister_kv_cache(self.instance_id).result(
+                self.req_client.unregister_kv_cache(self.instance_id).result(
                     timeout=self._mq_timeout
                 )
             except Exception:
                 logger.warning("Failed to unregister SGLang MP KV cache", exc_info=True)
             self._registered = False
-        self.mq_client.close()
+        self.req_client.close()

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -24,18 +24,17 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
     DEFAULT_MQ_TIMEOUT,
     HeartbeatThread,
     get_lmcache_chunk_size,
-    send_lmcache_request,
 )
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.kv_wrap import wrap_one_kv_cache
 
@@ -201,7 +200,9 @@ class LMCacheMPConnector:
         self._pending_lookups_lock = threading.Lock()
 
         self.context = zmq.Context.instance()
-        self.mq_client = MessageQueueClient(f"tcp://{host}:{port}", self.context)
+        self.mq_client = ZmqMultiprocessClient(
+            MessageQueueClient(f"tcp://{host}:{port}", self.context)
+        )
 
         self._lmcache_chunk_size = get_lmcache_chunk_size(self.mq_client)
         if self._lmcache_chunk_size % self.page_size != 0:
@@ -221,18 +222,14 @@ class LMCacheMPConnector:
         # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the
         # empty list -- which the server treats as one group spanning all layers
         # (matching the vLLM non-hybrid and TensorRT-LLM register paths).
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.REGISTER_KV_CACHE,
-            [
-                self.instance_id,
-                _wrap_sglang_kv_caches(k_pool, v_pool),
-                self.model_name,
-                self.tp_size,
-                EngineType.SGLANG,
-                {"tokens_per_block": self.page_size, "kv_list_layout": "k_v"},
-                [],
-            ],
+        self.mq_client.register_kv_cache(
+            self.instance_id,
+            _wrap_sglang_kv_caches(k_pool, v_pool),
+            self.model_name,
+            self.tp_size,
+            EngineType.SGLANG,
+            {"tokens_per_block": self.page_size, "kv_list_layout": "k_v"},
+            [],
         ).result(timeout=self._mq_timeout)
         self._registered = True
         self._start_heartbeat()
@@ -316,10 +313,8 @@ class LMCacheMPConnector:
         """
         # The daemon blocks up to ``self._mq_timeout`` for the result, so give
         # the response itself a little longer than that to cover the round trip.
-        matched_chunks = send_lmcache_request(
-            self.mq_client,
-            RequestType.WAIT_PREFETCH_STATUS,
-            [request_id, self._mq_timeout],
+        matched_chunks = self.mq_client.wait_prefetch_status(
+            request_id, self._mq_timeout
         ).result(timeout=self._mq_timeout + _WAIT_LOOKUP_RESPONSE_BUFFER_S)
         if matched_chunks is None:
             raise LMCacheTimeoutError(
@@ -337,19 +332,15 @@ class LMCacheMPConnector:
     ) -> None:
         if start >= end or not self.is_healthy:
             return
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.FREE_LOOKUP_LOCKS,
-            [
-                self._create_key(
-                    token_ids,
-                    start=start,
-                    end=end,
-                    request_id=request_id,
-                    no_worker_id=True,
-                ),
-                self.tp_size,
-            ],
+        self.mq_client.free_lookup_locks(
+            self._create_key(
+                token_ids,
+                start=start,
+                end=end,
+                request_id=request_id,
+                no_worker_id=True,
+            ),
+            self.tp_size,
         )
 
     def lookup_kv(self, token_ids: list[int], request_id: str) -> int:
@@ -395,11 +386,7 @@ class LMCacheMPConnector:
             request_id=request_id,
             no_worker_id=True,
         )
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.LOOKUP,
-            [lookup_key, self.tp_size],
-        ).result(timeout=self._mq_timeout)
+        self.mq_client.lookup(lookup_key, self.tp_size).result(timeout=self._mq_timeout)
         matched = self._wait_for_lookup(request_id)
         matched = self._global_min_tokens(matched)
 
@@ -451,7 +438,7 @@ class LMCacheMPConnector:
             self._free_lookup_locks(
                 pending.token_ids, 0, pending.matched_token_num, request_id
             )
-        send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
+        self.mq_client.end_session(request_id)
 
     def _submit_retrieve(
         self,
@@ -467,23 +454,19 @@ class LMCacheMPConnector:
     ]:
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        raw_future: MessagingFuture[tuple[bytes, bool]] = send_lmcache_request(
-            self.mq_client,
-            RequestType.RETRIEVE,
-            [
-                self._create_key(
-                    token_ids,
-                    start=offset,
-                    end=matched_end,
-                    request_id=request_id,
-                ),
-                self.instance_id,
-                # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
-                event.ipc_handle(),
-                skip_prefix_n_blocks,
-            ],
+        raw_future: MessagingFuture[tuple[bytes, bool]] = self.mq_client.retrieve(
+            self._create_key(
+                token_ids,
+                start=offset,
+                end=matched_end,
+                request_id=request_id,
+            ),
+            self.instance_id,
+            # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
+            # non-hybrid, so wrap the flat list as a single group.
+            [block_ids],
+            event.ipc_handle(),
+            skip_prefix_n_blocks,
         )
         future = raw_future.to_device_future(device=self.device)
         # The daemon imports this IPC event after the request crosses the wire.
@@ -624,22 +607,18 @@ class LMCacheMPConnector:
         )
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        future = send_lmcache_request(
-            self.mq_client,
-            RequestType.STORE,
-            [
-                self._create_key(
-                    store_metadata.token_ids,
-                    start=0,
-                    end=aligned_end,
-                    request_id=request_id,
-                ),
-                self.instance_id,
-                # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
-                event.ipc_handle(),
-            ],
+        future = self.mq_client.store(
+            self._create_key(
+                store_metadata.token_ids,
+                start=0,
+                end=aligned_end,
+                request_id=request_id,
+            ),
+            self.instance_id,
+            # STORE takes per-group block IDs (list[list[int]]); SGLang is
+            # non-hybrid, so wrap the flat list as a single group.
+            [block_ids],
+            event.ipc_handle(),
         ).to_device_future(device=self.device)
         # Keep the exporting device event alive until the caller releases the
         # future. Since we return without blocking, the local ``event`` would
@@ -665,22 +644,18 @@ class LMCacheMPConnector:
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
         success = (
-            send_lmcache_request(
-                self.mq_client,
-                RequestType.STORE,
-                [
-                    self._create_key(
-                        store_metadata.token_ids,
-                        start=0,
-                        end=aligned_end,
-                        request_id=request_id,
-                    ),
-                    self.instance_id,
-                    # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                    # non-hybrid, so wrap the flat list as a single group.
-                    [block_ids],
-                    event.ipc_handle(),
-                ],
+            self.mq_client.store(
+                self._create_key(
+                    store_metadata.token_ids,
+                    start=0,
+                    end=aligned_end,
+                    request_id=request_id,
+                ),
+                self.instance_id,
+                # STORE takes per-group block IDs (list[list[int]]); SGLang is
+                # non-hybrid, so wrap the flat list as a single group.
+                [block_ids],
+                event.ipc_handle(),
             )
             .to_device_future(device=self.device)
             .result(timeout=self._mq_timeout)
@@ -701,11 +676,9 @@ class LMCacheMPConnector:
             self._heartbeat = None
         if self._registered:
             try:
-                send_lmcache_request(
-                    self.mq_client,
-                    RequestType.UNREGISTER_KV_CACHE,
-                    [self.instance_id],
-                ).result(timeout=self._mq_timeout)
+                self.mq_client.unregister_kv_cache(self.instance_id).result(
+                    timeout=self._mq_timeout
+                )
             except Exception:
                 logger.warning("Failed to unregister SGLang MP KV cache", exc_info=True)
             self._registered = False

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -34,11 +34,12 @@ import zmq
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType, check_interprocess_event_support
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
 logger = init_logger(__name__)
@@ -77,14 +78,14 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         self._pending: dict = {}
 
         self._zmq_context = zmq.Context()
-        self._mq_client = ZmqMultiprocessClient(
+        self._req_client: RequestClient = ZmqMultiprocessClient(
             MessageQueueClient(_get_server_url(self._llm_args), self._zmq_context)
         )
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
         )
 
-        future = self._mq_client.get_chunk_size()
+        future = self._req_client.get_chunk_size()
         self._chunk_size = future.result(timeout=self._mq_timeout)
         logger.info(
             "LMCache MP scheduler: connected to server at %s (chunk_size=%d)",
@@ -154,8 +155,8 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         t1 = time.perf_counter()
 
         try:
-            self._mq_client.lookup(key, 1).result(timeout=self._mq_timeout)
-            result = self._mq_client.query_prefetch_status(
+            self._req_client.lookup(key, 1).result(timeout=self._mq_timeout)
+            result = self._req_client.query_prefetch_status(
                 str(request.request_id)
             ).result(timeout=self._mq_timeout)
             cached_tokens = result * self._chunk_size if result is not None else 0
@@ -183,7 +184,7 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
                 request_id=request.request_id,
             ).no_worker_id_version()
             try:
-                self._mq_client.free_lookup_locks(free_key, 1)
+                self._req_client.free_lookup_locks(free_key, 1)
             except Exception as e:
                 logger.warning("LMCache MP scheduler: free_lookup_locks failed: %s", e)
 
@@ -242,7 +243,7 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         release the server-side token-hash/session state for the request.
         """
         try:
-            self._mq_client.end_session(str(request.request_id))
+            self._req_client.end_session(str(request.request_id))
         except Exception as e:
             logger.warning("LMCache MP scheduler: end_session failed: %s", e)
         return False
@@ -262,7 +263,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
         self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
 
         self._zmq_context = zmq.Context()
-        self._mq_client = ZmqMultiprocessClient(
+        self._req_client: RequestClient = ZmqMultiprocessClient(
             MessageQueueClient(_get_server_url(self._llm_args), self._zmq_context)
         )
         self._mq_timeout = float(
@@ -281,7 +282,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
         self._world_size = tp_size * pp_size
         self._model_name = str(getattr(llm_args, "model", "unknown_model"))
 
-        future = self._mq_client.get_chunk_size()
+        future = self._req_client.get_chunk_size()
         self._chunk_size = future.result(timeout=self._mq_timeout)
 
     def _create_key(
@@ -340,7 +341,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             "head_dim": head_dim,
         }
 
-        future = self._mq_client.register_kv_cache(
+        future = self._req_client.register_kv_cache(
             self._instance_id,
             wrapped,
             self._model_name,
@@ -385,7 +386,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             key = self._create_key(spec.tokens, req_id)
             try:
                 success = (
-                    self._mq_client.retrieve(
+                    self._req_client.retrieve(
                         key,
                         self._instance_id,
                         [spec.block_ids],
@@ -444,7 +445,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             key = self._create_key(spec.tokens, req_id)
             try:
                 success = (
-                    self._mq_client.store(
+                    self._req_client.store(
                         key,
                         self._instance_id,
                         [spec.block_ids],

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -34,11 +34,11 @@ import zmq
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType, check_interprocess_event_support
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
-from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
 logger = init_logger(__name__)
@@ -53,16 +53,6 @@ def _get_server_url(llm_args: "TorchLlmArgs") -> str:
     if cfg is not None and cfg.server_url is not None:
         return cfg.server_url
     return os.environ.get("LMCACHE_SERVER_URL", DEFAULT_SERVER_URL)
-
-
-def _send_request(
-    mq_client: MessageQueueClient,
-    request_type: RequestType,
-    payloads: list,
-) -> MessagingFuture:
-    return mq_client.submit_request(
-        request_type, payloads, get_response_class(request_type)
-    )
 
 
 @dataclass
@@ -87,14 +77,14 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         self._pending: dict = {}
 
         self._zmq_context = zmq.Context()
-        self._mq_client = MessageQueueClient(
-            _get_server_url(self._llm_args), self._zmq_context
+        self._mq_client = ZmqMultiprocessClient(
+            MessageQueueClient(_get_server_url(self._llm_args), self._zmq_context)
         )
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
         )
 
-        future = _send_request(self._mq_client, RequestType.GET_CHUNK_SIZE, [])
+        future = self._mq_client.get_chunk_size()
         self._chunk_size = future.result(timeout=self._mq_timeout)
         logger.info(
             "LMCache MP scheduler: connected to server at %s (chunk_size=%d)",
@@ -164,13 +154,9 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         t1 = time.perf_counter()
 
         try:
-            _send_request(self._mq_client, RequestType.LOOKUP, [key, 1]).result(
-                timeout=self._mq_timeout
-            )
-            result = _send_request(
-                self._mq_client,
-                RequestType.QUERY_PREFETCH_STATUS,
-                [str(request.request_id)],
+            self._mq_client.lookup(key, 1).result(timeout=self._mq_timeout)
+            result = self._mq_client.query_prefetch_status(
+                str(request.request_id)
             ).result(timeout=self._mq_timeout)
             cached_tokens = result * self._chunk_size if result is not None else 0
         except Exception as e:
@@ -197,11 +183,7 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
                 request_id=request.request_id,
             ).no_worker_id_version()
             try:
-                _send_request(
-                    self._mq_client,
-                    RequestType.FREE_LOOKUP_LOCKS,
-                    [free_key, 1],
-                )
+                self._mq_client.free_lookup_locks(free_key, 1)
             except Exception as e:
                 logger.warning("LMCache MP scheduler: free_lookup_locks failed: %s", e)
 
@@ -260,11 +242,7 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         release the server-side token-hash/session state for the request.
         """
         try:
-            _send_request(
-                self._mq_client,
-                RequestType.END_SESSION,
-                [str(request.request_id)],
-            )
+            self._mq_client.end_session(str(request.request_id))
         except Exception as e:
             logger.warning("LMCache MP scheduler: end_session failed: %s", e)
         return False
@@ -284,8 +262,8 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
         self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
 
         self._zmq_context = zmq.Context()
-        self._mq_client = MessageQueueClient(
-            _get_server_url(self._llm_args), self._zmq_context
+        self._mq_client = ZmqMultiprocessClient(
+            MessageQueueClient(_get_server_url(self._llm_args), self._zmq_context)
         )
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
@@ -303,7 +281,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
         self._world_size = tp_size * pp_size
         self._model_name = str(getattr(llm_args, "model", "unknown_model"))
 
-        future = _send_request(self._mq_client, RequestType.GET_CHUNK_SIZE, [])
+        future = self._mq_client.get_chunk_size()
         self._chunk_size = future.result(timeout=self._mq_timeout)
 
     def _create_key(
@@ -362,18 +340,14 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             "head_dim": head_dim,
         }
 
-        future = _send_request(
-            self._mq_client,
-            RequestType.REGISTER_KV_CACHE,
-            [
-                self._instance_id,
-                wrapped,
-                self._model_name,
-                self._world_size,
-                EngineType.TRTLLM,
-                layout_hints,
-                [],
-            ],
+        future = self._mq_client.register_kv_cache(
+            self._instance_id,
+            wrapped,
+            self._model_name,
+            self._world_size,
+            EngineType.TRTLLM,
+            layout_hints,
+            [],
         )
         try:
             future.result(timeout=self._mq_timeout)
@@ -411,16 +385,12 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             key = self._create_key(spec.tokens, req_id)
             try:
                 success = (
-                    _send_request(
-                        self._mq_client,
-                        RequestType.RETRIEVE,
-                        [
-                            key,
-                            self._instance_id,
-                            [spec.block_ids],
-                            event.ipc_handle(),
-                            0,  # skip_first_n_tokens
-                        ],
+                    self._mq_client.retrieve(
+                        key,
+                        self._instance_id,
+                        [spec.block_ids],
+                        event.ipc_handle(),
+                        0,  # skip_first_n_tokens
                     )
                     .to_device_future()
                     .result(timeout=self._mq_timeout)
@@ -474,15 +444,11 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             key = self._create_key(spec.tokens, req_id)
             try:
                 success = (
-                    _send_request(
-                        self._mq_client,
-                        RequestType.STORE,
-                        [
-                            key,
-                            self._instance_id,
-                            [spec.block_ids],
-                            event.ipc_handle(),
-                        ],
+                    self._mq_client.store(
+                        key,
+                        self._instance_id,
+                        [spec.block_ids],
+                        event.ipc_handle(),
                     )
                     .to_device_future()
                     .result(timeout=self._mq_timeout)

--- a/lmcache/integration/vllm/experimental/dispatcher.py
+++ b/lmcache/integration/vllm/experimental/dispatcher.py
@@ -46,7 +46,6 @@ class QTensorFeature:
             q_model_name=LMCacheSDKCacheKind.QUERY.server_model_name(
                 ctx.worker_adapter.model_name
             ),
-            send_lmcache_request=ctx.send_lmcache_request,
         )
         self._capture = QRingBufferCapture(ctx.worker_adapter, self._q_ring_adapter)
 
@@ -103,7 +102,6 @@ class FeatureContext:
     """
 
     worker_adapter: LMCacheMPWorkerAdapter
-    send_lmcache_request: Callable[..., Any]
 
 
 FeatureFactory = Callable[[FeatureContext], "QTensorFeature"]

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -66,7 +66,6 @@ try:
         LMCacheMPSchedulerAdapter,
         LMCacheMPWorkerAdapter,
         ParallelStrategy,
-        send_lmcache_request,
     )
 
     try:
@@ -618,7 +617,6 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
                 ctx = FeatureContext(
                     worker_adapter=self.worker_adapter,
-                    send_lmcache_request=send_lmcache_request,
                 )
                 requested = (
                     {TRANSFER_QUERY} if self.transfer_intermediate_tensors else set()

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -21,6 +21,7 @@ from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     IPCCacheServerKey,
@@ -30,7 +31,6 @@ from lmcache.v1.multiprocess.group_view import (
     expand_engine_block_ids,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context import (
     EngineDrivenTransferContext,
     TransferContext,
@@ -164,31 +164,8 @@ class _IpcEvent(Protocol):
     def wait(self, stream: Any = None) -> None: ...
 
 
-def send_lmcache_request(
-    mq_client: MessageQueueClient,
-    request_type: RequestType,
-    payloads: list[Any],
-) -> MessagingFuture[Any]:
-    """
-    Helper function to send the request to the LMCache multiprocess server
-
-    Args:
-        mq_client: The LMCache multiprocess mode message queue client
-        request_type: The request type
-        payloads: The request payloads
-
-    Returns:
-        A messaging future for the request
-    """
-
-    future = mq_client.submit_request(
-        request_type, payloads, get_response_class(request_type)
-    )
-    return future
-
-
 def get_lmcache_chunk_size(
-    mq_client: MessageQueueClient,
+    mq_client: ZmqMultiprocessClient,
     timeout: float = DEFAULT_MQ_TIMEOUT,
 ) -> int:
     """
@@ -201,13 +178,13 @@ def get_lmcache_chunk_size(
     Returns:
         An integer representing the LMCache chunk size
     """
-    future = send_lmcache_request(mq_client, RequestType.GET_CHUNK_SIZE, [])
+    future = mq_client.get_chunk_size()
     lmcache_tokens_per_chunk = future.result(timeout=timeout)
     return lmcache_tokens_per_chunk
 
 
 def get_experimental(
-    mq_client: MessageQueueClient,
+    mq_client: ZmqMultiprocessClient,
     timeout: float = DEFAULT_MQ_TIMEOUT,
 ) -> set[str]:
     """Query the experimental capabilities a server advertises.
@@ -219,7 +196,7 @@ def get_experimental(
     Returns:
         Experimental features built into the server (now `transfer_query`).
     """
-    future = send_lmcache_request(mq_client, RequestType.GET_EXPERIMENTAL, [])
+    future = mq_client.get_experimental()
     try:
         return set(future.result(timeout=timeout))
     except TimeoutError:
@@ -262,7 +239,7 @@ def _raise_server_unreachable(server_url: str, timeout: float) -> NoReturn:
 
 
 def send_ping(
-    mq_client: MessageQueueClient,
+    mq_client: ZmqMultiprocessClient,
     timeout: float,
     instance_id: int | None = None,
 ) -> bool:
@@ -278,7 +255,7 @@ def send_ping(
         True if server is healthy, False on timeout or error.
     """
     try:
-        future = send_lmcache_request(mq_client, RequestType.PING, [instance_id])
+        future = mq_client.ping(instance_id)
         return future.result(timeout=timeout)
     except TimeoutError:
         return False
@@ -433,7 +410,7 @@ class HeartbeatThread(PeriodicThread):
 
     def __init__(
         self,
-        mq_client: MessageQueueClient,
+        mq_client: ZmqMultiprocessClient,
         health_event: threading.Event,
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         instance_id: int | None = None,
@@ -626,8 +603,9 @@ class LMCacheMPSchedulerAdapter:
         )
         assert len(server_urls) >= 1, "At least one server url required"
         self._server_urls: list[str] = list(server_urls)
-        self.mq_clients: dict[str, MessageQueueClient] = {
-            url: MessageQueueClient(url, context) for url in self._server_urls
+        self.mq_clients: dict[str, ZmqMultiprocessClient] = {
+            url: ZmqMultiprocessClient(MessageQueueClient(url, context))
+            for url in self._server_urls
         }
         if extra_config is not None:
             cfg = _resolve_extra_config(extra_config)
@@ -791,11 +769,7 @@ class LMCacheMPSchedulerAdapter:
         ).no_worker_id_version()
 
         futures: dict[str, MessagingFuture[Any]] = {
-            url: send_lmcache_request(
-                self.mq_clients[url],
-                RequestType.LOOKUP,
-                [key, self.tp_size],
-            )
+            url: self.mq_clients[url].lookup(key, self.tp_size)
             for url in self._server_urls
         }
 
@@ -851,11 +825,7 @@ class LMCacheMPSchedulerAdapter:
                     cache_salt=cs or "",
                     request_configs=request_configs,
                 ).no_worker_id_version()
-                send_lmcache_request(
-                    self.mq_clients[url],
-                    RequestType.FREE_LOOKUP_LOCKS,
-                    [tail_key, self.tp_size],
-                )
+                self.mq_clients[url].free_lookup_locks(tail_key, self.tp_size)
 
     @_lmcache_nvtx_annotate
     def check_lookup_result(self, request_id: str) -> int | None:
@@ -895,11 +865,7 @@ class LMCacheMPSchedulerAdapter:
         unresolved_urls = [u for u in self._server_urls if u not in per_server]
 
         futures: dict[str, MessagingFuture[Any]] = {
-            url: send_lmcache_request(
-                self.mq_clients[url],
-                RequestType.QUERY_PREFETCH_STATUS,
-                [request_id],
-            )
+            url: self.mq_clients[url].query_prefetch_status(request_id)
             for url in unresolved_urls
         }
 
@@ -1006,11 +972,7 @@ class LMCacheMPSchedulerAdapter:
             request_configs=request_configs,
         ).no_worker_id_version()
         for url in self._server_urls:
-            send_lmcache_request(
-                self.mq_clients[url],
-                RequestType.FREE_LOOKUP_LOCKS,
-                [base_key, self.tp_size],
-            )
+            self.mq_clients[url].free_lookup_locks(base_key, self.tp_size)
 
     def end_session(self, request_id: str) -> None:
         """
@@ -1022,11 +984,7 @@ class LMCacheMPSchedulerAdapter:
             return
 
         for url in self._server_urls:
-            send_lmcache_request(
-                self.mq_clients[url],
-                RequestType.END_SESSION,
-                [request_id],
-            )
+            self.mq_clients[url].end_session(request_id)
 
     def report_block_allocations(
         self,
@@ -1045,10 +1003,8 @@ class LMCacheMPSchedulerAdapter:
             return
 
         for url in self._server_urls:
-            send_lmcache_request(
-                self.mq_clients[url],
-                RequestType.REPORT_BLOCK_ALLOCATION,
-                [os.getpid(), self.model_name, records],
+            self.mq_clients[url].report_block_allocation(
+                os.getpid(), self.model_name, records
             )
 
     # Helper functions
@@ -1171,7 +1127,7 @@ class LMCacheMPWorkerAdapter:
             set_isolated_ipc(cfg[ExtraConfigDefault.isolated_ipc.name])
         else:
             self._mp_transfer_mode = None
-        self.mq_client = MessageQueueClient(server_url, context)
+        self.mq_client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
         self._mq_timeout = mq_timeout
 
         # Instance id for GPU worker. uuid4-derived (OS entropy) rather
@@ -1394,7 +1350,6 @@ class LMCacheMPWorkerAdapter:
                 self.blocks_in_chunk,
                 self.mq_client,
                 self._mq_timeout,
-                send_request=send_lmcache_request,
                 layout_hints=layout_hints,
                 engine_group_infos=self.engine_group_infos,
                 engine_type=EngineType.VLLM,
@@ -2048,16 +2003,13 @@ class LMCacheMPWorkerAdapter:
 
         logger.info("Unregistering kv caches")
         try:
-            unregister_type = (
-                RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
-                if isinstance(self.transfer_ctx, EngineDrivenTransferContext)
-                else RequestType.UNREGISTER_KV_CACHE
-            )
-            send_lmcache_request(
-                self.mq_client,
-                unregister_type,
-                [self.instance_id],
-            ).result(timeout=self._mq_timeout)
+            if isinstance(self.transfer_ctx, EngineDrivenTransferContext):
+                future = self.mq_client.unregister_kv_cache_engine_driven_context(
+                    self.instance_id
+                )
+            else:
+                future = self.mq_client.unregister_kv_cache(self.instance_id)
+            future.result(timeout=self._mq_timeout)
         except TimeoutError:
             logger.warning(
                 "LMCache server did not respond to unregister within %ss. "

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -21,7 +21,6 @@ from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.gpu_connector.utils import LayoutHints
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     IPCCacheServerKey,
@@ -36,6 +35,8 @@ from lmcache.v1.multiprocess.transfer_context import (
     TransferContext,
     create_transfer_context,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
 from lmcache.v1.platform.isolated_ipc import set_isolated_ipc
 
@@ -165,38 +166,38 @@ class _IpcEvent(Protocol):
 
 
 def get_lmcache_chunk_size(
-    mq_client: ZmqMultiprocessClient,
+    req_client: RequestClient,
     timeout: float = DEFAULT_MQ_TIMEOUT,
 ) -> int:
     """
     Helper function to get the LMCache chunk size from the server
 
     Args:
-        mq_client: The LMCache multiprocess mode message queue client
+        req_client: The LMCache multiprocess request client.
         timeout: Timeout in seconds for the blocking request.
 
     Returns:
         An integer representing the LMCache chunk size
     """
-    future = mq_client.get_chunk_size()
+    future = req_client.get_chunk_size()
     lmcache_tokens_per_chunk = future.result(timeout=timeout)
     return lmcache_tokens_per_chunk
 
 
 def get_experimental(
-    mq_client: ZmqMultiprocessClient,
+    req_client: RequestClient,
     timeout: float = DEFAULT_MQ_TIMEOUT,
 ) -> set[str]:
     """Query the experimental capabilities a server advertises.
 
     Args:
-        mq_client: The LMCache multiprocess mode message queue client.
+        req_client: The LMCache multiprocess request client.
         timeout: Seconds to wait for the server's response.
 
     Returns:
         Experimental features built into the server (now `transfer_query`).
     """
-    future = mq_client.get_experimental()
+    future = req_client.get_experimental()
     try:
         return set(future.result(timeout=timeout))
     except TimeoutError:
@@ -239,14 +240,14 @@ def _raise_server_unreachable(server_url: str, timeout: float) -> NoReturn:
 
 
 def send_ping(
-    mq_client: ZmqMultiprocessClient,
+    req_client: RequestClient,
     timeout: float,
     instance_id: int | None = None,
 ) -> bool:
     """Send a PING request and return the result.
 
     Args:
-        mq_client: The message queue client.
+        req_client: The request client.
         timeout: Seconds to wait for the server's response.
         instance_id: The worker's instance ID so the server can refresh its
             liveness, or None for an untracked prober (scheduler adapter).
@@ -255,7 +256,7 @@ def send_ping(
         True if server is healthy, False on timeout or error.
     """
     try:
-        future = mq_client.ping(instance_id)
+        future = req_client.ping(instance_id)
         return future.result(timeout=timeout)
     except TimeoutError:
         return False
@@ -410,14 +411,14 @@ class HeartbeatThread(PeriodicThread):
 
     def __init__(
         self,
-        mq_client: ZmqMultiprocessClient,
+        req_client: RequestClient,
         health_event: threading.Event,
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         instance_id: int | None = None,
     ):
         """
         Args:
-            mq_client: The message queue client used to send PING requests.
+            req_client: The request client used to send PING requests.
             health_event: A threading.Event shared with the adapter.
                 Set when the server is healthy, cleared when unhealthy.
                 Adapters check this event to decide whether to proceed
@@ -432,7 +433,7 @@ class HeartbeatThread(PeriodicThread):
             interval=interval,
             level=ThreadLevel.CRITICAL,
         )
-        self._mq_client = mq_client
+        self._req_client = req_client
         self._health_event = health_event
         self._interval = interval
         self._instance_id = instance_id
@@ -475,7 +476,7 @@ class HeartbeatThread(PeriodicThread):
         """
         was_healthy = self._health_event.is_set()
         healthy = send_ping(
-            self._mq_client, timeout=self._interval, instance_id=self._instance_id
+            self._req_client, timeout=self._interval, instance_id=self._instance_id
         )
 
         if self.stop_requested:
@@ -603,7 +604,7 @@ class LMCacheMPSchedulerAdapter:
         )
         assert len(server_urls) >= 1, "At least one server url required"
         self._server_urls: list[str] = list(server_urls)
-        self.mq_clients: dict[str, ZmqMultiprocessClient] = {
+        self.req_clients: dict[str, RequestClient] = {
             url: ZmqMultiprocessClient(MessageQueueClient(url, context))
             for url in self._server_urls
         }
@@ -632,13 +633,13 @@ class LMCacheMPSchedulerAdapter:
 
         # Read chunk size from lmcache
         chunk_sizes: dict[str, int] = {}
-        for url, client in self.mq_clients.items():
+        for url, client in self.req_clients.items():
             try:
                 chunk_sizes[url] = get_lmcache_chunk_size(
                     client, timeout=self._mq_timeout
                 )
             except TimeoutError:
-                for c in self.mq_clients.values():
+                for c in self.req_clients.values():
                     c.close()
                 _raise_server_unreachable(url, self._mq_timeout)
 
@@ -703,9 +704,9 @@ class LMCacheMPSchedulerAdapter:
         with self._heartbeat_lock:
             if self._heartbeats is not None:
                 return
-            for url, client in self.mq_clients.items():
+            for url, client in self.req_clients.items():
                 hb = HeartbeatThread(
-                    mq_client=client,
+                    req_client=client,
                     health_event=self._health_events[url],
                     interval=self._heartbeat_interval,
                 )
@@ -769,7 +770,7 @@ class LMCacheMPSchedulerAdapter:
         ).no_worker_id_version()
 
         futures: dict[str, MessagingFuture[Any]] = {
-            url: self.mq_clients[url].lookup(key, self.tp_size)
+            url: self.req_clients[url].lookup(key, self.tp_size)
             for url in self._server_urls
         }
 
@@ -825,7 +826,7 @@ class LMCacheMPSchedulerAdapter:
                     cache_salt=cs or "",
                     request_configs=request_configs,
                 ).no_worker_id_version()
-                self.mq_clients[url].free_lookup_locks(tail_key, self.tp_size)
+                self.req_clients[url].free_lookup_locks(tail_key, self.tp_size)
 
     @_lmcache_nvtx_annotate
     def check_lookup_result(self, request_id: str) -> int | None:
@@ -865,7 +866,7 @@ class LMCacheMPSchedulerAdapter:
         unresolved_urls = [u for u in self._server_urls if u not in per_server]
 
         futures: dict[str, MessagingFuture[Any]] = {
-            url: self.mq_clients[url].query_prefetch_status(request_id)
+            url: self.req_clients[url].query_prefetch_status(request_id)
             for url in unresolved_urls
         }
 
@@ -922,7 +923,7 @@ class LMCacheMPSchedulerAdapter:
 
     def shutdown(self) -> None:
         """Shutdown the scheduler adapter and its resources."""
-        for client in self.mq_clients.values():
+        for client in self.req_clients.values():
             client.close()
         with self._heartbeat_lock:
             for hb in self._heartbeats.values():
@@ -972,7 +973,7 @@ class LMCacheMPSchedulerAdapter:
             request_configs=request_configs,
         ).no_worker_id_version()
         for url in self._server_urls:
-            self.mq_clients[url].free_lookup_locks(base_key, self.tp_size)
+            self.req_clients[url].free_lookup_locks(base_key, self.tp_size)
 
     def end_session(self, request_id: str) -> None:
         """
@@ -984,7 +985,7 @@ class LMCacheMPSchedulerAdapter:
             return
 
         for url in self._server_urls:
-            self.mq_clients[url].end_session(request_id)
+            self.req_clients[url].end_session(request_id)
 
     def report_block_allocations(
         self,
@@ -1003,7 +1004,7 @@ class LMCacheMPSchedulerAdapter:
             return
 
         for url in self._server_urls:
-            self.mq_clients[url].report_block_allocation(
+            self.req_clients[url].report_block_allocation(
                 os.getpid(), self.model_name, records
             )
 
@@ -1127,7 +1128,7 @@ class LMCacheMPWorkerAdapter:
             set_isolated_ipc(cfg[ExtraConfigDefault.isolated_ipc.name])
         else:
             self._mp_transfer_mode = None
-        self.mq_client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
+        self.req_client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
         self._mq_timeout = mq_timeout
 
         # Instance id for GPU worker. uuid4-derived (OS entropy) rather
@@ -1180,10 +1181,10 @@ class LMCacheMPWorkerAdapter:
         # Read chunk size from lmcache
         try:
             lmcache_tokens_per_chunk = get_lmcache_chunk_size(
-                self.mq_client, timeout=self._mq_timeout
+                self.req_client, timeout=self._mq_timeout
             )
         except TimeoutError:
-            self.mq_client.close()
+            self.req_client.close()
             _raise_server_unreachable(server_url, self._mq_timeout)
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
         if lmcache_tokens_per_chunk % vllm_block_size != 0:
@@ -1197,7 +1198,7 @@ class LMCacheMPWorkerAdapter:
 
         # Experimental intermediate tensor transfer
         self.experimental: set[str] = get_experimental(
-            self.mq_client, timeout=self._mq_timeout
+            self.req_client, timeout=self._mq_timeout
         )
         self.dispatcher: "Dispatcher | None" = None
 
@@ -1348,7 +1349,7 @@ class LMCacheMPWorkerAdapter:
                 self.model_name,
                 self.world_size,
                 self.blocks_in_chunk,
-                self.mq_client,
+                self.req_client,
                 self._mq_timeout,
                 layout_hints=layout_hints,
                 engine_group_infos=self.engine_group_infos,
@@ -1377,7 +1378,7 @@ class LMCacheMPWorkerAdapter:
             if self._heartbeat is not None:
                 return
             heartbeat = HeartbeatThread(
-                mq_client=self.mq_client,
+                req_client=self.req_client,
                 health_event=self._health_event,
                 interval=self._heartbeat_interval,
                 instance_id=self.instance_id,
@@ -1994,7 +1995,7 @@ class LMCacheMPWorkerAdapter:
         Shutdown the LMCache MP worker adapter.
 
         Stops the heartbeat (if started) before UNREGISTER: no new ping
-        on the closing mq_client, and a straggler in-flight cycle cannot
+        on the closing request client, and a straggler in-flight cycle cannot
         re-register or flip the health event after unregistration.
         """
         with self._heartbeat_lock:
@@ -2004,11 +2005,11 @@ class LMCacheMPWorkerAdapter:
         logger.info("Unregistering kv caches")
         try:
             if isinstance(self.transfer_ctx, EngineDrivenTransferContext):
-                future = self.mq_client.unregister_kv_cache_engine_driven_context(
+                future = self.req_client.unregister_kv_cache_engine_driven_context(
                     self.instance_id
                 )
             else:
-                future = self.mq_client.unregister_kv_cache(self.instance_id)
+                future = self.req_client.unregister_kv_cache(self.instance_id)
             future.result(timeout=self._mq_timeout)
         except TimeoutError:
             logger.warning(
@@ -2024,7 +2025,7 @@ class LMCacheMPWorkerAdapter:
             self.transfer_ctx.close()
             self.transfer_ctx = None
 
-        self.mq_client.close()
+        self.req_client.close()
         self.request_telemetry.close()
 
     # Helper functions

--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -26,9 +26,9 @@ from lmcache.v1.gpu_connector.utils import (
     get_block_size,
     get_num_heads,
 )
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     EngineDrivenTransferContext,
     create_transfer_context,
@@ -84,7 +84,9 @@ class LMCacheSDKContext:
         """
         self._kind = kind
         self._zmq_context = zmq.Context()
-        self._mq_client = MessageQueueClient(url, self._zmq_context)
+        self._mq_client = ZmqMultiprocessClient(
+            MessageQueueClient(url, self._zmq_context)
+        )
         self._mq_timeout = timeout
         self._model_name = kind.server_model_name(model_name)
         self.instance_id = uuid.uuid4().int & ((1 << 63) - 1)
@@ -228,11 +230,6 @@ class LMCacheSDKContext:
             head_dim=head_dim,
         )
 
-        # First Party
-        from lmcache.integration.vllm.vllm_multi_process_adapter import (
-            send_lmcache_request,
-        )
-
         transfer_ctx.register(
             self.instance_id,
             self._kv_caches,
@@ -241,7 +238,6 @@ class LMCacheSDKContext:
             self.blocks_in_chunk,
             self._mq_client,
             self._mq_timeout,
-            send_request=send_lmcache_request,
             layout_hints=layout_hints,
         )
 
@@ -307,11 +303,7 @@ class LMCacheSDKContext:
             request_configs=request_configs,
         ).no_worker_id_version()
 
-        future = self._mq_client.submit_request(
-            RequestType.LOOKUP,
-            [key, self._world_size],
-            get_response_class(RequestType.LOOKUP),
-        )
+        future = self._mq_client.lookup(key, self._world_size)
         try:
             future.result(timeout=self._mq_timeout)
         except TimeoutError:
@@ -345,11 +337,9 @@ class LMCacheSDKContext:
             return self._finished_lookups[request_id]
 
         try:
-            result = self._mq_client.submit_request(
-                RequestType.QUERY_PREFETCH_STATUS,
-                [request_id],
-                get_response_class(RequestType.QUERY_PREFETCH_STATUS),
-            ).result(timeout=self._mq_timeout)
+            result = self._mq_client.query_prefetch_status(request_id).result(
+                timeout=self._mq_timeout
+            )
         except TimeoutError:
             logger.warning(
                 "QUERY_PREFETCH_STATUS timed out after %ss.",
@@ -374,11 +364,7 @@ class LMCacheSDKContext:
         self._pending_lookups.discard(request_id)
         self._finished_lookups.pop(request_id, None)
         try:
-            self._mq_client.submit_request(
-                RequestType.END_SESSION,
-                [request_id],
-                get_response_class(RequestType.END_SESSION),
-            ).result(timeout=self._mq_timeout)
+            self._mq_client.end_session(request_id).result(timeout=self._mq_timeout)
         except TimeoutError:
             logger.warning(
                 "END_SESSION timed out after %ss for request_id=%s.",

--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -26,13 +26,14 @@ from lmcache.v1.gpu_connector.utils import (
     get_block_size,
     get_num_heads,
 )
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     EngineDrivenTransferContext,
     create_transfer_context,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 import lmcache.lmcache_native as lmcache_native
 
 logger = init_logger(__name__)
@@ -50,7 +51,7 @@ ModifyFnType = Callable[
 
 class LMCacheSDKContext:
     """
-    Retrieve and store KV cache tensors via LMCache's MQ endpoints.
+    Retrieve and store KV cache tensors through an LMCache MP request client.
 
     The model layout must already be registered in the running LMCache server
     (e.g. by a vllm instance that called REGISTER_KV_CACHE).
@@ -84,7 +85,7 @@ class LMCacheSDKContext:
         """
         self._kind = kind
         self._zmq_context = zmq.Context()
-        self._mq_client = ZmqMultiprocessClient(
+        self._req_client: RequestClient = ZmqMultiprocessClient(
             MessageQueueClient(url, self._zmq_context)
         )
         self._mq_timeout = timeout
@@ -236,7 +237,7 @@ class LMCacheSDKContext:
             self._model_name,
             self._world_size,
             self.blocks_in_chunk,
-            self._mq_client,
+            self._req_client,
             self._mq_timeout,
             layout_hints=layout_hints,
         )
@@ -266,8 +267,8 @@ class LMCacheSDKContext:
         return self._transfer_ctx
 
     def close(self) -> None:
-        """Close the MQ client and ZMQ context."""
-        self._mq_client.close()
+        """Close the request client and ZMQ context."""
+        self._req_client.close()
 
     def maybe_submit_lookup_request(
         self,
@@ -303,7 +304,7 @@ class LMCacheSDKContext:
             request_configs=request_configs,
         ).no_worker_id_version()
 
-        future = self._mq_client.lookup(key, self._world_size)
+        future = self._req_client.lookup(key, self._world_size)
         try:
             future.result(timeout=self._mq_timeout)
         except TimeoutError:
@@ -337,7 +338,7 @@ class LMCacheSDKContext:
             return self._finished_lookups[request_id]
 
         try:
-            result = self._mq_client.query_prefetch_status(request_id).result(
+            result = self._req_client.query_prefetch_status(request_id).result(
                 timeout=self._mq_timeout
             )
         except TimeoutError:
@@ -364,7 +365,7 @@ class LMCacheSDKContext:
         self._pending_lookups.discard(request_id)
         self._finished_lookups.pop(request_id, None)
         try:
-            self._mq_client.end_session(request_id).result(timeout=self._mq_timeout)
+            self._req_client.end_session(request_id).result(timeout=self._mq_timeout)
         except TimeoutError:
             logger.warning(
                 "END_SESSION timed out after %ss for request_id=%s.",

--- a/lmcache/sdk/qringbuffer.py
+++ b/lmcache/sdk/qringbuffer.py
@@ -630,7 +630,7 @@ class QRingBufferAdapter:
                 self.q_model_name,
                 self._adapter.world_size,
                 self._adapter.blocks_in_chunk,
-                self._adapter.mq_client,
+                self._adapter.req_client,
                 self._adapter._mq_timeout,
                 layout_hints=vllm_layout_hints(),
                 engine_group_infos=self.q_engine_group_infos,
@@ -749,7 +749,7 @@ class QRingBufferAdapter:
         if not self.q_ring:
             return
         try:
-            self._adapter.mq_client.unregister_q_cache(
+            self._adapter.req_client.unregister_q_cache(
                 self._adapter.instance_id
             ).result(timeout=self._adapter._mq_timeout)
         except TimeoutError:

--- a/lmcache/sdk/qringbuffer.py
+++ b/lmcache/sdk/qringbuffer.py
@@ -17,7 +17,6 @@ from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.v1.gpu_connector.utils import get_device
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-from lmcache.v1.multiprocess.protocol import RequestType
 
 if TYPE_CHECKING:
     # Third Party
@@ -548,11 +547,9 @@ class QRingBufferAdapter:
         self,
         adapter: "LMCacheMPWorkerAdapter",
         q_model_name: str,
-        send_lmcache_request: Any,
     ) -> None:
         self._adapter = adapter
         self.q_model_name = q_model_name
-        self.send_lmcache_request = send_lmcache_request
 
         self.q_ring: QRingBuffer | None = None
         self.q_engine_group_infos: Sequence[EngineGroupInfo] | None = None
@@ -635,7 +632,6 @@ class QRingBufferAdapter:
                 self._adapter.blocks_in_chunk,
                 self._adapter.mq_client,
                 self._adapter._mq_timeout,
-                send_request=self.send_lmcache_request,
                 layout_hints=vllm_layout_hints(),
                 engine_group_infos=self.q_engine_group_infos,
             )
@@ -753,10 +749,8 @@ class QRingBufferAdapter:
         if not self.q_ring:
             return
         try:
-            self.send_lmcache_request(
-                self._adapter.mq_client,
-                RequestType.UNREGISTER_Q_CACHE,
-                [self._adapter.instance_id],
+            self._adapter.mq_client.unregister_q_cache(
+                self._adapter.instance_id
             ).result(timeout=self._adapter._mq_timeout)
         except TimeoutError:
             logger.warning(

--- a/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
@@ -37,8 +37,9 @@ from lmcache.v1.distributed.l2_adapters.factory import register_l2_adapter_facto
 from lmcache.v1.distributed.transfer_channel import get_transfer_channel_context
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
 from lmcache.v1.memory_management import MemoryObj
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.platform import HAS_EVENTFD, create_event_notifier
 
 logger = init_logger(__name__)
@@ -132,7 +133,7 @@ class P2PL2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=0)
         self._config = config
 
-        self._mq_client = ZmqMultiprocessClient(
+        self._req_client: RequestClient = ZmqMultiprocessClient(
             MessageQueueClient(config.peer_mq_server_url, zmq.Context.instance())
         )
         self._tc_context = get_transfer_channel_context()
@@ -224,7 +225,7 @@ class P2PL2Adapter(L2AdapterInterface):
             )
             return task_id
 
-        future = self._mq_client.p2p_lookup_and_lock(keys, group_layout_descs)
+        future = self._req_client.p2p_lookup_and_lock(keys, group_layout_descs)
         failed = False
         remote_task_id = -1
         try:
@@ -256,7 +257,7 @@ class P2PL2Adapter(L2AdapterInterface):
             logger.warning("P2P lookup task %d timed out; treating as a miss", task_id)
             return Bitmap(len(task.keys))
 
-        future = self._mq_client.p2p_query_lookup_results(task.remote_task_id)
+        future = self._req_client.p2p_query_lookup_results(task.remote_task_id)
         try:
             addresses = future.result(timeout=_LOOKUP_RPC_TIMEOUT_S)
         except TimeoutError:
@@ -276,7 +277,7 @@ class P2PL2Adapter(L2AdapterInterface):
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
         if not keys:
             return
-        self._mq_client.p2p_unlock_objects(keys)
+        self._req_client.p2p_unlock_objects(keys)
         for key in keys:
             self._remote_addresses.pop(key, None)
 
@@ -361,7 +362,7 @@ class P2PL2Adapter(L2AdapterInterface):
         self._tc_context.remove_transfer_channel_client(
             self._config.peer_transfer_channel_server_url
         )
-        self._mq_client.close()
+        self._req_client.close()
         self._store_efd.close()
         self._lookup_efd.close()
         self._load_efd.close()

--- a/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
@@ -37,8 +37,8 @@ from lmcache.v1.distributed.l2_adapters.factory import register_l2_adapter_facto
 from lmcache.v1.distributed.transfer_channel import get_transfer_channel_context
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.platform import HAS_EVENTFD, create_event_notifier
 
 logger = init_logger(__name__)
@@ -132,8 +132,8 @@ class P2PL2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=0)
         self._config = config
 
-        self._mq_client = MessageQueueClient(
-            config.peer_mq_server_url, zmq.Context.instance()
+        self._mq_client = ZmqMultiprocessClient(
+            MessageQueueClient(config.peer_mq_server_url, zmq.Context.instance())
         )
         self._tc_context = get_transfer_channel_context()
         self._tc_client = self._tc_context.get_transfer_channel_client(
@@ -224,11 +224,7 @@ class P2PL2Adapter(L2AdapterInterface):
             )
             return task_id
 
-        future = self._mq_client.submit_request(
-            RequestType.P2P_LOOKUP_AND_LOCK,
-            [keys, group_layout_descs],
-            get_response_class(RequestType.P2P_LOOKUP_AND_LOCK),
-        )
+        future = self._mq_client.p2p_lookup_and_lock(keys, group_layout_descs)
         failed = False
         remote_task_id = -1
         try:
@@ -260,11 +256,7 @@ class P2PL2Adapter(L2AdapterInterface):
             logger.warning("P2P lookup task %d timed out; treating as a miss", task_id)
             return Bitmap(len(task.keys))
 
-        future = self._mq_client.submit_request(
-            RequestType.P2P_QUERY_LOOKUP_RESULTS,
-            [task.remote_task_id],
-            get_response_class(RequestType.P2P_QUERY_LOOKUP_RESULTS),
-        )
+        future = self._mq_client.p2p_query_lookup_results(task.remote_task_id)
         try:
             addresses = future.result(timeout=_LOOKUP_RPC_TIMEOUT_S)
         except TimeoutError:
@@ -284,11 +276,7 @@ class P2PL2Adapter(L2AdapterInterface):
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
         if not keys:
             return
-        self._mq_client.submit_request(
-            RequestType.P2P_UNLOCK_OBJECTS,
-            [keys],
-            get_response_class(RequestType.P2P_UNLOCK_OBJECTS),
-        )
+        self._mq_client.p2p_unlock_objects(keys)
         for key in keys:
             self._remote_addresses.pop(key, None)
 

--- a/lmcache/v1/multiprocess/client.py
+++ b/lmcache/v1/multiprocess/client.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Method-oriented clients for the multiprocess server."""
+
+# Standard
+from typing import Any, Protocol
+
+# First Party
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import (
+    RequestType,
+    get_response_class,
+)
+
+
+class RequestClient(Protocol):
+    """Method-oriented multiprocess client contract shared by transports."""
+
+    def register_kv_cache(
+        self,
+        instance_id: int,
+        kv_cache: Any,
+        model_name: str,
+        world_size: int,
+        engine_type: Any,
+        layout_hints: Any,
+        engine_group_infos: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def unregister_kv_cache(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def register_q_cache(
+        self,
+        instance_id: int,
+        q_cache: Any,
+        model_name: str,
+        world_size: int,
+        engine_type: Any,
+        layout_hints: Any,
+        engine_group_infos: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def unregister_q_cache(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def store_q(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def store(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def retrieve(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int,
+    ) -> MessagingFuture[Any]: ...
+
+    def lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
+
+    def query_prefetch_status(self, request_id: str) -> MessagingFuture[Any]: ...
+
+    def wait_prefetch_status(
+        self, request_id: str, timeout: float
+    ) -> MessagingFuture[Any]: ...
+
+    def query_prefetch_lookup_hits(self, request_id: str) -> MessagingFuture[Any]: ...
+
+    def free_lookup_locks(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
+
+    def end_session(self, request_id: str) -> MessagingFuture[Any]: ...
+
+    def register_kv_cache_engine_driven_context(
+        self, payload: Any
+    ) -> MessagingFuture[Any]: ...
+
+    def unregister_kv_cache_engine_driven_context(
+        self, instance_id: int
+    ) -> MessagingFuture[Any]: ...
+
+    def prepare_store(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def commit_store(
+        self, key: Any, instance_id: int, data: bytes
+    ) -> MessagingFuture[Any]: ...
+
+    def prepare_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def commit_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def clear(self) -> MessagingFuture[Any]: ...
+
+    def get_chunk_size(self) -> MessagingFuture[Any]: ...
+
+    def ping(self, instance_id: int | None) -> MessagingFuture[Any]: ...
+
+    def report_block_allocation(
+        self,
+        instance_id: int,
+        model_name: str,
+        records: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def noop(self) -> MessagingFuture[Any]: ...
+
+    def cb_register_rope(
+        self,
+        instance_id: int,
+        cos_sin_caches_ipc: list[Any],
+        head_size: int,
+        is_neox_style: bool,
+        group_to_cache: list[int],
+        group_rot: list[list[int]],
+    ) -> MessagingFuture[Any]: ...
+
+    def cb_unregister_rope(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def cb_retrieve_pre_computed(
+        self,
+        key: Any,
+        match_results: list[Any],
+        block_ids: list[list[int]],
+        instance_id: int,
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def cb_unified_lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
+
+    def p2p_lookup_and_lock(
+        self, keys: list[Any], group_layout_descs: dict[int, Any]
+    ) -> MessagingFuture[Any]: ...
+
+    def p2p_query_lookup_results(self, task_id: int) -> MessagingFuture[Any]: ...
+
+    def p2p_unlock_objects(self, keys: list[Any]) -> MessagingFuture[Any]: ...
+
+    def get_experimental(self) -> MessagingFuture[Any]: ...
+
+    def close(self) -> None:
+        """Close the client and release its transport resources."""
+
+
+class ZmqMultiprocessClient:
+    """Expose named multiprocess RPC methods over the existing ZMQ client.
+
+    The wrapper changes only the Python call surface. Every method delegates to
+    :class:`MessageQueueClient` with the existing ``RequestType`` and positional
+    payload list, so the ZMQ wire protocol and server remain unchanged.
+
+    Args:
+        message_queue_client: Existing ZMQ message queue client to wrap.
+    """
+
+    def __init__(self, message_queue_client: MessageQueueClient) -> None:
+        self._message_queue_client = message_queue_client
+
+    def register_kv_cache(
+        self,
+        instance_id: int,
+        kv_cache: Any,
+        model_name: str,
+        world_size: int,
+        engine_type: Any,
+        layout_hints: Any,
+        engine_group_infos: list[Any],
+    ) -> MessagingFuture[Any]:
+        """Register a worker KV cache with the multiprocess server."""
+        return self._call(
+            RequestType.REGISTER_KV_CACHE,
+            instance_id,
+            kv_cache,
+            model_name,
+            world_size,
+            engine_type,
+            layout_hints,
+            engine_group_infos,
+        )
+
+    def unregister_kv_cache(self, instance_id: int) -> MessagingFuture[Any]:
+        """Unregister a worker KV cache."""
+        return self._call(RequestType.UNREGISTER_KV_CACHE, instance_id)
+
+    def register_q_cache(
+        self,
+        instance_id: int,
+        q_cache: Any,
+        model_name: str,
+        world_size: int,
+        engine_type: Any,
+        layout_hints: Any,
+        engine_group_infos: list[Any],
+    ) -> MessagingFuture[Any]:
+        """Register a worker Q cache with the multiprocess server."""
+        return self._call(
+            RequestType.REGISTER_Q_CACHE,
+            instance_id,
+            q_cache,
+            model_name,
+            world_size,
+            engine_type,
+            layout_hints,
+            engine_group_infos,
+        )
+
+    def unregister_q_cache(self, instance_id: int) -> MessagingFuture[Any]:
+        """Unregister a worker Q cache."""
+        return self._call(RequestType.UNREGISTER_Q_CACHE, instance_id)
+
+    def store_q(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]:
+        """Store Q-cache blocks."""
+        return self._call(
+            RequestType.STORE_Q, key, instance_id, block_ids, event_ipc_handle
+        )
+
+    def store(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]:
+        """Store KV-cache blocks."""
+        return self._call(
+            RequestType.STORE, key, instance_id, block_ids, event_ipc_handle
+        )
+
+    def retrieve(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int,
+    ) -> MessagingFuture[Any]:
+        """Retrieve KV-cache blocks."""
+        return self._call(
+            RequestType.RETRIEVE,
+            key,
+            instance_id,
+            block_ids,
+            event_ipc_handle,
+            skip_first_n_tokens,
+        )
+
+    def lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]:
+        """Start a prefix lookup."""
+        return self._call(RequestType.LOOKUP, key, tp_size)
+
+    def query_prefetch_status(self, request_id: str) -> MessagingFuture[Any]:
+        """Query a prefetch task without blocking for completion."""
+        return self._call(RequestType.QUERY_PREFETCH_STATUS, request_id)
+
+    def wait_prefetch_status(
+        self, request_id: str, timeout: float
+    ) -> MessagingFuture[Any]:
+        """Wait for a prefetch task to complete."""
+        return self._call(RequestType.WAIT_PREFETCH_STATUS, request_id, timeout)
+
+    def query_prefetch_lookup_hits(self, request_id: str) -> MessagingFuture[Any]:
+        """Query lookup hits while prefetch is in progress."""
+        return self._call(RequestType.QUERY_PREFETCH_LOOKUP_HITS, request_id)
+
+    def free_lookup_locks(self, key: Any, tp_size: int) -> MessagingFuture[Any]:
+        """Release read locks acquired by lookup."""
+        return self._call(RequestType.FREE_LOOKUP_LOCKS, key, tp_size)
+
+    def end_session(self, request_id: str) -> MessagingFuture[Any]:
+        """End a request session."""
+        return self._call(RequestType.END_SESSION, request_id)
+
+    def register_kv_cache_engine_driven_context(
+        self, payload: Any
+    ) -> MessagingFuture[Any]:
+        """Register an engine-driven transfer context."""
+        return self._call(RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT, payload)
+
+    def unregister_kv_cache_engine_driven_context(
+        self, instance_id: int
+    ) -> MessagingFuture[Any]:
+        """Unregister an engine-driven transfer context."""
+        return self._call(
+            RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT, instance_id
+        )
+
+    def prepare_store(self, key: Any, instance_id: int) -> MessagingFuture[Any]:
+        """Prepare an engine-driven store."""
+        return self._call(RequestType.PREPARE_STORE, key, instance_id)
+
+    def commit_store(
+        self, key: Any, instance_id: int, data: bytes
+    ) -> MessagingFuture[Any]:
+        """Commit an engine-driven store."""
+        return self._call(RequestType.COMMIT_STORE, key, instance_id, data)
+
+    def prepare_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]:
+        """Prepare an engine-driven retrieve."""
+        return self._call(RequestType.PREPARE_RETRIEVE, key, instance_id)
+
+    def commit_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]:
+        """Commit an engine-driven retrieve."""
+        return self._call(RequestType.COMMIT_RETRIEVE, key, instance_id)
+
+    def clear(self) -> MessagingFuture[Any]:
+        """Clear all server caches."""
+        return self._call(RequestType.CLEAR)
+
+    def get_chunk_size(self) -> MessagingFuture[Any]:
+        """Return the server chunk size."""
+        return self._call(RequestType.GET_CHUNK_SIZE)
+
+    def ping(self, instance_id: int | None) -> MessagingFuture[Any]:
+        """Check server health and refresh worker liveness."""
+        return self._call(RequestType.PING, instance_id)
+
+    def report_block_allocation(
+        self,
+        instance_id: int,
+        model_name: str,
+        records: list[Any],
+    ) -> MessagingFuture[Any]:
+        """Report block-allocation changes."""
+        return self._call(
+            RequestType.REPORT_BLOCK_ALLOCATION,
+            instance_id,
+            model_name,
+            records,
+        )
+
+    def noop(self) -> MessagingFuture[Any]:
+        """Send a no-op request."""
+        return self._call(RequestType.NOOP)
+
+    def cb_register_rope(
+        self,
+        instance_id: int,
+        cos_sin_caches_ipc: list[Any],
+        head_size: int,
+        is_neox_style: bool,
+        group_to_cache: list[int],
+        group_rot: list[list[int]],
+    ) -> MessagingFuture[Any]:
+        """Register CacheBlend RoPE state."""
+        return self._call(
+            RequestType.CB_REGISTER_ROPE,
+            instance_id,
+            cos_sin_caches_ipc,
+            head_size,
+            is_neox_style,
+            group_to_cache,
+            group_rot,
+        )
+
+    def cb_unregister_rope(self, instance_id: int) -> MessagingFuture[Any]:
+        """Unregister CacheBlend RoPE state."""
+        return self._call(RequestType.CB_UNREGISTER_ROPE, instance_id)
+
+    def cb_retrieve_pre_computed(
+        self,
+        key: Any,
+        match_results: list[Any],
+        block_ids: list[list[int]],
+        instance_id: int,
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]:
+        """Retrieve CacheBlend pre-computed blocks."""
+        return self._call(
+            RequestType.CB_RETRIEVE_PRE_COMPUTED,
+            key,
+            match_results,
+            block_ids,
+            instance_id,
+            event_ipc_handle,
+        )
+
+    def cb_unified_lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]:
+        """Run a CacheBlend unified lookup."""
+        return self._call(RequestType.CB_UNIFIED_LOOKUP, key, tp_size)
+
+    def p2p_lookup_and_lock(
+        self,
+        keys: list[Any],
+        group_layout_descs: dict[int, Any],
+    ) -> MessagingFuture[Any]:
+        """Look up and lock peer-transfer objects."""
+        return self._call(RequestType.P2P_LOOKUP_AND_LOCK, keys, group_layout_descs)
+
+    def p2p_query_lookup_results(self, task_id: int) -> MessagingFuture[Any]:
+        """Query peer-transfer lookup results."""
+        return self._call(RequestType.P2P_QUERY_LOOKUP_RESULTS, task_id)
+
+    def p2p_unlock_objects(self, keys: list[Any]) -> MessagingFuture[Any]:
+        """Release peer-transfer object locks."""
+        return self._call(RequestType.P2P_UNLOCK_OBJECTS, keys)
+
+    def get_experimental(self) -> MessagingFuture[Any]:
+        """Return the server's experimental capabilities."""
+        return self._call(RequestType.GET_EXPERIMENTAL)
+
+    # Compatibility aliases used by older CacheBlend plugins.
+    cb_register_rope_v3 = cb_register_rope
+    cb_unregister_rope_v3 = cb_unregister_rope
+    cb_retrieve_pre_computed_v3 = cb_retrieve_pre_computed
+
+    def close(self) -> None:
+        """Close the wrapped ZMQ client."""
+        self._message_queue_client.close()
+
+    def _call(
+        self, request_type: RequestType, *request_payloads: Any
+    ) -> MessagingFuture[Any]:
+        return self._message_queue_client.submit_request(
+            request_type,
+            list(request_payloads),
+            get_response_class(request_type),
+        )

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -31,8 +31,8 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints
-from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.transport.base import RequestClient
 import lmcache.lmcache_native as lmcache_native
 
 if TYPE_CHECKING:
@@ -124,24 +124,24 @@ class EngineDrivenContextMetadata:
 class EngineDrivenContext(ABC):
     """Abstract base class for CPU-side KV data transfer contexts.
 
-    All concrete implementations share a common message-queue client and
+    All concrete implementations share a common request client and
     expose a uniform two-phase ``prepare/commit`` interface so that the
     worker adapter is implementation-agnostic.
 
     Args:
         metadata: Layout metadata describing the chunk format.
-        mq_client: Message-queue client used for server communication.
+        req_client: Transport-neutral client used for server requests.
         mq_timeout: Timeout in seconds for blocking MQ requests.
     """
 
     def __init__(
         self,
         metadata: EngineDrivenContextMetadata,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
     ) -> None:
         self.metadata = metadata
-        self.mq_client = mq_client
+        self.req_client = req_client
         self.mq_timeout = mq_timeout
 
     @property
@@ -198,7 +198,7 @@ class EngineDrivenContext(ABC):
 
 def create_engine_driven_context(
     metadata: EngineDrivenContextMetadata,
-    mq_client: RequestClient,
+    req_client: RequestClient,
     mq_timeout: float,
     shm_name: str,
     pool_size: int,
@@ -214,7 +214,7 @@ def create_engine_driven_context(
 
     Args:
         metadata: Layout metadata for the non-GPU context.
-        mq_client: Message-queue client for server communication.
+        req_client: Transport-neutral client used for server requests.
         mq_timeout: Timeout in seconds for blocking MQ requests.
         shm_name: Shared-memory segment name. Empty values force pickle mode.
         pool_size: Shared-memory pool size in bytes. Non-positive values force
@@ -239,7 +239,7 @@ def create_engine_driven_context(
                 pool_size,
             )
             return EngineDrivenContextShm(
-                metadata, mq_client, mq_timeout, shm_name, pool_size
+                metadata, req_client, mq_timeout, shm_name, pool_size
             )
         except Exception:
             logger.warning(
@@ -253,7 +253,7 @@ def create_engine_driven_context(
     from .pickle import EngineDrivenContextPickle
 
     logger.info("Creating EngineDrivenContextPickle (pickle transport)")
-    return EngineDrivenContextPickle(metadata, mq_client, mq_timeout)
+    return EngineDrivenContextPickle(metadata, req_client, mq_timeout)
 
 
 # ---------------------------------------------------------------------------

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -31,8 +31,8 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 import lmcache.lmcache_native as lmcache_native
 
 if TYPE_CHECKING:
@@ -137,7 +137,7 @@ class EngineDrivenContext(ABC):
     def __init__(
         self,
         metadata: EngineDrivenContextMetadata,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
     ) -> None:
         self.metadata = metadata
@@ -198,7 +198,7 @@ class EngineDrivenContext(ABC):
 
 def create_engine_driven_context(
     metadata: EngineDrivenContextMetadata,
-    mq_client: MessageQueueClient,
+    mq_client: RequestClient,
     mq_timeout: float,
     shm_name: str,
     pool_size: int,

--- a/lmcache/v1/multiprocess/transfer_context/pickle.py
+++ b/lmcache/v1/multiprocess/transfer_context/pickle.py
@@ -8,12 +8,12 @@ import pickle
 import torch
 
 # First Party
-from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
     EngineDrivenContextMetadata,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
 
 
 class EngineDrivenContextPickle(EngineDrivenContext):
@@ -31,16 +31,16 @@ class EngineDrivenContextPickle(EngineDrivenContext):
     def __init__(
         self,
         metadata: EngineDrivenContextMetadata,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
     ) -> None:
-        super().__init__(metadata, mq_client, mq_timeout)
+        super().__init__(metadata, req_client, mq_timeout)
 
     def prepare_store(
         self, key: IPCCacheServerKey, instance_id: int
     ) -> tuple[list[torch.Tensor], list[int]] | None:
         """Send PREPARE_STORE RPC. For pickle, returns no pre-allocated buffers."""
-        future = self.mq_client.prepare_store(key, instance_id)
+        future = self.req_client.prepare_store(key, instance_id)
         try:
             future.result(timeout=self.mq_timeout)
         except TimeoutError:
@@ -56,7 +56,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
             ``True`` on success, ``False`` on failure or timeout.
         """
         serialised = pickle.dumps(chunks)
-        future = self.mq_client.commit_store(key, instance_id, serialised)
+        future = self.req_client.commit_store(key, instance_id, serialised)
         try:
             return bool(future.result(timeout=self.mq_timeout))
         except TimeoutError:
@@ -70,7 +70,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
         Returns:
             Chunks on hit, or None on miss/timeout.
         """
-        future = self.mq_client.prepare_retrieve(key, instance_id)
+        future = self.req_client.prepare_retrieve(key, instance_id)
         try:
             response = future.result(timeout=self.mq_timeout)
         except TimeoutError:
@@ -82,7 +82,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
 
     def commit_retrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
         """Send COMMIT_RETRIEVE (no-op for pickle path)."""
-        future = self.mq_client.commit_retrieve(key, instance_id)
+        future = self.req_client.commit_retrieve(key, instance_id)
         try:
             future.result(timeout=self.mq_timeout)
         except TimeoutError:

--- a/lmcache/v1/multiprocess/transfer_context/pickle.py
+++ b/lmcache/v1/multiprocess/transfer_context/pickle.py
@@ -8,9 +8,8 @@ import pickle
 import torch
 
 # First Party
+from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
     EngineDrivenContextMetadata,
@@ -32,7 +31,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
     def __init__(
         self,
         metadata: EngineDrivenContextMetadata,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
     ) -> None:
         super().__init__(metadata, mq_client, mq_timeout)
@@ -41,11 +40,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
         self, key: IPCCacheServerKey, instance_id: int
     ) -> tuple[list[torch.Tensor], list[int]] | None:
         """Send PREPARE_STORE RPC. For pickle, returns no pre-allocated buffers."""
-        future = self.mq_client.submit_request(
-            RequestType.PREPARE_STORE,
-            [key, instance_id],
-            get_response_class(RequestType.PREPARE_STORE),
-        )
+        future = self.mq_client.prepare_store(key, instance_id)
         try:
             future.result(timeout=self.mq_timeout)
         except TimeoutError:
@@ -61,11 +56,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
             ``True`` on success, ``False`` on failure or timeout.
         """
         serialised = pickle.dumps(chunks)
-        future = self.mq_client.submit_request(
-            RequestType.COMMIT_STORE,
-            [key, instance_id, serialised],
-            get_response_class(RequestType.COMMIT_STORE),
-        )
+        future = self.mq_client.commit_store(key, instance_id, serialised)
         try:
             return bool(future.result(timeout=self.mq_timeout))
         except TimeoutError:
@@ -79,11 +70,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
         Returns:
             Chunks on hit, or None on miss/timeout.
         """
-        future = self.mq_client.submit_request(
-            RequestType.PREPARE_RETRIEVE,
-            [key, instance_id],
-            get_response_class(RequestType.PREPARE_RETRIEVE),
-        )
+        future = self.mq_client.prepare_retrieve(key, instance_id)
         try:
             response = future.result(timeout=self.mq_timeout)
         except TimeoutError:
@@ -95,11 +82,7 @@ class EngineDrivenContextPickle(EngineDrivenContext):
 
     def commit_retrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
         """Send COMMIT_RETRIEVE (no-op for pickle path)."""
-        future = self.mq_client.submit_request(
-            RequestType.COMMIT_RETRIEVE,
-            [key, instance_id],
-            get_response_class(RequestType.COMMIT_RETRIEVE),
-        )
+        future = self.mq_client.commit_retrieve(key, instance_id)
         try:
             future.result(timeout=self.mq_timeout)
         except TimeoutError:

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -15,9 +15,8 @@ import torch
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
+from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
     EngineDrivenContextMetadata,
@@ -86,7 +85,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def __init__(
         self,
         metadata: EngineDrivenContextMetadata,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
         shm_name: str,
         pool_size: int,
@@ -160,11 +159,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def prepare_store(
         self, key: IPCCacheServerKey, instance_id: int
     ) -> tuple[list[torch.Tensor], list[int]] | None:
-        future = self.mq_client.submit_request(
-            RequestType.PREPARE_STORE,
-            [key, instance_id],
-            get_response_class(RequestType.PREPARE_STORE),
-        )
+        future = self.mq_client.prepare_store(key, instance_id)
         # wait() first so a timeout raises exactly one LMCacheTimeoutError
         # (one event); result() then returns without its own timeout.
         if not future.wait(timeout=self.mq_timeout):
@@ -187,11 +182,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def commit_store(
         self, key: IPCCacheServerKey, instance_id: int, _chunks: list[torch.Tensor]
     ) -> bool:
-        future = self.mq_client.submit_request(
-            RequestType.COMMIT_STORE,
-            [key, instance_id, b""],
-            get_response_class(RequestType.COMMIT_STORE),
-        )
+        future = self.mq_client.commit_store(key, instance_id, b"")
         try:
             return bool(future.result(timeout=self.mq_timeout))
         except TimeoutError:
@@ -200,11 +191,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def prepare_retrieve(
         self, key: IPCCacheServerKey, instance_id: int
     ) -> list[torch.Tensor] | None:
-        future = self.mq_client.submit_request(
-            RequestType.PREPARE_RETRIEVE,
-            [key, instance_id],
-            get_response_class(RequestType.PREPARE_RETRIEVE),
-        )
+        future = self.mq_client.prepare_retrieve(key, instance_id)
         try:
             response = future.result(timeout=self.mq_timeout)
         except TimeoutError:
@@ -215,11 +202,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
         return self._build_slot_tensors(slots) if slots else None
 
     def commit_retrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
-        future = self.mq_client.submit_request(
-            RequestType.COMMIT_RETRIEVE,
-            [key, instance_id],
-            get_response_class(RequestType.COMMIT_RETRIEVE),
-        )
+        future = self.mq_client.commit_retrieve(key, instance_id)
         try:
             return bool(future.result(timeout=self.mq_timeout))
         except TimeoutError:

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -15,12 +15,12 @@ import torch
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
-from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
     EngineDrivenContextMetadata,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.platform import current_device_spec
 
 logger = init_logger(__name__)
@@ -85,12 +85,12 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def __init__(
         self,
         metadata: EngineDrivenContextMetadata,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
         shm_name: str,
         pool_size: int,
     ) -> None:
-        super().__init__(metadata, mq_client, mq_timeout)
+        super().__init__(metadata, req_client, mq_timeout)
         if not shm_name or pool_size <= 0:
             raise ValueError("shm_name must be non-empty and pool_size must be > 0")
 
@@ -159,7 +159,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def prepare_store(
         self, key: IPCCacheServerKey, instance_id: int
     ) -> tuple[list[torch.Tensor], list[int]] | None:
-        future = self.mq_client.prepare_store(key, instance_id)
+        future = self.req_client.prepare_store(key, instance_id)
         # wait() first so a timeout raises exactly one LMCacheTimeoutError
         # (one event); result() then returns without its own timeout.
         if not future.wait(timeout=self.mq_timeout):
@@ -182,7 +182,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def commit_store(
         self, key: IPCCacheServerKey, instance_id: int, _chunks: list[torch.Tensor]
     ) -> bool:
-        future = self.mq_client.commit_store(key, instance_id, b"")
+        future = self.req_client.commit_store(key, instance_id, b"")
         try:
             return bool(future.result(timeout=self.mq_timeout))
         except TimeoutError:
@@ -191,7 +191,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def prepare_retrieve(
         self, key: IPCCacheServerKey, instance_id: int
     ) -> list[torch.Tensor] | None:
-        future = self.mq_client.prepare_retrieve(key, instance_id)
+        future = self.req_client.prepare_retrieve(key, instance_id)
         try:
             response = future.result(timeout=self.mq_timeout)
         except TimeoutError:
@@ -202,7 +202,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
         return self._build_slot_tensors(slots) if slots else None
 
     def commit_retrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
-        future = self.mq_client.commit_retrieve(key, instance_id)
+        future = self.req_client.commit_retrieve(key, instance_id)
         try:
             return bool(future.result(timeout=self.mq_timeout))
         except TimeoutError:

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -5,7 +5,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
-from typing import Any, Callable, Protocol, cast
+from typing import Any, Protocol, cast
 import os
 
 # Third Party
@@ -16,11 +16,10 @@ from lmcache import torch_dev
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints, get_device
+from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import RegisterEngineDrivenContextPayload
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import RegisterEngineDrivenContextResponse
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
@@ -171,9 +170,6 @@ class IPCEvent(Protocol):
         """Make ``stream`` wait for this event (async ordering primitive)."""
 
 
-SendRequest = Callable[[MessageQueueClient, RequestType, list[object]], MessagingFuture]
-
-
 def _single_group_block_ids(block_ids: list[list[int]]) -> list[int]:
     """Return the flat block-id list for transports without HMA support."""
     if len(block_ids) != 1:
@@ -217,9 +213,8 @@ class TransferContext(ABC):
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
-        send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
         engine_type: EngineType = EngineType.VLLM,
@@ -234,7 +229,6 @@ class TransferContext(ABC):
             blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
             mq_client: Message queue client used to communicate with server.
             mq_timeout: Timeout in seconds for synchronous request wait.
-            send_request: Request sender callable used to issue MQ requests.
             layout_hints: Optional inference-engine-provided layout hints.
             engine_group_infos: LMCache-owned engine KV cache group metadata.
             engine_type: Serving engine that produced the caches. Only
@@ -256,9 +250,8 @@ class TransferContext(ABC):
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
-        send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
@@ -273,7 +266,6 @@ class TransferContext(ABC):
             blocks_in_chunk: Number of Q ring blocks per LMCache chunk.
             mq_client: Message queue client used to communicate with server.
             mq_timeout: Timeout in seconds for synchronous request wait.
-            send_request: Request sender callable used to issue MQ requests.
             layout_hints: Optional inference-engine-provided layout hints.
             engine_group_infos: LMCache-owned engine KV cache group metadata.
 
@@ -423,8 +415,7 @@ class LMCacheDrivenTransferContext(TransferContext):
     """
 
     def __init__(self) -> None:
-        self._mq_client: MessageQueueClient | None = None
-        self._send_request: SendRequest | None = None
+        self._mq_client: RequestClient | None = None
         self._device: torch.device | None = None
         self._event_backend: EventIPCBackend | None = None
 
@@ -435,9 +426,8 @@ class LMCacheDrivenTransferContext(TransferContext):
         model_name: str,
         world_size: int,
         _blocks_in_chunk: int,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
-        send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
         engine_type: EngineType = EngineType.VLLM,
@@ -452,7 +442,6 @@ class LMCacheDrivenTransferContext(TransferContext):
             _blocks_in_chunk: Engine blocks per LMCache chunk.
             mq_client: Message-queue client used for requests.
             mq_timeout: Timeout for the registration response.
-            send_request: Request sender used by this context.
             layout_hints: Optional KV-layout metadata.
             engine_group_infos: Optional engine KV-group metadata.
             engine_type: Serving engine that produced the caches.
@@ -466,19 +455,14 @@ class LMCacheDrivenTransferContext(TransferContext):
         event_backend.check_event_support(device)
 
         self._mq_client = mq_client
-        self._send_request = send_request
-        future = send_request(
-            mq_client,
-            RequestType.REGISTER_KV_CACHE,
-            [
-                instance_id,
-                wrap_kv_caches(kv_caches),
-                model_name,
-                world_size,
-                engine_type,
-                layout_hints,
-                list(engine_group_infos),
-            ],
+        future = mq_client.register_kv_cache(
+            instance_id,
+            wrap_kv_caches(kv_caches),
+            model_name,
+            world_size,
+            engine_type,
+            layout_hints,
+            list(engine_group_infos),
         )
         future.result(timeout=mq_timeout)
         self._device = device
@@ -509,26 +493,20 @@ class LMCacheDrivenTransferContext(TransferContext):
         model_name: str,
         world_size: int,
         _blocks_in_chunk: int,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
-        send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
         self._mq_client = mq_client
-        self._send_request = send_request
-        future = send_request(
-            mq_client,
-            RequestType.REGISTER_Q_CACHE,
-            [
-                instance_id,
-                wrap_kv_caches(q_caches),
-                model_name,
-                world_size,
-                EngineType.VLLM,
-                layout_hints,
-                list(engine_group_infos),
-            ],
+        future = mq_client.register_q_cache(
+            instance_id,
+            wrap_kv_caches(q_caches),
+            model_name,
+            world_size,
+            EngineType.VLLM,
+            layout_hints,
+            list(engine_group_infos),
         )
         future.result(timeout=mq_timeout)
 
@@ -563,7 +541,6 @@ class LMCacheDrivenTransferContext(TransferContext):
         """
         if (
             self._mq_client is None
-            or self._send_request is None
             or self._device is None
             or self._event_backend is None
         ):
@@ -574,10 +551,8 @@ class LMCacheDrivenTransferContext(TransferContext):
         if event is None:
             raise RuntimeError("LMCache-driven transfer requires an IPC event.")
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._send_request(
-            self._mq_client,
-            RequestType.STORE,
-            [key, instance_id, block_ids, event_ipc_handle],
+        return self._mq_client.store(
+            key, instance_id, block_ids, event_ipc_handle
         ).to_device_future(device=self._device)
 
     def submit_q_store(
@@ -592,7 +567,6 @@ class LMCacheDrivenTransferContext(TransferContext):
     ) -> MessagingFuture:
         if (
             self._mq_client is None
-            or self._send_request is None
             or self._device is None
             or self._event_backend is None
         ):
@@ -601,10 +575,8 @@ class LMCacheDrivenTransferContext(TransferContext):
                 "Call register() before submit_q_store()."
             )
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._send_request(
-            self._mq_client,
-            RequestType.STORE_Q,
-            [key, instance_id, block_ids, event_ipc_handle],
+        return self._mq_client.store_q(
+            key, instance_id, block_ids, event_ipc_handle
         ).to_device_future(device=self._device)
 
     def submit_retrieve(
@@ -640,7 +612,6 @@ class LMCacheDrivenTransferContext(TransferContext):
         """
         if (
             self._mq_client is None
-            or self._send_request is None
             or self._device is None
             or self._event_backend is None
         ):
@@ -651,16 +622,17 @@ class LMCacheDrivenTransferContext(TransferContext):
         if event is None:
             raise RuntimeError("LMCache-driven transfer requires an IPC event.")
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._send_request(
-            self._mq_client,
-            RequestType.RETRIEVE,
-            [key, instance_id, block_ids, event_ipc_handle, skip_first_n_tokens],
+        return self._mq_client.retrieve(
+            key,
+            instance_id,
+            block_ids,
+            event_ipc_handle,
+            skip_first_n_tokens,
         ).to_device_future(device=self._device)
 
     def close(self) -> None:
         """Release the message queue and cached event-backend state."""
         self._mq_client = None
-        self._send_request = None
         self._device = None
         self._event_backend = None
 
@@ -701,9 +673,8 @@ class EngineDrivenTransferContext(TransferContext):
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        mq_client: MessageQueueClient,
+        mq_client: RequestClient,
         mq_timeout: float,
-        send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
         engine_type: EngineType = EngineType.VLLM,
@@ -744,22 +715,18 @@ class EngineDrivenTransferContext(TransferContext):
         dtype = getattr(torch, dtype_str)
         layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
 
-        future = send_request(
-            mq_client,
-            RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
-            [
-                RegisterEngineDrivenContextPayload(
-                    instance_id=instance_id,
-                    model_name=model_name,
-                    world_size=world_size,
-                    block_size=block_size,
-                    num_layers=num_layers,
-                    hidden_dim_size=hidden_dim_size,
-                    dtype_str=dtype_str,
-                    use_mla=use_mla_flag,
-                    num_physical_slots=blocks_in_chunk * block_size,
-                )
-            ],
+        future = mq_client.register_kv_cache_engine_driven_context(
+            RegisterEngineDrivenContextPayload(
+                instance_id=instance_id,
+                model_name=model_name,
+                world_size=world_size,
+                block_size=block_size,
+                num_layers=num_layers,
+                hidden_dim_size=hidden_dim_size,
+                dtype_str=dtype_str,
+                use_mla=use_mla_flag,
+                num_physical_slots=blocks_in_chunk * block_size,
+            )
         )
         response = future.result(timeout=mq_timeout)
         shm_name = ""

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -16,7 +16,6 @@ from lmcache import torch_dev
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints, get_device
-from lmcache.v1.multiprocess.client import RequestClient
 from lmcache.v1.multiprocess.custom_types import RegisterEngineDrivenContextPayload
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
@@ -29,6 +28,7 @@ from lmcache.v1.multiprocess.transfer_context.base import (
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.platform import get_device_spec, resolve_kv_wrapper_factory
 from lmcache.v1.platform.base.event_ipc import (
     EventIPCBackend,
@@ -213,7 +213,7 @@ class TransferContext(ABC):
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -227,7 +227,7 @@ class TransferContext(ABC):
             model_name: Model name used by cache keys.
             world_size: KV world size.
             blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
-            mq_client: Message queue client used to communicate with server.
+            req_client: Transport-neutral client used for server requests.
             mq_timeout: Timeout in seconds for synchronous request wait.
             layout_hints: Optional inference-engine-provided layout hints.
             engine_group_infos: LMCache-owned engine KV cache group metadata.
@@ -250,7 +250,7 @@ class TransferContext(ABC):
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -264,7 +264,7 @@ class TransferContext(ABC):
             model_name: Model name used by cache keys (model_name##query).
             world_size: KV world size.
             blocks_in_chunk: Number of Q ring blocks per LMCache chunk.
-            mq_client: Message queue client used to communicate with server.
+            req_client: Transport-neutral client used for server requests.
             mq_timeout: Timeout in seconds for synchronous request wait.
             layout_hints: Optional inference-engine-provided layout hints.
             engine_group_infos: LMCache-owned engine KV cache group metadata.
@@ -415,7 +415,7 @@ class LMCacheDrivenTransferContext(TransferContext):
     """
 
     def __init__(self) -> None:
-        self._mq_client: RequestClient | None = None
+        self._req_client: RequestClient | None = None
         self._device: torch.device | None = None
         self._event_backend: EventIPCBackend | None = None
 
@@ -426,7 +426,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         model_name: str,
         world_size: int,
         _blocks_in_chunk: int,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -440,7 +440,7 @@ class LMCacheDrivenTransferContext(TransferContext):
             model_name: Model identifier used by the server.
             world_size: Tensor-parallel world size.
             _blocks_in_chunk: Engine blocks per LMCache chunk.
-            mq_client: Message-queue client used for requests.
+            req_client: Transport-neutral client used for server requests.
             mq_timeout: Timeout for the registration response.
             layout_hints: Optional KV-layout metadata.
             engine_group_infos: Optional engine KV-group metadata.
@@ -454,8 +454,8 @@ class LMCacheDrivenTransferContext(TransferContext):
         event_backend = get_event_ipc_backend(device)
         event_backend.check_event_support(device)
 
-        self._mq_client = mq_client
-        future = mq_client.register_kv_cache(
+        self._req_client = req_client
+        future = req_client.register_kv_cache(
             instance_id,
             wrap_kv_caches(kv_caches),
             model_name,
@@ -493,13 +493,13 @@ class LMCacheDrivenTransferContext(TransferContext):
         model_name: str,
         world_size: int,
         _blocks_in_chunk: int,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
-        self._mq_client = mq_client
-        future = mq_client.register_q_cache(
+        self._req_client = req_client
+        future = req_client.register_q_cache(
             instance_id,
             wrap_kv_caches(q_caches),
             model_name,
@@ -540,7 +540,7 @@ class LMCacheDrivenTransferContext(TransferContext):
                 unsupported.
         """
         if (
-            self._mq_client is None
+            self._req_client is None
             or self._device is None
             or self._event_backend is None
         ):
@@ -551,7 +551,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         if event is None:
             raise RuntimeError("LMCache-driven transfer requires an IPC event.")
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._mq_client.store(
+        return self._req_client.store(
             key, instance_id, block_ids, event_ipc_handle
         ).to_device_future(device=self._device)
 
@@ -566,7 +566,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         _blocks_in_chunk: int,
     ) -> MessagingFuture:
         if (
-            self._mq_client is None
+            self._req_client is None
             or self._device is None
             or self._event_backend is None
         ):
@@ -575,7 +575,7 @@ class LMCacheDrivenTransferContext(TransferContext):
                 "Call register() before submit_q_store()."
             )
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._mq_client.store_q(
+        return self._req_client.store_q(
             key, instance_id, block_ids, event_ipc_handle
         ).to_device_future(device=self._device)
 
@@ -611,7 +611,7 @@ class LMCacheDrivenTransferContext(TransferContext):
                 unsupported.
         """
         if (
-            self._mq_client is None
+            self._req_client is None
             or self._device is None
             or self._event_backend is None
         ):
@@ -622,7 +622,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         if event is None:
             raise RuntimeError("LMCache-driven transfer requires an IPC event.")
         event_ipc_handle = self._event_backend.export_event(event, self._device)
-        return self._mq_client.retrieve(
+        return self._req_client.retrieve(
             key,
             instance_id,
             block_ids,
@@ -632,7 +632,7 @@ class LMCacheDrivenTransferContext(TransferContext):
 
     def close(self) -> None:
         """Release the message queue and cached event-backend state."""
-        self._mq_client = None
+        self._req_client = None
         self._device = None
         self._event_backend = None
 
@@ -673,7 +673,7 @@ class EngineDrivenTransferContext(TransferContext):
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        mq_client: RequestClient,
+        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -715,7 +715,7 @@ class EngineDrivenTransferContext(TransferContext):
         dtype = getattr(torch, dtype_str)
         layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
 
-        future = mq_client.register_kv_cache_engine_driven_context(
+        future = req_client.register_kv_cache_engine_driven_context(
             RegisterEngineDrivenContextPayload(
                 instance_id=instance_id,
                 model_name=model_name,
@@ -742,7 +742,7 @@ class EngineDrivenTransferContext(TransferContext):
         )
         self._engine_driven_context = create_engine_driven_context(
             metadata,
-            mq_client,
+            req_client,
             mq_timeout,
             shm_name=shm_name,
             pool_size=pool_size,

--- a/lmcache/v1/multiprocess/transport/__init__.py
+++ b/lmcache/v1/multiprocess/transport/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transport interfaces and implementations for multiprocess requests."""

--- a/lmcache/v1/multiprocess/transport/base.py
+++ b/lmcache/v1/multiprocess/transport/base.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transport-neutral multiprocess request client contract."""
+
+# Standard
+from typing import Any, Protocol
+
+# First Party
+from lmcache.v1.multiprocess.futures import MessagingFuture
+
+
+class RequestClient(Protocol):
+    """Define method-oriented multiprocess requests shared by transports."""
+
+    def register_kv_cache(
+        self,
+        instance_id: int,
+        kv_cache: Any,
+        model_name: str,
+        world_size: int,
+        engine_type: Any,
+        layout_hints: Any,
+        engine_group_infos: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def unregister_kv_cache(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def register_q_cache(
+        self,
+        instance_id: int,
+        q_cache: Any,
+        model_name: str,
+        world_size: int,
+        engine_type: Any,
+        layout_hints: Any,
+        engine_group_infos: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def unregister_q_cache(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def store_q(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def store(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def retrieve(
+        self,
+        key: Any,
+        instance_id: int,
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int,
+    ) -> MessagingFuture[Any]: ...
+
+    def lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
+
+    def query_prefetch_status(self, request_id: str) -> MessagingFuture[Any]: ...
+
+    def wait_prefetch_status(
+        self, request_id: str, timeout: float
+    ) -> MessagingFuture[Any]: ...
+
+    def query_prefetch_lookup_hits(self, request_id: str) -> MessagingFuture[Any]: ...
+
+    def free_lookup_locks(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
+
+    def end_session(self, request_id: str) -> MessagingFuture[Any]: ...
+
+    def register_kv_cache_engine_driven_context(
+        self, payload: Any
+    ) -> MessagingFuture[Any]: ...
+
+    def unregister_kv_cache_engine_driven_context(
+        self, instance_id: int
+    ) -> MessagingFuture[Any]: ...
+
+    def prepare_store(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def commit_store(
+        self, key: Any, instance_id: int, data: bytes
+    ) -> MessagingFuture[Any]: ...
+
+    def prepare_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def commit_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def clear(self) -> MessagingFuture[Any]: ...
+
+    def get_chunk_size(self) -> MessagingFuture[Any]: ...
+
+    def ping(self, instance_id: int | None) -> MessagingFuture[Any]: ...
+
+    def report_block_allocation(
+        self,
+        instance_id: int,
+        model_name: str,
+        records: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def noop(self) -> MessagingFuture[Any]: ...
+
+    def cb_register_rope(
+        self,
+        instance_id: int,
+        cos_sin_caches_ipc: list[Any],
+        head_size: int,
+        is_neox_style: bool,
+        group_to_cache: list[int],
+        group_rot: list[list[int]],
+    ) -> MessagingFuture[Any]: ...
+
+    def cb_unregister_rope(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def cb_retrieve_pre_computed(
+        self,
+        key: Any,
+        match_results: list[Any],
+        block_ids: list[list[int]],
+        instance_id: int,
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def cb_unified_lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
+
+    def p2p_lookup_and_lock(
+        self, keys: list[Any], group_layout_descs: dict[int, Any]
+    ) -> MessagingFuture[Any]: ...
+
+    def p2p_query_lookup_results(self, task_id: int) -> MessagingFuture[Any]: ...
+
+    def p2p_unlock_objects(self, keys: list[Any]) -> MessagingFuture[Any]: ...
+
+    def get_experimental(self) -> MessagingFuture[Any]: ...
+
+    def cb_register_rope_v3(
+        self,
+        instance_id: int,
+        cos_sin_caches_ipc: list[Any],
+        head_size: int,
+        is_neox_style: bool,
+        group_to_cache: list[int],
+        group_rot: list[list[int]],
+    ) -> MessagingFuture[Any]: ...
+
+    def cb_unregister_rope_v3(self, instance_id: int) -> MessagingFuture[Any]: ...
+
+    def cb_retrieve_pre_computed_v3(
+        self,
+        key: Any,
+        match_results: list[Any],
+        block_ids: list[list[int]],
+        instance_id: int,
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def close(self) -> None:
+        """Close the client and release its transport resources."""

--- a/lmcache/v1/multiprocess/transport/grpc_impl/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC transport implementation for multiprocess requests."""

--- a/lmcache/v1/multiprocess/transport/zmq_impl/__init__.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ZMQ transport implementation for multiprocess requests."""
+
+# First Party
+from lmcache.v1.multiprocess.transport.zmq_impl.client import (
+    ZmqMultiprocessClient,
+)
+
+__all__ = ["ZmqMultiprocessClient"]

--- a/lmcache/v1/multiprocess/transport/zmq_impl/client.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/client.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Method-oriented clients for the multiprocess server."""
+"""Method-oriented ZMQ client for the multiprocess server."""
 
 # Standard
-from typing import Any, Protocol
+from typing import Any
 
 # First Party
 from lmcache.v1.multiprocess.futures import MessagingFuture
@@ -11,144 +11,6 @@ from lmcache.v1.multiprocess.protocol import (
     RequestType,
     get_response_class,
 )
-
-
-class RequestClient(Protocol):
-    """Method-oriented multiprocess client contract shared by transports."""
-
-    def register_kv_cache(
-        self,
-        instance_id: int,
-        kv_cache: Any,
-        model_name: str,
-        world_size: int,
-        engine_type: Any,
-        layout_hints: Any,
-        engine_group_infos: list[Any],
-    ) -> MessagingFuture[Any]: ...
-
-    def unregister_kv_cache(self, instance_id: int) -> MessagingFuture[Any]: ...
-
-    def register_q_cache(
-        self,
-        instance_id: int,
-        q_cache: Any,
-        model_name: str,
-        world_size: int,
-        engine_type: Any,
-        layout_hints: Any,
-        engine_group_infos: list[Any],
-    ) -> MessagingFuture[Any]: ...
-
-    def unregister_q_cache(self, instance_id: int) -> MessagingFuture[Any]: ...
-
-    def store_q(
-        self,
-        key: Any,
-        instance_id: int,
-        block_ids: list[list[int]],
-        event_ipc_handle: bytes,
-    ) -> MessagingFuture[Any]: ...
-
-    def store(
-        self,
-        key: Any,
-        instance_id: int,
-        block_ids: list[list[int]],
-        event_ipc_handle: bytes,
-    ) -> MessagingFuture[Any]: ...
-
-    def retrieve(
-        self,
-        key: Any,
-        instance_id: int,
-        block_ids: list[list[int]],
-        event_ipc_handle: bytes,
-        skip_first_n_tokens: int,
-    ) -> MessagingFuture[Any]: ...
-
-    def lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
-
-    def query_prefetch_status(self, request_id: str) -> MessagingFuture[Any]: ...
-
-    def wait_prefetch_status(
-        self, request_id: str, timeout: float
-    ) -> MessagingFuture[Any]: ...
-
-    def query_prefetch_lookup_hits(self, request_id: str) -> MessagingFuture[Any]: ...
-
-    def free_lookup_locks(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
-
-    def end_session(self, request_id: str) -> MessagingFuture[Any]: ...
-
-    def register_kv_cache_engine_driven_context(
-        self, payload: Any
-    ) -> MessagingFuture[Any]: ...
-
-    def unregister_kv_cache_engine_driven_context(
-        self, instance_id: int
-    ) -> MessagingFuture[Any]: ...
-
-    def prepare_store(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
-
-    def commit_store(
-        self, key: Any, instance_id: int, data: bytes
-    ) -> MessagingFuture[Any]: ...
-
-    def prepare_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
-
-    def commit_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
-
-    def clear(self) -> MessagingFuture[Any]: ...
-
-    def get_chunk_size(self) -> MessagingFuture[Any]: ...
-
-    def ping(self, instance_id: int | None) -> MessagingFuture[Any]: ...
-
-    def report_block_allocation(
-        self,
-        instance_id: int,
-        model_name: str,
-        records: list[Any],
-    ) -> MessagingFuture[Any]: ...
-
-    def noop(self) -> MessagingFuture[Any]: ...
-
-    def cb_register_rope(
-        self,
-        instance_id: int,
-        cos_sin_caches_ipc: list[Any],
-        head_size: int,
-        is_neox_style: bool,
-        group_to_cache: list[int],
-        group_rot: list[list[int]],
-    ) -> MessagingFuture[Any]: ...
-
-    def cb_unregister_rope(self, instance_id: int) -> MessagingFuture[Any]: ...
-
-    def cb_retrieve_pre_computed(
-        self,
-        key: Any,
-        match_results: list[Any],
-        block_ids: list[list[int]],
-        instance_id: int,
-        event_ipc_handle: bytes,
-    ) -> MessagingFuture[Any]: ...
-
-    def cb_unified_lookup(self, key: Any, tp_size: int) -> MessagingFuture[Any]: ...
-
-    def p2p_lookup_and_lock(
-        self, keys: list[Any], group_layout_descs: dict[int, Any]
-    ) -> MessagingFuture[Any]: ...
-
-    def p2p_query_lookup_results(self, task_id: int) -> MessagingFuture[Any]: ...
-
-    def p2p_unlock_objects(self, keys: list[Any]) -> MessagingFuture[Any]: ...
-
-    def get_experimental(self) -> MessagingFuture[Any]: ...
-
-    def close(self) -> None:
-        """Close the client and release its transport resources."""
 
 
 class ZmqMultiprocessClient:

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -9,6 +9,7 @@ Covers:
 
 # Standard
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
 import argparse
 import json
 import threading
@@ -31,6 +32,7 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _send_lookup,
     _send_unregister_kv_cache,
 )
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.platform.ops_types import PageBufferShapeDesc
@@ -591,9 +593,9 @@ class _LookupRouter:
 
 
 class TestLookupProtocol:
-    def _make_client(self, endpoint: str) -> MessageQueueClient:
+    def _make_client(self, endpoint: str) -> ZmqMultiprocessClient:
         ctx = zmq.Context.instance()
-        return MessageQueueClient(endpoint, ctx)
+        return ZmqMultiprocessClient(MessageQueueClient(endpoint, ctx))
 
     def test_send_lookup_void_reply_is_success(
         self,
@@ -687,9 +689,9 @@ class _UnregisterRouter:
 
 
 class TestUnregisterKVCache:
-    def _make_client(self, endpoint: str) -> MessageQueueClient:
+    def _make_client(self, endpoint: str) -> ZmqMultiprocessClient:
         ctx = zmq.Context.instance()
-        return MessageQueueClient(endpoint, ctx)
+        return ZmqMultiprocessClient(MessageQueueClient(endpoint, ctx))
 
     def test_handle_mode_sends_unregister_kv_cache(
         self,
@@ -815,9 +817,9 @@ class TestRegisterKVCacheMLA:
     shape and every STORE / RETRIEVE afterwards would corrupt data.
     """
 
-    def _make_client(self, endpoint: str) -> MessageQueueClient:
+    def _make_client(self, endpoint: str) -> ZmqMultiprocessClient:
         ctx = zmq.Context.instance()
-        return MessageQueueClient(endpoint, ctx)
+        return ZmqMultiprocessClient(MessageQueueClient(endpoint, ctx))
 
     def _register(self, endpoint: str, kv_size):
         # First Party
@@ -1174,14 +1176,14 @@ class TestClientMultiWorker:
             success = True
             context: dict = {}
 
-        # ``_call`` returns different shapes per RequestType:
+        # The fake ZMQ transport returns different shapes per RequestType:
         #   LOOKUP -> None (void)
         #   QUERY_PREFETCH_STATUS -> hit_chunks (int) or None
         #   STORE / RETRIEVE (handle) -> (worker_id, True)
         #   PREPARE_* -> _FakePrep()
         #   COMMIT_* -> True
         #   END_SESSION -> None
-        def fake_call(_client, req_type, payloads):
+        def fake_response(req_type, payloads):
             calls.append((req_type, payloads))
             name = req_type.name
             if name == "GET_CHUNK_SIZE":
@@ -1202,6 +1204,10 @@ class TestClientMultiWorker:
                 pass
 
         class FakeClient:
+            def submit_request(self, req_type, payloads, _response_cls=None):
+                value = fake_response(req_type, payloads)
+                return SimpleNamespace(result=lambda timeout=None: value)
+
             def close(self) -> None:
                 pass
 
@@ -1211,7 +1217,6 @@ class TestClientMultiWorker:
             tensor_refs.append(weakref.ref(tensor))
             return [tensor], [object()], [], []
 
-        monkeypatch.setattr(sv_helpers, "_call", fake_call)
         monkeypatch.setattr(sv_helpers, "_make_event_handle", lambda: b"")
         monkeypatch.setattr(
             sv_helpers,

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -32,9 +32,9 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _send_lookup,
     _send_unregister_kv_cache,
 )
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.platform.ops_types import PageBufferShapeDesc
 
 

--- a/tests/sdk/test_dispatcher.py
+++ b/tests/sdk/test_dispatcher.py
@@ -34,9 +34,7 @@ def _feature_context(advertised: set[str] | None = None) -> FeatureContext:
     adapter = MagicMock(name="worker_adapter")
     adapter.model_name = MODEL
     adapter.experimental = {TRANSFER_QUERY} if advertised is None else advertised
-    return FeatureContext(
-        worker_adapter=adapter, send_lmcache_request=MagicMock(name="send")
-    )
+    return FeatureContext(worker_adapter=adapter)
 
 
 def test_query_cache_uses_the_suffixed_model_name() -> None:

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -5,10 +5,11 @@ from typing import Any
 import ast
 
 # First Party
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 
 
 class _RecordingMessageQueueClient(MessageQueueClient):
@@ -34,6 +35,9 @@ class _RecordingMessageQueueClient(MessageQueueClient):
 
 
 def test_all_request_types_have_explicit_named_methods() -> None:
+    contract_names = {
+        name for name, value in RequestClient.__dict__.items() if callable(value)
+    }
     method_names = {
         name
         for name, value in ZmqMultiprocessClient.__dict__.items()
@@ -41,6 +45,7 @@ def test_all_request_types_have_explicit_named_methods() -> None:
     }
     expected_names = {name.lower() for name in RequestType.__members__}
 
+    assert expected_names <= contract_names
     assert expected_names <= method_names
     assert "__getattr__" not in ZmqMultiprocessClient.__dict__
     assert "submit_request" not in ZmqMultiprocessClient.__dict__
@@ -50,8 +55,8 @@ def test_only_zmq_transport_layer_submits_request_envelopes() -> None:
     """Business callers must use named methods instead of ZMQ envelopes."""
     repo_root = Path(__file__).parents[3]
     allowed = {
-        repo_root / "lmcache/v1/multiprocess/client.py",
         repo_root / "lmcache/v1/multiprocess/mq.py",
+        repo_root / "lmcache/v1/multiprocess/transport/zmq_impl/client.py",
     }
     violations: list[str] = []
     for path in (repo_root / "lmcache").rglob("*.py"):

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from pathlib import Path
+from typing import Any
+import ast
+
+# First Party
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+
+
+class _RecordingMessageQueueClient(MessageQueueClient):
+    """Record requests without opening a ZMQ socket."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[RequestType, list[Any], Any | None]] = []
+        self.closed = False
+
+    def submit_request(
+        self,
+        request_type: RequestType,
+        request_payloads: list[Any],
+        response_cls: Any | None = None,
+    ) -> MessagingFuture[Any]:
+        future: MessagingFuture[Any] = MessagingFuture()
+        self.calls.append((request_type, request_payloads, response_cls))
+        future.set_result(request_type)
+        return future
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_all_request_types_have_explicit_named_methods() -> None:
+    method_names = {
+        name
+        for name, value in ZmqMultiprocessClient.__dict__.items()
+        if callable(value)
+    }
+    expected_names = {name.lower() for name in RequestType.__members__}
+
+    assert expected_names <= method_names
+    assert "__getattr__" not in ZmqMultiprocessClient.__dict__
+    assert "submit_request" not in ZmqMultiprocessClient.__dict__
+
+
+def test_only_zmq_transport_layer_submits_request_envelopes() -> None:
+    """Business callers must use named methods instead of ZMQ envelopes."""
+    repo_root = Path(__file__).parents[3]
+    allowed = {
+        repo_root / "lmcache/v1/multiprocess/client.py",
+        repo_root / "lmcache/v1/multiprocess/mq.py",
+    }
+    violations: list[str] = []
+    for path in (repo_root / "lmcache").rglob("*.py"):
+        if path in allowed:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "submit_request":
+                violations.append(f"{path.relative_to(repo_root)}:{node.lineno}")
+
+    assert violations == []
+
+
+def test_named_rpc_method_delegates_to_zmq_request_envelope() -> None:
+    transport = _RecordingMessageQueueClient()
+    client = ZmqMultiprocessClient(transport)
+
+    future = client.lookup("key", 4)
+
+    assert future.result(timeout=0) is RequestType.LOOKUP
+    assert transport.calls == [
+        (
+            RequestType.LOOKUP,
+            ["key", 4],
+            get_response_class(RequestType.LOOKUP),
+        )
+    ]
+
+
+def test_compatibility_alias_delegates_to_same_zmq_request_type() -> None:
+    transport = _RecordingMessageQueueClient()
+    client = ZmqMultiprocessClient(transport)
+
+    client.cb_unregister_rope_v3(7)
+
+    assert transport.calls == [
+        (
+            RequestType.CB_UNREGISTER_ROPE,
+            [7],
+            get_response_class(RequestType.CB_UNREGISTER_ROPE),
+        )
+    ]
+
+
+def test_close_delegates_to_zmq_client() -> None:
+    transport = _RecordingMessageQueueClient()
+    client = ZmqMultiprocessClient(transport)
+
+    client.close()
+
+    assert transport.closed

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -21,7 +21,6 @@ from lmcache.v1.multiprocess.posix_shm import (
     shm_open_pool_as_mmap,
     shm_unlink,
 )
-from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import (
     PrepareRetrieveResponse,
     PrepareStoreResponse,
@@ -470,6 +469,8 @@ def test_musa_data_context_keeps_layout_validation_device_agnostic(
     )
     future = MagicMock()
     future.result.return_value = RegisterEngineDrivenContextResponse()
+    mq_client = MagicMock()
+    mq_client.register_kv_cache_engine_driven_context.return_value = future
     ctx = EngineDrivenTransferContext()
 
     ctx.register(
@@ -478,9 +479,8 @@ def test_musa_data_context_keeps_layout_validation_device_agnostic(
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        mq_client=MagicMock(),
+        mq_client=mq_client,
         mq_timeout=1.0,
-        send_request=MagicMock(return_value=future),
     )
 
 
@@ -532,15 +532,16 @@ def test_musa_data_context_store_uses_device_agnostic_gather(
 
     monkeypatch.setattr(worker_transfer, "gather_paged_kv_to_cpu", _fake_gather)
     ctx = EngineDrivenTransferContext()
+    mq_client = MagicMock()
+    mq_client.register_kv_cache_engine_driven_context.return_value = future
     ctx.register(
         instance_id=1,
         kv_caches=_make_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        mq_client=MagicMock(),
+        mq_client=mq_client,
         mq_timeout=1.0,
-        send_request=MagicMock(return_value=future),
     )
 
     result = ctx.submit_store(
@@ -604,15 +605,16 @@ def test_musa_data_context_retrieve_uses_device_agnostic_scatter(
 
     monkeypatch.setattr(worker_transfer, "scatter_cpu_to_paged_kv", _fake_scatter)
     ctx = EngineDrivenTransferContext()
+    mq_client = MagicMock()
+    mq_client.register_kv_cache_engine_driven_context.return_value = future
     ctx.register(
         instance_id=1,
         kv_caches=_make_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        mq_client=MagicMock(),
+        mq_client=mq_client,
         mq_timeout=1.0,
-        send_request=MagicMock(return_value=future),
     )
 
     result = ctx.submit_retrieve(
@@ -831,7 +833,8 @@ def test_engine_driven_register_sends_num_physical_slots(
     )
     future = MagicMock()
     future.result.return_value = RegisterEngineDrivenContextResponse()
-    send_request = MagicMock(return_value=future)
+    mq_client = MagicMock()
+    mq_client.register_kv_cache_engine_driven_context.return_value = future
 
     EngineDrivenTransferContext().register(
         instance_id=1,
@@ -839,13 +842,12 @@ def test_engine_driven_register_sends_num_physical_slots(
         model_name="m",
         world_size=1,
         blocks_in_chunk=8,
-        mq_client=MagicMock(),
+        mq_client=mq_client,
         mq_timeout=1.0,
-        send_request=send_request,
         layout_hints={"kv_layout": "NHD"},
     )
 
-    payload = send_request.call_args.args[2][0]
+    payload = mq_client.register_kv_cache_engine_driven_context.call_args.args[0]
     assert isinstance(payload, RegisterEngineDrivenContextPayload)
     assert payload.num_physical_slots == 128
 
@@ -1631,26 +1633,14 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
 
     mq_client = MagicMock()
 
-    def _submit_request(req_type, payload, response_cls):  # noqa: ARG001
-        if req_type == RequestType.PREPARE_STORE:
-            return _CompletedFuture(
-                PrepareStoreResponse(context={"slots": slots, "chunk_indices": [0]})
-            )
-        if req_type == RequestType.COMMIT_STORE:
-            _, _, commit_cpu_data = payload
-            assert commit_cpu_data == b""
-            return _CompletedFuture(True)
-        if req_type == RequestType.PREPARE_RETRIEVE:
-            return _CompletedFuture(
-                PrepareRetrieveResponse(
-                    success=True, data=b"", context={"slots": slots}
-                )
-            )
-        if req_type == RequestType.COMMIT_RETRIEVE:
-            return _CompletedFuture(True)
-        raise AssertionError(f"Unexpected request type: {req_type}")
-
-    mq_client.submit_request.side_effect = _submit_request
+    mq_client.prepare_store.return_value = _CompletedFuture(
+        PrepareStoreResponse(context={"slots": slots, "chunk_indices": [0]})
+    )
+    mq_client.commit_store.return_value = _CompletedFuture(True)
+    mq_client.prepare_retrieve.return_value = _CompletedFuture(
+        PrepareRetrieveResponse(success=True, data=b"", context={"slots": slots})
+    )
+    mq_client.commit_retrieve.return_value = _CompletedFuture(True)
 
     context = EngineDrivenContextShm(
         metadata=EngineDrivenContextMetadata(
@@ -1675,6 +1665,7 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
             torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
         )
         assert context.commit_store(key, 1, store_views)
+        mq_client.commit_store.assert_called_once_with(key, 1, b"")
 
         retrieve_views = context.prepare_retrieve(key=key, instance_id=1)
         assert retrieve_views is not None

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -469,8 +469,8 @@ def test_musa_data_context_keeps_layout_validation_device_agnostic(
     )
     future = MagicMock()
     future.result.return_value = RegisterEngineDrivenContextResponse()
-    mq_client = MagicMock()
-    mq_client.register_kv_cache_engine_driven_context.return_value = future
+    req_client = MagicMock()
+    req_client.register_kv_cache_engine_driven_context.return_value = future
     ctx = EngineDrivenTransferContext()
 
     ctx.register(
@@ -479,7 +479,7 @@ def test_musa_data_context_keeps_layout_validation_device_agnostic(
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        mq_client=mq_client,
+        req_client=req_client,
         mq_timeout=1.0,
     )
 
@@ -532,15 +532,15 @@ def test_musa_data_context_store_uses_device_agnostic_gather(
 
     monkeypatch.setattr(worker_transfer, "gather_paged_kv_to_cpu", _fake_gather)
     ctx = EngineDrivenTransferContext()
-    mq_client = MagicMock()
-    mq_client.register_kv_cache_engine_driven_context.return_value = future
+    req_client = MagicMock()
+    req_client.register_kv_cache_engine_driven_context.return_value = future
     ctx.register(
         instance_id=1,
         kv_caches=_make_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        mq_client=mq_client,
+        req_client=req_client,
         mq_timeout=1.0,
     )
 
@@ -605,15 +605,15 @@ def test_musa_data_context_retrieve_uses_device_agnostic_scatter(
 
     monkeypatch.setattr(worker_transfer, "scatter_cpu_to_paged_kv", _fake_scatter)
     ctx = EngineDrivenTransferContext()
-    mq_client = MagicMock()
-    mq_client.register_kv_cache_engine_driven_context.return_value = future
+    req_client = MagicMock()
+    req_client.register_kv_cache_engine_driven_context.return_value = future
     ctx.register(
         instance_id=1,
         kv_caches=_make_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        mq_client=mq_client,
+        req_client=req_client,
         mq_timeout=1.0,
     )
 
@@ -833,8 +833,8 @@ def test_engine_driven_register_sends_num_physical_slots(
     )
     future = MagicMock()
     future.result.return_value = RegisterEngineDrivenContextResponse()
-    mq_client = MagicMock()
-    mq_client.register_kv_cache_engine_driven_context.return_value = future
+    req_client = MagicMock()
+    req_client.register_kv_cache_engine_driven_context.return_value = future
 
     EngineDrivenTransferContext().register(
         instance_id=1,
@@ -842,12 +842,12 @@ def test_engine_driven_register_sends_num_physical_slots(
         model_name="m",
         world_size=1,
         blocks_in_chunk=8,
-        mq_client=mq_client,
+        req_client=req_client,
         mq_timeout=1.0,
         layout_hints={"kv_layout": "NHD"},
     )
 
-    payload = mq_client.register_kv_cache_engine_driven_context.call_args.args[0]
+    payload = req_client.register_kv_cache_engine_driven_context.call_args.args[0]
     assert isinstance(payload, RegisterEngineDrivenContextPayload)
     assert payload.num_physical_slots == 128
 
@@ -1599,7 +1599,7 @@ def test_engine_driven_context_shm_tensor_view_from_buffer() -> None:
                 block_size=1,
                 use_mla=False,
             ),
-            mq_client=MagicMock(),
+            req_client=MagicMock(),
             mq_timeout=1.0,
             shm_name=shm_name,
             pool_size=4096,
@@ -1631,16 +1631,16 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
         }
     ]
 
-    mq_client = MagicMock()
+    req_client = MagicMock()
 
-    mq_client.prepare_store.return_value = _CompletedFuture(
+    req_client.prepare_store.return_value = _CompletedFuture(
         PrepareStoreResponse(context={"slots": slots, "chunk_indices": [0]})
     )
-    mq_client.commit_store.return_value = _CompletedFuture(True)
-    mq_client.prepare_retrieve.return_value = _CompletedFuture(
+    req_client.commit_store.return_value = _CompletedFuture(True)
+    req_client.prepare_retrieve.return_value = _CompletedFuture(
         PrepareRetrieveResponse(success=True, data=b"", context={"slots": slots})
     )
-    mq_client.commit_retrieve.return_value = _CompletedFuture(True)
+    req_client.commit_retrieve.return_value = _CompletedFuture(True)
 
     context = EngineDrivenContextShm(
         metadata=EngineDrivenContextMetadata(
@@ -1651,7 +1651,7 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
             block_size=1,
             use_mla=False,
         ),
-        mq_client=mq_client,
+        req_client=req_client,
         mq_timeout=1.0,
         shm_name=shm_name,
         pool_size=4096,
@@ -1665,7 +1665,7 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
             torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
         )
         assert context.commit_store(key, 1, store_views)
-        mq_client.commit_store.assert_called_once_with(key, 1, b"")
+        req_client.commit_store.assert_called_once_with(key, 1, b"")
 
         retrieve_views = context.prepare_retrieve(key=key, instance_id=1)
         assert retrieve_views is not None
@@ -1691,7 +1691,7 @@ def test_engine_driven_context_shm_init_raises_when_segment_missing() -> None:
                 block_size=1,
                 use_mla=False,
             ),
-            mq_client=MagicMock(),
+            req_client=MagicMock(),
             mq_timeout=1.0,
             shm_name="lmcache_missing_shm_segment",
             pool_size=4096,
@@ -1708,7 +1708,7 @@ def test_create_engine_driven_context_falls_back_to_pickle_without_shm_info() ->
             block_size=1,
             use_mla=False,
         ),
-        mq_client=MagicMock(),
+        req_client=MagicMock(),
         mq_timeout=1.0,
         shm_name="",
         pool_size=0,
@@ -1726,7 +1726,7 @@ def test_create_engine_driven_context_use_pickle_ignores_valid_shm_info() -> Non
             block_size=1,
             use_mla=False,
         ),
-        mq_client=MagicMock(),
+        req_client=MagicMock(),
         mq_timeout=1.0,
         shm_name="lmcache_valid_shm",
         pool_size=4096,
@@ -1748,7 +1748,7 @@ def test_engine_driven_context_shm_close_is_idempotent() -> None:
                 block_size=1,
                 use_mla=False,
             ),
-            mq_client=MagicMock(),
+            req_client=MagicMock(),
             mq_timeout=1.0,
             shm_name=shm_name,
             pool_size=4096,

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -14,7 +14,6 @@ import torch
 
 # First Party
 from lmcache.v1.multiprocess.futures import DeviceMessagingFuture, MessagingFuture
-from lmcache.v1.multiprocess.protocol import RequestType
 
 
 class _FakeEventBackend:
@@ -116,17 +115,10 @@ def test_worker_exports_events_through_platform_backend(
         lambda kv_caches: list(kv_caches.values()),
     )
 
-    sent: list[tuple[RequestType, list[object]]] = []
-
-    def send_request(
-        _client: object,
-        request_type: RequestType,
-        payload: list[object],
-    ) -> MessagingFuture:
-        sent.append((request_type, payload))
-        if request_type == RequestType.REGISTER_KV_CACHE:
-            return _resolved_future(True)
-        return MessagingFuture()
+    client = MagicMock()
+    client.register_kv_cache.return_value = _resolved_future(True)
+    client.store.return_value = MessagingFuture()
+    client.retrieve.return_value = MessagingFuture()
 
     context = worker_transfer.LMCacheDrivenTransferContext()
     kv_caches = {"layer_0": torch.empty(1)}
@@ -136,9 +128,8 @@ def test_worker_exports_events_through_platform_backend(
         "model",
         1,
         1,
-        MagicMock(),
+        client,
         1.0,
-        send_request,
     )
     stream = MagicMock(name="current_stream")
     monkeypatch.setattr(worker_transfer.torch_dev, "current_stream", lambda: stream)
@@ -166,14 +157,8 @@ def test_worker_exports_events_through_platform_backend(
 
     assert isinstance(store_future, DeviceMessagingFuture)
     assert isinstance(retrieve_future, DeviceMessagingFuture)
-    assert sent[1] == (
-        RequestType.STORE,
-        ["key", 1, [[0]], b"completion-handle"],
-    )
-    assert sent[2] == (
-        RequestType.RETRIEVE,
-        ["key", 1, [[0]], b"completion-handle", 2],
-    )
+    client.store.assert_called_once_with("key", 1, [[0]], b"completion-handle")
+    client.retrieve.assert_called_once_with("key", 1, [[0]], b"completion-handle", 2)
     assert [call[0] for call in backend.calls] == [
         "check",
         "create",

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -10,7 +10,6 @@ import threading
 
 # First Party
 from lmcache.v1.distributed.api import AttnWindowDesc
-from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -20,6 +19,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_response_class,
 )
 from lmcache.v1.multiprocess.protocols.base import HandlerType
+from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 
 # Test helpers
 from tests.v1.multiprocess import test_mq_handler_helpers
@@ -312,7 +312,7 @@ def test_adapter_free_lookup_locks_sends_request():
     mock_client = MagicMock(spec=MessageQueueClient)
     mock_future = MagicMock()
     mock_client.submit_request.return_value = mock_future
-    adapter.mq_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
+    adapter.req_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
     adapter._pending_lookups = set()
 
     token_ids = list(range(512))
@@ -369,7 +369,7 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     mock_future = MagicMock()
     mock_future.result.return_value = None  # LOOKUP returns None
     mock_client.submit_request.return_value = mock_future
-    adapter.mq_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
+    adapter.req_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
     adapter._pending_lookups = set()
     adapter._lookup_params = {}
 

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -10,6 +10,7 @@ import threading
 
 # First Party
 from lmcache.v1.distributed.api import AttnWindowDesc
+from lmcache.v1.multiprocess.client import ZmqMultiprocessClient
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -311,7 +312,7 @@ def test_adapter_free_lookup_locks_sends_request():
     mock_client = MagicMock(spec=MessageQueueClient)
     mock_future = MagicMock()
     mock_client.submit_request.return_value = mock_future
-    adapter.mq_clients = {"tcp://test:0": mock_client}
+    adapter.mq_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
     adapter._pending_lookups = set()
 
     token_ids = list(range(512))
@@ -368,7 +369,7 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     mock_future = MagicMock()
     mock_future.result.return_value = None  # LOOKUP returns None
     mock_client.submit_request.return_value = mock_future
-    adapter.mq_clients = {"tcp://test:0": mock_client}
+    adapter.mq_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
     adapter._pending_lookups = set()
     adapter._lookup_params = {}
 

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -95,7 +95,7 @@ def worker_with_transfer_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[AtomMPWorkerAdapter, MagicMock, dict[str, torch.Tensor]]:
     """Construct a worker with its MQ and transfer boundaries stubbed."""
-    client = MagicMock(name="mq_client")
+    client = MagicMock(name="req_client")
     transfer_context = MagicMock(name="transfer_context")
     monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
@@ -172,7 +172,7 @@ def test_atom_lookup_submits_valid_reader_count(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Scheduler lookups declare one reader for each rank-local object."""
-    client = MagicMock(name="mq_client")
+    client = MagicMock(name="req_client")
     future: MessagingFuture[None] = MessagingFuture()
     future.set_result(None)
     client.lookup.return_value = future
@@ -340,7 +340,7 @@ def test_atom_adapter_constructor_closes_client_on_failure(
     failure_kind: str,
 ) -> None:
     """GET_CHUNK_SIZE and validation failures do not leak the MQ client."""
-    client = MagicMock(name="mq_client")
+    client = MagicMock(name="req_client")
     monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
     if failure_kind == "chunk_query":
         monkeypatch.setattr(
@@ -365,7 +365,7 @@ def test_atom_constructor_preserves_error_when_client_close_fails(
     adapter_kind: str,
 ) -> None:
     """Cleanup errors cannot replace the constructor's original failure."""
-    client = MagicMock(name="mq_client")
+    client = MagicMock(name="req_client")
     client.close.side_effect = RuntimeError("close failed")
     monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(
@@ -660,7 +660,7 @@ def test_atom_shutdown_discards_late_recovery_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A callback returning after shutdown cannot republish context or health."""
-    client = MagicMock(name="mq_client")
+    client = MagicMock(name="req_client")
     initial_context = MagicMock(name="initial_context")
     recovery_context = MagicMock(name="recovery_context")
     recovery_entered = threading.Event()
@@ -741,7 +741,7 @@ def test_atom_heartbeat_publish_and_start_are_one_lifecycle_transition(
             assert release_start.wait(timeout=5.0)
             super().start()
 
-    client = MagicMock(name="mq_client")
+    client = MagicMock(name="req_client")
     transfer_context = MagicMock(name="transfer_context")
     monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -23,7 +23,6 @@ from lmcache.v1.gpu_connector.kv_format import detect_format
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-from lmcache.v1.multiprocess.protocol import RequestType
 import lmcache.lmcache_native as lmcache_native
 
 
@@ -83,6 +82,12 @@ class _FakeEvent:
 
     def wait(self, stream: object | None = None) -> None:
         del stream
+
+
+@pytest.fixture(autouse=True)
+def _use_named_client_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep constructor mocks at the method-oriented client boundary."""
+    monkeypatch.setattr(atom_adapter, "ZmqMultiprocessClient", lambda client: client)
 
 
 @pytest.fixture
@@ -170,7 +175,7 @@ def test_atom_lookup_submits_valid_reader_count(
     client = MagicMock(name="mq_client")
     future: MessagingFuture[None] = MessagingFuture()
     future.set_result(None)
-    client.submit_request.return_value = future
+    client.lookup.return_value = future
     monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     scheduler = AtomMPSchedulerAdapter(
@@ -183,11 +188,10 @@ def test_atom_lookup_submits_valid_reader_count(
 
     scheduler.maybe_submit_lookup_request("request-1", list(range(300)))
 
-    lookup_call = client.submit_request.call_args
-    assert lookup_call.args[0] is RequestType.LOOKUP
-    key = lookup_call.args[1][0]
+    lookup_call = client.lookup.call_args
+    key = lookup_call.args[0]
     assert key.require_num_kv_readers() == 1
-    assert lookup_call.args[1][1] == 2
+    assert lookup_call.args[1] == 2
 
 
 def test_atom_worker_registers_native_engine_type(
@@ -299,23 +303,19 @@ def test_atom_heartbeat_runs_recovery_before_publishing_health(
     """A successful ping only restores health after re-registration succeeds."""
     ping_results = iter([False, True])
 
-    def send_request(
-        _client: Any,
-        request_type: RequestType,
-        _payloads: list[Any],
-    ) -> MessagingFuture[Any]:
+    def ping(_instance_id: int) -> MessagingFuture[Any]:
         future: MessagingFuture[Any] = MessagingFuture()
-        result = next(ping_results) if request_type is RequestType.PING else True
-        future.set_result(result)
+        future.set_result(next(ping_results))
         return future
 
-    monkeypatch.setattr(atom_adapter, "_send_request", send_request)
+    client = MagicMock()
+    client.ping.side_effect = ping
     health_event = threading.Event()
     health_event.set()
     recover = MagicMock(return_value=True)
     unhealthy = MagicMock()
     heartbeat = atom_adapter._HeartbeatThread(
-        MagicMock(),
+        client,
         health_event,
         instance_id=7,
         interval=1.0,
@@ -389,15 +389,13 @@ def test_atom_initial_registration_failure_rolls_back_candidate(
     transfer_context.register.side_effect = register_error
     rollback_future: MessagingFuture[None] = MessagingFuture()
     rollback_future.set_result(None)
-    client.submit_request.return_value = rollback_future
+    client.unregister_kv_cache.return_value = rollback_future
 
     with pytest.raises(type(register_error)) as exc_info:
         worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
 
     assert exc_info.value is register_error
-    rollback_call = client.submit_request.call_args
-    assert rollback_call.args[0] is RequestType.UNREGISTER_KV_CACHE
-    assert rollback_call.args[1] == [worker.instance_id]
+    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
     transfer_context.close.assert_called_once_with()
     client.close.assert_called_once_with()
     assert worker.is_healthy is False
@@ -412,7 +410,7 @@ def test_atom_initial_registration_preserves_error_across_cleanup_failures(
     worker, transfer_context, caches = worker_with_transfer_context
     client = _mock_client(worker)
     transfer_context.register.side_effect = ValueError("original register failure")
-    client.submit_request.side_effect = RuntimeError("rollback failed")
+    client.unregister_kv_cache.side_effect = RuntimeError("rollback failed")
     transfer_context.close.side_effect = RuntimeError("context close failed")
     client.close.side_effect = RuntimeError("client close failed")
 
@@ -448,7 +446,7 @@ def test_atom_failed_recovery_rolls_back_candidate_and_keeps_old_context(
     )
     rollback_future: MessagingFuture[None] = MessagingFuture()
     rollback_future.set_result(None)
-    client.submit_request.return_value = rollback_future
+    client.unregister_kv_cache.return_value = rollback_future
 
     assert heartbeat.recover() is False
     failed_candidate.close.assert_called_once_with()
@@ -456,8 +454,7 @@ def test_atom_failed_recovery_rolls_back_candidate_and_keeps_old_context(
     assert worker._transfer_context is old_context
     assert worker._registered is True
     assert worker.is_healthy is False
-    rollback_call = client.submit_request.call_args
-    assert rollback_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
 
     assert heartbeat.recover() is True
     old_context.close.assert_called_once_with()
@@ -825,8 +822,7 @@ def test_atom_shutdown_unregisters_gpu_context(
 
     worker.shutdown()
 
-    request_types = [call.args[0] for call in client.submit_request.call_args_list]
-    assert request_types == [RequestType.UNREGISTER_KV_CACHE]
+    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
 
 
 @pytest.mark.parametrize(
@@ -871,7 +867,7 @@ def test_atom_shutdown_drains_unresolved_operation_before_unregister(
     assert wait_started.wait(timeout=5.0)
     transfer_context.close.assert_not_called()
     client.close.assert_not_called()
-    client.submit_request.assert_not_called()
+    client.unregister_kv_cache.assert_not_called()
 
     future.set_result(True)
     shutdown_thread.join(timeout=5.0)
@@ -881,8 +877,7 @@ def test_atom_shutdown_drains_unresolved_operation_before_unregister(
     assert returned.result(timeout=0) is True
     transfer_context.close.assert_called_once_with()
     client.close.assert_called_once_with()
-    unregister_call = client.submit_request.call_args
-    assert unregister_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
 
 
 @pytest.mark.parametrize(
@@ -934,7 +929,7 @@ def test_atom_restart_window_transfer_and_shutdown_terminate(
     assert raw_wait_started.wait(timeout=5.0)
     transfer_context.close.assert_not_called()
     client.close.assert_not_called()
-    client.submit_request.assert_not_called()
+    client.unregister_kv_cache.assert_not_called()
 
     raw_future.set_result((b"", False))
     shutdown_thread.join(timeout=5.0)
@@ -943,8 +938,7 @@ def test_atom_restart_window_transfer_and_shutdown_terminate(
     assert returned.result(timeout=0) is False
     transfer_context.close.assert_called_once_with()
     client.close.assert_called_once_with()
-    unregister_call = client.submit_request.call_args
-    assert unregister_call.args[0] is RequestType.UNREGISTER_KV_CACHE
+    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
 
 
 def test_atom_shutdown_finally_closes_client_when_context_close_fails(

--- a/tests/v1/test_experimental_dispatcher.py
+++ b/tests/v1/test_experimental_dispatcher.py
@@ -34,9 +34,7 @@ def _feature_context(advertised: set[str] | None = None) -> FeatureContext:
     adapter = MagicMock(name="worker_adapter")
     adapter.model_name = MODEL
     adapter.experimental = {TRANSFER_QUERY} if advertised is None else advertised
-    return FeatureContext(
-        worker_adapter=adapter, send_lmcache_request=MagicMock(name="send")
-    )
+    return FeatureContext(worker_adapter=adapter)
 
 
 def test_query_cache_uses_the_suffixed_model_name() -> None:

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -200,15 +200,15 @@ def test_wrap_sglang_kv_caches_rejects_mismatched_layers() -> None:
 def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
     """Registration identifies flat single-head pools as split K/V MHA."""
     adapter_mod, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
-    mq_client = MagicMock(name="rpc_client")
-    mq_client.register_kv_cache.return_value = SimpleNamespace(
+    req_client = MagicMock(name="rpc_client")
+    req_client.register_kv_cache.return_value = SimpleNamespace(
         result=MagicMock(return_value=None)
     )
 
     class FakeHeartbeatThread:
         def __init__(
             self,
-            mq_client: object,
+            req_client: object,
             health_event: threading.Event,
             interval: float,
             instance_id: int | None,
@@ -228,7 +228,7 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
         "MessageQueueClient",
         lambda _endpoint, _context: object(),
     )
-    monkeypatch.setattr(adapter_mod, "ZmqMultiprocessClient", lambda _raw: mq_client)
+    monkeypatch.setattr(adapter_mod, "ZmqMultiprocessClient", lambda _raw: req_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
     monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
     monkeypatch.setattr(
@@ -251,8 +251,8 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
         v_pool=v_pool,
     )
 
-    mq_client.register_kv_cache.assert_called_once()
-    assert mq_client.register_kv_cache.call_args.args[5] == {
+    req_client.register_kv_cache.assert_called_once()
+    assert req_client.register_kv_cache.call_args.args[5] == {
         "tokens_per_block": 2,
         "kv_list_layout": "k_v",
     }
@@ -293,7 +293,7 @@ def test_mp_connector_validates_pools_before_opening_mq(
 def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> None:
     _, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=False)
-    conn.mq_client = MagicMock(name="rpc_client")
+    conn.req_client = MagicMock(name="rpc_client")
 
     future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
 
@@ -301,7 +301,7 @@ def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> 
     assert future.query() is True
     # Unhealthy connector stored nothing -> the future must report failure.
     assert future.result(timeout=0) is False
-    conn.mq_client.store.assert_not_called()
+    conn.req_client.store.assert_not_called()
 
 
 def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(
@@ -309,14 +309,14 @@ def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(
 ) -> None:
     _, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=True)
-    conn.mq_client = MagicMock(name="rpc_client")
+    conn.req_client = MagicMock(name="rpc_client")
 
     # Fewer tokens than one chunk -> aligned_end == 0 -> no wire send.
     future = conn.store_kv_async(_store_metadata(num_tokens=_CHUNK_SIZE - 1))
 
     assert isinstance(future, MessagingFuture)
     assert future.result(timeout=0) is True
-    conn.mq_client.store.assert_not_called()
+    conn.req_client.store.assert_not_called()
 
 
 def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
@@ -324,7 +324,7 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
 ) -> None:
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=True)
-    conn.mq_client = MagicMock(name="rpc_client")
+    conn.req_client = MagicMock(name="rpc_client")
     conn.instance_id = 123
     conn.device = "cpu"
     # Stub the helpers store_kv_async calls so we exercise only its own logic.
@@ -333,7 +333,7 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
 
     sentinel = _SpyFuture()
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
-    conn.mq_client.store.return_value = _FakeRaw(sentinel)
+    conn.req_client.store.return_value = _FakeRaw(sentinel)
 
     future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
 
@@ -350,7 +350,7 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
     """The producer event outlives daemon import through the returned future."""
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
     connector = _make_connector(healthy=True)
-    connector.mq_client = MagicMock(name="rpc_client")
+    connector.req_client = MagicMock(name="rpc_client")
     connector.instance_id = 123
     connector.device = "cpu"
     connector.model_name = "test-model"
@@ -359,7 +359,7 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
     sentinel = _SpyFuture()
     raw = _FakeRaw(sentinel)
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
-    connector.mq_client.retrieve.return_value = raw
+    connector.req_client.retrieve.return_value = raw
 
     raw_future, future = connector._submit_retrieve(
         request_id="request-1",
@@ -393,7 +393,7 @@ def test_retrieve_failure_uses_single_cleanup_owner(
     """An event-free failure must not repeat server-side lock cleanup."""
     adapter_mod, _, _completed_future, _, LoadMetadata, _ = _import_adapter_symbols()
     connector = _make_connector(healthy=True)
-    connector.mq_client = MagicMock(name="rpc_client")
+    connector.req_client = MagicMock(name="rpc_client")
     connector.model_name = "test-model"
     connector.tp_size = 2
     connector.worker_id = 0
@@ -414,7 +414,7 @@ def test_retrieve_failure_uses_single_cleanup_owner(
         free_ranges.append((key.start, key.end))
         return _completed_future(True)
 
-    connector.mq_client.free_lookup_locks.side_effect = record_free_request
+    connector.req_client.free_lookup_locks.side_effect = record_free_request
 
     raw_future: MessagingFuture[tuple[bytes, bool]] = MessagingFuture()
     raw_future.set_result((event_handle, False))

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -200,8 +200,10 @@ def test_wrap_sglang_kv_caches_rejects_mismatched_layers() -> None:
 def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
     """Registration identifies flat single-head pools as split K/V MHA."""
     adapter_mod, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
-    mq_client = object()
-    requests: list[tuple[object, list[object]]] = []
+    mq_client = MagicMock(name="rpc_client")
+    mq_client.register_kv_cache.return_value = SimpleNamespace(
+        result=MagicMock(return_value=None)
+    )
 
     class FakeHeartbeatThread:
         def __init__(
@@ -224,8 +226,9 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
     monkeypatch.setattr(
         adapter_mod,
         "MessageQueueClient",
-        lambda _endpoint, _context: mq_client,
+        lambda _endpoint, _context: object(),
     )
+    monkeypatch.setattr(adapter_mod, "ZmqMultiprocessClient", lambda _raw: mq_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
     monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
     monkeypatch.setattr(
@@ -234,14 +237,6 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
         lambda _device_type: SimpleNamespace(is_handle_transfer_available=lambda: True),
     )
     monkeypatch.setattr(adapter_mod, "wrap_one_kv_cache", lambda tensor: tensor)
-
-    def send_request(
-        _client: object, request_type: object, payload: list[object]
-    ) -> object:
-        requests.append((request_type, payload))
-        return SimpleNamespace(result=MagicMock(return_value=None))
-
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_request)
 
     k_pool = [torch.empty(4, 1, 8) for _ in range(2)]
     v_pool = [torch.empty(4, 1, 8) for _ in range(2)]
@@ -256,10 +251,11 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
         v_pool=v_pool,
     )
 
-    assert len(requests) == 1
-    request_type, payload = requests[0]
-    assert request_type == adapter_mod.RequestType.REGISTER_KV_CACHE
-    assert payload[5] == {"tokens_per_block": 2, "kv_list_layout": "k_v"}
+    mq_client.register_kv_cache.assert_called_once()
+    assert mq_client.register_kv_cache.call_args.args[5] == {
+        "tokens_per_block": 2,
+        "kv_list_layout": "k_v",
+    }
 
 
 @pytest.mark.parametrize(
@@ -295,13 +291,9 @@ def test_mp_connector_validates_pools_before_opening_mq(
 
 
 def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> None:
-    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    _, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=False)
-
-    def _fail_send(*args, **kwargs):
-        pytest.fail("send_lmcache_request must not be called when unhealthy")
-
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", _fail_send)
+    conn.mq_client = MagicMock(name="rpc_client")
 
     future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
 
@@ -309,24 +301,22 @@ def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> 
     assert future.query() is True
     # Unhealthy connector stored nothing -> the future must report failure.
     assert future.result(timeout=0) is False
+    conn.mq_client.store.assert_not_called()
 
 
 def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(
     monkeypatch,
 ) -> None:
-    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    _, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=True)
-
-    def _fail_send(*args, **kwargs):
-        pytest.fail("send_lmcache_request must not be called with no aligned range")
-
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", _fail_send)
+    conn.mq_client = MagicMock(name="rpc_client")
 
     # Fewer tokens than one chunk -> aligned_end == 0 -> no wire send.
     future = conn.store_kv_async(_store_metadata(num_tokens=_CHUNK_SIZE - 1))
 
     assert isinstance(future, MessagingFuture)
     assert future.result(timeout=0) is True
+    conn.mq_client.store.assert_not_called()
 
 
 def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
@@ -334,7 +324,7 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
 ) -> None:
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=True)
-    conn.mq_client = object()  # type: ignore[assignment]
+    conn.mq_client = MagicMock(name="rpc_client")
     conn.instance_id = 123
     conn.device = "cpu"
     # Stub the helpers store_kv_async calls so we exercise only its own logic.
@@ -343,11 +333,7 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
 
     sentinel = _SpyFuture()
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
-    monkeypatch.setattr(
-        adapter_mod,
-        "send_lmcache_request",
-        lambda mq_client, request_type, payload: _FakeRaw(sentinel),
-    )
+    conn.mq_client.store.return_value = _FakeRaw(sentinel)
 
     future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
 
@@ -364,7 +350,7 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
     """The producer event outlives daemon import through the returned future."""
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
     connector = _make_connector(healthy=True)
-    connector.mq_client = object()  # type: ignore[assignment]
+    connector.mq_client = MagicMock(name="rpc_client")
     connector.instance_id = 123
     connector.device = "cpu"
     connector.model_name = "test-model"
@@ -373,11 +359,7 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
     sentinel = _SpyFuture()
     raw = _FakeRaw(sentinel)
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
-    monkeypatch.setattr(
-        adapter_mod,
-        "send_lmcache_request",
-        lambda mq_client, request_type, payload: raw,
-    )
+    connector.mq_client.retrieve.return_value = raw
 
     raw_future, future = connector._submit_retrieve(
         request_id="request-1",
@@ -411,7 +393,7 @@ def test_retrieve_failure_uses_single_cleanup_owner(
     """An event-free failure must not repeat server-side lock cleanup."""
     adapter_mod, _, _completed_future, _, LoadMetadata, _ = _import_adapter_symbols()
     connector = _make_connector(healthy=True)
-    connector.mq_client = object()  # type: ignore[assignment]
+    connector.mq_client = MagicMock(name="rpc_client")
     connector.model_name = "test-model"
     connector.tp_size = 2
     connector.worker_id = 0
@@ -428,16 +410,11 @@ def test_retrieve_failure_uses_single_cleanup_owner(
 
     free_ranges: list[tuple[int, int]] = []
 
-    def record_free_request(
-        _mq_client: object,
-        request_type: object,
-        payload: list[Any],
-    ) -> MessagingFuture[bool]:
-        assert request_type is adapter_mod.RequestType.FREE_LOOKUP_LOCKS
-        free_ranges.append((payload[0].start, payload[0].end))
+    def record_free_request(key: Any, _tp_size: int) -> MessagingFuture[bool]:
+        free_ranges.append((key.start, key.end))
         return _completed_future(True)
 
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", record_free_request)
+    connector.mq_client.free_lookup_locks.side_effect = record_free_request
 
     raw_future: MessagingFuture[tuple[bytes, bool]] = MessagingFuture()
     raw_future.set_result((event_handle, False))

--- a/tests/v1/test_tensorrt_mp_adapter.py
+++ b/tests/v1/test_tensorrt_mp_adapter.py
@@ -66,7 +66,7 @@ def test_failed_retrieve_waits_for_device_result_and_fails_closed(
     worker._metadata = module.LMCacheMPConnectorMetadata(
         loads={7: module._BlockSpec(tokens=[1, 2], block_ids=[3])}
     )
-    worker._mq_client = MagicMock(name="mq_client")
+    worker._req_client = MagicMock(name="req_client")
     worker._mq_timeout = 5.0
     worker._instance_id = 42
     worker._create_key = MagicMock(return_value=SimpleNamespace())
@@ -80,7 +80,7 @@ def test_failed_retrieve_waits_for_device_result_and_fails_closed(
     device_future.result.return_value = False
     raw_future = MagicMock(name="raw_future")
     raw_future.to_device_future.return_value = device_future
-    worker._mq_client.retrieve.return_value = raw_future
+    worker._req_client.retrieve.return_value = raw_future
 
     with pytest.raises(RuntimeError, match="refusing to use unloaded KV blocks"):
         worker.start_load_kv(MagicMock(name="stream"))

--- a/tests/v1/test_tensorrt_mp_adapter.py
+++ b/tests/v1/test_tensorrt_mp_adapter.py
@@ -80,8 +80,7 @@ def test_failed_retrieve_waits_for_device_result_and_fails_closed(
     device_future.result.return_value = False
     raw_future = MagicMock(name="raw_future")
     raw_future.to_device_future.return_value = device_future
-    send_request = MagicMock(return_value=raw_future)
-    monkeypatch.setattr(module, "_send_request", send_request)
+    worker._mq_client.retrieve.return_value = raw_future
 
     with pytest.raises(RuntimeError, match="refusing to use unloaded KV blocks"):
         worker.start_load_kv(MagicMock(name="stream"))

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -45,12 +45,12 @@ class FakeHeartbeatThread:
 
     def __init__(
         self,
-        mq_client: object = None,
+        req_client: object = None,
         health_event: threading.Event | None = None,
         interval: float = 0.0,
         instance_id: int | None = None,
     ) -> None:
-        self.mq_client = mq_client
+        self.req_client = req_client
         self.health_event = (
             health_event if health_event is not None else threading.Event()
         )
@@ -150,7 +150,7 @@ def fake_adapter(monkeypatch):
     ``(adapter, send_mock, future)``; ``future.result()`` defaults to succeed.
     ``HeartbeatThread`` is replaced by ``FakeHeartbeatThread``."""
     # Stub the raw ZMQ boundary so facade calls do not touch a real socket.
-    fake_client = MagicMock(name="mq_client")
+    fake_client = MagicMock(name="req_client")
     monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
@@ -686,11 +686,11 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
     first successful ping invokes the recover callback while the event
     is still cleared, then sets the event."""
     monkeypatch.setattr(
-        adapter_mod, "send_ping", lambda mq_client, timeout, instance_id=None: True
+        adapter_mod, "send_ping", lambda req_client, timeout, instance_id=None: True
     )
     health_event = threading.Event()  # cleared: pessimistic start state
     heartbeat = HeartbeatThread(
-        mq_client=MagicMock(name="mq_client"),
+        req_client=MagicMock(name="req_client"),
         health_event=health_event,
         interval=60.0,
     )
@@ -765,7 +765,7 @@ def test_dropped_retrieve_reported_once_via_healthy_get_finished(
 
 def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     """shutdown() stops the heartbeat before sending UNREGISTER, so no
-    stray heartbeat ping can race the closing mq_client."""
+    stray heartbeat ping can race the closing req_client."""
     adapter, send_mock, future = fake_adapter
     adapter.transfer_ctx = MagicMock()
     adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
@@ -813,7 +813,7 @@ def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> Non
     release_ping = threading.Event()
 
     def slow_ping(
-        mq_client: object, timeout: float, instance_id: int | None = None
+        req_client: object, timeout: float, instance_id: int | None = None
     ) -> bool:
         ping_entered.set()
         release_ping.wait(timeout=10.0)
@@ -822,7 +822,7 @@ def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> Non
     monkeypatch.setattr(adapter_mod, "send_ping", slow_ping)
     health_event = threading.Event()  # cleared: a success would take the edge
     heartbeat = HeartbeatThread(
-        mq_client=MagicMock(name="mq_client"),
+        req_client=MagicMock(name="req_client"),
         health_event=health_event,
         interval=60.0,
     )
@@ -890,7 +890,7 @@ def test_register_uses_local_context_when_self_transfer_ctx_nulled(
         def transfer_ctx(self, value):
             pass
 
-    fake_client = MagicMock(name="mq_client")
+    fake_client = MagicMock(name="req_client")
     monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -149,8 +149,7 @@ def fake_adapter(monkeypatch):
     """Build an adapter with the network boundary stubbed. Returns
     ``(adapter, send_mock, future)``; ``future.result()`` defaults to succeed.
     ``HeartbeatThread`` is replaced by ``FakeHeartbeatThread``."""
-    # Stub the MQ boundary so __init__'s chunk-size query and any later
-    # send_lmcache_request call don't touch a real socket.
+    # Stub the raw ZMQ boundary so facade calls do not touch a real socket.
     fake_client = MagicMock(name="mq_client")
     monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
@@ -158,8 +157,8 @@ def fake_adapter(monkeypatch):
 
     future = MagicMock(name="future")
     future.result.return_value = None
-    send_mock = MagicMock(name="send_lmcache_request", return_value=future)
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_mock)
+    send_mock = MagicMock(name="submit_request", return_value=future)
+    fake_client.submit_request = send_mock
 
     FakeHeartbeatThread.instances.clear()
     FakeHeartbeatThread.start_hook = None
@@ -200,7 +199,7 @@ def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
     assert adapter.kv_caches is new_caches
     assert send_mock.call_count == 1
     args, _kwargs = send_mock.call_args
-    assert args[1] == RequestType.REGISTER_KV_CACHE
+    assert args[0] == RequestType.REGISTER_KV_CACHE
 
 
 def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
@@ -235,8 +234,8 @@ def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     assert adapter.kv_caches is cpu_kv
     assert send_mock.call_count == 1
     args, _kwargs = send_mock.call_args
-    assert args[1] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
-    assert len(args[2]) == 1
+    assert args[0] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+    assert len(args[1]) == 1
     assert adapter.create_recorded_event() is None
 
 
@@ -264,7 +263,7 @@ def test_register_kv_caches_tuple_caches_use_engine_driven_context(
     assert adapter.kv_caches is tuple_kv
     assert send_mock.call_count == 1
     args, _kwargs = send_mock.call_args
-    assert args[1] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+    assert args[0] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
     assert adapter.create_recorded_event() is None
 
 
@@ -775,7 +774,9 @@ def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     stop_state_at_unregister: list[bool] = []
 
     def record_send(
-        mq_client: object, request_type: RequestType, payloads: list[object]
+        request_type: RequestType,
+        payloads: list[object],
+        _response_cls: object,
     ) -> MagicMock:
         if request_type == RequestType.UNREGISTER_KV_CACHE:
             stop_state_at_unregister.append(heartbeat.stop_requested)
@@ -800,8 +801,8 @@ def test_shutdown_without_heartbeat_sends_unregister(fake_adapter) -> None:
     assert FakeHeartbeatThread.instances == []
     assert send_mock.call_count == 1
     args, _kwargs = send_mock.call_args
-    assert args[1] == RequestType.UNREGISTER_KV_CACHE
-    assert args[2] == [adapter.instance_id]
+    assert args[0] == RequestType.UNREGISTER_KV_CACHE
+    assert args[1] == [adapter.instance_id]
 
 
 def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> None:
@@ -895,7 +896,7 @@ def test_register_uses_local_context_when_self_transfer_ctx_nulled(
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
     future = MagicMock(name="future")
     future.result.return_value = None
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", lambda *a, **kw: future)
+    fake_client.submit_request.return_value = future
     monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
     # First Party
     from lmcache.v1.multiprocess.transfer_context import worker_transfer


### PR DESCRIPTION
Part of #4877.

This is the first step of the staged multiprocess gRPC migration. It adds a method-oriented client contract while keeping the current ZMQ transport and wire protocol unchanged.

What changed:
- put the transport-neutral `RequestClient` contract in `multiprocess/transport/base.py`
- put `ZmqMultiprocessClient` in `multiprocess/transport/zmq_impl/` and reserve `grpc_impl/` for the later gRPC implementation
- rename transport-neutral client holders and parameters from `mq_client` to `req_client`
- expose explicit methods for every current request type, such as `lookup(...)`, `store(...)`, and `get_chunk_size(...)`
- migrate vLLM, SGLang, ATOM, TensorRT-LLM, SDK, transfer contexts, P2P, and server bench callers to invoke named methods directly
- keep `RequestType`, payload lists, and `submit_request(...)` inside the ZMQ implementation only
- add a source-level test that prevents business callers from using `submit_request(...)` again
- verify every named method still produces the existing ZMQ envelope

This PR does not add a gRPC implementation, protobuf stubs, server changes, URL scheme changes, or any ZMQ wire-protocol changes.

Tests:
- relevant multiprocess and integration regression suite: 872 passed, 38 skipped
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`