### PR TITLE
fix(mp/shm): fence unlink ownership across fork

### DIFF
--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -70,6 +70,16 @@ _ADDR_TO_MMAP: dict[int, _mmap.mmap] = {}
 _OWNED_NAMES: set[str] = set()
 
 
+def _after_fork_in_child() -> None:
+    """Fence parent unlink ownership from a forked child."""
+    global _REGISTRY_LOCK
+    _REGISTRY_LOCK = threading.Lock()
+    _OWNED_NAMES.clear()
+
+
+os.register_at_fork(after_in_child=_after_fork_in_child)
+
+
 def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap, int]:
     """Open (or create) a POSIX SHM segment and ``mmap`` it.
 

--- a/tests/v1/multiprocess/test_posix_shm.py
+++ b/tests/v1/multiprocess/test_posix_shm.py
@@ -7,6 +7,9 @@ shared by SHM-based transports.
 
 # Standard
 import os
+import subprocess
+import sys
+import textwrap
 
 # Third Party
 import pytest
@@ -76,3 +79,49 @@ def test_open_pool_as_mmap_zero_copy_view():
 def test_munmap_no_op_on_zero_addr():
     # Should not crash; best-effort no-op.
     shm_munmap(0, 4096)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+def test_forked_child_does_not_unlink_parent_segment():
+    script = textwrap.dedent(
+        """
+        import os
+        import sys
+
+        from lmcache.v1.multiprocess.posix_shm import (
+            shm_create_readwrite,
+            shm_map_readwrite,
+            shm_munmap,
+            shm_unlink,
+        )
+
+        name = f"/lmc_pshm_fork_{os.getpid()}"
+        child_name = f"/lmc_pshm_child_{os.getpid()}"
+        nbytes = 4096
+        addr = shm_create_readwrite(name, nbytes)
+        child_pid = os.fork()
+        if child_pid == 0:
+            shm_create_readwrite(child_name, nbytes)
+            sys.exit(0)
+
+        try:
+            _, status = os.waitpid(child_pid, 0)
+            assert os.waitstatus_to_exitcode(status) == 0
+
+            mapped_addr = shm_map_readwrite(name, nbytes)
+            shm_munmap(mapped_addr, nbytes)
+
+            try:
+                shm_map_readwrite(child_name, nbytes)
+            except FileNotFoundError:
+                pass
+            else:
+                raise AssertionError("child-owned segment was not unlinked")
+        finally:
+            shm_munmap(addr, nbytes)
+            shm_unlink(name)
+            shm_unlink(child_name)
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
## Summary

- reset the inherited POSIX-SHM registry lock in forked children
- clear parent-owned unlink leases after fork without discarding inherited mappings
- verify that parent segments survive child exit while child-created segments are still cleaned

## Problem

The process-global `_OWNED_NAMES` registry is copied by `fork()`. A child that exits normally therefore runs the inherited atexit cleanup and unlinks segments that are still owned and used by its parent. The registry lock can also be inherited in a locked state if another parent thread held it at fork time.

## Fix

Register an `after_in_child` fork callback that installs a fresh registry lock and drops inherited unlink ownership. The address-to-mmap registry remains available so the child can close its own inherited mappings during shutdown. Any segment created after the fork is added normally and remains owned by the child.

## Validation

Test-first failure on the unmodified implementation:

```text
FileNotFoundError: [Errno 2] No such file or directory: /lmc_pshm_fork_...
```

After the fix:

```text
uv run pytest -q tests/v1/multiprocess/test_posix_shm.py
5 passed, 80 warnings in 2.09s
```

The regression test also confirms that a segment created by the forked child is unlinked on child exit.

Repository hooks:

```text
uv tool run pre-commit run --files lmcache/v1/multiprocess/posix_shm.py tests/v1/multiprocess/test_posix_shm.py
All applicable hooks passed (SPDX, device checks, isort, ruff, ruff-format, codespell, mypy).
```

No performance benchmark is claimed; the callback runs once per fork and performs constant-time lock replacement plus clearing the child-private ownership set.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `c10ee4075cb2377dd6cef5b0d715a82fb8b5fff1` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_posix_shm.py
```

```text
5 passed, 80 warnings in 3.26s
```

The verbose raw pytest log contains 19 lines and has SHA-256 `18777a8ce30bc633243676ce64857d5ee552e382a4c990557376835061bc6754`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->