### PR TITLE
fix(mp): snapshot token IDs at session boundary

### DIFF
--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -59,7 +59,7 @@ class Session:
             full_token_ids: Complete token sequence.
         """
         with self._lock:
-            self.token_ids = full_token_ids
+            self.token_ids = list(full_token_ids)
 
     @overload
     def get_hashes(self, start: int, end: int) -> list: ...

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -40,6 +40,14 @@ class TestSession:
         session.set_tokens([4, 5, 6])
         assert session.token_ids == [4, 5, 6]
 
+    def test_set_tokens_snapshots_caller_input(self, session: Session) -> None:
+        tokens = [1, 2, 3, 4]
+        session.set_tokens(tokens)
+
+        tokens[0] = 999
+
+        assert session.token_ids == [1, 2, 3, 4]
+
     def test_get_hashes_basic(self, session: Session) -> None:
         """8 tokens, chunk_size=4 produces 2 hashes."""
         session.set_tokens(list(range(8)))


### PR DESCRIPTION
## Summary

- snapshot caller-provided token lists when updating a multiprocess `Session`
- prevent mutations performed outside the session lock from changing session state
- add a regression test that mutates the original list after `set_tokens()`

## Problem

`Session.set_tokens()` stored the caller-owned list by reference. A caller could mutate that list after the method returned, changing `session.token_ids` without acquiring the session lock. This also risks making the visible token sequence disagree with hashes cached by the session.

## Validation

Test-first reproduction before the fix:

```text
assert [999, 2, 3, 4] == [1, 2, 3, 4]
```

After the fix:

```text
python3 -m pytest -q tests/v1/multiprocess/test_session.py
28 passed, 84 warnings in 1.34s
```

Repository hooks:

```text
uv tool run pre-commit run --files lmcache/v1/multiprocess/session.py tests/v1/multiprocess/test_session.py
All applicable hooks passed (SPDX, device checks, isort, ruff, ruff-format, codespell, mypy).
```

No performance benchmark is claimed: the intentional ownership boundary adds one O(n) list snapshot per `set_tokens()` call. This patch does not change the existing rolling-hash invalidation policy.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `c9ab361b637cc34375243b9ce9043a7d5881f9ed` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_session.py
```

```text
28 passed, 82 warnings in 1.16s
```

The verbose raw pytest log contains 190 lines and has SHA-256 `eb84073195776b3f6c8fc8fade5f211fa0f4ffe04028c41dc8fa4af691cc5b01`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->