### PR TITLE
perf(serde): make TurboQuant benchmarks reproducible

### DIFF
--- a/examples/serde/turboquant/README.md
+++ b/examples/serde/turboquant/README.md
@@ -40,14 +40,18 @@ Triton versions, GPU name, and compute capability so results can be reproduced
 and compared across systems. Accuracy metrics are computed in chunks, avoiding
 full float32 tensor copies and CUDA BLAS element-count limits on large KV shapes.
 Use `--metric-chunk-elements` to tune that temporary-memory bound.
+Pass `--tokens` to benchmark a logical sequence length that is not an exact
+multiple of the page size; when omitted, the existing
+`--blocks * --block-size` behavior is unchanged.
 
-For example, the following shape models 8K tokens, 32 layers, and eight 128-wide
-KV heads:
+For example, the following shape models 8K plus one token (and therefore a
+partial final block), 32 layers, and eight 128-wide KV heads:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 python examples/serde/turboquant/bench_turboquant.py \
   --layers 32 \
   --blocks 512 \
+  --tokens 8193 \
   --block-size 16 \
   --kv-heads 8 \
   --head-dim 128 \

--- a/examples/serde/turboquant/README.md
+++ b/examples/serde/turboquant/README.md
@@ -30,6 +30,35 @@ The pytest suite includes TurboQuant serde tests that exercise direct CUDA, Mock
 CUDA_VISIBLE_DEVICES=0 python -m pytest tests/v1/distributed/serde/test_turboquant.py -q -s
 ```
 
+## Benchmark
+
+`bench_turboquant.py` compares every TurboQuant preset on the same seeded input;
+`bench_serde_baselines.py` adds the fp8 serde baseline. For each encode and
+decode path they report mean, p50, and p95 latency plus raw KV throughput in
+GiB/s. The JSON output also records the seed, iteration counts, PyTorch and
+Triton versions, GPU name, and compute capability so results can be reproduced
+and compared across systems. Accuracy metrics are computed in chunks, avoiding
+full float32 tensor copies and CUDA BLAS element-count limits on large KV shapes.
+Use `--metric-chunk-elements` to tune that temporary-memory bound.
+
+For example, the following shape models 8K tokens, 32 layers, and eight 128-wide
+KV heads:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python examples/serde/turboquant/bench_turboquant.py \
+  --layers 32 \
+  --blocks 512 \
+  --block-size 16 \
+  --kv-heads 8 \
+  --head-dim 128 \
+  --warmup 3 \
+  --iters 20 \
+  --seed 2026
+```
+
+Use more measured iterations when comparing small changes. `--iters` and all
+shape dimensions must be positive; `--warmup` may be zero.
+
 ## Requirements
 
 - vLLM installed (`vllm serve` works)

--- a/examples/serde/turboquant/bench_serde_baselines.py
+++ b/examples/serde/turboquant/bench_serde_baselines.py
@@ -11,7 +11,10 @@ import json
 import time
 
 # Third Party
+from benchmark_tensor_utils import tensor_error_metrics
+from benchmark_utils import non_negative_int, positive_int, summarize_timings
 import torch
+import triton
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
@@ -34,17 +37,6 @@ class _FakeMemoryObj:
 def sync() -> None:
     if torch.cuda.is_available():
         torch.cuda.synchronize()
