### PR TITLE
fix(mp): enforce EventBus bounds for native ingress

### DIFF
--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -113,6 +113,7 @@ class EventBus:
         self._wake = threading.Event()
         self._stop_flag = threading.Event()
         self._lock = threading.Lock()
+        self._queue_lock = threading.Lock()
         self._thread: threading.Thread | None = None
         self._registered_subscribers: list[EventSubscriber] = []
         self._discard_count: int = 0
@@ -203,21 +204,22 @@ class EventBus:
         if not self._config.enabled:
             return
 
-        if len(self._queue) >= self._config.max_queue_size:
-            self._discard_count += 1
-            now = time.monotonic()
-            if now - self._last_discard_warning >= 1.0:
-                logger.warning(
-                    "EventBus queue full (max_queue_size=%d), "
-                    "%d event(s) discarded so far",
-                    self._config.max_queue_size,
-                    self._discard_count,
-                )
-                self._last_discard_warning = now
-            return
+        with self._queue_lock:
+            if len(self._queue) >= self._config.max_queue_size:
+                self._discard_count += 1
+                now = time.monotonic()
+                if now - self._last_discard_warning >= 1.0:
+                    logger.warning(
+                        "EventBus queue full (max_queue_size=%d), "
+                        "%d event(s) discarded so far",
+                        self._config.max_queue_size,
+                        self._discard_count,
+                    )
+                    self._last_discard_warning = now
+                return
 
-        event.timestamp = time.time()
-        self._queue.append(event)
+            event.timestamp = time.time()
+            self._queue.append(event)
         self._wake.set()
 
     def start(self) -> None:

--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -204,23 +204,8 @@ class EventBus:
         if not self._config.enabled:
             return
 
