### PR TITLE
feat(multiprocess): add gRPC request transport

### DIFF
--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -28,6 +28,9 @@ trap 'rm -rf "${LMCACHE_TEST_TMPDIR}" 2>/dev/null || true' EXIT
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt
+# Generated gRPC bindings are intentionally not tracked. Generate them only
+# after the test dependencies have installed grpcio-tools.
+python lmcache/v1/multiprocess/transport/grpc_impl/protos/generate.py
 
 # ── Run unit tests with coverage ─────────────────────────────
 LMCACHE_TRACK_USAGE="false" \

--- a/docs/design/v1/multiprocess/transport/request_transport.md
+++ b/docs/design/v1/multiprocess/transport/request_transport.md
@@ -19,7 +19,7 @@ MP integration / SDK / benchmark
          RequestClient     -- named request methods
           /       \
          v         v
-   ZMQ facade   gRPC client (planned)
+   ZMQ facade   gRPC client
          |
          v
  MessageQueueClient
@@ -38,12 +38,11 @@ scheme:
 | Scheme | Implementation |
 |---|---|
 | no scheme, `tcp`, `ipc`, `inproc` | ZMQ |
-| `grpc`, `grpc+unix` | gRPC (not implemented yet) |
+| `grpc`, `grpc+unix` | gRPC |
 
 A bare `host:port` endpoint is normalized to `tcp://host:port`. Invalid or
-unknown schemes fail before a client is created. The gRPC schemes are reserved
-so gRPC support can land without changing business callers; selecting one
-currently raises `NotImplementedError`.
+unknown schemes fail before a client is created. The server selects the matching
+implementation through `--transport zmq` or `--transport grpc`.
 
 This abstraction covers MP request RPCs only. It does not select the mechanism
 used to move KV data between an engine worker and the server.

--- a/docs/source/mp/request_transport.rst
+++ b/docs/source/mp/request_transport.rst
@@ -25,7 +25,7 @@ Transport schemes
        binds ZMQ over TCP.
    * - ``grpc://host:port`` or ``grpc+unix:///path``
      - gRPC
-     - Not supported yet. gRPC support is planned soon.
+     - Supported.
 
 For a single vLLM connector, set the scheme in ``lmcache.mp.host`` and keep the
 port in ``lmcache.mp.port``. The current ZMQ configuration is:
@@ -37,8 +37,7 @@ port in ``lmcache.mp.port``. The current ZMQ configuration is:
      "lmcache.mp.port": 5555
    }
 
-When gRPC becomes available, selecting it will use the same configuration
-shape with a ``grpc://`` host:
+To select gRPC, use the same configuration shape with a ``grpc://`` host:
 
 .. code-block:: json
 
@@ -46,6 +45,13 @@ shape with a ``grpc://`` host:
      "lmcache.mp.host": "grpc://localhost",
      "lmcache.mp.port": 5555
    }
