### PR TITLE
fix(mp): make warm-prefetch completion consumption exactly once

### DIFF
--- a/lmcache/v1/multiprocess/warm_prefetch.py
+++ b/lmcache/v1/multiprocess/warm_prefetch.py
@@ -128,7 +128,9 @@ class WarmPrefetchJobs:
             return WarmStatus(state=PENDING)
 
         with self._lock:
-            self._jobs.pop(request_id, None)
+            consumed_handle = self._jobs.pop(request_id, None)
+        if consumed_handle is None:
+            return WarmStatus(state=UNKNOWN)
         found_keys = found.popcount()
         logger.info(
             "Warm prefetch %s completed: %d/%d keys loaded into L1",

--- a/tests/v1/multiprocess/test_warm_prefetch.py
+++ b/tests/v1/multiprocess/test_warm_prefetch.py
@@ -8,11 +8,19 @@ path), status is polled reactively, and completion releases **nothing** (no
 """
 
 # Standard
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, cast
+import threading
 
 # First Party
-from lmcache.v1.distributed.api import ObjectKey, PrefetchMode, TrimPolicy
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+    PrefetchMode,
+    TrimPolicy,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
 from lmcache.v1.multiprocess.warm_prefetch import (
     COMPLETED,
     PENDING,
@@ -48,6 +56,7 @@ class _FakeBitmap:
 class _FakeStorageManager:
     found: int = 0
     delay_polls: int = 0
+    completion_barrier: Optional[threading.Barrier] = None
 
     submit_args: Optional[dict] = None
     finish_called: bool = False
@@ -67,6 +76,8 @@ class _FakeStorageManager:
         if self._polls < self.delay_polls:
             self._polls += 1
             return None
+        if self.completion_barrier is not None:
+            self.completion_barrier.wait(timeout=5)
         return _FakeBitmap(self.found)
 
     def finish_read_prefetched(self, keys, read_locks: int = 1) -> None:
@@ -107,3 +118,29 @@ def test_poll_unknown_request_id():
     jobs = WarmPrefetchJobs()
     assert jobs.poll(sm, "does-not-exist").state == UNKNOWN
     assert sm.finish_called is False
+
+
+def test_concurrent_completed_poll_is_consumed_exactly_once() -> None:
+    """Only one concurrent poller may consume a completed job."""
+    sm = _FakeStorageManager(
+        found=1,
+        completion_barrier=threading.Barrier(2),
+    )
+    storage_manager = cast(StorageManager, sm)
+    jobs = WarmPrefetchJobs()
+    request_id = jobs.submit(
+        storage_manager,
+        [_key(0)],
+        layout_desc=cast(MemoryLayoutDesc, object()),
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        statuses = [
+            future.result(timeout=5)
+            for future in (
+                executor.submit(jobs.poll, storage_manager, request_id),
+                executor.submit(jobs.poll, storage_manager, request_id),
+            )
+        ]
+
+    assert sorted(status.state for status in statuses) == [COMPLETED, UNKNOWN]


### PR DESCRIPTION
**What this PR does / why we need it**:

WarmPrefetchJobs documents completion as exactly-once, but poll previously performed get, query, and pop as separate critical sections without checking which caller removed the job. Two concurrent pollers can both observe an immediately completed handle and both return COMPLETED.

This change makes the atomic job-table pop choose the single completion consumer. A concurrent loser now returns UNKNOWN, preserving the documented contract without holding the job-table lock across storage-manager polling.

**Validation**:

- Test-first reproduction on current dev: the new barrier test failed with [COMPLETED, COMPLETED].
- Linux Python 3.12, CPU-only: pytest -q tests/v1/multiprocess/test_warm_prefetch.py — **3 passed** in 1.15s.
- Concurrency stress: the barrier regression passed **200/200 iterations**.
- pre-commit for both changed Python files — SPDX, device rules, timeout rule, isort, ruff, ruff-format, codespell, and mypy all passed (Rust hooks skipped because this PR changes no Rust files).

**Special notes for your reviewers**:

The fix intentionally does not add TTL cleanup, cancellation, or locking around the storage-manager query. It only restores exactly-once completion consumption.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `c217849a9629c7384d86cfcabe7f520435eb3595` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_warm_prefetch.py
```

```text
3 passed, 108 warnings in 1.35s
```

The verbose raw pytest log contains 23 lines and has SHA-256 `d7927de2614d4b3bf6005ac42f02b983cfc47fb15e32dc92802fa6cdaefb72ae`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->