### PR TITLE
fix(mp): harden liveness reaper fanout

### DIFF
--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -147,7 +147,14 @@ class ManagementModule:
         """
         if instance_id is not None:
             for target in self._liveness_targets:
-                target.touch_instance(instance_id)
+                try:
+                    target.touch_instance(instance_id)
+                except Exception:
+                    logger.exception(
+                        "Failed to refresh liveness for instance %d on %s",
+                        instance_id,
+                        type(target).__name__,
+                    )
         return True
 
     def _reap_cycle(self) -> ThreadRunSummary:
@@ -159,15 +166,34 @@ class ManagementModule:
         Returns:
             A summary recording how many instances were reaped this scan.
         """
-        reaped: list[int] = []
+        reaped: set[int] = set()
+        failures = 0
         for target in self._liveness_targets:
-            reaped.extend(
-                target.reap_stale_instances(self._reap_timeout, self._reap_grace)
-            )
+            try:
+                reaped.update(
+                    target.reap_stale_instances(self._reap_timeout, self._reap_grace)
+                )
+            except Exception:
+                failures += 1
+                logger.exception(
+                    "Failed to reap stale instances from %s",
+                    type(target).__name__,
+                )
         for instance_id in reaped:
             for target in self._liveness_targets:
-                target.drop_instance_state(instance_id)
-        return ThreadRunSummary(success=True, message=f"reaped={len(reaped)}")
+                try:
+                    target.drop_instance_state(instance_id)
+                except Exception:
+                    failures += 1
+                    logger.exception(
+                        "Failed to drop instance %d state from %s",
+                        instance_id,
+                        type(target).__name__,
+                    )
+        return ThreadRunSummary(
+            success=failures == 0,
+            message=f"reaped={len(reaped)}, failures={failures}",
+        )
 
     def get_chunk_size(self) -> int:
         """Return the chunk size used for KV cache operations.

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -222,6 +222,31 @@ class _FakeTarget:
         self.dropped.append(instance_id)
 
 
+class _FailingTarget(_FakeTarget):
+    """Liveness target that raises during one selected fanout phase."""
+
+    def __init__(self, phase: str) -> None:
+        super().__init__()
+        self.phase = phase
+
+    def touch_instance(self, instance_id: int) -> None:
+        if self.phase == "touch":
+            raise RuntimeError("touch failed")
+        super().touch_instance(instance_id)
+
+    def reap_stale_instances(
+        self, reap_timeout_s: float, registration_grace_s: float
+    ) -> list[int]:
+        if self.phase == "reap":
+            raise RuntimeError("reap failed")
+        return super().reap_stale_instances(reap_timeout_s, registration_grace_s)
+
+    def drop_instance_state(self, instance_id: int) -> None:
+        if self.phase == "drop":
+            raise RuntimeError("drop failed")
+        super().drop_instance_state(instance_id)
+
+
 @pytest.fixture(autouse=True)
 def _reset_periodic_registry():
     """Keep the reaper out of the global registry across tests."""
@@ -238,6 +263,46 @@ def test_management_ping_touches_targets() -> None:
     assert mgmt.ping(42) is True
     assert mgmt.ping(None) is True
     assert target.touched == [42]
+
+
+def test_management_ping_isolates_target_failure() -> None:
+    healthy = _FakeTarget()
+    mgmt = ManagementModule(
+        MagicMock(), liveness_targets=[_FailingTarget("touch"), healthy]
+    )
+
+    assert mgmt.ping(42) is True
+    assert healthy.touched == [42]
+
+
+def test_management_reaper_isolates_scan_failure() -> None:
+    healthy = _FakeTarget()
+    healthy.to_reap = [7]
+    mgmt = ManagementModule(
+        MagicMock(), liveness_targets=[_FailingTarget("reap"), healthy]
+    )
+
+    summary = mgmt._reap_cycle()
+
+    assert healthy.dropped == [7]
+    assert summary.success is False
+    assert summary.message == "reaped=1, failures=1"
+
+
+def test_management_reaper_isolates_drop_failure() -> None:
+    source = _FakeTarget()
+    source.to_reap = [9]
+    observer = _FakeTarget()
+    mgmt = ManagementModule(
+        MagicMock(),
+        liveness_targets=[source, _FailingTarget("drop"), observer],
+    )
+
+    summary = mgmt._reap_cycle()
+
+    assert observer.dropped == [9]
+    assert summary.success is False
+    assert summary.message == "reaped=1, failures=1"
 
 
 def test_management_reaper_reaps_and_drops() -> None:
@@ -257,6 +322,22 @@ def test_management_reaper_reaps_and_drops() -> None:
         assert target.dropped == [7]
     finally:
         mgmt.close()
+
+
+def test_management_reaper_deduplicates_instance_fanout() -> None:
+    """A stale instance reported by multiple targets is dropped once per target."""
+    first = _FakeTarget()
+    second = _FakeTarget()
+    first.to_reap = [7]
+    second.to_reap = [7]
+    mgmt = ManagementModule(MagicMock(), liveness_targets=[first, second])
+
+    summary = mgmt._reap_cycle()
+
+    assert first.dropped == [7]
+    assert second.dropped == [7]
+    assert summary.success is True
+    assert summary.message == "reaped=1, failures=0"
 
 
 def test_management_reaper_disabled_when_timeout_zero() -> None:


### PR DESCRIPTION
## Summary

- deduplicate stale instance IDs reported by mirrored liveness targets
- isolate PING refresh, stale scans, and state-drop failures per target
- keep healthy targets progressing after one target fails
- preserve exception context and mark partial reaper cycles unsuccessful with a failure count

## Problem

Liveness state can be mirrored across multiple targets. Duplicate stale reports caused repeated cleanup and inflated the reaped count. Independently, one target exception aborted the serial fanout, so later targets were neither refreshed nor scanned/cleaned during that cycle.

## Validation

Test-first reproductions before the fixes:

```text
FAILED test_management_reaper_deduplicates_instance_fanout
assert [7, 7] == [7]

FAILED test_management_ping_isolates_target_failure
RuntimeError: touch failed
FAILED test_management_reaper_isolates_scan_failure
RuntimeError: reap failed
FAILED test_management_reaper_isolates_drop_failure
RuntimeError: drop failed
```

After the fixes (macOS, Python 3.12, CPU-only):

```text
uv run pytest -q tests/v1/multiprocess/test_worker_liveness.py
18 passed, 129 warnings in 2.07s
```

Repository pre-commit checks on both changed files passed: SPDX, banned APIs, isort, ruff, ruff-format, codespell, and mypy.

A runtime benchmark is not applicable: this changes periodic stale-worker cleanup correctness, not a request-path performance primitive.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `53b4c09f999864824f77e5ff7018284f1f2c6760` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_worker_liveness.py
```

```text
18 passed, 129 warnings in 1.03s
```

The verbose raw pytest log contains 89 lines and has SHA-256 `6eda030e0bd9015b4658ac53b88dcd05369c88812d8d99d18c484fe21a9fb355`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->