### PR TITLE
[SDK] Add topology-aware token selection plans

### DIFF
--- a/docs/design/sdk/request.md
+++ b/docs/design/sdk/request.md
@@ -10,6 +10,10 @@ cached KV, decode), which are encoded as different requests.
 `LMCacheRequestStream` binds all inference passes belonging to one request
 instead of leaving the management to the user.
 
+Decode-time retention policies can use a
+[topology-aware token-selection plan](token_selection.md) to keep logical token
+decisions separate from compressed, sliding-window, and hybrid cache geometry.
+
 ```py
 import lmcache.sdk as lmc_sdk
 

--- a/docs/design/sdk/token_selection.md
+++ b/docs/design/sdk/token_selection.md
@@ -10,6 +10,14 @@ tables. `lmcache.sdk.token_selection` separates those layers:
 - `expand_plan()` first validates every fence and family invariant, then emits
   full-block `PhysicalGroupOperation` values.
 
+This hides three kinds of adapter complexity from policy authors: translating
+logical token spans through compression and alignment into physical entry/byte
+ranges, atomically validating every member of a hybrid cache family, and
+rejecting stale request/topology/policy revisions before any destructive range
+is exposed. The serving adapter still owns the actual cache mutation and must
+handle explicit residual spans; the abstraction does not conceal that side
+effect or silently widen a partial physical block.
+
 ## Fail-closed boundaries
 
 Expansion returns no operations when request generation, decode round,
@@ -127,3 +135,7 @@ expansion = expand_plan(
 )
 assert expansion.validation.valid
 ```
+
+For a live LMCache/vLLM path in which the expanded physical range drives an
+actual `LMCacheRequestStream.modify_kv()` operation, see
+[`examples/token_dropping/topology_aware_token_dropping.py`](../../../examples/token_dropping/topology_aware_token_dropping.py).

--- a/docs/design/sdk/token_selection.md
+++ b/docs/design/sdk/token_selection.md
@@ -1,0 +1,129 @@
+# Topology-aware token-selection plans
+
+Token-selection policy should describe semantic retention decisions, not CUDA
+page indices, padded strides, rank-local addresses, or model-specific block
+tables. `lmcache.sdk.token_selection` separates those layers:
+
+- `TokenSelectionPlan` carries request/revision fences and logical group spans.
+- `CacheTopologyDescriptor` describes compression, alignment, sharding, active
+  windows, and cache-family membership.
+- `expand_plan()` first validates every fence and family invariant, then emits
+  full-block `PhysicalGroupOperation` values.
+
+## Fail-closed boundaries
+
+Expansion returns no operations when request generation, decode round,
+accepted sequence length, source KV revision, topology fingerprint, or policy
+revision differs from live state. The same applies to unknown groups, expired
+decisions, selections past the accepted-token boundary, or incomplete cache
+families. In each case `validation.recompute_required` is true.
+
+Plan serialization uses a total ordering over selection content. Even malformed
+duplicate-group input therefore has one stable digest before validation rejects
+it, independent of transport tuple order.
+
+Hybrid groups use symmetric `sibling_group_ids`, and every member must declare
+the same complete family. Overlapping or partially connected sibling graphs are
+rejected when the topology is built. Every selected family member must be
+present with the same action, logical span, and validity deadline. A partial
+hit is therefore an all-family miss and must be recomputed.
+
+## Compression and residuals
+
+Only complete logical compression blocks become physical entry ranges. For a
+C4 group, `[3, 10)` expands as:
+
+```text
+full logical block: [4, 8)
+physical entries:   [1, 2)
+residual spans:     [3, 4), [8, 10)
+```
+
+This prevents an invalidate or demotion from silently widening to tokens that
+the semantic plan did not select. The adapter must handle `residual_spans`
+explicitly, typically by preserving or recomputing them. A span containing no
+complete compressed block emits an empty physical range plus the full logical
+span as residual work.
+
+## Example
+
+```python
+from lmcache.sdk.token_selection import (
+    CacheGroupGeometry,
+    CacheSemanticKind,
+    CacheTopologyDescriptor,
+    GroupSelection,
+    LogicalSpan,
+    RetentionAction,
+    TokenSelectionPlan,
+    expand_plan,
+)
+
+main = CacheGroupGeometry(
+    group_id="compressed-main",
+    semantic_kind=CacheSemanticKind.COMPRESSED_DENSE,
+    logical_tokens_per_block=4,
+    physical_entries_per_block=1,
+    compression_ratio=4,
+    rank_sharding="tp-contiguous",
+    page_stride_bytes=256,
+    alignment_bytes=128,
+    sibling_group_ids=("indexer",),
+)
+indexer = CacheGroupGeometry(
+    group_id="indexer",
+    semantic_kind=CacheSemanticKind.INDEXER,
+    logical_tokens_per_block=1,
+    physical_entries_per_block=1,
+    compression_ratio=1,
+    rank_sharding="tp-contiguous",
+    page_stride_bytes=256,
+    alignment_bytes=128,
+    sibling_group_ids=("compressed-main",),
+)
+topology = CacheTopologyDescriptor.create(
+    model_architecture="HybridForCausalLM",
+    backend_name="paged-backend",
+    topology_version="v1",
+    groups=(main, indexer),
+)
+
+span = LogicalSpan(0, 256)
+plan = TokenSelectionPlan.create(
+    request_id="chat-42",
+    request_generation=3,
+    decode_round=2,
+    accepted_seq_len=256,
+    source_kv_revision=11,
+    topology_fingerprint=topology.fingerprint,
+    policy_revision="drop-policy-v7",
+    groups=(
+        GroupSelection(
+            "compressed-main",
+            CacheSemanticKind.COMPRESSED_DENSE,
+            span,
+            ("indexer",),
+            RetentionAction.INVALIDATE,
+        ),
+        GroupSelection(
+            "indexer",
+            CacheSemanticKind.INDEXER,
+            span,
+            ("compressed-main",),
+            RetentionAction.INVALIDATE,
+        ),
+    ),
+)
+expansion = expand_plan(
+    plan,
+    topology,
+    request_id="chat-42",
+    request_generation=3,
+    decode_round=2,
+    accepted_seq_len=256,
+    source_kv_revision=11,
+    policy_revision="drop-policy-v7",
+    current_step=2,
+)
+assert expansion.validation.valid
+```

