### PR TITLE
refactor(multiprocess): select request client transport by scheme

### DIFF
--- a/docs/design/v1/multiprocess/transport/request_transport.md
+++ b/docs/design/v1/multiprocess/transport/request_transport.md
@@ -1,0 +1,57 @@
+# Multiprocess Request Transport
+
+## Motivation
+
+MP clients previously constructed `MessageQueueClient` directly and submitted a
+`RequestType` with a positional payload list. This coupled every caller to ZMQ
+and made adding another request transport an application-wide change.
+
+The request transport is now split into a transport-neutral API and
+transport-specific implementations:
+
+```text
+MP integration / SDK / benchmark
+              |
+              v
+     RequestClientFactory  -- selects by URL scheme
+              |
+              v
+         RequestClient     -- named request methods
+          /       \
+         v         v
+   ZMQ facade   gRPC client (planned)
+         |
+         v
+ MessageQueueClient
+```
+
+## Design
+
+`RequestClient` defines named methods such as `lookup()`, `store()`, and
+`retrieve()`. The ZMQ facade translates each method back to the existing
+`RequestType`, payload order, and response type, so this refactor does not
+change the ZMQ wire protocol.
+
+`RequestClientFactory` normalizes an endpoint and selects an implementation by
+scheme:
+
+| Scheme | Implementation |
+|---|---|
+| no scheme, `tcp`, `ipc`, `inproc` | ZMQ |
+| `grpc`, `grpc+unix` | gRPC (not implemented yet) |
+
+A bare `host:port` endpoint is normalized to `tcp://host:port`. Invalid or
+unknown schemes fail before a client is created. The gRPC schemes are reserved
+so gRPC support can land without changing business callers; selecting one
+currently raises `NotImplementedError`.
+
+This abstraction covers MP request RPCs only. It does not select the mechanism
+used to move KV data between an engine worker and the server.
+
+## Extending the transport
+
+A new transport implements the `RequestClient` contract inside its own
+subdirectory and adds its scheme mapping to the factory. Application code must
+continue to depend only on `RequestClientFactory` and named request methods;
+transport-specific serialization and connection management stay behind that
+boundary.

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -12,5 +12,6 @@ the cache.
    installation
    quickstart
    /mp/configuration
+   /mp/request_transport
    benchmarking
    kv_cache_calculator

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -13,6 +13,5 @@ the cache.
    compatibility
    quickstart
    /mp/configuration
-   /mp/request_transport
    benchmarking
    kv_cache_calculator

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -57,7 +57,8 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
             ``lmcache.mp.port`` in ``kv_connector_extra_config``. The host may
             include a ZMQ transport prefix (e.g. ``tcp://``); a bare
             ``host``/``host:port`` is also accepted and is normalized to
-            ``tcp://`` automatically:
+            ``tcp://`` automatically. See :doc:`/mp/request_transport` for
+            supported endpoint schemes and transport-selection behavior:
 
             .. code-block:: bash
 

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -1,6 +1,11 @@
 Overview
 ========
 
+.. toctree::
+   :hidden:
+
+   request_transport
+
 LMCache multiprocess (MP) mode runs LMCache as a **standalone service** that
 vLLM instances connect to over ZMQ.  One LMCache server per node can serve
 multiple vLLM pods, providing process isolation, shared caching, and

--- a/docs/source/mp/request_transport.rst
+++ b/docs/source/mp/request_transport.rst
@@ -1,0 +1,53 @@
+Request Transport
+=================
+
+LMCache MP clients select the request transport from the LMCache server URL.
+This transport carries control and cache-operation requests; it is separate
+from ``--supported-transfer-mode``, which controls how KV data moves between
+the engine worker and the LMCache server.
+
+Transport schemes
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Endpoint
+     - Transport
+     - Status
+   * - ``host:port`` or ``tcp://host:port``
+     - ZMQ over TCP
+     - Supported. A URL without a scheme defaults to ``tcp://``.
+   * - ``ipc://path`` or ``inproc://name``
+     - ZMQ IPC or in-process
+     - Recognized by the client factory; the standard LMCache server currently
+       binds ZMQ over TCP.
+   * - ``grpc://host:port`` or ``grpc+unix:///path``
+     - gRPC
+     - Not supported yet. gRPC support is planned soon.
+
+For a single vLLM connector, set the scheme in ``lmcache.mp.host`` and keep the
+port in ``lmcache.mp.port``. The current ZMQ configuration is:
+
+.. code-block:: json
+
+   {
+     "lmcache.mp.host": "tcp://localhost",
+     "lmcache.mp.port": 5555
+   }
+
+When gRPC becomes available, selecting it will use the same configuration
+shape with a ``grpc://`` host:
+
+.. code-block:: json
+
+   {
+     "lmcache.mp.host": "grpc://localhost",
+     "lmcache.mp.port": 5555
+   }
+
+For multiple servers, specify the scheme on every entry in
+``lmcache.mp.server_urls``, for example
+``tcp://host1:5555,tcp://host2:5555``. All clients and servers in a deployment
+must use matching transports.

--- a/lmcache/cli/commands/bench/server_bench/client.py
+++ b/lmcache/cli/commands/bench/server_bench/client.py
@@ -656,7 +656,7 @@ class ServerBenchClient:
             try:
                 self._req_client.close()
             except Exception as exc:
-                self._log("  [warning] MessageQueueClient close failed: %s" % exc)
+                self._log("  [warning] Request client close failed: %s" % exc)
             finally:
                 self._req_client = None
         if self._zmq_context is not None:
@@ -705,8 +705,7 @@ class ServerBenchClient:
             parse_kvcache_shape_spec,
         )
         from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-        from lmcache.v1.multiprocess.mq import MessageQueueClient
-        from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+        from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 
         config = self._config
         use_gpu = config.is_gpu
@@ -724,8 +723,9 @@ class ServerBenchClient:
             % (config.rpc_url, config.mode)
         )
         self._zmq_context = zmq.Context()
-        self._req_client = ZmqMultiprocessClient(
-            MessageQueueClient(config.rpc_url, self._zmq_context)
+        self._req_client = RequestClientFactory.create(
+            config.rpc_url,
+            context=self._zmq_context,
         )
 
         self._chunk_size = _get_chunk_size(self._req_client)

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -105,7 +105,7 @@ def add_server_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--rpc-url",
         default="tcp://localhost:5555",
-        help=("ZMQ endpoint of the MP server (default: tcp://localhost:5555)"),
+        help=("MP request endpoint (default: tcp://localhost:5555)"),
     )
     parser.add_argument(
         "--mode",

--- a/lmcache/cli/commands/bench/server_bench/config.py
+++ b/lmcache/cli/commands/bench/server_bench/config.py
@@ -16,7 +16,7 @@ class BenchConfig:
     CLI-only concerns such as profiling stay with the command layer.
 
     Attributes:
-        rpc_url: ZMQ endpoint of the LMCache Server.
+        rpc_url: Multiprocess request endpoint of the LMCache server.
         http_url: HTTP endpoint used by management and checksum APIs.
         mode: ``"cpu"`` or ``"gpu"`` for mock Worker resources.
         transfer_mode: ``"auto"``, ``"engine_driven"``, or

--- a/lmcache/integration/atom/multi_process_adapter.py
+++ b/lmcache/integration/atom/multi_process_adapter.py
@@ -26,13 +26,12 @@ from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
     expand_engine_block_ids,
 )
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transfer_context import (
     TransferContext,
     create_transfer_context,
 )
 from lmcache.v1.multiprocess.transport.base import RequestClient
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
 
 logger = init_logger(__name__)
@@ -175,7 +174,7 @@ class AtomMPSchedulerAdapter:
         *,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
     ) -> None:
-        client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
+        client = RequestClientFactory.create(server_url, context=context)
         self._model_name = model_name
         self._parallel = parallel_config
         self._mq_timeout = mq_timeout
@@ -275,7 +274,7 @@ class AtomMPSchedulerAdapter:
         self._client.end_session(request_id)
 
     def shutdown(self) -> None:
-        """Close the scheduler-side message queue client."""
+        """Close the scheduler-side request client."""
         if self._closed:
             return
         self._closed = True
@@ -320,7 +319,7 @@ class AtomMPWorkerAdapter:
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         transfer_mode: str | None = None,
     ) -> None:
-        client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
+        client = RequestClientFactory.create(server_url, context=context)
         self._model_name = model_name
         self._block_size = block_size
         self._parallel = parallel_config

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -33,9 +33,8 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transport.base import RequestClient
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.kv_wrap import wrap_one_kv_cache
 
