### PR TITLE
fix(mp): stop previous EventBus on reinitialization

### DIFF
--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -378,11 +378,14 @@ def get_event_bus() -> EventBus:
 
 
 def init_event_bus(config: EventBusConfig | None = None) -> EventBus:
-    """Replace the global singleton with a new EventBus built from *config*.
+    """Replace and stop the global EventBus, then return its replacement.
 
-    Returns the newly created bus.
+    The replacement is published before the previous bus is stopped so new
+    callers cannot enqueue work on the bus being drained.
     """
     global _global_bus, _observability_enabled
+    previous_bus = _global_bus
     _global_bus = EventBus(config)
     _observability_enabled = config.enabled if config else True
+    previous_bus.stop()
     return _global_bus

--- a/tests/v1/mp_observability/test_event_bus.py
+++ b/tests/v1/mp_observability/test_event_bus.py
@@ -446,6 +446,20 @@ class TestGlobalSingleton:
         assert get_event_bus() is new
         assert get_event_bus() is not old
 
+    def test_init_stops_previous_bus(self):
+        old = init_event_bus(EventBusConfig(enabled=True))
+        subscriber = _RecordingSubscriber()
+        subscriber.shutdown = MagicMock(wraps=subscriber.shutdown)
+        old.register_subscriber(subscriber)
+        old.start()
+
+        new = init_event_bus(EventBusConfig(enabled=False))
+
+        assert get_event_bus() is new
+        assert old._thread is not None
+        assert old._thread.is_alive() is False
+        subscriber.shutdown.assert_called_once_with()
+
     def test_default_singleton_is_disabled(self):
         bus = get_event_bus()
         assert bus._config.enabled is False


### PR DESCRIPTION
## Summary

- publish the replacement global EventBus before retiring the previous instance
- stop the displaced bus so its drain thread exits and pending events flush
- run subscriber shutdown hooks during global reinitialization

## Problem

`init_event_bus()` previously overwrote the singleton without stopping the old bus. Reinitializing observability after the old bus was started left its daemon drain thread alive and skipped subscriber cleanup.

## Validation

Test-first reproduction before the fix:

```text
FAILED TestGlobalSingleton::test_init_stops_previous_bus
assert old._thread.is_alive() is False
```

After the fix (Linux, Python 3.12, CPU-only):

```text
python3 -m pytest -q tests/v1/mp_observability/test_event_bus.py
42 passed in 3.77s
```

Repository pre-commit checks on both changed files all passed: SPDX, banned APIs, isort, ruff, ruff-format, codespell, and mypy.

A runtime benchmark is not applicable: this is lifecycle/resource cleanup, not a throughput-path optimization.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `67ae45be3ae33481013817c2c8a23680c0383d5b` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/mp_observability/test_event_bus.py
```

```text
42 passed, 80 warnings in 3.44s
```

The verbose raw pytest log contains 135 lines and has SHA-256 `cb3e14224b2129c81c4f899564f8e1981d6886c8e5be76dadfd8651cb519a574`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->