### PR TITLE
[Bug] fix: reject cache key tags containing the serialization delimiters

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -415,7 +415,7 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
     return CacheEngineKey.from_string(key_str)
 
 
-def _validate_tag(name: str, value: Any) -> None:
+def _validate_tag(name: str, value: object) -> None:
     """Reject tag names and values that would break key serialization.
 
     ``CacheEngineKey.to_string`` joins tags as ``f"{name}%{value}"`` separated by

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -415,6 +415,41 @@ def parse_cache_key(key_str: str) -> Union[CacheEngineKey, LayerCacheEngineKey]:
     return CacheEngineKey.from_string(key_str)
 
 
+def _validate_tag(name: str, value: Any) -> None:
+    """Reject tag names and values that would break key serialization.
+
+    ``CacheEngineKey.to_string`` joins tags as ``f"{name}%{value}"`` separated by
+    ``"@"``, and ``to_dict`` uses the same ``%`` join. Neither escapes, so a
+    delimiter inside a tag makes the serialized key ambiguous:
+
+    - ``%`` in a *name* is the dangerous one. ``{"a%b": "c"}`` and
+      ``{"a": "b%c"}`` both serialize to ``...@a%b%c``, so two different keys
+      collide on the wire and one request reads the other's KV cache.
+    - ``@`` in a name or value adds a field, which the parsers reject with
+      ``ValueError`` rather than silently mis-parsing.
+
+    ``%`` inside a *value* is safe: the parsers split with ``maxsplit=1``, so
+    everything after the first ``%`` stays with the value.
+
+    Args:
+        name: Tag name, already stripped of the ``lmcache.tag.`` prefix.
+        value: Tag value.
+
+    Raises:
+        ValueError: If the tag would serialize ambiguously.
+    """
+    if "@" in name or "%" in name:
+        raise ValueError(
+            f"Invalid tag name {name!r} in CacheEngineKey: tag names cannot "
+            f"contain '@' or '%' because they delimit the serialized key"
+        )
+    if isinstance(value, str) and "@" in value:
+        raise ValueError(
+            f"Invalid tag value {value!r} for tag {name!r} in CacheEngineKey: "
+            f"tag values cannot contain '@' because it delimits the serialized key"
+        )
+
+
 @dataclass(slots=True)
 class CacheEngineKey:
     model_name: str
@@ -433,7 +468,9 @@ class CacheEngineKey:
                 if k.startswith("lmcache.tag."):
                     if tag_list is None:
                         tag_list = []
-                    tag_list.append((k[len("lmcache.tag.") :], v))
+                    name = k[len("lmcache.tag.") :]
+                    _validate_tag(name, v)
+                    tag_list.append((name, v))
         if self.dtype not in TORCH_DTYPE_TO_STR_DTYPE:
             raise ValueError(f"Unsupported dtype in CacheEngineKey: {self.dtype}")
         self._dtype_str = TORCH_DTYPE_TO_STR_DTYPE[self.dtype]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -700,3 +700,61 @@ class TestCacheKeyParsing:
         assert isinstance(parsed, LayerCacheEngineKey)
         assert parsed == original
         assert parsed.layer_id == 3
+
+
+# ============================================================
+# CacheEngineKey tag delimiter safety
+# ============================================================
+
+
+class TestCacheEngineKeyTagDelimiters:
+    """Tags must not contain the delimiters the serialized key is built from.
+
+    ``to_string`` joins tags as ``f"{name}%{value}"`` separated by ``"@"`` and
+    ``to_dict`` uses the same ``%`` join, neither of which escapes. Without
+    validation two different keys can serialize to the same string.
+    """
+
+    @staticmethod
+    def _key(request_configs):
+        return CacheEngineKey(
+            model_name="mistral",
+            world_size=1,
+            worker_id=0,
+            chunk_hash=255,
+            dtype=torch.bfloat16,
+            request_configs=request_configs,
+        )
+
+    def test_percent_in_tag_name_is_rejected(self):
+        """The collision case: ``{"a%b": "c"}`` and ``{"a": "b%c"}`` both
+        serialize to ``...@a%b%c``, so one request would read the other's
+        cached KV."""
+        with pytest.raises(ValueError, match="cannot contain"):
+            self._key({"lmcache.tag.a%b": "c"})
+
+    def test_at_sign_in_tag_name_is_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain"):
+            self._key({"lmcache.tag.a@b": "c"})
+
+    def test_at_sign_in_tag_value_is_rejected(self):
+        with pytest.raises(ValueError, match="cannot contain"):
+            self._key({"lmcache.tag.env": "prod@us"})
+
+    def test_percent_in_tag_value_is_allowed_and_round_trips(self):
+        """``%`` in a value is safe because the parsers split with
+        ``maxsplit=1``, so it must keep working."""
+        key = self._key({"lmcache.tag.env": "a%b"})
+        assert CacheEngineKey.from_string(key.to_string()) == key
+        assert CacheEngineKey.from_dict(key.to_dict()) == key
+
+    def test_non_tag_request_configs_are_not_validated(self):
+        """Only ``lmcache.tag.*`` entries reach the serialized key, so other
+        config must not be constrained."""
+        key = self._key({"lmcache.other@thing": "a%b@c"})
+        assert key.tags is None
+
+    def test_ordinary_tags_still_round_trip(self):
+        key = self._key({"lmcache.tag.env": "prod", "lmcache.tag.team": "search"})
+        assert CacheEngineKey.from_string(key.to_string()) == key
+        assert CacheEngineKey.from_dict(key.to_dict()) == key


### PR DESCRIPTION
**What this PR does / why we need it**:

- Validate tag names and values in `CacheEngineKey.__post_init__`, rejecting the `@` and `%` delimiters the serialized key is built from.
- Add regression coverage for the collision case and for the delimiter uses that must keep working.

`to_string` joins tags as `f"{name}%{value}"` separated by `@`, and `to_dict` uses the same `%` join. Neither escapes. The parsers split with `maxsplit=1`, which protects the value but not the name, so two distinct keys serialize identically:

```
tags {"a%b": "c"}  ->  mistral@1@0@00ff@bf16@a%b%c
tags {"a": "b%c"}  ->  mistral@1@0@00ff@bf16@a%b%c
```

Both parse back to `{"lmcache.tag.a": "b%c"}`. That string is the disk filename and the object key for remote backends, so a collision returns another key's KV tensors for a chunk, with no error raised anywhere.

Validation rather than escaping: escaping changes the wire format, so existing on-disk and object-store caches stop matching. Rejecting the delimiters leaves every currently valid key serializing byte-identically, and turns a silent collision into a `ValueError` at construction.

`%` inside a tag value stays legal, since `maxsplit=1` already handles it. `@` in a value is rejected because the parsers already fail on it, so this only moves the failure earlier.

**Special notes for your reviewers**:

- Ran `pytest tests/test_utils.py` with `--noconftest`, since the repo conftest imports the compiled `lmcache_native`, which does not build on this aarch64 machine. 6 new tests pass; 90 passed and 1 xpassed for the whole file. `ruff format --check` and `ruff check` clean.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