@@ -152,7 +151,7 @@ class _PendingLookup:
 class LMCacheMPConnector:
     """SGLang LMCache multi-process connector.
 
-    Talks to a standalone LMCache daemon over ZMQ.
+    Talks to a standalone LMCache daemon through the configured transport.
 
     - ``lookup_kv``: fires LOOKUP. Daemon prefetches missing
       chunks L2→L1 (DRAM), keeps the read locks held, returns the
@@ -201,8 +200,10 @@ class LMCacheMPConnector:
         self._pending_lookups_lock = threading.Lock()
 
         self.context = zmq.Context.instance()
-        self.req_client: RequestClient = ZmqMultiprocessClient(
-            MessageQueueClient(f"tcp://{host}:{port}", self.context)
+        server_url = f"{host}:{port}"
+        self.req_client: RequestClient = RequestClientFactory.create(
+            server_url,
+            context=self.context,
         )
 
         self._lmcache_chunk_size = get_lmcache_chunk_size(self.req_client)

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -4,7 +4,8 @@
 Implements ``LMCacheMPKvConnectorScheduler`` and
 ``LMCacheMPKvConnectorWorker`` — the two classes TRT-LLM's
 ``kv_connector_config`` requires — backed by a standalone LMCache server
-reached over ZMQ. Provides process isolation and shared caching across
+reached through the configured request transport. Provides process isolation
+and shared caching across
 multiple TRT-LLM instances on the same node.
 
 The KV pool tensor is shared with the server via :class:`RawCudaIPCWrapper`
@@ -37,9 +38,8 @@ from lmcache.utils import EngineType, check_interprocess_event_support
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transport.base import RequestClient
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
 logger = init_logger(__name__)
@@ -78,8 +78,9 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         self._pending: dict = {}
 
         self._zmq_context = zmq.Context()
-        self._req_client: RequestClient = ZmqMultiprocessClient(
-            MessageQueueClient(_get_server_url(self._llm_args), self._zmq_context)
+        self._req_client: RequestClient = RequestClientFactory.create(
+            _get_server_url(self._llm_args),
+            context=self._zmq_context,
         )
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
@@ -263,8 +264,9 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
         self._block_size: int = self._llm_args.kv_cache_config.tokens_per_block
 
         self._zmq_context = zmq.Context()
-        self._req_client: RequestClient = ZmqMultiprocessClient(
-            MessageQueueClient(_get_server_url(self._llm_args), self._zmq_context)
+        self._req_client: RequestClient = RequestClientFactory.create(
+            _get_server_url(self._llm_args),
+            context=self._zmq_context,
         )
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -412,14 +412,11 @@ def build_parallel_strategy_from_vllm_config(
     )
 
 
-def _ensure_zmq_scheme(server_url: str) -> str:
-    """Ensure a ZMQ server URL carries a transport scheme.
+def _ensure_transport_scheme(server_url: str) -> str:
+    """Ensure a multiprocess server URL carries a transport scheme.
 
-    ZeroMQ requires an explicit transport (e.g. ``tcp://``) in the address;
-    a bare ``host:port`` such as ``127.0.0.1:5557`` is rejected with
-    ``ZMQError: Invalid argument``. Users naturally configure
-    ``lmcache.mp.host`` as a plain IP/hostname, so prepend ``tcp://`` when no
-    scheme is present.
+    Preserve explicit schemes so the request client factory can select the
+    transport. Bare endpoints retain the legacy ZMQ TCP behavior.
 
     Args:
         server_url: A server URL, with or without a ``<scheme>://`` prefix.
@@ -506,9 +503,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             )
             server_urls = [f"{server_host}:{server_port}"]
 
-        # Normalize so a bare host:port (no transport scheme) is accepted;
-        # ZMQ requires an explicit transport such as ``tcp://``.
-        server_urls = [_ensure_zmq_scheme(u) for u in server_urls]
+        # Preserve explicit transport schemes and default bare host:port
+        # endpoints to the legacy ZMQ TCP transport.
+        server_urls = [_ensure_transport_scheme(u) for u in server_urls]
 
         # The server count is derived from lmcache.mp.server_urls.
         n_servers = len(server_urls)

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -29,14 +29,14 @@ from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
     expand_engine_block_ids,
 )
-from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
+from lmcache.v1.multiprocess.mq import MessagingFuture
 from lmcache.v1.multiprocess.transfer_context import (
     EngineDrivenTransferContext,
     TransferContext,
     create_transfer_context,
 )
 from lmcache.v1.multiprocess.transport.base import RequestClient
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
 from lmcache.v1.platform.isolated_ipc import set_isolated_ipc
 
@@ -578,7 +578,7 @@ class LMCacheMPSchedulerAdapter:
     ):
         """
         Args:
-            server_urls: The servers URL for the LMCache message queue
+            server_urls: LMCache multiprocess request server URLs.
             context: The ZMQ context
             model_name: The model name used for LMCache keys
             vllm_block_size: The block size used in vLLM
@@ -605,7 +605,7 @@ class LMCacheMPSchedulerAdapter:
         assert len(server_urls) >= 1, "At least one server url required"
         self._server_urls: list[str] = list(server_urls)
         self.req_clients: dict[str, RequestClient] = {
-            url: ZmqMultiprocessClient(MessageQueueClient(url, context))
+            url: RequestClientFactory.create(url, context=context)
             for url in self._server_urls
         }
         if extra_config is not None:
@@ -1084,7 +1084,7 @@ class LMCacheMPWorkerAdapter:
         """Initialize the worker adapter for current or legacy vLLM callers.
 
         Args:
-            server_url: The server URL for the LMCache message queue.
+            server_url: LMCache multiprocess request server URL.
             context: The ZMQ context.
             model_name: The model name used for LMCache keys.
             vllm_block_size: The block size used in vLLM, or legacy KV world
@@ -1128,7 +1128,7 @@ class LMCacheMPWorkerAdapter:
             set_isolated_ipc(cfg[ExtraConfigDefault.isolated_ipc.name])
         else:
             self._mp_transfer_mode = None
-        self.req_client = ZmqMultiprocessClient(MessageQueueClient(server_url, context))
+        self.req_client = RequestClientFactory.create(server_url, context=context)
         self._mq_timeout = mq_timeout
 
         # Instance id for GPU worker. uuid4-derived (OS entropy) rather

--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -27,13 +27,12 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_heads,
 )
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     EngineDrivenTransferContext,
     create_transfer_context,
 )
 from lmcache.v1.multiprocess.transport.base import RequestClient
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 import lmcache.lmcache_native as lmcache_native
 
 logger = init_logger(__name__)
@@ -74,7 +73,8 @@ class LMCacheSDKContext:
         Initialize the SDK context and register the SDK transfer strategy.
 
         Args:
-            url: ZMQ endpoint URL for the LMCache message queue.
+            url: Multiprocess request endpoint. The URL scheme selects the
+                transport.
             http_url: HTTP endpoint URL for fetching information.
             model_name: Model name used by the running LMCache server instance.
             kind: The type of cache.
@@ -85,8 +85,9 @@ class LMCacheSDKContext:
         """
         self._kind = kind
         self._zmq_context = zmq.Context()