+
+Start the server with the matching request transport:
+
+.. code-block:: bash
+
+   lmcache server --transport zmq --host localhost --port 5555
+   lmcache server --transport grpc --host localhost --port 5555
 
 For multiple servers, specify the scheme on every entry in
 ``lmcache.mp.server_urls``, for example

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Configuration for the multiprocess (ZMQ) server and HTTP frontend.
+Configuration for the multiprocess cache server and HTTP frontend.
 """
 
 # Standard
@@ -21,13 +21,16 @@ logger = init_logger(__name__)
 
 @dataclass
 class MPServerConfig:
-    """Configuration for the ZMQ-based multiprocess cache server."""
+    """Configuration for the multiprocess cache server."""
+
+    transport: Literal["zmq", "grpc"] = "zmq"
+    """Request transport exposed by the cache server."""
 
     host: str = "localhost"
-    """ZMQ server host."""
+    """Request server host."""
 
     port: int = 5555
-    """ZMQ server port."""
+    """Request server port."""
 
     chunk_size: int = 256
     """Chunk size for KV cache operations."""
@@ -263,7 +266,7 @@ def add_mp_server_args(
         The same parser with MP server arguments added.
     """
     mp_group = parser.add_argument_group(
-        "MP Server", "Configuration for the ZMQ multiprocess cache server"
+        "MP Server", "Configuration for the multiprocess cache server"
     )
     mp_group.add_argument(
         "--instance-id",
@@ -275,16 +278,22 @@ def add_mp_server_args(
         "minted at startup.",
     )
     mp_group.add_argument(
+        "--transport",
+        choices=("zmq", "grpc"),
+        default="zmq",
+        help="Request transport exposed by the cache server. Default is zmq.",
+    )
+    mp_group.add_argument(
         "--host",
         type=str,
         default="localhost",
-        help="Host to bind the ZMQ server. Default is localhost.",
+        help="Host to bind the request server. Default is localhost.",
     )
     mp_group.add_argument(
         "--port",
         type=int,
         default=5555,
-        help="Port to bind the ZMQ server. Default is 5555.",
+        help="Port to bind the request server. Default is 5555.",
     )
     mp_group.add_argument(
         "--chunk-size",
@@ -456,6 +465,7 @@ def parse_args_to_mp_server_config(
         raise ValueError("--runtime-plugin-config is not valid JSON: %s" % exc) from exc
     return MPServerConfig(
         instance_id=args.instance_id or str(uuid.uuid4()),
+        transport=args.transport,
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -68,6 +68,20 @@ from lmcache.v1.multiprocess.protocol import (
     get_handler_type,
     get_payload_classes,
 )
+from lmcache.v1.multiprocess.transport.grpc_impl.server import (
+    GrpcMultiprocessServer,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services import (
+    BlendServiceImpl,
+    ControllerServiceImpl,
+    DebugServiceImpl,
+    EngineDrivenServiceImpl,
+    LMCacheDrivenServiceImpl,
+    LookupServiceImpl,
+    ObservabilityServiceImpl,
+    P2PServiceImpl,
+    QStoreServiceImpl,
+)
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
 from lmcache.v1.platform.isolated_ipc import set_isolated_ipc
 
@@ -320,6 +334,109 @@ def _build_modules(
     ]
 
 
+def _build_zmq_request_server(
+    modules: list[EngineModule],
+    mp_config: MPServerConfig,
+) -> MessageQueueServer:
+    """Build the existing ZMQ server from module handler specifications."""
+    server = MessageQueueServer(
+        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
+        context=zmq.Context.instance(),
+    )
+    all_specs: list[HandlerSpec] = []
+    for module in modules:
+        all_specs.extend(module.get_handlers())
+    for spec in all_specs:
+        add_handler_helper(server, spec.request_type, spec.handler)
+
+    affinity_types = [
+        spec.request_type for spec in all_specs if spec.pool is ThreadPoolType.AFFINITY
+    ]
+    normal_types = [
+        spec.request_type for spec in all_specs if spec.pool is ThreadPoolType.NORMAL
+    ]
+    if affinity_types:
+        server.add_affinity_thread_pool(
+            affinity_types, max_workers=mp_config.max_gpu_workers
+        )
+    if normal_types:
+        server.add_normal_thread_pool(
+            normal_types, max_workers=mp_config.max_cpu_workers
+        )
+    return server
+
+
+def _build_grpc_request_server(
+    modules: list[EngineModule],
+    mp_config: MPServerConfig,
+) -> GrpcMultiprocessServer:
+    """Build the gRPC server from concrete module-backed services."""
+    lookup_module = next(
+        module for module in modules if isinstance(module, LookupModule)
+    )
+    management_module = next(
+        module for module in modules if isinstance(module, ManagementModule)
+    )
+    p2p_controller = next(
+        module for module in modules if isinstance(module, P2PController)
+    )
+    lmcache_driven_module = next(
+        (
+            module
+            for module in modules
+            if isinstance(module, LMCacheDrivenTransferModule)
+        ),
+        None,
+    )
+    engine_driven_module = next(
+        (
+            module
+            for module in modules
+            if isinstance(module, EngineDrivenTransferModule)
+        ),
+        None,
+    )
+    qstore_module = next(
+        (module for module in modules if isinstance(module, QStoreModule)),
+        None,
+    )
+    blend_module = None
+    if mp_config.engine_type == "blend":
+        # First Party
+        from lmcache.v1.multiprocess.modules.blend import BlendModule
+
+        blend_module = next(
+            module for module in modules if isinstance(module, BlendModule)
+        )
+
+    server = GrpcMultiprocessServer(
+        bind_url=f"grpc://{mp_config.host}:{mp_config.port}",
+        max_gpu_workers=mp_config.max_gpu_workers,
+        max_cpu_workers=mp_config.max_cpu_workers,
+    )
+    server.add_service(
+        "LMCacheDrivenService",
+        LMCacheDrivenServiceImpl(
+            lmcache_driven_module,
+            blend_module if blend_module is not None else lmcache_driven_module,
+        ),
+    )
+    server.add_service(
+        "EngineDrivenService",
+        EngineDrivenServiceImpl(engine_driven_module),
+    )
+    server.add_service("LookupService", LookupServiceImpl(lookup_module))
+    server.add_service("QStoreService", QStoreServiceImpl(qstore_module))
+    server.add_service("ControllerService", ControllerServiceImpl(management_module))
+    server.add_service("DebugService", DebugServiceImpl(management_module))
+    server.add_service(
+        "ObservabilityService", ObservabilityServiceImpl(management_module)
+    )
+    server.add_service("P2PService", P2PServiceImpl(p2p_controller))
+    server.add_service("BlendService", BlendServiceImpl(blend_module))
+    return server
+
+
 def run_cache_server(
     mp_config: MPServerConfig,
     storage_manager_config: StorageManagerConfig,
@@ -327,11 +444,11 @@ def run_cache_server(
     return_engine: bool = False,
     start_prometheus_http_server: bool = True,
     coordinator_config: CoordinatorConfig = DEFAULT_COORDINATOR_CONFIG,
-) -> tuple[MessageQueueServer, MPCacheServer] | None:
-    """Run the LMCache cache server with ZMQ message queue.
+) -> tuple[GrpcMultiprocessServer | MessageQueueServer, MPCacheServer] | None:
+    """Run the LMCache cache server with the selected request transport.
 
     Args:
-        mp_config: Configuration for the ZMQ multiprocess server.
+        mp_config: Configuration for the multiprocess server.
         storage_manager_config: Configuration for the storage manager.
         obs_config: Configuration for the observability stack.
         coordinator_config: Coordinator connection used by the P2P controller
@@ -344,7 +461,7 @@ def run_cache_server(
             ``/metrics`` to avoid port conflicts or redundant servers.
 
     Returns:
-        If return_engine is True: tuple of (MessageQueueServer, MPCacheServer).
+        If return_engine is True: tuple of (request server, MPCacheServer).
         If return_engine is False: None (blocks until interrupted).
     """
     # Before any event IPC backend is resolved (KV-cache registration), so
@@ -413,36 +530,17 @@ def run_cache_server(
     InitializeL2ConnectorUsage(event_bus, ctx.storage_manager)
     InitializeL1Usage(event_bus, ctx.storage_manager)
 
-    zmq_context = zmq.Context.instance()
-    server = MessageQueueServer(
-        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
-        context=zmq_context,
-    )
-
-    all_specs: list[HandlerSpec] = []
-    for module in modules:
-        all_specs.extend(module.get_handlers())
-
-    for spec in all_specs:
-        add_handler_helper(server, spec.request_type, spec.handler)
-
-    affinity_types = [
-        s.request_type for s in all_specs if s.pool == ThreadPoolType.AFFINITY
-    ]
-    normal_types = [
-        s.request_type for s in all_specs if s.pool == ThreadPoolType.NORMAL
-    ]
-    if affinity_types:
-        server.add_affinity_thread_pool(
-            affinity_types, max_workers=mp_config.max_gpu_workers
+    transport = mp_config.transport
+    if transport == "grpc":
+        server: GrpcMultiprocessServer | MessageQueueServer = (
+            _build_grpc_request_server(modules, mp_config)
         )
-    if normal_types:
-        server.add_normal_thread_pool(
-            normal_types, max_workers=mp_config.max_cpu_workers
-        )
+    else:
+        server = _build_zmq_request_server(modules, mp_config)
 
     logger.info(
-        "LMCache ZMQ cache server is running on tcp://%s:%d",
+        "LMCache %s cache server is running on %s:%d",
+        transport,
         mp_config.host,
         mp_config.port,
     )
@@ -480,9 +578,7 @@ def parse_args():
     Returns:
         Parsed arguments namespace.
     """
-    parser = argparse.ArgumentParser(
-        description="LMCache ZMQ Cache Server (without HTTP)"
-    )
+    parser = argparse.ArgumentParser(description="LMCache Cache Server (without HTTP)")
     add_mp_server_args(parser)
     add_storage_manager_args(parser)
     add_observability_args(parser)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -68,6 +68,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_handler_type,
     get_payload_classes,
 )
+from lmcache.v1.multiprocess.transport.factory import effective_transport
 from lmcache.v1.multiprocess.transport.grpc_impl.server import (
     GrpcMultiprocessServer,
 )
@@ -530,7 +531,7 @@ def run_cache_server(
     InitializeL2ConnectorUsage(event_bus, ctx.storage_manager)
     InitializeL1Usage(event_bus, ctx.storage_manager)
 
-    transport = mp_config.transport
+    transport = effective_transport(mp_config.transport)
     if transport == "grpc":
         server: GrpcMultiprocessServer | MessageQueueServer = (
             _build_grpc_request_server(modules, mp_config)

--- a/lmcache/v1/multiprocess/transport/factory.py
+++ b/lmcache/v1/multiprocess/transport/factory.py
@@ -52,8 +52,6 @@ class RequestClientFactory:
         Raises:
             ValueError: If the URL is empty, malformed, or uses an unsupported
                 scheme.
-            NotImplementedError: If the selected transport is recognized but
-                its implementation is not available yet.
         """
         scheme, normalized_url = _normalize_server_url(server_url)
         if scheme in _ZMQ_SCHEMES:

--- a/lmcache/v1/multiprocess/transport/factory.py
+++ b/lmcache/v1/multiprocess/transport/factory.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Request client factory selected by endpoint URL scheme."""
+"""Request client factory with a temporary gRPC validation override."""
 
 # Standard
-from typing import Any
+from typing import Any, Literal
 
 # First Party
 from lmcache.v1.multiprocess.transport.base import RequestClient
 
 _ZMQ_SCHEMES = frozenset({"inproc", "ipc", "tcp"})
 _GRPC_SCHEMES = frozenset({"grpc", "grpc+unix"})
+TransportKind = Literal["zmq", "grpc"]
 
 
 def _normalize_server_url(server_url: str) -> tuple[str, str]:
@@ -25,6 +26,21 @@ def _normalize_server_url(server_url: str) -> tuple[str, str]:
     return scheme, f"{scheme}://{target}"
 
 
+def effective_transport(configured_transport: TransportKind) -> TransportKind:
+    """Return the transport used for the current migration step.
+
+    Args:
+        configured_transport: Transport selected by configuration or URL scheme.
+
+    Returns:
+        The transport implementation to instantiate.
+    """
+    # FIXME(maobaolong): CI must exercise gRPC regardless of configuration in
+    # this stacked PR. Before merge, replace this line with:
+    #     return configured_transport
+    return "grpc"
+
+
 class RequestClientFactory:
     """Create a transport-specific request client from a server URL."""
 
@@ -34,11 +50,12 @@ class RequestClientFactory:
         *,
         context: Any | None = None,
     ) -> RequestClient:
-        """Create a request client selected by ``server_url`` scheme.
+        """Create a request client for the normalized ``server_url``.
 
-        Bare ``host:port`` endpoints retain the existing behavior and default
-        to ``tcp://``. ZMQ handles ``tcp://``, ``ipc://``, and ``inproc://``;
-        gRPC handles ``grpc://`` and ``grpc+unix://``.
+        This migration step temporarily sends every recognized endpoint scheme
+        through gRPC so CI exercises the new transport end to end. The ZMQ and
+        gRPC implementations both remain available for scheme-based selection
+        after this validation override is removed.
 
         Args:
             server_url: Multiprocess server endpoint, optionally without a
@@ -47,7 +64,7 @@ class RequestClientFactory:
                 transports that do not need a context may ignore it.
 
         Returns:
-            A method-oriented request client for the selected transport.
+            A method-oriented gRPC request client during this validation step.
 
         Raises:
             ValueError: If the URL is empty, malformed, or uses an unsupported
@@ -55,14 +72,18 @@ class RequestClientFactory:
         """
         scheme, normalized_url = _normalize_server_url(server_url)
         if scheme in _ZMQ_SCHEMES:
-            # First Party
-            from lmcache.v1.multiprocess.transport import zmq_impl
-
-            return zmq_impl.create_request_client(
-                normalized_url,
-                context=context,
+            configured_transport: TransportKind = "zmq"
+        elif scheme in _GRPC_SCHEMES:
+            configured_transport = "grpc"
+        else:
+            supported = sorted(_ZMQ_SCHEMES | _GRPC_SCHEMES)
+            raise ValueError(
+                f"Unsupported request client URL scheme {scheme!r}; "
+                f"supported schemes: {supported}"
             )
-        if scheme in _GRPC_SCHEMES:
+
+        transport = effective_transport(configured_transport)
+        if transport == "grpc":
             # First Party
             from lmcache.v1.multiprocess.transport import grpc_impl
 
@@ -71,8 +92,10 @@ class RequestClientFactory:
                 context=context,
             )
 
-        supported = sorted(_ZMQ_SCHEMES | _GRPC_SCHEMES)
-        raise ValueError(
-            f"Unsupported request client URL scheme {scheme!r}; "
-            f"supported schemes: {supported}"
+        # First Party
+        from lmcache.v1.multiprocess.transport import zmq_impl
+
+        return zmq_impl.create_request_client(
+            normalized_url,
+            context=context,
         )

--- a/lmcache/v1/multiprocess/transport/grpc_impl/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/__init__.py
@@ -2,27 +2,35 @@
 """gRPC transport implementation for multiprocess requests."""
 
 # Standard
-from typing import Any, NoReturn
+from typing import Any
+
+# First Party
+from lmcache.v1.multiprocess.transport.base import RequestClient
 
 
 def create_request_client(
     server_url: str,
     *,
     context: Any | None = None,
-) -> NoReturn:
-    """Report that the gRPC request client has not been introduced yet.
+) -> RequestClient:
+    """Create a generated-stub gRPC request client.
 
     Args:
         server_url: gRPC endpoint selected by the request client factory.
-        context: Unused optional transport context.
+        context: Ignored; accepted for parity with other transports.
 
-    Raises:
-        NotImplementedError: Always, until the gRPC implementation lands.
+    Returns:
+        A method-oriented gRPC request client.
     """
     del context
-    raise NotImplementedError(
-        f"gRPC request client for {server_url!r} is not available yet"
+
+    # First Party
+    from lmcache.v1.multiprocess.transport.grpc_impl.client import (
+        GrpcMultiprocessClient,
     )
+
+    # Descriptor-derived methods are installed on the class at import time.
+    return GrpcMultiprocessClient(server_url)  # type: ignore[abstract]
 
 
 __all__ = ["create_request_client"]

--- a/lmcache/v1/multiprocess/transport/grpc_impl/client.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/client.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Method-oriented client built directly from generated gRPC descriptors."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.parse import urlparse
+import uuid
+
+# Third Party
+import grpc
+
+# First Party
+from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.grpc_impl.descriptors import (
+    client_method_name,
+    iter_methods,
+    message_class,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.proto_codec import (
+    decode_response_to_python,
+    encode_request_from_call,
+)
+
+_GRPC_OPTIONS = (
+    ("grpc.max_send_message_length", -1),
+    ("grpc.max_receive_message_length", -1),
+)
+_CLIENT_ID_METADATA_KEY = "lmcache-client-id-bin"
+
+
+def parse_grpc_target(server_url: str) -> str:
+    """Convert an LMCache multiprocess endpoint into a gRPC target.
+
+    Args:
+        server_url: gRPC endpoint or a legacy TCP/IPC endpoint temporarily
+            redirected to gRPC by this stacked migration PR.
+
+    Returns:
+        A target accepted by ``grpc.insecure_channel``.
+
+    Raises:
+        ValueError: If the URL scheme or target is invalid.
+    """
+    if "://" not in server_url:
+        if not server_url:
+            raise ValueError("gRPC server target must not be empty")
+        return server_url
+
+    parsed = urlparse(server_url)
+    if parsed.scheme in {"grpc", "tcp"}:
+        if not parsed.netloc:
+            raise ValueError(f"Missing host in gRPC URL: {server_url!r}")
+        return parsed.netloc
+    if parsed.scheme in {"grpc+unix", "ipc", "unix"}:
+        path = f"/{parsed.netloc}{parsed.path}" if parsed.netloc else parsed.path
+        if not path:
+            raise ValueError(f"Missing socket path in gRPC URL: {server_url!r}")
+        return f"unix://{path}"
+    raise ValueError(f"Unsupported gRPC URL scheme: {parsed.scheme!r}")
+
+
+@dataclass(frozen=True)
+class _ClientRpc:
+    stub_method: Any
+    request_class: type[Any]
+
+
+ClientRpcCallable = Callable[..., MessagingFuture[Any]]
+
+
+class GrpcMultiprocessClient(RequestClient):
+    """Expose every generated unary RPC as a snake-case client method."""
+
+    def __init__(self, server_url: str) -> None:
+        self._channel = grpc.insecure_channel(
+            parse_grpc_target(server_url), options=_GRPC_OPTIONS
+        )
+        stubs: dict[str, Any] = {}
+        self._rpc_methods: dict[str, _ClientRpc] = {}
+        for binding, method in iter_methods():
+            service_name = binding.descriptor.name
+            stub = stubs.get(service_name)
+            if stub is None:
+                stub_class = getattr(binding.grpc_module, f"{service_name}Stub")
+                stub = stub_class(self._channel)
+                stubs[service_name] = stub
+            name = client_method_name(method.name)
+            if name in self._rpc_methods:
+                raise RuntimeError(f"Duplicate gRPC client method: {name}")
+            self._rpc_methods[name] = _ClientRpc(
+                stub_method=getattr(stub, method.name),
+                request_class=message_class(method.input_type),
+            )
+        self._metadata = ((_CLIENT_ID_METADATA_KEY, uuid.uuid4().bytes),)
+
+    def __getattr__(self, name: str) -> ClientRpcCallable:
+        """Resolve a generated RPC as a method-oriented client call."""
+        rpc = self._rpc_methods.get(name)
+        if rpc is None:
+            raise AttributeError(
+                f"{self.__class__.__name__!r} has no attribute {name!r}"
+            )
+
+        def invoke(*args: Any, **kwargs: Any) -> MessagingFuture[Any]:
+            return self._call(rpc, args, kwargs)
+
+        return invoke
+
+    def __dir__(self) -> list[str]:
+        """Include descriptor-derived RPC methods in introspection output."""
+        return sorted(set(super().__dir__()) | set(self._rpc_methods))
+
+    def cb_register_rope_v3(self, *args: Any, **kwargs: Any) -> MessagingFuture[Any]:
+        """Call the compatibility alias for ``CbRegisterRope``."""
+        return self.cb_register_rope(*args, **kwargs)
+
+    def cb_unregister_rope_v3(self, *args: Any, **kwargs: Any) -> MessagingFuture[Any]:
+        """Call the compatibility alias for ``CbUnregisterRope``."""
+        return self.cb_unregister_rope(*args, **kwargs)
+
+    def cb_retrieve_pre_computed_v3(
+        self, *args: Any, **kwargs: Any
+    ) -> MessagingFuture[Any]:
+        """Call the compatibility alias for ``CbRetrievePreComputed``."""
+        return self.cb_retrieve_pre_computed(*args, **kwargs)
+
+    def close(self) -> None:
+        """Close the underlying gRPC channel."""
+        self._channel.close()
+
+    def _call(
+        self,
+        rpc: _ClientRpc,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> MessagingFuture[Any]:
+        request = encode_request_from_call(rpc.request_class, args, kwargs)
+        future: MessagingFuture[Any] = MessagingFuture()
+        call = rpc.stub_method.future(
+            request,
+            metadata=self._metadata,
+            wait_for_ready=True,
+        )
+
+        def on_done(grpc_future: grpc.Future[Any]) -> None:
+            try:
+                result = decode_response_to_python(grpc_future.result())
+            except BaseException as exc:
+                future.set_exception(exc)
+            else:
+                future.set_result(result)
+
+        call.add_done_callback(on_done)
+        return future
+
+
+def _make_client_rpc_method(name: str) -> ClientRpcCallable:
+    def rpc_method(
+        self: GrpcMultiprocessClient,
+        *args: Any,
+        **kwargs: Any,
+    ) -> MessagingFuture[Any]:
+        return self._call(self._rpc_methods[name], args, kwargs)
+
+    rpc_method.__name__ = name
+    rpc_method.__qualname__ = f"GrpcMultiprocessClient.{name}"
+    return rpc_method
+
+
+def _install_client_rpc_methods() -> None:
+    """Install descriptor-derived RPC methods on the concrete client class."""
+    for _, method in iter_methods():
+        name = client_method_name(method.name)
+        if name in GrpcMultiprocessClient.__dict__:
+            raise RuntimeError(f"gRPC client method conflicts with {name!r}")
+        setattr(GrpcMultiprocessClient, name, _make_client_rpc_method(name))
+
+
+_install_client_rpc_methods()

--- a/lmcache/v1/multiprocess/transport/grpc_impl/descriptors.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/descriptors.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Discover generated gRPC services from protobuf descriptors."""
+
+# Standard
+from dataclasses import dataclass
+from functools import lru_cache
+from types import ModuleType
+import importlib
+import pkgutil
+import re
+
+# Third Party
+from google.protobuf.descriptor import MethodDescriptor, ServiceDescriptor
+from google.protobuf.message import Message
+from google.protobuf.message_factory import GetMessageClass
+
+# First Party
+from lmcache.v1.multiprocess.transport.grpc_impl import protos
+
+
+@dataclass(frozen=True)
+class ServiceBinding:
+    """Generated descriptor and gRPC module for one protobuf service."""
+
+    descriptor: ServiceDescriptor
+    grpc_module: ModuleType
+
+
+def client_method_name(method_name: str) -> str:
+    """Convert a protobuf RPC method name to the public client method name."""
+    name = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", method_name)
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    return name.lower().replace("p2_p", "p2p")
+
+
+def message_class(descriptor: object) -> type[Message]:
+    """Return the generated message class for a protobuf descriptor."""
+    return GetMessageClass(descriptor)  # type: ignore[arg-type, no-any-return]
+
+
+@lru_cache(maxsize=1)
+def get_service_bindings() -> dict[str, ServiceBinding]:
+    """Load every generated ``*_service_pb2`` module in the proto package."""
+    package_prefix = f"{protos.__name__}."
+    bindings: dict[str, ServiceBinding] = {}
+    for module_info in pkgutil.iter_modules(protos.__path__, package_prefix):
+        if not module_info.name.endswith("_service_pb2"):
+            continue
+        proto_module = importlib.import_module(module_info.name)
+        grpc_module = importlib.import_module(f"{module_info.name}_grpc")
+        for descriptor in proto_module.DESCRIPTOR.services_by_name.values():
+            if descriptor.name in bindings:
+                raise RuntimeError(f"Duplicate gRPC service: {descriptor.name}")
+            bindings[descriptor.name] = ServiceBinding(descriptor, grpc_module)
+    if not bindings:
+        raise RuntimeError(
+            "No generated gRPC services found. Run "
+            "`python -m lmcache.v1.multiprocess.transport.grpc_impl.protos.generate`."
+        )
+    return bindings
+
+
+def iter_methods() -> list[tuple[ServiceBinding, MethodDescriptor]]:
+    """Return all generated unary RPC methods in descriptor order."""
+    return [
+        (binding, method)
+        for binding in get_service_bindings().values()
+        for method in binding.descriptor.methods
+    ]

--- a/lmcache/v1/multiprocess/transport/grpc_impl/proto_codec.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/proto_codec.py
@@ -1,0 +1,925 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Protobuf/Python value codecs for the multiprocess gRPC transport.
+
+This module intentionally has no RPC method registry. The caller provides a
+generated request or response message class, and Python value conversion is
+derived from handler annotations plus protobuf field names. Adding an RPC
+should not require editing this file.
+"""
+
+# Standard
+from dataclasses import fields, is_dataclass
+from typing import (
+    Any,
+    Callable,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+)
+import enum
+import inspect
+import types
+
+# Third Party
+import msgspec
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
+from lmcache.v1.multiprocess.custom_types import (
+    CBMatchResult,
+    CBUnifiedLookupResult,
+    DeviceIPCWrapper,
+    PrepareRetrieveResponse,
+    PrepareStoreResponse,
+    RegisterEngineDrivenContextResponse,
+    get_customized_decoder,
+    get_customized_encoder,
+)
+
+_NONE_TYPE = type(None)
+
+ValueEncoder = Callable[[Any], Any]
+ValueDecoder = Callable[[Any], Any]
+FieldWriter = Callable[[Any, Any], None]
+FieldReader = Callable[[Any], Any]
+RequestEncoder = Callable[..., Any]
+RequestDecoder = Callable[[Any], tuple[Any, ...]]
+ResponseEncoder = Callable[[Any], Any]
+ResponseDecoder = Callable[[Any], Any]
+
+
+def _unwrap_optional(py_type: Any) -> tuple[Any, bool]:
+    origin = get_origin(py_type)
+    if origin not in (Union, types.UnionType):
+        return py_type, False
+    args = get_args(py_type)
+    non_none = tuple(arg for arg in args if arg is not _NONE_TYPE)
+    if len(non_none) == len(args):
+        return py_type, False
+    if len(non_none) != 1:
+        raise TypeError(f"unsupported optional union {py_type!r}")
+    return non_none[0], True
+
+
+def _is_enum_type(py_type: Any) -> bool:
+    return isinstance(py_type, type) and issubclass(py_type, enum.Enum)
+
+
+def _is_device_wrapper_type(py_type: Any) -> bool:
+    return isinstance(py_type, type) and issubclass(py_type, DeviceIPCWrapper)
+
+
+def _sequence_type(py_type: Any) -> tuple[Any, bool] | None:
+    origin = get_origin(py_type)
+    args = get_args(py_type)
+    if origin is list:
+        return (args[0] if args else Any), False
+    if origin is tuple and len(args) == 2 and args[1] is Ellipsis:
+        return args[0], True
+    return None
+
+
+def _fixed_tuple_types(py_type: Any) -> tuple[Any, ...] | None:
+    if get_origin(py_type) is not tuple:
+        return None
+    args = get_args(py_type)
+    if len(args) == 2 and args[1] is Ellipsis:
+        return None
+    return args
+
+
+def _structured_fields(py_type: Any) -> tuple[tuple[str, Any], ...] | None:
+    py_type, _ = _unwrap_optional(py_type)
+    if not isinstance(py_type, type) or is_typeddict(py_type):
+        return None
+
+    hints = get_type_hints(py_type)
+    if is_dataclass(py_type):
+        return tuple(
+            (field.name, hints.get(field.name, Any))
+            for field in fields(py_type)
+            if field.init
+        )
+    if issubclass(py_type, msgspec.Struct):
+        return tuple((name, hints.get(name, Any)) for name in py_type.__struct_fields__)
+    return None
+
+
+def _is_map_field(field: Any) -> bool:
+    return bool(
+        field.is_repeated
+        and field.message_type is not None
+        and field.message_type.GetOptions().map_entry
+    )
+
+
+def _encode_mapping(value: Any) -> bytes:
+    if not value:
+        return b""
+    return msgspec.msgpack.encode(dict(value))
+
+
+def _decode_mapping(value: bytes) -> dict[Any, Any]:
+    if not value:
+        return {}
+    decoded = msgspec.msgpack.decode(value)
+    if not isinstance(decoded, dict):
+        raise TypeError(f"expected a msgpack dict, got {type(decoded)!r}")
+    return decoded
+
+
+def _identity(value: Any) -> Any:
+    return value
+
+
+def _compile_scalar_codec(
+    field: Any, py_type: Any
+) -> tuple[ValueEncoder, ValueDecoder]:
+    if field.type == field.TYPE_BYTES:
+        if py_type is bytes:
+            return bytes, bytes
+        if py_type is dict or get_origin(py_type) is dict or is_typeddict(py_type):
+            return _encode_mapping, _decode_mapping
+    if field.type == field.TYPE_STRING:
+        if _is_enum_type(py_type):
+
+            def encode_enum(value: Any) -> str:
+                return str(value.value)
+
+            return encode_enum, py_type
+        if py_type is torch.dtype:
+
+            def encode_dtype(value: torch.dtype) -> str:
+                return str(value).removeprefix("torch.")
+
+            def decode_dtype(value: str) -> torch.dtype:
+                dtype = getattr(torch, value, None)
+                if not isinstance(dtype, torch.dtype):
+                    raise ValueError(f"unknown torch dtype name: {value!r}")
+                return dtype
+
+            return encode_dtype, decode_dtype
+    if py_type in (bool, int, float, str, bytes):
+        return py_type, py_type
+    return _identity, _identity
+
+
+def _compile_map_field(field: Any, py_type: Any) -> tuple[FieldWriter, FieldReader]:
+    args = get_args(py_type)
+    key_type, value_type = args if len(args) == 2 else (Any, Any)
+    key_field = field.message_type.fields_by_name["key"]
+    value_field = field.message_type.fields_by_name["value"]
+    encode_key, decode_key = _compile_scalar_codec(key_field, key_type)
+    field_name = field.name
+
+    if value_field.message_type is None:
+        encode_value, decode_value = _compile_scalar_codec(value_field, value_type)
+
+        def write_map(message: Any, value: Any) -> None:
+            container = getattr(message, field_name)
+            for key, item in value.items():
+                container[encode_key(key)] = encode_value(item)
+
+        def read_map(message: Any) -> dict[Any, Any]:
+            return {
+                decode_key(key): decode_value(item)
+                for key, item in getattr(message, field_name).items()
+            }
+
+        return write_map, read_map
+
+    write_value, read_value = _compile_message_codec(
+        value_field.message_type, value_type
+    )
+
+    def write_message_map(message: Any, value: Any) -> None:
+        container = getattr(message, field_name)
+        for key, item in value.items():
+            write_value(container[encode_key(key)], item)
+
+    def read_message_map(message: Any) -> dict[Any, Any]:
+        return {
+            decode_key(key): read_value(item)
+            for key, item in getattr(message, field_name).items()
+        }
+
+    return write_message_map, read_message_map
+
+
+def _compile_field_codec(field: Any, py_type: Any) -> tuple[FieldWriter, FieldReader]:
+    py_type, optional = _unwrap_optional(py_type)
+    if optional and (field.is_repeated or not field.has_presence):
+        raise TypeError(
+            f"field {field.full_name} cannot represent Python None; "
+            "declare it optional in the proto"
+        )
+
+    if _is_map_field(field):
+        writer, reader = _compile_map_field(field, py_type)
+    elif field.is_repeated:
+        sequence = _sequence_type(py_type)
+        if sequence is None:
+            raise TypeError(
+                f"field {field.full_name} is repeated but {py_type!r} is not"
+            )
+        item_type, as_tuple = sequence
+        field_name = field.name
+        if field.message_type is None:
+            encode_item, decode_item = _compile_scalar_codec(field, item_type)
+
+            def write_repeated(message: Any, value: Any) -> None:
+                getattr(message, field_name).extend(encode_item(item) for item in value)
+
+            def read_repeated(message: Any) -> Any:
+                decoded = [decode_item(item) for item in getattr(message, field_name)]
+                return tuple(decoded) if as_tuple else decoded
+
+            writer, reader = write_repeated, read_repeated
+        else:
+            write_item, read_item = _compile_message_codec(
+                field.message_type, item_type
+            )
+
+            def write_repeated_message(message: Any, value: Any) -> None:
+                container = getattr(message, field_name)
+                for item in value:
+                    write_item(container.add(), item)
+
+            def read_repeated_message(message: Any) -> Any:
+                decoded = [read_item(item) for item in getattr(message, field_name)]
+                return tuple(decoded) if as_tuple else decoded
+
+            writer, reader = write_repeated_message, read_repeated_message
+    elif field.message_type is not None:
+        write_child, read_child = _compile_message_codec(field.message_type, py_type)
+        field_name = field.name
+
+        def write_message(message: Any, value: Any) -> None:
+            child = getattr(message, field_name)
+            write_child(child, value)
+            child.SetInParent()
+
+        def read_message(message: Any) -> Any:
+            return read_child(getattr(message, field_name))
+
+        writer, reader = write_message, read_message
+    else:
+        encode_value, decode_value = _compile_scalar_codec(field, py_type)
+        field_name = field.name
+
+        def write_scalar(message: Any, value: Any) -> None:
+            setattr(message, field_name, encode_value(value))
+
+        def read_scalar(message: Any) -> Any:
+            return decode_value(getattr(message, field_name))
+
+        writer, reader = write_scalar, read_scalar
+
+    if not optional:
+        return writer, reader
+
+    field_name = field.name
+
+    def write_optional(message: Any, value: Any) -> None:
+        if value is not None:
+            writer(message, value)
+
+    def read_optional(message: Any) -> Any:
+        if not message.HasField(field_name):
+            return None
+        return reader(message)
+
+    return write_optional, read_optional
+
+
+def _compile_message_codec(
+    descriptor: Any, py_type: Any
+) -> tuple[FieldWriter, FieldReader]:
+    py_type, _ = _unwrap_optional(py_type)
+    proto_fields = tuple(descriptor.fields)
+
+    if _is_device_wrapper_type(py_type):
+
+        def write_wrapper(message: Any, value: DeviceIPCWrapper) -> None:
+            message.pickled_payload = DeviceIPCWrapper.Serialize(value)
+
+        def read_wrapper(message: Any) -> DeviceIPCWrapper:
+            return DeviceIPCWrapper.Deserialize(message.pickled_payload)
+
+        return write_wrapper, read_wrapper
+
+    if py_type is torch.Size:
+
+        def write_size(message: Any, value: torch.Size) -> None:
+            message.dims.extend(value)
+
+        def read_size(message: Any) -> torch.Size:
+            return torch.Size(message.dims)
+
+        return write_size, read_size
+
+    sequence = _sequence_type(py_type)
+    if sequence is not None and len(proto_fields) == 1:
+        return _compile_field_codec(proto_fields[0], py_type)
+
+    tuple_types = _fixed_tuple_types(py_type)
+    if tuple_types is not None:
+        if len(tuple_types) != len(proto_fields):
+            raise TypeError(
+                f"{py_type!r} has {len(tuple_types)} values but "
+                f"{descriptor.full_name} has {len(proto_fields)} fields"
+            )
+        tuple_codecs = tuple(
+            _compile_field_codec(field, item_type)
+            for field, item_type in zip(proto_fields, tuple_types, strict=True)
+        )
+
+        def write_tuple(message: Any, value: Any) -> None:
+            for item, (writer, _) in zip(value, tuple_codecs, strict=True):
+                writer(message, item)
+
+        def read_tuple(message: Any) -> tuple[Any, ...]:
+            return tuple(reader(message) for _, reader in tuple_codecs)
+
+        return write_tuple, read_tuple
+
+    py_fields = _structured_fields(py_type)
+    if py_fields is None or len(py_fields) != len(proto_fields):
+        raise TypeError(
+            f"no structural codec from {py_type!r} to {descriptor.full_name}"
+        )
+
+    struct_codecs: list[tuple[str, FieldWriter, FieldReader]] = []
+    for (name, field_type), field in zip(py_fields, proto_fields, strict=True):
+        if field.name not in (name, f"encoded_{name}"):
+            raise TypeError(
+                f"{py_type.__name__}.{name} does not match "
+                f"{descriptor.full_name}.{field.name}"
+            )
+        writer, reader = _compile_field_codec(field, field_type)
+        struct_codecs.append((name, writer, reader))
+
+    def write_struct(message: Any, value: Any) -> None:
+        for name, writer, _ in struct_codecs:
+            writer(message, getattr(value, name))
+
+    def read_struct(message: Any) -> Any:
+        return py_type(**{name: reader(message) for name, _, reader in struct_codecs})
+
+    return write_struct, read_struct
+
+
+def _proto_has_same_descriptor(value: Any, descriptor: Any) -> bool:
+    return hasattr(value, "DESCRIPTOR") and value.DESCRIPTOR is descriptor
+
+
+def _field_source_name(field_name: str, value: Any) -> str:
+    if hasattr(value, field_name):
+        return field_name
+    if field_name.startswith("encoded_") and hasattr(value, field_name[8:]):
+        return field_name[8:]
+    return field_name
+
+
+def _runtime_py_type_for_value(value: Any) -> Any:
+    if isinstance(value, enum.Enum):
+        return value.__class__
+    if isinstance(value, torch.dtype):
+        return torch.dtype
+    return type(value)
+
+
+def _write_field_from_runtime_value(message: Any, field: Any, value: Any) -> None:
+    if value is None:
+        return
+    if _is_map_field(field):
+        key_field = field.message_type.fields_by_name["key"]
+        value_field = field.message_type.fields_by_name["value"]
+        container = getattr(message, field.name)
+        for key, item in value.items():
+            encoded_key, _ = _compile_scalar_codec(
+                key_field, _runtime_py_type_for_value(key)
+            )
+            if value_field.message_type is None:
+                encoded_value, _ = _compile_scalar_codec(
+                    value_field, _runtime_py_type_for_value(item)
+                )
+                container[encoded_key(key)] = encoded_value(item)
+            else:
+                _write_message_from_runtime_value(
+                    container[encoded_key(key)], value_field.message_type, item
+                )
+        return
+
+    if field.is_repeated:
+        container = getattr(message, field.name)
+        if field.message_type is None:
+            for item in value:
+                encode_item, _ = _compile_scalar_codec(
+                    field, _runtime_py_type_for_value(item)
+                )
+                container.append(encode_item(item))
+        else:
+            for item in value:
+                _write_message_from_runtime_value(
+                    container.add(), field.message_type, item
+                )
+        return
+
+    if field.message_type is not None:
+        child = getattr(message, field.name)
+        _write_message_from_runtime_value(child, field.message_type, value)
+        child.SetInParent()
+        return
+
+    encode_value, _ = _compile_scalar_codec(field, _runtime_py_type_for_value(value))
+    setattr(message, field.name, encode_value(value))
+
+
+def _write_message_from_runtime_value(
+    message: Any,
+    descriptor: Any,
+    value: Any,
+) -> None:
+    if _proto_has_same_descriptor(value, descriptor):
+        message.CopyFrom(value)
+        return
+    if descriptor.name == "DeviceIpcWrapper":
+        message.pickled_payload = DeviceIPCWrapper.Serialize(value)
+        return
+    if descriptor.name == "TensorShape":
+        message.dims.extend(value)
+        return
+
+    proto_fields = tuple(descriptor.fields)
+    if isinstance(value, tuple) and len(value) == len(proto_fields):
+        for item, field in zip(value, proto_fields, strict=True):
+            _write_field_from_runtime_value(message, field, item)
+        return
+    if (
+        len(proto_fields) == 1
+        and not is_dataclass(value)
+        and not isinstance(value, msgspec.Struct)
+    ):
+        _write_field_from_runtime_value(message, proto_fields[0], value)
+        return
+
+    for field in proto_fields:
+        source_name = _field_source_name(field.name, value)
+        if isinstance(value, dict):
+            field_value = value.get(source_name)
+        else:
+            field_value = getattr(value, source_name)
+        _write_field_from_runtime_value(message, field, field_value)
+
+
+def _is_structured_runtime_value(value: Any, descriptor: Any) -> bool:
+    return (
+        _proto_has_same_descriptor(value, descriptor)
+        or is_dataclass(value)
+        or isinstance(value, (dict, msgspec.Struct))
+        or (isinstance(value, tuple) and len(value) == len(tuple(descriptor.fields)))
+    )
+
+
+def _compile_request_codec(
+    message_cls: Any,
+    payload_types: tuple[Any, ...],
+) -> tuple[RequestEncoder, RequestDecoder]:
+    proto_fields = tuple(message_cls.DESCRIPTOR.fields)
+    if len(payload_types) == len(proto_fields):
+        codecs = tuple(
+            _compile_field_codec(field, py_type)
+            for field, py_type in zip(proto_fields, payload_types, strict=True)
+        )
+        if not codecs:
+            return (lambda: message_cls()), (lambda message: ())
+        if len(codecs) == 1:
+            writer, reader = codecs[0]
+
+            def encode_one(value: Any) -> Any:
+                message = message_cls()
+                writer(message, value)
+                return message
+
+            def decode_one(message: Any) -> tuple[Any, ...]:
+                return (reader(message),)
+
+            return encode_one, decode_one
+
+        def encode_many(*payloads: Any) -> Any:
+            if len(payloads) != len(codecs):
+                raise TypeError(
+                    f"{message_cls.DESCRIPTOR.full_name} expects "
+                    f"{len(codecs)} payloads, got {len(payloads)}"
+                )
+            message = message_cls()
+            for value, (writer, _) in zip(payloads, codecs, strict=True):
+                writer(message, value)
+            return message
+
+        def decode_many(message: Any) -> tuple[Any, ...]:
+            return tuple(reader(message) for _, reader in codecs)
+
+        return encode_many, decode_many
+
+    if len(payload_types) == 1:
+        write_message, read_message = _compile_message_codec(
+            message_cls.DESCRIPTOR, payload_types[0]
+        )
+
+        def encode_flat(value: Any) -> Any:
+            message = message_cls()
+            write_message(message, value)
+            return message
+
+        def decode_flat(message: Any) -> tuple[Any, ...]:
+            return (read_message(message),)
+
+        return encode_flat, decode_flat
+
+    raise TypeError(
+        f"handler has {len(payload_types)} payloads but "
+        f"{message_cls.DESCRIPTOR.full_name} has {len(proto_fields)} fields"
+    )
+
+
+def _handler_params_and_payload_types(
+    handler: Callable[..., Any],
+) -> tuple[list[inspect.Parameter], tuple[Any, ...]]:
+    sig = inspect.signature(handler)
+    hints = get_type_hints(handler)
+    params = [
+        p
+        for p in sig.parameters.values()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    payload_types = tuple(hints.get(param.name, param.annotation) for param in params)
+    return (
+        params,
+        tuple(
+            Any if item is inspect.Signature.empty else item for item in payload_types
+        ),
+    )
+
+
+def compile_request_decoder(
+    message_cls: Any, handler: Callable[..., Any]
+) -> tuple[RequestDecoder, tuple[Any, ...]]:
+    """Compile a protobuf request decoder from a handler's annotations.
+
+    Args:
+        message_cls: Generated protobuf request class.
+        handler: Bound Python RPC implementation method.
+
+    Returns:
+        Callable that decodes one protobuf request into handler positional args,
+        plus the payload types inferred from the handler.
+    """
+    params, payload_types = _handler_params_and_payload_types(handler)
+    proto_fields = tuple(message_cls.DESCRIPTOR.fields)
+
+    if not params:
+        return (lambda _message: ()), payload_types
+
+    if len(params) == len(proto_fields) or len(params) == 1:
+        _encoder, decoder = _compile_request_codec(message_cls, payload_types)
+        return decoder, payload_types
+
+    fields_by_name = message_cls.DESCRIPTOR.fields_by_name
+    selected_codecs: list[tuple[Any, FieldReader]] = []
+    for param, py_type in zip(params, payload_types, strict=True):
+        field = fields_by_name.get(param.name)
+        if field is None:
+            field = fields_by_name.get(f"encoded_{param.name}")
+        if field is None:
+            raise TypeError(
+                f"{message_cls.DESCRIPTOR.full_name} has no field matching "
+                f"handler parameter {param.name!r}"
+            )
+        _writer, reader = _compile_field_codec(field, py_type)
+        selected_codecs.append((field, reader))
+
+    def decode_subset(message: Any) -> tuple[Any, ...]:
+        return tuple(reader(message) for _field, reader in selected_codecs)
+
+    return decode_subset, payload_types
+
+
+def compile_response_encoder(
+    message_cls: Any,
+    handler: Callable[..., Any],
+) -> tuple[ResponseEncoder, Any]:
+    """Compile a protobuf response encoder from a handler return annotation."""
+    sig = inspect.signature(handler)
+    hints = get_type_hints(handler)
+    response_type = hints.get("return", sig.return_annotation)
+    if response_type is inspect.Signature.empty:
+        response_type = Any
+    encoder = compile_response_encoder_for_type(message_cls, response_type)
+    return encoder, response_type
+
+
+def compile_response_encoder_for_type(
+    message_cls: Any,
+    response_type: Any,
+) -> ResponseEncoder:
+    """Compile a protobuf response encoder for a Python return type."""
+    proto_fields = tuple(message_cls.DESCRIPTOR.fields)
+    response_type, optional = _unwrap_optional(response_type)
+
+    if optional:
+
+        def encode_optional(result: Any) -> Any:
+            message = message_cls()
+            if result is not None:
+                _write_response_value(message, proto_fields, response_type, result)
+            return message
+
+        return encode_optional
+
+    def encode_response(result: Any) -> Any:
+        message = message_cls()
+        if response_type is None or response_type is type(None):
+            if proto_fields:
+                raise TypeError(
+                    f"{message_cls.DESCRIPTOR.full_name} must be an empty response"
+                )
+            return message
+        if result is None:
+            if proto_fields:
+                raise TypeError(
+                    f"{message_cls.DESCRIPTOR.full_name} got None for "
+                    "non-empty response"
+                )
+            return message
+        _write_response_value(message, proto_fields, response_type, result)
+        return message
+
+    return encode_response
+
+
+def _write_response_value(
+    message: Any,
+    proto_fields: tuple[Any, ...],
+    response_type: Any,
+    result: Any,
+) -> None:
+    if _proto_has_same_descriptor(result, message.DESCRIPTOR):
+        message.CopyFrom(result)
+        return
+
+    py_fields = _structured_fields(response_type)
+    if py_fields is not None and len(py_fields) == len(proto_fields):
+        writer, _reader = _compile_message_codec(message.DESCRIPTOR, response_type)
+        writer(message, result)
+        return
+
+    tuple_types = _fixed_tuple_types(response_type)
+    if tuple_types is not None and len(tuple_types) == len(proto_fields):
+        for field, item_type, item in zip(
+            proto_fields, tuple_types, result, strict=True
+        ):
+            writer, _reader = _compile_field_codec(field, item_type)
+            writer(message, item)
+        return
+
+    if len(proto_fields) == 1:
+        writer, _reader = _compile_field_codec(proto_fields[0], response_type)
+        writer(message, result)
+        return
+
+    _write_message_from_runtime_value(message, message.DESCRIPTOR, result)
+
+
+def encode_request_from_call(
+    message_cls: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Build a protobuf request from a client method call."""
+    if (
+        len(args) == 1
+        and not kwargs
+        and _proto_has_same_descriptor(args[0], message_cls.DESCRIPTOR)
+    ):
+        return args[0]
+    if args and kwargs:
+        raise TypeError("RPC call accepts either positional args or keyword fields")
+
+    message = message_cls()
+    proto_fields = tuple(message_cls.DESCRIPTOR.fields)
+    if kwargs:
+        fields_by_name = message_cls.DESCRIPTOR.fields_by_name
+        for name, value in kwargs.items():
+            field = fields_by_name.get(name)
+            if field is None:
+                raise TypeError(
+                    f"{message_cls.DESCRIPTOR.full_name} has no field {name!r}"
+                )
+            _write_field_from_runtime_value(message, field, value)
+        return message
+
+    if (
+        len(args) == 1
+        and len(proto_fields) != 1
+        and _is_structured_runtime_value(args[0], message_cls.DESCRIPTOR)
+    ):
+        _write_message_from_runtime_value(message, message_cls.DESCRIPTOR, args[0])
+        return message
+
+    if len(args) > len(proto_fields):
+        raise TypeError(
+            f"{message_cls.DESCRIPTOR.full_name} accepts at most "
+            f"{len(proto_fields)} positional values, got {len(args)}"
+        )
+    for field, value in zip(proto_fields, args, strict=False):
+        _write_field_from_runtime_value(message, field, value)
+    return message
+
+
+def decode_response_to_python(response: Any) -> Any:
+    """Decode a protobuf response into LMCache's Python-facing result shape."""
+    descriptor = response.DESCRIPTOR
+    proto_fields = tuple(descriptor.fields)
+    if not proto_fields:
+        return None
+
+    if descriptor.name == "CbUnifiedLookupResponse":
+        if not response.HasField("payload"):
+            return None
+        return _read_cb_unified_lookup_payload(response.payload)
+    if descriptor.name == "P2pQueryLookupResultsResponse":
+        if not response.HasField("addresses"):
+            return None
+        return [
+            _read_transfer_channel_address(item)
+            for item in response.addresses.addresses
+        ]
+    if descriptor.name == "RegisterKvCacheEngineDrivenContextResponse":
+        return RegisterEngineDrivenContextResponse(
+            shm_name=response.shm_name,
+            pool_size=response.pool_size,
+        )
+    if descriptor.name == "PrepareStoreResponse":
+        return PrepareStoreResponse(context=_decode_mapping(response.encoded_context))
+    if descriptor.name == "PrepareRetrieveResponse":
+        return PrepareRetrieveResponse(
+            success=response.success,
+            data=response.data,
+            context=_decode_mapping(response.encoded_context),
+        )
+
+    if len(proto_fields) == 1:
+        return _read_response_field(response, proto_fields[0])
+    return tuple(_read_response_field(response, field) for field in proto_fields)
+
+
+def decode_response_to_type(response: Any, response_type: Any) -> Any:
+    """Decode a protobuf response to its transport-neutral Python type.
+
+    Args:
+        response: Generated protobuf response instance.
+        response_type: Python response type declared by the multiprocess
+            protocol.
+
+    Returns:
+        The decoded Python response value.
+    """
+    if response_type is None or response_type is type(None):
+        return None
+
+    response_type, optional = _unwrap_optional(response_type)
+    fields = tuple(response.DESCRIPTOR.fields)
+    if optional:
+        if len(fields) != 1 or not fields[0].has_presence:
+            raise TypeError(
+                f"{response.DESCRIPTOR.full_name} cannot represent an optional response"
+            )
+        if not response.HasField(fields[0].name):
+            return None
+        _writer, reader = _compile_field_codec(fields[0], response_type)
+        return reader(response)
+
+    py_fields = _structured_fields(response_type)
+    if py_fields is not None and len(py_fields) == len(fields):
+        _writer, reader = _compile_message_codec(response.DESCRIPTOR, response_type)
+        return reader(response)
+
+    if len(fields) == 1:
+        _writer, reader = _compile_field_codec(fields[0], response_type)
+        return reader(response)
+
+    _writer, reader = _compile_message_codec(response.DESCRIPTOR, response_type)
+    return reader(response)
+
+
+def _read_response_field(message: Any, field: Any) -> Any:
+    if field.has_presence and not message.HasField(field.name):
+        return None
+    value = getattr(message, field.name)
+    if field.message_type is not None:
+        return _read_response_message(value)
+    if field.is_repeated:
+        return list(value)
+    return value
+
+
+def _read_response_message(message: Any) -> Any:
+    descriptor = message.DESCRIPTOR
+    if descriptor.name == "EventIpcHandleResult":
+        return (message.event_ipc_handle, message.success)
+    if descriptor.name == "TransferChannelAddress":
+        return _read_transfer_channel_address(message)
+    if descriptor.name == "TransferChannelAddressList":
+        return [_read_transfer_channel_address(item) for item in message.addresses]
+    if descriptor.name == "CBUnifiedLookupPayload":
+        return _read_cb_unified_lookup_payload(message)
+    if len(descriptor.fields) == 1:
+        return _read_response_field(message, descriptor.fields[0])
+    return tuple(_read_response_field(message, field) for field in descriptor.fields)
+
+
+def _read_cb_match_result(message: Any) -> CBMatchResult:
+    return CBMatchResult(
+        old_st=message.old_st,
+        old_ed=message.old_ed,
+        cur_st=message.cur_st,
+        cur_ed=message.cur_ed,
+        hash=message.hash,
+    )
+
+
+def _read_cb_unified_lookup_payload(message: Any) -> CBUnifiedLookupResult:
+    return CBUnifiedLookupResult(
+        prefix_coverage_tokens=message.prefix_coverage_tokens,
+        non_prefix_segments=[
+            _read_cb_match_result(item) for item in message.non_prefix_segments
+        ],
+        segmented_prefix_segments=[
+            _read_cb_match_result(item) for item in message.segmented_prefix_segments
+        ],
+    )
+
+
+def _read_transfer_channel_address(message: Any) -> TransferChannelAddress:
+    return TransferChannelAddress(offset=message.offset, size=message.size)
+
+
+# These serializers remain part of the gRPC transport compatibility API.
+_SPECIAL_ENCODER_DECODERS = {
+    DeviceIPCWrapper: (
+        get_customized_encoder(DeviceIPCWrapper),
+        get_customized_decoder(DeviceIPCWrapper),
+    ),
+    list[DeviceIPCWrapper]: (
+        get_customized_encoder(list[DeviceIPCWrapper]),
+        get_customized_decoder(list[DeviceIPCWrapper]),
+    ),
+    MemoryLayoutDesc: (
+        get_customized_encoder(MemoryLayoutDesc),
+        get_customized_decoder(MemoryLayoutDesc),
+    ),
+    dict[int, MemoryLayoutDesc]: (
+        get_customized_encoder(dict[int, MemoryLayoutDesc]),
+        get_customized_decoder(dict[int, MemoryLayoutDesc]),
+    ),
+}
+
+
+def msgspec_encode(obj: Any, cls: Any) -> bytes:
+    """Encode a value with the public msgspec utility serializers."""
+    if cls in _SPECIAL_ENCODER_DECODERS:
+        encoder, _ = _SPECIAL_ENCODER_DECODERS[cls]
+        return encoder.encode(obj)
+    if cls in (bool, int):
+        obj = cls(obj)
+    return msgspec.msgpack.encode(obj)
+
+
+def msgspec_decode(b_obj: bytes, cls: Any) -> Any:
+    """Decode a value with the public msgspec utility serializers."""
+    if cls in _SPECIAL_ENCODER_DECODERS:
+        _, decoder = _SPECIAL_ENCODER_DECODERS[cls]
+        return decoder.decode(b_obj)
+    if cls in (bool, int):
+        return cls(msgspec.msgpack.decode(b_obj))
+    return msgspec.msgpack.decode(b_obj, type=cls)
+
+
+__all__ = [
+    "compile_request_decoder",
+    "compile_response_encoder",
+    "decode_response_to_python",
+    "encode_request_from_call",
+    "msgspec_decode",
+    "msgspec_encode",
+]

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/.gitignore
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/.gitignore
@@ -1,0 +1,2 @@
+*_pb2.py
+*_pb2_grpc.py

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source protobuf schemas for the LMCache multiprocess gRPC transport."""

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/blend_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/blend_service.proto
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// BlendService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto";
+
+message CbMatchResult {
+  int64 old_st = 1;
+  int64 old_ed = 2;
+  int64 cur_st = 3;
+  int64 cur_ed = 4;
+  bytes hash = 5;
+}
+
+message CbUnregisterRopeRequest {
+  int64 instance_id = 1;
+}
+
+message CbUnregisterRopeResponse {}
+
+message CbRetrievePreComputedRequest {
+  IpcCacheServerKey key = 1;
+  repeated CbMatchResult cb_match_result = 2;
+  repeated BlockIdGroup gpu_block_ids = 3;
+  int64 instance_id = 4;
+  bytes event_ipc_handle = 5;
+}
+
+message CbRetrievePreComputedResponse {
+  EventIpcHandleResult result = 1;
+}
+
+message CbUnifiedLookupRequest {
+  IpcCacheServerKey key = 1;
+  int64 tp_size = 2;
+}
+
+message CbUnifiedLookupPayload {
+  int64 prefix_coverage_tokens = 1;
+  repeated CbMatchResult non_prefix_segments = 2;
+  repeated CbMatchResult segmented_prefix_segments = 3;
+}
+
+message CbUnifiedLookupResponse {
+  optional CbUnifiedLookupPayload payload = 1;
+}
+
+message RopeWindow {
+  repeated int64 values = 1;
+}
+
+message CbRegisterRopeRequest {
+  int64 instance_id = 1;
+  repeated DeviceIpcWrapper cos_sin_caches_ipc = 2;
+  int64 head_size = 3;
+  bool is_neox_style = 4;
+  repeated int64 group_to_cache = 5;
+  repeated RopeWindow group_rot = 6;
+}
+
+message CbRegisterRopeResponse {}
+
+service BlendService {
+  rpc CbRegisterRope(CbRegisterRopeRequest) returns (CbRegisterRopeResponse);
+  rpc CbUnregisterRope(CbUnregisterRopeRequest)
+      returns (CbUnregisterRopeResponse);
+  rpc CbRetrievePreComputed(CbRetrievePreComputedRequest)
+      returns (CbRetrievePreComputedResponse);
+  rpc CbUnifiedLookup(CbUnifiedLookupRequest) returns (CbUnifiedLookupResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared message types for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+// Cache key used by engine and CacheBlend RPCs.
+message IpcCacheServerKey {
+  string model_name = 1;
+  int64 world_size = 2;
+  optional int64 worker_id = 3;
+  repeated int64 token_ids = 4;
+  int64 start = 5;
+  int64 end = 6;
+  string request_id = 7;
+  string cache_salt = 8;
+  optional bytes encoded_request_configs = 9;
+  int64 num_kv_readers = 10;
+}
+
+// Store / Retrieve and CacheBlend retrieve share this reply shape.
+message EventIpcHandleResult {
+  bytes event_ipc_handle = 1;
+  bool success = 2;
+}
+
+// One list of block IDs per KV group in kernel order.
+message BlockIdGroup {
+  repeated int64 block_ids = 1;
+}
+
+// Device IPC wrappers preserve concrete Python subclass identity.
+message DeviceIpcWrapper {
+  bytes pickled_payload = 1;
+}
+
+// EngineGroupInfo mirrors the Python msgspec.Struct field-by-field.
+message EngineGroupInfo {
+  int64 engine_group_id = 1;
+  repeated int64 layer_indices = 2;
+  int64 tokens_per_block = 3;
+  int64 sw_size_tokens = 4;
+  int64 extra_object_group_tag = 5;
+  bool recurrent_state = 6;
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/controller_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/controller_service.proto
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ControllerService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message ClearRequest {}
+
+message ClearResponse {}
+
+message GetChunkSizeRequest {}
+
+message GetChunkSizeResponse {
+  int64 chunk_size = 1;
+}
+
+message GetExperimentalRequest {}
+
+message GetExperimentalResponse {
+  repeated string names = 1;
+}
+
+message PingRequest {
+  optional int64 instance_id = 1;
+}
+
+message PingResponse {
+  bool ok = 1;
+}
+
+service ControllerService {
+  rpc Clear(ClearRequest) returns (ClearResponse);
+  rpc GetChunkSize(GetChunkSizeRequest) returns (GetChunkSizeResponse);
+  rpc GetExperimental(GetExperimentalRequest) returns (GetExperimentalResponse);
+  rpc Ping(PingRequest) returns (PingResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/debug_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/debug_service.proto
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// DebugService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message NoopRequest {}
+
+message NoopResponse {
+  string message = 1;
+}
+
+service DebugService {
+  rpc Noop(NoopRequest) returns (NoopResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/engine_driven_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/engine_driven_service.proto
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine-driven transfer wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto";
+
+message RegisterKvCacheEngineDrivenContextRequest {
+  int64 instance_id = 1;
+  string model_name = 2;
+  int64 world_size = 3;
+  int64 block_size = 4;
+  int64 num_layers = 5;
+  int64 hidden_dim_size = 6;
+  string dtype_str = 7;
+  bool use_mla = 8;
+  optional int64 num_physical_slots = 9;
+}
+
+message RegisterKvCacheEngineDrivenContextResponse {
+  string shm_name = 1;
+  int64 pool_size = 2;
+}
+
+message UnregisterKvCacheEngineDrivenContextRequest {
+  int64 instance_id = 1;
+}
+
+message UnregisterKvCacheEngineDrivenContextResponse {}
+
+message PrepareStoreRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+}
+
+message PrepareStoreResponse {
+  bytes encoded_context = 1;
+}
+
+message CommitStoreRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+  bytes data = 3;
+}
+
+message CommitStoreResponse {
+  bool success = 1;
+}
+
+message PrepareRetrieveRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+}
+
+message PrepareRetrieveResponse {
+  bool success = 1;
+  bytes data = 2;
+  bytes encoded_context = 3;
+}
+
+message CommitRetrieveRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+}
+
+message CommitRetrieveResponse {
+  bool success = 1;
+}
+
+service EngineDrivenService {
+  rpc RegisterKvCacheEngineDrivenContext(
+      RegisterKvCacheEngineDrivenContextRequest)
+      returns (RegisterKvCacheEngineDrivenContextResponse);
+  rpc UnregisterKvCacheEngineDrivenContext(
+      UnregisterKvCacheEngineDrivenContextRequest)
+      returns (UnregisterKvCacheEngineDrivenContextResponse);
+  rpc PrepareStore(PrepareStoreRequest) returns (PrepareStoreResponse);
+  rpc CommitStore(CommitStoreRequest) returns (CommitStoreResponse);
+  rpc PrepareRetrieve(PrepareRetrieveRequest) returns (PrepareRetrieveResponse);
+  rpc CommitRetrieve(CommitRetrieveRequest) returns (CommitRetrieveResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/generate.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/generate.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Python gRPC bindings from the service proto files."""
+
+# Standard
+from pathlib import Path
+
+# Third Party
+from grpc_tools import protoc
+
+
+def generate() -> None:
+    """Generate protobuf and gRPC Python modules next to their proto sources.
+
+    Raises:
+        RuntimeError: If ``grpc_tools.protoc`` cannot compile the proto files.
+    """
+    root = Path(__file__).resolve().parents[6]
+    proto_dir = Path(__file__).resolve().parent
+    proto_files = sorted(
+        str(path.relative_to(root)) for path in proto_dir.glob("*.proto")
+    )
+    for pattern in ("*_pb2.py", "*_pb2_grpc.py"):
+        for generated_file in proto_dir.glob(pattern):
+            generated_file.unlink()
+    result = protoc.main(
+        [
+            "grpc_tools.protoc",
+            f"-I{root}",
+            f"--python_out={root}",
+            f"--grpc_python_out={root}",
+            *proto_files,
+        ]
+    )
+    if result != 0:
+        raise RuntimeError(f"grpc_tools.protoc failed with exit code {result}")
+
+
+if __name__ == "__main__":
+    generate()

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/lmcache_driven_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/lmcache_driven_service.proto
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// LMCache-driven transfer wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto";
+
+message RegisterKvCacheRequest {
+  int64 instance_id = 1;
+  repeated DeviceIpcWrapper kv_cache = 2;
+  string model_name = 3;
+  int64 world_size = 4;
+  string engine_type = 5;
+  bytes encoded_layout_hints = 6;
+  repeated EngineGroupInfo engine_group_infos = 7;
+}
+
+message RegisterKvCacheResponse {}
+
+message UnregisterKvCacheRequest {
+  int64 instance_id = 1;
+}
+
+message UnregisterKvCacheResponse {}
+
+message StoreRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+  repeated BlockIdGroup gpu_block_ids = 3;
+  bytes event_ipc_handle = 4;
+}
+
+message StoreResponse {
+  EventIpcHandleResult result = 1;
+}
+
+message RetrieveRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+  repeated BlockIdGroup gpu_block_ids = 3;
+  bytes event_ipc_handle = 4;
+  int64 skip_first_n_tokens = 5;
+}
+
+message RetrieveResponse {
+  EventIpcHandleResult result = 1;
+}
+
+service LMCacheDrivenService {
+  rpc RegisterKvCache(RegisterKvCacheRequest) returns (RegisterKvCacheResponse);
+  rpc UnregisterKvCache(UnregisterKvCacheRequest)
+      returns (UnregisterKvCacheResponse);
+  rpc Store(StoreRequest) returns (StoreResponse);
+  rpc Retrieve(RetrieveRequest) returns (RetrieveResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/lookup_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/lookup_service.proto
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lookup wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto";
+
+message LookupRequest {
+  IpcCacheServerKey key = 1;
+  int64 tp_size = 2;
+}
+
+message LookupResponse {}
+
+message QueryPrefetchStatusRequest {
+  string request_id = 1;
+}
+
+message QueryPrefetchStatusResponse {
+  optional int64 chunk_count = 1;
+}
+
+message WaitPrefetchStatusRequest {
+  string request_id = 1;
+  double timeout = 2;
+}
+
+message WaitPrefetchStatusResponse {
+  optional int64 chunk_count = 1;
+}
+
+message QueryPrefetchLookupHitsRequest {
+  string request_id = 1;
+}
+
+message QueryPrefetchLookupHitsResponse {
+  optional int64 chunk_count = 1;
+}
+
+message FreeLookupLocksRequest {
+  IpcCacheServerKey key = 1;
+  int64 tp_size = 2;
+}
+
+message FreeLookupLocksResponse {}
+
+message EndSessionRequest {
+  string request_id = 1;
+}
+
+message EndSessionResponse {}
+
+service LookupService {
+  rpc Lookup(LookupRequest) returns (LookupResponse);
+  rpc QueryPrefetchStatus(QueryPrefetchStatusRequest)
+      returns (QueryPrefetchStatusResponse);
+  rpc WaitPrefetchStatus(WaitPrefetchStatusRequest)
+      returns (WaitPrefetchStatusResponse);
+  rpc QueryPrefetchLookupHits(QueryPrefetchLookupHitsRequest)
+      returns (QueryPrefetchLookupHitsResponse);
+  rpc FreeLookupLocks(FreeLookupLocksRequest) returns (FreeLookupLocksResponse);
+  rpc EndSession(EndSessionRequest) returns (EndSessionResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/observability_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/observability_service.proto
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ObservabilityService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message BlockAllocationRecord {
+  string req_id = 1;
+  repeated int64 new_block_ids = 2;
+  repeated int64 new_token_ids = 3;
+}
+
+message ReportBlockAllocationRequest {
+  int64 instance_id = 1;
+  string model_name = 2;
+  repeated BlockAllocationRecord records = 3;
+}
+
+message ReportBlockAllocationResponse {}
+
+service ObservabilityService {
+  rpc ReportBlockAllocation(ReportBlockAllocationRequest)
+      returns (ReportBlockAllocationResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/p2p_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/p2p_service.proto
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// P2PService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message ObjectKey {
+  bytes chunk_hash = 1;
+  string model_name = 2;
+  int64 kv_rank = 3;
+  int64 object_group_id = 4;
+  string cache_salt = 5;
+}
+
+message TensorShape {
+  repeated int64 dims = 1;
+}
+
+message MemoryLayoutDesc {
+  repeated TensorShape shapes = 1;
+  repeated string dtypes = 2;
+}
+
+message TransferChannelAddress {
+  int64 offset = 1;
+  int64 size = 2;
+}
+
+message P2pLookupAndLockRequest {
+  repeated ObjectKey keys = 1;
+  map<int64, MemoryLayoutDesc> group_layout_descs = 2;
+}
+
+message P2pLookupAndLockResponse {
+  int64 task_id = 1;
+}
+
+message P2pQueryLookupResultsRequest {
+  int64 task_id = 1;
+}
+
+message TransferChannelAddressList {
+  repeated TransferChannelAddress addresses = 1;
+}
+
+message P2pQueryLookupResultsResponse {
+  optional TransferChannelAddressList addresses = 1;
+}
+
+message P2pUnlockObjectsRequest {
+  repeated ObjectKey keys = 1;
+}
+
+message P2pUnlockObjectsResponse {}
+
+service P2PService {
+  rpc P2PLookupAndLock(P2pLookupAndLockRequest)
+      returns (P2pLookupAndLockResponse);
+  rpc P2PQueryLookupResults(P2pQueryLookupResultsRequest)
+      returns (P2pQueryLookupResultsResponse);
+  rpc P2PUnlockObjects(P2pUnlockObjectsRequest)
+      returns (P2pUnlockObjectsResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/qstore_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/qstore_service.proto
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Experimental QStore wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "lmcache/v1/multiprocess/transport/grpc_impl/protos/lmcache_driven_service.proto";
+
+service QStoreService {
+  rpc RegisterQCache(RegisterKvCacheRequest) returns (RegisterKvCacheResponse);
+  rpc UnregisterQCache(UnregisterKvCacheRequest)
+      returns (UnregisterKvCacheResponse);
+  rpc StoreQ(StoreRequest) returns (StoreResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/server.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/server.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multiprocess server driven by generated gRPC service descriptors."""
+
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Callable
+import threading
+
+# Third Party
+import grpc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.affinity_pool import AffinityThreadPool
+from lmcache.v1.multiprocess.transport.grpc_impl.client import parse_grpc_target
+from lmcache.v1.multiprocess.transport.grpc_impl.descriptors import (
+    ServiceBinding,
+    get_service_bindings,
+    message_class,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.proto_codec import (
+    RequestDecoder,
+    ResponseEncoder,
+    compile_request_decoder,
+    compile_response_encoder,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    get_grpc_method_options,
+)
+
+logger = init_logger(__name__)
+
+_GRPC_OPTIONS = (
+    ("grpc.max_send_message_length", -1),
+    ("grpc.max_receive_message_length", -1),
+)
+_CLIENT_ID_METADATA_KEY = "lmcache-client-id-bin"
+
+
+@dataclass
+class _GrpcRequestHandler:
+    handler: Callable[..., Any]
+    handler_type: GrpcHandlerType
+    requires_client_affinity: bool
+    request_decoder: RequestDecoder
+    response_encoder: ResponseEncoder
+
+
+class _GeneratedServicer:
+    def __init__(
+        self,
+        binding: ServiceBinding,
+        handlers: dict[str, _GrpcRequestHandler],
+        normal_pool: ThreadPoolExecutor,
+        affinity_pool: AffinityThreadPool,
+        affinity_submit_lock: threading.Lock,
+    ) -> None:
+        self._binding = binding
+        self._handlers = handlers
+        self._normal_pool = normal_pool
+        self._affinity_pool = affinity_pool
+        self._affinity_submit_lock = affinity_submit_lock
+
+    def __getattr__(self, method_name: str) -> Callable[[Any, Any], Any]:
+        full_name = f"{self._binding.descriptor.full_name}.{method_name}"
+        handler = self._handlers.get(full_name)
+        if handler is None:
+            raise AttributeError(method_name)
+
+        def invoke(request: Any, context: grpc.ServicerContext) -> Any:
+            return self._dispatch(handler, request, context)
+
+        return invoke
+
+    def _dispatch(
+        self,
+        registered: _GrpcRequestHandler,
+        request: Any,
+        context: grpc.ServicerContext,
+    ) -> Any:
+        payloads = registered.request_decoder(request)
+        try:
+            if registered.handler_type is GrpcHandlerType.SYNC:
+                result = registered.handler(*payloads)
+            elif registered.requires_client_affinity:
+                affinity_key = self._affinity_key(context)
+                with self._affinity_submit_lock:
+                    future = self._affinity_pool.submit(
+                        registered.handler,
+                        *payloads,
+                        affinity_key=affinity_key,
+                    )
+                result = future.result()
+            else:
+                result = self._normal_pool.submit(
+                    registered.handler, *payloads
+                ).result()
+            return registered.response_encoder(result)
+        except NotImplementedError as exc:
+            context.abort(grpc.StatusCode.UNIMPLEMENTED, str(exc))
+            raise RuntimeError("gRPC context abort unexpectedly returned") from exc
+
+    @staticmethod
+    def _affinity_key(context: grpc.ServicerContext) -> int:
+        for key, value in context.invocation_metadata():
+            if key == _CLIENT_ID_METADATA_KEY:
+                return hash(value)
+        return hash(context.peer())
+
+
+class GrpcMultiprocessServer:
+    """Register concrete implementations against generated gRPC services."""
+
+    def __init__(
+        self,
+        bind_url: str,
+        max_cpu_workers: int,
+        max_gpu_workers: int,
+        grpc_workers: int = 32,
+    ) -> None:
+        self._bind_url = bind_url
+        self._handlers: dict[str, _GrpcRequestHandler] = {}
+        self._normal_pool = ThreadPoolExecutor(
+            max_workers=max_cpu_workers,
+            thread_name_prefix="grpc-normal",
+        )
+        self._affinity_pool = AffinityThreadPool(
+            max_workers=max_gpu_workers,
+            thread_name_prefix="grpc-affinity",
+        )
+        self._affinity_submit_lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(
+            max_workers=grpc_workers,
+            thread_name_prefix="grpc-server",
+        )
+        self._server = grpc.server(self._executor, options=_GRPC_OPTIONS)
+        self._bound_port = self._server.add_insecure_port(parse_grpc_target(bind_url))
+        if self._bound_port == 0:
+            raise RuntimeError(f"Failed to bind gRPC multiprocess server: {bind_url}")
+        self._closed = threading.Event()
+
+    @property
+    def bound_port(self) -> int:
+        """Return the TCP port selected by gRPC, including for port zero."""
+        return self._bound_port
+
+    def add_service(self, service_name: str, implementation: object) -> None:
+        """Register methods from a concrete protobuf service implementation.
+
+        Args:
+            service_name: Name declared by the generated protobuf service.
+            implementation: Object with one same-named method per proto RPC.
+
+        Raises:
+            ValueError: If the generated service does not exist.
+            TypeError: If an RPC implementation is missing.
+        """
+        binding = get_service_bindings().get(service_name)
+        if binding is None:
+            raise ValueError(f"Unknown generated gRPC service: {service_name}")
+
+        service_handlers: dict[str, _GrpcRequestHandler] = {}
+        for method in binding.descriptor.methods:
+            handler = getattr(implementation, method.name, None)
+            if not callable(handler):
+                raise TypeError(
+                    f"{implementation.__class__.__name__} must implement "
+                    f"{service_name}.{method.name}"
+                )
+            request_decoder, _ = compile_request_decoder(
+                message_class(method.input_type), handler
+            )
+            response_encoder, _ = compile_response_encoder(
+                message_class(method.output_type), handler
+            )
+            handler_type, requires_affinity = get_grpc_method_options(handler)
+            full_name = method.full_name
+            registered = _GrpcRequestHandler(
+                handler=handler,
+                handler_type=handler_type,
+                requires_client_affinity=requires_affinity,
+                request_decoder=request_decoder,
+                response_encoder=response_encoder,
+            )
+            self._handlers[full_name] = registered
+            service_handlers[full_name] = registered
+
+        servicer = _GeneratedServicer(
+            binding,
+            service_handlers,
+            self._normal_pool,
+            self._affinity_pool,
+            self._affinity_submit_lock,
+        )
+        add_servicer = getattr(
+            binding.grpc_module,
+            f"add_{service_name}Servicer_to_server",
+        )
+        add_servicer(servicer, self._server)
+
+    def start(self) -> None:
+        """Start accepting gRPC requests."""
+        self._server.start()
+        logger.info("LMCache gRPC cache server is running on %s", self._bind_url)
+
+    def close(self) -> None:
+        """Stop the gRPC server and its request executors."""
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        self._server.stop(grace=None)
+        self._normal_pool.shutdown(wait=False)
+        self._affinity_pool.shutdown(wait=False)
+        self._executor.shutdown(wait=False)

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Concrete implementations for generated multiprocess gRPC services."""
+
+# Local
+from .blend import BlendServiceImpl
+from .controller import ControllerServiceImpl
+from .debug import DebugServiceImpl
+from .engine_driven import EngineDrivenServiceImpl
+from .lmcache_driven import LMCacheDrivenServiceImpl
+from .lookup import LookupServiceImpl
+from .observability import ObservabilityServiceImpl
+from .p2p import P2PServiceImpl
+from .qstore import QStoreServiceImpl
+
+__all__ = [
+    "BlendServiceImpl",
+    "ControllerServiceImpl",
+    "DebugServiceImpl",
+    "EngineDrivenServiceImpl",
+    "LMCacheDrivenServiceImpl",
+    "LookupServiceImpl",
+    "ObservabilityServiceImpl",
+    "P2PServiceImpl",
+    "QStoreServiceImpl",
+]

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/base.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/base.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduling metadata for concrete gRPC service methods."""
+
+# Standard
+from enum import Enum, auto
+from typing import Any, Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+T = TypeVar("T")
+
+_HANDLER_TYPE_ATTR = "__lmcache_grpc_handler_type__"
+_REQUIRES_AFFINITY_ATTR = "__lmcache_grpc_requires_affinity__"
+
+
+class GrpcHandlerType(Enum):
+    """Select how a concrete gRPC service method is executed."""
+
+    SYNC = auto()
+    BLOCKING = auto()
+
+
+def grpc_method(
+    handler_type: GrpcHandlerType = GrpcHandlerType.SYNC,
+    *,
+    requires_client_affinity: bool = False,
+) -> Callable[[F], F]:
+    """Attach server scheduling metadata to a service implementation method."""
+
+    def decorate(func: F) -> F:
+        setattr(func, _HANDLER_TYPE_ATTR, handler_type)
+        setattr(func, _REQUIRES_AFFINITY_ATTR, requires_client_affinity)
+        return func
+
+    return decorate
+
+
+def get_grpc_method_options(
+    handler: Callable[..., Any],
+) -> tuple[GrpcHandlerType, bool]:
+    """Return scheduling metadata attached by :func:`grpc_method`."""
+    source = getattr(handler, "__func__", handler)
+    return (
+        getattr(source, _HANDLER_TYPE_ATTR, GrpcHandlerType.SYNC),
+        getattr(source, _REQUIRES_AFFINITY_ATTR, False),
+    )
+
+
+def require_service(service: T | None, feature: str) -> T:
+    """Return an enabled service or report the RPC as unimplemented."""
+    if service is None:
+        raise NotImplementedError(f"{feature} is not enabled on this server")
+    return service

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/blend.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/blend.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``BlendService`` surface."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import (
+    CBMatchResult,
+    CBUnifiedLookupResult,
+    DeviceIPCWrapper,
+    IPCCacheServerKey,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+    require_service,
+)
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.modules.blend import BlendModule
+
+
+class BlendServiceImpl:
+    """Implement CacheBlend RPCs when the blend module is enabled."""
+
+    def __init__(self, blend: BlendModule | None) -> None:
+        self._blend = blend
+
+    def CbRegisterRope(
+        self,
+        instance_id: int,
+        cos_sin_caches_ipc: list[DeviceIPCWrapper],
+        head_size: int,
+        is_neox_style: bool,
+        group_to_cache: list[int],
+        group_rot: list[list[int]],
+    ) -> None:
+        """Register rope metadata for CacheBlend re-RoPE."""
+        return require_service(self._blend, "CacheBlend").cb_register_rope(
+            instance_id,
+            cos_sin_caches_ipc,
+            head_size,
+            is_neox_style,
+            group_to_cache,
+            group_rot,
+        )
+
+    def CbUnregisterRope(self, instance_id: int) -> None:
+        """Unregister CacheBlend rope metadata."""
+        return require_service(self._blend, "CacheBlend").cb_unregister_rope(
+            instance_id
+        )
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def CbRetrievePreComputed(
+        self,
+        key: IPCCacheServerKey,
+        cb_match_result: list[CBMatchResult],
+        gpu_block_ids: list[list[int]],
+        instance_id: int,
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, bool]:
+        """Retrieve precomputed CacheBlend chunks."""
+        return require_service(self._blend, "CacheBlend").cb_retrieve_pre_computed(
+            key, cb_match_result, gpu_block_ids, instance_id, event_ipc_handle
+        )
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def CbUnifiedLookup(
+        self,
+        key: IPCCacheServerKey,
+        tp_size: int,
+    ) -> CBUnifiedLookupResult | None:
+        """Run the CacheBlend unified lookup."""
+        return require_service(self._blend, "CacheBlend").cb_unified_lookup(
+            key, tp_size
+        )

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/controller.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/controller.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``ControllerService`` surface."""
+
+# First Party
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+)
+
+
+class ControllerServiceImpl:
+    """Implement controller RPCs with the management module."""
+
+    def __init__(self, management: ManagementModule) -> None:
+        self._management = management
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def Clear(self) -> None:
+        """Clear all stored KV cache data."""
+        return self._management.clear()
+
+    def GetChunkSize(self) -> int:
+        """Return the configured chunk size."""
+        return self._management.get_chunk_size()
+
+    def GetExperimental(self) -> list[str]:
+        """Return enabled experimental server features."""
+        return self._management.get_experimental()
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def Ping(self, instance_id: int | None) -> bool:
+        """Refresh worker liveness and report server reachability."""
+        return self._management.ping(instance_id)

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/debug.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/debug.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``DebugService`` surface."""
+
+# First Party
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+
+
+class DebugServiceImpl:
+    """Implement debug RPCs with the management module."""
+
+    def __init__(self, management: ManagementModule) -> None:
+        self._management = management
+
+    def Noop(self) -> str:
+        """Return a simple health-check string."""
+        return self._management.debug()

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/engine_driven.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/engine_driven.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``EngineDrivenService`` surface."""
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import (
+    IPCCacheServerKey,
+    PrepareRetrieveResponse,
+    PrepareStoreResponse,
+    RegisterEngineDrivenContextPayload,
+    RegisterEngineDrivenContextResponse,
+)
+from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
+    EngineDrivenTransferModule,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+    require_service,
+)
+
+
+class EngineDrivenServiceImpl:
+    """Implement engine-driven transfer RPCs."""
+
+    def __init__(self, transfer: EngineDrivenTransferModule | None) -> None:
+        self._transfer = transfer
+
+    def RegisterKvCacheEngineDrivenContext(
+        self,
+        payload: RegisterEngineDrivenContextPayload,
+    ) -> RegisterEngineDrivenContextResponse:
+        """Register an engine-driven KV context."""
+        return require_service(
+            self._transfer, "engine-driven transfer"
+        ).register_kv_cache_engine_driven_context(payload)
+
+    def UnregisterKvCacheEngineDrivenContext(self, instance_id: int) -> None:
+        """Unregister an engine-driven KV context."""
+        return require_service(
+            self._transfer, "engine-driven transfer"
+        ).unregister_kv_cache(instance_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def PrepareStore(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+    ) -> PrepareStoreResponse:
+        """Prepare an engine-driven store."""
+        return require_service(self._transfer, "engine-driven transfer").prepare_store(
+            key, instance_id
+        )
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def CommitStore(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        data: bytes,
+    ) -> bool:
+        """Commit an engine-driven store."""
+        return require_service(self._transfer, "engine-driven transfer").commit_store(
+            key, instance_id, data
+        )
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def PrepareRetrieve(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+    ) -> PrepareRetrieveResponse:
+        """Prepare an engine-driven retrieve."""
+        return require_service(
+            self._transfer, "engine-driven transfer"
+        ).prepare_retrieve(key, instance_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def CommitRetrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
+        """Commit an engine-driven retrieve."""
+        return require_service(
+            self._transfer, "engine-driven transfer"
+        ).commit_retrieve(key, instance_id)

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/lmcache_driven.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/lmcache_driven.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``LMCacheDrivenService`` surface."""
+
+# Standard
+from typing import Protocol
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, KVCache
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    LMCacheDrivenTransferModule,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+    require_service,
+)
+
+
+class _StoreModule(Protocol):
+    def store(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, bool]:
+        """Store KV chunks for an engine worker."""
+        ...
+
+
+class LMCacheDrivenServiceImpl:
+    """Implement LMCache-driven transfer RPCs."""
+
+    def __init__(
+        self,
+        transfer: LMCacheDrivenTransferModule | None,
+        store_module: _StoreModule | None,
+    ) -> None:
+        self._transfer = transfer
+        self._store_module = store_module
+
+    def RegisterKvCache(
+        self,
+        instance_id: int,
+        kv_cache: KVCache,
+        model_name: str,
+        world_size: int,
+        engine_type: EngineType,
+        layout_hints: LayoutHints,
+        engine_group_infos: list[EngineGroupInfo],
+    ) -> None:
+        """Register an LMCache-driven KV cache context."""
+        return require_service(
+            self._transfer, "LMCache-driven transfer"
+        ).register_kv_cache(
+            instance_id,
+            kv_cache,
+            model_name,
+            world_size,
+            engine_type,
+            layout_hints,
+            engine_group_infos,
+        )
+
+    def UnregisterKvCache(self, instance_id: int) -> None:
+        """Unregister an LMCache-driven KV cache context."""
+        return require_service(
+            self._transfer, "LMCache-driven transfer"
+        ).unregister_kv_cache(instance_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def Store(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, bool]:
+        """Store KV blocks, using the blend path when enabled."""
+        return require_service(self._store_module, "LMCache-driven transfer").store(
+            key, instance_id, gpu_block_ids, event_ipc_handle
+        )
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def Retrieve(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int,
+    ) -> tuple[bytes, bool]:
+        """Retrieve KV blocks into an LMCache-driven cache context."""
+        return require_service(self._transfer, "LMCache-driven transfer").retrieve(
+            key,
+            instance_id,
+            gpu_block_ids,
+            event_ipc_handle,
+            skip_first_n_tokens,
+        )

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/lookup.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/lookup.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``LookupService`` surface."""
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.modules.lookup import LookupModule
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+)
+
+
+class LookupServiceImpl:
+    """Implement lookup RPCs with the lookup module."""
+
+    def __init__(self, lookup: LookupModule) -> None:
+        self._lookup = lookup
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def Lookup(self, key: IPCCacheServerKey, tp_size: int) -> None:
+        """Start a prefix lookup and prefetch."""
+        return self._lookup.lookup(key, tp_size)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def QueryPrefetchStatus(self, request_id: str) -> int | None:
+        """Poll prefix prefetch completion."""
+        return self._lookup.query_prefetch_status(request_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def WaitPrefetchStatus(self, request_id: str, timeout: float) -> int | None:
+        """Wait for prefix prefetch completion."""
+        return self._lookup.wait_prefetch_status(request_id, timeout)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def QueryPrefetchLookupHits(self, request_id: str) -> int | None:
+        """Return a prefetch lookup hit count."""
+        return self._lookup.query_prefetch_lookup_hits(request_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def FreeLookupLocks(self, key: IPCCacheServerKey, tp_size: int) -> None:
+        """Release lookup read locks."""
+        return self._lookup.free_lookup_locks(key, tp_size)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def EndSession(self, request_id: str) -> None:
+        """End a cache session."""
+        return self._lookup.end_session(request_id)

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/observability.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/observability.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``ObservabilityService`` surface."""
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import BlockAllocationRecord
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+)
+
+
+class ObservabilityServiceImpl:
+    """Implement observability RPCs with the management module."""
+
+    def __init__(self, management: ManagementModule) -> None:
+        self._management = management
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def ReportBlockAllocation(
+        self,
+        instance_id: int,
+        model_name: str,
+        records: list[BlockAllocationRecord],
+    ) -> None:
+        """Publish block allocation records to the event bus."""
+        return self._management.report_block_allocations(
+            instance_id, model_name, records
+        )

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/p2p.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/p2p.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``P2PService`` surface."""
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
+from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+)
+
+
+class P2PServiceImpl:
+    """Implement peer transfer RPCs with the P2P controller."""
+
+    def __init__(self, controller: P2PController) -> None:
+        self._controller = controller
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def P2PLookupAndLock(
+        self,
+        keys: list[ObjectKey],
+        group_layout_descs: dict[int, MemoryLayoutDesc],
+    ) -> int:
+        """Start a peer lookup and lock matching objects."""
+        return self._controller.p2p_lookup_and_lock(keys, group_layout_descs)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def P2PQueryLookupResults(
+        self, task_id: int
+    ) -> list[TransferChannelAddress] | None:
+        """Poll the result of a peer lookup."""
+        return self._controller.p2p_query_lookup_results(task_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING)
+    def P2PUnlockObjects(self, keys: list[ObjectKey]) -> None:
+        """Release peer read locks for object keys."""
+        return self._controller.p2p_unlock_objects(keys)

--- a/lmcache/v1/multiprocess/transport/grpc_impl/services/qstore.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/services/qstore.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gRPC adapter for the generated ``QStoreService`` surface."""
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, KVCache
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.modules.experimental.qstore import QStoreModule
+from lmcache.v1.multiprocess.transport.grpc_impl.services.base import (
+    GrpcHandlerType,
+    grpc_method,
+    require_service,
+)
+
+
+class QStoreServiceImpl:
+    """Implement experimental QStore RPCs when enabled."""
+
+    def __init__(self, qstore: QStoreModule | None) -> None:
+        self._qstore = qstore
+
+    def RegisterQCache(
+        self,
+        instance_id: int,
+        kv_cache: KVCache,
+        model_name: str,
+        world_size: int,
+        engine_type: EngineType,
+        layout_hints: LayoutHints,
+        engine_group_infos: list[EngineGroupInfo],
+    ) -> None:
+        """Register an experimental paged-Q cache context."""
+        return require_service(self._qstore, "QStore").register_q_cache(
+            instance_id,
+            kv_cache,
+            model_name,
+            world_size,
+            engine_type,
+            layout_hints,
+            engine_group_infos,
+        )
+
+    def UnregisterQCache(self, instance_id: int) -> None:
+        """Unregister an experimental paged-Q cache context."""
+        return require_service(self._qstore, "QStore").unregister_q_cache(instance_id)
+
+    @grpc_method(GrpcHandlerType.BLOCKING, requires_client_affinity=True)
+    def StoreQ(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, bool]:
+        """Store experimental paged-Q blocks."""
+        return require_service(self._qstore, "QStore").store_q(
+            key, instance_id, gpu_block_ids, event_ipc_handle
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
+    "grpcio-tools==1.78.0",
     "torch==2.13.0",
     "wheel",
 ]
@@ -151,6 +152,13 @@ disallow_untyped_calls = false
 warn_return_any = false
 
 follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+module = [
+    "lmcache.v1.multiprocess.transport.grpc_impl.protos.*",
+]
+ignore_errors = true
+follow_imports = "skip"
 
 [tool.codespell]
 ignore-words-list = "afterall,allready,notin,te,cann"

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,8 +4,8 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
+grpcio-tools==1.78.0
 # torch is not here because vllm installation will implicitly install it for the dockerfile
 # and users should be deliberate about choosing their torch version (or letting their serving
 # engine be deliberate for them)
 wheel
-

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,6 +25,8 @@ py-cpuinfo
 pytest
 pyyaml
 pyzmq >= 25.0.0
+grpcio>=1.78.0
+protobuf>=6.31.1,<7
 redis
 safetensors
 setuptools>=77.0.3,<81.0.0

--- a/requirements/proto.txt
+++ b/requirements/proto.txt
@@ -1,0 +1,2 @@
+# Pinned for deterministic local and CI generation; outputs are not tracked.
+grpcio-tools==1.78.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,5 @@
+-r proto.txt
+
 buildkite-test-collector
 pytest>=7.0,<9.1  # avoid some plugins breaking in 8.x
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ zero changes to this file.
 
 # Standard
 from pathlib import Path
+from types import ModuleType
+import importlib.util
 import sys
 
 ROOT_DIR = Path(__file__).parent
@@ -18,6 +20,7 @@ if str(ROOT_DIR) not in sys.path:
 
 # Third Party
 from setuptools import find_packages, setup  # noqa: E402
+from setuptools.command.build_py import build_py as _build_py  # noqa: E402
 
 # First Party
 from setup_extensions import BuildPolicy, BuildProfile  # noqa: E402
@@ -34,10 +37,44 @@ def _read_requirements(path: Path) -> list[str]:
     return reqs
 
 
+def _load_proto_generator() -> ModuleType:
+    """Load the proto generator without importing the LMCache package."""
+    generator_path = (
+        ROOT_DIR
+        / "lmcache"
+        / "v1"
+        / "multiprocess"
+        / "transport"
+        / "grpc_impl"
+        / "protos"
+        / "generate.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_lmcache_proto_generate", generator_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load gRPC proto generator: {generator_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _BuildPyWithGrpcStubs(_build_py):
+    """Generate ignored gRPC bindings before packaging LMCache."""
+
+    def run(self) -> None:
+        distribution_name = self.distribution.get_name().replace("_", "-").lower()
+        if distribution_name != "lmcache-cli":
+            generator = _load_proto_generator()
+            generator.generate()
+        super().run()
+
+
 if __name__ == "__main__":
     policy = BuildPolicy()
     profile = policy.resolve_profile()
     ext_modules, cmdclass, req_file = policy.collect_extensions(profile)
+    cmdclass["build_py"] = _BuildPyWithGrpcStubs
 
     install_requires = _read_requirements(ROOT_DIR / "requirements" / "common.txt")
     extras_require: dict[str, list[str]] = {}

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -33,6 +33,7 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _send_unregister_kv_cache,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.transport import factory as transport_factory
 from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform.ops_types import PageBufferShapeDesc
@@ -429,6 +430,16 @@ def router_endpoint() -> str:
     return endpoint
 
 
+@pytest.fixture
+def use_configured_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the temporary gRPC override for ZMQ wire-protocol tests."""
+    monkeypatch.setattr(
+        transport_factory,
+        "effective_transport",
+        lambda configured_transport: configured_transport,
+    )
+
+
 # ------------------------------------------------------------------ #
 #  _allocate_kv_cache (dtype branching)
 # ------------------------------------------------------------------ #
@@ -592,6 +603,7 @@ class _LookupRouter:
                 self._router.send_multipart([identity, uid_f, type_f, body])
 
 
+@pytest.mark.usefixtures("use_configured_transport")
 class TestLookupProtocol:
     def _make_client(self, endpoint: str) -> RequestClient:
         ctx = zmq.Context.instance()
@@ -688,6 +700,7 @@ class _UnregisterRouter:
                 self._router.send_multipart([identity, uid_f, type_f])
 
 
+@pytest.mark.usefixtures("use_configured_transport")
 class TestUnregisterKVCache:
     def _make_client(self, endpoint: str) -> RequestClient:
         ctx = zmq.Context.instance()
@@ -807,6 +820,7 @@ class _RegisterEngineDrivenRouter:
                 self._router.send_multipart([identity, uid_f, type_f, body])
 
 
+@pytest.mark.usefixtures("use_configured_transport")
 class TestRegisterKVCacheMLA:
     """The data-mode register must set ``use_mla`` from ``layout_hints``.
 

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
@@ -2,8 +2,8 @@
 """In-process, real-NIXL integration test for the P2P L2 adapter.
 
 Stands up a peer side (a real ``StorageManager`` with objects in L1, a NIXL
-transfer-channel context registered against that L1, and an MQ server hosting a
-``P2PController``) and a local side (the global NIXL context over a destination
+transfer-channel context registered against that L1, and a gRPC server hosting
+a ``P2PController``) and a local side (the global NIXL context over a destination
 buffer + a ``P2PL2Adapter``). It then drives the adapter through the full
 lookup -> load (loopback RDMA read) -> unlock lifecycle and verifies the pulled
 bytes match the peer's.
@@ -30,8 +30,6 @@ if not torch_dev.is_available():
     )
 
 nixl = pytest.importorskip("nixl")
-# Third Party
-import zmq  # noqa: E402
 
 # First Party
 from lmcache.v1.distributed.api import (  # noqa: E402
@@ -62,8 +60,12 @@ from lmcache.v1.multiprocess.config import (  # noqa: E402
     P2PConfig,
 )
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController  # noqa: E402
-from lmcache.v1.multiprocess.mq import MessageQueueServer  # noqa: E402
-from lmcache.v1.multiprocess.protocol import get_payload_classes  # noqa: E402
+from lmcache.v1.multiprocess.transport.grpc_impl.server import (  # noqa: E402
+    GrpcMultiprocessServer,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services.p2p import (  # noqa: E402
+    P2PServiceImpl,
+)
 
 _PAGE = 4096
 _NUM_KEYS = 3
@@ -123,7 +125,7 @@ def test_p2p_adapter_end_to_end():
 
     peer_sm = _make_storage_manager(64 * 1024 * 1024)
     peer_tc_ctx = None
-    mq_server = None
+    grpc_server = None
     adapter = None
     local_buf = torch.zeros((_NUM_KEYS + 1) * _PAGE, dtype=torch.uint8)
 
@@ -145,24 +147,21 @@ def test_p2p_adapter_end_to_end():
             peer_l1_desc, listen_url=peer_tc_url, advertise_url=peer_tc_url
         )
 
-        # --- Peer side: MQ server hosting the P2P controller ---
+        # --- Peer side: gRPC server hosting the P2P controller ---
         controller = P2PController(
             _PeerContext(peer_sm),
             P2PConfig(),
             CoordinatorConfig(),
             instance_id="peer",
         )
-        peer_mq_url = f"tcp://{_next_url()}"
-        mq_server = MessageQueueServer(peer_mq_url, zmq.Context.instance())
-        specs = controller.get_handlers()
-        for spec in specs:
-            mq_server.add_blocking_handler(
-                spec.request_type,
-                get_payload_classes(spec.request_type),
-                spec.handler,
-            )
-        mq_server.add_normal_thread_pool([s.request_type for s in specs], max_workers=4)
-        mq_server.start()
+        peer_mq_url = f"grpc://{_next_url()}"
+        grpc_server = GrpcMultiprocessServer(
+            bind_url=peer_mq_url,
+            max_cpu_workers=4,
+            max_gpu_workers=4,
+        )
+        grpc_server.add_service("P2PService", P2PServiceImpl(controller))
+        grpc_server.start()
 
         # --- Local side: global NIXL context over the destination buffer ---
         local_tc_url = _next_url()
@@ -209,8 +208,8 @@ def test_p2p_adapter_end_to_end():
     finally:
         if adapter is not None:
             adapter.close()
-        if mq_server is not None:
-            mq_server.close()
+        if grpc_server is not None:
+            grpc_server.close()
         delete_transfer_channel_context()
         if peer_tc_ctx is not None:
             peer_tc_ctx.close()

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -8,7 +8,6 @@ import time
 # Third Party
 import pytest
 import torch
-import zmq
 
 # First Party
 from lmcache import torch_dev, torch_device_type
@@ -33,7 +32,7 @@ from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
 # Configuration constants
 SERVER_HOST = "localhost"
 SERVER_PORT = 5599
-SERVER_URL = f"tcp://{SERVER_HOST}:{SERVER_PORT}"
+SERVER_URL = f"grpc://{SERVER_HOST}:{SERVER_PORT}"
 CHUNK_SIZE = 256
 CPU_BUFFER_SIZE = 5.0
 DEFAULT_TIMEOUT = 20.0
@@ -230,7 +229,13 @@ def retrieve_keys(
         start = i * BLOCKS_PER_KEY
         end = start + BLOCKS_PER_KEY
         block_ids = gpu_block_ids[start:end]
-        future = client.retrieve(key, instance_id, [block_ids], event_handle, 0)
+        future = client.retrieve(
+            key,
+            instance_id,
+            [block_ids],
+            event_handle,
+            0,
+        )
         result = future.to_device_future().result(timeout=timeout)
         results.append(result)
     return results
@@ -288,24 +293,14 @@ def server_process() -> Generator[mp.Process, None, None]:
             process.join()
 
 
-@pytest.fixture(scope="module")
-def zmq_context() -> Generator[zmq.Context, None, None]:
-    """
-    Fixture that provides a ZMQ context for the test module.
-    """
-    context = zmq.Context.instance()
-    yield context
-    # Context cleanup is handled by ZMQ
-
-
 @pytest.fixture(scope="function")
 def client(
-    server_process: mp.Process, zmq_context: zmq.Context
+    server_process: mp.Process,
 ) -> Generator[RequestClient, None, None]:
     """
     Fixture that provides a message queue client for each test function.
     """
-    client = RequestClientFactory.create(SERVER_URL, context=zmq_context)
+    client = RequestClientFactory.create(SERVER_URL)
     yield client
     # Client cleanup
     client.close()

--- a/tests/v1/multiprocess/test_client.py
+++ b/tests/v1/multiprocess/test_client.py
@@ -9,6 +9,13 @@ from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.grpc_impl.client import (
+    GrpcMultiprocessClient,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.descriptors import (
+    client_method_name,
+    iter_methods,
+)
 from lmcache.v1.multiprocess.transport.zmq_impl import ZmqMultiprocessClient
 
 
@@ -38,17 +45,35 @@ def test_all_request_types_have_explicit_named_methods() -> None:
     contract_names = {
         name for name, value in RequestClient.__dict__.items() if callable(value)
     }
-    method_names = {
+    expected_names = {name.lower() for name in RequestType.__members__}
+
+    assert expected_names <= contract_names
+    zmq_method_names = {
         name
         for name, value in ZmqMultiprocessClient.__dict__.items()
         if callable(value)
     }
-    expected_names = {name.lower() for name in RequestType.__members__}
-
-    assert expected_names <= contract_names
-    assert expected_names <= method_names
-    assert "__getattr__" not in ZmqMultiprocessClient.__dict__
+    assert expected_names <= zmq_method_names
     assert "submit_request" not in ZmqMultiprocessClient.__dict__
+
+    grpc_client = GrpcMultiprocessClient(  # type: ignore[abstract]
+        "grpc://127.0.0.1:1"
+    )
+    try:
+        generated_names = {
+            client_method_name(method.name) for _, method in iter_methods()
+        }
+        assert generated_names <= set(dir(grpc_client))
+        assert all(callable(getattr(grpc_client, name)) for name in generated_names)
+        assert generated_names <= GrpcMultiprocessClient.__dict__.keys()
+        assert "submit_request" not in GrpcMultiprocessClient.__dict__
+    finally:
+        grpc_client.close()
+
+
+def test_transport_clients_explicitly_inherit_shared_contract() -> None:
+    assert RequestClient in ZmqMultiprocessClient.__bases__
+    assert RequestClient in GrpcMultiprocessClient.__bases__
 
 
 def test_zmq_client_explicitly_inherits_shared_contract() -> None:

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -178,6 +178,15 @@ def test_isolated_ipc_flag_enables():
     assert _parse_mp(["--no-isolated-ipc"]).isolated_ipc is False
 
 
+def test_transport_defaults_to_zmq():
+    assert _parse_mp([]).transport == "zmq"
+    assert MPServerConfig().transport == "zmq"
+
+
+def test_transport_flag_selects_grpc():
+    assert _parse_mp(["--transport", "grpc"]).transport == "grpc"
+
+
 # -- Engine type --------------------------------------------------------------
 
 

--- a/tests/v1/multiprocess/test_grpc_transport.py
+++ b/tests/v1/multiprocess/test_grpc_transport.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for the generated-service gRPC transport."""
+
+# Standard
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.multiprocess.custom_types import (
+    BlockAllocationRecord,
+    CBMatchResult,
+    CBUnifiedLookupResult,
+    IPCCacheServerKey,
+    PrepareStoreResponse,
+    RegisterEngineDrivenContextPayload,
+    RegisterEngineDrivenContextResponse,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.client import (
+    GrpcMultiprocessClient,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.descriptors import (
+    get_service_bindings,
+    iter_methods,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.server import (
+    GrpcMultiprocessServer,
+)
+from lmcache.v1.multiprocess.transport.grpc_impl.services import (
+    BlendServiceImpl,
+    ControllerServiceImpl,
+    DebugServiceImpl,
+    EngineDrivenServiceImpl,
+    LMCacheDrivenServiceImpl,
+    LookupServiceImpl,
+    ObservabilityServiceImpl,
+    P2PServiceImpl,
+    QStoreServiceImpl,
+)
+
+
+@dataclass
+class _Calls:
+    lookup: tuple[IPCCacheServerKey, int] | None = None
+    allocation: tuple[int, str, list[BlockAllocationRecord]] | None = None
+
+
+@pytest.fixture
+def grpc_client() -> Iterator[tuple[GrpcMultiprocessClient, _Calls]]:
+    calls = _Calls()
+
+    class FakeModules:
+        def lookup(self, key: IPCCacheServerKey, tp_size: int) -> None:
+            calls.lookup = (key, tp_size)
+
+        def store(
+            self,
+            key: IPCCacheServerKey,
+            instance_id: int,
+            block_ids: list[list[int]],
+            event_ipc_handle: bytes,
+        ) -> tuple[bytes, bool]:
+            assert instance_id == 7
+            assert block_ids == [[1, 2], [3]]
+            assert event_ipc_handle == b"input-event"
+            return b"output-event", key.model_name == "model"
+
+        def prepare_store(
+            self, key: IPCCacheServerKey, instance_id: int
+        ) -> PrepareStoreResponse:
+            assert key.request_configs == {"blend": True}
+            assert instance_id == 7
+            return PrepareStoreResponse(
+                context={"slots": [{"offset": 8}], "chunk_indices": [2]}
+            )
+
+        def register_kv_cache_engine_driven_context(
+            self, payload: RegisterEngineDrivenContextPayload
+        ) -> RegisterEngineDrivenContextResponse:
+            assert payload.num_physical_slots == 32
+            return RegisterEngineDrivenContextResponse("shared-memory", 4096)
+
+        def ping(self, instance_id: int | None) -> bool:
+            return instance_id == 7
+
+        def debug(self) -> str:
+            return "ok"
+
+        def report_block_allocations(
+            self,
+            instance_id: int,
+            model_name: str,
+            records: list[BlockAllocationRecord],
+        ) -> None:
+            calls.allocation = (instance_id, model_name, records)
+
+        def cb_unified_lookup(
+            self, key: IPCCacheServerKey, tp_size: int
+        ) -> CBUnifiedLookupResult | None:
+            assert key.model_name == "model"
+            assert tp_size == 2
+            return CBUnifiedLookupResult(
+                prefix_coverage_tokens=16,
+                non_prefix_segments=[CBMatchResult(0, 2, 4, 6, b"hash")],
+            )
+
+        def p2p_lookup_and_lock(
+            self,
+            keys: list[ObjectKey],
+            group_layout_descs: dict[int, MemoryLayoutDesc],
+        ) -> int:
+            assert keys[0].cache_salt == "tenant"
+            assert group_layout_descs[0].shapes == [torch.Size([2, 4])]
+            assert group_layout_descs[0].dtypes == [torch.float16]
+            return 41
+
+    modules: Any = FakeModules()
+    server = GrpcMultiprocessServer(
+        "grpc://127.0.0.1:0",
+        max_cpu_workers=2,
+        max_gpu_workers=1,
+    )
+    server.add_service("LMCacheDrivenService", LMCacheDrivenServiceImpl(None, modules))
+    server.add_service("EngineDrivenService", EngineDrivenServiceImpl(modules))
+    server.add_service("LookupService", LookupServiceImpl(modules))
+    server.add_service("QStoreService", QStoreServiceImpl(None))
+    server.add_service("ControllerService", ControllerServiceImpl(modules))
+    server.add_service("DebugService", DebugServiceImpl(modules))
+    server.add_service("ObservabilityService", ObservabilityServiceImpl(modules))
+    server.add_service("P2PService", P2PServiceImpl(modules))
+    server.add_service("BlendService", BlendServiceImpl(modules))
+    server.start()
+    client = GrpcMultiprocessClient(  # type: ignore[abstract]
+        f"grpc://127.0.0.1:{server.bound_port}"
+    )
+    try:
+        yield client, calls
+    finally:
+        client.close()
+        server.close()
+
+
+def test_rpc_surface_is_derived_from_split_service_descriptors() -> None:
+    """RPC discovery follows generated services without a request-type enum."""
+    bindings = get_service_bindings()
+    assert {
+        "LMCacheDrivenService",
+        "EngineDrivenService",
+        "LookupService",
+        "QStoreService",
+    }.issubset(bindings)
+    assert "EngineService" not in bindings
+    assert {method.name for _, method in iter_methods()} >= {
+        "Store",
+        "PrepareStore",
+        "Lookup",
+        "StoreQ",
+    }
+
+
+def test_generated_grpc_services_communicate_end_to_end(
+    grpc_client: tuple[GrpcMultiprocessClient, _Calls],
+) -> None:
+    client, calls = grpc_client
+    key = IPCCacheServerKey(
+        model_name="model",
+        world_size=2,
+        worker_id=None,
+        token_ids=(1, 2, 3),
+        start=0,
+        end=3,
+        request_id="request",
+        cache_salt="tenant",
+        request_configs={"blend": True},
+        num_kv_readers=2,
+    )
+
+    assert client.lookup(key, 2).result(timeout=5) is None
+    assert calls.lookup == (key, 2)
+    assert client.store(key, 7, [[1, 2], [3]], b"input-event").result(5) == (
+        b"output-event",
+        True,
+    )
+    assert client.prepare_store(key, 7).result(5) == PrepareStoreResponse(
+        context={"slots": [{"offset": 8}], "chunk_indices": [2]}
+    )
+    registration = client.register_kv_cache_engine_driven_context(
+        RegisterEngineDrivenContextPayload(
+            instance_id=7,
+            model_name="model",
+            world_size=2,
+            block_size=16,
+            num_layers=32,
+            hidden_dim_size=128,
+            dtype_str="float16",
+            use_mla=False,
+            num_physical_slots=32,
+        )
+    ).result(5)
+    assert registration == RegisterEngineDrivenContextResponse("shared-memory", 4096)
+    assert client.ping(7).result(5) is True
+    assert client.noop().result(5) == "ok"
+
+    records = [BlockAllocationRecord("request", [4], [5, 6])]
+    assert client.report_block_allocation(7, "model", records).result(5) is None
+    assert calls.allocation == (7, "model", records)
+
+    blend_result = client.cb_unified_lookup(key, 2).result(5)
+    assert blend_result == CBUnifiedLookupResult(
+        prefix_coverage_tokens=16,
+        non_prefix_segments=[CBMatchResult(0, 2, 4, 6, b"hash")],
+    )
+
+    task_id = client.p2p_lookup_and_lock(
+        [ObjectKey(b"chunk", "model", 0, cache_salt="tenant")],
+        {0: MemoryLayoutDesc([torch.Size([2, 4])], [torch.float16])},
+    ).result(5)
+    assert task_id == 41

--- a/tests/v1/multiprocess/test_transport_factory.py
+++ b/tests/v1/multiprocess/test_transport_factory.py
@@ -60,11 +60,6 @@ def test_factory_selects_grpc_by_scheme(
     create.assert_called_once_with(normalized_url, context=context)
 
 
-def test_factory_reports_unavailable_grpc_implementation() -> None:
-    with pytest.raises(NotImplementedError, match="not available yet"):
-        RequestClientFactory.create("grpc://localhost:5555")
-
-
 @pytest.mark.parametrize("server_url", ["", "grpc://", "http://localhost:5555"])
 def test_factory_rejects_invalid_or_unsupported_urls(server_url: str) -> None:
     with pytest.raises(ValueError):

--- a/tests/v1/multiprocess/test_transport_factory.py
+++ b/tests/v1/multiprocess/test_transport_factory.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # First Party
+from lmcache.v1.multiprocess.transport import factory as transport_factory
 from lmcache.v1.multiprocess.transport import grpc_impl, zmq_impl
 from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 
@@ -21,20 +22,38 @@ from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
         ("inproc://lmcache", "inproc://lmcache"),
     ],
 )
-def test_factory_selects_zmq_by_scheme(
+def test_factory_temporarily_forces_zmq_schemes_to_grpc(
     monkeypatch: pytest.MonkeyPatch,
     server_url: str,
     normalized_url: str,
 ) -> None:
-    client = MagicMock(name="zmq_request_client")
+    client = MagicMock(name="grpc_request_client")
     create = MagicMock(return_value=client)
     context = object()
-    monkeypatch.setattr(zmq_impl, "create_request_client", create)
+    monkeypatch.setattr(grpc_impl, "create_request_client", create)
 
     result = RequestClientFactory.create(server_url, context=context)
 
     assert result is client
     create.assert_called_once_with(normalized_url, context=context)
+
+
+def test_configured_zmq_path_remains_available_without_ci_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = MagicMock(name="zmq_request_client")
+    create = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        transport_factory,
+        "effective_transport",
+        lambda configured_transport: configured_transport,
+    )
+    monkeypatch.setattr(zmq_impl, "create_request_client", create)
+
+    result = RequestClientFactory.create("tcp://localhost:5555")
+
+    assert result is client
+    create.assert_called_once_with("tcp://localhost:5555", context=None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Part of #4877.

This PR is rebased directly onto `dev` after #4882 merged. It now contains only the gRPC request transport changes.

This adds gRPC client and server implementations while preserving ZMQ. Servers normally select the transport with `--transport zmq|grpc`; clients normally select it from the endpoint scheme: `tcp://`, `ipc://`, or `inproc://` for ZMQ, and `grpc://` or `grpc+unix://` for gRPC.

For CI validation, a `FIXME(maobaolong)` override currently forces both clients and servers to use gRPC regardless of configuration. Before merge, the single `return "grpc"` line must be restored to `return configured_transport`.

gRPC discovers services and methods from generated protobuf descriptors and calls generated stubs directly; it does not use the ZMQ `RequestType` registry. The proto and implementation layout follows the server modules, and generated protobuf Python bindings remain ignored and are produced during build.

Generate locally with:

```bash
python lmcache/v1/multiprocess/transport/grpc_impl/protos/generate.py
```

Validation:

- `855 passed, 37 skipped` across multiprocess and affected adapter tests
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`
- Sphinx HTML build completed successfully