### PR TITLE
fix(mp): reject transfer mode mismatches at registration

### DIFF
--- a/lmcache/v1/multiprocess/modules/transfer_mode_guard.py
+++ b/lmcache/v1/multiprocess/modules/transfer_mode_guard.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit registration errors for unsupported MP transfer modes."""
+
+# Standard
+from typing import NoReturn
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.custom_types import (
+    KVCache,
+    RegisterEngineDrivenContextPayload,
+)
+from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
+from lmcache.v1.multiprocess.engine_module import HandlerSpec, ThreadPoolType
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.protocols.engine import (
+    RegisterEngineDrivenContextResponse,
+)
+
+_TRANSFER_MODES = {"auto", "engine_driven", "lmcache_driven"}
+
+
+class TransferModeGuardModule:
+    """Reject registration requests disabled by the server configuration.
+
+    A mode-specific transfer module owns each supported registration request.
+    This guard owns only the complementary request types, so mismatched clients
+    receive a deterministic error instead of falling through as an unregistered
+    request. ``auto`` builds both transfer modules and therefore needs no guard
+    handlers.
+    """
+
+    def __init__(self, ctx: MPCacheServerContext, supported_transfer_mode: str) -> None:
+        if supported_transfer_mode not in _TRANSFER_MODES:
+            raise ValueError(
+                f"Unsupported supported_transfer_mode '{supported_transfer_mode}'"
+            )
+        self._ctx = ctx
+        self._supported_transfer_mode = supported_transfer_mode
+
+    @property
+    def context(self) -> MPCacheServerContext:
+        """Return the shared engine context."""
+        return self._ctx
+
+    def get_handlers(self) -> list[HandlerSpec]:
+        """Return handlers for registration modes this server rejects."""
+        if self._supported_transfer_mode == "auto":
+            return []
+        if self._supported_transfer_mode == "engine_driven":
+            return [
+                HandlerSpec(
+                    RequestType.REGISTER_KV_CACHE,
+                    self._reject_lmcache_driven,
+                    ThreadPoolType.SYNC,
+                ),
+                HandlerSpec(
+                    RequestType.REGISTER_Q_CACHE,
+                    self._reject_lmcache_driven,
+                    ThreadPoolType.SYNC,
+                ),
+            ]
+        return [
+            HandlerSpec(
+                RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+                self._reject_engine_driven,
+                ThreadPoolType.SYNC,
+            )
+        ]
+
+    def report_status(self) -> dict:
+        """Expose the configured transfer mode in server status."""
+        return {"supported_transfer_mode": self._supported_transfer_mode}
+
+    def close(self) -> None:
+        """The guard owns no resources."""
+
+    def _reject_lmcache_driven(
+        self,
+        _instance_id: int,
+        _kv_cache: KVCache,
+        _model_name: str,
+        _world_size: int,
+        _engine_type: EngineType,
+        _layout_hints: LayoutHints,
+        _engine_group_infos: list[EngineGroupInfo],
+    ) -> None:
+        self._raise_mismatch("lmcache_driven")
+
+    def _reject_engine_driven(
+        self, _payload: RegisterEngineDrivenContextPayload
+    ) -> RegisterEngineDrivenContextResponse:
+        self._raise_mismatch("engine_driven")
+
+    def _raise_mismatch(self, requested: str) -> NoReturn:
+        raise ValueError(
+            f"Client requested transfer mode '{requested}', but the server "
+            "was started with "
+            f"supported_transfer_mode='{self._supported_transfer_mode}'. "
+            "Use the same transfer mode on the client and server, or start "
+            "the server with supported_transfer_mode='auto'."
+        )

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -40,6 +40,23 @@ T = TypeVar("T")
 # Internal type used for the client-server communication
 RequestUID = int
 
+_REMOTE_ERROR_MARKER = b"lmcache.remote-error.v1"
+_MAX_REMOTE_ERROR_MESSAGE_CHARS = 4096
+
+
+class RemoteHandlerError(RuntimeError):
+    """A server handler failed before producing its declared response."""
+
+
+def _remote_error_frames(
+    prefix_frames: list[bytes], exception: BaseException
+) -> list[bytes]:
+    """Build a bounded, traceback-free error response."""
+    error_type = type(exception).__name__
+    message = str(exception)[:_MAX_REMOTE_ERROR_MESSAGE_CHARS]
+    payload = msgspec.msgpack.encode((error_type, message))
+    return prefix_frames + [_REMOTE_ERROR_MARKER, payload]
+
 
 # Helper functions
 def encode_request_uid(uid: RequestUID) -> bytes:
@@ -360,11 +377,30 @@ class MessageQueueClient:
 
         if request_uid in self.pending_futures:
             future = self.pending_futures.pop(request_uid)
-            if b_response:
-                response = msgspec_decode(b_response[0], cls=response_cls)
-                future.set_result(response)
-            else:
-                future.set_result(None)
+            try:
+                if b_response and b_response[0] == _REMOTE_ERROR_MARKER:
+                    if len(b_response) != 2:
+                        raise ValueError(
+                            "Malformed remote error response: expected marker "
+                            "and payload"
+                        )
+                    error_type, message = msgspec_decode(
+                        b_response[1], cls=tuple[str, str]
+                    )
+                    future.set_exception(
+                        RemoteHandlerError(
+                            f"Remote {request_type.name} handler failed with "
+                            f"{error_type}: {message}"
+                        )
+                    )
+                elif b_response:
+                    response = msgspec_decode(b_response[0], cls=response_cls)
+                    future.set_result(response)
+                else:
+                    future.set_result(None)
+            except Exception as exc:
+                future.set_exception(exc)
+                raise
 
     def submit_request(
         self,
@@ -585,8 +621,10 @@ class MessageQueueServer:
                 self.output_queue.put(frames_to_send)
                 self._output_efd.notify()
 
-            except Exception:
+            except Exception as exc:
                 logger.exception("Error in blocking handler")
+                self.output_queue.put(_remote_error_frames(prefix_frames, exc))
+                self._output_efd.notify()
 
         future.add_done_callback(_notify_response)
 
@@ -626,20 +664,33 @@ class MessageQueueServer:
                 identity, b_request_uid, b_request_type, *payloads = msg
                 request_type = msgspec_decode(b_request_type, cls=RequestType)
 
+                prefix_frames = [identity, b_request_uid, b_request_type]
                 if handler_entry := self.handlers.get(request_type):
                     try:
                         self._call_handler(
                             handler_entry=handler_entry,
                             payloads=payloads,
-                            prefix_frames=[identity, b_request_uid, b_request_type],
+                            prefix_frames=prefix_frames,
                         )
-                    except Exception:
+                    except Exception as exc:
                         logger.exception("Error handling request %s", request_type)
+                        self.socket.send_multipart(
+                            _remote_error_frames(prefix_frames, exc)
+                        )
                 else:
                     logger.error(
                         "No handler registered for request type %s", request_type
                     )
                     logger.error("Available handlers: %s", list(self.handlers.keys()))
+                    self.socket.send_multipart(
+                        _remote_error_frames(
+                            prefix_frames,
+                            LookupError(
+                                "No handler registered for request type "
+                                f"{request_type.name}"
+                            ),
+                        )
+                    )
 
             # Send the responses
             if outbound_state and outbound_state & zmq.POLLIN:

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -62,6 +62,9 @@ from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.modules.management import ManagementModule
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
+from lmcache.v1.multiprocess.modules.transfer_mode_guard import (
+    TransferModeGuardModule,
+)
 from lmcache.v1.multiprocess.mq import MessageQueueServer
 from lmcache.v1.multiprocess.protocol import (
     RequestType,
@@ -305,6 +308,9 @@ def _build_modules(
         worker_registration_grace_seconds=mp_config.worker_registration_grace_seconds,
         experimental_transfer=experimental_transfer,
     )
+    transfer_mode_guard = TransferModeGuardModule(
+        ctx, mp_config.supported_transfer_mode
+    )
 
     # ManagementModule precedes the transfer/blend modules so close() stops
     # and joins the reaper before those modules clear their state and before
@@ -314,6 +320,7 @@ def _build_modules(
         lookup_module,
         p2p_controller,
         management,
+        transfer_mode_guard,
         *transfer_modules,
         *experimental_modules,
         *blend_modules,

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -361,6 +361,73 @@ def test_mq_noop_multiple_clients():
     )
 
 
+def _raise_sync_handler_error() -> str:
+    raise RuntimeError("sync boom")
+
+
+def _raise_blocking_handler_error(key: IPCCacheServerKey, tp_size: int) -> None:
+    raise RuntimeError(f"blocking boom for {key.request_id}/{tp_size}")
+
+
+@pytest.mark.parametrize(
+    ("request_type", "handler", "payloads", "expected_message"),
+    [
+        (
+            RequestType.NOOP,
+            _raise_sync_handler_error,
+            [],
+            "Remote NOOP handler failed with RuntimeError: sync boom",
+        ),
+        (
+            RequestType.LOOKUP,
+            _raise_blocking_handler_error,
+            [create_cache_key(7), 2],
+            "Remote LOOKUP handler failed with RuntimeError: "
+            "blocking boom for test_request_7/2",
+        ),
+    ],
+)
+def test_mq_handler_error_reaches_client_future(
+    request_type, handler, payloads, expected_message
+):
+    context = zmq.Context.instance()
+    endpoint = f"inproc://handler-error-{request_type.name}-{time.monotonic_ns()}"
+    server = MessageQueueServer(endpoint, context)
+    add_handler_helper(server, request_type, handler)
+    if isinstance(server.handlers[request_type], BlockingRequestHandler):
+        server.add_normal_thread_pool([request_type], max_workers=1)
+    server.start()
+    client = MessageQueueClient(endpoint, context)
+    try:
+        future = client.submit_request(request_type, payloads)
+
+        with pytest.raises(RuntimeError, match=expected_message):
+            future.result(timeout=1)
+    finally:
+        client.close()
+        server.close()
+
+
+def test_mq_missing_handler_reaches_client_future():
+    context = zmq.Context.instance()
+    endpoint = f"inproc://missing-handler-{time.monotonic_ns()}"
+    server = MessageQueueServer(endpoint, context)
+    server.start()
+    client = MessageQueueClient(endpoint, context)
+    try:
+        future = client.submit_request(RequestType.NOOP, [])
+
+        with pytest.raises(
+            RuntimeError,
+            match="Remote NOOP handler failed with LookupError: "
+            "No handler registered for request type NOOP",
+        ):
+            future.result(timeout=1)
+    finally:
+        client.close()
+        server.close()
+
+
 @pytest.mark.cuda
 @pytest.mark.skipif(
     not (torch_dev.is_available() and torch_device_type == "cuda"),

--- a/tests/v1/multiprocess/test_transfer_mode_guard.py
+++ b/tests/v1/multiprocess/test_transfer_mode_guard.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for explicit MP transfer-mode mismatch registration failures."""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+import zmq
+
+# First Party
+from lmcache.v1.multiprocess.custom_types import (
+    RegisterEngineDrivenContextPayload,
+)
+from lmcache.v1.multiprocess.modules.transfer_mode_guard import (
+    TransferModeGuardModule,
+)
+from lmcache.v1.multiprocess.mq import (
+    MessageQueueServer,
+    RemoteHandlerError,
+)
+from lmcache.v1.multiprocess.protocol import get_payload_classes
+from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.server import add_handler_helper
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
+
+
+@pytest.mark.parametrize(
+    ("supported", "rejected"),
+    [
+        (
+            "engine_driven",
+            {
+                RequestType.REGISTER_KV_CACHE,
+                RequestType.REGISTER_Q_CACHE,
+            },
+        ),
+        (
+            "lmcache_driven",
+            {RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT},
+        ),
+        ("auto", set()),
+    ],
+)
+def test_guard_registers_only_unsupported_modes(
+    supported: str, rejected: set[RequestType]
+) -> None:
+    module = TransferModeGuardModule(MagicMock(), supported)
+
+    assert {spec.request_type for spec in module.get_handlers()} == rejected
+    assert module.report_status() == {"supported_transfer_mode": supported}
+
+
+@pytest.mark.parametrize(
+    ("supported", "request_type", "requested"),
+    [
+        ("engine_driven", RequestType.REGISTER_KV_CACHE, "lmcache_driven"),
+        ("engine_driven", RequestType.REGISTER_Q_CACHE, "lmcache_driven"),
+        (
+            "lmcache_driven",
+            RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+            "engine_driven",
+        ),
+    ],
+)
+def test_guard_error_names_requested_and_supported_modes(
+    supported: str,
+    request_type: RequestType,
+    requested: str,
+) -> None:
+    module = TransferModeGuardModule(MagicMock(), supported)
+    handler = {spec.request_type: spec.handler for spec in module.get_handlers()}[
+        request_type
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"requested transfer mode '{requested}'.*"
+            rf"supported_transfer_mode='{supported}'"
+        ),
+    ):
+        handler(*([None] * len(get_payload_classes(request_type))))
+
+
+def test_guard_rejects_unknown_server_mode() -> None:
+    with pytest.raises(ValueError, match="Unsupported supported_transfer_mode"):
+        TransferModeGuardModule(MagicMock(), "invalid")
+
+
+def test_mode_mismatch_reaches_client_without_timeout() -> None:
+    """A mismatched registration completes with the server's useful error."""
+    context = zmq.Context()
+    server = MessageQueueServer("tcp://127.0.0.1:*", context)
+    server_url = server.socket.getsockopt_string(zmq.LAST_ENDPOINT)
+    module = TransferModeGuardModule(MagicMock(), "lmcache_driven")
+    for spec in module.get_handlers():
+        add_handler_helper(server, spec.request_type, spec.handler)
+    server.start()
+    client = RequestClientFactory.create(server_url, context=context)
+
+    try:
+        future = client.register_kv_cache_engine_driven_context(
+            RegisterEngineDrivenContextPayload(
+                instance_id=7,
+                model_name="test-model",
+                world_size=1,
+                block_size=16,
+                num_layers=1,
+                hidden_dim_size=128,
+                dtype_str="float16",
+                use_mla=False,
+                num_physical_slots=16,
+            )
+        )
+
+        with pytest.raises(
+            RemoteHandlerError,
+            match=(
+                "requested transfer mode 'engine_driven'.*"
+                "supported_transfer_mode='lmcache_driven'"
+            ),
+        ):
+            future.result(timeout=1)
+    finally:
+        client.close()
+        server.close()
+        context.term()