-        self._req_client: RequestClient = ZmqMultiprocessClient(
-            MessageQueueClient(url, self._zmq_context)
+        self._req_client: RequestClient = RequestClientFactory.create(
+            url,
+            context=self._zmq_context,
         )
         self._mq_timeout = timeout
         self._model_name = kind.server_model_name(model_name)

--- a/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
@@ -37,9 +37,8 @@ from lmcache.v1.distributed.l2_adapters.factory import register_l2_adapter_facto
 from lmcache.v1.distributed.transfer_channel import get_transfer_channel_context
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
 from lmcache.v1.memory_management import MemoryObj
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.transport.base import RequestClient
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform import HAS_EVENTFD, create_event_notifier
 
 logger = init_logger(__name__)
@@ -68,7 +67,7 @@ class P2PL2AdapterConfig(L2AdapterConfigBase):
     """Config for the P2P L2 adapter.
 
     Fields:
-    - peer_mq_server_url: ZMQ url of the peer's MQ server (lookup/unlock RPCs).
+    - peer_mq_server_url: Peer request server URL (lookup/unlock RPCs).
     - peer_transfer_channel_server_url: the peer's transfer-channel server url.
     - lookup_timeout_s: deadline for a lookup result before it counts as a miss.
     - load_timeout_s: deadline for a load before it counts as a failure.
@@ -116,7 +115,7 @@ class P2PL2AdapterConfig(L2AdapterConfigBase):
     def help(cls) -> str:
         return (
             "P2P L2 adapter config fields:\n"
-            "- peer_mq_server_url (str): ZMQ url of the peer's MQ server (required)\n"
+            "- peer_mq_server_url (str): peer request server URL (required)\n"
             "- peer_transfer_channel_server_url (str): the peer's transfer channel "
             "server url (required)\n"
             "- lookup_timeout_s (float): lookup result deadline in seconds "
@@ -133,8 +132,9 @@ class P2PL2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=0)
         self._config = config
 
-        self._req_client: RequestClient = ZmqMultiprocessClient(
-            MessageQueueClient(config.peer_mq_server_url, zmq.Context.instance())
+        self._req_client: RequestClient = RequestClientFactory.create(
+            config.peer_mq_server_url,
+            context=zmq.Context.instance(),
         )
         self._tc_context = get_transfer_channel_context()
         self._tc_client = self._tc_context.get_transfer_channel_client(

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -181,6 +181,30 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
 
 
 @dataclass
+class RegisterEngineDrivenContextResponse:
+    """Shared response for engine-driven context registration."""
+
+    shm_name: str = ""
+    pool_size: int = 0
+
+
+@dataclass
+class PrepareStoreResponse:
+    """Shared response for an engine-driven store preparation."""
+
+    context: dict = field(default_factory=dict)
+
+
+@dataclass
+class PrepareRetrieveResponse:
+    """Shared response for an engine-driven retrieve preparation."""
+
+    success: bool
+    data: bytes = b""
+    context: dict = field(default_factory=dict)
+
+
+@dataclass
 class CustomizedSerdeConfig:
     serializer: Callable[[Any], bytes]
     deserializer: Callable[[bytes], Any]

--- a/lmcache/v1/multiprocess/futures.py
+++ b/lmcache/v1/multiprocess/futures.py
@@ -77,6 +77,11 @@ class MessagingFuture(Generic[T]):
     def set_exception(self, exception: BaseException) -> None:
         """Set a request exception and mark this future as complete.
 
+        Note:
+            The current ZMQ transport does not call this method; only unit tests
+            exercise it in this change. It is part of the shared future interface
+            for asynchronous transports such as gRPC to propagate RPC failures.
+
         Args:
             exception: Failure raised while processing the request.
         """

--- a/lmcache/v1/multiprocess/futures.py
+++ b/lmcache/v1/multiprocess/futures.py
@@ -16,6 +16,7 @@ class MessagingFuture(Generic[T]):
     def __init__(self) -> None:
         self.is_done_ = threading.Event()
         self.result_: T | None = None
+        self.exception_: BaseException | None = None
         self._retained_references: list[object] = []
 
     def query(self) -> bool:
@@ -57,6 +58,8 @@ class MessagingFuture(Generic[T]):
         flag = self.wait(timeout)
         if not flag:
             raise LMCacheTimeoutError("Future result not available within timeout")
+        if self.exception_ is not None:
+            raise self.exception_
         return cast(T, self.result_)
 
     def set_result(self, result: T) -> None:
@@ -69,6 +72,15 @@ class MessagingFuture(Generic[T]):
             result (T): The result to set.
         """
         self.result_ = result
+        self.is_done_.set()
+
+    def set_exception(self, exception: BaseException) -> None:
+        """Set a request exception and mark this future as complete.
+
+        Args:
+            exception: Failure raised while processing the request.
+        """
+        self.exception_ = exception
         self.is_done_.set()
 
     def retain_reference(self, value: object) -> None:

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -13,48 +13,19 @@ This module defines the protocol for:
 - END_SESSION: End a session and clean up associated resources
 """
 
-# Standard
-from dataclasses import dataclass, field
-
 # First Party
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
+    PrepareRetrieveResponse,
+    PrepareStoreResponse,
     RegisterEngineDrivenContextPayload,
+    RegisterEngineDrivenContextResponse,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
-
-
-@dataclass
-class PrepareStoreResponse:
-    """Response for PREPARE_STORE."""
-
-    context: dict = field(
-        default_factory=dict
-    )  # pickle: {}, shm will put slot info here
-
-
-@dataclass
-class PrepareRetrieveResponse:
-    """Response for PREPARE_RETRIEVE."""
-
-    success: bool
-    data: bytes = b""
-    context: dict = field(
-        default_factory=dict
-    )  # pickle: {}, shm will put slot info here
-
-
-@dataclass
-class RegisterEngineDrivenContextResponse:
-    """Response for REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT."""
-
-    shm_name: str = ""
-    pool_size: int = 0
-
 
 # Define request names for this protocol group
 REQUEST_NAMES = [

--- a/lmcache/v1/multiprocess/transport/base.py
+++ b/lmcache/v1/multiprocess/transport/base.py
@@ -9,7 +9,7 @@ from lmcache.v1.multiprocess.futures import MessagingFuture
 
 
 class RequestClient(Protocol):
-    """Define method-oriented multiprocess requests shared by transports."""
+    """Base class for method-oriented multiprocess request clients."""
 
     def register_kv_cache(
         self,

--- a/lmcache/v1/multiprocess/transport/factory.py
+++ b/lmcache/v1/multiprocess/transport/factory.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request client factory selected by endpoint URL scheme."""
+
+# Standard
+from typing import Any
+
+# First Party
+from lmcache.v1.multiprocess.transport.base import RequestClient
+
+_ZMQ_SCHEMES = frozenset({"inproc", "ipc", "tcp"})
+_GRPC_SCHEMES = frozenset({"grpc", "grpc+unix"})
+
+
+def _normalize_server_url(server_url: str) -> tuple[str, str]:
+    url = server_url.strip()
+    if not url:
+        raise ValueError("Request client server URL must not be empty")
+    if "://" not in url:
+        return "tcp", f"tcp://{url}"
+
+    scheme, target = url.split("://", 1)
+    scheme = scheme.lower()
+    if not scheme or not target:
+        raise ValueError(f"Invalid request client server URL: {server_url!r}")
+    return scheme, f"{scheme}://{target}"
+
+
+class RequestClientFactory:
+    """Create a transport-specific request client from a server URL."""
+
+    @staticmethod
+    def create(
+        server_url: str,
+        *,
+        context: Any | None = None,
+    ) -> RequestClient:
+        """Create a request client selected by ``server_url`` scheme.
+
+        Bare ``host:port`` endpoints retain the existing behavior and default
+        to ``tcp://``. ZMQ handles ``tcp://``, ``ipc://``, and ``inproc://``;
+        gRPC handles ``grpc://`` and ``grpc+unix://``.
+
+        Args:
+            server_url: Multiprocess server endpoint, optionally without a
+                scheme for the legacy ZMQ TCP default.
+            context: Optional transport context. ZMQ accepts a ``zmq.Context``;
+                transports that do not need a context may ignore it.
+
+        Returns:
+            A method-oriented request client for the selected transport.
+
+        Raises:
+            ValueError: If the URL is empty, malformed, or uses an unsupported
+                scheme.
+            NotImplementedError: If the selected transport is recognized but
+                its implementation is not available yet.
+        """
+        scheme, normalized_url = _normalize_server_url(server_url)
+        if scheme in _ZMQ_SCHEMES:
+            # First Party
+            from lmcache.v1.multiprocess.transport import zmq_impl
+
+            return zmq_impl.create_request_client(
+                normalized_url,
+                context=context,
+            )
+        if scheme in _GRPC_SCHEMES:
+            # First Party
+            from lmcache.v1.multiprocess.transport import grpc_impl
+
+            return grpc_impl.create_request_client(
+                normalized_url,
+                context=context,
+            )
+
+        supported = sorted(_ZMQ_SCHEMES | _GRPC_SCHEMES)
+        raise ValueError(
+            f"Unsupported request client URL scheme {scheme!r}; "
+            f"supported schemes: {supported}"
+        )

--- a/lmcache/v1/multiprocess/transport/grpc_impl/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/__init__.py
@@ -1,2 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 """gRPC transport implementation for multiprocess requests."""
+
+# Standard
+from typing import Any, NoReturn
+
+
+def create_request_client(
+    server_url: str,
+    *,
+    context: Any | None = None,
+) -> NoReturn:
+    """Report that the gRPC request client has not been introduced yet.
+
+    Args:
+        server_url: gRPC endpoint selected by the request client factory.
+        context: Unused optional transport context.
+
+    Raises:
+        NotImplementedError: Always, until the gRPC implementation lands.
+    """
+    del context
+    raise NotImplementedError(
+        f"gRPC request client for {server_url!r} is not available yet"
+    )
+
+
+__all__ = ["create_request_client"]

--- a/lmcache/v1/multiprocess/transport/zmq_impl/__init__.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/__init__.py
@@ -1,9 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 """ZMQ transport implementation for multiprocess requests."""
 
+# Standard
+from typing import Any
+
 # First Party
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.multiprocess.transport.zmq_impl.client import (
     ZmqMultiprocessClient,
 )
 
-__all__ = ["ZmqMultiprocessClient"]
+
+def create_request_client(
+    server_url: str,
+    *,
+    context: Any | None = None,
+) -> RequestClient:
+    """Create a method-oriented request client backed by ZMQ.
+
+    Args:
+        server_url: ZMQ endpoint URL.
+        context: Optional existing ``zmq.Context`` shared by the caller.
+
+    Returns:
+        A ZMQ-backed request client.
+    """
+    if context is None:
+        # Third Party
+        import zmq
+
+        context = zmq.Context.instance()
+    return ZmqMultiprocessClient(MessageQueueClient(server_url, context))
+
+
+__all__ = ["ZmqMultiprocessClient", "create_request_client"]

--- a/lmcache/v1/multiprocess/transport/zmq_impl/client.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/client.py
@@ -11,9 +11,10 @@ from lmcache.v1.multiprocess.protocol import (
     RequestType,
     get_response_class,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
 
 
-class ZmqMultiprocessClient:
+class ZmqMultiprocessClient(RequestClient):
     """Expose named multiprocess RPC methods over the existing ZMQ client.
 
     The wrapper changes only the Python call surface. Every method delegates to

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -34,6 +34,7 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.transport import zmq_impl
 from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 from lmcache.v1.platform.ops_types import PageBufferShapeDesc
 
@@ -1067,7 +1068,6 @@ class TestClientMultiWorker:
         from lmcache.cli.commands.bench.server_bench import helpers as sv_helpers
         from lmcache.cli.commands.bench.server_bench.client import ServerBenchClient
         from lmcache.cli.commands.bench.server_bench.config import BenchConfig
-        from lmcache.v1.multiprocess import mq
 
         tensor_refs: list[weakref.ReferenceType[torch.Tensor]] = []
         register_results = iter([True, False])
@@ -1100,7 +1100,7 @@ class TestClientMultiWorker:
             return True
 
         monkeypatch.setattr(zmq, "Context", lambda: context)
-        monkeypatch.setattr(mq, "MessageQueueClient", lambda *_args: transport)
+        monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *_args: transport)
         monkeypatch.setattr(sv_helpers, "_get_chunk_size", lambda _client: 16)
         monkeypatch.setattr(
             sv_helpers,
@@ -1164,7 +1164,6 @@ class TestClientMultiWorker:
             ServerBenchClient,
         )
         from lmcache.cli.commands.bench.server_bench.config import BenchConfig
-        from lmcache.v1.multiprocess import mq
 
         calls: list[tuple] = []
         tensor_refs: list[weakref.ReferenceType[torch.Tensor]] = []
@@ -1224,7 +1223,7 @@ class TestClientMultiWorker:
             fake_allocate,
         )
         monkeypatch.setattr(zmq, "Context", FakeContext)
-        monkeypatch.setattr(mq, "MessageQueueClient", lambda *_args: FakeClient())
+        monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *_args: FakeClient())
 
         kv_size = 1 if is_mla else 2
         bench_client = ServerBenchClient(

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -32,10 +32,9 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _send_lookup,
     _send_unregister_kv_cache,
 )
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocols.base import RequestType
-from lmcache.v1.multiprocess.transport import zmq_impl
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform.ops_types import PageBufferShapeDesc
 
 
@@ -594,9 +593,9 @@ class _LookupRouter:
 
 
 class TestLookupProtocol:
-    def _make_client(self, endpoint: str) -> ZmqMultiprocessClient:
+    def _make_client(self, endpoint: str) -> RequestClient:
         ctx = zmq.Context.instance()
-        return ZmqMultiprocessClient(MessageQueueClient(endpoint, ctx))
+        return RequestClientFactory.create(endpoint, context=ctx)
 
     def test_send_lookup_void_reply_is_success(
         self,
@@ -690,9 +689,9 @@ class _UnregisterRouter:
 
 
 class TestUnregisterKVCache:
-    def _make_client(self, endpoint: str) -> ZmqMultiprocessClient:
+    def _make_client(self, endpoint: str) -> RequestClient:
         ctx = zmq.Context.instance()
-        return ZmqMultiprocessClient(MessageQueueClient(endpoint, ctx))
+        return RequestClientFactory.create(endpoint, context=ctx)
 
     def test_handle_mode_sends_unregister_kv_cache(
         self,
@@ -818,9 +817,9 @@ class TestRegisterKVCacheMLA:
     shape and every STORE / RETRIEVE afterwards would corrupt data.
     """
 
-    def _make_client(self, endpoint: str) -> ZmqMultiprocessClient:
+    def _make_client(self, endpoint: str) -> RequestClient:
         ctx = zmq.Context.instance()
-        return ZmqMultiprocessClient(MessageQueueClient(endpoint, ctx))
+        return RequestClientFactory.create(endpoint, context=ctx)
 
     def _register(self, endpoint: str, kv_size):
         # First Party
@@ -1100,7 +1099,11 @@ class TestClientMultiWorker:
             return True
 
         monkeypatch.setattr(zmq, "Context", lambda: context)
-        monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *_args: transport)
+        monkeypatch.setattr(
+            RequestClientFactory,
+            "create",
+            lambda *_args, **_kwargs: transport,
+        )
         monkeypatch.setattr(sv_helpers, "_get_chunk_size", lambda _client: 16)
         monkeypatch.setattr(
             sv_helpers,
@@ -1175,26 +1178,25 @@ class TestClientMultiWorker:
             success = True
             context: dict = {}
 
-        # The fake ZMQ transport returns different shapes per RequestType:
+        # The fake request client returns different shapes per named method:
         #   LOOKUP -> None (void)
         #   QUERY_PREFETCH_STATUS -> hit_chunks (int) or None
         #   STORE / RETRIEVE (handle) -> (worker_id, True)
         #   PREPARE_* -> _FakePrep()
         #   COMMIT_* -> True
         #   END_SESSION -> None
-        def fake_response(req_type, payloads):
-            calls.append((req_type, payloads))
-            name = req_type.name
-            if name == "GET_CHUNK_SIZE":
+        def fake_response(method_name, payloads):
+            calls.append((method_name, payloads))
+            if method_name == "get_chunk_size":
                 return 16
-            if name == "QUERY_PREFETCH_STATUS":
+            if method_name == "query_prefetch_status":
                 # No cache hits -> only STORE side fires.
                 return 0
-            if name in ("STORE", "RETRIEVE"):
+            if method_name in ("store", "retrieve"):
                 return (0, True)
-            if name.startswith("PREPARE_"):
+            if method_name.startswith("prepare_"):
                 return _FakePrep()
-            if name.startswith("COMMIT_"):
+            if method_name.startswith("commit_"):
                 return True
             return None
 
@@ -1203,9 +1205,12 @@ class TestClientMultiWorker:
                 pass
 
         class FakeClient:
-            def submit_request(self, req_type, payloads, _response_cls=None):
-                value = fake_response(req_type, payloads)
-                return SimpleNamespace(result=lambda timeout=None: value)
+            def __getattr__(self, method_name):
+                def request(*payloads):
+                    value = fake_response(method_name, payloads)
+                    return SimpleNamespace(result=lambda timeout=None: value)
+
+                return request
 
             def close(self) -> None:
                 pass
@@ -1223,7 +1228,11 @@ class TestClientMultiWorker:
             fake_allocate,
         )
         monkeypatch.setattr(zmq, "Context", FakeContext)
-        monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *_args: FakeClient())
+        monkeypatch.setattr(
+            RequestClientFactory,
+            "create",
+            lambda *_args, **_kwargs: FakeClient(),
+        )
 
         kv_size = 1 if is_mla else 2
         bench_client = ServerBenchClient(
@@ -1272,8 +1281,8 @@ class TestClientMultiWorker:
         calls, result = self._run(monkeypatch, is_mla=True, tp_size=2)
         lookup, store_result = result
         # Extract STORE + RETRIEVE calls with their instance_id argument.
-        stores = [c for c in calls if c[0].name == "STORE"]
-        retrieves = [c for c in calls if c[0].name == "RETRIEVE"]
+        stores = [c for c in calls if c[0] == "store"]
+        retrieves = [c for c in calls if c[0] == "retrieve"]
         # MLA: rank 0 only.
         assert len(stores) == 1, "MLA tp=2 should STORE once (rank 0)"
         # payloads is [key, instance_id, block_ids, event_handle].
@@ -1305,7 +1314,7 @@ class TestClientMultiWorker:
     ) -> None:
         calls, result = self._run(monkeypatch, is_mla=False, tp_size=2)
         _lookup, store_result = result
