### PR TITLE
ci: upgrade CodeQL action for bundle download retries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,7 +79,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -107,6 +107,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- upgrade both `github/codeql-action/init` and `github/codeql-action/analyze` from v4.30.8 to v4.37.9
- use the CodeQL Action official fix released in v4.37.5 for transient network errors during bundle streaming
- when streaming fails, fall back to the existing downloader, which retries the download three times with exponential backoff

## Context

[CodeQL run 33610588671](https://github.com/LMCache/LMCache/actions/runs/33610588671/job/100184518713?pr=4177) failed during initialization with `ECONNRESET` while downloading `codeql-bundle-v2.26.4`, before analysis started.

This PR implements the retry behavior by upgrading CodeQL Action rather than duplicating the initialization step in the workflow. It picks up the upstream fix from [github/codeql-action#4061](https://github.com/github/codeql-action/pull/4061). The v4.37.0 update in #4104 predates that fix, which first shipped in v4.37.5.

## Validation

- CodeQL Advanced: `Analyze (actions)` and `Analyze (python)` passed
- `actionlint 1.7.7`
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`
- DCO passed