### PR TITLE
fix(mp/shm): validate POSIX mapping sizes

### DIFF
--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -70,6 +70,12 @@ _ADDR_TO_MMAP: dict[int, _mmap.mmap] = {}
 _OWNED_NAMES: set[str] = set()
 
 
+def _validate_nbytes(nbytes: int) -> None:
+    """Require a positive explicit POSIX SHM mapping length."""
+    if nbytes <= 0:
+        raise ValueError(f"POSIX SHM size must be positive, got {nbytes}")
+
+
 def _validate_mapping_size(fd: int, name: str, nbytes: int) -> None:
     """Reject mappings larger than the SHM object's backing capacity."""
     actual_nbytes = os.fstat(fd).st_size
@@ -87,6 +93,7 @@ def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap,
     before returning so we don't leak descriptors; the kernel keeps
     the mapping alive as long as ``mmap_obj`` stays alive.
     """
+    _validate_nbytes(nbytes)
     flags = os.O_RDWR | (os.O_CREAT | os.O_EXCL if create else 0)
     fd = _posixshmem.shm_open(_slashed(name), flags, mode=0o600)
     mm: _mmap.mmap | None = None
@@ -148,6 +155,7 @@ def shm_create_readwrite(name: str, nbytes: int) -> int:
 
     Raises:
         OSError: If the segment already exists or creation fails.
+        ValueError: If ``nbytes`` is not positive.
     """
     sm_name = _strip_leading_slash(name)
     mm, addr = _open_and_mmap(sm_name, nbytes, create=True)
@@ -172,7 +180,8 @@ def shm_map_readwrite(name: str, nbytes: int) -> int:
 
     Raises:
         OSError: If the segment cannot be opened or mapped.
-        ValueError: If ``nbytes`` exceeds the segment's actual size.
+        ValueError: If ``nbytes`` is not positive or exceeds the segment's
+            actual size.
     """
     sm_name = _strip_leading_slash(name)
     mm, addr = _open_and_mmap(sm_name, nbytes, create=False)
@@ -277,9 +286,11 @@ def shm_open_pool_as_mmap(name: str, nbytes: int) -> _mmap.mmap:
 
     Raises:
         OSError: If the segment cannot be opened or mapped.
-        ValueError: If ``nbytes`` exceeds the segment's actual size.
+        ValueError: If ``nbytes`` is not positive or exceeds the segment's
+            actual size.
     """
     sm_name = _strip_leading_slash(name)
+    _validate_nbytes(nbytes)
     fd = _posixshmem.shm_open(_slashed(sm_name), os.O_RDWR, mode=0o600)
     try:
         _validate_mapping_size(fd, sm_name, nbytes)

--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -70,6 +70,16 @@ _ADDR_TO_MMAP: dict[int, _mmap.mmap] = {}
 _OWNED_NAMES: set[str] = set()
 
 
+def _validate_mapping_size(fd: int, name: str, nbytes: int) -> None:
+    """Reject mappings larger than the SHM object's backing capacity."""
+    actual_nbytes = os.fstat(fd).st_size
+    if nbytes > actual_nbytes:
+        raise ValueError(
+            f"POSIX SHM mapping for {name!r} exceeds segment capacity: "
+            f"requested {nbytes} bytes, segment contains {actual_nbytes} bytes"
+        )
+
+
 def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap, int]:
     """Open (or create) a POSIX SHM segment and ``mmap`` it.
 
@@ -83,6 +93,8 @@ def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap,
     try:
         if create:
             os.ftruncate(fd, nbytes)
+        else:
+            _validate_mapping_size(fd, name, nbytes)
         mm = _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
         addr = _addr_of_mmap(mm)
     except BaseException:
@@ -148,8 +160,8 @@ def shm_create_readwrite(name: str, nbytes: int) -> int:
 def shm_map_readwrite(name: str, nbytes: int) -> int:
     """Open an existing shared-memory segment and return its address.
 
-    ``nbytes`` must match the segment's actual size; ``mmap`` will
-    raise on a mismatch.
+    ``nbytes`` may map a prefix of the segment but must not exceed its
+    actual backing capacity.
 
     Args:
         name: The name of the shared-memory segment.
@@ -160,6 +172,7 @@ def shm_map_readwrite(name: str, nbytes: int) -> int:
 
     Raises:
         OSError: If the segment cannot be opened or mapped.
+        ValueError: If ``nbytes`` exceeds the segment's actual size.
     """
     sm_name = _strip_leading_slash(name)
     mm, addr = _open_and_mmap(sm_name, nbytes, create=False)
@@ -264,10 +277,12 @@ def shm_open_pool_as_mmap(name: str, nbytes: int) -> _mmap.mmap:
 
     Raises:
         OSError: If the segment cannot be opened or mapped.
+        ValueError: If ``nbytes`` exceeds the segment's actual size.
     """
     sm_name = _strip_leading_slash(name)
     fd = _posixshmem.shm_open(_slashed(sm_name), os.O_RDWR, mode=0o600)
     try:
+        _validate_mapping_size(fd, sm_name, nbytes)
         return _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
     finally:
         os.close(fd)

--- a/tests/v1/multiprocess/test_posix_shm.py
+++ b/tests/v1/multiprocess/test_posix_shm.py
@@ -6,6 +6,7 @@ shared by SHM-based transports.
 """
 
 # Standard
+from collections.abc import Callable
 import os
 
 # Third Party
@@ -70,6 +71,23 @@ def test_open_pool_as_mmap_zero_copy_view():
             mm.close()
     finally:
         shm_munmap(addr, nbytes)
+        shm_unlink(name)
+
+
+@pytest.mark.parametrize(
+    "open_segment",
+    [shm_map_readwrite, shm_open_pool_as_mmap],
+)
+def test_mapping_rejects_size_above_segment_capacity(
+    open_segment: Callable[[str, int], object],
+) -> None:
+    name = _unique_name("oversize")
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(ValueError, match="exceeds segment capacity"):
+            open_segment(name, 1024 * 1024)
+    finally:
+        shm_munmap(addr, 4096)
         shm_unlink(name)
 
 

--- a/tests/v1/multiprocess/test_posix_shm.py
+++ b/tests/v1/multiprocess/test_posix_shm.py
@@ -91,6 +91,31 @@ def test_mapping_rejects_size_above_segment_capacity(
         shm_unlink(name)
 
 
+@pytest.mark.parametrize("nbytes", [0, -1])
+def test_create_rejects_non_positive_size(nbytes: int) -> None:
+    name = _unique_name(f"create{nbytes}")
+    with pytest.raises(ValueError, match="must be positive"):
+        shm_create_readwrite(name, nbytes)
+
+
+@pytest.mark.parametrize("nbytes", [0, -1])
+@pytest.mark.parametrize(
+    "open_segment",
+    [shm_map_readwrite, shm_open_pool_as_mmap],
+)
+def test_mapping_rejects_non_positive_size(
+    open_segment: Callable[[str, int], object], nbytes: int
+) -> None:
+    name = _unique_name(f"map{nbytes}")
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(ValueError, match="must be positive"):
+            open_segment(name, nbytes)
+    finally:
+        shm_munmap(addr, 4096)
+        shm_unlink(name)
+
+
 def test_munmap_no_op_on_zero_addr():
     # Should not crash; best-effort no-op.
     shm_munmap(0, 4096)


### PR DESCRIPTION
**What this PR does / why we need it**:

The POSIX SHM helpers accept a segment name and a byte count, then return either a raw address or an `mmap` used by SHM-based transfers. The requested length needs to be checked before returning a buffer to the caller.

This PR addresses two boundary cases:

- Zero or negative lengths were left to `ftruncate`/`mmap` to handle, producing platform-dependent behavior instead of a consistent argument error.
- When attaching to an existing segment, the helpers did not check the requested length against the backing object's capacity. An oversized mapping could be accepted before any data was accessed. The regression test creates a 4 KiB segment and requests a 1 MiB mapping through each attach API; it checks rejection without accessing the oversized buffer.

The goal is to reject invalid sizes at creation/attachment, where the error is attributable to the supplied length, rather than leave it to a later buffer consumer.

**Changes**:

- Raise `ValueError` for non-positive lengths in `shm_create_readwrite`, `shm_map_readwrite`, and `shm_open_pool_as_mmap`.
- Use `os.fstat(fd).st_size` on the opened descriptor to reject an attachment larger than the backing object before calling `mmap`.
- Keep smaller prefix mappings valid. The check is an upper bound, not an exact-size requirement, because Darwin can report page-rounded SHM capacity.
- Document the size contract and add eight parametrized regression cases across creation and both attachment APIs.

**Special notes for your reviewers**:

Only `posix_shm.py` and its tests change. Function signatures, valid mapping behavior, transfer protocols, and mapping/unlink ownership are unchanged. This is a CPU shared-memory boundary check, not a GPU performance change or a claim that a production crash was reproduced. The capacity check applies at attachment time; it does not protect against another process subsequently truncating the segment.

**Validation**:

```bash
python -m pytest -q tests/v1/multiprocess/test_posix_shm.py tests/v1/multiprocess/test_engine_driven_transfer.py
```

Previously recorded results (not rerun for this description edit):

- macOS arm64, Python 3.12.13, locally built native extensions, exact head `b81dd65a9b1f8471c79cd05881e267b7680708f3`: **57 passed, 437 warnings in 1.92s**.
- Linux: **57 passed, 437 warnings in 4.56s**.
- Changed-file Ruff lint/format and `git diff --check` passed.

The final-head macOS raw pytest log has SHA-256 `24979f3de856607ed351ec6f4b842615f87a33ee793f310587a0716e04076b59`. These are targeted tests, not a full-suite or GPU validation claim.

AI-assisted implementation and description editing.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
