### PR TITLE
[Bugfix][Test] Keep store_layer's yield count constant when the store is skipped

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -615,10 +615,23 @@ class LMCacheEngine:
             objects (on CPU) and puts the memory objects of layer i-1 to the
             storage backends. In the last iteration, it puts the memory objects
             of the last layer to the storage backends.
+
+            The generator yields ``num_layers + 1`` times on **every** path,
+            including the ones that skip the store (freeze mode, or an
+            unhealthy engine). Callers commit to that number of advances
+            before they can know the outcome -- the vLLM v1 connector
+            advances once per layer in ``save_kv_layer`` and once more in
+            ``wait_for_save`` -- so a path that yields fewer times raises
+            ``StopIteration`` inside the serving loop.
         """
         # Health check: block operation if LMCache is unhealthy
         if not self.is_healthy():
             logger.warning("LMCache is unhealthy, skipping store_layer operation")
+            # Callers commit to a fixed number of advances before they can know
+            # whether the store will be skipped, so every exit path has to yield
+            # the same number of times (see the docstring).
+            for _ in range(self.num_layers + 1):
+                yield
             return
 
         assert self.storage_manager is not None
@@ -650,9 +663,12 @@ class LMCacheEngine:
                 "Freeze mode enabled, skipping store_layer for %d tokens",
                 num_to_store_tokens,
             )
-            # Still need to yield to avoid StopIteration
+            # Still need to yield to avoid StopIteration: once per layer plus
+            # the final yield the hit and miss paths below both reach.
             for layer_id in range(self.num_layers):
                 yield
+            self.stats_monitor.on_store_finished(monitor_req_id, 0)
+            yield
             return
 
         starts = []

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -2065,3 +2065,61 @@ def test_retrieve_cleanup_ref_count_and_unpin() -> None:
 
     mem_obj_not_pinned.ref_count_down.assert_called_once()
     mem_obj_not_pinned.unpin.assert_not_called()
+
+
+class _AlwaysUnhealthyMonitor:
+    """Minimal HealthMonitor stand-in that always reports unhealthy."""
+
+    def is_healthy(self) -> bool:
+        """Report the engine as unhealthy."""
+        return False
+
+
+@pytest.mark.parametrize("skip_reason", ["frozen", "unhealthy"])
+def test_store_layer_yields_full_arity_when_store_is_skipped(
+    skip_reason, autorelease_v1
+):
+    """``store_layer`` yields ``num_layers + 1`` times even when it skips.
+
+    The vLLM v1 connector advances the generator once per model layer in
+    ``save_kv_layer`` and once more in ``wait_for_save``, committing to that
+    count before it can know whether the store will be skipped. Freeze mode is
+    toggled at runtime (the HTTP freeze endpoint, and the controller's own full
+    sync), and the health monitor can flip a live engine to unhealthy, so both
+    skip paths are reachable mid-serving. A path that yields fewer times raises
+    ``StopIteration`` inside the serving loop.
+    """
+    num_layers = 32
+    chunk_size = 256
+    kv_shape = (num_layers, 2, chunk_size, 8, 128)
+
+    cfg = LMCacheEngineConfig.from_legacy(chunk_size=chunk_size, use_layerwise=True)
+    engine = autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            dumb_metadata(kv_shape),
+            create_gpu_connector(1024, num_layers),
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
+    )
+
+    if skip_reason == "frozen":
+        engine.freeze(True)
+        assert engine.is_frozen()
+    else:
+        engine.set_health_monitor(_AlwaysUnhealthyMonitor())
+        assert not engine.is_healthy()
+
+    tokens = generate_tokens(chunk_size * 2, torch_device_type)
+    storer = engine.store_layer(tokens, req_id="arity-check")
+
+    # save_kv_layer advances once per layer ...
+    for layer_id in range(num_layers):
+        next(storer)
+    # ... and wait_for_save advances once more.
+    next(storer)
+
+    with pytest.raises(StopIteration):
+        next(storer)


### PR DESCRIPTION
Fixes #4927

**What this PR does / why we need it**:

`LMCacheEngine.store_layer` is a generator whose callers advance it a fixed
number of times: `LMCacheConnectorV1Impl.save_kv_layer` advances once per model
layer (`vllm_v1_adapter.py:1093`) and `wait_for_save` advances once more
(`vllm_v1_adapter.py:1124`). They commit to that count before they can know
whether the store will be skipped.

Two exit paths yielded fewer times, so advancing the generator raised
`StopIteration` inside the vLLM worker:

| path | yields | expected |
|---|---|---|
| normal (hit or miss) | `num_layers + 1` | correct |
| freeze mode | `num_layers` | one short |
| unhealthy engine | `0` | none at all |

Both are reachable on a live server. Freeze is toggled at runtime through the
HTTP endpoint, and the cache controller enters it itself for the duration of a
full sync (`full_sync_sender.py:217`); the health monitor can flip a healthy
engine to unhealthy mid-serving.

This yields the full `num_layers + 1` on both paths, closes the stats-monitor
request the freeze path had already opened via `on_store_request`, and
documents the arity contract on the method.

**Special notes for your reviewers**:

- **Verified on hardware** (NVIDIA L4, CUDA 12.9, torch 2.9.1+cu129, `dev` @
  `913016b`): both parametrizations of the new test fail before the change and
  pass after it; `tests/v1/test_cache_engine.py` reports **69 passed** with the
  fix applied.
- The freeze path already carried the comment *"Still need to yield to avoid
  StopIteration"* - the intent was right, the count was one short. That loop
  came from #2268, which fixed the earlier StopIteration crashes #1844 / #2453.
- The retrieve-side twin of this is #4133 / #899, fixed by the still-open
  #4574. That PR's author flagged the same inconsistency in `retrieve_layer`'s
  unhealthy path and scoped it out; `store_layer` was never in its scope. The
  two changes are independent and do not conflict.
- The freeze path now calls `on_store_finished(monitor_req_id, 0)` before its
  final yield, mirroring the miss path. Without it the monitor request opened a
  few lines earlier is never closed. Happy to split that out if you would
  rather keep this to the arity alone.
- The test drives the generator through the public API only - `engine.freeze()`
  for the freeze case, `engine.set_health_monitor()` with a minimal
  always-unhealthy stand-in for the other - and asserts the documented advance
  count rather than the implementation.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
