### PR TITLE
[Bench] Add hybrid KV-cache geometry reference oracle

### DIFF
--- a/benchmarks/microbenchmark/hybrid_geometry_reference.ipynb
+++ b/benchmarks/microbenchmark/hybrid_geometry_reference.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "03e6699a",
+   "metadata": {},
+   "source": [
+    "# Hybrid KV-cache geometry differential check\n",
+    "\n",
+    "This Run-All notebook executes the engine-neutral reference oracle against LMCache's production token-range slicing and sliding-window downsampling helpers. It uses no model or GPU and writes no benchmark artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "41a5d0cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T06:00:43.149248Z",
+     "iopub.status.busy": "2026-09-04T06:00:43.149129Z",
+     "iopub.status.idle": "2026-09-04T06:00:46.550410Z",
+     "shell.execute_reply": "2026-09-04T06:00:46.549913Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "$ /Users/0z5a/Documents/infra/lmcache-liveness-isolation/.venv/bin/python -m benchmarks.microbenchmark.hybrid_geometry_reference_e2e --cases 10000 --seed 20260904\n",
+      "seed=20260904\n",
+      "cases=10000\n",
+      "groups_checked=35091\n",
+      "max_groups_per_case=6\n",
+      "elapsed_seconds=2.563696\n",
+      "token_range_differential=PASS\n",
+      "window_downsampling_differential=PASS\n",
+      "physical_slot_invariant=PASS\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-09-04 14:00:43,683] LMCache INFO:\u001b[0m torch_dev=StubCPUDevice(device_type=cpu), torch_device_type=cpu \u001b[3m(_device_detect.py:312:lmcache.v1.platform._device_detect)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "cwd = Path.cwd().resolve()\n",
+    "repo_root = next(\n",
+    "    candidate\n",
+    "    for candidate in (cwd, *cwd.parents)\n",
+    "    if (candidate / \"lmcache\").is_dir() and (candidate / \"benchmarks\").is_dir()\n",
+    ")\n",
+    "command = [\n",
+    "    sys.executable,\n",
+    "    \"-m\",\n",
+    "    \"benchmarks.microbenchmark.hybrid_geometry_reference_e2e\",\n",
+    "    \"--cases\",\n",
+    "    \"10000\",\n",
+    "    \"--seed\",\n",
+    "    \"20260904\",\n",
+    "]\n",
+    "completed = subprocess.run(\n",
+    "    command, cwd=repo_root, text=True, capture_output=True, check=False\n",
+    ")\n",
+    "print(\"$\", \" \".join(command))\n",
+    "print(completed.stdout, end=\"\")\n",
+    "if completed.stderr:\n",
+    "    print(completed.stderr, file=sys.stderr, end=\"\")\n",
+    "completed.check_returncode()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/microbenchmark/hybrid_geometry_reference.py
+++ b/benchmarks/microbenchmark/hybrid_geometry_reference.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small, engine-neutral reference model for hybrid KV-cache geometry.
+
+The implementation deliberately enumerates logical token positions instead of
+sharing the production slicing helpers.  It is intended as a differential-test
+oracle for serving-engine adapters that expose multiple paged-block address
+spaces with different block sizes, compression ratios, or sliding windows.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GroupGeometry:
+    """Logical and physical geometry for one engine block-address space."""
+
+    group_id: int
+    tokens_per_block: int
+    physical_slots_per_block: int
+    window_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.group_id < 0:
+            raise ValueError("group_id must be non-negative")
+        if self.tokens_per_block <= 0:
+            raise ValueError("tokens_per_block must be positive")
+        if self.physical_slots_per_block <= 0:
+            raise ValueError("physical_slots_per_block must be positive")
+        if self.tokens_per_block % self.physical_slots_per_block:
+            raise ValueError(
+                "tokens_per_block must be a multiple of physical_slots_per_block"
+            )
+        if self.window_tokens is not None:
+            if self.window_tokens <= 0:
+                raise ValueError("window_tokens must be positive when present")
+            if self.window_tokens % self.tokens_per_block:
+                raise ValueError(
+                    "window_tokens must align to the group's tokens_per_block"
+                )
+
+    @property
+    def compression_ratio(self) -> int:
+        """Return logical tokens represented by one physical slot."""
+        return self.tokens_per_block // self.physical_slots_per_block
+
+
+def reference_block_ids_for_token_range(
+    allocated_block_ids: Mapping[int, Sequence[int]],
+    geometries: Sequence[GroupGeometry],
+    token_start: int,
+    token_end: int,
+) -> dict[int, list[int]]:
+    """Map an aligned logical-token range to block IDs for every group.
+
+    Unlike the production implementation, this oracle visits each logical
+    token in the requested range and records the block whenever its address
+    changes.  This keeps the implementation independent enough to catch unit,
+    offset, and mixed-block-size regressions in optimized slicing code.
+    """
+    ordered = _validate_geometries(geometries)
+    _validate_tables(allocated_block_ids, ordered)
+    if token_start < 0 or token_end < 0:
+        raise ValueError("token range endpoints must be non-negative")
+    if token_end < token_start:
+        raise ValueError("token_end must not precede token_start")
+
+    result: dict[int, list[int]] = {}
+    for geometry in ordered:
+        if token_start % geometry.tokens_per_block or (
+            token_end % geometry.tokens_per_block
+        ):
+            raise ValueError(
+                f"token range [{token_start}, {token_end}) does not align to "
+                f"group {geometry.group_id} tokens_per_block "
+                f"{geometry.tokens_per_block}"
+            )
+        table = allocated_block_ids[geometry.group_id]
+        selected: list[int] = []
+        previous_position: int | None = None
+        for token_position in range(token_start, token_end):
+            block_position = token_position // geometry.tokens_per_block
+            if block_position == previous_position:
+                continue
+            if block_position >= len(table):
+                raise ValueError(
+                    f"block table for group {geometry.group_id} is too short: "
+                    f"position {block_position} is required but length is "
+                    f"{len(table)}"
+                )
+            selected.append(table[block_position])
+            previous_position = block_position
+        result[geometry.group_id] = selected
+    return result
+
+
+def reference_windowed_block_ids(
+    block_ids: Mapping[int, Sequence[int]],
+    geometries: Sequence[GroupGeometry],
+    logical_chunk_tokens: int,
+) -> dict[int, list[int]]:
+    """Keep the required tail blocks of each logical chunk for every group."""
+    ordered = _validate_geometries(geometries)
+    _validate_tables(block_ids, ordered)
+    if logical_chunk_tokens <= 0:
+        raise ValueError("logical_chunk_tokens must be positive")
+
+    result: dict[int, list[int]] = {}
+    for geometry in ordered:
+        if logical_chunk_tokens % geometry.tokens_per_block:
+            raise ValueError(
+                f"logical chunk size {logical_chunk_tokens} does not align to "
+                f"group {geometry.group_id} tokens_per_block "
+                f"{geometry.tokens_per_block}"
+            )
+        blocks_per_chunk = logical_chunk_tokens // geometry.tokens_per_block
+        table = block_ids[geometry.group_id]
+        if len(table) % blocks_per_chunk:
+            raise ValueError(
+                f"block table for group {geometry.group_id} has length "
+                f"{len(table)}, which is not a multiple of {blocks_per_chunk}"
+            )
+        keep_blocks = blocks_per_chunk
+        if (
+            geometry.window_tokens is not None
+            and geometry.window_tokens < logical_chunk_tokens
+        ):
+            keep_blocks = geometry.window_tokens // geometry.tokens_per_block
+
+        selected: list[int] = []
+        for chunk_start in range(0, len(table), blocks_per_chunk):
+            chunk = table[chunk_start : chunk_start + blocks_per_chunk]
+            selected.extend(chunk[-keep_blocks:])
+        result[geometry.group_id] = selected
+    return result
+
+
+def reference_num_physical_slots(
+    logical_tokens: int,
+    geometry: GroupGeometry,
+) -> int:
+    """Return the exact physical slots needed for a logical token count."""
+    if logical_tokens < 0:
+        raise ValueError("logical_tokens must be non-negative")
+    if logical_tokens % geometry.compression_ratio:
+        raise ValueError(
+            f"logical_tokens {logical_tokens} does not align to compression "
+            f"ratio {geometry.compression_ratio} for group {geometry.group_id}"
+        )
+    slots = 0
+    for logical_position in range(
+        0,
+        logical_tokens,
+        geometry.compression_ratio,
+    ):
+        del logical_position
+        slots += 1
+    return slots
+
+
+def _validate_geometries(
+    geometries: Sequence[GroupGeometry],
+) -> tuple[GroupGeometry, ...]:
+    ordered = tuple(sorted(geometries, key=lambda item: item.group_id))
+    ids = [item.group_id for item in geometries]
+    if len(ids) != len(set(ids)):
+        raise ValueError("group IDs must be unique")
+    if [item.group_id for item in ordered] != list(range(len(ordered))):
+        raise ValueError("group IDs must be dense and start at zero")
+    return ordered
+
+
+def _validate_tables(
+    block_ids: Mapping[int, Sequence[int]],
+    geometries: Sequence[GroupGeometry],
+) -> None:
+    expected = {item.group_id for item in geometries}
+    missing = expected - block_ids.keys()
+    if missing:
+        raise ValueError(f"missing block table for group(s) {sorted(missing)}")
+    extra = block_ids.keys() - expected
+    if extra:
+        raise ValueError(f"unexpected block table for group(s) {sorted(extra)}")
+    for group_id, table in block_ids.items():
+        if any(
+            isinstance(block_id, bool) or not isinstance(block_id, int) or block_id < 0
+            for block_id in table
+        ):
+            raise ValueError(
+                f"block table for group {group_id} must contain non-negative integers"
+            )

--- a/benchmarks/microbenchmark/hybrid_geometry_reference_e2e.py
+++ b/benchmarks/microbenchmark/hybrid_geometry_reference_e2e.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run reproducible differential checks for hybrid KV-cache geometry."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from math import lcm
+from typing import Any, cast
+import argparse
+import random
+import time
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.kv_layer_groups import KernelGroupInfo
+from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    downsample_and_stage_block_ids,
+)
+from lmcache.v1.platform.ops_types import PageBufferShapeDesc
+
+# Local
+from .hybrid_geometry_reference import (
+    GroupGeometry,
+    reference_block_ids_for_token_range,
+    reference_num_physical_slots,
+    reference_windowed_block_ids,
+)
+
+_BLOCK_SIZES = (1, 2, 4, 8, 16, 32, 64, 128, 256)
+
+
+@dataclass
+class _Manager:
+    geometries: list[GroupGeometry]
+    chunk_tokens: int
+
+    @property
+    def num_kernel_groups(self) -> int:
+        return len(self.geometries)
+
+    def get_subchunk_sw_size_tokens(self, group_id: int) -> int:
+        window = self.geometries[group_id].window_tokens
+        return self.chunk_tokens if window is None else window
+
+
+class _Context:
+    def __init__(self, geometries: list[GroupGeometry], chunk_tokens: int):
+        self.geometries = geometries
+        self.lmcache_tokens_per_chunk = chunk_tokens
+        self.kv_layer_groups_manager = _Manager(geometries, chunk_tokens)
+
+    def calculate_num_blocks(self, num_tokens: int, group_id: int) -> int:
+        return num_tokens // self.geometries[group_id].tokens_per_block
+
+    def stage_block_ids(self, block_ids: list[list[int]]) -> list[list[int]]:
+        return block_ids
+
+
+def run_differential_checks(cases: int, seed: int) -> None:
+    """Compare optimized runtime helpers against the reference model."""
+    if cases <= 0:
+        raise ValueError("cases must be positive")
+    rng = random.Random(seed)
+    started = time.monotonic()
+    groups_checked = 0
+    max_groups = 0
+
+    for case_index in range(cases):
+        group_count = rng.randint(1, 6)
+        tokens_per_block = [rng.choice(_BLOCK_SIZES) for _ in range(group_count)]
+        alignment = lcm(*tokens_per_block)
+        start = rng.randint(0, 8) * alignment
+        end = start + rng.randint(0, 8) * alignment
+        geometries: list[GroupGeometry] = []
+        allocated: dict[int, list[int]] = {}
+
+        for group_id, block_size in enumerate(tokens_per_block):
+            divisors = [
+                candidate
+                for candidate in _BLOCK_SIZES
+                if candidate <= block_size and block_size % candidate == 0
+            ]
+            slots = rng.choice(divisors)
+            possible_windows = [None] + list(
+                range(block_size, 256 + block_size, block_size)
+            )
+            geometry = GroupGeometry(
+                group_id=group_id,
+                tokens_per_block=block_size,
+                physical_slots_per_block=slots,
+                window_tokens=rng.choice(possible_windows),
+            )
+            geometries.append(geometry)
+            allocated[group_id] = [
+                case_index * 10_000_000 + group_id * 1_000_000 + offset
+                for offset in range(end // block_size + rng.randint(0, 4))
+            ]
+            logical_tokens = rng.randint(0, 128) * geometry.compression_ratio
+            expected_slots = logical_tokens // geometry.compression_ratio
+            actual_slots = reference_num_physical_slots(logical_tokens, geometry)
+            shape_desc = PageBufferShapeDesc()
+            shape_desc.bs = slots
+            runtime_group = KernelGroupInfo(
+                layer_indices=[group_id],
+                shape_desc=shape_desc,
+                dtype=torch.float16,
+                tokens_per_block=block_size,
+            )
+            if (
+                actual_slots != expected_slots
+                or runtime_group.calculate_slots(logical_tokens) != actual_slots
+            ):
+                raise AssertionError(
+                    f"physical-slot mismatch in case {case_index}, group {group_id}"
+                )
+
+        expected_slice = reference_block_ids_for_token_range(
+            allocated,
+            geometries,
+            start,
+            end,
+        )
+        actual_slice = slice_block_ids_per_group(
+            allocated,
+            tokens_per_block,
+            start,
+            end,
+        )
+        if actual_slice != [
+            expected_slice[group_id] for group_id in range(group_count)
+        ]:
+            raise AssertionError(f"token-range mismatch in case {case_index}")
+
+        num_chunks = rng.randint(0, 16)
+        window_tables = {
+            group_id: [
+                case_index * 10_000_000 + group_id * 1_000_000 + offset
+                for offset in range(num_chunks * 256 // geometry.tokens_per_block)
+            ]
+            for group_id, geometry in enumerate(geometries)
+        }
+        expected_window = reference_windowed_block_ids(
+            window_tables,
+            geometries,
+            logical_chunk_tokens=256,
+        )
+        actual_window = downsample_and_stage_block_ids(
+            cast(Any, _Context(geometries, chunk_tokens=256)),
+            [list(window_tables[group_id]) for group_id in range(group_count)],
+        )
+        if actual_window != [
+            expected_window[group_id] for group_id in range(group_count)
+        ]:
+            raise AssertionError(f"window mismatch in case {case_index}")
+
+        groups_checked += group_count
+        max_groups = max(max_groups, group_count)
+
+    elapsed = time.monotonic() - started
+    print(f"seed={seed}")
+    print(f"cases={cases}")
+    print(f"groups_checked={groups_checked}")
+    print(f"max_groups_per_case={max_groups}")
+    print(f"elapsed_seconds={elapsed:.6f}")
+    print("token_range_differential=PASS")
+    print("window_downsampling_differential=PASS")
+    print("physical_slot_invariant=PASS")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", type=int, default=10_000)
+    parser.add_argument("--seed", type=int, default=20260904)
+    args = parser.parse_args()
+    run_differential_checks(args.cases, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 buildkite-test-collector
+hypothesis>=6,<7
 pytest>=7.0,<9.1  # avoid some plugins breaking in 8.x
 pytest-asyncio
 pytest-benchmark

--- a/tests/benchmarks/test_hybrid_geometry_reference.py
+++ b/tests/benchmarks/test_hybrid_geometry_reference.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Property tests for the engine-neutral hybrid geometry reference model."""
+
+# Standard
+from math import lcm
+from typing import Any, cast
+
+# Third Party
+from hypothesis import given, settings
+from hypothesis import strategies as st
+import pytest
+import torch
+
+# First Party
+from benchmarks.microbenchmark.hybrid_geometry_reference import (
+    GroupGeometry,
+    reference_block_ids_for_token_range,
+    reference_num_physical_slots,
+    reference_windowed_block_ids,
+)
+from lmcache.v1.kv_layer_groups import KernelGroupInfo
+from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    downsample_and_stage_block_ids,
+)
+from lmcache.v1.platform.ops_types import PageBufferShapeDesc
+
+_BLOCK_SIZES = (1, 2, 4, 8, 16, 32, 64, 128, 256)
+
+
+@st.composite
+def _aligned_geometry_cases(draw):
+    tokens_per_block = draw(
+        st.lists(
+            st.sampled_from(_BLOCK_SIZES),
+            min_size=1,
+            max_size=6,
+        )
+    )
+    alignment = lcm(*tokens_per_block)
+    start = draw(st.integers(min_value=0, max_value=8)) * alignment
+    end = start + draw(st.integers(min_value=0, max_value=8)) * alignment
+    extra_blocks = draw(st.integers(min_value=0, max_value=4))
+    allocated = {
+        group_id: [
+            group_id * 1_000_000 + offset
+            for offset in range(end // block_size + extra_blocks)
+        ]
+        for group_id, block_size in enumerate(tokens_per_block)
+    }
+    return allocated, tokens_per_block, start, end
+
+
+@st.composite
+def _window_geometry_cases(draw):
+    logical_chunk_tokens = 256
+    tokens_per_block = draw(
+        st.lists(
+            st.sampled_from(_BLOCK_SIZES),
+            min_size=1,
+            max_size=6,
+        )
+    )
+    windows = [
+        draw(
+            st.one_of(
+                st.none(),
+                st.sampled_from(
+                    list(
+                        range(
+                            block_size,
+                            logical_chunk_tokens + block_size,
+                            block_size,
+                        )
+                    )
+                ),
+            )
+        )
+        for block_size in tokens_per_block
+    ]
+    num_chunks = draw(st.integers(min_value=0, max_value=16))
+    geometries = [
+        GroupGeometry(
+            group_id=group_id,
+            tokens_per_block=block_size,
+            physical_slots_per_block=block_size,
+            window_tokens=windows[group_id],
+        )
+        for group_id, block_size in enumerate(tokens_per_block)
+    ]
+    block_ids = {
+        group_id: [
+            group_id * 1_000_000 + offset
+            for offset in range(num_chunks * logical_chunk_tokens // block_size)
+        ]
+        for group_id, block_size in enumerate(tokens_per_block)
+    }
+    return logical_chunk_tokens, geometries, block_ids
+
+
+class _ReferenceManager:
+    def __init__(self, geometries: list[GroupGeometry], chunk_tokens: int):
+        self.geometries = geometries
+        self.chunk_tokens = chunk_tokens
+        self.num_kernel_groups = len(geometries)
+
+    def get_subchunk_sw_size_tokens(self, group_id: int) -> int:
+        window = self.geometries[group_id].window_tokens
+        return self.chunk_tokens if window is None else window
+
+
+class _ReferenceContext:
+    def __init__(self, geometries: list[GroupGeometry], chunk_tokens: int):
+        self.geometries = geometries
+        self.lmcache_tokens_per_chunk = chunk_tokens
+        self.kv_layer_groups_manager = _ReferenceManager(geometries, chunk_tokens)
+
+    def calculate_num_blocks(self, num_tokens: int, group_id: int) -> int:
+        return num_tokens // self.geometries[group_id].tokens_per_block
+
+    def stage_block_ids(self, block_ids: list[list[int]]) -> list[list[int]]:
+        return block_ids
+
+
+@given(_aligned_geometry_cases())
+@settings(max_examples=300, deadline=None, derandomize=True)
+def test_reference_matches_runtime_group_slicing(case) -> None:
+    """Runtime slicing matches an independently enumerated reference map."""
+    allocated, tokens_per_block, start, end = case
+
+    actual = slice_block_ids_per_group(
+        allocated,
+        tokens_per_block,
+        start,
+        end,
+    )
+    expected = reference_block_ids_for_token_range(
+        allocated,
+        [
+            GroupGeometry(
+                group_id=group_id,
+                tokens_per_block=block_size,
+                physical_slots_per_block=block_size,
+            )
+            for group_id, block_size in enumerate(tokens_per_block)
+        ],
+        start,
+        end,
+    )
+
+    assert actual == [expected[group_id] for group_id in range(len(expected))]
+    assert [len(ids) for ids in actual] == [
+        (end - start) // block_size for block_size in tokens_per_block
+    ]
+
+
+@given(_window_geometry_cases())
+@settings(max_examples=300, deadline=None, derandomize=True)
+def test_reference_matches_runtime_window_downsampling(case) -> None:
+    """Runtime SWA tail selection matches the independent reference model."""
+    logical_chunk_tokens, geometries, block_ids = case
+    context = _ReferenceContext(geometries, logical_chunk_tokens)
+
+    actual = downsample_and_stage_block_ids(
+        cast(Any, context),
+        [list(block_ids[group_id]) for group_id in range(len(geometries))],
+    )
+    expected = reference_windowed_block_ids(
+        block_ids,
+        geometries,
+        logical_chunk_tokens,
+    )
+
+    assert actual == [expected[group_id] for group_id in range(len(expected))]
+
+
+@given(
+    tokens_per_block=st.sampled_from(_BLOCK_SIZES),
+    compression_ratio=st.sampled_from(_BLOCK_SIZES),
+    block_count=st.integers(min_value=0, max_value=512),
+)
+@settings(max_examples=200, deadline=None, derandomize=True)
+def test_physical_slot_reference_respects_compression(
+    tokens_per_block: int,
+    compression_ratio: int,
+    block_count: int,
+) -> None:
+    """Logical tokens map to the exact physical-slot count for each group."""
+    physical_slots_per_block = max(1, tokens_per_block // compression_ratio)
+    if tokens_per_block % physical_slots_per_block:
+        return
+    geometry = GroupGeometry(
+        group_id=0,
+        tokens_per_block=tokens_per_block,
+        physical_slots_per_block=physical_slots_per_block,
+    )
+    logical_tokens = block_count * tokens_per_block
+    shape_desc = PageBufferShapeDesc()
+    shape_desc.bs = physical_slots_per_block
+    runtime_group = KernelGroupInfo(
+        layer_indices=[0],
+        shape_desc=shape_desc,
+        dtype=torch.float16,
+        tokens_per_block=tokens_per_block,
+    )
+
+    expected = reference_num_physical_slots(logical_tokens, geometry)
+    assert expected == block_count * physical_slots_per_block
+    assert runtime_group.calculate_slots(logical_tokens) == expected
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "message"),
+    [
+        (-16, 16, "non-negative"),
+        (32, 16, "not precede"),
+        (1, 16, "align"),
+        (0, 15, "align"),
+    ],
+)
+def test_reference_rejects_invalid_token_ranges(
+    start: int,
+    end: int,
+    message: str,
+) -> None:
+    geometry = GroupGeometry(0, tokens_per_block=16, physical_slots_per_block=8)
+    with pytest.raises(ValueError, match=message):
+        reference_block_ids_for_token_range(
+            {0: [10, 11]},
+            [geometry],
+            start,
+            end,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"group_id": -1, "tokens_per_block": 16, "physical_slots_per_block": 16},
+        {"group_id": 0, "tokens_per_block": 0, "physical_slots_per_block": 16},
+        {"group_id": 0, "tokens_per_block": 16, "physical_slots_per_block": 0},
+        {"group_id": 0, "tokens_per_block": 16, "physical_slots_per_block": 6},
+        {
+            "group_id": 0,
+            "tokens_per_block": 16,
+            "physical_slots_per_block": 8,
+            "window_tokens": 12,
+        },
+    ],
+)
+def test_reference_rejects_invalid_group_geometry(kwargs) -> None:
+    with pytest.raises(ValueError):
+        GroupGeometry(**kwargs)
+
+
+def test_reference_rejects_duplicate_and_missing_groups() -> None:
+    duplicate = [GroupGeometry(0, 16, 16), GroupGeometry(0, 16, 16)]
+    missing = [GroupGeometry(0, 16, 16), GroupGeometry(2, 16, 16)]
+
+    with pytest.raises(ValueError, match="unique"):
+        reference_block_ids_for_token_range({0: [1]}, duplicate, 0, 16)
+    with pytest.raises(ValueError, match="dense"):
+        reference_block_ids_for_token_range({0: [1], 2: [2]}, missing, 0, 16)
+
+
+def test_reference_rejects_short_and_malformed_block_tables() -> None:
+    geometries = [GroupGeometry(0, 16, 8), GroupGeometry(1, 32, 32)]
+
+    with pytest.raises(ValueError, match="missing block table"):
+        reference_block_ids_for_token_range({0: [10, 11]}, geometries, 0, 32)
+    with pytest.raises(ValueError, match="too short"):
+        reference_block_ids_for_token_range({0: [10], 1: [20]}, geometries, 0, 32)
+    with pytest.raises(ValueError, match="non-negative integers"):
+        reference_block_ids_for_token_range({0: [10, -1], 1: [20]}, geometries, 0, 32)
+
+
+def test_deepseek_style_mixed_geometry_reference() -> None:
+    """One range maps independently across dense, SWA, and state groups."""
+    geometries = [
+        GroupGeometry(0, 256, 64),
+        GroupGeometry(1, 64, 64, window_tokens=256),
+        GroupGeometry(2, 4, 4, window_tokens=4),
+    ]
+    allocated = {
+        0: [10, 11],
+        1: list(range(100, 108)),
+        2: list(range(1_000, 1_128)),
+    }
+
+    mapped = reference_block_ids_for_token_range(
+        allocated,
+        geometries,
+        token_start=256,
+        token_end=512,
+    )
+
+    assert mapped == {
+        0: [11],
+        1: [104, 105, 106, 107],
+        2: list(range(1_064, 1_128)),
+    }
+    assert [reference_num_physical_slots(256, item) for item in geometries] == [
+        64,
+        256,
+        256,
+    ]


### PR DESCRIPTION
## Summary

- add an engine-neutral reference model for mixed KV-cache block geometry
- differential-test production token-range slicing and sliding-window downsampling with deterministic Hypothesis generators
- cross-check compressed logical-token to physical-slot calculations against `KernelGroupInfo.calculate_slots`
- fail closed in the oracle on misaligned ranges, malformed/short block tables, duplicate or sparse group IDs, and incompatible slot geometry
- include a reviewer-runnable Run-All notebook and a bounded 10,000-case E2E driver

## Why

Hybrid/recurrent models can combine multiple engine block-address spaces, different `tokens_per_block`, compressed physical slots, and per-group sliding windows. Existing fixed examples cover important known shapes, but do not exercise their cross-product or provide an independent reference implementation.

The oracle deliberately enumerates logical token positions rather than sharing LMCache's optimized slicing code. That makes it useful for catching offset, unit, and per-group indexing regressions without changing runtime behavior.

## Reviewer reproduction

Install test dependencies (this PR adds Hypothesis to `requirements/test.txt`), then either Run All:

- [`benchmarks/microbenchmark/hybrid_geometry_reference.ipynb`](https://github.com/0z5a/LMCache/blob/test/hybrid-geometry-reference-oracle/benchmarks/microbenchmark/hybrid_geometry_reference.ipynb)

or run the same bounded differential driver directly:

```bash
python -m benchmarks.microbenchmark.hybrid_geometry_reference_e2e \
  --cases 10000 \
  --seed 20260904
```

Final-head output at `e42ecb74a858`:

```text
seed=20260904
cases=10000
groups_checked=35091
max_groups_per_case=6
elapsed_seconds=2.564283
token_range_differential=PASS
window_downsampling_differential=PASS
physical_slot_invariant=PASS
```

This is correctness test infrastructure and does not require or occupy a GPU. The elapsed value is diagnostic, not a performance claim.

## Tests

```bash
python -m pytest -q \
  tests/benchmarks/test_hybrid_geometry_reference.py \
  tests/v1/test_kv_cache_groups.py
```

```text
28 passed, 115 warnings in 1.75s
```

The property suite runs 300 deterministic mixed-group range examples, 300 deterministic sliding-window examples, and 200 compressed-slot examples. `SKIP=rust-fmt,rust-clippy pre-commit run --all-files` also passed all applicable hooks (SPDX, device/timeout guards, isort, ruff, ruff-format, codespell, clang-format, and mypy). Rust hooks were skipped on macOS for this Python/notebook-only change.

Evidence hashes:

```text
a89b61757b911d436d87b7edb2eb417a7f8d6e4fa1a744299f6e81d9469fce4a  differential E2E log
80c649b8ecddd8966f1243d3a251d8cd3f556e405fb83e8bf147fd2c3f905f1a  pytest log
6f86696414854db60e44090ff6234c6edbfafc25d45d755d507f2f35f5bf9c0a  pre-commit log
c483e6c68d5e5811421af49a3b392fb1e2077f4029fd030b2c16b215f60b10bc  executed notebook
```
