### PR TITLE
fix(hybrid): preserve opaque group identity and page geometry

### DIFF
--- a/csrc/cuda/mp_mem_kernels.cu
+++ b/csrc/cuda/mp_mem_kernels.cu
@@ -450,9 +450,6 @@ void multi_layer_block_kv_transfer(
     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
     EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
   int head_bytes = shape_desc.hs * shape_desc.element_size;
-  TORCH_CHECK(head_bytes % sizeof(uint16_t) == 0, "head_size * element_size (",
-              head_bytes, ") must be divisible by 2 for vectorized access");
-
   if (engine_kv_format == EngineKVFormat::NL_X_NB_BSV_BSS) {
     // Blocked-scale indexer cache: the per-token fp32 scale must be a whole
     // number of transfer units, so pin 4-byte units regardless of row width.
@@ -467,8 +464,12 @@ void multi_layer_block_kv_transfer(
     LAUNCH_TEMPLATED(uint4);  // 16 bytes per copy
   } else if (head_bytes % sizeof(uint32_t) == 0) {
     LAUNCH_TEMPLATED(uint32_t);  // 4 bytes per copy
+  } else if (head_bytes % sizeof(uint16_t) == 0) {
+    LAUNCH_TEMPLATED(uint16_t);  // 2 bytes per copy
   } else {
-    LAUNCH_TEMPLATED(uint16_t);  // 2 bytes per copy (minimum granularity)
+    // Opaque page records can have a byte-odd row width. Preserve the whole
+    // record with a scalar fallback instead of rejecting or truncating it.
+    LAUNCH_TEMPLATED(uint8_t);
   }
 }
 

--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -28,22 +28,23 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Current unsalted:
+  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   Current salted appends @<cache_salt> to the current unsalted shape.
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
   //   Salted  :
   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
   //
-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
-  // format, so existing cache directories remain valid.
-  //
-  // NOTE: both model_name and cache_salt are forbidden from containing
-  // '@' (invariant enforced on the Python side), so splitting on '@'
-  // is unambiguous — no marker, no rsplit.
+  // Four fields are intentionally not interpreted: that shape can be a
+  // legacy salted key or a current unsalted key, and both map correctly by
+  // preserving every field after kv_rank verbatim.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Current ObjectKey serialization has four or five fields; three-field
+  // legacy keys remain readable for cache compatibility.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -52,34 +53,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() < 3 || parts.size() > 5) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
-  // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
+  // Emit the model and normalized rank, preserving all remaining fields.
   std::string result;
-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
-                 cache_salt.size() + 32);
+  result.reserve(key.size() + 16);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
-  result += KEY_SEP;
-  result += chunk_hash;
-  if (!cache_salt.empty()) {
+  for (size_t i = 2; i < parts.size(); ++i) {
     result += KEY_SEP;
-    result += cache_salt;
+    result += parts[i];
   }
   result += FILE_EXT;
   return result;

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -52,17 +52,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   // Build the filesystem-safe filename from a serialized key string.
   //
   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
+  //   Current unsalted:
+  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
+  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
+  //   without object_group_id remain supported.
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
+  //   Current unsalted:
+  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
+  //   Current salted appends "@{cache_salt}" before ".data".
   //
   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
-  // cache_salt are forbidden from containing '@' (enforced on the
-  // Python side), so the parse is unambiguous.
+  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
+  // are preserved because four fields can represent either a legacy salted
+  // key or a current unsalted key.
   static std::string key_to_filename(const std::string& key);
 
   static std::string replace_all(const std::string& str,

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -431,15 +431,16 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         padding, and any sibling layers on a shared pool, live between
         row and S).
 
-        Output for NHD: [num_blocks, block_size, 1, head_size] with
+        Preferred output for NHD: [num_blocks, block_size, 1, head_size] with
         strides (S, head_size, head_size, 1). HND swaps dims 1 and 2:
         [num_blocks, 1, block_size, head_size] with strides
         (S, block_size * head_size, head_size, 1).
 
         head_size = ceil(row / block_size), rounded up to the kernels'
-        vector alignment, and block_size * head_size may exceed the row
-        by at most this layer's own page padding
-        (spec.page_size_bytes), never reaching sibling bytes.
+        vector alignment. If that aligned shape does not fit in the declared
+        page, the complete page is exposed as one opaque physical slot. Group
+        metadata retains the independent logical token count, so scheduling
+        and cache identity do not change.
         """
         assert isinstance(kv_cache, torch.Tensor), (
             "single-layer KV cache must be a torch.Tensor"
@@ -469,19 +470,36 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
             if candidate * block_size * elem <= page_bytes:
                 head_size = candidate
                 break
-        if head_size == 0:
-            raise ValueError(
-                f"cannot tile a {row}-element state row into {block_size} "
-                f"aligned tokens within the {page_bytes}-byte page"
+        if head_size != 0:
+            if kv_layout == "NHD":
+                inner = (block_size, 1, head_size)
+                inner_strides = (head_size, head_size, 1)
+            else:
+                inner = (1, block_size, head_size)
+                inner_strides = (block_size * head_size, head_size, 1)
+            return kv_cache.as_strided(
+                (num_blocks, *inner), (kv_cache.stride(0), *inner_strides)
             )
-        if kv_layout == "NHD":
-            inner = (block_size, 1, head_size)
-            inner_strides = (head_size, head_size, 1)
-        else:
-            inner = (1, block_size, head_size)
-            inner_strides = (block_size * head_size, head_size, 1)
+
+        if page_bytes % elem:
+            raise ValueError(
+                f"declared Mamba page size {page_bytes} bytes is not aligned "
+                f"to tensor element size {elem}"
+            )
+        page_elems = page_bytes // elem
+        if page_elems < row:
+            raise ValueError(
+                f"declared Mamba page has {page_elems} elements but the state "
+                f"row requires {row}"
+            )
+        if page_elems > block_step:
+            raise ValueError(
+                f"declared Mamba page has {page_elems} elements but the "
+                f"physical block stride is only {block_step}"
+            )
         return kv_cache.as_strided(
-            (num_blocks, *inner), (kv_cache.stride(0), *inner_strides)
+            (num_blocks, 1, page_elems),
+            (kv_cache.stride(0), page_elems, 1),
         )
 
 

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -164,6 +164,37 @@ def _synthetic_attention_shape(elems_per_page: int, block_size: int) -> tuple[in
     return _SYNTHETIC_NUM_HEADS, elems_per_page // denom
 
 
+def _complete_kernel_pages(
+    kv_cache: torch.Tensor,
+    logical_to_kernel_ratio: int,
+) -> tuple[torch.Tensor, int]:
+    """Return the zero-copy prefix covered by complete logical pages.
+
+    A shared pool may be sized in kernel-page units even when a cache group
+    consumes several kernel pages per logical page. The remainder cannot be
+    addressed by the scheduler, so it must be excluded from registration.
+
+    Args:
+        kv_cache: Contiguous tensor whose first dimension is kernel pages.
+        logical_to_kernel_ratio: Kernel pages in one logical page.
+
+    Returns:
+        The prefix containing complete logical pages and its logical page
+        count.
+
+    Raises:
+        ValueError: If the pool cannot hold one complete logical page.
+    """
+    logical_pages = kv_cache.shape[0] // logical_to_kernel_ratio
+    if logical_pages == 0:
+        raise ValueError(
+            f"kernel page count {kv_cache.shape[0]} cannot hold one logical "
+            f"page requiring {logical_to_kernel_ratio} kernel pages"
+        )
+    complete_kernel_pages = logical_pages * logical_to_kernel_ratio
+    return kv_cache[:complete_kernel_pages], logical_pages
+
+
 class KVCacheGroupEdit(ABC):
     """One structural edit rule for a KV cache group's registered cache.
 
@@ -319,7 +350,7 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
 
         Raises:
             ValueError: If the layout is not the expected kernel-paged shape,
-                the sizes do not divide evenly, or the kernel pages of one
+                one logical page cannot be formed, or the kernel pages of one
                 logical block do not tile its page bytes exactly (which would
                 indicate an undeclared packed layout that must not be edited).
         """
@@ -342,12 +373,6 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
             )
         ratio = logical_block_size // kernel_block_size
 
-        num_kernel_pages = kv_cache.shape[0]
-        if num_kernel_pages % ratio != 0:
-            raise ValueError(
-                f"kernel page count {num_kernel_pages} is not a multiple of "
-                f"the logical/kernel block ratio {ratio}"
-            )
         kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
         if kernel_page_bytes * ratio != spec.page_size_bytes:
             raise ValueError(
@@ -360,12 +385,14 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
                 "re-view as logical pages"
             )
 
-        num_blocks = num_kernel_pages // ratio
+        complete_cache, num_blocks = _complete_kernel_pages(kv_cache, ratio)
         elems_per_page = spec.page_size_bytes // kv_cache.element_size()
         num_heads, head_size = _synthetic_attention_shape(
             elems_per_page, logical_block_size
         )
-        return kv_cache.view(num_blocks, 2, logical_block_size, num_heads, head_size)
+        return complete_cache.view(
+            num_blocks, 2, logical_block_size, num_heads, head_size
+        )
 
 
 ######################
@@ -458,6 +485,79 @@ class _MambaUnifiedViewEdit(KVCacheGroupEdit):
         )
 
 
+class _PaddedAttentionPageViewEdit(KVCacheGroupEdit):
+    """Expose a padded attention allocation as opaque logical pages.
+
+    The semantic tensor may occupy only a prefix of the page declared by the
+    engine. LMCache must transfer the complete declared page while preserving
+    the authoritative stride between physical blocks. The returned dimensions
+    describe addressing only; they do not reinterpret the bytes as semantic
+    K/V axes.
+
+    Pages with a uniform token width retain one physical slot per logical
+    token. Packed pages use one physical slot for the entire opaque page;
+    logical tokens remain represented independently by the group metadata.
+    """
+
+    name = "padded-attention-page-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        """Return whether an attention tensor has a padded physical stride."""
+        kind = get_kv_cache_spec_kind(spec)
+        return (
+            (
+                kind == KVCacheSpecKind.MLA_ATTENTION
+                or kind in _SUBPAGEABLE_ATTENTION_KINDS
+            )
+            and not _declares_slot_compression(spec)
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 4
+            and kv_cache[0].is_contiguous()
+            and kv_cache.stride(0) > kv_cache.shape[1:].numel()
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """Return a stride-preserving ``[blocks, slots, width]`` page view.
+
+        Raises:
+            ValueError: If the declared page is not element-aligned, is
+                smaller than the semantic tensor page, or exceeds the physical
+                stride between blocks.
+        """
+        assert isinstance(kv_cache, torch.Tensor)
+        element_size = kv_cache.element_size()
+        page_bytes = spec.page_size_bytes
+        if page_bytes % element_size:
+            raise ValueError(
+                f"declared attention page size {page_bytes} bytes is not "
+                f"aligned to tensor element size {element_size}"
+            )
+        page_elems = page_bytes // element_size
+        semantic_page_elems = kv_cache.shape[1:].numel()
+        if page_elems < semantic_page_elems:
+            raise ValueError(
+                f"declared attention page has {page_elems} elements but the "
+                f"semantic tensor page requires {semantic_page_elems}"
+            )
+        if page_elems > kv_cache.stride(0):
+            raise ValueError(
+                f"declared attention page has {page_elems} elements but the "
+                f"physical block stride is only {kv_cache.stride(0)}"
+            )
+
+        physical_slots = spec.block_size if page_elems % spec.block_size == 0 else 1
+        slot_width = page_elems // physical_slots
+        return kv_cache.as_strided(
+            (kv_cache.shape[0], physical_slots, slot_width),
+            (kv_cache.stride(0), slot_width, 1),
+        )
+
+
 class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
     """Re-view a kernel-paged attention tensor as logical-block pages.
 
@@ -494,7 +594,7 @@ class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
 
         Raises:
             ValueError: If the layout is not the expected kernel-paged shape,
-                the sizes do not divide evenly, or the kernel pages of one
+                one logical page cannot be formed, or the kernel pages of one
                 logical block do not tile its page bytes exactly (which would
                 indicate an undeclared packed layout that must not be edited).
         """
@@ -508,12 +608,6 @@ class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
             )
         ratio = logical_block_size // kernel_block_size
 
-        num_kernel_pages = kv_cache.shape[0]
-        if num_kernel_pages % ratio != 0:
-            raise ValueError(
-                f"kernel page count {num_kernel_pages} is not a multiple of "
-                f"the logical/kernel block ratio {ratio}"
-            )
         kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
         if kernel_page_bytes * ratio != spec.page_size_bytes:
             raise ValueError(
@@ -526,13 +620,15 @@ class _SubpagedMLAAttentionViewEdit(KVCacheGroupEdit):
                 "re-view as logical pages"
             )
 
-        return kv_cache.view(num_kernel_pages // ratio, logical_block_size, -1)
+        complete_cache, num_blocks = _complete_kernel_pages(kv_cache, ratio)
+        return complete_cache.view(num_blocks, logical_block_size, -1)
 
 
 # Rule registry, in match priority order.
 _EDITS: tuple[KVCacheGroupEdit, ...] = (
     _MambaUnifiedViewEdit(),
     _MambaPageViewEdit(),
+    _PaddedAttentionPageViewEdit(),
     _SubpagedMLAAttentionViewEdit(),
     _SubpagedAttentionViewEdit(),
 )

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -32,17 +32,24 @@ def _is_attention_spec(spec: Any) -> bool:
     return any(cls.__name__ == "AttentionSpec" for cls in type(spec).__mro__)
 
 
+def _is_dcp_replicated_spec(spec: Any) -> bool:
+    """Return whether every leaf spec is explicitly replicated under DCP."""
+    inner = getattr(spec, "kv_cache_specs", None)
+    specs = list(inner.values()) if isinstance(inner, dict) else [spec]
+    return bool(specs) and all(getattr(leaf, "dcp_replicated", False) for leaf in specs)
+
+
 def get_tokens_per_block(kv_cache_spec: Any, dcp_size: int) -> int:
     """Global tokens covered by one block id of ``kv_cache_spec``.
 
-    Attention blocks span ``block_size * dcp_size`` tokens under DCP
-    (vLLM's ``resolve_kv_cache_block_sizes`` rule); recurrent state is
-    replicated, not sharded, and stays at ``block_size``.
+    Sharded attention blocks span ``block_size * dcp_size`` tokens under DCP.
+    Attention specs explicitly marked ``dcp_replicated`` and recurrent state
+    remain at ``block_size``.
     """
     block_size = kv_cache_spec.block_size
     if dcp_size <= 1:
         return block_size
-    if _is_attention_spec(kv_cache_spec):
+    if _is_attention_spec(kv_cache_spec) and not _is_dcp_replicated_spec(kv_cache_spec):
         return block_size * dcp_size
     return block_size
 

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -208,11 +208,11 @@ class KernelGroupInfo:
     """Sliding window size in logical tokens for this group's layers.
     ``-1`` means the layers are not sliding-window attention."""
     extra_object_group_tag: int = 0
-    """Connector-private extra-group tag. ``0`` = a regular group, bucketed
-    by (recurrent, window) under ``separate_object_groups``; ``> 0`` = an
-    extra group (e.g. the CacheBlend fused-aux pool) that buckets by tag —
-    groups sharing a tag share an object group, and extras always sort
-    after the regular groups."""
+    """Connector-private extra-group tag. ``0`` = a regular group; under
+    ``separate_object_groups``, recurrent regular groups remain independent
+    while attention regular groups bucket by window. ``> 0`` = an extra group
+    (e.g. the CacheBlend fused-aux pool) that buckets by tag — groups sharing a
+    tag share an object group, and extras always sort after the regular groups."""
     recurrent_state: bool = False
     """Whether this group's pages hold recurrent state snapshots (Mamba/GDN)
     rather than per-token attention KV. The window reflects restore
@@ -268,14 +268,16 @@ KVLayerGroupInfo = KernelGroupInfo  # Alias for compatibility
 class _ObjectBucket(NamedTuple):
     """Object-group bucket key under ``separate_object_groups``.
 
-    Regular groups (``extra_tag == 0``) bucket by ``(recurrent, sw_chunks)``;
-    tagged extras bucket by ``extra_tag`` (their other fields ride along for
-    bookkeeping but extras never mix with regular groups).
+    Regular attention groups (``extra_tag == 0``) bucket by ``sw_chunks``;
+    regular recurrent groups also carry their kernel-group index so each stays
+    independent. Tagged extras bucket by ``extra_tag`` (their other fields ride
+    along for bookkeeping but extras never mix with regular groups).
     """
 
     extra_tag: int
     recurrent: bool
     sw_chunks: int
+    recurrent_group_idx: int
 
 
 @dataclass
@@ -353,10 +355,10 @@ class KVLayerGroupsManager:
             engine_group_infos: Engine KV cache group metadata, one info per
                 kernel group in kernel-group order, or empty.
             lmcache_logical_chunk_size: Tokens per LMCache chunk
-            separate_object_groups: When True, split kernel groups
-                into one object group per sliding-window size; when False
-                (default), all kernel groups share a single full-attention
-                object group.
+            separate_object_groups: When True, keep each recurrent kernel group
+                in its own object group and bucket attention kernel groups by
+                sliding-window size; when False (default), all kernel groups
+                share a single full-attention object group.
         """
         # Import here to break a circular import via
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
@@ -669,11 +671,12 @@ class KVLayerGroupsManager:
         """Bucket kernel groups into object groups.
 
         Puts all kernel groups into a single object group when object-group
-        separation is disabled (the default). Otherwise groups the kernel
-        groups by (recurrent, sliding-window chunks), except that tagged
-        extra groups (``extra_object_group_tag``, connector-private) bucket
-        by tag — and always sort after the regular groups, so the shared
-        group ids match a registration without any extras.
+        separation is disabled (the default). Otherwise each regular recurrent
+        kernel group becomes its own object group, while regular attention
+        groups bucket by sliding-window chunks. Tagged extra groups
+        (``extra_object_group_tag``, connector-private) bucket by tag and always
+        sort after the regular groups, so the shared group ids match a
+        registration without any extras.
 
         Args:
             engine_group_infos: LMCache-owned engine KV cache group metadata.
@@ -702,6 +705,11 @@ class KVLayerGroupsManager:
                 extra_tag=group.extra_object_group_tag,
                 recurrent=group.recurrent_state,
                 sw_chunks=sw_size_chunks,
+                recurrent_group_idx=(
+                    kernel_group_idx
+                    if group.extra_object_group_tag == 0 and group.recurrent_state
+                    else -1
+                ),
             )
             groups_by_bucket[bucket].append(kernel_group_idx)
             bucket_sw_size[bucket] = sw_size_chunks

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -11,6 +11,15 @@ import time
 # Third Party
 import pytest
 
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    _object_key_to_filename,
+)
+from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+    _object_key_to_string,
+)
+
 
 def _import_fs_client() -> type:
     try:
@@ -80,6 +89,62 @@ def _submit_and_wait(
 ) -> tuple[int, bool, str, list[bool] | None]:
     future_id = getattr(client, method_name)([key], [view])
     return _wait_for_completion(client, future_id)
+
+
+@pytest.mark.parametrize(
+    ("wire_key", "filename"),
+    [
+        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
+        (
+            "model@00000000@aabb@tenant",
+            "model@0x00000000@aabb@tenant.data",
+        ),
+    ],
+)
+def test_legacy_key_shapes_keep_their_filenames(
+    tmp_path, wire_key: str, filename: str
+) -> None:
+    """Three/four-field keys written by older clients remain readable."""
+    LMCacheFSClient = _import_fs_client()
+    payload = bytearray(b"legacy-payload")
+    client = LMCacheFSClient(str(tmp_path), 1)
+    try:
+        completion = _submit_and_wait(
+            client, "submit_batch_set", wire_key, memoryview(payload)
+        )
+        assert completion[1], completion[2]
+        assert (tmp_path / filename).read_bytes() == payload
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("cache_salt", ["", "tenant"])
+def test_current_object_group_keys_match_python_filename(
+    tmp_path, cache_salt: str
+) -> None:
+    """Native FS and Python FS use one path for current ObjectKeys."""
+    LMCacheFSClient = _import_fs_client()
+    key = ObjectKey(
+        chunk_hash=bytes.fromhex("aabbccdd"),
+        model_name="org/model",
+        kv_rank=0x01020304,
+        object_group_id=0x2A,
+        cache_salt=cache_salt,
+    )
+    payload = bytearray(b"object-group-payload")
+    client = LMCacheFSClient(str(tmp_path), 1)
+    try:
+        completion = _submit_and_wait(
+            client,
+            "submit_batch_set",
+            _object_key_to_string(key),
+            memoryview(payload),
+        )
+        assert completion[1], completion[2]
+        expected_path = tmp_path / _object_key_to_filename(key)
+        assert expected_path.read_bytes() == payload
+    finally:
+        client.close()
 
 
 def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -512,6 +512,42 @@ class TestKernelAndObjectGroups:
         assert manager.object_groups[1].sw_size_chunks >= 1
         assert attn_desc.num_chunks_in_sw[1] == manager.object_groups[1].sw_size_chunks
 