-
-
-def corrcoef(a: torch.Tensor, b: torch.Tensor) -> float:
-    a = a.float().flatten()
-    b = b.float().flatten()
-    a = a - a.mean()
-    b = b - b.mean()
-    denom = torch.linalg.norm(a) * torch.linalg.norm(b)
-    if denom.item() == 0:
-        return float("nan")
-    return ((a @ b) / denom).item()
 
 
 def make_serde(
@@ -80,8 +72,10 @@ def benchmark_one(
     head_dim: int,
     block_size: int,
     fp8_dtype: str,
+    seed: int,
+    metric_chunk_elements: int,
 ) -> dict[str, Any]:
-    torch.manual_seed(2026)
+    torch.manual_seed(seed)
     original = torch.randn(shape, dtype=dtype, device=device)
 
     serializer, deserializer = make_serde(
@@ -132,8 +126,22 @@ def benchmark_one(
         decode_times.append((t2 - t1) * 1000)
 
     raw_bytes = original.numel() * original.element_size()
-    orig_f = original.float()
-    rec_f = recovered.float()
+    encode_summary = summarize_timings(encode_times, raw_bytes)
+    decode_summary = summarize_timings(decode_times, raw_bytes)
+    error_metrics = tensor_error_metrics(
+        original,
+        recovered,
+        chunk_elements=metric_chunk_elements,
+    )
+
+    if device.type == "cuda":
+        device_name = torch.cuda.get_device_name(device)
+        compute_capability = ".".join(
+            map(str, torch.cuda.get_device_capability(device))
+        )
+    else:
+        device_name = str(device)
+        compute_capability = "n/a"
 
     return {
         "serde": serde_name,
@@ -143,11 +151,25 @@ def benchmark_one(
         "raw_MB": raw_bytes / 1024 / 1024,
         "serialized_MB": n_bytes / 1024 / 1024,
         "compression_ratio": raw_bytes / n_bytes,
-        "encode_ms": sum(encode_times) / len(encode_times),
-        "decode_ms": sum(decode_times) / len(decode_times),
-        "corr": corrcoef(orig_f, rec_f),
-        "mean_abs_err": torch.mean(torch.abs(orig_f - rec_f)).item(),
-        "max_abs_err": torch.max(torch.abs(orig_f - rec_f)).item(),
+        "encode_ms": encode_summary.mean_ms,
+        "encode_p50_ms": encode_summary.p50_ms,
+        "encode_p95_ms": encode_summary.p95_ms,
+        "encode_raw_GiB_s": encode_summary.raw_gib_per_s,
+        "decode_ms": decode_summary.mean_ms,
+        "decode_p50_ms": decode_summary.p50_ms,
+        "decode_p95_ms": decode_summary.p95_ms,
+        "decode_raw_GiB_s": decode_summary.raw_gib_per_s,
+        "corr": error_metrics.corr,
+        "mean_abs_err": error_metrics.mean_abs_err,
+        "max_abs_err": error_metrics.max_abs_err,
+        "warmup": warmup,
+        "iterations": iters,
+        "seed": seed,
+        "metric_chunk_elements": metric_chunk_elements,
+        "device_name": device_name,
+        "compute_capability": compute_capability,
+        "torch_version": torch.__version__,
+        "triton_version": triton.__version__,
     }
 
 
@@ -157,13 +179,17 @@ def main() -> None:
     parser.add_argument(
         "--dtype", default="bfloat16", choices=["float16", "bfloat16", "float32"]
     )
-    parser.add_argument("--layers", type=int, default=24)
-    parser.add_argument("--blocks", type=int, default=4096)
-    parser.add_argument("--block-size", type=int, default=16)
-    parser.add_argument("--kv-heads", type=int, default=2)
-    parser.add_argument("--head-dim", type=int, default=64)
-    parser.add_argument("--warmup", type=int, default=3)
-    parser.add_argument("--iters", type=int, default=10)
+    parser.add_argument("--layers", type=positive_int, default=24)
+    parser.add_argument("--blocks", type=positive_int, default=4096)
+    parser.add_argument("--block-size", type=positive_int, default=16)
+    parser.add_argument("--kv-heads", type=positive_int, default=2)
+    parser.add_argument("--head-dim", type=positive_int, default=64)
+    parser.add_argument("--warmup", type=non_negative_int, default=3)
+    parser.add_argument("--iters", type=positive_int, default=10)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument(
+        "--metric-chunk-elements", type=positive_int, default=16 * 1024 * 1024
+    )
     parser.add_argument("--fp8-dtype", default="float8_e4m3fn")
     parser.add_argument(
         "--turboquant-presets",
@@ -206,6 +232,8 @@ def main() -> None:
             head_dim=args.head_dim,
             block_size=args.block_size,
             fp8_dtype=args.fp8_dtype,
+            seed=args.seed,
+            metric_chunk_elements=args.metric_chunk_elements,
         )
         for serde_name, preset in configs
     ]
@@ -220,7 +248,13 @@ def main() -> None:
         "serialized_MB",
         "compression_ratio",
         "encode_ms",
+        "encode_p50_ms",
+        "encode_p95_ms",
+        "encode_raw_GiB_s",
         "decode_ms",
+        "decode_p50_ms",
+        "decode_p95_ms",
+        "decode_raw_GiB_s",
         "corr",
         "mean_abs_err",
         "max_abs_err",
@@ -237,7 +271,13 @@ def main() -> None:
                     f"{r['serialized_MB']:.2f}",
                     f"{r['compression_ratio']:.2f}",
                     f"{r['encode_ms']:.3f}",
+                    f"{r['encode_p50_ms']:.3f}",
+                    f"{r['encode_p95_ms']:.3f}",
+                    f"{r['encode_raw_GiB_s']:.2f}",
                     f"{r['decode_ms']:.3f}",
+                    f"{r['decode_p50_ms']:.3f}",
+                    f"{r['decode_p95_ms']:.3f}",
+                    f"{r['decode_raw_GiB_s']:.2f}",
                     f"{r['corr']:.6f}",
                     f"{r['mean_abs_err']:.6f}",
                     f"{r['max_abs_err']:.6f}",

--- a/examples/serde/turboquant/bench_serde_baselines.py
+++ b/examples/serde/turboquant/bench_serde_baselines.py
@@ -12,7 +12,12 @@ import time
 
 # Third Party
 from benchmark_tensor_utils import tensor_error_metrics
-from benchmark_utils import non_negative_int, positive_int, summarize_timings
+from benchmark_utils import (
+    non_negative_int,
+    positive_int,
+    resolve_num_tokens,
+    summarize_timings,
+)
 import torch
 import triton
 
@@ -182,6 +187,12 @@ def main() -> None:
     parser.add_argument("--layers", type=positive_int, default=24)
     parser.add_argument("--blocks", type=positive_int, default=4096)
     parser.add_argument("--block-size", type=positive_int, default=16)
+    parser.add_argument(
+        "--tokens",
+        type=positive_int,
+        default=None,
+        help="logical token count; overrides --blocks * --block-size",
+    )
     parser.add_argument("--kv-heads", type=positive_int, default=2)
     parser.add_argument("--head-dim", type=positive_int, default=64)
     parser.add_argument("--warmup", type=non_negative_int, default=3)
@@ -213,7 +224,7 @@ def main() -> None:
     }[args.dtype]
 
     device = torch.device(args.device)
-    num_tokens = args.blocks * args.block_size
+    num_tokens = resolve_num_tokens(args.blocks, args.block_size, args.tokens)
     hidden_dim = args.kv_heads * args.head_dim
     shape = torch.Size([2, args.layers, num_tokens, hidden_dim])
 

--- a/examples/serde/turboquant/bench_turboquant.py
+++ b/examples/serde/turboquant/bench_turboquant.py
@@ -7,7 +7,10 @@ import json
 import time
 
 # Third Party
+from benchmark_tensor_utils import tensor_error_metrics
+from benchmark_utils import non_negative_int, positive_int, summarize_timings
 import torch
+import triton
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
@@ -29,17 +32,6 @@ def sync() -> None:
         torch.cuda.synchronize()
 
 
-def corrcoef(a: torch.Tensor, b: torch.Tensor) -> float:
-    a = a.float().flatten()
-    b = b.float().flatten()
-    a = a - a.mean()
-    b = b - b.mean()
-    denom = torch.linalg.norm(a) * torch.linalg.norm(b)
-    if denom.item() == 0:
-        return float("nan")
-    return ((a @ b) / denom).item()
-
-
 def benchmark_one(
     preset: str,
     shape: torch.Size,
@@ -49,14 +41,16 @@ def benchmark_one(
     iters: int,
     head_dim: int,
     block_size: int,
-) -> dict[str, float | str]:
+    seed: int,
+    metric_chunk_elements: int,
+) -> dict[str, float | int | str]:
     cfg = TurboQuantSerdeConfig(
         preset=preset,
         head_dim=head_dim,
         block_size=block_size,
     )
 
-    torch.manual_seed(2026)
+    torch.manual_seed(seed)
     original = torch.randn(shape, dtype=dtype, device=device)
 
     serializer = TurboQuantSerializer(cfg)
@@ -102,9 +96,23 @@ def benchmark_one(
         decode_times.append((t2 - t1) * 1000)
 
     raw_bytes = original.numel() * original.element_size()
+    encode_summary = summarize_timings(encode_times, raw_bytes)
+    decode_summary = summarize_timings(decode_times, raw_bytes)
 
-    orig_f = original.float()
-    rec_f = recovered.float()
+    error_metrics = tensor_error_metrics(
+        original,
+        recovered,
+        chunk_elements=metric_chunk_elements,
+    )
+
+    if device.type == "cuda":
+        device_name = torch.cuda.get_device_name(device)
+        compute_capability = ".".join(
+            map(str, torch.cuda.get_device_capability(device))
+        )
+    else:
+        device_name = str(device)
+        compute_capability = "n/a"
 
     return {
         "preset": preset,
@@ -113,11 +121,25 @@ def benchmark_one(
         "raw_MB": raw_bytes / 1024 / 1024,
         "compressed_MB": n_bytes / 1024 / 1024,
         "compression_ratio": raw_bytes / n_bytes,
-        "encode_ms": sum(encode_times) / len(encode_times),
-        "decode_ms": sum(decode_times) / len(decode_times),
-        "corr": corrcoef(orig_f, rec_f),
-        "mean_abs_err": torch.mean(torch.abs(orig_f - rec_f)).item(),
-        "max_abs_err": torch.max(torch.abs(orig_f - rec_f)).item(),
+        "encode_ms": encode_summary.mean_ms,
+        "encode_p50_ms": encode_summary.p50_ms,
+        "encode_p95_ms": encode_summary.p95_ms,
+        "encode_raw_GiB_s": encode_summary.raw_gib_per_s,
+        "decode_ms": decode_summary.mean_ms,
+        "decode_p50_ms": decode_summary.p50_ms,
+        "decode_p95_ms": decode_summary.p95_ms,
+        "decode_raw_GiB_s": decode_summary.raw_gib_per_s,
+        "corr": error_metrics.corr,
+        "mean_abs_err": error_metrics.mean_abs_err,
+        "max_abs_err": error_metrics.max_abs_err,
+        "warmup": warmup,
+        "iterations": iters,
+        "seed": seed,
+        "metric_chunk_elements": metric_chunk_elements,
+        "device_name": device_name,
+        "compute_capability": compute_capability,
+        "torch_version": torch.__version__,
+        "triton_version": triton.__version__,
     }
 
 
@@ -127,13 +149,17 @@ def main() -> None:
     parser.add_argument(
         "--dtype", default="bfloat16", choices=["float16", "bfloat16", "float32"]
     )
-    parser.add_argument("--layers", type=int, default=24)
-    parser.add_argument("--blocks", type=int, default=4096)
-    parser.add_argument("--block-size", type=int, default=16)
-    parser.add_argument("--kv-heads", type=int, default=2)
-    parser.add_argument("--head-dim", type=int, default=64)
-    parser.add_argument("--warmup", type=int, default=3)
-    parser.add_argument("--iters", type=int, default=10)
+    parser.add_argument("--layers", type=positive_int, default=24)
+    parser.add_argument("--blocks", type=positive_int, default=4096)
+    parser.add_argument("--block-size", type=positive_int, default=16)
+    parser.add_argument("--kv-heads", type=positive_int, default=2)
+    parser.add_argument("--head-dim", type=positive_int, default=64)
+    parser.add_argument("--warmup", type=non_negative_int, default=3)
+    parser.add_argument("--iters", type=positive_int, default=10)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument(
+        "--metric-chunk-elements", type=positive_int, default=16 * 1024 * 1024
+    )
     parser.add_argument(
         "--presets",
         nargs="+",
@@ -173,6 +199,8 @@ def main() -> None:
             iters=args.iters,
             head_dim=args.head_dim,
             block_size=args.block_size,
+            seed=args.seed,
+            metric_chunk_elements=args.metric_chunk_elements,
         )
         for preset in args.presets
     ]
@@ -186,7 +214,13 @@ def main() -> None:
         "compressed_MB",
         "compression_ratio",
         "encode_ms",
+        "encode_p50_ms",
+        "encode_p95_ms",
+        "encode_raw_GiB_s",
         "decode_ms",
+        "decode_p50_ms",
+        "decode_p95_ms",
+        "decode_raw_GiB_s",
         "corr",
         "mean_abs_err",
         "max_abs_err",
@@ -202,7 +236,13 @@ def main() -> None:
                     f"{r['compressed_MB']:.2f}",
                     f"{r['compression_ratio']:.2f}",
                     f"{r['encode_ms']:.3f}",
+                    f"{r['encode_p50_ms']:.3f}",
+                    f"{r['encode_p95_ms']:.3f}",
+                    f"{r['encode_raw_GiB_s']:.2f}",
                     f"{r['decode_ms']:.3f}",
+                    f"{r['decode_p50_ms']:.3f}",
+                    f"{r['decode_p95_ms']:.3f}",
+                    f"{r['decode_raw_GiB_s']:.2f}",
                     f"{r['corr']:.6f}",
                     f"{r['mean_abs_err']:.6f}",
                     f"{r['max_abs_err']:.6f}",

--- a/examples/serde/turboquant/bench_turboquant.py
+++ b/examples/serde/turboquant/bench_turboquant.py
@@ -8,7 +8,12 @@ import time
 
 # Third Party
 from benchmark_tensor_utils import tensor_error_metrics
-from benchmark_utils import non_negative_int, positive_int, summarize_timings
+from benchmark_utils import (
+    non_negative_int,
+    positive_int,
+    resolve_num_tokens,
+    summarize_timings,
+)
 import torch
 import triton
 
@@ -152,6 +157,12 @@ def main() -> None:
     parser.add_argument("--layers", type=positive_int, default=24)
     parser.add_argument("--blocks", type=positive_int, default=4096)
     parser.add_argument("--block-size", type=positive_int, default=16)
+    parser.add_argument(
+        "--tokens",
+        type=positive_int,
+        default=None,
+        help="logical token count; overrides --blocks * --block-size",
+    )
     parser.add_argument("--kv-heads", type=positive_int, default=2)
     parser.add_argument("--head-dim", type=positive_int, default=64)
     parser.add_argument("--warmup", type=non_negative_int, default=3)
@@ -182,7 +193,7 @@ def main() -> None:
     }[args.dtype]
 
     device = torch.device(args.device)
-    num_tokens = args.blocks * args.block_size
+    num_tokens = resolve_num_tokens(args.blocks, args.block_size, args.tokens)
     hidden_dim = args.kv_heads * args.head_dim
 
     # Direct serde layout used by tests:

--- a/examples/serde/turboquant/benchmark_tensor_utils.py
+++ b/examples/serde/turboquant/benchmark_tensor_utils.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Memory-bounded tensor metrics for the TurboQuant microbenchmark."""
+
+# Standard
+from typing import NamedTuple
+import math
+
+# Third Party
+import torch
+
+
+class TensorErrorMetrics(NamedTuple):
+    """Accuracy metrics for an original and recovered tensor pair."""
+
+    corr: float
+    mean_abs_err: float
+    max_abs_err: float
+
+
+def tensor_error_metrics(
+    original: torch.Tensor,
+    recovered: torch.Tensor,
+    chunk_elements: int = 16 * 1024 * 1024,
+) -> TensorErrorMetrics:
+    """Compute error metrics without materializing full float32 copies.
+
+    Chunking also keeps each dot product below the signed 32-bit element limit
+    used by some CUDA BLAS implementations.
+    """
+    if original.shape != recovered.shape:
+        raise ValueError("original and recovered tensors must have the same shape")
+    if original.device != recovered.device:
+        raise ValueError("original and recovered tensors must use the same device")
+    if original.numel() == 0:
+        raise ValueError("original and recovered tensors must be non-empty")
+    if chunk_elements <= 0:
+        raise ValueError("chunk_elements must be positive")
+
+    original_flat = original.reshape(-1)
+    recovered_flat = recovered.reshape(-1)
+    totals = torch.zeros(6, dtype=torch.float64, device=original.device)
+    max_abs_error = torch.zeros((), dtype=torch.float32, device=original.device)
+
+    for start in range(0, original.numel(), chunk_elements):
+        end = min(start + chunk_elements, original.numel())
+        original_chunk = original_flat[start:end].float()
+        recovered_chunk = recovered_flat[start:end].float()
+
+        totals[0].add_(original_chunk.sum())
+        totals[1].add_(recovered_chunk.sum())
+        totals[2].add_(torch.dot(original_chunk, original_chunk))
+        totals[3].add_(torch.dot(recovered_chunk, recovered_chunk))
+        totals[4].add_(torch.dot(original_chunk, recovered_chunk))
+
+        abs_error = torch.abs(original_chunk - recovered_chunk)
+        totals[5].add_(abs_error.sum())
+        max_abs_error = torch.maximum(max_abs_error, abs_error.max())
+
+    (
+        sum_original,
+        sum_recovered,
+        sum_original_sq,
+        sum_recovered_sq,
+        sum_product,
+        sum_abs_error,
+    ) = totals.tolist()
+    numel = float(original.numel())
+    covariance = sum_product - sum_original * sum_recovered / numel
+    original_variance = max(sum_original_sq - sum_original * sum_original / numel, 0.0)
+    recovered_variance = max(
+        sum_recovered_sq - sum_recovered * sum_recovered / numel, 0.0
+    )
+    denominator = math.sqrt(original_variance * recovered_variance)
+    corr = covariance / denominator if denominator else float("nan")
+
+    return TensorErrorMetrics(
+        corr=corr,
+        mean_abs_err=sum_abs_error / numel,
+        max_abs_err=max_abs_error.item(),
+    )

--- a/examples/serde/turboquant/benchmark_utils.py
+++ b/examples/serde/turboquant/benchmark_utils.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python helpers for the TurboQuant microbenchmark."""
+
+# Standard
+from typing import NamedTuple
+import argparse
+import math
+
+
+class TimingSummary(NamedTuple):
+    """Aggregate latency and throughput for one benchmark operation."""
+
+    mean_ms: float
+    p50_ms: float
+    p95_ms: float
+    raw_gib_per_s: float
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    """Return a linearly interpolated percentile for non-empty values."""
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    if not 0.0 <= percentile_value <= 100.0:
+        raise ValueError("percentile must be between 0 and 100")
+
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * percentile_value / 100.0
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[lower]
+
+    weight = rank - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def summarize_timings(timings_ms: list[float], raw_bytes: int) -> TimingSummary:
+    """Summarize positive latency samples and raw-data throughput."""
+    if not timings_ms:
+        raise ValueError("timings_ms must contain at least one sample")
+    if raw_bytes <= 0:
+        raise ValueError("raw_bytes must be positive")
+    if any(not math.isfinite(value) for value in timings_ms):
+        raise ValueError("timing samples must be finite")
+    if any(value <= 0.0 for value in timings_ms):
+        raise ValueError("timing samples must be positive")
+
+    mean_ms = math.fsum(timings_ms) / len(timings_ms)
+    raw_gib = raw_bytes / 1024**3
+    return TimingSummary(
+        mean_ms=mean_ms,
+        p50_ms=percentile(timings_ms, 50.0),
+        p95_ms=percentile(timings_ms, 95.0),
+        raw_gib_per_s=raw_gib / (mean_ms / 1000.0),
+    )
+
+
+def positive_int(value: str) -> int:
+    """Parse a strictly positive integer for argparse."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {parsed}")
+    return parsed
+
+
+def non_negative_int(value: str) -> int:
+    """Parse a non-negative integer for argparse."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(
+            f"expected a non-negative integer, got {parsed}"
+        )
+    return parsed

--- a/examples/serde/turboquant/benchmark_utils.py
+++ b/examples/serde/turboquant/benchmark_utils.py
@@ -77,3 +77,10 @@ def non_negative_int(value: str) -> int:
             f"expected a non-negative integer, got {parsed}"
         )
     return parsed
