### PR TITLE
[MP][Ascend] Detect per-layer MLA/DSA tuples as NL_X_TWO_X_NB_BS_HS

### DIFF
--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -154,6 +154,18 @@ enum class EngineKVFormat : int {
   One list entry per layer; each entry is a (K, V) pair of paged tensors.
   */
   NL_X_TWO_X_NB_BS_NH_HS = 16,
+
+  /*
+  used by:
+  - vLLM-Ascend per-layer MLA / DSA tuples (DeepSeek-V2/V3 MLA, V3.2 DSA)
+  One list entry per layer; each entry is a tuple of 2 (MLA: latent, rope)
+  or 3 (DSA: latent, rope, dsa) paged tensors, each
+  [num_blocks, block_size, 1, width_i] with a single latent KV head and
+  mutually unequal plane widths. Like NL_X_NB_BS_HS the object is one flat
+  plane of the summed width (kv_size == 1, is_mla); only its paged source
+  arrives as per-plane tuples.
+  */
+  NL_X_TWO_X_NB_BS_HS = 17,
 };
 
 // __host__ __device__ under CUDA/HIP so the kernels can call these; the guard
@@ -268,6 +280,11 @@ LMC_KV_FORMAT_HD constexpr FormatFacts format_facts(EngineKVFormat f) {
       break;
     case EngineKVFormat::NL_X_TWO_X_NB_BS_NH_HS:
       facts.is_layer_list = true;
+      facts.is_kv_second_tuple = true;
+      break;
+    case EngineKVFormat::NL_X_TWO_X_NB_BS_HS:
+      facts.is_layer_list = true;
+      facts.is_mla = true;
       facts.is_kv_second_tuple = true;
       break;
     default:

--- a/csrc/lmcache_native/pybind.cpp
+++ b/csrc/lmcache_native/pybind.cpp
@@ -44,7 +44,8 @@ PYBIND11_MODULE(lmcache_native, m) {
       .value("NL_X_NB_BSV_BSS", EngineKVFormat::NL_X_NB_BSV_BSS)
       .value("NL_X_TWO_NB_NH_ONE_BS_HS",
              EngineKVFormat::NL_X_TWO_NB_NH_ONE_BS_HS)
-      .value("NL_X_TWO_X_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_X_NB_BS_NH_HS);
+      .value("NL_X_TWO_X_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_X_NB_BS_NH_HS)
+      .value("NL_X_TWO_X_NB_BS_HS", EngineKVFormat::NL_X_TWO_X_NB_BS_HS);
 
   m.attr("GPUKVFormat") = m.attr("EngineKVFormat");
 

--- a/lmcache/lmcache_native.pyi
+++ b/lmcache/lmcache_native.pyi
@@ -28,6 +28,7 @@ class EngineKVFormat(IntEnum):
     NL_X_NB_BSV_BSS = 14
     NL_X_TWO_NB_NH_ONE_BS_HS = 15
     NL_X_TWO_X_NB_BS_NH_HS = 16
+    NL_X_TWO_X_NB_BS_HS = 17
 
 # Backward-compat alias for EngineKVFormat.
 GPUKVFormat = EngineKVFormat

--- a/lmcache/v1/gpu_connector/kv_format/detectors/base.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/base.py
@@ -22,14 +22,14 @@ def measure_list_depth_until_tensor(
 ) -> tuple[int, int, DiscoverableKVCache]:
     """Return ``(list_depth, tensor_ndim, first_tensor)`` for *kv_caches*.
 
-    Descends the first element of each list or tuple down to the inner tensor,
-    counting the list/tuple-nesting depth on the way.
+    Descends the first element of each list down to the inner tensor, counting
+    the list-nesting depth on the way.
     """
     list_depth = 0
     node = kv_caches
-    while isinstance(node, (list, tuple)):
+    while isinstance(node, list):
         if not node:
-            raise ValueError("encountered an empty kv_caches list or tuple")
+            raise ValueError("encountered an empty kv_caches list")
         list_depth += 1
         node = node[0]
     return list_depth, node.ndim, node

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -99,6 +99,22 @@ class VLLM_Detector(EngineDetector):
             if first_tensor.dtype == torch.uint8 and int(first_tensor.shape[-1]) == 132:
                 return lmcache_native.EngineKVFormat.NL_X_NB_BSV_BSS, kv_caches
             return lmcache_native.EngineKVFormat.NL_X_NB_BS_HS, kv_caches
-        if list_depth == 2 and tensor_ndim == 4 and len(kv_caches[0]) == 2:
-            return lmcache_native.EngineKVFormat.NL_X_TWO_X_NB_BS_NH_HS, kv_caches
+        if list_depth == 2 and tensor_ndim == 4:
+            planes0 = kv_caches[0]
+            if isinstance(planes0, (tuple, list)):
+                # MLA / DSA tuples: every plane has a single latent KV head
+                # and the plane widths are mutually unequal (a DSA cache is
+                # always a 3-tuple). Equal-width pairs stay generic (K, V).
+                single_head = all(int(t.shape[2]) == 1 for t in planes0)
+                widths = {int(t.shape[-1]) for t in planes0}
+                if single_head and (len(planes0) == 3 or len(widths) > 1):
+                    return (
+                        lmcache_native.EngineKVFormat.NL_X_TWO_X_NB_BS_HS,
+                        kv_caches,
+                    )
+                if len(planes0) == 2:
+                    return (
+                        lmcache_native.EngineKVFormat.NL_X_TWO_X_NB_BS_NH_HS,
+                        kv_caches,
+                    )
         return None, kv_caches

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_x_nb_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_x_nb_bs_hs.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer MLA/DSA tuple format: ``NL x [planes x [NB, BS, 1, HS]]``.
+
+Each layer's KV cache is stored as a tuple of 2 (MLA: ``latent, rope``) or
+3 (DSA: ``latent, rope, dsa``) paged tensors
+``[num_blocks, block_size, 1, width]``, produced by vLLM-Ascend for
+DeepSeek-V2/V3 MLA and V3.2 DSA models. All planes share a single latent
+KV head and their widths are mutually unequal, which is what distinguishes
+this format from the per-layer ``(K, V)`` tuple format
+(:class:`NL_X_TWO_X_NB_BS_NH_HS_Spec`) shape-wise.
+
+Like ``NL_X_NB_BS_HS`` the transferred object is one flat plane of the
+**summed** width (``kv_size == 1``, ``is_mla``); only the paged source
+arrives as per-plane tuples, so device transfer kernels carve the planes
+by offset instead of by a leading K/V axis.
+"""
+
+# Each spec indexes ``kv_caches`` (nested list/tuple) per its format, so the
+# ``.shape`` / ``[...]`` access is well-defined though mypy cannot prove it.
+# mypy: disable-error-code="union-attr"
+# Standard
+from typing import cast
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.gpu_connector.kv_format.specs.base import KVFormatSpec
+import lmcache.lmcache_native as lmcache_native
+
+
+class NL_X_TWO_X_NB_BS_HS_Spec(KVFormatSpec):
+    engine_kv_format = lmcache_native.EngineKVFormat.NL_X_TWO_X_NB_BS_HS
+    attention_backends = (
+        "vLLM-Ascend MLA (latent, rope) tuples",
+        "vLLM-Ascend DSA (latent, rope, dsa) tuples",
+    )
+    is_layer_list = True
+    is_mla = True
+    is_kv_second_tuple = True
+
+    def num_layers(self) -> int:
+        return len(self.kv_caches)
+
+    def num_blocks(self) -> int:
+        return self.kv_caches[0][0].shape[0]
+
+    def block_size(self, layer_idx: int = 0) -> int:
+        return self.kv_caches[layer_idx][0].shape[1]
+
+    def page_buffer_size(self) -> int:
+        return self.kv_caches[0][0].shape[0] * self.kv_caches[0][0].shape[1]
+
+    def kv_size(self) -> int:
+        # One flat plane of the summed width; the per-plane carve lives in
+        # the transfer kernels, not in the object layout.
+        return 1
+
+    def num_heads(self, layer_idx: int = 0) -> int:
+        return 1
+
+    def hidden_dim(self, layer_idx: int = 0) -> int:
+        widths = (int(t.shape[-1]) for t in self.kv_caches[layer_idx])
+        return sum(widths, 0)
+
+    def head_size(self, layer_idx: int = 0) -> int:
+        return self.hidden_dim(layer_idx)
+
+    def tokens_per_layer(self) -> int:
+        return self.kv_caches[0][0].shape[0] * self.kv_caches[0][0].shape[1]
+
+    def elements_per_layer(self) -> int:
+        return sum(t.numel() for t in self.kv_caches[0])
+
+    def dtype(self, layer_idx: int = 0) -> torch.dtype:
+        return self.kv_caches[layer_idx][0].dtype
+
+    def data_ptrs(self, layer_indices: list[int]) -> list[int]:
+        # Interleaved [latent_i, rope_i(, dsa_i), ...] per layer -- the order
+        # the multi_layer_kv_transfer kernel iterates planes.
+        layers = cast(
+            "list[tuple[torch.Tensor, ...]]",
+            self.kv_caches,
+        )
+        ptrs: list[int] = []
+        for i in layer_indices:
+            for plane in layers[i]:
+                ptrs.append(plane.data_ptr())
+        return ptrs

--- a/tests/v1/gpu_connector/test_kv_format_classification.py
+++ b/tests/v1/gpu_connector/test_kv_format_classification.py
@@ -52,6 +52,7 @@ EXPECTED = {
     F.NL_X_NB_BS_HS: (False, False, True, True, False),
     F.NL_X_NBBS_ONE_HS: (False, False, True, True, False),
     F.NL_X_NB_BSV_BSS: (False, False, True, True, False),
+    F.NL_X_TWO_X_NB_BS_HS: (False, False, True, True, True),
 }
 
 # Facts that only the spec carries (no native predicate mirrors them):
@@ -74,6 +75,7 @@ EXPECTED_SPEC_FACTS = {
     F.NL_X_NBBS_ONE_HS: (False, False, False, True),
     F.NL_X_NB_BSV_BSS: (False, False, False, False),
     F.NL_X_TWO_X_NB_BS_NH_HS: (False, False, False, False),
+    F.NL_X_TWO_X_NB_BS_HS: (False, False, False, False),
 }
 
 

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -171,3 +171,36 @@ def test_extract_kv_cache_shapes_mixed_nested():
         [_t(NB, BS, NH, HS)],
     ]
     assert extract_kv_cache_shapes(kv) == {(NB, BS, NH, HS), (NB, BS, HS)}
+
+
+def test_vllm_mla_tuple_unequal_widths():
+    # vLLM-Ascend MLA: per-layer (latent, rope) planes, single latent head,
+    # mutually unequal widths -> the flat summed-width MLA tuple format.
+    if not hasattr(F, "NL_X_TWO_X_NB_BS_HS"):
+        pytest.skip("extension lacks NL_X_TWO_X_NB_BS_HS")
+    kv = [(_t(NB, BS, 1, HS * 8), _t(NB, BS, 1, HS)) for _ in range(NL)]
+    fmt, out = detect_format(kv, EngineType.VLLM, {"kv_layout": "NHD"})
+    assert fmt == F.NL_X_TWO_X_NB_BS_HS
+    # Contiguous-view recovery may normalize tuples to lists; storage must be
+    # shared with the input planes.
+    assert [p.data_ptr() for p in out[0]] == [p.data_ptr() for p in kv[0]]
+
+
+def test_vllm_dsa_tuple_three_planes():
+    # vLLM-Ascend DSA: per-layer (latent, rope, dsa) 3-tuples.
+    if not hasattr(F, "NL_X_TWO_X_NB_BS_HS"):
+        pytest.skip("extension lacks NL_X_TWO_X_NB_BS_HS")
+    kv = [
+        (_t(NB, BS, 1, HS * 8), _t(NB, BS, 1, HS), _t(NB, BS, 1, HS * 2))
+        for _ in range(NL)
+    ]
+    fmt, _ = detect_format(kv, EngineType.VLLM, {"kv_layout": "NHD"})
+    assert fmt == F.NL_X_TWO_X_NB_BS_HS
+
+
+def test_vllm_tuple_equal_widths_stays_kv_pair():
+    # Equal-width single-head pairs are indistinguishable from generic (K, V)
+    # and must keep the per-layer (K, V) tuple classification.
+    kv = [(_t(NB, BS, 1, HS), _t(NB, BS, 1, HS)) for _ in range(NL)]
+    fmt, _ = detect_format(kv, EngineType.VLLM, {"kv_layout": "NHD"})
+    assert fmt == F.NL_X_TWO_X_NB_BS_NH_HS


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #4061.

vLLM-Ascend exposes the KV cache of DeepSeek-V2/V3 MLA and V3.2 DSA models as per-layer tuples of 2 (MLA: `latent, rope`) or 3 (DSA: `latent, rope, dsa`) paged tensors `[num_blocks, block_size, 1, width]`. This layout was previously undetectable: shape-based detection routed any two-element `list_depth == 2, tensor_ndim == 4` cache to the generic per-layer `(K, V)` format (`NL_X_TWO_X_NB_BS_NH_HS`), and 3-plane DSA tuples fell through entirely.

This adds the `NL_X_TWO_X_NB_BS_HS` engine KV format to cover these tuples:

- New `EngineKVFormat::NL_X_TWO_X_NB_BS_HS` (= 17) in `csrc/engine_kv_format.h` with a `format_facts` entry (`is_layer_list`, `is_mla`, `is_kv_second_tuple`), exported through pybind and `lmcache_native.pyi`.
- `VLLM_Detector` now distinguishes MLA/DSA tuples from generic `(K, V)` pairs: a single latent KV head per plane plus mutually unequal plane widths (or a 3-tuple, always DSA) selects the new format; equal-width pairs keep the generic classification.
- `measure_list_depth_until_tensor` now descends only lists (not tuples), so per-plane tuples are counted at the layer level instead of as extra nesting depth.
- New `NL_X_TWO_X_NB_BS_HS_Spec`: like `NL_X_NB_BS_HS` the transferred object is one flat plane of the summed width (`kv_size == 1`, `is_mla`); `data_ptrs` returns planes interleaved per layer so the multi-layer transfer kernels carve them by offset.

This is part of Phase 1 of the Ascend NPU MP-mode support plan (#4061): making MP-mode format detection and serialization handle Ascend-specific KV layouts.

**Special notes for your reviewers**:

- Detection is shape-based: equal-width single-head pairs are shape-wise indistinguishable from generic `(K, V)` and deliberately stay `NL_X_TWO_X_NB_BS_NH_HS`.
- The enum value (17, mirrored between the C++ enum and the `.pyi`) follows the MP-mode format convention.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Tests added under `tests/v1/gpu_connector/`: classification facts for the new format, MLA unequal-width detection, DSA 3-tuple detection, and equal-width pairs keeping their generic classification.