-        stores = [c for c in calls if c[0].name == "STORE"]
+        stores = [c for c in calls if c[0] == "store"]
         # Non-MLA: every rank stores.
         assert len(stores) == 2
         # payloads is [key, instance_id, block_ids, event_handle].
@@ -1335,7 +1344,7 @@ class TestClientMultiWorker:
         tp: int,
     ) -> None:
         calls, _result = self._run(monkeypatch, is_mla=is_mla, tp_size=tp)
-        lookups = [c for c in calls if c[0].name == "LOOKUP"]
+        lookups = [c for c in calls if c[0] == "lookup"]
         assert len(lookups) == 1, (
             "LOOKUP should fire exactly once regardless of tp_size "
             "(is_mla=%s, tp=%d)" % (is_mla, tp)

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
@@ -21,6 +21,7 @@ from lmcache.v1.distributed.transfer_channel.api import (
     TransferChannelReadResult,
 )
 from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.transport import zmq_impl
 
 _LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 
@@ -57,7 +58,7 @@ def _adapter(lookup_timeout_s: float = 10.0, load_timeout_s: float = 10.0):
     notifier = MagicMock()
 
     with (
-        patch.object(p2p_mod, "MessageQueueClient", return_value=mq),
+        patch.object(zmq_impl, "MessageQueueClient", return_value=mq),
         patch.object(p2p_mod, "get_transfer_channel_context", return_value=tc_ctx),
         patch.object(p2p_mod, "PeriodicEventNotifier") as mock_pen,
     ):
@@ -132,7 +133,7 @@ def test_factory_creates_adapter():
     from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 
     with (
-        patch.object(p2p_mod, "MessageQueueClient", return_value=MagicMock()),
+        patch.object(zmq_impl, "MessageQueueClient", return_value=MagicMock()),
         patch.object(p2p_mod, "get_transfer_channel_context", return_value=MagicMock()),
         patch.object(p2p_mod, "PeriodicEventNotifier") as mock_pen,
     ):

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
@@ -20,8 +20,7 @@ from lmcache.v1.distributed.transfer_channel.api import (
     TransferChannelAddress,
     TransferChannelReadResult,
 )
-from lmcache.v1.multiprocess.protocol import RequestType
-from lmcache.v1.multiprocess.transport import zmq_impl
+from lmcache.v1.multiprocess.transport.base import RequestClient
 
 _LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 
@@ -48,7 +47,7 @@ class _FakeFuture:
 
 @contextmanager
 def _adapter(lookup_timeout_s: float = 10.0, load_timeout_s: float = 10.0):
-    mq = MagicMock()
+    req_client = MagicMock(spec=RequestClient)
     tc_ctx = MagicMock()
     tc_client = MagicMock()
     tc_ctx.get_transfer_channel_client.return_value = tc_client
@@ -58,7 +57,11 @@ def _adapter(lookup_timeout_s: float = 10.0, load_timeout_s: float = 10.0):
     notifier = MagicMock()
 
     with (
-        patch.object(zmq_impl, "MessageQueueClient", return_value=mq),
+        patch.object(
+            p2p_mod.RequestClientFactory,
+            "create",
+            return_value=req_client,
+        ),
         patch.object(p2p_mod, "get_transfer_channel_context", return_value=tc_ctx),
         patch.object(p2p_mod, "PeriodicEventNotifier") as mock_pen,
     ):
@@ -71,22 +74,9 @@ def _adapter(lookup_timeout_s: float = 10.0, load_timeout_s: float = 10.0):
         )
         adapter = P2PL2Adapter(config)
         try:
-            yield adapter, mq, tc_ctx, tc_client, notifier
+            yield adapter, req_client, tc_ctx, tc_client, notifier
         finally:
             adapter.close()
-
-
-def _lookup_side_effect(remote_task_id, addresses):
-    """submit_request dispatcher keyed on request type."""
-
-    def _dispatch(request_type, payloads, response_cls=None):
-        if request_type == RequestType.P2P_LOOKUP_AND_LOCK:
-            return _FakeFuture(value=remote_task_id)
-        if request_type == RequestType.P2P_QUERY_LOOKUP_RESULTS:
-            return _FakeFuture(value=addresses)
-        return _FakeFuture(value=None)
-
-    return _dispatch
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +123,11 @@ def test_factory_creates_adapter():
     from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 
     with (
-        patch.object(zmq_impl, "MessageQueueClient", return_value=MagicMock()),
+        patch.object(
+            p2p_mod.RequestClientFactory,
+            "create",
+            return_value=MagicMock(spec=RequestClient),
+        ),
         patch.object(p2p_mod, "get_transfer_channel_context", return_value=MagicMock()),
         patch.object(p2p_mod, "PeriodicEventNotifier") as mock_pen,
     ):
@@ -176,18 +170,17 @@ def test_lookup_forwards_group_layout_descs_and_returns_addresses():
         TransferChannelAddress(offset=200, size=20),
         TransferChannelAddress(offset=-1, size=0),  # not found on peer
     ]
-    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
-        mq.submit_request.side_effect = _lookup_side_effect(42, addresses)
+    with _adapter() as (adapter, req_client, _tc_ctx, _tc, _notifier):
+        req_client.p2p_lookup_and_lock.return_value = _FakeFuture(value=42)
+        req_client.p2p_query_lookup_results.return_value = _FakeFuture(value=addresses)
 
         group_layout_descs = {0: _LAYOUT}
         task_id = adapter.submit_lookup_and_lock_task(keys, group_layout_descs)
 
         # The real group_layout_descs dict is forwarded into the lookup
         # payload.
-        lookup_call = mq.submit_request.call_args_list[0]
-        assert lookup_call.args[0] == RequestType.P2P_LOOKUP_AND_LOCK
-        assert lookup_call.args[1] == [keys, group_layout_descs]
-        assert lookup_call.args[1][1] is group_layout_descs
+        req_client.p2p_lookup_and_lock.assert_called_once_with(keys, group_layout_descs)
+        assert req_client.p2p_lookup_and_lock.call_args.args[1] is group_layout_descs
 
         bitmap = adapter.query_lookup_and_lock_result(task_id)
         assert bitmap is not None
@@ -204,17 +197,12 @@ def test_lookup_forwards_group_layout_descs_and_returns_addresses():
 def test_lookup_query_not_ready_then_ready():
     keys = [_key(0)]
     addresses = [TransferChannelAddress(offset=100, size=10)]
-    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
+    with _adapter() as (adapter, req_client, _tc_ctx, _tc, _notifier):
         responses = iter([_FakeFuture(value=None), _FakeFuture(value=addresses)])
-
-        def _dispatch(request_type, payloads, response_cls=None):
-            if request_type == RequestType.P2P_LOOKUP_AND_LOCK:
-                return _FakeFuture(value=7)
-            if request_type == RequestType.P2P_QUERY_LOOKUP_RESULTS:
-                return next(responses)
-            return _FakeFuture(value=None)
-
-        mq.submit_request.side_effect = _dispatch
+        req_client.p2p_lookup_and_lock.return_value = _FakeFuture(value=7)
+        req_client.p2p_query_lookup_results.side_effect = lambda _task_id: next(
+            responses
+        )
         task_id = adapter.submit_lookup_and_lock_task(keys, {0: _LAYOUT})
 
         # First pulse: peer not ready yet.