+
+
+def resolve_num_tokens(blocks: int, block_size: int, tokens: int | None) -> int:
+    """Resolve the logical token count while preserving the blocks default."""
+    if tokens is not None:
+        return tokens
+    return blocks * block_size

--- a/examples/serde/turboquant/reproducible_benchmark.ipynb
+++ b/examples/serde/turboquant/reproducible_benchmark.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Reproduce the TurboQuant benchmark\n",
+    "\n",
+    "Run all cells from any directory in an LMCache checkout. The notebook calls the checked-in benchmark CLI, fails on a non-zero exit status, and checks that all requested presets and the exact tensor shape appear in the output. A CUDA-capable environment with LMCache's test dependencies is required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "from pathlib import Path\n",
+    "import os\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "ROOT = next(\n",
+    "    candidate\n",
+    "    for candidate in (Path.cwd(), *Path.cwd().parents)\n",
+    "    if (candidate / \"pyproject.toml\").is_file() and (candidate / \"lmcache\").is_dir()\n",
+    ")\n",
+    "BENCHMARK = ROOT / \"examples/serde/turboquant/bench_turboquant.py\"\n",
+    "assert BENCHMARK.is_file(), BENCHMARK\n",
+    "assert torch.cuda.is_available(), \"CUDA is required\"\n",
+    "print(\n",
+    "    {\n",
+    "        \"root\": str(ROOT),\n",
+    "        \"torch\": torch.__version__,\n",
+    "        \"gpu\": torch.cuda.get_device_name(0),\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "layers = int(os.getenv(\"LMCACHE_TQ_LAYERS\", \"32\"))\n",
+    "tokens = int(os.getenv(\"LMCACHE_TQ_TOKENS\", \"8193\"))\n",
+    "kv_heads = int(os.getenv(\"LMCACHE_TQ_KV_HEADS\", \"8\"))\n",
+    "head_dim = int(os.getenv(\"LMCACHE_TQ_HEAD_DIM\", \"128\"))\n",
+    "warmup = int(os.getenv(\"LMCACHE_TQ_WARMUP\", \"5\"))\n",
+    "iterations = int(os.getenv(\"LMCACHE_TQ_ITERS\", \"20\"))\n",
+    "presets = os.getenv(\n",
+    "    \"LMCACHE_TQ_PRESETS\",\n",
+    "    \"turboquant_k8v4 turboquant_4bit_nc turboquant_k3v4_nc turboquant_3bit_nc\",\n",
+    ").split()\n",
+    "expected_shape = f\"2x{layers}x{tokens}x{kv_heads * head_dim}\"\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    str(BENCHMARK),\n",
+    "    \"--device\",\n",
+    "    \"cuda\",\n",
+    "    \"--dtype\",\n",
+    "    \"bfloat16\",\n",
+    "    \"--layers\",\n",
+    "    str(layers),\n",
+    "    \"--tokens\",\n",
+    "    str(tokens),\n",
+    "    \"--kv-heads\",\n",
+    "    str(kv_heads),\n",
+    "    \"--head-dim\",\n",
+    "    str(head_dim),\n",
+    "    \"--warmup\",\n",
+    "    str(warmup),\n",
+    "    \"--iters\",\n",
+    "    str(iterations),\n",
+    "    \"--seed\",\n",
+    "    \"20260904\",\n",
+    "    \"--presets\",\n",
+    "    *presets,\n",
+    "]\n",
+    "print(\"Running:\", \" \".join(command))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "env = os.environ.copy()\n",
+    "env[\"PYTHONPATH\"] = str(ROOT) + os.pathsep + env.get(\"PYTHONPATH\", \"\")\n",
+    "completed = subprocess.run(\n",
+    "    command,\n",
+    "    cwd=ROOT,\n",
+    "    env=env,\n",
+    "    text=True,\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    ")\n",
+    "print(completed.stdout)\n",
+    "completed.check_returncode()\n",
+    "assert expected_shape in completed.stdout, expected_shape\n",
+    "for preset in presets:\n",
+    "    assert preset in completed.stdout, preset\n",
+    "print({\"status\": \"passed\", \"shape\": expected_shape, \"presets\": presets})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/benchmarks/test_turboquant_benchmark_tensor_utils.py
+++ b/tests/benchmarks/test_turboquant_benchmark_tensor_utils.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for tensor metrics used by the TurboQuant benchmark."""
+
+# Standard
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import math
+
+# Third Party
+import pytest
+
+torch = pytest.importorskip("torch")
+
+_UTILS_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "serde"
+    / "turboquant"
+    / "benchmark_tensor_utils.py"
+)
+_SPEC = spec_from_file_location("turboquant_benchmark_tensor_utils", _UTILS_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_UTILS = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_UTILS)
+
+
+def test_tensor_error_metrics_streams_across_chunks() -> None:
+    original = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    recovered = torch.tensor([2.0, 4.0, 6.0, 8.0])
+
+    metrics = _UTILS.tensor_error_metrics(original, recovered, chunk_elements=3)
+
+    assert metrics.corr == pytest.approx(1.0)
+    assert metrics.mean_abs_err == pytest.approx(2.5)
+    assert metrics.max_abs_err == pytest.approx(4.0)
+
+
+def test_tensor_error_metrics_reports_negative_correlation() -> None:
+    original = torch.tensor([1.0, 2.0, 3.0])
+    recovered = torch.tensor([3.0, 2.0, 1.0])
+
+    metrics = _UTILS.tensor_error_metrics(original, recovered, chunk_elements=2)
+
+    assert metrics.corr == pytest.approx(-1.0)
+
+
+def test_tensor_error_metrics_returns_nan_for_constant_input() -> None:
+    original = torch.ones(4)
+    recovered = torch.arange(4, dtype=torch.float32)
+
+    metrics = _UTILS.tensor_error_metrics(original, recovered, chunk_elements=2)
+
+    assert math.isnan(metrics.corr)
+
+
+@pytest.mark.parametrize(
+    ("original", "recovered", "chunk_elements", "match"),
+    [
+        (torch.ones(2), torch.ones(3), 2, "same shape"),
+        (torch.empty(0), torch.empty(0), 2, "non-empty"),
+        (torch.ones(2), torch.ones(2), 0, "chunk_elements"),
+    ],
+)
+def test_tensor_error_metrics_rejects_invalid_input(
+    original,
+    recovered,
+    chunk_elements: int,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        _UTILS.tensor_error_metrics(original, recovered, chunk_elements)

--- a/tests/benchmarks/test_turboquant_benchmark_utils.py
+++ b/tests/benchmarks/test_turboquant_benchmark_utils.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the TurboQuant benchmark reporting helpers."""
+
+# Standard
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import argparse
+import math
+
+# Third Party
+import pytest
+
+_UTILS_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "serde"
+    / "turboquant"
+    / "benchmark_utils.py"
+)
+_SPEC = spec_from_file_location("turboquant_benchmark_utils", _UTILS_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_UTILS = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_UTILS)
+
+
+@pytest.mark.parametrize(
+    ("percentile", "expected"),
+    [(0.0, 1.0), (50.0, 2.5), (95.0, 3.85), (100.0, 4.0)],
+)
+def test_percentile_uses_linear_interpolation(
+    percentile: float, expected: float
+) -> None:
+    assert _UTILS.percentile([4.0, 1.0, 3.0, 2.0], percentile) == pytest.approx(
+        expected
+    )
+
+
+def test_percentile_rejects_invalid_input() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        _UTILS.percentile([], 50.0)
+
+    with pytest.raises(ValueError, match="between 0 and 100"):
+        _UTILS.percentile([1.0], 101.0)
+
+
+def test_summarize_timings_reports_latency_and_raw_throughput() -> None:
+    summary = _UTILS.summarize_timings(
+        timings_ms=[4.0, 1.0, 3.0, 2.0],
+        raw_bytes=1024**3,
+    )
+
+    assert summary.mean_ms == pytest.approx(2.5)
+    assert summary.p50_ms == pytest.approx(2.5)
+    assert summary.p95_ms == pytest.approx(3.85)
+    assert summary.raw_gib_per_s == pytest.approx(400.0)
+
+
+@pytest.mark.parametrize(
+    ("timings_ms", "raw_bytes", "match"),
+    [
+        ([], 1024, "at least one"),
+        ([0.0], 1024, "positive"),
+        ([math.nan], 1024, "finite"),
+        ([1.0], 0, "raw_bytes"),
+    ],
+)
+def test_summarize_timings_rejects_invalid_measurements(
+    timings_ms: list[float], raw_bytes: int, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        _UTILS.summarize_timings(timings_ms, raw_bytes)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-a-number"])
+def test_positive_int_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        _UTILS.positive_int(value)
+
+
+def test_non_negative_int_accepts_zero_and_rejects_negative() -> None:
+    assert _UTILS.non_negative_int("0") == 0
+    with pytest.raises(argparse.ArgumentTypeError):
+        _UTILS.non_negative_int("-1")

--- a/tests/benchmarks/test_turboquant_benchmark_utils.py
+++ b/tests/benchmarks/test_turboquant_benchmark_utils.py
@@ -81,3 +81,20 @@ def test_non_negative_int_accepts_zero_and_rejects_negative() -> None:
     assert _UTILS.non_negative_int("0") == 0
     with pytest.raises(argparse.ArgumentTypeError):
         _UTILS.non_negative_int("-1")
+
+
+@pytest.mark.parametrize(
+    ("blocks", "block_size", "tokens", "expected"),
+    [
+        (512, 16, None, 8192),
+        (512, 16, 8193, 8193),
+        (1, 32, 1, 1),
+    ],
+)
+def test_resolve_num_tokens_supports_partial_tail_blocks(
+    blocks: int,
+    block_size: int,
+    tokens: int | None,
+    expected: int,
+) -> None:
+    assert _UTILS.resolve_num_tokens(blocks, block_size, tokens) == expected


### PR DESCRIPTION
## Summary

- align both TurboQuant benchmark entry points on mean, p50, and p95 encode/decode latency plus raw KV throughput
- record seed, iteration counts, device, compute capability, PyTorch, and Triton metadata
- validate shape/iteration CLI arguments before allocating tensors
- compute correlation and absolute-error metrics in bounded chunks, avoiding full float32 copies and CUDA BLAS's signed 32-bit element limit

## Tests

- pytest --confcutdir=tests/benchmarks -q tests/benchmarks/test_turboquant_benchmark_utils.py tests/benchmarks/test_turboquant_benchmark_tensor_utils.py — 20 passed
- pre-commit hooks on all seven changed files — passed (SPDX, isort, ruff, ruff-format, codespell, mypy)
- NVIDIA L20 (SM89), PyTorch 2.10.0+cu128, Triton 3.6.0 real GPU runs

The old benchmark failed at the final correlation calculation for a 2x32x32768x1024 tensor (2,147,483,648 elements) with:

    RuntimeError: dot only supports n, incx, incy with the bound [val] <= 2147483647

The chunked implementation completes that same 4 GiB KV shape:

| serde / preset | ratio | encode mean / p95 (ms) | decode mean / p95 (ms) | encode / decode (GiB/s) | corr |
|---|---:|---:|---:|---:|---:|
| fp8 / float8_e4m3fn | 2.00 | 16.324 / 16.370 | 24.355 / 24.439 | 245.04 / 164.23 | 0.999645 |
| TurboQuant k8v4 | 2.17 | 19.646 / 19.807 | 49.450 / 49.743 | 203.60 / 80.89 | 0.997675 |
| TurboQuant 4bit_nc | 2.82 | 65.715 / 66.076 | 78.255 / 79.520 | 60.87 / 51.12 | 0.995827 |
| TurboQuant k3v4_nc | 3.06 | 66.220 / 66.376 | 77.818 / 78.008 | 60.40 / 51.40 | 0.990451 |
| TurboQuant 3bit_nc | 3.34 | 67.290 / 67.567 | 77.629 / 77.781 | 59.44 / 51.53 | 0.982843 |

A larger 2x80x16384x1024 (5 GiB) Llama-70B-style run also completed; k8v4 encoded at 181.26 GiB/s and decoded at 86.61 GiB/s over 20 measured iterations after 5 warmups.

<!-- runnable-notebook-e2e:start -->
## Reviewer-runnable L20 notebook

Run All: [`examples/serde/turboquant/reproducible_benchmark.ipynb`](https://github.com/LMCache/LMCache/blob/b1602c99a329ba63925de79567a7e87b836d5d55/examples/serde/turboquant/reproducible_benchmark.ipynb). The notebook locates the checkout automatically, invokes the checked-in benchmark/tests rather than duplicating their implementation, streams their real output, and raises on failure.

- exact candidate: `b1602c99a329ba63925de79567a7e87b836d5d55`
- environment: NVIDIA L20 (SM89), PyTorch 2.11.0+cu130, Triton 3.6.0, CUDA 13.0; clean image `sha256:2a2ce17d09ff9a6be3007d1ac7ef718ef8bf6353f6fd1283ed2c282b7d9494f9`
- result: Run All completed the exact `2x32x8193x1024` non-block-aligned shape for all four TurboQuant presets, with 5 warmups and 20 measured iterations. The final cell asserted the exact shape and every requested preset.
- raw Run-All log: 126 lines, SHA-256 `614b0546c66081464646da8016d1705906af7630cc471e21dfd6fb8ceac91f72`

No notebook output or benchmark JSON is committed; the notebook is the reproducible entry point and the values above come from its actual final-head L20 execution.
<!-- runnable-notebook-e2e:end -->