### PR TITLE
fix(multiprocess): avoid RequestType alias collisions on Python 3.10

### DIFF
--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -77,12 +77,6 @@ class RequestType(enum.Enum):
     CB_UNREGISTER_ROPE = enum.auto()
     CB_RETRIEVE_PRE_COMPUTED = enum.auto()
     CB_UNIFIED_LOOKUP = enum.auto()
-    # Deprecated aliases (same member, same wire value) for blend plugins that
-    # still use the ``_V3`` names. Remove once the plugin has moved to the
-    # unversioned names above.
-    CB_REGISTER_ROPE_V3 = CB_REGISTER_ROPE
-    CB_UNREGISTER_ROPE_V3 = CB_UNREGISTER_ROPE
-    CB_RETRIEVE_PRE_COMPUTED_V3 = CB_RETRIEVE_PRE_COMPUTED
 
     # P2P operations
     P2P_LOOKUP_AND_LOCK = enum.auto()
@@ -91,6 +85,12 @@ class RequestType(enum.Enum):
 
     # Experimental transfer intermediate tensor
     GET_EXPERIMENTAL = enum.auto()
+
+    # Deprecated aliases must follow every auto-valued member. On Python 3.10,
+    # placing aliases before auto() can reuse the preceding member's value.
+    CB_REGISTER_ROPE_V3 = CB_REGISTER_ROPE
+    CB_UNREGISTER_ROPE_V3 = CB_UNREGISTER_ROPE
+    CB_RETRIEVE_PRE_COMPUTED_V3 = CB_RETRIEVE_PRE_COMPUTED
 
 
 @dataclass

--- a/tests/v1/multiprocess/test_protocols.py
+++ b/tests/v1/multiprocess/test_protocols.py
@@ -48,3 +48,16 @@ def test_deprecated_cb_aliases_are_not_separate_members() -> None:
     # (one definition per member) is unaffected by them.
     names = {member.name for member in RequestType}
     assert not names & set(DEPRECATED_CB_ALIASES)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "P2P_LOOKUP_AND_LOCK",
+        "P2P_QUERY_LOOKUP_RESULTS",
+        "P2P_UNLOCK_OBJECTS",
+        "GET_EXPERIMENTAL",
+    ],
+)
+def test_compatibility_aliases_do_not_reuse_later_auto_values(name: str) -> None:
+    assert RequestType[name].name == name


### PR DESCRIPTION
## Summary

- Move the deprecated Blend request aliases after all auto-valued RequestType members.
- Add regression coverage ensuring the later P2P and experimental request types remain canonical members.

## Why

#4758 preserved the old Blend V3 names as aliases so their wire values would remain compatible. Those aliases were placed before later enum.auto() members, however.

On Python 3.10, enum.auto() continues from the most recently assigned alias value. As a result, P2P_LOOKUP_AND_LOCK receives the same value as CB_UNIFIED_LOOKUP (28) and becomes its alias. Protocol definitions and server handlers are keyed by RequestType, so the P2P entry can then overwrite the Blend entry silently.

Moving compatibility aliases to the end preserves their existing wire values while keeping P2P_LOOKUP_AND_LOCK, P2P_QUERY_LOOKUP_RESULTS, P2P_UNLOCK_OBJECTS, and GET_EXPERIMENTAL distinct across supported Python versions.

## Testing

- Verified the resulting RequestType values directly with Python 3.10.
- pytest -q tests/v1/multiprocess/test_protocols.py
- SKIP=rust-fmt,rust-clippy pre-commit run --all-files