--- a/examples/token_dropping/README.md
+++ b/examples/token_dropping/README.md
@@ -150,6 +150,16 @@ example, including a 256-token LMCache chunk size and
 python examples/token_dropping/topology_aware_token_dropping.py
 ```
 
+For an offline deployment where vLLM logs a local snapshot path as
+`cache_model_name`, keep `--model` as the served API alias and pass that exact
+path to both `--hf-model` and `--cache-model`:
+
+```sh
+python examples/token_dropping/topology_aware_token_dropping.py \
+  --hf-model /path/to/snapshot \
+  --cache-model /path/to/snapshot
+```
+
 The script performs a real prefill, expands a logical middle-chunk
 invalidation into physical entry and byte ranges, uses that expansion to edit
 and store the live KV tensor, and resumes decode. Its JSON output also shows

--- a/examples/token_dropping/README.md
+++ b/examples/token_dropping/README.md
@@ -29,6 +29,7 @@ smaller model and a shorter dataset to fit the T4's memory.
 
 | Notebook | Strategy | Needs query tensor? |
 | --- | --- | --- |
+| [topology_aware_token_dropping.ipynb](./topology_aware_token_dropping.ipynb) | Runnable notebook wrapper with service health checks and assertions over the live topology-plan result. | No |
 | [topology_aware_token_dropping.py](./topology_aware_token_dropping.py) | Expands a fenced semantic plan against the live dense-cache topology, applies its physical range through `modify_kv()`, and proves that a stale generation fails closed. | No |
 | [random_token_dropping.ipynb](./random_token_dropping.ipynb) | Drops a random subset of past tokens. Uses the KV cache only. | No |
 | [snapkv_token_dropping.ipynb](./snapkv_token_dropping.ipynb) | SnapKV: keeps the first and last window, as well as the tokens the recent-window queries attend to most. Needs each request's query tensor to score importance. | Yes |
@@ -149,6 +150,11 @@ example, including a 256-token LMCache chunk size and
 ```sh
 python examples/token_dropping/topology_aware_token_dropping.py
 ```
+
+The equivalent notebook entry point is
+[`topology_aware_token_dropping.ipynb`](./topology_aware_token_dropping.ipynb).
+It reuses the script above, checks both live services first, and asserts the
+expected cache edit and stale-generation result.
 
 For an offline deployment where vLLM logs a local snapshot path as
 `cache_model_name`, keep `--model` as the served API alias and pass that exact

--- a/examples/token_dropping/README.md
+++ b/examples/token_dropping/README.md
@@ -29,6 +29,7 @@ smaller model and a shorter dataset to fit the T4's memory.
 
 | Notebook | Strategy | Needs query tensor? |
 | --- | --- | --- |
+| [topology_aware_token_dropping.py](./topology_aware_token_dropping.py) | Expands a fenced semantic plan against the live dense-cache topology, applies its physical range through `modify_kv()`, and proves that a stale generation fails closed. | No |
 | [random_token_dropping.ipynb](./random_token_dropping.ipynb) | Drops a random subset of past tokens. Uses the KV cache only. | No |
 | [snapkv_token_dropping.ipynb](./snapkv_token_dropping.ipynb) | SnapKV: keeps the first and last window, as well as the tokens the recent-window queries attend to most. Needs each request's query tensor to score importance. | Yes |
 | [rkv_token_dropping.ipynb](./rkv_token_dropping.ipynb) | R-KV: SnapKV's importance term minus a **redundancy** term, so a token is kept only if it is both attended-to and says something new. Three optimized variants live in [rkv_variants/](./rkv_variants). | Yes |
@@ -138,6 +139,22 @@ passes. However, it can also be configured via `"lmcache.mp.q.ring_depth":2`.
 The random-dropping example, being the simplest example that demonstrates 
 decode throughput improvement, does **not** need this patch or flag. It only
 works with the KV cache.
+
+### Running the topology-aware example
+
+Start LMCache and vLLM with the same settings used by the random-dropping
+example, including a 256-token LMCache chunk size and
+`--return-tokens-as-token-ids`. Then run:
+
+```sh
+python examples/token_dropping/topology_aware_token_dropping.py
+```
+
+The script performs a real prefill, expands a logical middle-chunk
+invalidation into physical entry and byte ranges, uses that expansion to edit
+and store the live KV tensor, and resumes decode. Its JSON output also shows
+that replaying the same plan against a new request generation emits no physical
+operations and requires recomputation.
 
 ## Dataset
 

--- a/examples/token_dropping/topology_aware_token_dropping.ipynb
+++ b/examples/token_dropping/topology_aware_token_dropping.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "# Topology-aware token-dropping end to end\n",
+    "\n",
+    "This notebook is a runnable wrapper around `topology_aware_token_dropping.py`, so the CLI and notebook exercise the same implementation. Start LMCache and vLLM as described in the token-dropping README before running all cells. The final cell performs a real prefill, retrieves and edits live KV through the SDK, stores it, resumes decode, and asserts that replay against a stale request generation fails closed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "configuration",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "# Standard\n",
+    "from pathlib import Path\n",
+    "from urllib.request import urlopen\n",
+    "import json\n",
+    "import os\n",
+    "import shlex\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "served_model = os.environ.get(\"VLLM_SERVED_MODEL_NAME\", \"Qwen/Qwen3-0.6B\")\n",
+    "hf_model = os.environ.get(\"HF_MODEL_NAME\", served_model)\n",
+    "cache_model = os.environ.get(\"LMCACHE_MODEL_NAME\", served_model)\n",
+    "vllm_url = os.environ.get(\"VLLM_URL\", \"http://localhost:8000\")\n",
+    "lmcache_url = os.environ.get(\"LMCACHE_URL\", \"http://localhost:8080\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preflight",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for health_url in (f\"{lmcache_url}/healthcheck\", f\"{vllm_url}/v1/models\"):\n",
+    "    with urlopen(health_url, timeout=10) as response:  # noqa: S310\n",
+    "        assert response.status == 200, (health_url, response.status)\n",
+    "print(\"LMCache and vLLM health checks passed\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run-and-assert",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = (\n",
+    "    Path(\"topology_aware_token_dropping.py\"),\n",
+    "    Path(\"examples/token_dropping/topology_aware_token_dropping.py\"),\n",
+    ")\n",
+    "script = next((path for path in candidates if path.is_file()), None)\n",
+    "if script is None:\n",
+    "    raise FileNotFoundError(\"run from the repository root or examples/token_dropping\")\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    str(script),\n",
+    "    \"--model\",\n",
+    "    served_model,\n",
+    "    \"--hf-model\",\n",
+    "    hf_model,\n",
+    "    \"--cache-model\",\n",
+    "    cache_model,\n",
+    "    \"--vllm-url\",\n",
+    "    vllm_url,\n",
+    "    \"--lmcache-url\",\n",
+    "    lmcache_url,\n",
+    "]\n",
+    "print(\"$\", shlex.join(command))\n",
+    "completed = subprocess.run(command, check=True, capture_output=True, text=True)\n",
+    "if completed.stderr:\n",
+    "    print(completed.stderr, file=sys.stderr)\n",
+    "print(completed.stdout)\n",
+    "start = completed.stdout.find(\"{\")\n",
+    "if start < 0:\n",
+    "    raise RuntimeError(\"example did not emit JSON evidence\")\n",
+    "evidence = json.JSONDecoder().raw_decode(completed.stdout[start:])[0]\n",
+    "assert evidence[\"source_cached_tokens\"] == 1024\n",
+    "assert evidence[\"kept_cached_tokens\"] == 512\n",
+    "assert evidence[\"stale_generation_operations\"] == 0\n",
+    "assert \"request_generation_mismatch\" in evidence[\"stale_generation_validation\"]\n",
+    "assert evidence[\"decode_output_tokens\"] > 0\n",
+    "print(\"Topology-aware live KV edit and stale-generation checks passed\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/token_dropping/topology_aware_token_dropping.py
+++ b/examples/token_dropping/topology_aware_token_dropping.py
@@ -35,6 +35,14 @@ POLICY_REVISION = "middle-chunk-drop-v1"
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument(
+        "--hf-model",
+        help="HF model ID/path; defaults to --model",
+    )
+    parser.add_argument(
+        "--cache-model",
+        help="LMCache registration name; defaults to --model",
+    )
     parser.add_argument("--vllm-url", default="http://localhost:8000")
     parser.add_argument("--lmcache-url", default="http://localhost:8080")
     parser.add_argument("--lmcache-mq-url", default="tcp://localhost:6555")
@@ -208,8 +216,10 @@ def main() -> None:
             "chunk size/max tokens must be positive; use >=3 prompt chunks"
         )
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
-    model_config = AutoConfig.from_pretrained(args.model, trust_remote_code=True)
+    hf_model = args.hf_model or args.model
+    cache_model = args.cache_model or args.model
+    tokenizer = AutoTokenizer.from_pretrained(hf_model, trust_remote_code=True)
+    model_config = AutoConfig.from_pretrained(hf_model, trust_remote_code=True)
     prompt_tokens = args.chunk_size * args.prompt_chunks
     seed = tokenizer.encode(
         "Topology plans keep cache policy independent from physical layout. ",
@@ -220,7 +230,7 @@ def main() -> None:
     ctx = lmc_sdk.kvcache.connect(
         url=args.lmcache_mq_url,
         http_url=args.lmcache_url,
-        model_name=args.model,
+        model_name=cache_model,
         timeout=args.timeout,
     )
     try:
@@ -244,7 +254,9 @@ def main() -> None:
         )
         evidence.update(
             {
-                "model": args.model,
+                "served_model_name": args.model,
+                "hf_model_name": hf_model,
+                "cache_model_name": cache_model,
                 "request_stream_id": stream.request_stream_id,
                 "prefill_output_tokens": prefill.output_tokens,
                 "decode_output_tokens": decode.output_tokens,

--- a/examples/token_dropping/topology_aware_token_dropping.py
+++ b/examples/token_dropping/topology_aware_token_dropping.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run a topology-aware token-selection plan against a live LMCache request."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Mapping, Sequence
+import argparse
+import json
+import time
+
+# Third Party
+from transformers import AutoConfig, AutoTokenizer, PretrainedConfig
+from utils import make_post_completion, rerotate_k_cache
+import torch
+
+# First Party
+from lmcache.sdk.token_selection import (
+    CacheGroupGeometry,
+    CacheSemanticKind,
+    CacheTopologyDescriptor,
+    GroupSelection,
+    LogicalSpan,
+    PlanValidationCode,
+    RetentionAction,
+    TokenSelectionPlan,
+    expand_plan,
+)
+import lmcache.sdk as lmc_sdk
+
+POLICY_REVISION = "middle-chunk-drop-v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--vllm-url", default="http://localhost:8000")
+    parser.add_argument("--lmcache-url", default="http://localhost:8080")
+    parser.add_argument("--lmcache-mq-url", default="tcp://localhost:6555")
+    parser.add_argument("--chunk-size", type=int, default=256)
+    parser.add_argument("--prompt-chunks", type=int, default=4)
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    return parser.parse_args()
+
+
+def build_topology(kv_tensor: torch.Tensor, chunk_size: int) -> CacheTopologyDescriptor:
+    """Describe the live dense KV layout without exposing tensor addresses."""
+    bytes_per_token = (
+        kv_tensor.shape[0]
+        * kv_tensor.shape[1]
+        * kv_tensor.shape[3]
+        * kv_tensor.element_size()
+    )
+    dense = CacheGroupGeometry(
+        group_id="dense-kv",
+        semantic_kind=CacheSemanticKind.DENSE_ATTENTION,
+        logical_tokens_per_block=chunk_size,
+        physical_entries_per_block=chunk_size,
+        compression_ratio=1,
+        rank_sharding="single-rank-contiguous",
+        page_stride_bytes=bytes_per_token,
+        alignment_bytes=kv_tensor.element_size(),
+    )
+    return CacheTopologyDescriptor.create(
+        model_architecture="live-vllm-dense-kv",
+        backend_name="lmcache-mp",
+        topology_version="v1",
+        groups=(dense,),
+    )
+
+
+def build_plan(
+    *,
+    request_id: str,
+    topology: CacheTopologyDescriptor,
+    cached_tokens: int,
+    chunk_size: int,
+) -> TokenSelectionPlan:
+    """Select the middle half of complete chunks for invalidation."""
+    num_chunks = cached_tokens // chunk_size
+    if num_chunks < 3:
+        raise ValueError("at least three complete cached chunks are required")
+    drop_count = max(1, num_chunks // 2)
+    drop_start_chunk = max(1, (num_chunks - drop_count) // 2)
+    drop_start_chunk = min(drop_start_chunk, num_chunks - drop_count)
+    span = LogicalSpan(
+        drop_start_chunk * chunk_size,
+        (drop_start_chunk + drop_count) * chunk_size,
+    )
+    return TokenSelectionPlan.create(
+        request_id=request_id,
+        request_generation=0,
+        decode_round=0,
+        accepted_seq_len=cached_tokens,
+        source_kv_revision=0,
+        topology_fingerprint=topology.fingerprint,
+        policy_revision=POLICY_REVISION,
+        groups=(
+            GroupSelection(
+                group_id="dense-kv",
+                semantic_kind=CacheSemanticKind.DENSE_ATTENTION,
+                logical_span=span,
+                required_siblings=(),
+                action=RetentionAction.INVALIDATE,
+            ),
+        ),
+    )
+
+
+def expand_live_plan(
+    plan: TokenSelectionPlan,
+    topology: CacheTopologyDescriptor,
+    *,
+    request_generation: int = 0,
+):
+    return expand_plan(
+        plan,
+        topology,
+        request_id=plan.request_id,
+        request_generation=request_generation,
+        decode_round=0,
+        accepted_seq_len=plan.accepted_seq_len,
+        source_kv_revision=0,
+        policy_revision=POLICY_REVISION,
+        current_step=0,
+    )
+
+
+def apply_topology_plan(
+    request_stream: lmc_sdk.request.LMCacheRequestStream,
+    model_config: PretrainedConfig,
+    chunk_size: int,
+    timeout: float,
+) -> dict[str, object]:
+    """Expand one semantic plan and use it to edit the live cached tensor."""
+    evidence: dict[str, object] = {}
+
+    def edit(
+        tensors: Mapping[lmc_sdk.context.LMCacheSDKCacheKind, torch.Tensor],
+        token_source: Sequence[int],
+    ) -> tuple[torch.Tensor, Sequence[int]]:
+        kv_tensor = tensors[lmc_sdk.context.LMCacheSDKCacheKind.KV]
+        cached_tokens = int(kv_tensor.shape[2])
+        topology = build_topology(kv_tensor, chunk_size)
+        plan = build_plan(
+            request_id=request_stream.request_stream_id,
+            topology=topology,
+            cached_tokens=cached_tokens,
+            chunk_size=chunk_size,
+        )
+        expansion = expand_live_plan(plan, topology)
+        if not expansion.validation.valid or len(expansion.operations) != 1:
+            raise RuntimeError(f"valid plan did not expand: {expansion.validation}")
+        operation = expansion.operations[0]
+        if operation.requires_residual_handling:
+            raise RuntimeError("this example requires a full-chunk selection")
+        if operation.full_block_logical_span is None:
+            raise RuntimeError("selection did not contain a full physical block")
+
+        lo = operation.full_block_logical_span.start_token
+        hi = operation.full_block_logical_span.end_token
+        keep_idx = torch.cat([torch.arange(lo), torch.arange(hi, cached_tokens)])
+        kept_ids = list(token_source[:lo]) + list(token_source[hi:cached_tokens])
+        compacted = rerotate_k_cache(
+            kv_tensor[:, :, keep_idx, :].clone(),
+            old_positions=keep_idx,
+            new_positions=torch.arange(keep_idx.numel(), dtype=torch.long),
+            model_config=model_config,
+        )
+
+        stale = expand_live_plan(plan, topology, request_generation=1)
+        stale_codes = [issue.code for issue in stale.validation.issues]
+        generation_mismatch = PlanValidationCode.REQUEST_GENERATION_MISMATCH
+        if stale.operations or generation_mismatch not in stale_codes:
+            raise RuntimeError("stale request generation did not fail closed")
+
+        evidence.update(
+            {
+                "topology_fingerprint": topology.fingerprint,
+                "plan_digest": plan.plan_digest,
+                "logical_drop_span": [lo, hi],
+                "physical_entry_range": [
+                    operation.physical_entry_start,
+                    operation.physical_entry_end,
+                ],
+                "physical_byte_range": [operation.byte_start, operation.byte_end],
+                "source_cached_tokens": cached_tokens,
+                "kept_cached_tokens": len(kept_ids),
+                "stale_generation_validation": [code.value for code in stale_codes],
+                "stale_generation_operations": len(stale.operations),
+            }
+        )
+        return compacted, kept_ids
+
+    request_stream.modify_kv(edit, timeout=timeout)
+    if not evidence:
+        raise RuntimeError("cache edit completed without expansion evidence")
+    return evidence
+
+
+def main() -> None:
+    args = parse_args()
+    invalid_size = args.chunk_size <= 0 or args.max_tokens <= 0
+    if invalid_size or args.prompt_chunks < 3:
+        raise ValueError(
+            "chunk size/max tokens must be positive; use >=3 prompt chunks"
+        )
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    model_config = AutoConfig.from_pretrained(args.model, trust_remote_code=True)
+    prompt_tokens = args.chunk_size * args.prompt_chunks
+    seed = tokenizer.encode(
+        "Topology plans keep cache policy independent from physical layout. ",
+        add_special_tokens=False,
+    )
+    prompt = (seed * ((prompt_tokens + len(seed) - 1) // len(seed)))[:prompt_tokens]
+    post_completion = make_post_completion(args.vllm_url, args.model, args.timeout)
+    ctx = lmc_sdk.kvcache.connect(
+        url=args.lmcache_mq_url,
+        http_url=args.lmcache_url,
+        model_name=args.model,
+        timeout=args.timeout,
+    )
+    try:
+        stream = lmc_sdk.request.create_request(
+            contexts=[ctx],
+            post_completion=post_completion,
+            prompt_token_ids=prompt,
+            cache_salt=f"topology-aware-drop-{time.time_ns()}",
+        )
+        prefill = stream.generate(
+            {"max_tokens": 1, "temperature": 0.0, "ignore_eos": True}
+        )
+        evidence = apply_topology_plan(
+            stream,
+            model_config=model_config,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )
+        decode = stream.generate(
+            {"max_tokens": args.max_tokens, "temperature": 0.0, "ignore_eos": True}
+        )
+        evidence.update(
+            {
+                "model": args.model,
+                "request_stream_id": stream.request_stream_id,
+                "prefill_output_tokens": prefill.output_tokens,
+                "decode_output_tokens": decode.output_tokens,
+                "decode_text_preview": stream.output_text[:160],
+            }
+        )
+        print(json.dumps(evidence, indent=2))
+    finally:
+        ctx.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/lmcache/sdk/__init__.py
+++ b/lmcache/sdk/__init__.py
@@ -2,10 +2,18 @@
 """Public LMCache SDK helpers."""
 
 # First Party
-from lmcache.sdk import batch, context, kvcache, qcache, request
+from lmcache.sdk import batch, context, kvcache, qcache, request, token_selection
 from lmcache.sdk.cache_kind import LMCacheSDKCacheKind
 
-__all__ = ["batch", "context", "kvcache", "qcache", "request", "LMCacheSDKCacheKind"]
+__all__ = [
+    "batch",
+    "context",
+    "kvcache",
+    "qcache",
+    "request",
+    "token_selection",
+    "LMCacheSDKCacheKind",
+]
 
 
 def connect(

--- a/lmcache/sdk/token_selection.py
+++ b/lmcache/sdk/token_selection.py
@@ -1,0 +1,714 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Topology-aware, model-agnostic token-selection plans."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+
+
+def _selection_sort_key(
+    selection: GroupSelection,
+) -> tuple[str, str, int, int, tuple[str, ...], str, int]:
+    """Return a total ordering for canonical plan serialization."""
+    return (
+        selection.group_id,
+        selection.semantic_kind.value,
+        selection.logical_span.start_token,
+        selection.logical_span.end_token,
+        selection.required_siblings,
+        selection.action.value,
+        -1 if selection.valid_until_step is None else selection.valid_until_step,
+    )
+
+
+class CacheSemanticKind(str, Enum):
+    """Semantic role of a cache group."""
+
+    DENSE_ATTENTION = "dense_attention"
+    SLIDING_WINDOW = "sliding_window"
+    COMPRESSED_SPARSE = "compressed_sparse"
+    COMPRESSED_DENSE = "compressed_dense"
+    INDEXER = "indexer"
+    COMPRESSOR_STATE = "compressor_state"
+    RECURRENT_STATE = "recurrent_state"
+    SPECULATIVE_STATE = "speculative_state"
+
+
+class RetentionAction(str, Enum):
+    """Semantic action requested for a logical token span."""
+
+    KEEP = "keep"
+    DEMOTE_TO_L1 = "demote_to_l1"
+    DEMOTE_TO_L2 = "demote_to_l2"
+    INVALIDATE = "invalidate"
+    RECOMPUTE_REQUIRED = "recompute_required"
+
+
+class PlanValidationCode(str, Enum):
+    """Stable reason codes for fail-closed plan validation."""
+
+    REQUEST_ID_MISMATCH = "request_id_mismatch"
+    REQUEST_GENERATION_MISMATCH = "request_generation_mismatch"
+    DECODE_ROUND_MISMATCH = "decode_round_mismatch"
+    ACCEPTED_SEQ_LEN_MISMATCH = "accepted_seq_len_mismatch"
+    SOURCE_KV_REVISION_MISMATCH = "source_kv_revision_mismatch"
+    TOPOLOGY_MISMATCH = "topology_mismatch"
+    POLICY_REVISION_MISMATCH = "policy_revision_mismatch"
+    DUPLICATE_GROUP = "duplicate_group"
+    UNKNOWN_GROUP = "unknown_group"
+    SEMANTIC_KIND_MISMATCH = "semantic_kind_mismatch"
+    SPAN_AFTER_ACCEPTED_SEQUENCE = "span_after_accepted_sequence"
+    SLIDING_WINDOW_BOUNDARY = "sliding_window_boundary"
+    SIBLING_DECLARATION_MISMATCH = "sibling_declaration_mismatch"
+    MISSING_FAMILY_MEMBER = "missing_family_member"
+    INCONSISTENT_FAMILY_ACTION = "inconsistent_family_action"
+    INCONSISTENT_FAMILY_SPAN = "inconsistent_family_span"
+    EXPIRED_SELECTION = "expired_selection"
+    EXPLICIT_RECOMPUTE = "explicit_recompute"
+
+
+@dataclass(frozen=True, order=True)
+class LogicalSpan:
+    """Half-open logical token range ``[start_token, end_token)``."""
+
+    start_token: int
+    end_token: int
+
+    def __post_init__(self) -> None:
+        if self.start_token < 0:
+            raise ValueError("start_token must be non-negative")
+        if self.end_token <= self.start_token:
+            raise ValueError("end_token must be greater than start_token")
+
+    @property
+    def token_count(self) -> int:
+        """Return the number of logical tokens in the span."""
+        return self.end_token - self.start_token
+
+
+@dataclass(frozen=True)
+class CacheGroupGeometry:
+    """Logical-to-physical geometry for one independently addressable group."""
+
+    group_id: str
+    semantic_kind: CacheSemanticKind
+    logical_tokens_per_block: int
+    physical_entries_per_block: int
+    compression_ratio: int
+    rank_sharding: str
+    page_stride_bytes: int
+    alignment_bytes: int
+    sibling_group_ids: tuple[str, ...] = ()
+    window_size_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("group_id must not be empty")
+        for name in (
+            "logical_tokens_per_block",
+            "physical_entries_per_block",
+            "compression_ratio",
+            "page_stride_bytes",
+            "alignment_bytes",
+        ):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+        if not self.rank_sharding:
+            raise ValueError("rank_sharding must not be empty")
+        if (
+            self.logical_tokens_per_block
+            != self.physical_entries_per_block * self.compression_ratio
+        ):
+            raise ValueError(
+                "logical_tokens_per_block must equal "
+                "physical_entries_per_block * compression_ratio"
+            )
+        if self.page_stride_bytes % self.alignment_bytes:
+            raise ValueError("page_stride_bytes must be alignment_bytes aligned")
+        siblings = tuple(sorted(self.sibling_group_ids))
+        if len(siblings) != len(set(siblings)):
+            raise ValueError("sibling_group_ids must be unique")
+        if self.group_id in siblings:
+            raise ValueError("a cache group cannot be its own sibling")
+        object.__setattr__(self, "sibling_group_ids", siblings)
+        if self.semantic_kind == CacheSemanticKind.SLIDING_WINDOW:
+            if self.window_size_tokens is None or self.window_size_tokens <= 0:
+                raise ValueError("sliding-window groups require a positive window size")
+        elif self.window_size_tokens is not None:
+            raise ValueError("only sliding-window groups may define window_size_tokens")
+
+
+@dataclass(frozen=True)
+class CacheTopologyDescriptor:
+    """Versioned cache geometry exposed by a model/backend adapter."""
+
+    model_architecture: str
+    backend_name: str
+    topology_version: str
+    groups: tuple[CacheGroupGeometry, ...]
+    fingerprint: str
+
+    def __post_init__(self) -> None:
+        for name in ("model_architecture", "backend_name", "topology_version"):
+            if not getattr(self, name):
+                raise ValueError(f"{name} must not be empty")
+        groups = tuple(sorted(self.groups, key=lambda group: group.group_id))
+        if not groups:
+            raise ValueError("a topology must contain at least one cache group")
+        if len({group.group_id for group in groups}) != len(groups):
+            raise ValueError("cache group ids must be unique")
+        object.__setattr__(self, "groups", groups)
+        by_id = {group.group_id: group for group in groups}
+        for group in groups:
+            for sibling_id in group.sibling_group_ids:
+                sibling = by_id.get(sibling_id)
+                if sibling is None:
+                    raise ValueError(
+                        f"group {group.group_id} references unknown sibling "
+                        f"{sibling_id}"
+                    )
+                if group.group_id not in sibling.sibling_group_ids:
+                    raise ValueError(
+                        f"sibling relationship {group.group_id}<->{sibling_id} "
+                        "must be symmetric"
+                    )
+            family = frozenset((group.group_id, *group.sibling_group_ids))
+            for member_id in sorted(family):
+                member = by_id[member_id]
+                member_family = frozenset((member.group_id, *member.sibling_group_ids))
+                if member_family != family:
+                    raise ValueError(
+                        "sibling relationships must describe complete, "
+                        f"non-overlapping cache families; {group.group_id} "
+                        f"and {member_id} disagree"
+                    )
+        expected = _topology_fingerprint(
+            self.model_architecture,
+            self.backend_name,
+            self.topology_version,
+            groups,
+        )
+        if self.fingerprint != expected:
+            raise ValueError("topology fingerprint does not match descriptor content")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        model_architecture: str,
+        backend_name: str,
+        topology_version: str,
+        groups: tuple[CacheGroupGeometry, ...],
+    ) -> CacheTopologyDescriptor:
+        """Build a descriptor with a deterministic content fingerprint."""
+        normalized = tuple(sorted(groups, key=lambda group: group.group_id))
+        return cls(
+            model_architecture=model_architecture,
+            backend_name=backend_name,
+            topology_version=topology_version,
+            groups=normalized,
+            fingerprint=_topology_fingerprint(
+                model_architecture,
+                backend_name,
+                topology_version,
+                normalized,
+            ),
+        )
+
+    def group(self, group_id: str) -> CacheGroupGeometry | None:
+        """Return a group by id without exposing a mutable mapping."""
+        return next(
+            (group for group in self.groups if group.group_id == group_id), None
+        )
+
+
+@dataclass(frozen=True)
+class GroupSelection:
+    """A semantic retention decision for one cache group."""
+
+    group_id: str
+    semantic_kind: CacheSemanticKind
+    logical_span: LogicalSpan
+    required_siblings: tuple[str, ...]
+    action: RetentionAction
+    valid_until_step: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("group_id must not be empty")
+        siblings = tuple(sorted(self.required_siblings))
+        if len(siblings) != len(set(siblings)):
+            raise ValueError("required_siblings must be unique")
+        if self.group_id in siblings:
+            raise ValueError("a selection cannot require itself as a sibling")
+        object.__setattr__(self, "required_siblings", siblings)
+        if self.valid_until_step is not None and self.valid_until_step < 0:
+            raise ValueError("valid_until_step must be non-negative")
+
+
+@dataclass(frozen=True)
+class TokenSelectionPlan:
+    """Immutable semantic plan, independent of page tables and rank addresses."""
+
+    request_id: str
+    request_generation: int
+    decode_round: int
+    accepted_seq_len: int
+    source_kv_revision: int
+    topology_fingerprint: str
+    policy_revision: str
+    groups: tuple[GroupSelection, ...]
+    plan_digest: str
+
+    def __post_init__(self) -> None:
+        if not self.request_id:
+            raise ValueError("request_id must not be empty")
+        for name in (
+            "request_generation",
+            "decode_round",
+            "accepted_seq_len",
+            "source_kv_revision",
+        ):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be non-negative")
+        if not self.topology_fingerprint:
+            raise ValueError("topology_fingerprint must not be empty")
+        if not self.policy_revision:
+            raise ValueError("policy_revision must not be empty")
+        groups = tuple(sorted(self.groups, key=_selection_sort_key))
+        if not groups:
+            raise ValueError("a token-selection plan must contain at least one group")
+        object.__setattr__(self, "groups", groups)
+        expected = _plan_digest(
+            request_id=self.request_id,
+            request_generation=self.request_generation,
+            decode_round=self.decode_round,
+            accepted_seq_len=self.accepted_seq_len,
+            source_kv_revision=self.source_kv_revision,
+            topology_fingerprint=self.topology_fingerprint,
+            policy_revision=self.policy_revision,
+            groups=groups,
+        )
+        if self.plan_digest != expected:
+            raise ValueError("plan digest does not match plan content")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        request_id: str,
+        request_generation: int,
+        decode_round: int,
+        accepted_seq_len: int,
+        source_kv_revision: int,
+        topology_fingerprint: str,
+        policy_revision: str,
+        groups: tuple[GroupSelection, ...],
+    ) -> TokenSelectionPlan:
+        """Build an immutable plan with a deterministic content digest."""
+        normalized = tuple(sorted(groups, key=_selection_sort_key))
+        return cls(
+            request_id=request_id,
+            request_generation=request_generation,
+            decode_round=decode_round,
+            accepted_seq_len=accepted_seq_len,
+            source_kv_revision=source_kv_revision,
+            topology_fingerprint=topology_fingerprint,
+            policy_revision=policy_revision,
+            groups=normalized,
+            plan_digest=_plan_digest(
+                request_id=request_id,
+                request_generation=request_generation,
+                decode_round=decode_round,
+                accepted_seq_len=accepted_seq_len,
+                source_kv_revision=source_kv_revision,
+                topology_fingerprint=topology_fingerprint,
+                policy_revision=policy_revision,
+                groups=normalized,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PlanValidationIssue:
+    """One stable fail-closed validation finding."""
+
+    code: PlanValidationCode
+    message: str
+    group_id: str | None = None
+
+
+@dataclass(frozen=True)
+class PlanValidationResult:
+    """Validation result with all detected issues."""
+
+    issues: tuple[PlanValidationIssue, ...] = ()
+
+    @property
+    def valid(self) -> bool:
+        """Return whether physical expansion is safe."""
+        return not self.issues
+
+    @property
+    def recompute_required(self) -> bool:
+        """Return whether callers must fall back to cache miss and recompute."""
+        return bool(self.issues)
+
+
+@dataclass(frozen=True)
+class PhysicalGroupOperation:
+    """Topology-expanded full-block operation plus explicit residual spans."""
+
+    group_id: str
+    semantic_kind: CacheSemanticKind
+    action: RetentionAction
+    logical_span: LogicalSpan
+    full_block_logical_span: LogicalSpan | None
+    physical_entry_start: int
+    physical_entry_end: int
+    byte_start: int
+    byte_end: int
+    residual_spans: tuple[LogicalSpan, ...]
+    rank_sharding: str
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("group_id must not be empty")
+        if self.physical_entry_start < 0:
+            raise ValueError("physical_entry_start must be non-negative")
+        if self.physical_entry_end < self.physical_entry_start:
+            raise ValueError("physical entry range must not be negative")
+        if self.byte_start < 0 or self.byte_end < self.byte_start:
+            raise ValueError("byte range must not be negative")
+        if not self.rank_sharding:
+            raise ValueError("rank_sharding must not be empty")
+
+    @property
+    def physical_entry_count(self) -> int:
+        """Return the number of full-block physical entries."""
+        return self.physical_entry_end - self.physical_entry_start
+
+    @property
+    def requires_residual_handling(self) -> bool:
+        """Return whether partial logical blocks need adapter handling."""
+        return bool(self.residual_spans)
+
+
+@dataclass(frozen=True)
+class PlanExpansion:
+    """Fail-closed validation and physical expansion result."""
+
+    validation: PlanValidationResult
+    operations: tuple[PhysicalGroupOperation, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.validation.recompute_required and self.operations:
+            raise ValueError("invalid plans cannot expose physical operations")
+
+
+def validate_plan(
+    plan: TokenSelectionPlan,
+    topology: CacheTopologyDescriptor,
+    *,
+    request_id: str,
+    request_generation: int,
+    decode_round: int,
+    accepted_seq_len: int,
+    source_kv_revision: int,
+    policy_revision: str,
+    current_step: int,
+) -> PlanValidationResult:
+    """Validate a plan against live request and topology revisions."""
+    if current_step < 0:
+        raise ValueError("current_step must be non-negative")
+    issues: list[PlanValidationIssue] = []
+
+    def add(
+        code: PlanValidationCode, message: str, group_id: str | None = None
+    ) -> None:
+        issues.append(
+            PlanValidationIssue(code=code, message=message, group_id=group_id)
+        )
+
+    expected_values = (
+        (plan.request_id, request_id, PlanValidationCode.REQUEST_ID_MISMATCH),
+        (
+            plan.request_generation,
+            request_generation,
+            PlanValidationCode.REQUEST_GENERATION_MISMATCH,
+        ),
+        (plan.decode_round, decode_round, PlanValidationCode.DECODE_ROUND_MISMATCH),
+        (
+            plan.accepted_seq_len,
+            accepted_seq_len,
+            PlanValidationCode.ACCEPTED_SEQ_LEN_MISMATCH,
+        ),
+        (
+            plan.source_kv_revision,
+            source_kv_revision,
+            PlanValidationCode.SOURCE_KV_REVISION_MISMATCH,
+        ),
+        (
+            plan.topology_fingerprint,
+            topology.fingerprint,
+            PlanValidationCode.TOPOLOGY_MISMATCH,
+        ),
+        (
+            plan.policy_revision,
+            policy_revision,
+            PlanValidationCode.POLICY_REVISION_MISMATCH,
+        ),
+    )
+    for actual, expected, code in expected_values:
+        if actual != expected:
+            add(code, f"plan value {actual!r} does not match live value {expected!r}")
+
+    selections: dict[str, GroupSelection] = {}
+    for selection in plan.groups:
+        if selection.group_id in selections:
+            add(
+                PlanValidationCode.DUPLICATE_GROUP,
+                "plan contains more than one selection for the group",
+                selection.group_id,
+            )
+            continue
+        selections[selection.group_id] = selection
+        geometry = topology.group(selection.group_id)
+        if geometry is None:
+            add(
+                PlanValidationCode.UNKNOWN_GROUP,
+                "selection does not exist in the topology",
+                selection.group_id,
+            )
+            continue
+        if selection.semantic_kind != geometry.semantic_kind:
+            add(
+                PlanValidationCode.SEMANTIC_KIND_MISMATCH,
+                "selection semantic kind differs from the topology",
+                selection.group_id,
+            )
+        if selection.logical_span.end_token > plan.accepted_seq_len:
+            add(
+                PlanValidationCode.SPAN_AFTER_ACCEPTED_SEQUENCE,
+                "selection extends past the accepted sequence boundary",
+                selection.group_id,
+            )
+        if geometry.window_size_tokens is not None:
+            window_start = max(0, plan.accepted_seq_len - geometry.window_size_tokens)
+            if selection.logical_span.start_token < window_start:
+                add(
+                    PlanValidationCode.SLIDING_WINDOW_BOUNDARY,
+                    f"selection begins before active window token {window_start}",
+                    selection.group_id,
+                )
+        if set(selection.required_siblings) != set(geometry.sibling_group_ids):
+            add(
+                PlanValidationCode.SIBLING_DECLARATION_MISMATCH,
+                "selection siblings differ from topology family membership",
+                selection.group_id,
+            )
+        if (
+            selection.valid_until_step is not None
+            and current_step > selection.valid_until_step
+        ):
+            add(
+                PlanValidationCode.EXPIRED_SELECTION,
+                "selection validity has expired",
+                selection.group_id,
+            )
+        if selection.action == RetentionAction.RECOMPUTE_REQUIRED:
+            add(
+                PlanValidationCode.EXPLICIT_RECOMPUTE,
+                "selection explicitly requires recomputation",
+                selection.group_id,
+            )
+
+    checked_families: set[frozenset[str]] = set()
+    for group_id, selection in selections.items():
+        geometry = topology.group(group_id)
+        if geometry is None:
+            continue
+        family = frozenset((group_id, *geometry.sibling_group_ids))
+        if family in checked_families:
+            continue
+        checked_families.add(family)
+        missing = sorted(family - selections.keys())
+        for missing_id in missing:
+            add(
+                PlanValidationCode.MISSING_FAMILY_MEMBER,
+                f"cache family is missing required group {missing_id}",
+                group_id,
+            )
+        present = [selections[item] for item in family if item in selections]
+        if not present:
+            continue
+        first = present[0]
+        if any(item.action != first.action for item in present[1:]):
+            add(
+                PlanValidationCode.INCONSISTENT_FAMILY_ACTION,
+                "cache family selections must use one atomic action",
+                group_id,
+            )
+        if any(
+            item.logical_span != first.logical_span
+            or item.valid_until_step != first.valid_until_step
+            for item in present[1:]
+        ):
+            add(
+                PlanValidationCode.INCONSISTENT_FAMILY_SPAN,
+                "cache family selections must share span and validity",
+                group_id,
+            )
+
+    return PlanValidationResult(issues=tuple(issues))
+
+
+def expand_plan(
+    plan: TokenSelectionPlan,
+    topology: CacheTopologyDescriptor,
+    *,
+    request_id: str,
+    request_generation: int,
+    decode_round: int,
+    accepted_seq_len: int,
+    source_kv_revision: int,
+    policy_revision: str,
+    current_step: int,
+) -> PlanExpansion:
+    """Validate then map a semantic plan to safe full-block operations."""
+    validation = validate_plan(
+        plan,
+        topology,
+        request_id=request_id,
+        request_generation=request_generation,
+        decode_round=decode_round,
+        accepted_seq_len=accepted_seq_len,
+        source_kv_revision=source_kv_revision,
+        policy_revision=policy_revision,
+        current_step=current_step,
+    )
+    if not validation.valid:
+        return PlanExpansion(validation=validation)
+    operations = tuple(
+        _expand_selection(selection, topology.group(selection.group_id))
+        for selection in plan.groups
+    )
+    return PlanExpansion(validation=validation, operations=operations)
+
+
+def _expand_selection(
+    selection: GroupSelection,
+    geometry: CacheGroupGeometry | None,
+) -> PhysicalGroupOperation:
+    assert geometry is not None
+    span = selection.logical_span
+    tokens_per_block = geometry.logical_tokens_per_block
+    first_full_block = (span.start_token + tokens_per_block - 1) // tokens_per_block
+    end_full_block = max(first_full_block, span.end_token // tokens_per_block)
+    full_start_token = first_full_block * tokens_per_block
+    full_end_token = end_full_block * tokens_per_block
+
+    residuals: list[LogicalSpan] = []
+    prefix_end = min(span.end_token, full_start_token)
+    if span.start_token < prefix_end:
+        residuals.append(LogicalSpan(span.start_token, prefix_end))
+    suffix_start = max(prefix_end, full_end_token)
+    if suffix_start < span.end_token:
+        residuals.append(LogicalSpan(suffix_start, span.end_token))
+
+    full_span = (
+        LogicalSpan(full_start_token, full_end_token)
+        if full_start_token < full_end_token
+        else None
+    )
+    entry_start = first_full_block * geometry.physical_entries_per_block
+    entry_end = end_full_block * geometry.physical_entries_per_block
+    return PhysicalGroupOperation(
+        group_id=selection.group_id,
+        semantic_kind=selection.semantic_kind,
+        action=selection.action,
+        logical_span=span,
+        full_block_logical_span=full_span,
+        physical_entry_start=entry_start,
+        physical_entry_end=entry_end,
+        byte_start=entry_start * geometry.page_stride_bytes,
+        byte_end=entry_end * geometry.page_stride_bytes,
+        residual_spans=tuple(residuals),
+        rank_sharding=geometry.rank_sharding,
+    )
+
+
+def _topology_fingerprint(
+    model_architecture: str,
+    backend_name: str,
+    topology_version: str,
+    groups: tuple[CacheGroupGeometry, ...],
+) -> str:
+    payload = {
+        "backend_name": backend_name,
+        "groups": [
+            {
+                "alignment_bytes": group.alignment_bytes,
+                "compression_ratio": group.compression_ratio,
+                "group_id": group.group_id,
+                "logical_tokens_per_block": group.logical_tokens_per_block,
+                "page_stride_bytes": group.page_stride_bytes,
+                "physical_entries_per_block": group.physical_entries_per_block,
+                "rank_sharding": group.rank_sharding,
+                "semantic_kind": group.semantic_kind.value,
+                "sibling_group_ids": list(group.sibling_group_ids),
+                "window_size_tokens": group.window_size_tokens,
+            }
+            for group in groups
+        ],
+        "model_architecture": model_architecture,
+        "topology_version": topology_version,
+    }
+    return _sha256(payload)
+
+
+def _plan_digest(
+    *,
+    request_id: str,
+    request_generation: int,
+    decode_round: int,
+    accepted_seq_len: int,
+    source_kv_revision: int,
+    topology_fingerprint: str,
+    policy_revision: str,
+    groups: tuple[GroupSelection, ...],
+) -> str:
+    payload = {
+        "accepted_seq_len": accepted_seq_len,
+        "decode_round": decode_round,
+        "groups": [
+            {
+                "action": selection.action.value,
+                "group_id": selection.group_id,
+                "logical_span": {
+                    "end_token": selection.logical_span.end_token,
+                    "start_token": selection.logical_span.start_token,
+                },
+                "required_siblings": list(selection.required_siblings),
+                "semantic_kind": selection.semantic_kind.value,
+                "valid_until_step": selection.valid_until_step,
+            }
+            for selection in groups
+        ],
+        "policy_revision": policy_revision,
+        "request_generation": request_generation,
+        "request_id": request_id,
+        "source_kv_revision": source_kv_revision,
+        "topology_fingerprint": topology_fingerprint,
+    }
+    return _sha256(payload)
+
+
+def _sha256(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()

--- a/tests/sdk/test_token_selection.py
+++ b/tests/sdk/test_token_selection.py
@@ -1,0 +1,507 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Public-contract tests for topology-aware token-selection plans."""
+
+# Standard
+from collections.abc import Callable
+from dataclasses import replace
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.sdk.token_selection import (
+    CacheGroupGeometry,
+    CacheSemanticKind,
+    CacheTopologyDescriptor,
+    GroupSelection,
+    LogicalSpan,
+    PlanExpansion,
+    PlanValidationCode,
+    RetentionAction,
+    TokenSelectionPlan,
+    expand_plan,
+)
+
+
+def _geometry(
+    group_id: str = "main",
+    *,
+    semantic_kind: CacheSemanticKind = CacheSemanticKind.DENSE_ATTENTION,
+    compression_ratio: int = 1,
+    siblings: tuple[str, ...] = (),
+    window_size_tokens: int | None = None,
+) -> CacheGroupGeometry:
+    return CacheGroupGeometry(
+        group_id=group_id,
+        semantic_kind=semantic_kind,
+        logical_tokens_per_block=compression_ratio,
+        physical_entries_per_block=1,
+        compression_ratio=compression_ratio,
+        rank_sharding="tp-contiguous",
+        page_stride_bytes=256,
+        alignment_bytes=128,
+        sibling_group_ids=siblings,
+        window_size_tokens=window_size_tokens,
+    )
+
+
+def _topology(*groups: CacheGroupGeometry) -> CacheTopologyDescriptor:
+    return CacheTopologyDescriptor.create(
+        model_architecture="HybridForCausalLM",
+        backend_name="paged-backend",
+        topology_version="v1",
+        groups=tuple(groups) or (_geometry(),),
+    )
+
+
+def _selection(
+    geometry: CacheGroupGeometry,
+    *,
+    span: LogicalSpan | None = None,
+    action: RetentionAction = RetentionAction.INVALIDATE,
+    valid_until_step: int | None = None,
+) -> GroupSelection:
+    return GroupSelection(
+        group_id=geometry.group_id,
+        semantic_kind=geometry.semantic_kind,
+        logical_span=span or LogicalSpan(0, 256),
+        required_siblings=geometry.sibling_group_ids,
+        action=action,
+        valid_until_step=valid_until_step,
+    )
+
+
+def _plan(
+    topology: CacheTopologyDescriptor,
+    *groups: GroupSelection,
+    accepted_seq_len: int = 256,
+) -> TokenSelectionPlan:
+    return TokenSelectionPlan.create(
+        request_id="request-1",
+        request_generation=3,
+        decode_round=7,
+        accepted_seq_len=accepted_seq_len,
+        source_kv_revision=11,
+        topology_fingerprint=topology.fingerprint,
+        policy_revision="policy-v2",
+        groups=tuple(groups),
+    )
+
+
+def _expand(
+    plan: TokenSelectionPlan,
+    topology: CacheTopologyDescriptor,
+    **overrides: object,
+) -> PlanExpansion:
+    context: dict[str, object] = {
+        "request_id": "request-1",
+        "request_generation": 3,
+        "decode_round": 7,
+        "accepted_seq_len": 256,
+        "source_kv_revision": 11,
+        "policy_revision": "policy-v2",
+        "current_step": 8,
+    }
+    context.update(overrides)
+    return expand_plan(plan, topology, **context)  # type: ignore[arg-type]
+
+
+def _codes(expansion: PlanExpansion) -> set[PlanValidationCode]:
+    return {issue.code for issue in expansion.validation.issues}
+
+
+@pytest.mark.parametrize(
+    ("semantic_kind", "compression_ratio", "expected_entries"),
+    [
+        (CacheSemanticKind.DENSE_ATTENTION, 1, 256),
+        (CacheSemanticKind.COMPRESSED_DENSE, 4, 64),
+        (CacheSemanticKind.COMPRESSED_SPARSE, 128, 2),
+    ],
+)
+def test_aligned_logical_span_maps_to_expected_physical_entries(
+    semantic_kind: CacheSemanticKind,
+    compression_ratio: int,
+    expected_entries: int,
+) -> None:
+    """Dense, C4, and C128 mappings use topology rather than model names."""
+    geometry = _geometry(
+        semantic_kind=semantic_kind,
+        compression_ratio=compression_ratio,
+    )
+    topology = _topology(geometry)
+    expansion = _expand(_plan(topology, _selection(geometry)), topology)
+
+    assert expansion.validation.valid
+    assert len(expansion.operations) == 1
+    operation = expansion.operations[0]
+    assert operation.physical_entry_start == 0
+    assert operation.physical_entry_end == expected_entries
+    assert operation.physical_entry_count == expected_entries
+    assert operation.byte_end == expected_entries * geometry.page_stride_bytes
+    assert operation.full_block_logical_span == LogicalSpan(0, 256)
+    assert not operation.requires_residual_handling
+
+
+def test_partial_compression_maps_only_full_blocks_and_exposes_residuals() -> None:
+    """Partial compressed blocks are never silently widened for invalidation."""
+    geometry = _geometry(
+        semantic_kind=CacheSemanticKind.COMPRESSED_DENSE,
+        compression_ratio=4,
+    )
+    topology = _topology(geometry)
+    selection = _selection(geometry, span=LogicalSpan(3, 10))
+    plan = _plan(topology, selection, accepted_seq_len=10)
+    expansion = _expand(plan, topology, accepted_seq_len=10)
+
+    assert expansion.validation.valid
+    operation = expansion.operations[0]
+    assert operation.full_block_logical_span == LogicalSpan(4, 8)
+    assert operation.physical_entry_start == 1
+    assert operation.physical_entry_end == 2
+    assert operation.residual_spans == (LogicalSpan(3, 4), LogicalSpan(8, 10))
+    assert operation.requires_residual_handling
+
+
+def test_span_without_a_full_compressed_block_is_residual_only() -> None:
+    """A sub-block edit produces no destructive physical range."""
+    geometry = _geometry(
+        semantic_kind=CacheSemanticKind.COMPRESSED_DENSE,
+        compression_ratio=128,
+    )
+    topology = _topology(geometry)
+    selection = _selection(geometry, span=LogicalSpan(3, 10))
+    expansion = _expand(
+        _plan(topology, selection, accepted_seq_len=10),
+        topology,
+        accepted_seq_len=10,
+    )
+
+    operation = expansion.operations[0]
+    assert operation.full_block_logical_span is None
+    assert operation.physical_entry_count == 0
+    assert operation.byte_start == operation.byte_end == 256
+    assert operation.residual_spans == (LogicalSpan(3, 10),)
+
+
+def test_sliding_window_enforces_strict_active_boundary() -> None:
+    """Selections cannot claim tokens already outside the active window."""
+    geometry = _geometry(
+        semantic_kind=CacheSemanticKind.SLIDING_WINDOW,
+        window_size_tokens=128,
+    )
+    topology = _topology(geometry)
+
+    valid = _expand(
+        _plan(topology, _selection(geometry, span=LogicalSpan(128, 256))),
+        topology,
+    )
+    invalid = _expand(
+        _plan(topology, _selection(geometry, span=LogicalSpan(127, 256))),
+        topology,
+    )
+
+    assert valid.validation.valid
+    assert _codes(invalid) == {PlanValidationCode.SLIDING_WINDOW_BOUNDARY}
+    assert not invalid.operations
+
+
+def test_complete_hybrid_family_expands_atomically() -> None:
+    """All members of a hybrid family expand together."""
+    main = _geometry(
+        "compressed-main",
+        semantic_kind=CacheSemanticKind.COMPRESSED_DENSE,
+        compression_ratio=4,
+        siblings=("indexer",),
+    )
+    indexer = _geometry(
+        "indexer",
+        semantic_kind=CacheSemanticKind.INDEXER,
+        siblings=("compressed-main",),
+    )
+    topology = _topology(indexer, main)
+    plan = _plan(topology, _selection(main), _selection(indexer))
+
+    expansion = _expand(plan, topology)
+
+    assert expansion.validation.valid
+    assert [operation.group_id for operation in expansion.operations] == [
+        "compressed-main",
+        "indexer",
+    ]
+    assert [operation.physical_entry_count for operation in expansion.operations] == [
+        64,
+        256,
+    ]
+
+
+def test_missing_hybrid_sibling_fails_closed_without_operations() -> None:
+    """A partial family hit becomes recompute rather than partial reuse."""
+    main = _geometry(
+        "compressed-main",
+        semantic_kind=CacheSemanticKind.COMPRESSED_DENSE,
+        compression_ratio=4,
+        siblings=("indexer",),
+    )
+    indexer = _geometry(
+        "indexer",
+        semantic_kind=CacheSemanticKind.INDEXER,
+        siblings=("compressed-main",),
+    )
+    topology = _topology(main, indexer)
+
+    expansion = _expand(_plan(topology, _selection(main)), topology)
+
+    assert PlanValidationCode.MISSING_FAMILY_MEMBER in _codes(expansion)
+    assert not expansion.operations
+
+
+@pytest.mark.parametrize("difference", ["action", "span"])
+def test_hybrid_family_rejects_non_atomic_decisions(difference: str) -> None:
+    """Family members must share one action, logical span, and validity."""
+    main = _geometry("main", siblings=("indexer",))
+    indexer = _geometry(
+        "indexer",
+        semantic_kind=CacheSemanticKind.INDEXER,
+        siblings=("main",),
+    )
+    topology = _topology(main, indexer)
+    indexer_selection = _selection(indexer)
+    if difference == "action":
+        indexer_selection = replace(indexer_selection, action=RetentionAction.KEEP)
+        expected = PlanValidationCode.INCONSISTENT_FAMILY_ACTION
+    else:
+        indexer_selection = replace(
+            indexer_selection,
+            logical_span=LogicalSpan(1, 256),
+        )
+        expected = PlanValidationCode.INCONSISTENT_FAMILY_SPAN
+
+    expansion = _expand(
+        _plan(topology, _selection(main), indexer_selection),
+        topology,
+    )
+
+    assert expected in _codes(expansion)
+    assert not expansion.operations
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("request_id", "other", PlanValidationCode.REQUEST_ID_MISMATCH),
+        (
+            "request_generation",
+            4,
+            PlanValidationCode.REQUEST_GENERATION_MISMATCH,
+        ),
+        ("decode_round", 8, PlanValidationCode.DECODE_ROUND_MISMATCH),
+        ("accepted_seq_len", 255, PlanValidationCode.ACCEPTED_SEQ_LEN_MISMATCH),
+        (
+            "source_kv_revision",
+            12,
+            PlanValidationCode.SOURCE_KV_REVISION_MISMATCH,
+        ),
+        (
+            "policy_revision",
+            "policy-v3",
+            PlanValidationCode.POLICY_REVISION_MISMATCH,
+        ),
+    ],
+)
+def test_live_request_revision_mismatches_fail_closed(
+    field: str,
+    value: object,
+    expected: PlanValidationCode,
+) -> None:
+    """Every live request fence is checked before physical expansion."""
+    topology = _topology(_geometry())
+    plan = _plan(topology, _selection(topology.groups[0]))
+
+    expansion = _expand(plan, topology, **{field: value})
+
+    assert expected in _codes(expansion)
+    assert not expansion.operations
+
+
+def test_topology_fingerprint_mismatch_fails_closed() -> None:
+    """A plan cannot be expanded under different cache geometry."""
+    original = _topology(_geometry())
+    changed = _topology(
+        _geometry(
+            semantic_kind=CacheSemanticKind.COMPRESSED_DENSE,
+            compression_ratio=4,
+        )
+    )
+    plan = _plan(original, _selection(original.groups[0]))
+
+    expansion = _expand(plan, changed)
+
+    assert PlanValidationCode.TOPOLOGY_MISMATCH in _codes(expansion)
+    assert PlanValidationCode.SEMANTIC_KIND_MISMATCH in _codes(expansion)
+    assert not expansion.operations
+
+
+def test_unknown_and_duplicate_groups_fail_closed() -> None:
+    """Unknown group ids and ambiguous duplicate selections never expand."""
+    geometry = _geometry()
+    topology = _topology(geometry)
+    unknown = GroupSelection(
+        group_id="unknown",
+        semantic_kind=CacheSemanticKind.DENSE_ATTENTION,
+        logical_span=LogicalSpan(0, 256),
+        required_siblings=(),
+        action=RetentionAction.INVALIDATE,
+    )
+
+    unknown_expansion = _expand(_plan(topology, unknown), topology)
+    duplicate_expansion = _expand(
+        _plan(topology, _selection(geometry), _selection(geometry)),
+        topology,
+    )
+
+    assert _codes(unknown_expansion) == {PlanValidationCode.UNKNOWN_GROUP}
+    assert _codes(duplicate_expansion) == {PlanValidationCode.DUPLICATE_GROUP}
+    assert unknown_expansion.validation.recompute_required
+    assert duplicate_expansion.validation.recompute_required
+    assert not unknown_expansion.operations
+    assert not duplicate_expansion.operations
+
+
+def test_span_past_accepted_tokens_fails_closed() -> None:
+    """Speculative or rejected decode tokens cannot enter physical edits."""
+    topology = _topology(_geometry())
+    plan = _plan(
+        topology,
+        _selection(topology.groups[0], span=LogicalSpan(0, 257)),
+    )
+
+    expansion = _expand(plan, topology)
+
+    assert _codes(expansion) == {PlanValidationCode.SPAN_AFTER_ACCEPTED_SEQUENCE}
+    assert not expansion.operations
+
+
+def test_expired_or_explicit_recompute_plan_never_expands() -> None:
+    """Expired decisions and explicit recompute actions are fail-closed."""
+    topology = _topology(_geometry())
+    selection = _selection(
+        topology.groups[0],
+        action=RetentionAction.RECOMPUTE_REQUIRED,
+        valid_until_step=7,
+    )
+
+    expansion = _expand(_plan(topology, selection), topology, current_step=8)
+
+    assert _codes(expansion) == {
+        PlanValidationCode.EXPIRED_SELECTION,
+        PlanValidationCode.EXPLICIT_RECOMPUTE,
+    }
+    assert not expansion.operations
+
+
+def test_negative_live_step_is_rejected_as_caller_error() -> None:
+    """A nonsensical live step does not participate in plan validation."""
+    topology = _topology(_geometry())
+    plan = _plan(topology, _selection(topology.groups[0]))
+
+    with pytest.raises(ValueError, match="current_step"):
+        _expand(plan, topology, current_step=-1)
+
+
+def test_selection_siblings_must_match_topology() -> None:
+    """The algorithm cannot silently omit topology-declared family members."""
+    main = _geometry("main", siblings=("indexer",))
+    indexer = _geometry(
+        "indexer",
+        semantic_kind=CacheSemanticKind.INDEXER,
+        siblings=("main",),
+    )
+    topology = _topology(main, indexer)
+    wrong = replace(_selection(main), required_siblings=())
+
+    expansion = _expand(_plan(topology, wrong, _selection(indexer)), topology)
+
+    assert PlanValidationCode.SIBLING_DECLARATION_MISMATCH in _codes(expansion)
+    assert not expansion.operations
+
+
+def test_topology_requires_symmetric_existing_siblings() -> None:
+    """Malformed family graphs are rejected when the descriptor is built."""
+    missing = _geometry("main", siblings=("missing",))
+    with pytest.raises(ValueError, match="unknown sibling"):
+        _topology(missing)
+
+    main = _geometry("main", siblings=("indexer",))
+    indexer = _geometry("indexer", semantic_kind=CacheSemanticKind.INDEXER)
+    with pytest.raises(ValueError, match="must be symmetric"):
+        _topology(main, indexer)
+
+
+def test_topology_rejects_overlapping_incomplete_families() -> None:
+    """Pairwise-symmetric edges must still form one complete family clique."""
+    first = _geometry("first", siblings=("second",))
+    second = _geometry("second", siblings=("first", "third"))
+    third = _geometry("third", siblings=("second",))
+
+    with pytest.raises(ValueError, match="complete, non-overlapping"):
+        _topology(first, second, third)
+
+
+def test_descriptor_and_plan_digests_are_order_independent() -> None:
+    """Equivalent tuple order produces stable topology and plan identities."""
+    first = _geometry("first", siblings=("second",))
+    second = _geometry("second", siblings=("first",))
+    forward = _topology(first, second)
+    reverse = _topology(second, first)
+
+    assert forward.fingerprint == reverse.fingerprint
+    forward_plan = _plan(forward, _selection(first), _selection(second))
+    reverse_plan = _plan(reverse, _selection(second), _selection(first))
+    assert forward_plan.plan_digest == reverse_plan.plan_digest
+
+
+def test_duplicate_group_digest_is_stable_before_fail_closed_validation() -> None:
+    """Malformed duplicate selections still have one canonical wire identity."""
+    geometry = _geometry()
+    topology = _topology(geometry)
+    keep = _selection(geometry, action=RetentionAction.KEEP)
+    invalidate = _selection(geometry, action=RetentionAction.INVALIDATE)
+
+    forward = _plan(topology, keep, invalidate)
+    reverse = _plan(topology, invalidate, keep)
+
+    assert forward.plan_digest == reverse.plan_digest
+    assert _codes(_expand(forward, topology)) == {PlanValidationCode.DUPLICATE_GROUP}
+
+
+def test_tampered_digest_is_rejected_before_expansion() -> None:
+    """Serialized plan content cannot silently diverge from its identity."""
+    topology = _topology(_geometry())
+    plan = _plan(topology, _selection(topology.groups[0]))
+
+    with pytest.raises(ValueError, match="plan digest"):
+        replace(plan, plan_digest="sha256:" + "0" * 64)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda geometry: replace(
+            geometry,
+            logical_tokens_per_block=4,
+            compression_ratio=2,
+        ),
+        lambda geometry: replace(
+            geometry,
+            page_stride_bytes=192,
+            alignment_bytes=128,
+        ),
+        lambda geometry: replace(geometry, window_size_tokens=128),
+    ],
+)
+def test_invalid_geometry_is_rejected(
+    mutate: Callable[[CacheGroupGeometry], CacheGroupGeometry],
+) -> None:
+    """Inconsistent compression, alignment, or window metadata is invalid."""
+    with pytest.raises(ValueError):
+        mutate(_geometry())


### PR DESCRIPTION
## Summary

- add deterministic `CacheTopologyDescriptor` and `TokenSelectionPlan` SDK types
- keep semantic retention decisions independent of model names, page tables, padded strides, and rank-local addresses
- validate request generation, decode round, accepted length, source-KV revision, topology fingerprint, policy revision, group identity, and selection lifetime before expansion
- require hybrid sibling families to be complete, non-overlapping equivalence sets rather than merely pairwise-symmetric fragments
- give all selection content a total canonical order so malformed duplicate selections produce an order-independent digest before fail-closed validation
- map dense, compressed, and sliding-window logical spans to full-block physical entry/byte ranges
- surface partial compressed blocks as explicit residual spans instead of silently widening destructive operations

`expand_plan()` is fail closed: any validation issue yields no physical operations and `validation.recompute_required == True`.

This PR intentionally does not add a scoring algorithm or model-specific DeepSeek logic. It provides an independent topology/plan foundation for Q-across-decode work such as #4527 and follows the SDK direction established by #3820. It is also independent of #4900, although their revision fields are designed to compose.

## Correctness coverage

The 30 focused CPU cases cover:

- Dense 256 logical -> 256 physical
- C4 256 logical -> 64 physical
- C128 256 logical -> 2 physical
- strict sliding-window boundaries
- partial compressed spans and residual-only sub-block spans
- complete, missing, internally inconsistent, overlapping, and incomplete hybrid families
- every live request/revision fence and accepted-token boundary
- unknown/duplicate groups, expired plans, and explicit recompute
- symmetric topology graphs, geometry/alignment invariants, stable content digests, and tamper rejection
- order-independent digests for malformed duplicate selections

The residual-only case caught and prevented a negative physical range during development; the final regression asserts an empty `start == end` physical range with the full logical span retained as residual work.

## Validation

Candidate `edd06a8604c1aec212642605c007efd5a64afe65` is rebased on `dev` at `86483cd63a544a0b52c51c0b139f39fa02be03d3`.

- `python -m pytest -q tests/sdk`: **66 passed, 1 skipped**
- targeted topology/plan suite: **30 passed**
- changed-file `pre-commit`: **passed** (SPDX, device-API bans, timeout ban, isort, Ruff, Ruff format, codespell, mypy; Rust hook skipped on macOS)
- `git diff --check`: **passed**
- DCO: **passed**
- Buildkite `k3-unit-tests`: **passed** ([build #8607](https://buildkite.com/lmcache/k3-unit-tests/builds/8607), 21m40s)

The wider macOS test collection requires optional Triton and vLLM packages that are not installed locally; those modules fail during import before reaching this change. The focused SDK suite and project CI are the relevant executable gates.

## Control-plane benchmark

Apple M5 / macOS 26.6.1 / Python 3.12.13, seven independent fresh-process repetitions:

- two-group hybrid validation + physical expansion, 20,000 iterations/repetition: median **6.240 us/op** (range **5.975-6.609 us/op**), median **160,249 ops/s**
- incomplete-family fail-closed validation, 50,000 iterations/repetition: median **2.428 us/op** (range **2.271-2.563 us/op**), median **411,916 ops/s**
- every valid replay checksum was **40,000** and every fail-closed replay checksum was **50,000**

These are absolute local CPU control-plane measurements, not GPU, live-serving, or cross-machine performance claims.

## InfraSWE diagnostic

- latest InfraSWE revision `16f06c366db17562e411ffeb18b978c04ecb7cd5`: **283 passed**
- diagnostic ProjectFit: **85.54/100**
- BenchmarkTrust: **91.43/100**
- official ProjectFit: **unresolved**

The diagnostic is bound to the exact candidate/base SHAs, five-file change set, seven raw fresh-process replays, local verification, DCO, and Buildkite status. It is not an official decision: no maintainer-sealed Draft, hidden probes, E2 system trace, or live-serving cell is available. Benchmark and scoring artifacts are retained outside the LMCache source branch; this PR adds no JSON evidence files.

## Runnable L20 end-to-end notebook

Reviewer-runnable artifact: [`examples/token_dropping/topology_aware_token_dropping.ipynb`](https://github.com/LMCache/LMCache/blob/27d7e3208c7ea46172a8806b6e5869ba326e909c/examples/token_dropping/topology_aware_token_dropping.ipynb). It wraps the checked-in CLI, so notebook and command-line runs exercise the same implementation. Start LMCache and vLLM with the commands in [the token-dropping README](https://github.com/LMCache/LMCache/blob/27d7e3208c7ea46172a8806b6e5869ba326e909c/examples/token_dropping/README.md), then **Run All**.

Reproduced on NVIDIA L20; vLLM 0.25.1; PyTorch 2.11.0+cu130; CUDA 13.0; Qwen/Qwen3-0.6B; LMCacheMPConnector; 256-token chunks.

- notebook commit: `27d7e32`
- candidate code image: `5118d72` (the later commit only adds the notebook/README link)
- image digest: `sha256:beb68087dd27d00f7985de9528c7b01a6a55f645d687e6435bf0d99ab0ed3c67`
- result: live KV compacted from **1,024 to 512 tokens**, with logical/physical span `[256, 768)` and byte range `[29360128, 88080384)`
- stale-generation replay failed closed with `request_generation_mismatch` and produced **zero physical operations**
- serving resumed for **32 output tokens**
- notebook Run-All log: 51 lines, SHA-256 `4191aaf01a1a6951a7ad12f129096db2569bf123fc28a3b1c8267930e21ed5ec`
- direct CLI log: 49 lines, SHA-256 `2f824b19ad842763ba8022c99437cc06bb45b6bb45d01627224b0086b816d557`

### What the abstraction hides

The plan layer hides logical-to-physical block expansion, compression/alignment boundaries, sliding-window clipping, hybrid sibling atomicity, stable topology/policy/revision fencing, and fail-closed stale-plan validation. It intentionally does **not** hide the serving adapter's responsibilities: choosing/scoring tokens, mutating tensors, applying residual sub-block work, synchronizing ranks, and advancing the lifecycle only after the physical effect is visible.