@@ -226,36 +214,28 @@ def test_lookup_query_not_ready_then_ready():
 
 def test_lookup_submit_timeout_yields_miss():
     keys = [_key(0), _key(1)]
-    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
-
-        def _dispatch(request_type, payloads, response_cls=None):
-            if request_type == RequestType.P2P_LOOKUP_AND_LOCK:
-                return _FakeFuture(exc=TimeoutError())
-            return _FakeFuture(value=None)
-
-        mq.submit_request.side_effect = _dispatch
+    with _adapter() as (adapter, req_client, _tc_ctx, _tc, _notifier):
+        req_client.p2p_lookup_and_lock.return_value = _FakeFuture(exc=TimeoutError())
         task_id = adapter.submit_lookup_and_lock_task(keys, {0: _LAYOUT})
 
         bitmap = adapter.query_lookup_and_lock_result(task_id)
         assert bitmap is not None
         assert bitmap.popcount() == 0
         # No P2P_QUERY_LOOKUP_RESULTS was issued for a failed lookup.
-        assert all(
-            c.args[0] != RequestType.P2P_QUERY_LOOKUP_RESULTS
-            for c in mq.submit_request.call_args_list
-        )
+        req_client.p2p_query_lookup_results.assert_not_called()
 
 
 def test_lookup_deadline_expired_yields_miss():
     keys = [_key(0)]
-    with _adapter(lookup_timeout_s=0.01) as (adapter, mq, _tc_ctx, _tc, _notifier):
+    with _adapter(lookup_timeout_s=0.01) as (
+        adapter,
+        req_client,
+        _tc_ctx,
+        _tc,
+        _notifier,
+    ):
         # Lookup id resolves, but the query is never ready before the deadline.
-        def _dispatch(request_type, payloads, response_cls=None):
-            if request_type == RequestType.P2P_LOOKUP_AND_LOCK:
-                return _FakeFuture(value=7)
-            return _FakeFuture(value=None)
-
-        mq.submit_request.side_effect = _dispatch
+        req_client.p2p_lookup_and_lock.return_value = _FakeFuture(value=7)
         task_id = adapter.submit_lookup_and_lock_task(keys, {0: _LAYOUT})
         time.sleep(0.02)
         bitmap = adapter.query_lookup_and_lock_result(task_id)
@@ -340,19 +320,17 @@ def test_load_deadline_expired_yields_failure():
 
 def test_unlock_sends_rpc_and_clears_addresses():
     keys = [_key(0), _key(1)]
-    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
+    with _adapter() as (adapter, req_client, _tc_ctx, _tc, _notifier):
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=1, size=1)
         adapter.submit_unlock(keys)
-        unlock_call = mq.submit_request.call_args
-        assert unlock_call.args[0] == RequestType.P2P_UNLOCK_OBJECTS
-        assert unlock_call.args[1] == [keys]
+        req_client.p2p_unlock_objects.assert_called_once_with(keys)
         assert keys[0] not in adapter._remote_addresses
 
 
 def test_unlock_empty_is_noop():
-    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
+    with _adapter() as (adapter, req_client, _tc_ctx, _tc, _notifier):
         adapter.submit_unlock([])
-        mq.submit_request.assert_not_called()
+        req_client.p2p_unlock_objects.assert_not_called()
 
 
 def test_store_completes_immediately_without_leaking():
@@ -404,22 +382,22 @@ def test_report_status():
 
 
 def test_close_unregisters_fds_and_closes_client():
-    with _adapter() as (adapter, mq, tc_ctx, _tc, notifier):
+    with _adapter() as (adapter, req_client, tc_ctx, _tc, notifier):
         lookup_fd = adapter.get_lookup_and_lock_event_fd()
         load_fd = adapter.get_load_event_fd()
         adapter.close()
         unregistered = {c.args[0] for c in notifier.unregister_fd.call_args_list}
         assert lookup_fd in unregistered
         assert load_fd in unregistered
-        mq.close.assert_called()
+        req_client.close.assert_called()
         # The transfer-channel client is dropped from the context on close.
         tc_ctx.remove_transfer_channel_client.assert_called_once_with("peer:7600")
 
 
 def test_close_is_idempotent():
-    with _adapter() as (adapter, mq, tc_ctx, _tc, _notifier):
+    with _adapter() as (adapter, req_client, tc_ctx, _tc, _notifier):
         adapter.close()
         adapter.close()
         # The second close is a no-op: no duplicate teardown of shared resources.
-        mq.close.assert_called_once()
+        req_client.close.assert_called_once()
         tc_ctx.remove_transfer_channel_client.assert_called_once_with("peer:7600")

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -25,12 +25,9 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
 )
-from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import (
-    RequestType,
-    get_response_class,
-)
 from lmcache.v1.multiprocess.server import run_cache_server
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
 
 # Configuration constants
@@ -157,7 +154,7 @@ BLOCKS_PER_KEY = 16
 
 
 def lookup_all(
-    client: MessageQueueClient,
+    client: RequestClient,
     keys: list[IPCCacheServerKey],
     timeout: float = DEFAULT_TIMEOUT,
 ) -> int:
