### PR TITLE
test(serde): wait for observable TurboQuant stores

### DIFF
--- a/examples/serde/turboquant/storage_manager_roundtrip.ipynb
+++ b/examples/serde/turboquant/storage_manager_roundtrip.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Reproduce TurboQuant StorageManager round trips\n",
+    "\n",
+    "Run all cells from any directory in an LMCache checkout. This invokes the checked-in Mock-L2 and FS-L2 round-trip tests for all four TurboQuant presets and fails if CUDA tests are skipped or any case fails."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "from pathlib import Path\n",
+    "import os\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "ROOT = next(\n",
+    "    candidate\n",
+    "    for candidate in (Path.cwd(), *Path.cwd().parents)\n",
+    "    if (candidate / \"pyproject.toml\").is_file() and (candidate / \"lmcache\").is_dir()\n",
+    ")\n",
+    "TEST_FILE = ROOT / \"tests/v1/distributed/serde/test_turboquant.py\"\n",
+    "assert TEST_FILE.is_file(), TEST_FILE\n",
+    "assert torch.cuda.is_available(), \"CUDA is required\"\n",
+    "print(\n",
+    "    {\n",
+    "        \"root\": str(ROOT),\n",
+    "        \"torch\": torch.__version__,\n",
+    "        \"gpu\": torch.cuda.get_device_name(0),\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "selection = (\n",
+    "    \"test_turboquant_storage_manager_roundtrip \"\n",
+    "    \"or test_turboquant_fs_storage_manager_roundtrip\"\n",
+    ")\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    \"-m\",\n",
+    "    \"pytest\",\n",
+    "    \"-q\",\n",
+    "    \"-s\",\n",
+    "    str(TEST_FILE),\n",
+    "    \"-k\",\n",
+    "    selection,\n",
+    "]\n",
+    "env = os.environ.copy()\n",
+    "env[\"PYTHONPATH\"] = str(ROOT) + os.pathsep + env.get(\"PYTHONPATH\", \"\")\n",
+    "print(\"Running:\", \" \".join(command))\n",
+    "completed = subprocess.run(\n",
+    "    command,\n",
+    "    cwd=ROOT,\n",
+    "    env=env,\n",
+    "    text=True,\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    ")\n",
+    "print(completed.stdout)\n",
+    "completed.check_returncode()\n",
+    "assert \"8 passed\" in completed.stdout, \"expected all 8 CUDA round-trip cases to run\"\n",
+    "print({\"status\": \"passed\", \"cuda_roundtrips\": 8})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/v1/distributed/serde/test_turboquant.py
+++ b/tests/v1/distributed/serde/test_turboquant.py
@@ -231,6 +231,51 @@ def _wait_for_prefetch_status(
     return None
 
 
+def _mock_l2_store_is_complete(
+    sm: StorageManager,
+    expected_object_count: int,
+) -> bool:
+    """Return whether the mock L2 store is observable and fully settled."""
+    status = sm.report_status()
+    store = status["store_controller"]
+    l1 = status["l1_manager"]
+    adapter = status["l2_adapters"][0]
+    return (
+        adapter["stored_object_count"] >= expected_object_count
+        and store["in_flight_task_count"] == 0
+        and store["pending_keys_count"] == 0
+        and l1["write_locked_count"] == 0
+        and l1["read_locked_count"] == 0
+        and l1["temporary_count"] == 0
+    )
+
+
+def _fs_l2_store_is_complete(
+    sm: StorageManager,
+    base_path: str,
+    expected_object_count: int,
+) -> bool:
+    """Return whether final FS objects exist and the store is fully settled."""
+    root = Path(base_path)
+    tmp_root = root / "tmp"
+    stored_object_count = sum(
+        1
+        for path in root.rglob("*")
+        if path.is_file() and not path.is_relative_to(tmp_root)
+    )
+    status = sm.report_status()
+    store = status["store_controller"]
+    l1 = status["l1_manager"]
+    return (
+        stored_object_count >= expected_object_count
+        and store["in_flight_task_count"] == 0
+        and store["pending_keys_count"] == 0
+        and l1["write_locked_count"] == 0
+        and l1["read_locked_count"] == 0
+        and l1["temporary_count"] == 0
+    )
+
+
 def _finish_read_prefetched_until_clean(
     sm: StorageManager,
     keys: list[ObjectKey],
@@ -339,16 +384,11 @@ def test_turboquant_storage_manager_roundtrip(
 
         sm.finish_write(list(ret.keys()))
 
-        # Wait until both the store controller and the serde wrapper cleanup
-        # have released temporary objects and locks.
+        # The controller pops pending keys before it creates the L2 task, so
+        # its pending/in-flight counters can both briefly read zero. First
+        # require the backend-visible object count, then confirm cleanup.
         ok = _wait_for_condition(
-            lambda: (
-                sm.report_status()["store_controller"]["in_flight_task_count"] == 0
-                and sm.report_status()["store_controller"]["pending_keys_count"] == 0
-                and sm.report_status()["l1_manager"]["write_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["read_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["temporary_count"] == 0
-            ),
+            lambda: _mock_l2_store_is_complete(sm, len(keys)),
             timeout=120.0,
         )
         assert ok, "Store to L2 did not fully complete"
@@ -576,14 +616,10 @@ def test_turboquant_fs_storage_manager_roundtrip(
 
         sm.finish_write(list(ret.keys()))
 
+        # Final files prove that the asynchronous store ran. Queue counters
+        # alone have a zero/zero transition window before task submission.
         ok = _wait_for_condition(
-            lambda: (
-                sm.report_status()["store_controller"]["in_flight_task_count"] == 0
-                and sm.report_status()["store_controller"]["pending_keys_count"] == 0
-                and sm.report_status()["l1_manager"]["write_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["read_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["temporary_count"] == 0
-            ),
+            lambda: _fs_l2_store_is_complete(sm, base_dir, len(keys)),
             timeout=120.0,
         )
         assert ok, "Store to FS L2 did not fully complete"


### PR DESCRIPTION
## Summary

- make the TurboQuant StorageManager round-trip tests wait for backend-visible stores
- only treat a store as complete after the controller and L1 cleanup have also settled
- cover both MockL2Adapter object counts and final FSL2Adapter files

## Why

Buildkite build 8657 for #4912 failed `test_turboquant_fs_storage_manager_roundtrip[turboquant_k3v4_nc-0.85]` because the test observed zero stored files. The store controller removes pending keys before it increments the in-flight count, leaving a short zero/zero transition where the old predicate could return before any object reached L2. This is unrelated to #4912 itself.

The new predicates anchor completion on an observable L2 result first, then require the queue and L1 lock/temporary counters to drain. This follows the same pattern already used by the serde end-to-end tests.

## Tests

- `SKIP=rust-fmt,rust-clippy uvx pre-commit run --files tests/v1/distributed/serde/test_turboquant.py` — all hooks passed
- L20 / CUDA, Python 3.10: patched Mock-L2 + FS-L2 matrix, all four TurboQuant presets — **8 passed in 19.20s**
- unpatched L20 reproduction, FS-L2 all four presets ×20 — **75 passed, 5 failed** in 23m39s
- unpatched L20 reproduction, FS-L2 `turboquant_k3v4_nc` ×50 — **49 passed, 1 failed** in 22m57s
- patched L20 validation, FS-L2 all four presets ×20 — **80 passed** in 1m58s
- patched L20 validation, FS-L2 `turboquant_k3v4_nc` ×50 — **50 passed** in 1m12s

The failures in both unpatched stress runs are the premature completion symptom fixed here. These are correctness stress results, not throughput benchmarks.

## Non-goals

This does not change StorageManager runtime behavior or TurboQuant serialization.

<!-- runnable-notebook-e2e:start -->
## Reviewer-runnable L20 notebook

Run All: [`examples/serde/turboquant/storage_manager_roundtrip.ipynb`](https://github.com/LMCache/LMCache/blob/2a43ac20bd42070da71591e47ed132090d4a221f/examples/serde/turboquant/storage_manager_roundtrip.ipynb). The notebook locates the checkout automatically, invokes the checked-in benchmark/tests rather than duplicating their implementation, streams their real output, and raises on failure.

- exact candidate: `2a43ac20bd42070da71591e47ed132090d4a221f`
- environment: NVIDIA L20 (SM89), PyTorch 2.5.1+cu121, Triton 3.1.0
- result: Run All executed the checked-in Mock-L2 and FS-L2 StorageManager round trips for every TurboQuant preset: `8 passed, 14 deselected, 109 warnings in 14.45s`. The notebook fails if CUDA cases are skipped.
- raw Run-All log: 1,060 lines, SHA-256 `2b7f6de91cac9c8422e65d5174727a0649303b0e8c99765a16ac6eb37047bba9`

No notebook output or benchmark JSON is committed; the notebook is the reproducible entry point and the values above come from its actual final-head L20 execution.
<!-- runnable-notebook-e2e:end -->