### PR TITLE
fix(layerwise): restore SGLang cache rank in direct transfers

### DIFF
--- a/examples/sgl_integration/direct_layerwise_roundtrip.ipynb
+++ b/examples/sgl_integration/direct_layerwise_roundtrip.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Reproduce the direct SGLang layerwise round trip\n",
+    "\n",
+    "Run all cells from any directory in an LMCache checkout. This executes the new direct layerwise CUDA round trip together with the adjacent SGLang connector matrix. It fails if any selected case fails or is skipped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "from pathlib import Path\n",
+    "import os\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "ROOT = next(\n",
+    "    candidate\n",
+    "    for candidate in (Path.cwd(), *Path.cwd().parents)\n",
+    "    if (candidate / \"pyproject.toml\").is_file() and (candidate / \"lmcache\").is_dir()\n",
+    ")\n",
+    "TEST_FILE = ROOT / \"tests/v1/test_gpu_connector.py\"\n",
+    "assert TEST_FILE.is_file(), TEST_FILE\n",
+    "assert torch.cuda.is_available(), \"CUDA is required\"\n",
+    "print(\n",
+    "    {\n",
+    "        \"root\": str(ROOT),\n",
+    "        \"torch\": torch.__version__,\n",
+    "        \"gpu\": torch.cuda.get_device_name(0),\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    \"-m\",\n",
+    "    \"pytest\",\n",
+    "    \"-q\",\n",
+    "    \"-s\",\n",
+    "    str(TEST_FILE),\n",
+    "    \"-k\",\n",
+    "    \"sglang_layerwise_connector_direct_roundtrip or sglang_connector_with_gpu_and_mla\",\n",
+    "]\n",
+    "env = os.environ.copy()\n",
+    "env[\"PYTHONPATH\"] = str(ROOT) + os.pathsep + env.get(\"PYTHONPATH\", \"\")\n",
+    "print(\"Running:\", \" \".join(command))\n",
+    "completed = subprocess.run(\n",
+    "    command,\n",
+    "    cwd=ROOT,\n",
+    "    env=env,\n",
+    "    text=True,\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    ")\n",
+    "print(completed.stdout)\n",
+    "completed.check_returncode()\n",
+    "assert \"5 passed\" in completed.stdout, (\n",
+    "    \"expected the direct regression plus four adjacent cases\"\n",
+    ")\n",
+    "print({\"status\": \"passed\", \"selected_cuda_cases\": 5})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1814,8 +1814,8 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                 else:
                     device_ops.single_layer_kv_transfer_sgl(
                         memory_obj.tensor,
-                        self.kvcaches[0][layer_id],
-                        self.kvcaches[1][layer_id],
+                        self.kvcaches[0][layer_id].unsqueeze(1),
+                        self.kvcaches[1][layer_id].unsqueeze(1),
                         slot_mapping[start:end],
                         lmcache_native.TransferDirection.H2D,
                         token_major=True,
@@ -1939,8 +1939,8 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                 else:
                     device_ops.single_layer_kv_transfer_sgl(
                         memory_obj.tensor,
-                        self.kvcaches[0][layer_id],
-                        self.kvcaches[1][layer_id],
+                        self.kvcaches[0][layer_id].unsqueeze(1),
+                        self.kvcaches[1][layer_id].unsqueeze(1),
                         slot_mapping[start:end],
                         lmcache_native.TransferDirection.D2H,
                         token_major=True,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -13,6 +13,7 @@ import torch
 from lmcache import torch_dev, torch_device_type
 from lmcache.v1.gpu_connector.gpu_connectors import (
     SGLangGPUConnector,
+    SGLangLayerwiseGPUConnector,
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemGPUConnectorV3,
@@ -925,3 +926,100 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
         engine_kv_formats=[engine_kv_format] * len(kv_list),
     )
     return metadata
+
+
+def test_sglang_layerwise_connector_direct_roundtrip():
+    """The direct layerwise path round-trips 3-D per-layer SGLang caches."""
+    num_blocks = 64
+    block_size = 16
+    num_layers = 4
+    num_heads = 8
+    head_size = 128
+    num_tokens = 512
+    chunk_size = 256
+    dtype = torch.bfloat16
+
+    allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+    gpu_kv_src = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        use_mla=False,
+        device=torch_device_type,
+        dtype=dtype,
+    )
+    gpu_kv_dst = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        use_mla=False,
+        device=torch_device_type,
+        dtype=dtype,
+    )
+    slot_mapping = torch.randperm(
+        num_blocks * block_size,
+        device=torch_device_type,
+        dtype=torch.int64,
+    )[:num_tokens]
+    starts = list(range(0, num_tokens, chunk_size))
+    ends = [min(start + chunk_size, num_tokens) for start in starts]
+
+    connector = SGLangLayerwiseGPUConnector(
+        num_heads * head_size,
+        num_layers,
+        use_gpu=False,
+        chunk_size=chunk_size,
+        dtype=dtype,
+        device=torch_device_type,
+    )
+    memory_objs = []
+    for _ in range(num_layers):
+        layer_objs = []
+        for start, end in zip(starts, ends, strict=False):
+            memory_obj = allocator.allocate(
+                connector.get_shape(end - start), dtype, MemoryFormat.KV_T2D
+            )
+            assert memory_obj is not None
+            layer_objs.append(memory_obj)
+        memory_objs.append(layer_objs)
+
+    gather = connector.batched_from_gpu(
+        memory_objs,
+        starts,
+        ends,
+        kvcaches=gpu_kv_src,
+        slot_mapping=slot_mapping,
+        sync=True,
+    )
+    for _ in range(num_layers + 1):
+        next(gather)
+    with pytest.raises(StopIteration):
+        next(gather)
+
+    scatter = connector.batched_to_gpu(
+        starts,
+        ends,
+        kvcaches=gpu_kv_dst,
+        slot_mapping=slot_mapping,
+        sync=True,
+    )
+    next(scatter)
+    for layer_objs in memory_objs:
+        scatter.send(layer_objs)
+    with pytest.raises(StopIteration):
+        next(scatter)
+
+    torch.cuda.synchronize()
+    check_sglang_paged_kv_cache_equal(
+        gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size
+    )
+
+    for layer_objs in memory_objs:
+        for memory_obj in layer_objs:
+            allocator.free(memory_obj)
+    assert allocator.memcheck()
+    allocator.close()


