### PR TITLE
fix(gpu): handle split staging for fused KV layouts

### DIFF
--- a/csrc/cuda/mem_kernels.cu
+++ b/csrc/cuda/mem_kernels.cu
@@ -211,11 +211,11 @@ __global__ void single_layer_kv_transfer_kernel(
 }
 
 template <EngineKVFormat format>
-__device__ __forceinline__ int64_t
-page_buffer_offset(const int k_or_v, const int token_idx,
-                   const int scalar_offset, const int scalars_per_token,
-                   const int page_buffer_size, const int block_size,
-                   const int head_size, const int64_t block_stride_xwords) {
+__device__ __forceinline__ int64_t page_buffer_offset(
+    const int k_or_v, const int token_idx, const int scalar_offset,
+    const int scalars_per_token, const int page_buffer_size,
+    const int block_size, const int head_size, const bool split_fused_kv,
+    const int64_t block_stride_xwords) {
   /*
   logical semantics of arguments (agnostic to physical format):
   k_or_v:            0 for key, 1 for value
@@ -294,31 +294,43 @@ page_buffer_offset(const int k_or_v, const int token_idx,
            head_offset;
   } else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||
                        format == EngineKVFormat::NL_X_NB_NH_BS_CS) {
-    const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
+    // The paged pool always packs K and V in each head. LMCache staging may
+    // expose that content as either one packed plane or two canonical planes.
+    const int fused_head_size = 2 * head_size;
+    const int scalar_head_size = split_fused_kv ? head_size : fused_head_size;
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
-    const int head_idx = scalar_offset / hs2;
-    const int head_offset = scalar_offset % hs2;
-    const int num_heads = scalars_per_token / hs2;
+    const int head_idx = scalar_offset / scalar_head_size;
+    const int head_offset = scalar_offset % scalar_head_size;
+    const int num_heads = scalars_per_token / scalar_head_size;
     // vLLM blocks-first pools pass the real per-block step; 0 means tight.
     const int64_t block_step =
         block_stride_xwords > 0
             ? block_stride_xwords
-            : static_cast<int64_t>(num_heads) * block_size * hs2;
-    return block_idx * block_step + head_idx * block_size * hs2 +
-           block_offset * hs2 + head_offset;
+            : static_cast<int64_t>(num_heads) * block_size * fused_head_size;
+    return block_idx * block_step + head_idx * block_size * fused_head_size +
+           block_offset * fused_head_size +
+           (split_fused_kv ? k_or_v * head_size : 0) + head_offset;
   } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS ||
                        format == EngineKVFormat::NL_X_NB_BS_NH_CS) {
+    // The paged pool always packs K and V in each head. LMCache staging may
+    // expose that content as either one packed plane or two canonical planes.
+    const int fused_head_size = 2 * head_size;
+    const int scalar_head_size = split_fused_kv ? head_size : fused_head_size;
+    const int head_idx = scalar_offset / scalar_head_size;
+    const int head_offset = scalar_offset % scalar_head_size;
+    const int num_heads = scalars_per_token / scalar_head_size;
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
     // vLLM blocks-first pools pass the real per-block step; 0 means tight.
     const int64_t block_step =
         block_stride_xwords > 0
             ? block_stride_xwords
-            : static_cast<int64_t>(block_size) * scalars_per_token;
+            : static_cast<int64_t>(block_size) * num_heads * fused_head_size;
     return block_idx * block_step +
-           static_cast<int64_t>(block_offset) * scalars_per_token +
-           scalar_offset;
+           static_cast<int64_t>(block_offset) * num_heads * fused_head_size +
+           head_idx * fused_head_size +
+           (split_fused_kv ? k_or_v * head_size : 0) + head_offset;
   }
   // DSA indexer: page [BSxvals][BSxscales]; 4B units, so scale == 1 unit
   else if constexpr (format == EngineKVFormat::NL_X_NB_BSV_BSS) {
@@ -455,7 +467,7 @@ __global__ void load_and_reshape_multi_layer_fused_kernel(
                          num_tokens, num_layers);
     const int64_t vllm_offset = page_buffer_offset<format>(
         k_or_v, slot_idx, i, scalars_per_token, page_buffer_size, block_size,
-        head_size, block_stride_xwords);
+        head_size, false, block_stride_xwords);
     if (DIRECTION)
       chunk.key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
     else
@@ -483,7 +495,8 @@ __global__ void load_and_reshape_multi_layer_kernel(
     const int64_t* __restrict__ slot_mapping,   // [num_tokens]
     const int scalars_per_token, const int num_tokens, const int num_layers,
     const int page_buffer_size, const int block_size, const int head_size,
-    const int skip_prefix_n_tokens, const int64_t block_stride_xwords) {
+    const int skip_prefix_n_tokens, const bool split_fused_kv,
+    const int64_t block_stride_xwords) {
   const int token_id = blockIdx.x;
   const int layer_id = blockIdx.y;
   const int k_or_v = blockIdx.z;
@@ -506,7 +519,7 @@ __global__ void load_and_reshape_multi_layer_kernel(
 
     const int64_t vllm_offset = page_buffer_offset<format>(
         k_or_v, slot_idx, i, scalars_per_token, page_buffer_size, block_size,
-        head_size, block_stride_xwords);
+        head_size, split_fused_kv, block_stride_xwords);
 
     if (DIRECTION)  // 1 is paged buffer to LMCache
       key_value[lmcache_offset] = paged_buffer_ptr[vllm_offset];
@@ -613,12 +626,13 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  *  - direction: H2D  means LMCache to PagedBuffer, D2H  means PagedBuffer to
  * LMCache
  */
-#define LAUNCH_KERNEL_WITH_FORMAT(T, DIRECTION, FORMAT)                  \
-  lmc::load_and_reshape_multi_layer_kernel<T, DIRECTION, FORMAT>         \
-      <<<grid, block, 0, stream>>>(                                      \
-          key_value_ptr, page_buffer_ptrs, slot_mapping_ptr, num_xwords, \
-          num_tokens, num_layers, page_buffer_size, block_size,          \
-          head_size_xword, skip_prefix_n_tokens, block_stride_xwords);   \
+#define LAUNCH_KERNEL_WITH_FORMAT(T, DIRECTION, FORMAT)                      \
+  lmc::load_and_reshape_multi_layer_kernel<T, DIRECTION, FORMAT>             \
+      <<<grid, block, 0, stream>>>(key_value_ptr, page_buffer_ptrs,          \
+                                   slot_mapping_ptr, num_xwords, num_tokens, \
+                                   num_layers, page_buffer_size, block_size, \
+                                   head_size_xword, skip_prefix_n_tokens,    \
+                                   split_fused_kv, block_stride_xwords);     \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
 template <typename T>
@@ -661,10 +675,23 @@ void multi_layer_kv_transfer_templated(
       "NL_X_NB_BSV_BSS requires 4-byte transfer units (row bytes "
       "must be divisible by 4 and not by 8)");
 
-  // Fused packs K+V in the trailing dim (kv_size == 1, like MLA): single pass.
-  int k_or_v_size =
-      (::is_mla(engine_kv_format) || ::is_fused_packed(engine_kv_format)) ? 1
-                                                                          : 2;
+  int k_or_v_size = ::is_mla(engine_kv_format) ? 1 : 2;
+  bool split_fused_kv = false;
+  if (::is_fused_packed(engine_kv_format)) {
+    k_or_v_size = key_value.size(0);
+    TORCH_CHECK(k_or_v_size == 1 || k_or_v_size == 2,
+                "fused K/V transfer expects one packed plane or two split "
+                "planes, got ",
+                k_or_v_size);
+    TORCH_CHECK(head_size_xword > 0,
+                "head_size is required for fused K/V transfer");
+    split_fused_kv = k_or_v_size == 2;
+    const int scalars_per_head =
+        split_fused_kv ? head_size_xword : 2 * head_size_xword;
+    TORCH_CHECK(num_xwords % scalars_per_head == 0,
+                "fused K/V transfer width must be divisible by its per-head "
+                "width");
+  }
 
   dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -23,11 +23,11 @@ from lmcache.v1.gpu_connector.utils import (
     get_device,
     get_elements_per_layer,
     get_group_data_ptrs,
-    get_head_size,
     get_num_blocks,
     get_num_layers,
     get_page_buffer_size,
     get_tokens_per_layer,
+    get_transfer_head_size,
     normalize_and_discover_per_layer_formats,
     normalize_kv_and_discover_format,
     resolve_block_stride_and_log_layout,
@@ -262,7 +262,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         self.num_blocks = get_num_blocks(kv_caches, self.engine_kv_format)
         self.block_size = get_block_size(kv_caches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
-        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
+        self.head_size = get_transfer_head_size(kv_caches, self.engine_kv_format)
         self.block_stride_elems = (
             resolve_block_stride_and_log_layout(
                 kv_caches, self.engine_kv_format, layer_idx=0, group_idx=0
@@ -483,7 +483,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)
         self.block_size = get_block_size(self.kvcaches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
-        self.head_size = get_head_size(self.kvcaches, self.engine_kv_format)
+        self.head_size = get_transfer_head_size(self.kvcaches, self.engine_kv_format)
         self.block_stride_elems = (
             resolve_block_stride_and_log_layout(
                 self.kvcaches, self.engine_kv_format, layer_idx=0, group_idx=0

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -366,6 +366,40 @@ def get_head_size(
     return get_spec(kv_caches, engine_kv_format).head_size(layer_idx)
 
 
+def get_transfer_head_size(
+    kv_caches: DiscoverableKVCache,
+    engine_kv_format: "lmcache_native.EngineKVFormat",
+    layer_idx: int = 0,
+) -> int:
+    """Return the per-K/V head size expected by token-transfer kernels.
+
+    Fused formats expose their packed trailing content size through
+    :func:`get_head_size`. Transfer kernels address K and V independently, so
+    they require the size of one half instead. Non-fused and MLA formats use
+    their reported head size unchanged.
+
+    Args:
+        kv_caches: Registered KV-cache tensors.
+        engine_kv_format: Detected physical engine layout.
+        layer_idx: Layer whose geometry should be inspected.
+
+    Returns:
+        The per-K/V head size in tensor elements.
+
+    Raises:
+        ValueError: If a fused format reports an odd packed content size.
+    """
+    head_size = get_head_size(kv_caches, engine_kv_format, layer_idx)
+    if get_spec_class(engine_kv_format).is_fused_packed:
+        if head_size % 2 != 0:
+            raise ValueError(
+                "fused K/V content size must contain two equal K/V halves, "
+                f"got {head_size}"
+            )
+        return head_size // 2
+    return head_size
+
+
 def get_tokens_per_layer(
     kv_caches: DiscoverableKVCache, engine_kv_format: "lmcache_native.EngineKVFormat"
 ) -> int:

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -245,8 +245,46 @@ class KernelGroupInfo:
 
     @property
     def hidden_dim_size(self) -> int:
-        """Hidden dimension size (``num_heads * head_size``)."""
+        """Physical engine hidden dimension (``num_heads * head_size``)."""
         return self.shape_desc.nh * self.shape_desc.hs
+
+    def get_lmcache_shape(self, num_tokens: int) -> torch.Size:
+        """Return this group's stable LMCache memory-object shape.
+
+        ``shape_desc`` describes the physical engine pool. Fused formats use
+        one plane whose trailing content packs K and V, while LMCache's
+        ``KV_2LTD`` objects keep two canonical planes. Normalizing here keeps
+        allocations identical before and after the layer-groups manager is
+        registered in :class:`LMCacheMetadata`.
+
+        Args:
+            num_tokens: Number of tokens represented by the memory object.
+
+        Returns:
+            The canonical LMCache tensor shape for this kernel group.
+
+        Raises:
+            ValueError: If a fused format reports an odd packed head size.
+        """
+        kv_size = self.shape_desc.kv_size
+        head_size = self.shape_desc.hs
+        if self.engine_kv_format is not None:
+            # Import lazily to avoid the kv_format -> utils -> kv_layer_groups
+            # cycle during module initialization.
+            # First Party
+            from lmcache.v1.gpu_connector.kv_format import get_spec_class
+
+            if get_spec_class(self.engine_kv_format).is_fused_packed:
+                if head_size % 2 != 0:
+                    raise ValueError(
+                        "fused K/V content size must contain two equal K/V "
+                        f"halves, got {head_size}"
+                    )
+                kv_size = 2
+                head_size //= 2
+        return torch.Size(
+            [kv_size, self.num_layers, num_tokens, self.shape_desc.nh * head_size]
+        )
 
     @property
     def slots_per_block(self) -> int:

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -90,17 +90,8 @@ class LMCacheMetadata:
             num_tokens = self.chunk_size
         klg_manager = self.kv_layer_groups_manager
         if klg_manager is not None and klg_manager.kernel_groups:
-            # Read kv_size from each group's shape_desc rather than self.use_mla
-            # so heterogeneous groups (should any ever co-exist) are handled.
             return [
-                torch.Size(
-                    [
-                        group.shape_desc.kv_size,
-                        group.num_layers,
-                        num_tokens,
-                        group.hidden_dim_size,
-                    ]
-                )
+                group.get_lmcache_shape(num_tokens)
                 for group in klg_manager.kernel_groups
             ]
         return [

--- a/tests/v1/gpu_connector/test_blocks_first_cs_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_cs_kv_format.py
@@ -17,6 +17,8 @@ import torch
 from lmcache import device_ops, torch_device_type
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import utils as U
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.multiprocess.transfer_context.base import (
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
@@ -54,6 +56,7 @@ def test_accessors():
     assert U.get_block_size(norm, fmt) == BS
     assert U.get_num_heads(norm, fmt) == NH
     assert U.get_head_size(norm, fmt) == HS * 2
+    assert U.get_transfer_head_size(norm, fmt) == HS
     assert U.get_hidden_dim_size(norm, fmt) == NH * HS * 2
     assert U.get_page_buffer_size(norm, fmt) == NB * BS
     assert U.get_tokens_per_layer(norm, fmt) == NB * BS
@@ -62,6 +65,32 @@ def test_accessors():
     # so it must recognize this format too.
     assert U.get_dtype(norm, fmt) == _raw_blocks_first_caches()[0].dtype
     assert not lmcache_native.is_mla(fmt)
+
+
+def test_group_metadata_uses_canonical_kv_planes():
+    fmt, norm = U.normalize_kv_and_discover_format(
+        _raw_blocks_first_caches(), EngineType.VLLM, HINTS
+    )
+    manager = KVLayerGroupsManager(norm, [fmt] * NL)
+    group = manager.kernel_groups[0]
+    assert group.shape_desc.hs == 2 * HS  # physical fused engine width
+    assert group.hidden_dim_size == NH * 2 * HS
+    assert group.get_lmcache_shape(BS) == torch.Size([2, NL, BS, NH * HS])
+
+    metadata = LMCacheMetadata(
+        model_name="test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=norm[0].dtype,
+        kv_shape=(NL, 2, BS, NH, HS),
+        chunk_size=BS,
+    )
+    expected = [torch.Size([2, NL, BS, NH * HS])]
+    assert metadata.get_shapes() == expected
+    metadata.kv_layer_groups_manager = manager
+    assert metadata.get_shapes() == expected
 
 
 def test_mp_gather_scatter_roundtrip():

--- a/tests/v1/gpu_connector/test_blocks_first_kernel_roundtrip.py
+++ b/tests/v1/gpu_connector/test_blocks_first_kernel_roundtrip.py
@@ -37,8 +37,10 @@ def make_pool(
     return buf, [buf[:, layer] for layer in range(NL)]
 
 
-def torch_gather(buf: torch.Tensor, order: str, slots: torch.Tensor) -> torch.Tensor:
-    """[1, NL, T, SPT] reference: token-major per layer, heads flattened."""
+def torch_gather(
+    buf: torch.Tensor, order: str, slots: torch.Tensor, staging_kv_size: int
+) -> torch.Tensor:
+    """Reference gather in packed or canonical split LMCache layout."""
     blocks, offsets = slots // BS, slots % BS
     buf = buf[:, :NL]
     if order == "BLHNC":  # buf [NB, NL, NH, BS, CS]
@@ -57,13 +59,22 @@ def torch_gather(buf: torch.Tensor, order: str, slots: torch.Tensor) -> torch.Te
             ],
             dim=1,
         )
-    return out.unsqueeze(0)  # [1, NL, T, SPT]
+    out = out.reshape(NL, len(slots), NH, CS)
+    if staging_kv_size == 1:
+        return out.reshape(1, NL, len(slots), SPT)
+    return torch.stack(
+        (
+            out[..., : CS // 2].reshape(NL, len(slots), SPT // 2),
+            out[..., CS // 2 :].reshape(NL, len(slots), SPT // 2),
+        )
+    )
 
 
 @cuda_only
 @pytest.mark.parametrize("order", ["BLHNC", "BLNHC"])
 @pytest.mark.parametrize("pad_layers", [0, 2])
-def test_kernel_roundtrip_matches_torch(order, pad_layers):
+@pytest.mark.parametrize("staging_kv_size", [1, 2])
+def test_kernel_roundtrip_matches_torch(order, pad_layers, staging_kv_size):
     buf, views = make_pool(order, pad_layers)
     fmt, kv = detect_format(views, EngineType.VLLM, {"kv_layout": order})
     expected_fmt = (
@@ -78,7 +89,14 @@ def test_kernel_roundtrip_matches_torch(order, pad_layers):
     # layers, so stride(0) exceeds the per-layer tight step even unpadded.
     block_stride = kv[0].stride(0)
     slots = torch.tensor([5, 6, 7, 12, 13, 14, 15, 28], device="cuda")
-    staging = torch.zeros(1, NL, len(slots), SPT, dtype=torch.float32, device="cuda")
+    staging = torch.zeros(
+        staging_kv_size,
+        NL,
+        len(slots),
+        SPT // staging_kv_size,
+        dtype=torch.float32,
+        device="cuda",
+    )
 
     device_ops.multi_layer_kv_transfer(
         staging,
@@ -94,7 +112,7 @@ def test_kernel_roundtrip_matches_torch(order, pad_layers):
         block_stride,
     )
     torch.cuda.synchronize()
-    ref = torch_gather(buf, order, slots.cpu())
+    ref = torch_gather(buf, order, slots.cpu(), staging_kv_size)
     assert torch.equal(staging.cpu(), ref.cpu())
 
     # Zero the touched blocks, write back, expect original bytes restored.


### PR DESCRIPTION
**What this PR does / why we need it**:

vLLM blocks-first KV pools can pack K and V into the trailing content dimension (`CS = 2 * head_size`). The in-process V2/V3 connectors previously forwarded that packed width as the transfer kernel's per-K/V head size. In addition, registering `KVLayerGroupsManager` could change V3's LMCache object allocation from the legacy canonical `[2, L, T, H]` shape to the physical fused `[1, L, T, 2H]` shape between requests. Together these caused incorrect offsets or a `2H` versus `H` copy mismatch during native store/restore.

This change:

- introduces a format-aware per-K/V transfer head size;
- keeps LMCache memory-object shapes stable before and after layer-group registration;
- teaches the CUDA transfer kernel to support both packed one-plane and canonical split two-plane staging buffers for HND and NHD fused layouts; and
- adds CPU metadata and CUDA round-trip regression coverage, including padded block strides.

**Special notes for your reviewers**:

Validation:

- `SKIP=mypy,rust-fmt,rust-clippy pre-commit run --all-files` (all applicable Python/CUDA hooks passed; no Rust files changed)
- direct `mypy` on all changed Python production files
- CPU format/metadata regression: 5 passed
- NVIDIA RTX 6000D, CUDA 13.0, PyTorch 2.13.0+cu130: 8 CUDA round-trip cases passed (`HND/NHD x packed/split staging x tight/padded block stride`)
- vLLM V3 + Qwen3-0.6B manual regression: 5/5 cold-store/hot-restore cases passed, 1,280 tokens stored and restored, exact output text/tokens, zero tracebacks and zero dimension errors

The current `dev` runtime also emits an existing `Double unpin occurred` warning after each successful manual restore. This PR does not touch pin lifecycle; the store/restore data-path cases above all pass independently.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
