### PR TITLE
fix(mp): isolate malformed native EventBus records

### DIFF
--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -116,6 +116,7 @@ class EventBus:
         self._thread: threading.Thread | None = None
         self._registered_subscribers: list[EventSubscriber] = []
         self._discard_count: int = 0
+        self._malformed_native_event_count: int = 0
         self._last_discard_warning: float = 0.0
         self._subscriber_exception_counts: dict[str, int] = {}
 
@@ -288,6 +289,10 @@ class EventBus:
         """Cumulative count of events dropped because the queue was full."""
         return self._discard_count
 
+    def malformed_native_events_count(self) -> int:
+        """Cumulative count of malformed native records skipped during drain."""
+        return self._malformed_native_event_count
+
     def subscriber_exception_counts(self) -> dict[str, int]:
         """Snapshot of per-subscriber callback exception counts.
 
@@ -314,17 +319,22 @@ class EventBus:
         # Drain events buffered on the C++ side (from CUDA host callbacks)
         if _has_native_recorder:
             native_events = _device_ops.drain_recorded_events()
-            for name, sid, ts, str_meta, int_meta in native_events:
-                metadata: dict[str, Any] = dict(str_meta)
-                metadata.update(int_meta)
-                self._queue.append(
-                    Event(
+            for native_event in native_events:
+                try:
+                    name, sid, ts, str_meta, int_meta = native_event
+                    metadata: dict[str, Any] = dict(str_meta)
+                    metadata.update(int_meta)
+                    event = Event(
                         event_type=EventType(name),
                         session_id=sid,
                         timestamp=ts,
                         metadata=metadata,
                     )
-                )
+                except Exception:
+                    self._malformed_native_event_count += 1
+                    logger.exception("EventBus: dropping malformed native event")
+                    continue
+                self._queue.append(event)
 
         with self._lock:
             snapshot = dict(self._subscribers)

--- a/tests/v1/mp_observability/test_event_bus.py
+++ b/tests/v1/mp_observability/test_event_bus.py
@@ -293,6 +293,24 @@ class TestExceptionIsolation:
 
         assert good_sub.shutdown_called
 
+    def test_malformed_native_event_does_not_block_valid_event(self, bus):
+        received: list[Event] = []
+        bus.subscribe(EventType.L1_READ_FINISHED, received.append)
+        native_ops = MagicMock()
+        native_ops.drain_recorded_events.return_value = [
+            ("unknown.event", "bad", 1.0, {}, {}),
+            (EventType.L1_READ_FINISHED.value, "good", 2.0, {}, {}),
+        ]
+
+        with (
+            patch.object(_bus_module, "_has_native_recorder", True),
+            patch.object(_bus_module, "_device_ops", native_ops, create=True),
+        ):
+            bus._drain_all()
+
+        assert [event.session_id for event in received] == ["good"]
+        assert bus.malformed_native_events_count() == 1
+
 
 # ---------------------------------------------------------------------------
 # Backpressure


### PR DESCRIPTION
## Summary

- decode each native EventBus record inside its own exception boundary
- count and log malformed native records instead of aborting the drain cycle
- continue dispatching later valid events from the same native batch

## Problem

`EventType(name)` and native metadata conversion ran outside the existing per-callback exception isolation. A single unknown or malformed native record raised from `_drain_all()`, terminated that drain cycle, and prevented every later valid record in the batch from being dispatched.

## Validation

Test-first reproduction before the fix:

```text
FAILED TestExceptionIsolation::test_malformed_native_event_does_not_block_valid_event
ValueError: unknown.event is not a valid EventType
```

After the fix (Linux, Python 3.12, CPU-only):

```text
python3 -m pytest -q tests/v1/mp_observability/test_event_bus.py
42 passed in 3.78s
```

Repository pre-commit checks on both changed files all passed: SPDX, banned APIs, isort, ruff, ruff-format, codespell, and mypy.

A throughput benchmark is not applicable because this changes malformed-record error isolation; the normal valid-record path only adds the surrounding exception boundary.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `b441c78538f1fd3e33ff7e69e4c004c9dd5423ed` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/mp_observability/test_event_bus.py
```

```text
42 passed, 80 warnings in 3.76s
```

The verbose raw pytest log contains 148 lines and has SHA-256 `45ee11f076248e5f164d832a2d6801b8868eedbe8f9d85cc626e242499b909bd`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->