-        with self._queue_lock:
-            if len(self._queue) >= self._config.max_queue_size:
-                self._discard_count += 1
-                now = time.monotonic()
-                if now - self._last_discard_warning >= 1.0:
-                    logger.warning(
-                        "EventBus queue full (max_queue_size=%d), "
-                        "%d event(s) discarded so far",
-                        self._config.max_queue_size,
-                        self._discard_count,
-                    )
-                    self._last_discard_warning = now
-                return
-
-            event.timestamp = time.time()
-            self._queue.append(event)
-        self._wake.set()
+        if self._admit_event(event, stamp_timestamp=True):
+            self._wake.set()
 
     def start(self) -> None:
         """Start the background drain thread.  No-op when disabled or
@@ -319,13 +304,14 @@ class EventBus:
             for name, sid, ts, str_meta, int_meta in native_events:
                 metadata: dict[str, Any] = dict(str_meta)
                 metadata.update(int_meta)
-                self._queue.append(
+                self._admit_event(
                     Event(
                         event_type=EventType(name),
                         session_id=sid,
                         timestamp=ts,
                         metadata=metadata,
-                    )
+                    ),
+                    stamp_timestamp=False,
                 )
 
         with self._lock:
@@ -355,6 +341,27 @@ class EventBus:
                         name,
                         event.event_type.value,
                     )
+
+    def _admit_event(self, event: Event, *, stamp_timestamp: bool) -> bool:
+        """Atomically admit one event without exceeding the queue bound."""
+        with self._queue_lock:
+            if len(self._queue) >= self._config.max_queue_size:
+                self._discard_count += 1
+                now = time.monotonic()
+                if now - self._last_discard_warning >= 1.0:
+                    logger.warning(
+                        "EventBus queue full (max_queue_size=%d), "
+                        "%d event(s) discarded so far",
+                        self._config.max_queue_size,
+                        self._discard_count,
+                    )
+                    self._last_discard_warning = now
+                return False
+
+            if stamp_timestamp:
+                event.timestamp = time.time()
+            self._queue.append(event)
+            return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/mp_observability/test_event_bus.py
+++ b/tests/v1/mp_observability/test_event_bus.py
@@ -3,7 +3,9 @@
 """Tests for EventBus, EventSubscriber, and singleton management."""
 
 # Standard
+from collections import deque
 from unittest.mock import MagicMock, patch
+import threading
 import time
 
 # Third Party
@@ -308,6 +310,41 @@ class TestBackpressure:
 
         assert len(b._queue) == 5
         assert b._discard_count == 5
+
+    def test_concurrent_publishers_preserve_queue_bound(self):
+        class _CoordinatedDeque(deque[Event]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.first_len = threading.Event()
+                self.second_len = threading.Event()
+
+            def __len__(self) -> int:
+                observed = super().__len__()
+                if not self.first_len.is_set():
+                    self.first_len.set()
+                    self.second_len.wait(timeout=0.25)
+                else:
+                    self.second_len.set()
+                return observed
+
+        b = EventBus(EventBusConfig(enabled=True, max_queue_size=1))
+        b._queue = _CoordinatedDeque()
+        start = threading.Barrier(3)
+
+        def publish() -> None:
+            start.wait()
+            b.publish(_make_event())
+
+        publishers = [threading.Thread(target=publish) for _ in range(2)]
+        for publisher in publishers:
+            publisher.start()
+        start.wait()
+        for publisher in publishers:
+            publisher.join(timeout=1.0)
+
+        assert all(not publisher.is_alive() for publisher in publishers)
+        assert len(b._queue) == 1
+        assert b.dropped_events_count() == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/mp_observability/test_event_bus.py
+++ b/tests/v1/mp_observability/test_event_bus.py
@@ -346,6 +346,34 @@ class TestBackpressure:
         assert len(b._queue) == 1
         assert b.dropped_events_count() == 1
 
+    def test_native_ingress_shares_queue_bound_and_drop_count(self):
+        b = EventBus(EventBusConfig(enabled=True, max_queue_size=2))
+        received: list[Event] = []
+        b.subscribe(EventType.L1_READ_FINISHED, received.append)
+        b.publish(_make_event(session_id="python"))
+
+        native_ops = MagicMock()
+        native_ops.drain_recorded_events.return_value = [
+            (
+                EventType.L1_READ_FINISHED.value,
+                f"native-{index}",
+                float(index + 1),
+                {},
+                {},
+            )
+            for index in range(3)
+        ]
+
+        with (
+            patch.object(_bus_module, "_has_native_recorder", True),
+            patch.object(_bus_module, "_device_ops", native_ops, create=True),
+        ):
+            b.stop()
+
+        assert [event.session_id for event in received] == ["python", "native-0"]
+        assert received[1].timestamp == 1.0
+        assert b.dropped_events_count() == 2
+
 
 # ---------------------------------------------------------------------------
 # Self-monitoring accessors


### PR DESCRIPTION
## Summary

- route Python and native-recorder events through one atomic queue-admission helper
- enforce `max_queue_size` for native bursts and include rejected native records in the existing drop counter
- preserve recorder-supplied timestamps for accepted native events

## Problem

The Python `publish()` path enforces the configured queue bound, but `_drain_all()` appended native recorder events directly to the deque. A native burst could therefore grow the queue beyond `max_queue_size` and bypass `dropped_events_count()`.

This PR is stacked on #4914, which makes Python publisher admission atomic. The net-new change is commit `92a5fafc`; the PR remains Draft until #4914 merges and this branch is rebased onto `dev`.

## Test-first reproduction

On parent commit `ee5501da`, a queue with capacity 2 and one queued Python event accepted all three native events:

```text
FAILED TestBackpressure::test_native_ingress_shares_queue_bound_and_drop_count
expected [python, native-0]
actual   [python, native-0, native-1, native-2]
```

The regression test uses the public publish/subscribe/stop lifecycle with a deterministic mock native-recorder batch. It also verifies that the accepted native event keeps its recorder timestamp and that the two rejected records increment the shared drop count.

## Final-head validation

Exact commit: `92a5fafc`

Reviewer-runnable command:

```bash
python -m pytest -vv tests/v1/mp_observability/test_event_bus.py
```

```text
collected 43 items
43 passed, 80 warnings in 3.44s
```

The complete 156-line raw pytest log has SHA-256 `0507c16d2b45cb1c2d1cec7eaf08041323b086b76e192c17e5c796d424217316`.

Repository-wide pre-commit checks passed: SPDX, device rules, host-registration rule, TimeoutError rule, isort, Ruff, Ruff format, codespell, clang-format, and mypy. Rust hooks were explicitly skipped for this Python-only macOS validation, per `AGENTS.md`. The captured pre-commit output has SHA-256 `6f86696414854db60e44090ff6234c6edbfafc25d45d755d507f2f35f5bf9c0a`.

This is a CPU control-plane/backpressure change. A GPU notebook would only wrap the same deterministic native-recorder seam and would not exercise more production code, so the checked-in pytest is the direct runnable reproduction. No throughput or CUDA E2E claim is made.

## Scope

This PR does not change native record decoding or malformed-record isolation; that remains isolated in #4915.

- [x] tests added
- [ ] user-facing documentation changed