### PR TITLE
fix(vllm): resolve the DCP interleave in a role-invariant way

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -220,7 +220,10 @@ def get_vllm_scheduler_block_size(
     return scheduler_block_size
 
 
-def get_dcp_decorated_model_name(vllm_config: VllmConfig) -> str:
+def get_dcp_decorated_model_name(
+    vllm_config: VllmConfig,
+    kv_cache_config: "KVCacheConfig | None" = None,
+) -> str:
     """Decorate the model name with its non-trivial DCP interleave layout.
 
     Embedding the DCP interleave size in the LMCache model name prevents a
@@ -228,6 +231,7 @@ def get_dcp_decorated_model_name(vllm_config: VllmConfig) -> str:
 
     Args:
         vllm_config: The active vLLM configuration.
+        kv_cache_config: vLLM's resolved KV cache group configuration.
 
     Returns:
         The decorated cache model name, or the original model name when DCP or
@@ -236,7 +240,19 @@ def get_dcp_decorated_model_name(vllm_config: VllmConfig) -> str:
     model_name = vllm_config.model_config.model
     parallel_config = vllm_config.parallel_config
     dcp_size = getattr(parallel_config, "decode_context_parallel_size", 1)
-    interleave = getattr(parallel_config, "cp_kv_cache_interleave_size", 1)
+    interleave = original = getattr(parallel_config, "cp_kv_cache_interleave_size", 1)
+    # adjust_dcp_kv_cache_interleave_size runs per worker, so the scheduler's
+    # config keeps the pre-adjustment value. Delegate to vLLM (idempotent, and
+    # gated differently across versions), then restore what it owns.
+    adjust = getattr(vllm_config, "adjust_dcp_kv_cache_interleave_size", None)
+    if adjust is not None and kv_cache_config is not None:
+        try:
+            adjust(kv_cache_config)
+            interleave = getattr(
+                parallel_config, "cp_kv_cache_interleave_size", original
+            )
+        finally:
+            parallel_config.cp_kv_cache_interleave_size = original
     if dcp_size <= 1 or interleave == 1:
         return model_name
     return f"{model_name}{_DCP_LAYOUT_NAMESPACE}d{dcp_size}-interleave{interleave}"
@@ -471,7 +487,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         scheduler_block_size = get_vllm_scheduler_block_size(
             vllm_config, kv_cache_config
         )
-        cache_model_name = get_dcp_decorated_model_name(vllm_config)
+        cache_model_name = get_dcp_decorated_model_name(vllm_config, kv_cache_config)
 
         assert vllm_config.kv_transfer_config is not None
 

--- a/tests/v1/test_vllm_dcp_support.py
+++ b/tests/v1/test_vllm_dcp_support.py
@@ -436,6 +436,34 @@ def test_trivial_interleave_preserves_legacy_cache_identity():
     )
 
 
+@requires_vllm
+@pytest.mark.parametrize("gated", [False, True])
+def test_dcp_cache_identity_ignores_worker_mutated_interleave(gated):
+    """Workers adjust the interleave, the scheduler does not; names must match."""
+    _, get_dcp_decorated_model_name, _, _ = _import_connector_geometry_helpers()
+
+    def config(interleave):
+        cfg = _geometry_config(dcp_size=8, interleave=interleave, base_block_size=1536)
+
+        def adjust(kv_cache_config):
+            # ``gated`` mimics vLLM main, which aligns only for NixlConnector.
+            if not gated:
+                cfg.parallel_config.cp_kv_cache_interleave_size = min(
+                    g.kv_cache_spec.block_size for g in kv_cache_config.kv_cache_groups
+                )
+
+        cfg.adjust_dcp_kv_cache_interleave_size = adjust
+        return cfg
+
+    kv_cache_config = _hybrid_kv_cache_config(1536, 1536)
+    scheduler = config(1)
+    worker = config(1 if gated else 1536)
+    assert get_dcp_decorated_model_name(
+        scheduler, kv_cache_config
+    ) == get_dcp_decorated_model_name(worker, kv_cache_config)
+    assert scheduler.parallel_config.cp_kv_cache_interleave_size == 1
+
+
 # --------------------------------------------------------------------------- #
 # validate_dcp_support: fail closed on unproven topologies                     #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
`get_dcp_decorated_model_name` read `cp_kv_cache_interleave_size` straight off `parallel_config`. Workers block-align that field in `adjust_dcp_kv_cache_interleave_size`, called from `ensure_kv_transfer_initialized`; the scheduler's copy keeps the pre-adjustment value.

Where vLLM performs that adjustment, the two roles derive different names, so the workers register and store under one while the scheduler looks up another:

```
Worker_TP0_DCP0  cache_model_name=moonshotai/Kimi-K3##lmcache-dcp-layout-v1-d8-interleave1536
EngineCore       cache_model_name=moonshotai/Kimi-K3
LMCache ERROR: No GPU context found for model moonshotai/Kimi-K3 with world size 8 during lookup!
```

Stores succeeded and retrieves never fired. On Kimi-K3 MI355X TP8/DCP8: 120 GB/GPU written to DRAM, 0 bytes read back, `ext_cache_hit=0.0%`.

## Change

Delegate to vLLM's own normalization, which is idempotent, and restore the field afterwards since only vLLM owns it. Reproducing the rule instead would be wrong on one version or the other — main gates block-alignment behind `NixlConnector`, the ROCm nightly does not.

The cache key format is unchanged, so any deployment where the two roles already agreed keeps its existing keys and its cache.

## Not addressed here

- `validate_dcp_support` reads the same field the same way, so it validates nothing in the scheduler role. Harmless today because the worker's check still runs.
- The key does not include the attention block size, so two deployments sharing a `dcp_size` and an explicit interleave but differing in block size still collide. Pre-existing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how DCP cache keys are derived for scheduler lookups; deployments that already agreed on names are unchanged, but mis-keyed environments now share one key across roles.
> 
> **Overview**
> **Fixes LMCache external KV misses under decode-context parallelism** when vLLM workers block-align `cp_kv_cache_interleave_size` but the scheduler keeps the pre-adjustment value, so workers and the scheduler used different `cache_model_name` strings for the same deployment.
> 
> `get_dcp_decorated_model_name` now accepts optional `kv_cache_config` and, when vLLM exposes `adjust_dcp_kv_cache_interleave_size`, runs that normalization before reading interleave for the `##lmcache-dcp-layout-v1-…` suffix, then **restores** `parallel_config.cp_kv_cache_interleave_size` so only vLLM owns the field long-term. `LMCacheMPConnector` passes resolved KV cache config when resolving the name.
> 
> Adds a parametrized test that scheduler vs worker interleave mutations still yield identical decorated names (including vLLM-main-style gated adjustment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93eb78c3a36662c0e085ebc7d41c03ece92a641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->