### PR TITLE
fix(mp/shm): retain blocked munmap leases

### DIFF
--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -171,8 +171,10 @@ def shm_map_readwrite(name: str, nbytes: int) -> int:
 def shm_munmap(addr: int, nbytes: int = 0) -> None:
     """Best-effort release of a previously mapped segment by address.
 
-    The underlying mmap is closed exactly once; subsequent calls with
-    the same address are no-ops.
+    The underlying mmap is closed exactly once. If exported views still
+    prevent closing it, the registry entry is retained so a later call can
+    retry after those views have been released. Calls after a successful
+    close are no-ops.
 
     Args:
         addr: The virtual address of the mapped segment.
@@ -181,21 +183,30 @@ def shm_munmap(addr: int, nbytes: int = 0) -> None:
     """
     if not addr:
         return
+
+    close_error: BufferError | ValueError | None = None
     with _REGISTRY_LOCK:
-        mm = _ADDR_TO_MMAP.pop(addr, None)
-    if mm is None:
-        return
-    try:
-        mm.close()
-    except (BufferError, ValueError) as exc:
-        # ``BufferError`` means callers still hold an exported view
-        # (e.g. a torch tensor backed by this mmap); they will release
-        # the mapping themselves on GC. ``ValueError`` means already
-        # closed -- treat both as best-effort no-ops.
+        mm = _ADDR_TO_MMAP.get(addr)
+        if mm is None:
+            return
+        try:
+            mm.close()
+        except BufferError as exc:
+            # Keep the mapping registered: once callers release their exported
+            # views, another shm_munmap call can complete the close.
+            close_error = exc
+        except ValueError as exc:
+            # An externally closed mmap no longer needs a registry lease.
+            _ADDR_TO_MMAP.pop(addr, None)
+            close_error = exc
+        else:
+            _ADDR_TO_MMAP.pop(addr, None)
+
+    if close_error is not None:
         logger.warning(
             "shm_munmap: mmap.close() skipped for addr=%#x: %s",
             addr,
-            exc,
+            close_error,
         )
 
 

--- a/tests/v1/multiprocess/test_posix_shm.py
+++ b/tests/v1/multiprocess/test_posix_shm.py
@@ -12,6 +12,7 @@ import os
 import pytest
 
 # First Party
+from lmcache.v1.multiprocess import posix_shm
 from lmcache.v1.multiprocess.posix_shm import (
     shm_create_readwrite,
     shm_map_readwrite,
@@ -76,3 +77,27 @@ def test_open_pool_as_mmap_zero_copy_view():
 def test_munmap_no_op_on_zero_addr():
     # Should not crash; best-effort no-op.
     shm_munmap(0, 4096)
+
+
+def test_munmap_can_retry_after_exported_view_is_released():
+    """A blocked close must keep the mapping reachable for a later retry."""
+    name = _unique_name("retry")
+    addr = shm_create_readwrite(name, 4096)
+    mm = posix_shm._ADDR_TO_MMAP[addr]
+    exported_view = memoryview(mm)
+
+    try:
+        shm_munmap(addr, 4096)
+        assert addr in posix_shm._ADDR_TO_MMAP
+        assert not mm.closed
+
+        exported_view.release()
+        shm_munmap(addr, 4096)
+        assert addr not in posix_shm._ADDR_TO_MMAP
+        assert mm.closed
+    finally:
+        exported_view.release()
+        if not mm.closed:
+            mm.close()
+        posix_shm._ADDR_TO_MMAP.pop(addr, None)
+        shm_unlink(name)


### PR DESCRIPTION
**What this PR does / why we need it**:

When `mmap.close()` raises `BufferError` because an exported view is still alive, `shm_munmap` currently removes the address from `_ADDR_TO_MMAP` before attempting the close. The live mapping is then unreachable through the public cleanup path: releasing the view and retrying `shm_munmap` becomes a no-op, so explicit cleanup cannot converge before process exit.

This change keeps the registry lease until `mmap.close()` succeeds. A blocked close remains retryable after exported views are released; successfully closed or already-closed mappings are removed exactly once.

The regression test was written first and failed on the previous implementation with:

    assert addr in posix_shm._ADDR_TO_MMAP
    E assert <addr> in {}

**Special notes for your reviewers**:

Validation on macOS:

    uv run pytest -q tests/v1/multiprocess/test_posix_shm.py tests/v1/multiprocess/test_engine_driven_transfer.py
    50 passed, 437 warnings in 1.31s

Validation on Linux (jk01):

    python -m pytest -q tests/v1/multiprocess/test_posix_shm.py tests/v1/multiprocess/test_engine_driven_transfer.py
    50 passed, 437 warnings in 4.98s

Static checks:

    uvx ruff check lmcache/v1/multiprocess/posix_shm.py tests/v1/multiprocess/test_posix_shm.py
    All checks passed!

    uvx ruff format --check lmcache/v1/multiprocess/posix_shm.py tests/v1/multiprocess/test_posix_shm.py
    2 files already formatted

    git diff --check
    passed

No GPU benchmark is applicable because this changes POSIX mmap cleanup behavior only.

This is independent of, but adjacent to, #4931; both branches are based directly on the current `dev` head and can be rebased in either merge order.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<!-- final-head-e2e-log:start -->
## Final-head reproducible integration log

Validated from an isolated worktree at exact commit `75e8454bb81bed0d0412e2229ee7995803bcae1c` on macOS arm64 / Python 3.12.13 with the locally built LMCache native extensions:

```bash
python -m pytest -q tests/v1/multiprocess/test_posix_shm.py tests/v1/multiprocess/test_engine_driven_transfer.py
```

```text
50 passed, 437 warnings in 1.19s
```

The verbose raw pytest log contains 178 lines and has SHA-256 `05943ab0e4ceff0943a315b27cf14c5cc8b0aabda03b7e777abfcdcad564c504`. The command above is the reviewer-runnable reproduction entry point and exercises the same checked-in tests and candidate code. This is a CPU control-plane/integration change, so a GPU notebook would add an indirect wrapper without increasing coverage; GPU/benchmark PRs carry Run-All notebooks separately.
<!-- final-head-e2e-log:end -->