+    def test_recurrent_kernel_groups_get_distinct_object_groups(self):
+        tensors = [torch.randn(2, 32, 32, 8, 64, dtype=torch.float16) for _ in range(4)]
+        manager = _build_manager(
+            tensors,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,), sw_size_tokens=256, recurrent_state=True),
+                EngineGroupInfo(1, (1,), sw_size_tokens=256, recurrent_state=True),
+                EngineGroupInfo(2, (2,), sw_size_tokens=256, recurrent_state=True),
+                EngineGroupInfo(3, (3,)),
+            ],
+            separate_object_groups=True,
+        )
+
+        assert manager.num_kernel_groups == 4
+        assert manager.num_object_groups == 4
+        assert [
+            object_group.kernel_group_indices for object_group in manager.object_groups
+        ] == [[0], [1], [2], [3]]
+        object_group_idx_by_kernel_group = {
+            kernel_group_idx: object_group_idx
+            for object_group_idx, object_group in enumerate(manager.object_groups)
+            for kernel_group_idx in object_group.kernel_group_indices
+        }
+        assert [
+            object_group_idx_by_kernel_group[kernel_group_idx]
+            for kernel_group_idx in range(manager.num_kernel_groups)
+        ] == [0, 1, 2, 3]
+        attn_desc = manager.get_attn_desc()
+        assert attn_desc.group_kinds == (
+            "recurrent",
+            "recurrent",
+            "recurrent",
+            "attention",
+        )
+        assert attn_desc.num_chunks_in_sw == [1, 1, 1, -1]
+
     def test_object_group_separation_standalone_group_buckets_alone(self):
         # A tagged extra group (connector-private pool) buckets alone even
         # though its window (-1) matches the full-attention bucket. The rest

