### PR TITLE
fix(mp): return handler failures to clients

### DIFF
--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -40,6 +40,23 @@ T = TypeVar("T")
 # Internal type used for the client-server communication
 RequestUID = int
 
+_REMOTE_ERROR_MARKER = b"lmcache.remote-error.v1"
+_MAX_REMOTE_ERROR_MESSAGE_CHARS = 4096
+
+
+class RemoteHandlerError(RuntimeError):
+    """A server handler failed before producing its declared response."""
+
+
+def _remote_error_frames(
+    prefix_frames: list[bytes], exception: BaseException
+) -> list[bytes]:
+    """Build a bounded, traceback-free error response."""
+    error_type = type(exception).__name__
+    message = str(exception)[:_MAX_REMOTE_ERROR_MESSAGE_CHARS]
+    payload = msgspec.msgpack.encode((error_type, message))
+    return prefix_frames + [_REMOTE_ERROR_MARKER, payload]
+
 
 # Helper functions
 def encode_request_uid(uid: RequestUID) -> bytes:
@@ -360,11 +377,30 @@ class MessageQueueClient:
 
         if request_uid in self.pending_futures:
             future = self.pending_futures.pop(request_uid)
-            if b_response:
-                response = msgspec_decode(b_response[0], cls=response_cls)
-                future.set_result(response)
-            else:
-                future.set_result(None)
+            try:
+                if b_response and b_response[0] == _REMOTE_ERROR_MARKER:
+                    if len(b_response) != 2:
+                        raise ValueError(
+                            "Malformed remote error response: expected marker "
+                            "and payload"
+                        )
+                    error_type, message = msgspec_decode(
+                        b_response[1], cls=tuple[str, str]
+                    )
+                    future.set_exception(
+                        RemoteHandlerError(
+                            f"Remote {request_type.name} handler failed with "
+                            f"{error_type}: {message}"
+                        )
+                    )
+                elif b_response:
+                    response = msgspec_decode(b_response[0], cls=response_cls)
+                    future.set_result(response)
+                else:
+                    future.set_result(None)
+            except Exception as exc:
+                future.set_exception(exc)
+                raise
 
     def submit_request(
         self,
@@ -585,8 +621,10 @@ class MessageQueueServer:
                 self.output_queue.put(frames_to_send)
                 self._output_efd.notify()
 
-            except Exception:
+            except Exception as exc:
                 logger.exception("Error in blocking handler")
+                self.output_queue.put(_remote_error_frames(prefix_frames, exc))
+                self._output_efd.notify()
 
         future.add_done_callback(_notify_response)
 
@@ -626,20 +664,33 @@ class MessageQueueServer:
                 identity, b_request_uid, b_request_type, *payloads = msg
                 request_type = msgspec_decode(b_request_type, cls=RequestType)
 
+                prefix_frames = [identity, b_request_uid, b_request_type]
                 if handler_entry := self.handlers.get(request_type):
                     try:
                         self._call_handler(
                             handler_entry=handler_entry,
                             payloads=payloads,
-                            prefix_frames=[identity, b_request_uid, b_request_type],
+                            prefix_frames=prefix_frames,
                         )
-                    except Exception:
+                    except Exception as exc:
                         logger.exception("Error handling request %s", request_type)
+                        self.socket.send_multipart(
+                            _remote_error_frames(prefix_frames, exc)
+                        )
                 else:
                     logger.error(
                         "No handler registered for request type %s", request_type
                     )
                     logger.error("Available handlers: %s", list(self.handlers.keys()))
+                    self.socket.send_multipart(
+                        _remote_error_frames(
+                            prefix_frames,
+                            LookupError(
+                                "No handler registered for request type "
+                                f"{request_type.name}"
+                            ),
+                        )
+                    )
 
             # Send the responses
             if outbound_state and outbound_state & zmq.POLLIN:

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -361,6 +361,73 @@ def test_mq_noop_multiple_clients():
     )
 
 
