### PR TITLE
[Bugfix][Test] Rebase the partial slot mapping in the SGLang layerwise load path

### DIFF
--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1755,7 +1755,13 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
         :param ends: The ending indices of the KV cache in the corresponding
             token sequence.
 
-        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        :param kwargs: Must contain 'slot_mapping' and 'sync'. May contain
+            'offset', the number of leading tokens of the request that are
+            absent from 'slot_mapping'; ``starts``/``ends`` are absolute token
+            indices, so the slot of token ``i`` is ``slot_mapping[i - offset]``.
+
+        :raises ValueError: If 'slot_mapping' or 'sync' is not provided in
+            kwargs, or if a chunk starts before 'offset'.
         """
 
         self.initialize_kvcaches_ptr(**kwargs)
@@ -1770,12 +1776,24 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
             raise ValueError("'sync' should be provided in kwargs.")
 
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
+        # The SGLang load path hands us a partial slot mapping: its element 0
+        # is token `token_offset`, not token 0 (LMCacheConnector.load_kv
+        # enforces len(token_ids) - offset == len(slot_mapping)).
+        token_offset: int = kwargs.get("offset", 0)
 
         self._lazy_initialize_buffer(self.kvcaches)
 
+        if starts and starts[0] < token_offset:
+            raise ValueError(
+                f"chunk start ({starts[0]}) must not precede the SGLang "
+                f"slot-map offset ({token_offset})"
+            )
+
         slot_mapping_chunks = []
         for start, end in zip(starts, ends, strict=False):
-            slot_mapping_chunks.append(slot_mapping[start:end])
+            slot_mapping_chunks.append(
+                slot_mapping[start - token_offset : end - token_offset]
+            )
 
         slot_mapping_full = torch.cat(slot_mapping_chunks, dim=0)
 
@@ -1795,7 +1813,9 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
             )
             assert tmp_gpu_buffer_obj.tensor is not None
 
-        offset = starts[0]
+        # Base for indexing into the staging buffer, which is packed per
+        # request. Distinct from `token_offset`, which rebases the slot map.
+        buffer_base = starts[0]
 
         for layer_id in range(self.num_layers):
             memory_objs_layer = yield
@@ -1808,15 +1828,15 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
             ):
                 assert memory_obj.metadata.fmt == MemoryFormat.KV_T2D
                 if self.use_gpu:
-                    tmp_gpu_buffer_obj.tensor[start - offset : end - offset].copy_(
-                        memory_obj.tensor, non_blocking=True
-                    )
+                    tmp_gpu_buffer_obj.tensor[
+                        start - buffer_base : end - buffer_base
+                    ].copy_(memory_obj.tensor, non_blocking=True)
                 else:
                     device_ops.single_layer_kv_transfer_sgl(
                         memory_obj.tensor,
                         self.kvcaches[0][layer_id],
                         self.kvcaches[1][layer_id],
-                        slot_mapping[start:end],
+                        slot_mapping[start - token_offset : end - token_offset],
                         lmcache_native.TransferDirection.H2D,
                         token_major=True,
                     )

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -13,6 +13,7 @@ import torch
 from lmcache import torch_dev, torch_device_type
 from lmcache.v1.gpu_connector.gpu_connectors import (
     SGLangGPUConnector,
+    SGLangLayerwiseGPUConnector,
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemGPUConnectorV3,
@@ -925,3 +926,175 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
         engine_kv_formats=[engine_kv_format] * len(kv_list),
     )
     return metadata
+
+
+# NOTE: only the staging-buffer path (use_gpu=True) is covered. The direct
+# path (use_gpu=False) cannot round-trip today: batched_from_gpu passes a 3-D
+# per-layer tensor to single_layer_kv_transfer_sgl, which indexes dim 3, so it
+# raises IndexError even with offset=0 and a full-length mapping. That defect
+# is independent of the slot-mapping rebase fixed here.
+@pytest.mark.parametrize("use_gpu", [True])
+def test_sglang_layerwise_connector_partial_slot_mapping(use_gpu):
+    """Load rebases a partial slot map; store indexes a full one absolutely.
+
+    The two SGLang paths carry different slot-mapping contracts, both enforced
+    by ``LMCacheConnector``:
+
+    - load (``load_kv``) requires ``len(token_ids) - offset ==
+      len(slot_mapping)``, i.e. a *partial* map whose element 0 is the slot of
+      token ``offset``. ``starts``/``ends`` stay absolute, so ``batched_to_gpu``
+      must look up token ``i`` at ``slot_mapping[i - offset]``.
+    - store (``store_kv``) requires ``len(token_ids) == len(slot_mapping)``,
+      i.e. a *full-length* map that ``batched_from_gpu`` indexes absolutely.
+
+    A round trip through both, with a nonzero offset, pins each contract: the
+    tokens gathered from ``src`` must land on exactly the destination slots the
+    partial map names.
+    """
+    num_blocks = 100
+    block_size = 16
+    num_layers = 4
+    num_heads = 8
+    head_size = 128
+    device = torch_device_type
+    dtype = torch.bfloat16
+    hidden_dim = num_heads * head_size
+
+    offset = 300
+    num_tokens = 512
+    chunk_size = 256
+
+    allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+
+    gpu_kv_src = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        use_mla=False,
+        device=device,
+        dtype=dtype,
+    )
+    gpu_kv_dst = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        use_mla=False,
+        device=device,
+        dtype=dtype,
+    )
+
+    # The store path sees the whole request; the load path sees only the tail
+    # beginning at `offset`, which is exactly `full_slot_mapping[offset:]`.
+    all_slots = random.sample(range(0, num_blocks * block_size), offset + num_tokens)
+    full_slot_mapping = torch.tensor(all_slots, device=device, dtype=torch.int64)
+    partial_slot_mapping = full_slot_mapping[offset:].clone()
+
+    starts = list(range(offset, offset + num_tokens, chunk_size))
+    ends = [min(start + chunk_size, offset + num_tokens) for start in starts]
+
+    with pytest.raises(AssertionError):
+        check_sglang_paged_kv_cache_equal(
+            gpu_kv_src, gpu_kv_dst, partial_slot_mapping, num_heads, head_size
+        )
+
+    connector = SGLangLayerwiseGPUConnector(
+        hidden_dim,
+        num_layers,
+        use_gpu=use_gpu,
+        chunk_size=chunk_size,
+        dtype=dtype,
+        device=device,
+    )
+
+    memory_objs = []
+    for _ in range(num_layers):
+        layer_objs = []
+        for start, end in zip(starts, ends, strict=False):
+            memory_obj = allocator.allocate(
+                connector.get_shape(end - start), dtype, MemoryFormat.KV_T2D
+            )
+            assert memory_obj is not None
+            layer_objs.append(memory_obj)
+        memory_objs.append(layer_objs)
+
+    gather = connector.batched_from_gpu(
+        memory_objs,
+        starts,
+        ends,
+        kvcaches=gpu_kv_src,
+        slot_mapping=full_slot_mapping,
+        sync=True,
+    )
+    for _ in range(num_layers + 1):
+        next(gather)
+    with pytest.raises(StopIteration):
+        next(gather)
+
+    scatter = connector.batched_to_gpu(
+        starts,
+        ends,
+        kvcaches=gpu_kv_dst,
+        slot_mapping=partial_slot_mapping,
+        offset=offset,
+        sync=True,
+    )
+    next(scatter)
+    for layer_objs in memory_objs:
+        scatter.send(layer_objs)
+    with pytest.raises(StopIteration):
+        next(scatter)
+
+    torch.cuda.synchronize()
+
+    check_sglang_paged_kv_cache_equal(
+        gpu_kv_src, gpu_kv_dst, partial_slot_mapping, num_heads, head_size
+    )
+
+    for layer_objs in memory_objs:
+        for memory_obj in layer_objs:
+            allocator.free(memory_obj)
+    assert allocator.memcheck()
+
+    allocator.close()
+
+
+def test_sglang_layerwise_connector_rejects_start_before_offset():
+    """A chunk starting before ``offset`` cannot be addressed in the map."""
+    num_layers = 2
+    num_heads = 8
+    head_size = 128
+
+    connector = SGLangLayerwiseGPUConnector(
+        num_heads * head_size,
+        num_layers,
+        use_gpu=False,
+        chunk_size=256,
+        dtype=torch.bfloat16,
+        device=torch_device_type,
+    )
+    kvcaches = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=8,
+        block_size=16,
+        num_heads=num_heads,
+        head_size=head_size,
+        use_mla=False,
+        device=torch_device_type,
+        dtype=torch.bfloat16,
+    )
+    slot_mapping = torch.arange(16, device=torch_device_type, dtype=torch.int64)
+
+    scatter = connector.batched_to_gpu(
+        [0],
+        [16],
+        kvcaches=kvcaches,
+        slot_mapping=slot_mapping,
+        offset=8,
+        sync=True,
+    )
+    with pytest.raises(ValueError, match="must not precede"):
+        next(scatter)


### PR DESCRIPTION
Fixes #4921

**What this PR does / why we need it**:

`SGLangLayerwiseGPUConnector.batched_to_gpu` never read the `offset` kwarg and
sliced the slot mapping with absolute token indices. On the SGLang load path the
mapping is partial — `LMCacheConnector.load_kv` enforces
`len(token_ids) - offset == len(slot_mapping)`, so element 0 is the slot of
token `offset`. Every retrieved token was therefore written to the slot of a
token `offset` positions later: silent KV corruption on any request with a warm
device radix-cache prefix. Only `offset == 0` was correct.

The store path is the opposite contract — `store_kv` enforces
`len(token_ids) == len(slot_mapping)` (full length) — so `batched_from_gpu` is
correct as it stands and is deliberately left alone.

Changes:

- Read `offset` from kwargs as `token_offset` and rebase both slot-mapping
  slices (the chunk list feeding `slot_mapping_full`, and the direct
  `single_layer_kv_transfer_sgl` call).
- Rename the pre-existing local `offset = starts[0]` to `buffer_base`. It
  indexes the staging buffer, not the slot map; the name collision with the
  kwarg is the most likely reason the bug was introduced, so the rename is part
  of the fix rather than incidental cleanup.
- Raise `ValueError` when a chunk starts before `offset` (that token is not
  addressable in the mapping), mirroring `_slot_slice` in the MUSA connector.
- Document the mapping contract on `batched_to_gpu`.

**Special notes for your reviewers**:

- **Verified on hardware.** `dev` @ `913016b`, NVIDIA L4 (driver 580.173.02,
  CUDA 12.9, torch 2.9.1+cu129, Ubuntu 22.04), source build:
  - new test on unpatched `dev` → **fails**:
    `RuntimeError: The size of tensor a (212) must match the size of tensor b (256)`
    at `gpu_connectors.py:1811`
  - with the rebase → **passes**
  - full `tests/v1/test_gpu_connector.py` with the fix → **34 passed, 1 skipped, 0 failed**
- The 212 is the bug in one number: the partial mapping holds 512 entries, and
  slicing it at absolute `[300:556]` yields 212 elements instead of 256. In
  production the mapping has more slack (`start_load_kv` passes
  `slot_mapping[:retrieve_token_num]`), so the shifted slices stay in bounds and
  corrupt silently rather than raising.
- `SGLangGPUConnector.to_gpu` (non-layerwise, same file) and
  `SGLangLayerwiseMUSAConnector` via `_slot_slice` already rebase; this brings
  the CUDA layerwise path in line with both.
- **The test covers `use_gpu=True` only.** While verifying I found the
  `use_gpu=False` path cannot round-trip at all, independently of this change:
  `batched_from_gpu`'s direct branch hands the 3-D per-layer tensor to
  `single_layer_kv_transfer_sgl`, which indexes dim 3 (the buffered branch
  passes `.view(t, 1, h, d)`). Reproduced with `offset=0` and a full-length
  mapping — `IndexError: Dimension out of range ... but got 3` at
  `gpu_connectors.py:1960`. Out of scope here; happy to file it separately.
- **`SGLangLayerwiseXPUConnector` has the identical offset defect**
  (`xpu_connectors.py`, layerwise `batched_to_gpu`). Left out to keep this PR to
  one device path, and I have no XPU hardware to verify on. Happy to fold it in.
- Root-cause note on coverage: every `offset` in `tests/v1/test_gpu_connector.py`
  was `offset=0`, and `tests/v1/test_xpu_sglang_connector.py` never mentions
  `offset`. MUSA was the only platform testing a nonzero offset, and the only
  one that was correct. This closes that gap for CUDA.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