--- a/tests/v1/test_mp_mem_kernels.py
+++ b/tests/v1/test_mp_mem_kernels.py
@@ -251,6 +251,7 @@ def call_block_kernel(
     is_mla: bool,
     tokens_per_object: int,
     skip_prefix_n_blocks: int = 0,
+    block_stride_elems: int = 0,
 ) -> None:
     device = vllm_tensors[0].device
 
@@ -262,6 +263,7 @@ def call_block_kernel(
     shape_desc.nh = nh
     shape_desc.hs = hs
     shape_desc.element_size = vllm_tensors[0].element_size()
+    shape_desc.block_stride_elems = block_stride_elems
 
     ptrs = [t.data_ptr() for t in vllm_tensors]
     paged_buffer_ptrs_tensor = torch.tensor(ptrs, dtype=torch.int64, device=device)

--- a/tests/v1/test_mp_mem_kernels.py
+++ b/tests/v1/test_mp_mem_kernels.py
@@ -402,6 +402,169 @@ def test_block_transfer_roundtrip(
             )
 
 
+def test_block_transfer_roundtrip_byte_odd_opaque_page():
+    """Byte-odd opaque rows round-trip without touching block padding."""
+    device = torch.device(torch_device_type)
+    nl, nb, bs, nh, hs = 2, 40, 16, 1, 561
+    block_stride_elems = bs * hs + 37
+    tokens_per_object = 256
+    blocks_per_object = tokens_per_object // bs
+    total_blocks = blocks_per_object
+
+    source_pools = [
+        (torch.arange(nb * block_stride_elems, device=device) + layer_idx)
+        .remainder(251)
+        .to(torch.uint8)
+        for layer_idx in range(nl)
+    ]
+    target_pools = [
+        torch.zeros(nb * block_stride_elems, dtype=torch.uint8, device=device)
+        for _ in range(nl)
+    ]
+    source_vllm = [
+        pool.as_strided((nb, bs, hs), (block_stride_elems, hs, 1))
+        for pool in source_pools
+    ]
+    target_vllm = [
+        pool.as_strided((nb, bs, hs), (block_stride_elems, hs, 1))
+        for pool in target_pools
+    ]
+    mem_objects = create_memory_objects(
+        1,
+        nl,
+        tokens_per_object,
+        hs,
+        1,
+        torch.uint8,
+        device,
+    )
+
+    block_ids_d2h = list(range(total_blocks))
+    block_ids_h2d = list(range(total_blocks, 2 * total_blocks))
+    call_block_kernel(
+        source_vllm,
+        mem_objects,
+        block_ids_d2h,
+        FMT_MLA,
+        lmcache_native.TransferDirection.D2H,
+        nl,
+        nb,
+        bs,
+        nh,
+        hs,
+        True,
+        tokens_per_object,
+        block_stride_elems=block_stride_elems,
+    )
+    call_block_kernel(
+        target_vllm,
+        mem_objects,
+        block_ids_h2d,
+        FMT_MLA,
+        lmcache_native.TransferDirection.H2D,
+        nl,
+        nb,
+        bs,
+        nh,
+        hs,
+        True,
+        tokens_per_object,
+        block_stride_elems=block_stride_elems,
+    )
+    torch_dev.synchronize()
+
+    for src_block, dst_block in zip(block_ids_d2h, block_ids_h2d, strict=True):
+        for source, target in zip(source_vllm, target_vllm, strict=True):
+            assert torch.equal(target[dst_block], source[src_block])
+
+    for target_pool in target_pools:
+        for block_idx in block_ids_h2d:
+            padding_start = block_idx * block_stride_elems + bs * hs
+            padding_end = (block_idx + 1) * block_stride_elems
+            assert torch.count_nonzero(target_pool[padding_start:padding_end]) == 0
+
+
+def test_block_transfer_roundtrip_packed_opaque_page():
+    """A packed logical page round-trips as one complete opaque slot."""
+    device = torch.device(torch_device_type)
+    nl, nb, bs, nh, hs = 2, 20, 1, 1, 177_408
+    block_stride_elems = 200_000
+    slots_per_object = 8
+    total_blocks = slots_per_object
+
+    source_pools = [
+        (torch.arange(nb * block_stride_elems, device=device) + layer_idx)
+        .remainder(251)
+        .to(torch.uint8)
+        for layer_idx in range(nl)
+    ]
+    target_pools = [
+        torch.zeros(nb * block_stride_elems, dtype=torch.uint8, device=device)
+        for _ in range(nl)
+    ]
+    source_vllm = [
+        pool.as_strided((nb, bs, hs), (block_stride_elems, hs, 1))
+        for pool in source_pools
+    ]
+    target_vllm = [
+        pool.as_strided((nb, bs, hs), (block_stride_elems, hs, 1))
+        for pool in target_pools
+    ]
+    mem_objects = create_memory_objects(
+        1,
+        nl,
+        slots_per_object,
+        hs,
+        1,
+        torch.uint8,
+        device,
+    )
+
+    block_ids_d2h = list(range(total_blocks))
+    block_ids_h2d = list(range(total_blocks, 2 * total_blocks))
+    call_block_kernel(
+        source_vllm,
+        mem_objects,
+        block_ids_d2h,
+        FMT_MLA,
+        lmcache_native.TransferDirection.D2H,
+        nl,
+        nb,
+        bs,
+        nh,
+        hs,
+        True,
+        slots_per_object,
+        block_stride_elems=block_stride_elems,
+    )
+    call_block_kernel(
+        target_vllm,
+        mem_objects,
+        block_ids_h2d,
+        FMT_MLA,
+        lmcache_native.TransferDirection.H2D,
+        nl,
+        nb,
+        bs,
+        nh,
+        hs,
+        True,
+        slots_per_object,
+        block_stride_elems=block_stride_elems,
+    )
+    torch_dev.synchronize()
+
+    for src_block, dst_block in zip(block_ids_d2h, block_ids_h2d, strict=True):
+        for source, target in zip(source_vllm, target_vllm, strict=True):
+            assert torch.equal(target[dst_block], source[src_block])
+
+    for target_pool in target_pools:
+        for block_idx in block_ids_h2d:
+            padding_start = block_idx * block_stride_elems + hs
+            padding_end = (block_idx + 1) * block_stride_elems
+            assert torch.count_nonzero(target_pool[padding_start:padding_end]) == 0
+
+
 @pytest.mark.parametrize(
     "engine_kv_format,nl,nh,hs,is_mla",
     FORMAT_PARAMS,

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -423,6 +423,78 @@ def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
 
 
 @requires_vllm
+def test_exact_fit_recurrent_page_uses_one_opaque_slot():
+    """A valid page remains transferable when token rows cannot be aligned."""
+    # Third Party
+    from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
+    from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        apply_kv_cache_group_edits,
+    )
+    from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+    from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+    import lmcache.lmcache_native as lmcache_native
+
+    num_blocks = 3
+    logical_block_size = 4096
+    page_elems = 1_085_440
+    block_stride = 2 * page_elems
+    pool = torch.zeros(num_blocks * block_stride, dtype=torch.uint8)
+    recurrent = pool.as_strided(
+        (num_blocks, 1, 1, page_elems),
+        (block_stride, page_elems, page_elems, 1),
+        storage_offset=page_elems,
+    )
+    recurrent[1, 0, 0, :32] = torch.arange(32, dtype=torch.uint8)
+    spec = VllmMambaSpec(
+        block_size=logical_block_size,
+        shapes=((page_elems,),),
+        dtypes=(torch.uint8,),
+        page_size_padded=page_elems,
+        mamba_cache_mode="align",
+    )
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["recurrent"], spec)],
+        kv_cache_layout="NHD",
+    )
+
+    edited = apply_kv_cache_group_edits(
+        config,
+        {"recurrent": recurrent},
+        {"kv_layout": "NHD"},
+    )["recurrent"]
+
+    assert isinstance(edited, torch.Tensor)
+    assert edited.shape == (num_blocks, 1, page_elems)
+    assert edited.stride() == (block_stride, page_elems, 1)
+    assert edited.data_ptr() == recurrent.data_ptr()
+    assert torch.equal(edited[1, 0], recurrent[1, 0, 0])
+
+    manager = KVLayerGroupsManager(
+        [edited],
+        engine_kv_formats=[lmcache_native.EngineKVFormat.NL_X_NB_BS_HS],
+        engine_group_infos=[
+            EngineGroupInfo(
+                engine_group_id=0,
+                layer_indices=(0,),
+                tokens_per_block=logical_block_size,
+            )
+        ],
+        lmcache_tokens_per_chunk=logical_block_size,
+    )
+    group = manager.kernel_groups[0]
+    assert group.slots_per_block == 1
+    assert group.tokens_per_block == logical_block_size
+    assert group.calculate_slots(logical_block_size) == 1
+    assert group.shape_desc.hs == page_elems
+    assert group.shape_desc.block_stride_elems == block_stride
+
+
+@requires_vllm
 def test_padded_attention_page_preserves_declared_opaque_tail():
     """Registration exposes all declared bytes and preserves block stride."""
     # Third Party

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -501,9 +501,9 @@ def test_padded_attention_page_preserves_declared_opaque_tail():
     from vllm.v1.kv_cache_interface import (
         KVCacheConfig,
         KVCacheGroupSpec,
-        MLAAttentionSpec,
     )
     from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
     # First Party
     from lmcache.integration.vllm.kv_cache_group_edits import (
@@ -571,9 +571,9 @@ def test_packed_attention_page_uses_one_opaque_physical_slot():
     from vllm.v1.kv_cache_interface import (
         KVCacheConfig,
         KVCacheGroupSpec,
-        MLAAttentionSpec,
     )
     from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
     # First Party
     from lmcache.integration.vllm.kv_cache_group_edits import (
@@ -667,13 +667,10 @@ def test_subpaged_attention_excludes_incomplete_logical_page_tail(
 ):
     """A kernel-page pool registers every complete logical page."""
     # Third Party
-    from vllm.v1.kv_cache_interface import (
-        FullAttentionSpec as VllmFullAttentionSpec,
-        KVCacheConfig,
-        KVCacheGroupSpec,
-        MLAAttentionSpec,
-    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec as VllmFullAttentionSpec
+    from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec
     from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+    from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
     # First Party
     from lmcache.integration.vllm.kv_cache_group_edits import (

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -6,10 +6,12 @@ and ``get_tokens_per_block`` (attention-only block scaling). No GPU needed."""
 # Standard
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from typing import Literal
 import importlib.util
 
 # Third Party
 import pytest
+import torch
 
 # First Party
 from lmcache.integration.vllm.kv_cache_groups import get_tokens_per_block
@@ -266,6 +268,8 @@ class AttentionSpec:
 class FullAttentionSpec(AttentionSpec):
     """Double for a concrete paged-attention spec."""
 
+    dcp_replicated: bool = False
+
 
 @dataclass
 class UniformTypeKVCacheSpecs:
@@ -286,6 +290,12 @@ def test_attention_group_scaled_by_dcp(dcp_size: int):
     """One attention block id spans block_size * dcp global tokens."""
     spec = _attention_spec(1024)
     assert get_tokens_per_block(spec, dcp_size) == 1024 * dcp_size
+
+
+def test_dcp_replicated_attention_group_is_not_scaled():
+    """A replicated attention spec keeps ordinary block coordinates."""
+    spec = FullAttentionSpec(block_size=16, dcp_replicated=True)
+    assert get_tokens_per_block(spec, 4) == 16
 
 
 def test_mamba_group_never_scaled():
@@ -410,6 +420,243 @@ def test_mamba_alignment_uses_resolved_page_not_cli_block_size():
     validate_mamba_step_alignment(
         _geometry_config(max_num_batched_tokens=4096), kv_config
     )
+
+
+@requires_vllm
+def test_padded_attention_page_preserves_declared_opaque_tail():
+    """Registration exposes all declared bytes and preserves block stride."""
+    # Third Party
+    from vllm.v1.kv_cache_interface import (
+        KVCacheConfig,
+        KVCacheGroupSpec,
+        MLAAttentionSpec,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        apply_kv_cache_group_edits,
+    )
+
+    num_blocks = 3
+    semantic_page_elems = 32
+    declared_page_elems = 40
+    block_stride_elems = 80
+    pool = torch.arange(num_blocks * block_stride_elems, dtype=torch.uint8)
+    attention = pool.as_strided(
+        (num_blocks, 1, 4, 8),
+        (block_stride_elems, semantic_page_elems, 8, 1),
+    )
+    attention_spec = MLAAttentionSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.uint8,
+        page_size_padded=declared_page_elems,
+    )
+    recurrent_spec = VllmMambaSpec(
+        block_size=4,
+        shapes=((13,),),
+        dtypes=(torch.float32,),
+        page_size_padded=64,
+        mamba_cache_mode="align",
+    )
+    recurrent_pool = torch.zeros(num_blocks * 16, dtype=torch.float32)
+    recurrent = recurrent_pool.as_strided(
+        (num_blocks, 1, 1, 13),
+        (16, 13, 13, 1),
+    )
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attention"], attention_spec),
+            KVCacheGroupSpec(["recurrent"], recurrent_spec),
+        ],
+        kv_cache_layout="NHD",
+    )
+
+    edited = apply_kv_cache_group_edits(
+        config,
+        {"attention": attention, "recurrent": recurrent},
+        {"kv_layout": "NHD"},
+    )["attention"]
+
+    assert isinstance(edited, torch.Tensor)
+    assert edited.shape == (num_blocks, 4, 10)
+    assert edited.stride() == (block_stride_elems, 10, 1)
+    assert edited.data_ptr() == attention.data_ptr()
+    assert torch.equal(
+        edited[1].reshape(-1),
+        pool[block_stride_elems : block_stride_elems + declared_page_elems],
+    )
+
+
+@requires_vllm
+def test_packed_attention_page_uses_one_opaque_physical_slot():
+    """A non-token-factorable page remains one exact logical block record."""
+    # Third Party
+    from vllm.v1.kv_cache_interface import (
+        KVCacheConfig,
+        KVCacheGroupSpec,
+        MLAAttentionSpec,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        apply_kv_cache_group_edits,
+    )
+    from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+    from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+    import lmcache.lmcache_native as lmcache_native
+
+    num_blocks = 3
+    logical_block_size = 512
+    semantic_record_bytes = 304
+    semantic_page_bytes = logical_block_size * semantic_record_bytes
+    declared_page_bytes = 177_408
+    block_stride_bytes = 200_000
+    pool = torch.arange(num_blocks * block_stride_bytes, dtype=torch.int64).to(
+        torch.uint8
+    )
+    attention = pool.as_strided(
+        (num_blocks, 1, logical_block_size, semantic_record_bytes),
+        (block_stride_bytes, semantic_page_bytes, semantic_record_bytes, 1),
+    )
+    attention_spec = MLAAttentionSpec(
+        block_size=logical_block_size,
+        num_kv_heads=1,
+        head_size=semantic_record_bytes,
+        dtype=torch.uint8,
+        page_size_padded=declared_page_bytes,
+    )
+    recurrent_spec = VllmMambaSpec(
+        block_size=logical_block_size,
+        shapes=((13,),),
+        dtypes=(torch.float32,),
+        page_size_padded=logical_block_size * torch.float32.itemsize,
+        mamba_cache_mode="align",
+    )
+    recurrent_pool = torch.zeros(num_blocks * logical_block_size, dtype=torch.float32)
+    recurrent = recurrent_pool.as_strided(
+        (num_blocks, 1, 1, 13),
+        (logical_block_size, 13, 13, 1),
+    )
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attention"], attention_spec),
+            KVCacheGroupSpec(["recurrent"], recurrent_spec),
+        ],
+        kv_cache_layout="NHD",
+    )
+
+    edited = apply_kv_cache_group_edits(
+        config,
+        {"attention": attention, "recurrent": recurrent},
+        {"kv_layout": "NHD"},
+    )["attention"]
+
+    assert isinstance(edited, torch.Tensor)
+    assert edited.shape == (num_blocks, 1, declared_page_bytes)
+    assert edited.stride() == (block_stride_bytes, declared_page_bytes, 1)
+    assert edited.data_ptr() == attention.data_ptr()
+    assert torch.equal(
+        edited[1].reshape(-1),
+        pool[block_stride_bytes : block_stride_bytes + declared_page_bytes],
+    )
+
+    manager = KVLayerGroupsManager(
+        [edited],
+        engine_kv_formats=[lmcache_native.EngineKVFormat.NL_X_NB_BS_HS],
+        engine_group_infos=[
+            EngineGroupInfo(
+                engine_group_id=0,
+                layer_indices=(0,),
+                tokens_per_block=logical_block_size,
+            )
+        ],
+        lmcache_tokens_per_chunk=4096,
+    )
+    group = manager.kernel_groups[0]
+    assert group.slots_per_block == 1
+    assert group.tokens_per_block == logical_block_size
+    assert group.calculate_slots(4096) == 8
+    assert group.shape_desc.hs == declared_page_bytes
+    assert group.shape_desc.block_stride_elems == block_stride_bytes
+
+
+@requires_vllm
+@pytest.mark.parametrize("attention_kind", ["mla", "standard"])
+def test_subpaged_attention_excludes_incomplete_logical_page_tail(
+    attention_kind: Literal["mla", "standard"],
+):
+    """A kernel-page pool registers every complete logical page."""
+    # Third Party
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec as VllmFullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+        MLAAttentionSpec,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
+
+    # First Party
+    from lmcache.integration.vllm.kv_cache_group_edits import (
+        apply_kv_cache_group_edits,
+    )
+
+    if attention_kind == "mla":
+        attention_spec = MLAAttentionSpec(
+            block_size=4,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.uint8,
+        )
+        attention = torch.arange(11 * 2 * 8, dtype=torch.uint8).reshape(11, 2, 8)
+        expected = attention[:10].reshape(5, 4, 8)
+    else:
+        attention_spec = VllmFullAttentionSpec(
+            block_size=4,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.uint8,
+        )
+        attention = torch.arange(11 * 2 * 2 * 8, dtype=torch.uint8).reshape(
+            11, 2, 2, 1, 8
+        )
+        expected = attention[:10].reshape(5, 2, 4, 1, 8)
+
+    recurrent_spec = VllmMambaSpec(
+        block_size=4,
+        shapes=((13,),),
+        dtypes=(torch.float32,),
+        page_size_padded=64,
+        mamba_cache_mode="align",
+    )
+    recurrent_pool = torch.zeros(5 * 16, dtype=torch.float32)
+    recurrent = recurrent_pool.as_strided((5, 1, 1, 13), (16, 13, 13, 1))
+    config = KVCacheConfig(
+        num_blocks=5,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attention"], attention_spec),
+            KVCacheGroupSpec(["recurrent"], recurrent_spec),
+        ],
+        kv_cache_layout="NHD",
+    )
+
+    edited = apply_kv_cache_group_edits(
+        config,
+        {"attention": attention, "recurrent": recurrent},
+        {"kv_layout": "NHD"},
+    )["attention"]
+
+    assert isinstance(edited, torch.Tensor)
+    assert edited.data_ptr() == attention.data_ptr()
+    assert torch.equal(edited, expected)
 
 
 @requires_vllm
@@ -584,6 +831,16 @@ def test_uniform_type_wrapper_still_scales_under_dcp():
     )
     assert get_tokens_per_block(wrapped, 2) == 2048
     assert get_tokens_per_block(wrapped, 1) == 1024
+
+
+def test_uniform_wrapper_of_replicated_attention_is_not_scaled():
+    """Replication on every wrapped leaf keeps the wrapper unscaled."""
+    inner = FullAttentionSpec(block_size=16, dcp_replicated=True)
+    wrapped = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={"layer.0": inner, "layer.1": inner},
+    )
+    assert get_tokens_per_block(wrapped, 4) == 16
 
 
 def test_uniform_type_wrapper_of_mamba_is_not_scaled():

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -459,7 +459,6 @@ def test_exact_fit_recurrent_page_uses_one_opaque_slot():
         num_blocks=num_blocks,
         kv_cache_tensors=[],
         kv_cache_groups=[KVCacheGroupSpec(["recurrent"], spec)],
-        kv_cache_layout="NHD",
     )
 
     edited = apply_kv_cache_group_edits(
@@ -503,7 +502,9 @@ def test_padded_attention_page_preserves_declared_opaque_tail():
         KVCacheGroupSpec,
     )
     from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
-    from vllm.v1.kv_cache_interface import MLAAttentionSpec
+    from vllm.v1.kv_cache_interface import (
+        MLAAttentionSpec,
+    )
 
     # First Party
     from lmcache.integration.vllm.kv_cache_group_edits import (
@@ -545,7 +546,6 @@ def test_padded_attention_page_preserves_declared_opaque_tail():
             KVCacheGroupSpec(["attention"], attention_spec),
             KVCacheGroupSpec(["recurrent"], recurrent_spec),
         ],
-        kv_cache_layout="NHD",
     )
 
     edited = apply_kv_cache_group_edits(
@@ -573,7 +573,9 @@ def test_packed_attention_page_uses_one_opaque_physical_slot():
         KVCacheGroupSpec,
     )
     from vllm.v1.kv_cache_interface import MambaSpec as VllmMambaSpec
-    from vllm.v1.kv_cache_interface import MLAAttentionSpec
+    from vllm.v1.kv_cache_interface import (
+        MLAAttentionSpec,
+    )
 
     # First Party
     from lmcache.integration.vllm.kv_cache_group_edits import (
@@ -622,7 +624,6 @@ def test_packed_attention_page_uses_one_opaque_physical_slot():
             KVCacheGroupSpec(["attention"], attention_spec),
             KVCacheGroupSpec(["recurrent"], recurrent_spec),
         ],
-        kv_cache_layout="NHD",
     )
 
     edited = apply_kv_cache_group_edits(
@@ -714,7 +715,6 @@ def test_subpaged_attention_excludes_incomplete_logical_page_tail(
             KVCacheGroupSpec(["attention"], attention_spec),
             KVCacheGroupSpec(["recurrent"], recurrent_spec),
         ],
-        kv_cache_layout="NHD",
     )
 
     edited = apply_kv_cache_group_edits(


### PR DESCRIPTION
Part of #4888. Builds on the DCP-interleaved geometry foundation merged in
#4834.

## Summary

Separate logical token spans from physical cache-page geometry so hybrid cache
groups can transfer padded, packed, and exact-fit pages without losing bytes or
crossing into sibling pages.

## Problem

A serving engine can expose one logical block as a physical page whose declared
byte width does not factor into uniform, vector-aligned token rows. For example,
a 1,085,440-byte recurrent page spanning 4,096 logical tokens has 265-byte token
rows; rounding those rows for vector transfer would exceed the page. Attention
pages can similarly contain a declared opaque tail or packed records that are
not token-uniform.

Rejecting these pages prevents valid hybrid layouts from registering. Treating
their dimensions as semantic K/V axes can truncate the declared page or touch a
sibling page in a shared pool.

## Change

- Give recurrent groups independent object-group identities.
- Keep logical `tokens_per_block` separate from physical slots per block.
- Preserve authoritative block strides and complete declared page bytes.
- Represent non-factorable attention and recurrent pages as one opaque physical
  slot while retaining their logical token span in group metadata.
- Trim incomplete kernel-page tails that the scheduler cannot address.
- Use the existing vector kernels when aligned and a scalar byte-copy fallback
  only for byte-odd rows.
- Preserve every object-group field in native filesystem key serialization,
  while retaining legacy three- and four-field filename compatibility.

## Compatibility

Selection is based on public cache specs, shapes, strides, and group metadata;
there are no model-name checks. Ordinary aligned pages retain their existing
layout and vector path. Invalid declared pages fail during registration instead
of producing a partial transfer.

## Validation

Focused tests cover group isolation, replicated and sharded DCP spans, padded
tails, packed attention pages, exact-fit recurrent pages, incomplete page tails,
native key compatibility, byte-odd CUDA transfers, block strides, and unchanged
ordinary geometry. Ruff lint/format and `git diff --check` pass; upstream CI is
required for the CUDA and vLLM environments.