@@ -170,18 +167,12 @@ def lookup_all(
     for key in keys:
         lookup_key = key.no_worker_id_version()
         # Phase 1: Submit lookup (server tracks by request_id, returns None)
-        client.submit_request(
-            RequestType.LOOKUP,
-            [lookup_key, 1],
-            get_response_class(RequestType.LOOKUP),
-        ).result(timeout=timeout)
+        client.lookup(lookup_key, 1).result(timeout=timeout)
         # Phase 2: Poll by request_id until done
         while True:
-            result = client.submit_request(
-                RequestType.QUERY_PREFETCH_STATUS,
-                [lookup_key.request_id],
-                get_response_class(RequestType.QUERY_PREFETCH_STATUS),
-            ).result(timeout=timeout)
+            result = client.query_prefetch_status(lookup_key.request_id).result(
+                timeout=timeout
+            )
             if result is not None:
                 total += result
                 break
@@ -208,7 +199,7 @@ def _recorded_event_handle() -> bytes:
 
 
 def store_keys(
-    client: MessageQueueClient,
+    client: RequestClient,
     keys: list[IPCCacheServerKey],
     instance_id: int,
     gpu_block_ids: list[int],
@@ -220,17 +211,13 @@ def store_keys(
         start = i * BLOCKS_PER_KEY
         end = start + BLOCKS_PER_KEY
         block_ids = gpu_block_ids[start:end]
-        future = client.submit_request(
-            RequestType.STORE,
-            [key, instance_id, [block_ids], event_handle],
-            get_response_class(RequestType.STORE),
-        )
+        future = client.store(key, instance_id, [block_ids], event_handle)
         result = future.to_device_future().result(timeout=timeout)
         assert result is True, f"Store should succeed for key {i}"
 
 
 def retrieve_keys(
-    client: MessageQueueClient,
+    client: RequestClient,
     keys: list[IPCCacheServerKey],
     instance_id: int,
     gpu_block_ids: list[int],
@@ -243,11 +230,7 @@ def retrieve_keys(
         start = i * BLOCKS_PER_KEY
         end = start + BLOCKS_PER_KEY
         block_ids = gpu_block_ids[start:end]
-        future = client.submit_request(
-            RequestType.RETRIEVE,
-            [key, instance_id, [block_ids], event_handle, 0],
-            get_response_class(RequestType.RETRIEVE),
-        )
+        future = client.retrieve(key, instance_id, [block_ids], event_handle, 0)
         result = future.to_device_future().result(timeout=timeout)
         results.append(result)
     return results
@@ -318,11 +301,11 @@ def zmq_context() -> Generator[zmq.Context, None, None]:
 @pytest.fixture(scope="function")
 def client(
     server_process: mp.Process, zmq_context: zmq.Context
-) -> Generator[MessageQueueClient, None, None]:
+) -> Generator[RequestClient, None, None]:
     """
     Fixture that provides a message queue client for each test function.
     """
-    client = MessageQueueClient(server_url=SERVER_URL, context=zmq_context)
+    client = RequestClientFactory.create(SERVER_URL, context=zmq_context)
     yield client
     # Client cleanup
     client.close()
@@ -344,7 +327,7 @@ def client_context() -> Generator[ClientContext, None, None]:
 
 @pytest.fixture(scope="function")
 def registered_instance(
-    client: MessageQueueClient, client_context: ClientContext
+    client: RequestClient, client_context: ClientContext
 ) -> Generator[int, None, None]:
     """
     Fixture that registers a KV cache instance and returns the instance ID.
@@ -355,18 +338,14 @@ def registered_instance(
     # Register KV cache. No engine group infos are sent, so the server
     # detects ``slots_per_block`` from the tensors and treats every group
     # as uncompressed (``compress_ratio == 1``).
-    future = client.submit_request(
-        RequestType.REGISTER_KV_CACHE,
-        [
-            instance_id,
-            client_context.get_kv_cache(),
-            "testmodel",
-            1,
-            EngineType.VLLM,
-            {},
-            [],
-        ],
-        get_response_class(RequestType.REGISTER_KV_CACHE),
+    future = client.register_kv_cache(
+        instance_id,
+        client_context.get_kv_cache(),
+        "testmodel",
+        1,
+        EngineType.VLLM,
+        {},
+        [],
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
     assert result is None, "Register should return None"
@@ -375,14 +354,8 @@ def registered_instance(
 
     # Unregister KV cache
     try:
-        client.submit_request(
-            RequestType.CLEAR, [], get_response_class(RequestType.CLEAR)
-        ).result(timeout=DEFAULT_TIMEOUT)
-        future = client.submit_request(
-            RequestType.UNREGISTER_KV_CACHE,
-            [instance_id],
-            get_response_class(RequestType.UNREGISTER_KV_CACHE),
-        )
+        client.clear().result(timeout=DEFAULT_TIMEOUT)
+        future = client.unregister_kv_cache(instance_id)
         future.result(timeout=DEFAULT_TIMEOUT)
     except Exception as e:
         print(f"Error during unregister: {e}")
@@ -401,7 +374,7 @@ def test_server_running(server_process: mp.Process):
 
 
 def test_register_unregister_kv_cache(
-    client: MessageQueueClient, client_context: ClientContext
+    client: RequestClient, client_context: ClientContext
 ):
     """
     Test registering and unregistering a KV cache.
@@ -410,34 +383,26 @@ def test_register_unregister_kv_cache(
 
     # Register. No engine group infos: geometry is detected from the
     # tensors (uncompressed).
-    future = client.submit_request(
-        RequestType.REGISTER_KV_CACHE,
-        [
-            instance_id,
-            client_context.get_kv_cache(),
-            "testmodel",
-            1,
-            EngineType.VLLM,
-            {},
-            [],
-        ],
-        get_response_class(RequestType.REGISTER_KV_CACHE),
+    future = client.register_kv_cache(
+        instance_id,
+        client_context.get_kv_cache(),
+        "testmodel",
+        1,
+        EngineType.VLLM,
+        {},
+        [],
     )
     result = future.result(timeout=DEFAULT_TIMEOUT)
     assert result is None
 
     # Unregister
-    future = client.submit_request(
-        RequestType.UNREGISTER_KV_CACHE,
-        [instance_id],
-        get_response_class(RequestType.UNREGISTER_KV_CACHE),
-    )
+    future = client.unregister_kv_cache(instance_id)
     result = future.result(timeout=DEFAULT_TIMEOUT)
     assert result is None
 
 
 def test_store_and_lookup(
-    client: MessageQueueClient,
+    client: RequestClient,
     client_context: ClientContext,
     registered_instance: int,
 ):
@@ -463,7 +428,7 @@ def test_store_and_lookup(
 
 
 def test_store_fails_closed_on_incomplete_block_ids(
-    client: MessageQueueClient,
+    client: RequestClient,
     client_context: ClientContext,
     registered_instance: int,
 ):
@@ -486,15 +451,11 @@ def test_store_fails_closed_on_incomplete_block_ids(
     event_handle = _recorded_event_handle()
 
     result = (
-        client.submit_request(
-            RequestType.STORE,
-            [
-                key,
-                registered_instance,
-                [list(range(BLOCKS_PER_KEY // 2))],
-                event_handle,
-            ],
-            get_response_class(RequestType.STORE),
+        client.store(
+            key,
+            registered_instance,
+            [list(range(BLOCKS_PER_KEY // 2))],
+            event_handle,
         )
         .to_device_future()
         .result(timeout=DEFAULT_TIMEOUT)
@@ -504,7 +465,7 @@ def test_store_fails_closed_on_incomplete_block_ids(
 
 
 def test_store_retrieve_verify(
-    client: MessageQueueClient,
+    client: RequestClient,
     client_context: ClientContext,
     registered_instance: int,
 ):
@@ -555,7 +516,7 @@ def test_store_retrieve_verify(
 
 
 def test_retrieve_partial_miss(
-    client: MessageQueueClient,
+    client: RequestClient,
     client_context: ClientContext,
     registered_instance: int,
 ):
@@ -613,7 +574,7 @@ def test_retrieve_partial_miss(
 
 
 def test_multiple_retrieve_operations(
-    client: MessageQueueClient,
+    client: RequestClient,
     client_context: ClientContext,
     registered_instance: int,
 ):
@@ -694,7 +655,7 @@ def test_multiple_retrieve_operations(
 
 
 def test_multiple_store_operations(
-    client: MessageQueueClient,
+    client: RequestClient,
     client_context: ClientContext,
     registered_instance: int,
 ):
@@ -721,15 +682,11 @@ def test_multiple_store_operations(
 
 
 def test_get_chunk_size(
-    client: MessageQueueClient,
+    client: RequestClient,
 ):
     """
     Test retrieving the chunk size from the server.
     """
-    chunk_size = client.submit_request(
-        RequestType.GET_CHUNK_SIZE,
-        [],
-        get_response_class(RequestType.GET_CHUNK_SIZE),
-    ).result(timeout=DEFAULT_TIMEOUT)
+    chunk_size = client.get_chunk_size().result(timeout=DEFAULT_TIMEOUT)
 
     assert chunk_size == CHUNK_SIZE, f"Chunk size should be {CHUNK_SIZE}"

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -74,20 +74,31 @@ def test_only_zmq_transport_layer_submits_request_envelopes() -> None:
     assert violations == []
 
 
-def test_production_callers_create_clients_through_factory() -> None:
-    """Transport implementations must not leak into business callers."""
+def test_business_callers_create_clients_through_factory() -> None:
+    """Transport implementations must not leak into business callers or tests."""
     repo_root = Path(__file__).parents[3]
     transport_root = repo_root / "lmcache/v1/multiprocess/transport"
+    implementation_tests = {
+        repo_root / "tests/v1/multiprocess/test_client.py",
+        repo_root / "tests/v1/multiprocess/test_mq.py",
+    }
     violations: list[str] = []
-    for path in (repo_root / "lmcache").rglob("*.py"):
-        if path.is_relative_to(transport_root):
-            continue
-        tree = ast.parse(path.read_text())
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.ImportFrom) or node.module is None:
+    for source_root in (repo_root / "lmcache", repo_root / "tests"):
+        for path in source_root.rglob("*.py"):
+            if path.is_relative_to(transport_root) or path in implementation_tests:
                 continue
-            if node.module.startswith("lmcache.v1.multiprocess.transport.zmq_impl"):
-                violations.append(f"{path.relative_to(repo_root)}:{node.lineno}")
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom) or node.module is None:
+                    continue
+                imports_raw_client = (
+                    node.module == "lmcache.v1.multiprocess.mq"
+                    and any(alias.name == "MessageQueueClient" for alias in node.names)
+                )
+                if imports_raw_client or node.module.startswith(
+                    "lmcache.v1.multiprocess.transport.zmq_impl"
+                ):
+                    violations.append(f"{path.relative_to(repo_root)}:{node.lineno}")
 
     assert violations == []
 

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -70,6 +70,24 @@ def test_only_zmq_transport_layer_submits_request_envelopes() -> None:
     assert violations == []
 
 
+def test_production_callers_create_clients_through_factory() -> None:
+    """Transport implementations must not leak into business callers."""
+    repo_root = Path(__file__).parents[3]
+    transport_root = repo_root / "lmcache/v1/multiprocess/transport"
+    violations: list[str] = []
+    for path in (repo_root / "lmcache").rglob("*.py"):
+        if path.is_relative_to(transport_root):
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module is None:
+                continue
+            if node.module.startswith("lmcache.v1.multiprocess.transport.zmq_impl"):
+                violations.append(f"{path.relative_to(repo_root)}:{node.lineno}")
+
+    assert violations == []
+
+
 def test_named_rpc_method_delegates_to_zmq_request_envelope() -> None:
     transport = _RecordingMessageQueueClient()
     client = ZmqMultiprocessClient(transport)

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -51,6 +51,10 @@ def test_all_request_types_have_explicit_named_methods() -> None:
     assert "submit_request" not in ZmqMultiprocessClient.__dict__
 
 
+def test_zmq_client_explicitly_inherits_shared_contract() -> None:
+    assert RequestClient in ZmqMultiprocessClient.__bases__
+
+
 def test_only_zmq_transport_layer_submits_request_envelopes() -> None:
     """Business callers must use named methods instead of ZMQ envelopes."""
     repo_root = Path(__file__).parents[3]

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -11,7 +11,6 @@ import threading
 # First Party
 from lmcache.v1.distributed.api import AttnWindowDesc
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
     RequestType,
     get_handler_type,
@@ -19,7 +18,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_response_class,
 )
 from lmcache.v1.multiprocess.protocols.base import HandlerType
-from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
+from lmcache.v1.multiprocess.transport.base import RequestClient
 
 # Test helpers
 from tests.v1.multiprocess import test_mq_handler_helpers
@@ -309,10 +308,10 @@ def test_adapter_free_lookup_locks_sends_request():
     adapter._server_urls = ["tcp://test:0"]
     adapter._mq_timeout = 30.0
 
-    mock_client = MagicMock(spec=MessageQueueClient)
+    mock_client = MagicMock(spec=RequestClient)
     mock_future = MagicMock()
-    mock_client.submit_request.return_value = mock_future
-    adapter.req_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
+    mock_client.free_lookup_locks.return_value = mock_future
+    adapter.req_clients = {"tcp://test:0": mock_client}
     adapter._pending_lookups = set()
 
     token_ids = list(range(512))
@@ -324,23 +323,14 @@ def test_adapter_free_lookup_locks_sends_request():
         request_configs={"lmcache.skip_save": True},
     )
 
-    mock_client.submit_request.assert_called_once()
-    call_args = mock_client.submit_request.call_args
-    req_type = call_args[0][0]
-    payloads = call_args[0][1]
-    assert req_type == RequestType.FREE_LOOKUP_LOCKS
-
-    # Payload should be [key, tp_size]
-    assert isinstance(payloads, list)
-    assert len(payloads) == 2
-
-    key = payloads[0]
+    mock_client.free_lookup_locks.assert_called_once()
+    key, tp_size = mock_client.free_lookup_locks.call_args.args
     assert isinstance(key, IPCCacheServerKey)
     assert key.worker_id is None
     assert key.model_name == "test_model"
     assert key.request_id == "req-1"
     assert key.request_configs == {"lmcache.skip_save": True}
-    assert payloads[1] == 1  # tp_size
+    assert tp_size == 1
 
 
 def test_adapter_free_lookup_locks_key_matches_lookup():
@@ -365,11 +355,12 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
     adapter._heartbeat_lock = threading.Lock()
     adapter._heartbeat_interval = 5.0
 
-    mock_client = MagicMock(spec=MessageQueueClient)
+    mock_client = MagicMock(spec=RequestClient)
     mock_future = MagicMock()
     mock_future.result.return_value = None  # LOOKUP returns None
-    mock_client.submit_request.return_value = mock_future
-    adapter.req_clients = {"tcp://test:0": ZmqMultiprocessClient(mock_client)}
+    mock_client.lookup.return_value = mock_future
+    mock_client.free_lookup_locks.return_value = mock_future
+    adapter.req_clients = {"tcp://test:0": mock_client}
     adapter._pending_lookups = set()
     adapter._lookup_params = {}
 
@@ -382,11 +373,9 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
             token_ids,
             request_configs={"lmcache.skip_save": True},
         )
-    lookup_call = mock_client.submit_request.call_args
-    lookup_payloads = lookup_call[0][1]
-    lookup_key = lookup_payloads[0]
+    lookup_key = mock_client.lookup.call_args.args[0]
 
-    mock_client.submit_request.reset_mock()
+    mock_client.reset_mock()
 
     # Submit free_lookup_locks with aligned end
     tokens_per_chunk = adapter.lmcache_tokens_per_chunk
@@ -398,11 +387,8 @@ def test_adapter_free_lookup_locks_key_matches_lookup():
         request_id="req-1",
         request_configs={"lmcache.skip_save": True},
     )
-    free_call = mock_client.submit_request.call_args
-    free_payloads = free_call[0][1]
-    assert len(free_payloads) == 2
-    free_key = free_payloads[0]
-    assert free_payloads[1] == 1  # tp_size
+    free_key, tp_size = mock_client.free_lookup_locks.call_args.args
+    assert tp_size == 1
 
     # Keys should be identical
     assert lookup_key.model_name == free_key.model_name

--- a/tests/v1/multiprocess/test_futures.py
+++ b/tests/v1/multiprocess/test_futures.py
@@ -99,6 +99,18 @@ def test_messaging_future_basic_usage():
     assert result == 42, f"Expected result 42, got {result}"
 
 
+def test_messaging_future_propagates_request_exception():
+    """A transport failure is raised when the future result is consumed."""
+    future = MessagingFuture[int]()
+    error = RuntimeError("request failed")
+
+    future.set_exception(error)
+
+    assert future.query()
+    with pytest.raises(RuntimeError, match="request failed"):
+        future.result()
+
+
 def test_messaging_future_with_thread():
     """Test MessagingFuture with result set from another thread."""
     future = MessagingFuture[str]()

--- a/tests/v1/multiprocess/test_transport_factory.py
+++ b/tests/v1/multiprocess/test_transport_factory.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for scheme-based multiprocess request client selection."""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.transport import grpc_impl, zmq_impl
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
+
+
+@pytest.mark.parametrize(
+    ("server_url", "normalized_url"),
+    [
+        ("localhost:5555", "tcp://localhost:5555"),
+        ("TCP://localhost:5555", "tcp://localhost:5555"),
+        ("ipc:///tmp/lmcache.sock", "ipc:///tmp/lmcache.sock"),
+        ("inproc://lmcache", "inproc://lmcache"),
+    ],
+)
+def test_factory_selects_zmq_by_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+    server_url: str,
+    normalized_url: str,
+) -> None:
+    client = MagicMock(name="zmq_request_client")
+    create = MagicMock(return_value=client)
+    context = object()
+    monkeypatch.setattr(zmq_impl, "create_request_client", create)
+
+    result = RequestClientFactory.create(server_url, context=context)
+
+    assert result is client
+    create.assert_called_once_with(normalized_url, context=context)
+
+
+@pytest.mark.parametrize(
+    ("server_url", "normalized_url"),
+    [
+        ("grpc://localhost:5555", "grpc://localhost:5555"),
+        ("GRPC+UNIX:///tmp/lmcache.sock", "grpc+unix:///tmp/lmcache.sock"),
+    ],
+)
+def test_factory_selects_grpc_by_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+    server_url: str,
+    normalized_url: str,
+) -> None:
+    client = MagicMock(name="grpc_request_client")
+    create = MagicMock(return_value=client)
+    context = object()
+    monkeypatch.setattr(grpc_impl, "create_request_client", create)
+
+    result = RequestClientFactory.create(server_url, context=context)
+
+    assert result is client
+    create.assert_called_once_with(normalized_url, context=context)
+
+
+def test_factory_reports_unavailable_grpc_implementation() -> None:
+    with pytest.raises(NotImplementedError, match="not available yet"):
+        RequestClientFactory.create("grpc://localhost:5555")
+
+
+@pytest.mark.parametrize("server_url", ["", "grpc://", "http://localhost:5555"])
+def test_factory_rejects_invalid_or_unsupported_urls(server_url: str) -> None:
+    with pytest.raises(ValueError):
+        RequestClientFactory.create(server_url)

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -23,6 +23,7 @@ from lmcache.v1.gpu_connector.kv_format import detect_format
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.transport import zmq_impl
 import lmcache.lmcache_native as lmcache_native
 
 
@@ -87,7 +88,7 @@ class _FakeEvent:
 @pytest.fixture(autouse=True)
 def _use_named_client_mock(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep constructor mocks at the method-oriented client boundary."""
-    monkeypatch.setattr(atom_adapter, "ZmqMultiprocessClient", lambda client: client)
+    monkeypatch.setattr(zmq_impl, "ZmqMultiprocessClient", lambda client: client)
 
 
 @pytest.fixture
@@ -97,7 +98,7 @@ def worker_with_transfer_context(
     """Construct a worker with its MQ and transfer boundaries stubbed."""
     client = MagicMock(name="req_client")
     transfer_context = MagicMock(name="transfer_context")
-    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     monkeypatch.setattr(
         atom_adapter,
@@ -176,7 +177,7 @@ def test_atom_lookup_submits_valid_reader_count(
     future: MessagingFuture[None] = MessagingFuture()
     future.set_result(None)
     client.lookup.return_value = future
-    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     scheduler = AtomMPSchedulerAdapter(
         server_url="tcp://127.0.0.1:5555",
@@ -341,7 +342,7 @@ def test_atom_adapter_constructor_closes_client_on_failure(
 ) -> None:
     """GET_CHUNK_SIZE and validation failures do not leak the MQ client."""
     client = MagicMock(name="req_client")
-    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
     if failure_kind == "chunk_query":
         monkeypatch.setattr(
             atom_adapter,
@@ -367,7 +368,7 @@ def test_atom_constructor_preserves_error_when_client_close_fails(
     """Cleanup errors cannot replace the constructor's original failure."""
     client = MagicMock(name="req_client")
     client.close.side_effect = RuntimeError("close failed")
-    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(
         atom_adapter,
         "_get_chunk_size",
@@ -673,7 +674,7 @@ def test_atom_shutdown_discards_late_recovery_registration(
 
     recovery_context.register.side_effect = delayed_register
     contexts = iter([initial_context, recovery_context])
-    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     monkeypatch.setattr(
         atom_adapter,
@@ -743,7 +744,7 @@ def test_atom_heartbeat_publish_and_start_are_one_lifecycle_transition(
 
     client = MagicMock(name="req_client")
     transfer_context = MagicMock(name="transfer_context")
-    monkeypatch.setattr(atom_adapter, "MessageQueueClient", lambda *args: client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     monkeypatch.setattr(
         atom_adapter,

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -23,7 +23,6 @@ from lmcache.v1.gpu_connector.kv_format import detect_format
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-from lmcache.v1.multiprocess.transport import zmq_impl
 import lmcache.lmcache_native as lmcache_native
 
 
@@ -85,10 +84,14 @@ class _FakeEvent:
         del stream
 
 
-@pytest.fixture(autouse=True)
-def _use_named_client_mock(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep constructor mocks at the method-oriented client boundary."""
-    monkeypatch.setattr(zmq_impl, "ZmqMultiprocessClient", lambda client: client)
+def _patch_request_client_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    client: MagicMock,
+) -> None:
+    """Make the transport-neutral factory return the supplied client."""
+    factory = MagicMock(name="request_client_factory")
+    factory.create.return_value = client
+    monkeypatch.setattr(atom_adapter, "RequestClientFactory", factory)
 
 
 @pytest.fixture
@@ -98,7 +101,7 @@ def worker_with_transfer_context(
     """Construct a worker with its MQ and transfer boundaries stubbed."""
     client = MagicMock(name="req_client")
     transfer_context = MagicMock(name="transfer_context")
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
+    _patch_request_client_factory(monkeypatch, client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     monkeypatch.setattr(
         atom_adapter,
@@ -177,7 +180,7 @@ def test_atom_lookup_submits_valid_reader_count(
     future: MessagingFuture[None] = MessagingFuture()
     future.set_result(None)
     client.lookup.return_value = future
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
+    _patch_request_client_factory(monkeypatch, client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     scheduler = AtomMPSchedulerAdapter(
         server_url="tcp://127.0.0.1:5555",
@@ -342,7 +345,7 @@ def test_atom_adapter_constructor_closes_client_on_failure(
 ) -> None:
     """GET_CHUNK_SIZE and validation failures do not leak the MQ client."""
     client = MagicMock(name="req_client")
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
+    _patch_request_client_factory(monkeypatch, client)
     if failure_kind == "chunk_query":
         monkeypatch.setattr(
             atom_adapter,
@@ -368,7 +371,7 @@ def test_atom_constructor_preserves_error_when_client_close_fails(
     """Cleanup errors cannot replace the constructor's original failure."""
     client = MagicMock(name="req_client")
     client.close.side_effect = RuntimeError("close failed")
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
+    _patch_request_client_factory(monkeypatch, client)
     monkeypatch.setattr(
         atom_adapter,
         "_get_chunk_size",
@@ -674,7 +677,7 @@ def test_atom_shutdown_discards_late_recovery_registration(
 
     recovery_context.register.side_effect = delayed_register
     contexts = iter([initial_context, recovery_context])
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
+    _patch_request_client_factory(monkeypatch, client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     monkeypatch.setattr(
         atom_adapter,
@@ -744,7 +747,7 @@ def test_atom_heartbeat_publish_and_start_are_one_lifecycle_transition(
 
     client = MagicMock(name="req_client")
     transfer_context = MagicMock(name="transfer_context")
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *args: client)
+    _patch_request_client_factory(monkeypatch, client)
     monkeypatch.setattr(atom_adapter, "_get_chunk_size", lambda *args: 256)
     monkeypatch.setattr(
         atom_adapter,

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -19,6 +19,7 @@ import torch
 
 # First Party
 from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.transport import zmq_impl
 
 pytestmark = pytest.mark.sglang
 
@@ -224,11 +225,11 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
         SimpleNamespace(Context=SimpleNamespace(instance=lambda: object())),
     )
     monkeypatch.setattr(
-        adapter_mod,
+        zmq_impl,
         "MessageQueueClient",
         lambda _endpoint, _context: object(),
     )
-    monkeypatch.setattr(adapter_mod, "ZmqMultiprocessClient", lambda _raw: req_client)
+    monkeypatch.setattr(zmq_impl, "ZmqMultiprocessClient", lambda _raw: req_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
     monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
     monkeypatch.setattr(

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -19,7 +19,6 @@ import torch
 
 # First Party
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.transport import zmq_impl
 
 pytestmark = pytest.mark.sglang
 
@@ -224,12 +223,13 @@ def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
         "zmq",
         SimpleNamespace(Context=SimpleNamespace(instance=lambda: object())),
     )
+    request_client_factory = MagicMock(name="request_client_factory")
+    request_client_factory.create.return_value = req_client
     monkeypatch.setattr(
-        zmq_impl,
-        "MessageQueueClient",
-        lambda _endpoint, _context: object(),
+        adapter_mod,
+        "RequestClientFactory",
+        request_client_factory,
     )
-    monkeypatch.setattr(zmq_impl, "ZmqMultiprocessClient", lambda _raw: req_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
     monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
     monkeypatch.setattr(

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -26,8 +26,7 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
     ParallelStrategy,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-from lmcache.v1.multiprocess.protocol import RequestType
-from lmcache.v1.multiprocess.transport import zmq_impl
+from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.platform.isolated_ipc import is_isolated_ipc, set_isolated_ipc
 
 
@@ -145,21 +144,39 @@ def _patch_transfer_context_factory(
     return contexts
 
 
+def _patch_request_client_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    client: MagicMock,
+) -> None:
+    """Make the transport-neutral factory return the supplied client."""
+    factory = MagicMock(name="request_client_factory")
+    factory.create.return_value = client
+    monkeypatch.setattr(adapter_mod, "RequestClientFactory", factory)
+
+
+def _return_future_from_request_methods(
+    client: MagicMock,
+    future: MagicMock,
+) -> None:
+    """Configure every request method on a client mock with one future."""
+    for name, method in RequestClient.__dict__.items():
+        if not name.startswith("_") and name != "close" and callable(method):
+            getattr(client, name).return_value = future
+
+
 @pytest.fixture
 def fake_adapter(monkeypatch):
     """Build an adapter with the network boundary stubbed. Returns
-    ``(adapter, send_mock, future)``; ``future.result()`` defaults to succeed.
+    ``(adapter, req_client, future)``; ``future.result()`` defaults to succeed.
     ``HeartbeatThread`` is replaced by ``FakeHeartbeatThread``."""
-    # Stub the raw ZMQ boundary so facade calls do not touch a real socket.
-    fake_client = MagicMock(name="req_client")
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *a, **kw: fake_client)
+    req_client = MagicMock(name="req_client", spec=RequestClient)
+    _patch_request_client_factory(monkeypatch, req_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
 
     future = MagicMock(name="future")
     future.result.return_value = None
-    send_mock = MagicMock(name="submit_request", return_value=future)
-    fake_client.submit_request = send_mock
+    _return_future_from_request_methods(req_client, future)
 
     FakeHeartbeatThread.instances.clear()
     FakeHeartbeatThread.start_hook = None
@@ -182,15 +199,13 @@ def fake_adapter(monkeypatch):
     )
 
     adapter = _make_worker_adapter()
-    # __init__ issues exactly one MQ call (the chunk-size query). Reset
-    # so individual tests start with a clean call count.
-    send_mock.reset_mock()
-    return adapter, send_mock, future
+    req_client.reset_mock()
+    return adapter, req_client, future
 
 
 def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
     """Public register_kv_caches stores the dict and submits one request."""
-    adapter, send_mock, _ = fake_adapter
+    adapter, req_client, _ = fake_adapter
     fake_tensor = MagicMock()
     fake_tensor.device.type = "cuda"
     new_caches = {"layer.0": fake_tensor, "layer.1": fake_tensor}
@@ -198,9 +213,7 @@ def test_register_kv_caches_updates_kv_caches_and_submits(fake_adapter):
     adapter.register_kv_caches(new_caches)
 
     assert adapter.kv_caches is new_caches
-    assert send_mock.call_count == 1
-    args, _kwargs = send_mock.call_args
-    assert args[0] == RequestType.REGISTER_KV_CACHE
+    req_client.register_kv_cache.assert_called_once()
 
 
 def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
@@ -218,7 +231,7 @@ def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     fake_adapter, monkeypatch
 ):
     """CPU-only capability fallback registers without requiring an event."""
-    adapter, send_mock, _ = fake_adapter
+    adapter, req_client, _ = fake_adapter
     monkeypatch.setattr(
         "lmcache.v1.multiprocess.transfer_context.worker_transfer._supports_async_primitives",
         lambda: False,
@@ -233,10 +246,8 @@ def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     adapter.register_kv_caches(cpu_kv)
 
     assert adapter.kv_caches is cpu_kv
-    assert send_mock.call_count == 1
-    args, _kwargs = send_mock.call_args
-    assert args[0] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
-    assert len(args[1]) == 1
+    req_client.register_kv_cache_engine_driven_context.assert_called_once()
+    assert len(req_client.register_kv_cache_engine_driven_context.call_args.args) == 1
     assert adapter.create_recorded_event() is None
 
 
@@ -244,7 +255,7 @@ def test_register_kv_caches_tuple_caches_use_engine_driven_context(
     fake_adapter, monkeypatch
 ):
     """CPU-only tuple caches register without requiring an IPC event."""
-    adapter, send_mock, _ = fake_adapter
+    adapter, req_client, _ = fake_adapter
     monkeypatch.setattr(
         "lmcache.v1.multiprocess.transfer_context.worker_transfer._supports_async_primitives",
         lambda: False,
@@ -262,9 +273,7 @@ def test_register_kv_caches_tuple_caches_use_engine_driven_context(
     adapter.register_kv_caches(tuple_kv)
 
     assert adapter.kv_caches is tuple_kv
-    assert send_mock.call_count == 1
-    args, _kwargs = send_mock.call_args
-    assert args[0] == RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+    req_client.register_kv_cache_engine_driven_context.assert_called_once()
     assert adapter.create_recorded_event() is None
 
 
@@ -767,23 +776,18 @@ def test_dropped_retrieve_reported_once_via_healthy_get_finished(
 def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     """shutdown() stops the heartbeat before sending UNREGISTER, so no
     stray heartbeat ping can race the closing req_client."""
-    adapter, send_mock, future = fake_adapter
+    adapter, req_client, future = fake_adapter
     adapter.transfer_ctx = MagicMock()
     adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
     heartbeat = FakeHeartbeatThread.instances[0]
 
     stop_state_at_unregister: list[bool] = []
 
-    def record_send(
-        request_type: RequestType,
-        payloads: list[object],
-        _response_cls: object,
-    ) -> MagicMock:
-        if request_type == RequestType.UNREGISTER_KV_CACHE:
-            stop_state_at_unregister.append(heartbeat.stop_requested)
+    def record_unregister(_instance_id: int) -> MagicMock:
+        stop_state_at_unregister.append(heartbeat.stop_requested)
         return future
 
-    send_mock.side_effect = record_send
+    req_client.unregister_kv_cache.side_effect = record_unregister
 
     adapter.shutdown()
 
@@ -795,15 +799,12 @@ def test_shutdown_without_heartbeat_sends_unregister(fake_adapter) -> None:
     """shutdown() on an adapter whose heartbeat was never lazily started
     (cold shutdown before any traffic) still sends UNREGISTER and does
     not raise."""
-    adapter, send_mock, _future = fake_adapter
+    adapter, req_client, _future = fake_adapter
 
     adapter.shutdown()
 
     assert FakeHeartbeatThread.instances == []
-    assert send_mock.call_count == 1
-    args, _kwargs = send_mock.call_args
-    assert args[0] == RequestType.UNREGISTER_KV_CACHE
-    assert args[1] == [adapter.instance_id]
+    req_client.unregister_kv_cache.assert_called_once_with(adapter.instance_id)
 
 
 def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> None:
@@ -891,13 +892,13 @@ def test_register_uses_local_context_when_self_transfer_ctx_nulled(
         def transfer_ctx(self, value):
             pass
 
-    fake_client = MagicMock(name="req_client")
-    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *a, **kw: fake_client)
+    req_client = MagicMock(name="req_client", spec=RequestClient)
+    _patch_request_client_factory(monkeypatch, req_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
     future = MagicMock(name="future")
     future.result.return_value = None
-    fake_client.submit_request.return_value = future
+    _return_future_from_request_methods(req_client, future)
     monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
     # First Party
     from lmcache.v1.multiprocess.transfer_context import worker_transfer

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -27,6 +27,7 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.transport import zmq_impl
 from lmcache.v1.platform.isolated_ipc import is_isolated_ipc, set_isolated_ipc
 
 
@@ -151,7 +152,7 @@ def fake_adapter(monkeypatch):
     ``HeartbeatThread`` is replaced by ``FakeHeartbeatThread``."""
     # Stub the raw ZMQ boundary so facade calls do not touch a real socket.
     fake_client = MagicMock(name="req_client")
-    monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *a, **kw: fake_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
 
@@ -891,7 +892,7 @@ def test_register_uses_local_context_when_self_transfer_ctx_nulled(
             pass
 
     fake_client = MagicMock(name="req_client")
-    monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
+    monkeypatch.setattr(zmq_impl, "MessageQueueClient", lambda *a, **kw: fake_client)
     monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
     monkeypatch.setattr(adapter_mod, "get_experimental", lambda *a, **kw: set())
     future = MagicMock(name="future")


### PR DESCRIPTION
Stacked on #4878. This PR should be reviewed after #4878; once that PR merges, this branch will be rebased onto the updated dev branch.

Part of #4877.

This adds a request client factory so integrations no longer construct the ZMQ client directly.

What changed:
- add RequestClientFactory under multiprocess/transport
- keep bare host:port endpoints on the existing tcp:// ZMQ default
- route tcp://, ipc://, and inproc:// endpoints to zmq_impl
- route grpc:// and grpc+unix:// endpoints to grpc_impl
- migrate vLLM, SGLang, ATOM, TensorRT-LLM, SDK, P2P, and server bench construction through the factory
- add a source check that prevents production callers from importing the ZMQ implementation directly

The actual gRPC client is not part of this PR yet. Selecting a gRPC scheme reaches the grpc_impl entry point and returns a clear NotImplementedError. A later stacked change can add that implementation without changing callers or the factory contract.

Tests:
- relevant multiprocess and integration regression suite: 883 passed, 38 skipped
- SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files