### PR DESCRIPTION
## Summary

- restore the unit page/block axis before direct SGLang layerwise D2H transfers
- apply the same rank restoration to direct H2D transfers
- add an end-to-end direct-path round-trip regression test

## Problem

`SGLangLayerwiseGPUConnector` indexes a layer out of each SGLang KV cache before calling `single_layer_kv_transfer_sgl`. That produces a 3-D `[slots, heads, head_dim]` view, while the transfer contract expects 4-D page geometry and reads `size(3)`.

The buffered path already reshapes each layer to `[slots, 1, heads, head_dim]`. The direct `use_gpu=False` path passed the 3-D view unchanged, so an ordinary gather failed before any round trip could complete.

The fix uses `unsqueeze(1)` in both direct directions. This is a metadata-only view: it does not allocate or copy KV data.

## Reproduction before the fix

NVIDIA L20, CUDA, bfloat16, four layers, two 256-token chunks:

```text
FAILED test_sglang_layerwise_connector_direct_roundtrip
IndexError: Dimension out of range (expected to be in range of [-3, 2], but got 3)
lmcache/v1/platform/torch_ops.py:2080
```

## Validation

```text
new direct round-trip:
1 passed, 36 warnings in 5.52s

all SGLang-selected connector tests:
5 passed, 29 deselected, 37 warnings in 5.40s

full functional connector suite (excluding its unrelated benchmark case):
32 passed, 1 skipped, 1 deselected, 37 warnings in 7.31s

single_layer_kv_transfer_sgl CPU/CUDA primitive checks:
3 passed, 71 deselected, 15 warnings in 4.17s
```

Changed-file pre-commit checks passed: SPDX, banned API checks, isort, ruff, ruff-format, codespell, and mypy.

## Relationship to existing work

This is the separate `use_gpu=False` defect documented in #4921 and in the notes of #4922. #4922 fixes partial slot-map rebasing in the buffered load path; this PR fixes the independent rank mismatch in direct D2H and H2D transfers. It does not close #4921. If #4922 lands first, I will rebase the small overlapping H2D call site.

<!-- runnable-notebook-e2e:start -->
## Reviewer-runnable L20 notebook

Run All: [`examples/sgl_integration/direct_layerwise_roundtrip.ipynb`](https://github.com/LMCache/LMCache/blob/f8aa90b334475571c8b5b4e9dfe55713c9f35235/examples/sgl_integration/direct_layerwise_roundtrip.ipynb). The notebook locates the checkout automatically, invokes the checked-in benchmark/tests rather than duplicating their implementation, streams their real output, and raises on failure.

- exact candidate: `f8aa90b334475571c8b5b4e9dfe55713c9f35235`
- environment: NVIDIA L20 (SM89), PyTorch 2.5.1+cu121, Triton 3.1.0
- result: Run All executed the new direct layerwise CUDA round trip plus the four adjacent SGLang connector cases: `5 passed, 29 deselected, 81 warnings in 4.46s`. The notebook fails if a selected CUDA case is skipped.
- raw Run-All log: 247 lines, SHA-256 `64ee69d23a7cb80429d8065d1f3d541df11ed6939d733e7f30ead8a9e534d4ab`

No notebook output or benchmark JSON is committed; the notebook is the reproducible entry point and the values above come from its actual final-head L20 execution.
<!-- runnable-notebook-e2e:end -->