+def _raise_sync_handler_error() -> str:
+    raise RuntimeError("sync boom")
+
+
+def _raise_blocking_handler_error(key: IPCCacheServerKey, tp_size: int) -> None:
+    raise RuntimeError(f"blocking boom for {key.request_id}/{tp_size}")
+
+
+@pytest.mark.parametrize(
+    ("request_type", "handler", "payloads", "expected_message"),
+    [
+        (
+            RequestType.NOOP,
+            _raise_sync_handler_error,
+            [],
+            "Remote NOOP handler failed with RuntimeError: sync boom",
+        ),
+        (
+            RequestType.LOOKUP,
+            _raise_blocking_handler_error,
+            [create_cache_key(7), 2],
+            "Remote LOOKUP handler failed with RuntimeError: "
+            "blocking boom for test_request_7/2",
+        ),
+    ],
+)
+def test_mq_handler_error_reaches_client_future(
+    request_type, handler, payloads, expected_message
+):
+    context = zmq.Context.instance()
+    endpoint = f"inproc://handler-error-{request_type.name}-{time.monotonic_ns()}"
+    server = MessageQueueServer(endpoint, context)
+    add_handler_helper(server, request_type, handler)
+    if isinstance(server.handlers[request_type], BlockingRequestHandler):
+        server.add_normal_thread_pool([request_type], max_workers=1)
+    server.start()
+    client = MessageQueueClient(endpoint, context)
+    try:
+        future = client.submit_request(request_type, payloads)
+
+        with pytest.raises(RuntimeError, match=expected_message):
+            future.result(timeout=1)
+    finally:
+        client.close()
+        server.close()
+
+
+def test_mq_missing_handler_reaches_client_future():
+    context = zmq.Context.instance()
+    endpoint = f"inproc://missing-handler-{time.monotonic_ns()}"
+    server = MessageQueueServer(endpoint, context)
+    server.start()
+    client = MessageQueueClient(endpoint, context)
+    try:
+        future = client.submit_request(RequestType.NOOP, [])
+
+        with pytest.raises(
+            RuntimeError,
+            match="Remote NOOP handler failed with LookupError: "
+            "No handler registered for request type NOOP",
+        ):
+            future.result(timeout=1)
+    finally:
+        client.close()
+        server.close()
+
+
 @pytest.mark.cuda
 @pytest.mark.skipif(
     not (torch_dev.is_available() and torch_device_type == "cuda"),


### PR DESCRIPTION
## Summary

- add an exception terminal state to `MessagingFuture`
- return a versioned, bounded error frame when sync or blocking handlers fail
- return the same terminal error for unregistered request types
- keep full tracebacks server-side while sending only exception type and a message capped at 4096 characters

## Broken invariant

Every accepted MQ request must eventually complete its client future with either a response or an error. Previously, sync exceptions, blocking exceptions, and missing handlers were only logged by the server. The requester remained pending until its local timeout, obscuring the original failure and contributing to the silent registration/failure behavior described in #4759.

Healthy response frames are unchanged; the new marker is emitted only on failure.

## Test-first reproduction

Before the fix:

```text
test_messaging_future_propagates_exception: AttributeError: no set_exception
test_mq_handler_error_reaches_client_future[NOOP]: LMCacheTimeoutError
test_mq_handler_error_reaches_client_future[LOOKUP]: LMCacheTimeoutError
test_mq_missing_handler_reaches_client_future: LMCacheTimeoutError
```

## Validation

```text
uv run pytest -q tests/v1/multiprocess/test_mq.py tests/v1/multiprocess/test_futures.py
42 passed, 14 skipped, 134 warnings in 38.83s
```

Repository pre-commit hooks passed on all four changed files: SPDX, banned APIs, isort, ruff, ruff-format, codespell, and mypy.

A runtime benchmark is not applicable because this changes only MQ failure completion; successful request encoding and response frames are unchanged.

## Non-goals

- no remote traceback serialization
- no retry policy changes
- no transfer-mode capability negotiation in this PR
- no changes to healthy handler results

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `b2904fa65886900c41c33d9255a7e6982fde25f7` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_futures.py tests/v1/multiprocess/test_mq.py
```

```text
42 passed, 14 skipped, 134 warnings in 33.33s
```

The verbose raw pytest log contains 129 lines and has SHA-256 `1303f53b0f41f53e076a324a7eb595c183bf07d9dd07e4250132af8fa3dd8531`. Repository pre-commit hooks passed on both changed files at this exact head (SPDX, device/timeout rules, isort, ruff, ruff-format, codespell, and mypy; non-applicable Rust hooks skipped). The command above is the reviewer-runnable reproduction entry point. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->