### PR DESCRIPTION
## Summary

- install explicit registration guards only for transfer modes disabled by the server
- return requested and supported mode names instead of falling through to an unregistered request
- keep `auto` accepting both transfer paths and expose the configured mode in server status

## Broken invariant

A client/server transfer-mode mismatch should fail during KV-cache registration with an actionable error. Previously the server had no handler for the disabled registration request, so the client could only observe a generic missing-handler failure (or, before remote error frames, wait until timeout).

This preserves the existing wire request types and is compatible with older clients.

## Dependency

This is a stacked Draft on #4919, which carries the bounded remote handler-error frame. The implementation unique to this PR is commit `36229a5b`; its prerequisite commit is patch-equivalent to #4919. Once #4919 lands, the shared changes disappear from this diff.

## Test-first reproduction

The new suite initially failed at collection because the transfer-mode guard did not exist. The end-to-end ZMQ case then exposed and fixed the exact handler signature/return annotations required by the protocol registry.

The first full Buildkite run found a repository-wide architecture guard violation because this regression test constructed the raw ZMQ implementation directly. The test now constructs its client through `RequestClientFactory`, matching the public transport contract; the guard and the end-to-end mismatch case pass together.

## Validation

```bash
python -m pytest -q \
  tests/v1/multiprocess/test_futures.py \
  tests/v1/multiprocess/test_mq.py \
  tests/v1/multiprocess/test_transfer_mode_guard.py \
  tests/v1/multiprocess/test_client.py
```

```text
57 passed, 14 skipped, 134 warnings in 53.36s
```

```text
pre-commit run --all-files: passed
git diff --check: passed
```

A throughput benchmark is not applicable: this adds only a registration failure path and no successful store/retrieve hot-path work. The ZMQ regression asserts that the mismatch reaches the client within a 1-second bound.

Relates to #4759.

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `36229a5b9c5b3d538df3499cb93cc880046c42d1` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions.

The verbose raw pytest log contains 160 lines and has SHA-256 `59dab676e4fd67b98eab9ed07311f8548c6b4a7312d73eeb15b7ec2ce420d863`. Repository pre-commit hooks passed on all changed files at this exact tree (SPDX, device/timeout rules, isort, ruff, ruff-format, codespell, clang-format, and mypy; non-applicable Rust hooks skipped). The command above is the reviewer-runnable reproduction entry point and includes the remote-error prerequisite, the transfer-mode registration contract, and the factory-use architecture guard.

This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->