### PR TITLE
[Bench] Add hybrid cache correctness trace harness

### DIFF
--- a/benchmarks/hybrid_cache_correctness/README.md
+++ b/benchmarks/hybrid_cache_correctness/README.md
@@ -58,6 +58,10 @@ python -m benchmarks.hybrid_cache_correctness.live_e2e \
   --output-dir /tmp/lmcache-hybrid-correctness-e2e
 ```
 
+For an offline deployment where vLLM logs a local snapshot path as
+`cache_model_name`, keep `--model` as the served API alias and pass that exact
+path to both `--hf-model` and `--cache-model`.
+
 The driver makes two deterministic multi-step requests with the same prompt
 and cache salt. For every accepted token it captures the real vLLM token,
 log-probability and top-k set, retrieves the real contiguous KV tensor through

--- a/benchmarks/hybrid_cache_correctness/README.md
+++ b/benchmarks/hybrid_cache_correctness/README.md
@@ -48,6 +48,10 @@ must not be combined as one performance score.
 
 ## Live exact-prefix end-to-end check
 
+Use [`live_e2e.ipynb`](./live_e2e.ipynb) for a notebook that checks both
+services, invokes the same driver described below, asserts an exact match, and
+verifies that all three JSON artifacts were written.
+
 With an LMCache server on ports 6555/8080 and a vLLM server on port 8000
 started with `LMCacheMPConnector`, `--no-enable-prefix-caching`, and
 `--return-tokens-as-token-ids`, run:

--- a/benchmarks/hybrid_cache_correctness/README.md
+++ b/benchmarks/hybrid_cache_correctness/README.md
@@ -1,0 +1,47 @@
+# Hybrid cache correctness trace harness
+
+This harness compares cache-disabled or reference execution with L1/L2/hybrid
+cache execution at five layers:
+
+1. selected token, log-probability, and top-k overlap;
+2. logits max/mean absolute error, KL divergence, and cosine similarity;
+3. request generation, accepted length, block table, prefix, and drop-round
+   digests;
+4. per-group/rank logical spans, physical pages, dtype, shape, stride, content
+   digest, and representation revision;
+5. ordered store/retrieve/reuse/abort/preempt/resume lifecycle events.
+
+The trace format is canonical JSON with a deterministic SHA-256 identity.
+`compare_traces()` reports all differences and orders `first_divergence` by
+decode step and then output → logits → request → cache → lifecycle. This makes
+an output mismatch actionable without hiding an earlier request/cache fault.
+`run_id` and metadata are included in the trace identity for provenance, but
+they intentionally do not affect semantic matching. Experiment drivers must
+therefore enforce compatible model, hardware, and capture configurations.
+
+## Capture contract
+
+Adapters should capture one `TraceFrame` after each accepted decode step. Do
+not add rejected speculative tokens to `accepted_seq_len`. `CacheGroupFrame`
+must be emitted for every rank and every member of a hybrid cache family; hash
+the actual byte representation with `sha256_digest()`.
+
+Lifecycle `sequence` values must reflect observation order. A backend should
+emit separate submitted, complete, and source-reusable events rather than
+treating submission as completion.
+
+## Compare two runs
+
+```bash
+python benchmarks/hybrid_cache_correctness/trace_harness.py \
+  reference.json candidate.json --output first-divergence.json
+```
+
+Exit code 0 means all captured evidence matches within the numerical
+tolerances. Exit code 1 means a divergence was found. The report remains useful
+when full logits are intentionally omitted; logit metrics are then `null`.
+
+Recommended experiment axes are cache off/L1/L2/L1+L2, BF16/FP8, aligned and
+unaligned prefixes, concurrency 1/8/32/64, graph mode, preemption/abort, and
+first/exact/partial reuse. Results from different hardware or capture contracts
+must not be combined as one performance score.

--- a/benchmarks/hybrid_cache_correctness/README.md
+++ b/benchmarks/hybrid_cache_correctness/README.md
@@ -45,3 +45,28 @@ Recommended experiment axes are cache off/L1/L2/L1+L2, BF16/FP8, aligned and
 unaligned prefixes, concurrency 1/8/32/64, graph mode, preemption/abort, and
 first/exact/partial reuse. Results from different hardware or capture contracts
 must not be combined as one performance score.
+
+## Live exact-prefix end-to-end check
+
+With an LMCache server on ports 6555/8080 and a vLLM server on port 8000
+started with `LMCacheMPConnector`, `--no-enable-prefix-caching`, and
+`--return-tokens-as-token-ids`, run:
+
+```bash
+python -m benchmarks.hybrid_cache_correctness.live_e2e \
+  --model Qwen/Qwen3-0.6B \
+  --output-dir /tmp/lmcache-hybrid-correctness-e2e
+```
+
+The driver makes two deterministic multi-step requests with the same prompt
+and cache salt. For every accepted token it captures the real vLLM token,
+log-probability and top-k set, retrieves the real contiguous KV tensor through
+the LMCache SDK, hashes its bytes, and records request/cache/lifecycle state.
+The second request exercises exact-prefix reuse, then the driver writes both
+traces and their comparison report outside the source tree and exits non-zero
+on the first mismatch. The reported timings are diagnostic values from that
+run; they are not a cross-machine performance score.
+
+The SDK does not expose vLLM's internal GPU block table, so this adapter labels
+`physical_page_ids` as the observed LMCache contiguous chunk ordinals. It does
+not present those ordinals as engine page addresses.

--- a/benchmarks/hybrid_cache_correctness/__init__.py
+++ b/benchmarks/hybrid_cache_correctness/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hybrid-cache correctness trace and comparison helpers."""
+
+# First Party
+from benchmarks.hybrid_cache_correctness.trace_harness import (
+    CacheGroupFrame,
+    FrameComparison,
+    HybridCorrectnessTrace,
+    LifecycleEvent,
+    LifecyclePhase,
+    OutputFrame,
+    RequestStateFrame,
+    TopKEntry,
+    TraceComparisonReport,
+    TraceDivergence,
+    TraceFrame,
+    compare_traces,
+    read_trace,
+    sha256_digest,
+    trace_digest,
+    write_report,
+    write_trace,
+)
+
+__all__ = [
+    "CacheGroupFrame",
+    "FrameComparison",
+    "HybridCorrectnessTrace",
+    "LifecycleEvent",
+    "LifecyclePhase",
+    "OutputFrame",
+    "RequestStateFrame",
+    "TopKEntry",
+    "TraceComparisonReport",
+    "TraceDivergence",
+    "TraceFrame",
+    "compare_traces",
+    "read_trace",
+    "sha256_digest",
+    "trace_digest",
+    "write_report",
+    "write_trace",
+]

--- a/benchmarks/hybrid_cache_correctness/live_e2e.ipynb
+++ b/benchmarks/hybrid_cache_correctness/live_e2e.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "# Live hybrid-cache correctness end to end\n",
+    "\n",
+    "This notebook is a runnable wrapper around `benchmarks.hybrid_cache_correctness.live_e2e`, so CLI and notebook runs use the same capture and comparison implementation. Start LMCache and vLLM with `LMCacheMPConnector`, `--no-enable-prefix-caching`, and `--return-tokens-as-token-ids` before running all cells. The final cell captures two deterministic exact-prefix runs, writes the traces outside the source tree, and fails if any output, request, KV-content, or lifecycle evidence diverges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "configuration",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "# Standard\n",
+    "from pathlib import Path\n",
+    "from urllib.request import urlopen\n",
+    "import json\n",
+    "import os\n",
+    "import shlex\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "served_model = os.environ.get(\"VLLM_SERVED_MODEL_NAME\", \"Qwen/Qwen3-0.6B\")\n",
+    "hf_model = os.environ.get(\"HF_MODEL_NAME\", served_model)\n",
+    "cache_model = os.environ.get(\"LMCACHE_MODEL_NAME\", served_model)\n",
+    "vllm_url = os.environ.get(\"VLLM_URL\", \"http://localhost:8000\")\n",
+    "lmcache_url = os.environ.get(\"LMCACHE_URL\", \"http://localhost:8080\")\n",
+    "default_output = \"/tmp/lmcache-hybrid-correctness-e2e\"\n",
+    "output_dir = Path(os.environ.get(\"LMCACHE_E2E_OUTPUT_DIR\", default_output))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preflight",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for health_url in (f\"{lmcache_url}/healthcheck\", f\"{vllm_url}/v1/models\"):\n",
+    "    with urlopen(health_url, timeout=10) as response:  # noqa: S310\n",
+    "        assert response.status == 200, (health_url, response.status)\n",
+    "print(\"LMCache and vLLM health checks passed\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run-and-assert",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_candidates = (Path.cwd(), *Path.cwd().parents)\n",
+    "repo_root = next(\n",
+    "    (path for path in repo_candidates if (path / \"pyproject.toml\").is_file()),\n",
+    "    None,\n",
+    ")\n",
+    "if repo_root is None:\n",
+    "    raise FileNotFoundError(\"run from the LMCache repository\")\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    \"-m\",\n",
+    "    \"benchmarks.hybrid_cache_correctness.live_e2e\",\n",
+    "    \"--model\",\n",
+    "    served_model,\n",
+    "    \"--hf-model\",\n",
+    "    hf_model,\n",
+    "    \"--cache-model\",\n",
+    "    cache_model,\n",
+    "    \"--vllm-url\",\n",
+    "    vllm_url,\n",
+    "    \"--lmcache-url\",\n",
+    "    lmcache_url,\n",
+    "    \"--prompt-tokens\",\n",
+    "    \"1024\",\n",
+    "    \"--steps\",\n",
+    "    \"4\",\n",
+    "    \"--top-k\",\n",
+    "    \"5\",\n",
+    "    \"--output-dir\",\n",
+    "    str(output_dir),\n",
+    "]\n",
+    "print(\"$\", shlex.join(command))\n",
+    "completed = subprocess.run(\n",
+    "    command, check=True, capture_output=True, text=True, cwd=repo_root\n",
+    ")\n",
+    "if completed.stderr:\n",
+    "    print(completed.stderr, file=sys.stderr)\n",
+    "print(completed.stdout)\n",
+    "start = completed.stdout.find(\"{\")\n",
+    "if start < 0:\n",
+    "    raise RuntimeError(\"live driver did not emit JSON evidence\")\n",
+    "evidence = json.JSONDecoder().raw_decode(completed.stdout[start:])[0]\n",
+    "assert evidence[\"matched\"] is True\n",
+    "assert evidence[\"first_divergence\"] is None\n",
+    "assert evidence[\"frames\"] == 4\n",
+    "for artifact in (\"reference.json\", \"candidate.json\", \"report.json\"):\n",
+    "    assert (output_dir / artifact).is_file(), artifact\n",
+    "print(f\"Exact-prefix traces matched; artifacts: {output_dir}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/hybrid_cache_correctness/live_e2e.py
+++ b/benchmarks/hybrid_cache_correctness/live_e2e.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capture and compare two live vLLM + LMCache exact-prefix runs."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+import argparse
+import json
+import time
+
+# Third Party
+from transformers import AutoTokenizer
+import httpx
+import torch
+
+# First Party
+from benchmarks.hybrid_cache_correctness import (
+    CacheGroupFrame,
+    HybridCorrectnessTrace,
+    LifecycleEvent,
+    LifecyclePhase,
+    OutputFrame,
+    RequestStateFrame,
+    TopKEntry,
+    TraceFrame,
+    compare_traces,
+    sha256_digest,
+    write_report,
+    write_trace,
+)
+import lmcache.sdk as lmc_sdk
+
+
+@dataclass(frozen=True)
+class CapturedToken:
+    token_id: int
+    text: str
+    logprob: float
+    top_k: tuple[TopKEntry, ...]
+
+
+class RecordingCompletion:
+    """vLLM streaming completion adapter that retains real output evidence."""
+
+    def __init__(self, url: str, model: str, timeout: float, top_k: int) -> None:
+        self.url = url.rstrip("/")
+        self.model = model
+        self.timeout = timeout
+        self.top_k = top_k
+        self.calls: list[list[CapturedToken]] = []
+
+    def __call__(
+        self,
+        prompt_token_ids: list[int],
+        sampling_params: dict[str, Any],
+        cache_salt: str,
+    ) -> Iterable[lmc_sdk.request.TokenEvent]:
+        payload = {
+            **sampling_params,
+            "model": self.model,
+            "prompt": prompt_token_ids,
+            "stream": True,
+            "logprobs": self.top_k,
+        }
+        if cache_salt:
+            payload["cache_salt"] = cache_salt
+        captured: list[CapturedToken] = []
+        self.calls.append(captured)
+        timeout = httpx.Timeout(
+            connect=self.timeout,
+            read=None,
+            write=self.timeout,
+            pool=self.timeout,
+        )
+        with httpx.stream(
+            "POST",
+            f"{self.url}/v1/completions",
+            json=payload,
+            timeout=timeout,
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                if line == "data: [DONE]":
+                    break
+                body = json.loads(line.removeprefix("data: "))
+                choices = body.get("choices") or []
+                if not choices:
+                    continue
+                choice = choices[0]
+                logprobs = choice.get("logprobs") or {}
+                token_names = logprobs.get("tokens") or []
+                token_logprobs = logprobs.get("token_logprobs") or []
+                top_logprobs = logprobs.get("top_logprobs") or []
+                if not token_names or not token_logprobs or not top_logprobs:
+                    raise RuntimeError("vLLM response omitted requested logprobs")
+                token_id = parse_token_id(token_names[-1])
+                logprob = float(token_logprobs[-1])
+                entries = tuple(
+                    TopKEntry(parse_token_id(name), float(value))
+                    for name, value in sorted(top_logprobs[-1].items())
+                )
+                event = CapturedToken(
+                    token_id=token_id,
+                    text=str(choice.get("text", "")),
+                    logprob=logprob,
+                    top_k=entries,
+                )
+                captured.append(event)
+                yield lmc_sdk.request.TokenEvent(token_id=token_id, text=event.text)
+
+
+def parse_token_id(token: str) -> int:
+    if ":" not in token:
+        raise ValueError(
+            f"token ids require vLLM --return-tokens-as-token-ids; received {token!r}"
+        )
+    return int(token.rsplit(":", 1)[-1])
+
+
+def tensor_bytes(tensor: torch.Tensor) -> bytes:
+    return tensor.detach().contiguous().view(torch.uint8).cpu().numpy().tobytes()
+
+
+def digest_json(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return sha256_digest(encoded)
+
+
+def capture_run(
+    *,
+    run_id: str,
+    request_id: str,
+    prompt: list[int],
+    cache_salt: str,
+    model: str,
+    vllm_url: str,
+    lmcache_url: str,
+    lmcache_mq_url: str,
+    steps: int,
+    top_k: int,
+    timeout: float,
+) -> tuple[HybridCorrectnessTrace, list[dict[str, float]]]:
+    recorder = RecordingCompletion(vllm_url, model, timeout, top_k)
+    ctx = lmc_sdk.kvcache.connect(
+        url=lmcache_mq_url,
+        http_url=lmcache_url,
+        model_name=model,
+        timeout=timeout,
+    )
+    frames: list[TraceFrame] = []
+    events: list[LifecycleEvent] = []
+    timings: list[dict[str, float]] = []
+    try:
+        stream = lmc_sdk.request.create_request(
+            contexts=[ctx],
+            post_completion=recorder,
+            prompt_token_ids=prompt,
+            cache_salt=cache_salt,
+        )
+        for step in range(steps):
+            perf = stream.generate(
+                {"max_tokens": 1, "temperature": 0.0, "ignore_eos": True}
+            )
+            captured = recorder.calls[-1]
+            if len(captured) != 1:
+                raise RuntimeError(f"step {step} returned {len(captured)} tokens")
+            sequence = len(events)
+            events.append(
+                LifecycleEvent(
+                    sequence=sequence,
+                    step=step,
+                    phase=LifecyclePhase.RETRIEVE_SUBMITTED,
+                    request_generation=0,
+                    operation_id=step,
+                    group_id="dense-kv",
+                )
+            )
+            kv = stream.retrieve(
+                lmc_sdk.context.LMCacheSDKCacheKind.KV,
+                timeout=timeout,
+            )
+            events.append(
+                LifecycleEvent(
+                    sequence=sequence + 1,
+                    step=step,
+                    phase=LifecyclePhase.RETRIEVE_COMPLETE,
+                    request_generation=0,
+                    operation_id=step,
+                    group_id="dense-kv",
+                    detail_digest=sha256_digest(tensor_bytes(kv)),
+                )
+            )
+            cached_tokens = int(kv.shape[2])
+            chunk_size = ctx.chunk_size
+            chunks = tuple(range((cached_tokens + chunk_size - 1) // chunk_size))
+            token = captured[0]
+            frames.append(
+                TraceFrame(
+                    step=step,
+                    output=OutputFrame(
+                        token_id=token.token_id,
+                        logprob=token.logprob,
+                        top_k=token.top_k,
+                    ),
+                    request=RequestStateFrame(
+                        request_generation=0,
+                        accepted_seq_len=len(stream.tokens),
+                        block_table_digest=digest_json(chunks),
+                        prefix_digest=digest_json(stream.tokens),
+                        drop_round_digest=digest_json({"drop_round": 0}),
+                    ),
+                    cache_groups=(
+                        CacheGroupFrame(
+                            group_id="dense-kv",
+                            rank=0,
+                            semantic_kind="dense_attention_sdk_contiguous",
+                            logical_start=0,
+                            logical_end=cached_tokens,
+                            physical_page_ids=chunks,
+                            dtype=str(kv.dtype),
+                            shape=tuple(kv.shape),
+                            stride=tuple(kv.stride()),
+                            content_digest=sha256_digest(tensor_bytes(kv)),
+                            revision="sdk-retrieve-v1",
+                        ),
+                    ),
+                )
+            )
+            timings.append(
+                {
+                    "duration_s": perf.duration,
+                    "ttft_s": perf.ttft,
+                    "input_tokens_per_s": perf.input_tput,
+                }
+            )
+    finally:
+        ctx.close()
+    return (
+        HybridCorrectnessTrace(
+            run_id=run_id,
+            request_id=request_id,
+            frames=tuple(frames),
+            lifecycle_events=tuple(events),
+            metadata=(
+                ("cache_salt", cache_salt),
+                ("capture", "live-vllm-lmcache-sdk"),
+                ("model", model),
+            ),
+        ),
+        timings,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--vllm-url", default="http://localhost:8000")
+    parser.add_argument("--lmcache-url", default="http://localhost:8080")
+    parser.add_argument("--lmcache-mq-url", default="tcp://localhost:6555")
+    parser.add_argument("--prompt-tokens", type=int, default=1024)
+    parser.add_argument("--steps", type=int, default=4)
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("/tmp/lmcache-hybrid-correctness-e2e"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.prompt_tokens <= 0 or args.steps <= 0 or args.top_k <= 0:
+        raise ValueError("prompt tokens, steps, and top-k must be positive")
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    seed = tokenizer.encode(
+        "Hybrid cache traces localize the first correctness divergence. ",
+        add_special_tokens=False,
+    )
+    prompt = (seed * ((args.prompt_tokens + len(seed) - 1) // len(seed)))[
+        : args.prompt_tokens
+    ]
+    cache_salt = f"hybrid-correctness-e2e-{time.time_ns()}"
+    common = {
+        "request_id": "hybrid-correctness-e2e-request",
+        "prompt": prompt,
+        "cache_salt": cache_salt,
+        "model": args.model,
+        "vllm_url": args.vllm_url,
+        "lmcache_url": args.lmcache_url,
+        "lmcache_mq_url": args.lmcache_mq_url,
+        "steps": args.steps,
+        "top_k": args.top_k,
+        "timeout": args.timeout,
+    }
+    reference, reference_timings = capture_run(run_id="reference", **common)
+    candidate, candidate_timings = capture_run(run_id="candidate", **common)
+    report = compare_traces(reference, candidate)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    write_trace(reference, args.output_dir / "reference.json")
+    write_trace(candidate, args.output_dir / "candidate.json")
+    write_report(report, args.output_dir / "report.json")
+    summary = {
+        "matched": report.matched,
+        "first_divergence": (
+            asdict(report.first_divergence)
+            if report.first_divergence is not None
+            else None
+        ),
+        "frames": len(report.frame_metrics),
+        "reference_timings": reference_timings,
+        "candidate_timings": candidate_timings,
+        "output_dir": str(args.output_dir),
+    }
+    print(json.dumps(summary, indent=2))
+    if not report.matched:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybrid_cache_correctness/live_e2e.py
+++ b/benchmarks/hybrid_cache_correctness/live_e2e.py
@@ -138,7 +138,8 @@ def capture_run(
     request_id: str,
     prompt: list[int],
     cache_salt: str,
-    model: str,
+    served_model: str,
+    cache_model: str,
     vllm_url: str,
     lmcache_url: str,
     lmcache_mq_url: str,
@@ -146,11 +147,11 @@ def capture_run(
     top_k: int,
     timeout: float,
 ) -> tuple[HybridCorrectnessTrace, list[dict[str, float]]]:
-    recorder = RecordingCompletion(vllm_url, model, timeout, top_k)
+    recorder = RecordingCompletion(vllm_url, served_model, timeout, top_k)
     ctx = lmc_sdk.kvcache.connect(
         url=lmcache_mq_url,
         http_url=lmcache_url,
-        model_name=model,
+        model_name=cache_model,
         timeout=timeout,
     )
     frames: list[TraceFrame] = []
@@ -250,7 +251,8 @@ def capture_run(
             metadata=(
                 ("cache_salt", cache_salt),
                 ("capture", "live-vllm-lmcache-sdk"),
-                ("model", model),
+                ("served_model", served_model),
+                ("cache_model", cache_model),
             ),
         ),
         timings,
@@ -260,6 +262,14 @@ def capture_run(
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument(
+        "--hf-model",
+        help="HF tokenizer ID/path; defaults to --model",
+    )
+    parser.add_argument(
+        "--cache-model",
+        help="LMCache registration name; defaults to --model",
+    )
     parser.add_argument("--vllm-url", default="http://localhost:8000")
     parser.add_argument("--lmcache-url", default="http://localhost:8080")
     parser.add_argument("--lmcache-mq-url", default="tcp://localhost:6555")
@@ -279,7 +289,9 @@ def main() -> None:
     args = parse_args()
     if args.prompt_tokens <= 0 or args.steps <= 0 or args.top_k <= 0:
         raise ValueError("prompt tokens, steps, and top-k must be positive")
-    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    hf_model = args.hf_model or args.model
+    cache_model = args.cache_model or args.model
+    tokenizer = AutoTokenizer.from_pretrained(hf_model, trust_remote_code=True)
     seed = tokenizer.encode(
         "Hybrid cache traces localize the first correctness divergence. ",
         add_special_tokens=False,
@@ -292,7 +304,8 @@ def main() -> None:
         "request_id": "hybrid-correctness-e2e-request",
         "prompt": prompt,
         "cache_salt": cache_salt,
-        "model": args.model,
+        "served_model": args.model,
+        "cache_model": cache_model,
         "vllm_url": args.vllm_url,
         "lmcache_url": args.lmcache_url,
         "lmcache_mq_url": args.lmcache_mq_url,
@@ -317,6 +330,9 @@ def main() -> None:
         "frames": len(report.frame_metrics),
         "reference_timings": reference_timings,
         "candidate_timings": candidate_timings,
+        "served_model_name": args.model,
+        "hf_model_name": hf_model,
+        "cache_model_name": cache_model,
         "output_dir": str(args.output_dir),
     }
     print(json.dumps(summary, indent=2))

--- a/benchmarks/hybrid_cache_correctness/trace_harness.py
+++ b/benchmarks/hybrid_cache_correctness/trace_harness.py
@@ -1,0 +1,652 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic trace replay and first-divergence reporting for hybrid caches."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+import argparse
+import hashlib
+import json
+import math
+import re
+
+_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+_LEVEL_ORDER = {"output": 0, "logits": 1, "request": 2, "cache": 3, "lifecycle": 4}
+
+
+class LifecyclePhase(str, Enum):
+    """Lifecycle events relevant to asynchronous hybrid-cache correctness."""
+
+    STORE_SUBMITTED = "store_submitted"
+    STORE_COMPLETE = "store_complete"
+    RETRIEVE_SUBMITTED = "retrieve_submitted"
+    RETRIEVE_COMPLETE = "retrieve_complete"
+    SOURCE_REUSABLE = "source_reusable"
+    REQUEST_ABORTED = "request_aborted"
+    REQUEST_PREEMPTED = "request_preempted"
+    REQUEST_RESUMED = "request_resumed"
+
+
+def _require_digest(name: str, value: str) -> None:
+    if not _DIGEST_PATTERN.fullmatch(value):
+        raise ValueError(f"{name} must be a sha256 digest")
+
+
+def _require_finite(name: str, value: float) -> None:
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+
+
+@dataclass(frozen=True)
+class TopKEntry:
+    """One token and log-probability from a frame's top-k output."""
+
+    token_id: int
+    logprob: float
+
+    def __post_init__(self) -> None:
+        if self.token_id < 0:
+            raise ValueError("token_id must be non-negative")
+        _require_finite("logprob", self.logprob)
+
+
+@dataclass(frozen=True)
+class OutputFrame:
+    """Output-level evidence for one decode step."""
+
+    token_id: int
+    logprob: float
+    top_k: tuple[TopKEntry, ...]
+    logits: tuple[float, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if self.token_id < 0:
+            raise ValueError("token_id must be non-negative")
+        _require_finite("logprob", self.logprob)
+        top_k = tuple(self.top_k)
+        if len({entry.token_id for entry in top_k}) != len(top_k):
+            raise ValueError("top_k token ids must be unique")
+        object.__setattr__(self, "top_k", top_k)
+        if self.logits is not None:
+            logits = tuple(self.logits)
+            if not logits:
+                raise ValueError("logits must not be empty")
+            for value in logits:
+                _require_finite("logit", value)
+            object.__setattr__(self, "logits", logits)
+
+
+@dataclass(frozen=True)
+class RequestStateFrame:
+    """Request state needed to localize scheduling/cache divergence."""
+
+    request_generation: int
+    accepted_seq_len: int
+    block_table_digest: str
+    prefix_digest: str
+    drop_round_digest: str
+
+    def __post_init__(self) -> None:
+        if self.request_generation < 0:
+            raise ValueError("request_generation must be non-negative")
+        if self.accepted_seq_len < 0:
+            raise ValueError("accepted_seq_len must be non-negative")
+        for name in ("block_table_digest", "prefix_digest", "drop_round_digest"):
+            _require_digest(name, getattr(self, name))
+
+
+@dataclass(frozen=True)
+class CacheGroupFrame:
+    """Per-rank physical and content evidence for one cache group."""
+
+    group_id: str
+    rank: int
+    semantic_kind: str
+    logical_start: int
+    logical_end: int
+    physical_page_ids: tuple[int, ...]
+    dtype: str
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    content_digest: str
+    revision: str
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("group_id must not be empty")
+        if self.rank < 0:
+            raise ValueError("rank must be non-negative")
+        if not self.semantic_kind:
+            raise ValueError("semantic_kind must not be empty")
+        if self.logical_start < 0 or self.logical_end <= self.logical_start:
+            raise ValueError("logical span must be a non-empty half-open range")
+        pages = tuple(self.physical_page_ids)
+        if any(page < 0 for page in pages):
+            raise ValueError("physical page ids must be non-negative")
+        object.__setattr__(self, "physical_page_ids", pages)
+        if not self.dtype:
+            raise ValueError("dtype must not be empty")
+        shape = tuple(self.shape)
+        stride = tuple(self.stride)
+        if not shape or any(dimension <= 0 for dimension in shape):
+            raise ValueError("shape dimensions must be positive")
+        if len(stride) != len(shape) or any(value < 0 for value in stride):
+            raise ValueError("stride must have one non-negative value per dimension")
+        object.__setattr__(self, "shape", shape)
+        object.__setattr__(self, "stride", stride)
+        _require_digest("content_digest", self.content_digest)
+        if not self.revision:
+            raise ValueError("revision must not be empty")
+
+    @property
+    def identity(self) -> tuple[str, int]:
+        """Return the stable group/rank key used during comparison."""
+        return self.group_id, self.rank
+
+
+@dataclass(frozen=True)
+class TraceFrame:
+    """All layered evidence captured at one decode step."""
+
+    step: int
+    output: OutputFrame
+    request: RequestStateFrame
+    cache_groups: tuple[CacheGroupFrame, ...]
+
+    def __post_init__(self) -> None:
+        if self.step < 0:
+            raise ValueError("step must be non-negative")
+        groups = tuple(sorted(self.cache_groups, key=lambda group: group.identity))
+        identities = [group.identity for group in groups]
+        if len(identities) != len(set(identities)):
+            raise ValueError("cache group/rank identities must be unique per frame")
+        object.__setattr__(self, "cache_groups", groups)
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """Ordered lifecycle evidence associated with a request operation."""
+
+    sequence: int
+    step: int
+    phase: LifecyclePhase
+    request_generation: int
+    operation_id: int
+    group_id: str | None = None
+    detail_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("sequence", "step", "request_generation", "operation_id"):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be non-negative")
+        if self.group_id == "":
+            raise ValueError("group_id must not be empty")
+        if self.detail_digest is not None:
+            _require_digest("detail_digest", self.detail_digest)
+
+
+@dataclass(frozen=True)
+class HybridCorrectnessTrace:
+    """Deterministic multi-level correctness trace for one benchmark run."""
+
+    run_id: str
+    request_id: str
+    frames: tuple[TraceFrame, ...]
+    lifecycle_events: tuple[LifecycleEvent, ...] = ()
+    metadata: tuple[tuple[str, str], ...] = ()
+    schema_version: str = "1.0"
+
+    def __post_init__(self) -> None:
+        if self.schema_version != "1.0":
+            raise ValueError("unsupported trace schema_version")
+        if not self.run_id or not self.request_id:
+            raise ValueError("run_id and request_id must not be empty")
+        frames = tuple(self.frames)
+        if not frames:
+            raise ValueError("a trace must contain at least one frame")
+        steps = [frame.step for frame in frames]
+        if steps != sorted(steps) or len(steps) != len(set(steps)):
+            raise ValueError("trace frame steps must be strictly increasing")
+        generations = [frame.request.request_generation for frame in frames]
+        if generations != sorted(generations):
+            raise ValueError("request generations must be monotonic")
+        previous_length_by_generation: dict[int, int] = {}
+        for frame in frames:
+            generation = frame.request.request_generation
+            previous = previous_length_by_generation.get(generation, -1)
+            if frame.request.accepted_seq_len < previous:
+                raise ValueError(
+                    "accepted_seq_len must be monotonic within a generation"
+                )
+            previous_length_by_generation[generation] = frame.request.accepted_seq_len
+        object.__setattr__(self, "frames", frames)
+        events = tuple(self.lifecycle_events)
+        sequences = [event.sequence for event in events]
+        if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
+            raise ValueError("lifecycle event sequences must be strictly increasing")
+        object.__setattr__(self, "lifecycle_events", events)
+        metadata = tuple(sorted(self.metadata))
+        if any(not key or not value for key, value in metadata):
+            raise ValueError("metadata keys and values must not be empty")
+        if len({key for key, _ in metadata}) != len(metadata):
+            raise ValueError("metadata keys must be unique")
+        object.__setattr__(self, "metadata", metadata)
+
+
+@dataclass(frozen=True)
+class TraceDivergence:
+    """One localized difference between a reference and candidate trace."""
+
+    level: str
+    step: int
+    subject: str
+    fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FrameComparison:
+    """Numerical output metrics for one common decode step."""
+
+    step: int
+    token_match: bool
+    logprob_abs_diff: float
+    top_k_overlap: float
+    logits_max_abs_diff: float | None
+    logits_mean_abs_diff: float | None
+    logits_kl_divergence: float | None
+    logits_cosine_similarity: float | None
+
+
+@dataclass(frozen=True)
+class TraceComparisonReport:
+    """Deterministic layered comparison with a first-divergence pointer."""
+
+    reference_digest: str
+    candidate_digest: str
+    matched: bool
+    first_divergence: TraceDivergence | None
+    divergences: tuple[TraceDivergence, ...]
+    frame_metrics: tuple[FrameComparison, ...]
+
+
+def sha256_digest(data: bytes | bytearray | memoryview) -> str:
+    """Return the canonical digest used for cache content and trace identity."""
+    return "sha256:" + hashlib.sha256(bytes(data)).hexdigest()
+
+
+def trace_digest(trace: HybridCorrectnessTrace) -> str:
+    """Return a stable digest of the canonical serialized trace."""
+    return sha256_digest(_canonical_json(_trace_to_dict(trace)).encode())
+
+
+def write_trace(trace: HybridCorrectnessTrace, path: Path) -> None:
+    """Write a canonical trace document."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_canonical_json(_trace_to_dict(trace)) + "\n", encoding="utf-8")
+
+
+def read_trace(path: Path) -> HybridCorrectnessTrace:
+    """Read and validate a trace document."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("trace document must contain a JSON object")
+    return _trace_from_dict(payload)
+
+
+def write_report(report: TraceComparisonReport, path: Path) -> None:
+    """Write a canonical comparison report."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_canonical_json(asdict(report)) + "\n", encoding="utf-8")
+
+
+def compare_traces(
+    reference: HybridCorrectnessTrace,
+    candidate: HybridCorrectnessTrace,
+    *,
+    absolute_tolerance: float = 1e-5,
+    relative_tolerance: float = 1e-4,
+) -> TraceComparisonReport:
+    """Compare all trace levels and report the earliest localized divergence."""
+    if absolute_tolerance < 0 or relative_tolerance < 0:
+        raise ValueError("comparison tolerances must be non-negative")
+    divergences: list[TraceDivergence] = []
+    metrics: list[FrameComparison] = []
+    reference_frames = {frame.step: frame for frame in reference.frames}
+    candidate_frames = {frame.step: frame for frame in candidate.frames}
+
+    if reference.request_id != candidate.request_id:
+        divergences.append(
+            TraceDivergence(
+                level="request",
+                step=min(reference.frames[0].step, candidate.frames[0].step),
+                subject="trace",
+                fields=("request_id",),
+            )
+        )
+
+    for step in sorted(reference_frames.keys() | candidate_frames.keys()):
+        reference_frame = reference_frames.get(step)
+        candidate_frame = candidate_frames.get(step)
+        if reference_frame is None or candidate_frame is None:
+            divergences.append(
+                TraceDivergence(
+                    level="output",
+                    step=step,
+                    subject="frame",
+                    fields=(
+                        "missing_reference"
+                        if reference_frame is None
+                        else "missing_candidate",
+                    ),
+                )
+            )
+            continue
+        frame_metrics, frame_divergences = _compare_frame(
+            reference_frame,
+            candidate_frame,
+            absolute_tolerance=absolute_tolerance,
+            relative_tolerance=relative_tolerance,
+        )
+        metrics.append(frame_metrics)
+        divergences.extend(frame_divergences)
+
+    if reference.lifecycle_events != candidate.lifecycle_events:
+        mismatch_index = _first_mismatch_index(
+            reference.lifecycle_events, candidate.lifecycle_events
+        )
+        reference_event = (
+            reference.lifecycle_events[mismatch_index]
+            if mismatch_index < len(reference.lifecycle_events)
+            else None
+        )
+        candidate_event = (
+            candidate.lifecycle_events[mismatch_index]
+            if mismatch_index < len(candidate.lifecycle_events)
+            else None
+        )
+        event = reference_event or candidate_event
+        assert event is not None
+        divergences.append(
+            TraceDivergence(
+                level="lifecycle",
+                step=event.step,
+                subject=f"event[{mismatch_index}]",
+                fields=_different_fields(reference_event, candidate_event),
+            )
+        )
+
+    ordered = tuple(
+        sorted(
+            divergences,
+            key=lambda item: (item.step, _LEVEL_ORDER[item.level], item.subject),
+        )
+    )
+    return TraceComparisonReport(
+        reference_digest=trace_digest(reference),
+        candidate_digest=trace_digest(candidate),
+        matched=not ordered,
+        first_divergence=ordered[0] if ordered else None,
+        divergences=ordered,
+        frame_metrics=tuple(metrics),
+    )
+
+
+def _compare_frame(
+    reference: TraceFrame,
+    candidate: TraceFrame,
+    *,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+) -> tuple[FrameComparison, tuple[TraceDivergence, ...]]:
+    divergences: list[TraceDivergence] = []
+    output_fields: list[str] = []
+    if reference.output.token_id != candidate.output.token_id:
+        output_fields.append("token_id")
+    logprob_diff = abs(reference.output.logprob - candidate.output.logprob)
+    if not _is_close(
+        reference.output.logprob,
+        candidate.output.logprob,
+        absolute_tolerance,
+        relative_tolerance,
+    ):
+        output_fields.append("logprob")
+    reference_top_k = {entry.token_id for entry in reference.output.top_k}
+    candidate_top_k = {entry.token_id for entry in candidate.output.top_k}
+    denominator = max(len(reference_top_k), len(candidate_top_k), 1)
+    top_k_overlap = len(reference_top_k & candidate_top_k) / denominator
+    if reference_top_k != candidate_top_k:
+        output_fields.append("top_k")
+    if output_fields:
+        divergences.append(
+            TraceDivergence("output", reference.step, "decode", tuple(output_fields))
+        )
+
+    logits_metrics, logits_fields = _compare_logits(
+        reference.output.logits,
+        candidate.output.logits,
+        absolute_tolerance,
+        relative_tolerance,
+    )
+    if logits_fields:
+        divergences.append(
+            TraceDivergence("logits", reference.step, "decode", logits_fields)
+        )
+
+    request_fields = _different_dataclass_fields(reference.request, candidate.request)
+    if request_fields:
+        divergences.append(
+            TraceDivergence("request", reference.step, "request", request_fields)
+        )
+
+    reference_groups = {group.identity: group for group in reference.cache_groups}
+    candidate_groups = {group.identity: group for group in candidate.cache_groups}
+    for identity in sorted(reference_groups.keys() | candidate_groups.keys()):
+        reference_group = reference_groups.get(identity)
+        candidate_group = candidate_groups.get(identity)
+        fields = _different_fields(reference_group, candidate_group)
+        if fields:
+            divergences.append(
+                TraceDivergence(
+                    "cache",
+                    reference.step,
+                    f"{identity[0]}@rank{identity[1]}",
+                    fields,
+                )
+            )
+
+    return (
+        FrameComparison(
+            step=reference.step,
+            token_match=reference.output.token_id == candidate.output.token_id,
+            logprob_abs_diff=logprob_diff,
+            top_k_overlap=top_k_overlap,
+            logits_max_abs_diff=logits_metrics[0],
+            logits_mean_abs_diff=logits_metrics[1],
+            logits_kl_divergence=logits_metrics[2],
+            logits_cosine_similarity=logits_metrics[3],
+        ),
+        tuple(divergences),
+    )
+
+
+def _compare_logits(
+    reference: tuple[float, ...] | None,
+    candidate: tuple[float, ...] | None,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+) -> tuple[
+    tuple[float | None, float | None, float | None, float | None], tuple[str, ...]
+]:
+    if reference is None and candidate is None:
+        return (None, None, None, None), ()
+    if reference is None or candidate is None:
+        return (None, None, None, None), ("presence",)
+    if len(reference) != len(candidate):
+        return (None, None, None, None), ("length",)
+    differences = [
+        abs(left - right) for left, right in zip(reference, candidate, strict=True)
+    ]
+    maximum = max(differences, default=0.0)
+    mean = sum(differences) / len(differences)
+    reference_log_probabilities = _log_softmax(reference)
+    candidate_log_probabilities = _log_softmax(candidate)
+    kl_divergence = sum(
+        math.exp(left) * (left - right)
+        for left, right in zip(
+            reference_log_probabilities,
+            candidate_log_probabilities,
+            strict=True,
+        )
+    )
+    dot = sum(left * right for left, right in zip(reference, candidate, strict=True))
+    reference_norm = math.sqrt(sum(value * value for value in reference))
+    candidate_norm = math.sqrt(sum(value * value for value in candidate))
+    if reference_norm == 0 and candidate_norm == 0:
+        cosine = 1.0
+    elif reference_norm == 0 or candidate_norm == 0:
+        cosine = 0.0
+    else:
+        cosine = max(-1.0, min(1.0, dot / (reference_norm * candidate_norm)))
+    fields = (
+        ("values",)
+        if any(
+            not _is_close(left, right, absolute_tolerance, relative_tolerance)
+            for left, right in zip(reference, candidate, strict=True)
+        )
+        else ()
+    )
+    return (maximum, mean, kl_divergence, cosine), fields
+
+
+def _log_softmax(values: tuple[float, ...]) -> tuple[float, ...]:
+    maximum = max(values)
+    exponentials = tuple(math.exp(value - maximum) for value in values)
+    log_total = maximum + math.log(sum(exponentials))
+    return tuple(value - log_total for value in values)
+
+
+def _is_close(left: float, right: float, absolute: float, relative: float) -> bool:
+    return abs(left - right) <= absolute + relative * abs(left)
+
+
+def _different_dataclass_fields(reference: Any, candidate: Any) -> tuple[str, ...]:
+    reference_values = asdict(reference)
+    candidate_values = asdict(candidate)
+    return tuple(
+        key
+        for key in reference_values
+        if reference_values[key] != candidate_values[key]
+    )
+
+
+def _different_fields(
+    reference: object | None, candidate: object | None
+) -> tuple[str, ...]:
+    if reference is None:
+        return ("missing_reference",)
+    if candidate is None:
+        return ("missing_candidate",)
+    return _different_dataclass_fields(reference, candidate)
+
+
+def _first_mismatch_index(
+    reference: tuple[Any, ...], candidate: tuple[Any, ...]
+) -> int:
+    for index, (left, right) in enumerate(zip(reference, candidate, strict=False)):
+        if left != right:
+            return index
+    return min(len(reference), len(candidate))
+
+
+def _canonical_json(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _trace_to_dict(trace: HybridCorrectnessTrace) -> dict[str, object]:
+    payload = asdict(trace)
+    payload["metadata"] = dict(trace.metadata)
+    return payload
+
+
+def _trace_from_dict(payload: Mapping[str, Any]) -> HybridCorrectnessTrace:
+    frames = tuple(
+        TraceFrame(
+            step=int(frame["step"]),
+            output=OutputFrame(
+                token_id=int(frame["output"]["token_id"]),
+                logprob=float(frame["output"]["logprob"]),
+                top_k=tuple(
+                    TopKEntry(
+                        token_id=int(entry["token_id"]), logprob=float(entry["logprob"])
+                    )
+                    for entry in frame["output"]["top_k"]
+                ),
+                logits=(
+                    tuple(float(value) for value in frame["output"]["logits"])
+                    if frame["output"]["logits"] is not None
+                    else None
+                ),
+            ),
+            request=RequestStateFrame(**frame["request"]),
+            cache_groups=tuple(
+                CacheGroupFrame(**group) for group in frame["cache_groups"]
+            ),
+        )
+        for frame in payload["frames"]
+    )
+    events = tuple(
+        LifecycleEvent(
+            sequence=int(event["sequence"]),
+            step=int(event["step"]),
+            phase=LifecyclePhase(event["phase"]),
+            request_generation=int(event["request_generation"]),
+            operation_id=int(event["operation_id"]),
+            group_id=event.get("group_id"),
+            detail_digest=event.get("detail_digest"),
+        )
+        for event in payload.get("lifecycle_events", [])
+    )
+    metadata_payload = payload.get("metadata", {})
+    if not isinstance(metadata_payload, dict):
+        raise ValueError("trace metadata must be a JSON object")
+    return HybridCorrectnessTrace(
+        run_id=str(payload["run_id"]),
+        request_id=str(payload["request_id"]),
+        frames=frames,
+        lifecycle_events=events,
+        metadata=tuple(
+            (str(key), str(value)) for key, value in metadata_payload.items()
+        ),
+        schema_version=str(payload.get("schema_version", "")),
+    )
+
+
+def main() -> None:
+    """Compare two trace files from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--absolute-tolerance", type=float, default=1e-5)
+    parser.add_argument("--relative-tolerance", type=float, default=1e-4)
+    args = parser.parse_args()
+    report = compare_traces(
+        read_trace(args.reference),
+        read_trace(args.candidate),
+        absolute_tolerance=args.absolute_tolerance,
+        relative_tolerance=args.relative_tolerance,
+    )
+    rendered = _canonical_json(asdict(report))
+    if args.output is not None:
+        write_report(report, args.output)
+    print(rendered)
+    raise SystemExit(0 if report.matched else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/test_hybrid_cache_correctness.py
+++ b/tests/benchmarks/test_hybrid_cache_correctness.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for deterministic hybrid-cache trace comparison."""
+
+# Standard
+from dataclasses import replace
+from pathlib import Path
+import json
+
+# Third Party
+import pytest
+
+# First Party
+from benchmarks.hybrid_cache_correctness import (
+    CacheGroupFrame,
+    HybridCorrectnessTrace,
+    LifecycleEvent,
+    LifecyclePhase,
+    OutputFrame,
+    RequestStateFrame,
+    TopKEntry,
+    TraceFrame,
+    compare_traces,
+    read_trace,
+    sha256_digest,
+    trace_digest,
+    write_report,
+    write_trace,
+)
+
+
+def _digest(label: str) -> str:
+    return sha256_digest(label.encode())
+
+
+def _group(
+    group_id: str = "main",
+    *,
+    rank: int = 0,
+    content: str = "main-content",
+) -> CacheGroupFrame:
+    return CacheGroupFrame(
+        group_id=group_id,
+        rank=rank,
+        semantic_kind="compressed_dense",
+        logical_start=0,
+        logical_end=16,
+        physical_page_ids=(4, 5),
+        dtype="bfloat16",
+        shape=(2, 2, 8, 128),
+        stride=(2048, 1024, 128, 1),
+        content_digest=_digest(content),
+        revision="kv-v3",
+    )
+
+
+def _frame(
+    step: int = 0,
+    *,
+    token_id: int = 7,
+    logprob: float = -0.2,
+    logits: tuple[float, ...] | None = (0.1, 0.2, 0.3),
+    groups: tuple[CacheGroupFrame, ...] | None = None,
+    accepted_seq_len: int = 16,
+) -> TraceFrame:
+    return TraceFrame(
+        step=step,
+        output=OutputFrame(
+            token_id=token_id,
+            logprob=logprob,
+            top_k=(TopKEntry(7, -0.2), TopKEntry(9, -0.4)),
+            logits=logits,
+        ),
+        request=RequestStateFrame(
+            request_generation=3,
+            accepted_seq_len=accepted_seq_len,
+            block_table_digest=_digest(f"blocks-{step}"),
+            prefix_digest=_digest("prefix"),
+            drop_round_digest=_digest(f"drop-{step}"),
+        ),
+        cache_groups=groups if groups is not None else (_group(),),
+    )
+
+
+def _trace(
+    *frames: TraceFrame,
+    events: tuple[LifecycleEvent, ...] | None = None,
+) -> HybridCorrectnessTrace:
+    return HybridCorrectnessTrace(
+        run_id="run-1",
+        request_id="request-1",
+        frames=frames or (_frame(),),
+        lifecycle_events=(
+            events
+            if events is not None
+            else (
+                LifecycleEvent(
+                    sequence=0,
+                    step=0,
+                    phase=LifecyclePhase.RETRIEVE_SUBMITTED,
+                    request_generation=3,
+                    operation_id=2,
+                    group_id="main",
+                    detail_digest=_digest("retrieve"),
+                ),
+            )
+        ),
+        metadata=(("backend", "paged"), ("cache_mode", "l1+l2")),
+    )
+
+
+def test_identical_trace_has_no_divergence() -> None:
+    """A deterministic replay compares equal at every level."""
+    trace = _trace(_frame(0), _frame(1, accepted_seq_len=17))
+
+    report = compare_traces(trace, trace)
+
+    assert report.matched
+    assert report.first_divergence is None
+    assert not report.divergences
+    assert report.reference_digest == report.candidate_digest
+    assert all(metric.token_match for metric in report.frame_metrics)
+    assert all(metric.logits_max_abs_diff == 0 for metric in report.frame_metrics)
+    assert all(metric.logits_kl_divergence == 0 for metric in report.frame_metrics)
+
+
+def test_small_numerical_differences_respect_tolerance() -> None:
+    """Logprob and logits noise within tolerance remains a match."""
+    reference = _trace(_frame())
+    candidate_frame = replace(
+        _frame(),
+        output=replace(
+            _frame().output,
+            logprob=-0.200001,
+            logits=(0.100001, 0.199999, 0.300001),
+        ),
+    )
+
+    report = compare_traces(reference, _trace(candidate_frame))
+
+    assert report.matched
+    assert report.frame_metrics[0].logits_max_abs_diff == pytest.approx(1e-6)
+    assert report.frame_metrics[0].logits_cosine_similarity == pytest.approx(1.0)
+
+
+def test_first_token_divergence_is_localized() -> None:
+    """The earliest changed token is reported with output-level priority."""
+    reference = _trace(_frame(0), _frame(1, accepted_seq_len=17))
+    changed = replace(
+        _frame(1, accepted_seq_len=17), output=replace(_frame().output, token_id=8)
+    )
+    candidate = _trace(_frame(0), changed)
+
+    report = compare_traces(reference, candidate)
+
+    assert not report.matched
+    assert report.first_divergence is not None
+    assert report.first_divergence.level == "output"
+    assert report.first_divergence.step == 1
+    assert report.first_divergence.fields == ("token_id",)
+
+
+def test_logits_divergence_reports_numerical_metrics() -> None:
+    """Logit drift reports max/mean error, KL, and cosine similarity."""
+    reference = _trace(_frame(logits=(0.0, 1.0, 2.0)))
+    candidate = _trace(_frame(logits=(0.0, 1.0, 3.0)))
+
+    report = compare_traces(reference, candidate)
+
+    assert report.first_divergence is not None
+    assert report.first_divergence.level == "logits"
+    metric = report.frame_metrics[0]
+    assert metric.logits_max_abs_diff == 1.0
+    assert metric.logits_mean_abs_diff == pytest.approx(1 / 3)
+    assert metric.logits_kl_divergence is not None
+    assert metric.logits_kl_divergence > 0
+    assert metric.logits_cosine_similarity is not None
+    assert 0 < metric.logits_cosine_similarity < 1
+
+
+def test_extreme_logits_produce_finite_kl_divergence() -> None:
+    """Stable log-softmax avoids divide-by-zero when probabilities underflow."""
+    reference = _trace(_frame(logits=(-10_000.0, 0.0)))
+    candidate = _trace(_frame(logits=(0.0, -10_000.0)))
+
+    report = compare_traces(reference, candidate)
+
+    divergence = report.frame_metrics[0].logits_kl_divergence
+    assert divergence is not None
+    assert divergence == pytest.approx(10_000.0)
+
+
+def test_logits_presence_or_length_mismatch_is_explicit() -> None:
+    """Unavailable or differently shaped logits never receive fake metrics."""
+    reference = _trace(_frame(logits=None))
+    present = compare_traces(reference, _trace(_frame(logits=(1.0, 2.0))))
+    different_length = compare_traces(
+        _trace(_frame(logits=(1.0, 2.0))),
+        _trace(_frame(logits=(1.0, 2.0, 3.0))),
+    )
+
+    assert present.first_divergence is not None
+    assert present.first_divergence.fields == ("presence",)
+    assert present.frame_metrics[0].logits_max_abs_diff is None
+    assert different_length.first_divergence is not None
+    assert different_length.first_divergence.fields == ("length",)
+
+
+def test_request_divergence_precedes_cache_divergence_at_same_step() -> None:
+    """First-divergence ordering follows output, logits, request, cache."""
+    reference = _trace(_frame())
+    changed_frame = replace(
+        _frame(),
+        request=replace(_frame().request, accepted_seq_len=15),
+        cache_groups=(_group(content="changed"),),
+    )
+
+    report = compare_traces(reference, _trace(changed_frame))
+
+    assert report.first_divergence is not None
+    assert report.first_divergence.level == "request"
+    assert report.first_divergence.fields == ("accepted_seq_len",)
+    assert {item.level for item in report.divergences} == {"request", "cache"}
+
+
+def test_cache_group_missing_content_and_revision_are_localized() -> None:
+    """Per-group/rank evidence identifies missing and incompatible cache state."""
+    reference = _trace(_frame(groups=(_group(), _group("indexer"))))
+    changed_main = replace(
+        _group(),
+        content_digest=_digest("changed"),
+        revision="kv-v4",
+    )
+    candidate = _trace(_frame(groups=(changed_main,)))
+
+    report = compare_traces(reference, candidate)
+
+    cache = [item for item in report.divergences if item.level == "cache"]
+    assert len(cache) == 2
+    assert cache[0].subject == "indexer@rank0"
+    assert cache[0].fields == ("missing_candidate",)
+    assert cache[1].subject == "main@rank0"
+    assert cache[1].fields == ("content_digest", "revision")
+
+
+def test_top_k_overlap_is_reported() -> None:
+    """Top-k set drift is visible independently from the selected token."""
+    reference = _trace(_frame())
+    changed_output = replace(
+        _frame().output,
+        top_k=(TopKEntry(7, -0.2), TopKEntry(10, -0.5)),
+    )
+    report = compare_traces(reference, _trace(replace(_frame(), output=changed_output)))
+
+    assert report.first_divergence is not None
+    assert report.first_divergence.fields == ("top_k",)
+    assert report.frame_metrics[0].top_k_overlap == 0.5
+
+
+def test_missing_decode_frame_is_reported() -> None:
+    """A truncated replay identifies its first absent step."""
+    reference = _trace(_frame(0), _frame(1, accepted_seq_len=17))
+    candidate = _trace(_frame(0))
+
+    report = compare_traces(reference, candidate)
+
+    assert report.first_divergence is not None
+    assert report.first_divergence.step == 1
+    assert report.first_divergence.subject == "frame"
+    assert report.first_divergence.fields == ("missing_candidate",)
+
+
+def test_lifecycle_event_divergence_is_localized() -> None:
+    """Async completion order changes are reported at lifecycle level."""
+    reference = _trace()
+    changed = replace(
+        reference.lifecycle_events[0],
+        phase=LifecyclePhase.RETRIEVE_COMPLETE,
+    )
+
+    report = compare_traces(reference, _trace(events=(changed,)))
+
+    assert report.first_divergence is not None
+    assert report.first_divergence.level == "lifecycle"
+    assert report.first_divergence.subject == "event[0]"
+    assert report.first_divergence.fields == ("phase",)
+
+
+def test_request_identity_mismatch_is_not_a_match() -> None:
+    """Equal frames from another request remain a request-level divergence."""
+    reference = _trace()
+    candidate = replace(reference, request_id="request-2", run_id="run-2")
+
+    report = compare_traces(reference, candidate)
+
+    assert not report.matched
+    assert report.first_divergence is not None
+    assert report.first_divergence.level == "request"
+    assert report.first_divergence.subject == "trace"
+    assert report.first_divergence.fields == ("request_id",)
+
+
+def test_trace_round_trip_and_digest_are_deterministic(tmp_path: Path) -> None:
+    """Canonical JSON replay preserves the complete evidence identity."""
+    trace = _trace(_frame(0), _frame(1, accepted_seq_len=17))
+    path = tmp_path / "trace.json"
+
+    write_trace(trace, path)
+    replayed = read_trace(path)
+
+    assert replayed == trace
+    assert trace_digest(replayed) == trace_digest(trace)
+    assert path.read_text(encoding="utf-8").endswith("\n")
+    assert json.loads(path.read_text(encoding="utf-8"))["metadata"] == {
+        "backend": "paged",
+        "cache_mode": "l1+l2",
+    }
+
+
+def test_comparison_report_is_machine_readable(tmp_path: Path) -> None:
+    """Reports serialize with the first divergence and stable trace digests."""
+    report = compare_traces(_trace(_frame(token_id=7)), _trace(_frame(token_id=8)))
+    path = tmp_path / "report.json"
+
+    write_report(report, path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert not payload["matched"]
+    assert payload["first_divergence"]["level"] == "output"
+    assert payload["reference_digest"].startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    "trace",
+    [
+        lambda: _trace(_frame(1), _frame(0)),
+        lambda: _trace(_frame(0, accepted_seq_len=17), _frame(1, accepted_seq_len=16)),
+    ],
+)
+def test_invalid_replay_order_is_rejected(trace: object) -> None:
+    """Non-monotonic steps or accepted lengths cannot masquerade as replay."""
+    with pytest.raises(ValueError, match="must be"):
+        trace()  # type: ignore[operator]
+
+
+def test_duplicate_group_rank_and_nonfinite_evidence_are_rejected() -> None:
+    """Ambiguous group state and NaN metrics fail during trace construction."""
+    with pytest.raises(ValueError, match="identities"):
+        _frame(groups=(_group(), _group()))
+    with pytest.raises(ValueError, match="finite"):
+        _frame(logprob=float("nan"))
+
+
+def test_sha256_digest_accepts_buffer_protocol_values() -> None:
+    """Tensor adapters can hash byte-oriented content without copies in callers."""
+    expected = sha256_digest(b"cache-bytes")
+    assert sha256_digest(bytearray(b"cache-bytes")) == expected
+    assert sha256_digest(memoryview(b"cache-bytes")) == expected
+
+
+def test_negative_tolerance_is_rejected() -> None:
+    """Invalid comparison configuration never produces a report."""
+    with pytest.raises(ValueError, match="tolerances"):
+        compare_traces(_trace(), _trace(), absolute_tolerance=-1)


### PR DESCRIPTION
## Summary

- add a deterministic canonical-JSON trace format for hybrid cache correctness
- capture output, logits, request state, per-group/per-rank cache state, and asynchronous lifecycle evidence
- compare reference and candidate runs with stable metrics and a step-ordered first-divergence pointer
- provide a CLI plus capture/adapter guidance for cache-off, L1, L2, and L1+L2 experiments

## Correctness contract

The harness records five independent evidence layers:

1. selected token, log-probability, and top-k overlap
2. logits max/mean absolute error, KL divergence, and cosine similarity
3. request generation, accepted sequence length, and block/prefix/drop-round digests
4. logical/physical spans, representation metadata, and content digest for every cache group and rank
5. ordered store/retrieve/reuse/abort/preempt/resume lifecycle events

`first_divergence` is ordered by decode step and then output -> logits -> request -> cache -> lifecycle. Trace provenance (`run_id` and metadata) is included in the trace SHA-256 identity but intentionally does not affect semantic matching; experiment drivers remain responsible for compatible cells.

## Validation

- `19 passed` in `tests/benchmarks/test_hybrid_cache_correctness.py`
- all selected pre-commit hooks passed: SPDX, isort, ruff, ruff-format, codespell, and mypy
- DCO and Buildkite `k3-unit-tests` passed

Fresh-process CPU benchmark, 8 frames/trace, 4 groups/frame, 128 logits/frame:

- 7 replays x 2,000 comparisons
- median of replay medians: `1.061 ms/compare`
- median throughput: `940.69 compares/s` (range `913.38-969.05`)
- all 7 x 19 pytest cases passed
- all 42 replay probes passed, including correct first-divergence localization at output, logits, request, cache, and lifecycle layers
- all 14 canonical serialization and round-trip checks passed

Single-L20 synthetic capture smoke test (PyTorch 2.7.1+cu126):

- physical GPU 2 was checked immediately before the run at 0% utilization and 14 MiB used
- BF16 groups `(2, 16, 64, 128)` and `(2, 16, 256, 128)`, 2.5 MiB captured
- content digest capture median `8.33 ms` across 7 samples
- identical trace: match
- one-element mutation: first divergence `cache`, `main@rank0`, `content_digest`

This is deliberately reported as a synthetic single-GPU capture smoke test, not as a two-GPU or model-level hybrid-cache correctness result. A real 2xL20 A/B run was not available because only one GPU was unallocated.

## InfraSWE v0.5 score

Scored with InfraSWE source `191b9099f6d634b65998dac5604aeefc433673e7` and the frozen `project-fit-kernel-v0.5` formula:

- InfraCert hard gates: **pass**
- diagnostic/provisional ProjectFit: **92.02 / 100**
- Benchmark Trust: **93.06 / 100** (`E1-framework`)
- official ProjectFit: **unresolved**, not claimed

The original provisional score predates the live driver and runnable notebook added in this PR. It is retained only as historical diagnostic evidence and has not been recomputed or promoted to an official score. Official scoring remains blocked by the absent project-owned performance baseline, hidden probes, maintainer-reviewed/sealed Draft, and complete deployment cells.

## Scope

This benchmark utility is independent of #4900 and #4901. The checked-in live adapter captures current LMCache request, lifecycle, and KV-content evidence; future adapters can additionally consume generation-fence and topology-plan metadata from those changes without making this PR depend on them.

## Runnable L20 end-to-end notebook

Reviewer-runnable artifact: [`benchmarks/hybrid_cache_correctness/live_e2e.ipynb`](https://github.com/LMCache/LMCache/blob/4997e62674f9030d3a525fbadfa90186a212b18b/benchmarks/hybrid_cache_correctness/live_e2e.ipynb). Start LMCache and vLLM as documented in [the benchmark README](https://github.com/LMCache/LMCache/blob/4997e62674f9030d3a525fbadfa90186a212b18b/benchmarks/hybrid_cache_correctness/README.md), then **Run All**. The notebook invokes the checked-in `live_e2e` module, emits JSON evidence, writes all artifacts outside the source tree, and fails immediately on a mismatch.

Reproduced on NVIDIA L20; vLLM 0.25.1; PyTorch 2.11.0+cu130; CUDA 13.0; Qwen/Qwen3-0.6B; LMCacheMPConnector; 256-token chunks.

- notebook commit: `4997e62`
- candidate code image: `8e70c03` (the later commit only adds the notebook/README link)
- image digest: `sha256:2a2ce17d09ff9a6be3007d1ac7ef718ef8bf6353f6fd1283ed2c282b7d9494f9`
- two independent, real four-step exact-prefix serving runs: `matched=true`, `first_divergence=null`, `frames=4`
- compared generated token/logprob/top-k evidence, request/lifecycle state, and retrieved KV content digests
- notebook artifacts: candidate `e3289d323659c7c90a9ba684487612cb4ac767d1c6200cba731fed41ee273372`; reference `7ec4a302766631628c36a3d4a26dea66967d17461f6b8bfe9450d8ff3da40c5a`; report `174fb3964896c6f736deb0733fefdfaf066db485b99a1ad7907fc338c1e0fe8a`
- notebook Run-All log: 86 lines, SHA-256 `31b7d8c7629ae0dd69f32ac0dc2b6807a08858ac4fdc1397a49a721a9e150782`
- direct module log: 84 lines, SHA-256 `670653df741da2bf24e4101935d084f8fa088a5a0d21ea1f5f5bd47bb40537db`

The observed per-step durations are retained as diagnostic log fields only; they are **not** presented as a benchmark score or cross-machine performance claim.
