### PR TITLE
fix(mp): reject affinity submissions after shutdown

### DIFF
--- a/lmcache/v1/multiprocess/affinity_pool.py
+++ b/lmcache/v1/multiprocess/affinity_pool.py
@@ -40,6 +40,8 @@ class AffinityThreadPool:
         max_workers: int,
         thread_name_prefix: str = "affinity",
     ) -> None:
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
         self._num_workers = max_workers
         self._queues: list[queue.Queue] = [queue.Queue() for _ in range(max_workers)]
         self._threads: list[threading.Thread] = []

--- a/lmcache/v1/multiprocess/affinity_pool.py
+++ b/lmcache/v1/multiprocess/affinity_pool.py
@@ -47,6 +47,7 @@ class AffinityThreadPool:
         self._key_to_slot: dict[int, int] = {}
         self._next_slot = 0
         self._overflow_warned = False
+        self._shutdown = False
         for i in range(max_workers):
             t = threading.Thread(
                 target=self._worker,
@@ -136,6 +137,8 @@ class AffinityThreadPool:
 
         Returns a :class:`concurrent.futures.Future`.
         """
+        if self._shutdown:
+            raise RuntimeError("cannot schedule new futures after shutdown")
         future: Future = Future()
         slot = self._slot_for_key(affinity_key)
         self._queues[slot].put((future, fn, args, kwargs))
@@ -147,8 +150,10 @@ class AffinityThreadPool:
         Sends a shutdown sentinel to every worker.  If *wait* is true, blocks
         until all workers have exited.
         """
-        for q in self._queues:
-            q.put(_SHUTDOWN)
+        if not self._shutdown:
+            self._shutdown = True
+            for q in self._queues:
+                q.put(_SHUTDOWN)
         if wait:
             for t in self._threads:
                 t.join()

--- a/tests/v1/multiprocess/test_affinity_pool.py
+++ b/tests/v1/multiprocess/test_affinity_pool.py
@@ -246,3 +246,14 @@ def test_shutdown_no_wait():
     pool.submit(lambda: time.sleep(0.5), affinity_key=0)
     # Should return immediately without waiting
     pool.shutdown(wait=False)
+
+
+@pytest.mark.parametrize("wait", [True, False])
+def test_submit_after_shutdown_raises(wait: bool):
+    pool = AffinityThreadPool(max_workers=1)
+    pool.shutdown(wait=wait)
+
+    with pytest.raises(
+        RuntimeError, match="cannot schedule new futures after shutdown"
+    ):
+        pool.submit(lambda: None, affinity_key=0)

--- a/tests/v1/multiprocess/test_affinity_pool.py
+++ b/tests/v1/multiprocess/test_affinity_pool.py
@@ -12,6 +12,12 @@ import pytest
 from lmcache.v1.multiprocess.affinity_pool import AffinityThreadPool
 
 
+@pytest.mark.parametrize("max_workers", [0, -1])
+def test_rejects_nonpositive_worker_count(max_workers: int):
+    with pytest.raises(ValueError, match="max_workers must be greater than 0"):
+        AffinityThreadPool(max_workers=max_workers)
+
+
 def test_submit_returns_correct_result():
     pool = AffinityThreadPool(max_workers=2)
     future = pool.submit(lambda x: x * 2, 21, affinity_key=0)


### PR DESCRIPTION
## Summary

- reject nonpositive affinity worker counts during construction
- track the `AffinityThreadPool` shutdown lifecycle
- reject submissions after either waiting or non-waiting shutdown
- keep repeated shutdown calls idempotent and permit a later waiting call to join workers

## Problems

`AffinityThreadPool` accepted zero or negative worker counts, creating an unusable pool that later failed during routing. It also accepted work after `shutdown()` had enqueued worker sentinels, returning a pending `Future` that could never complete.

## Validation

Test-first reproductions before the fixes:

```text
test_rejects_nonpositive_worker_count[0]  FAILED: DID NOT RAISE ValueError
test_rejects_nonpositive_worker_count[-1] FAILED: DID NOT RAISE ValueError
test_submit_after_shutdown_raises[True]   FAILED: DID NOT RAISE RuntimeError
test_submit_after_shutdown_raises[False]  FAILED: DID NOT RAISE RuntimeError
```

After the fixes:

```text
uv run pytest -q tests/v1/multiprocess/test_affinity_pool.py
17 passed, 81 warnings in 0.92s
```

Repository hooks:

```text
uv tool run pre-commit run --files lmcache/v1/multiprocess/affinity_pool.py tests/v1/multiprocess/test_affinity_pool.py
All applicable hooks passed.
```

No throughput benchmark is claimed because the behavioral changes affect invalid construction and rejected post-shutdown submissions; normal submissions add one boolean branch.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `9a28a02597eed6063a4065b133dcd23c13a6d813` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_affinity_pool.py
```

```text
17 passed, 81 warnings in 1.41s
```

The verbose raw pytest log contains 113 lines and has SHA-256 `e57eeedeb5fcc885287481a57d35b6502ab450c0c53ef093b2d9ac0f4519ab6e`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->