### PR TITLE
[Test][MP] Give each MQ test its own free port

### DIFF
--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -3,6 +3,7 @@
 from multiprocessing.synchronize import Event as EventClass
 from typing import Any, Callable
 import multiprocessing as mp
+import socket
 import sys
 import threading
 import time
@@ -169,6 +170,19 @@ def _run_client_test(
             sys.exit(1)
 
 
+def free_tcp_url() -> str:
+    """Return a ``tcp://`` URL on a currently free loopback port.
+
+    A hardcoded port makes two concurrent runs collide: the second server's
+    bind fails and its clients then fail on a timeout that names neither the
+    port nor the cause. The probe socket only listens, so closing it leaves no
+    connection in ``TIME_WAIT`` to block the server's bind.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return f"tcp://127.0.0.1:{probe.getsockname()[1]}"
+
+
 class MessageQueueTestHelper:
     """
     Helper class to facilitate testing MessageQueueServer and MessageQueueClient.
@@ -182,7 +196,7 @@ class MessageQueueTestHelper:
         3. Call run_test() to execute the test with client requests
 
     Example:
-        helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5556")
+        helper = MessageQueueTestHelper()
         helper.register_handler(RequestType.NOOP, noop_handler)
         helper.run_test(
             request_type=RequestType.NOOP,
@@ -193,8 +207,8 @@ class MessageQueueTestHelper:
         )
     """
 
-    def __init__(self, server_url: str = "tcp://127.0.0.1:5556"):
-        self.server_url = server_url
+    def __init__(self, server_url: "str | None" = None):
+        self.server_url = server_url or free_tcp_url()
         self.handlers: dict[RequestType, Callable] = {}
         self.ctx = mp.get_context("spawn")
 
@@ -290,17 +304,19 @@ class MessageQueueTestHelper:
             server_process.terminate()
             server_process.join()
 
-        # Report any failures
+        # Report any failures. The server is reported first: when it fails to
+        # start, every client fails as a consequence, and naming only the
+        # client hides the cause.
+        if server_process.exitcode != 0:
+            pytest.fail(
+                f"Server process failed with exit code {server_process.exitcode}"
+            )
+
         if failed_clients:
             failure_details = ", ".join(
                 [f"Client {cid}: {reason}" for cid, reason in failed_clients]
             )
             pytest.fail(f"Some clients failed: {failure_details}")
-
-        if server_process.exitcode != 0:
-            pytest.fail(
-                f"Server process failed with exit code {server_process.exitcode}"
-            )
 
 
 # ==============================================================================
@@ -314,7 +330,7 @@ def test_mq_noop_request():
     NOOP takes no payloads and returns a string response.
     """
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5556")
+    helper = MessageQueueTestHelper()
     helper.register_handler(RequestType.NOOP, test_mq_handler_helpers.noop_handler)
 
     # Run test with single request
@@ -331,7 +347,7 @@ def test_mq_noop_multiple_requests():
     Test MessageQueue with multiple NOOP requests.
     Verifies that server can handle multiple sequential requests.
     """
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5557")
+    helper = MessageQueueTestHelper()
     helper.register_handler(RequestType.NOOP, test_mq_handler_helpers.noop_handler)
 
     # Run test with multiple requests
@@ -348,7 +364,7 @@ def test_mq_noop_multiple_clients():
     Test MessageQueue with multiple concurrent clients.
     Verifies that server can handle requests from multiple clients simultaneously.
     """
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5558")
+    helper = MessageQueueTestHelper()
     helper.register_handler(RequestType.NOOP, test_mq_handler_helpers.noop_handler)
 
     # Run test with multiple clients, each sending multiple requests
@@ -384,7 +400,7 @@ def test_mq_register_kv_cache():
     gpu_id = 0
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5559")
+    helper = MessageQueueTestHelper()
     helper.register_handler(
         RequestType.REGISTER_KV_CACHE, test_mq_handler_helpers.register_kv_cache_handler
     )
@@ -414,7 +430,7 @@ def test_mq_unregister_kv_cache():
     gpu_id = 0
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5560")
+    helper = MessageQueueTestHelper()
     helper.register_handler(
         RequestType.UNREGISTER_KV_CACHE,
         test_mq_handler_helpers.unregister_kv_cache_handler,
@@ -437,7 +453,7 @@ def test_mq_unregister_kv_cache_multiple_clients():
     gpu_id = 0
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5561")
+    helper = MessageQueueTestHelper()
     helper.register_handler(
         RequestType.UNREGISTER_KV_CACHE,
         test_mq_handler_helpers.unregister_kv_cache_handler,
@@ -466,7 +482,7 @@ def test_mq_store():
     test_handle = b"\x00" * 64
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5562")
+    helper = MessageQueueTestHelper()
     helper.register_handler(RequestType.STORE, test_mq_handler_helpers.store_handler)
 
     # Run test with STORE request
@@ -491,7 +507,7 @@ def test_mq_retrieve():
     test_handle = b"\x00" * 64
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5563")
+    helper = MessageQueueTestHelper()
     helper.register_handler(
         RequestType.RETRIEVE, test_mq_handler_helpers.retrieve_handler
     )
@@ -518,7 +534,7 @@ def test_mq_lookup():
     expected_response = None
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5564")
+    helper = MessageQueueTestHelper()
     helper.register_handler(RequestType.LOOKUP, test_mq_handler_helpers.lookup_handler)
 
     # Run test with LOOKUP request
@@ -542,7 +558,7 @@ def test_mq_lookup_with_different_key():
     expected_response = None
 
     # Create test helper and register handler
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5565")
+    helper = MessageQueueTestHelper()
     helper.register_handler(RequestType.LOOKUP, test_mq_handler_helpers.lookup_handler)
 
     # Run test with LOOKUP request
@@ -573,7 +589,7 @@ def test_mq_report_block_allocation():
         ),
     ]
 
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5566")
+    helper = MessageQueueTestHelper()
     helper.register_handler(
         RequestType.REPORT_BLOCK_ALLOCATION,
         test_mq_handler_helpers.report_block_allocations_handler,
@@ -593,7 +609,7 @@ def test_mq_report_block_allocation_empty():
     """
     records: list[BlockAllocationRecord] = []
 
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5567")
+    helper = MessageQueueTestHelper()
     helper.register_handler(
         RequestType.REPORT_BLOCK_ALLOCATION,
         test_mq_handler_helpers.report_block_allocations_handler,
@@ -625,8 +641,8 @@ def test_shared_loop_lifecycle():
     # No loop before any clients exist
     assert ClientPollingLoop._instance is None
 
-    client_a = MessageQueueClient("tcp://127.0.0.1:16000", context)
-    client_b = MessageQueueClient("tcp://127.0.0.1:16001", context)
+    client_a = MessageQueueClient(free_tcp_url(), context)
+    client_b = MessageQueueClient(free_tcp_url(), context)
 
     # Both share the same singleton
     loop = ClientPollingLoop._instance
@@ -656,7 +672,7 @@ def test_shared_loop_dispatch():
     # First Party
     from lmcache.v1.multiprocess.mq import ClientPollingLoop
 
-    server_url = "tcp://127.0.0.1:16020"
+    server_url = free_tcp_url()
     context = zmq.Context.instance()
 
     # Start server in-process
@@ -703,7 +719,7 @@ def test_client_survives_undecodable_response() -> None:
     stranded. The observable contract is that only the offending request is
     lost: a later, well-formed request must still complete normally.
     """
-    server_url = "tcp://127.0.0.1:16030"
+    server_url = free_tcp_url()
     context = zmq.Context.instance()
 
     unknown_value = max(member.value for member in RequestType) + 1
@@ -758,14 +774,14 @@ def test_shared_loop_recreate():
 
     context = zmq.Context.instance()
 
-    client = MessageQueueClient("tcp://127.0.0.1:16010", context)
+    client = MessageQueueClient(free_tcp_url(), context)
     first_loop = ClientPollingLoop._instance
     assert first_loop is not None
     client.close()
     assert ClientPollingLoop._instance is None
 
     # New client creates a brand-new loop
-    client2 = MessageQueueClient("tcp://127.0.0.1:16011", context)
+    client2 = MessageQueueClient(free_tcp_url(), context)
     second_loop = ClientPollingLoop._instance
     assert second_loop is not None
     assert second_loop is not first_loop
@@ -783,7 +799,7 @@ def test_add_normal_thread_pool():
     Test that add_normal_thread_pool assigns handler executors.
     """
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15700", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     add_handler_helper(
         server, RequestType.LOOKUP, test_mq_handler_helpers.lookup_handler
@@ -810,7 +826,7 @@ def test_add_affinity_thread_pool():
     from lmcache.v1.multiprocess.affinity_pool import AffinityThreadPool
 
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15700", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     add_handler_helper(server, RequestType.STORE, test_mq_handler_helpers.store_handler)
     add_handler_helper(
@@ -839,7 +855,7 @@ def test_normal_pool_error_on_sync_handler():
     Test that add_normal_thread_pool raises TypeError for SYNC handlers.
     """
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15701", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     add_handler_helper(server, RequestType.NOOP, test_mq_handler_helpers.noop_handler)
 
@@ -854,7 +870,7 @@ def test_affinity_pool_error_on_sync_handler():
     Test that add_affinity_thread_pool raises TypeError for SYNC handlers.
     """
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15701", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     add_handler_helper(server, RequestType.NOOP, test_mq_handler_helpers.noop_handler)
 
@@ -869,7 +885,7 @@ def test_pool_error_on_unregistered():
     Test that pool methods raise ValueError for unregistered request types.
     """
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15702", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     with pytest.raises(ValueError, match="No handler registered"):
         server.add_normal_thread_pool([RequestType.STORE], max_workers=1)
@@ -888,7 +904,7 @@ def test_multiple_pools():
     from lmcache.v1.multiprocess.affinity_pool import AffinityThreadPool
 
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15703", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     add_handler_helper(server, RequestType.STORE, test_mq_handler_helpers.store_handler)
     add_handler_helper(
@@ -927,7 +943,7 @@ def test_start_fails_without_pool_assignment():
     has no executor assigned.
     """
     context = zmq.Context.instance()
-    server = MessageQueueServer("tcp://127.0.0.1:15704", context)
+    server = MessageQueueServer(free_tcp_url(), context)
 
     add_handler_helper(server, RequestType.STORE, test_mq_handler_helpers.store_handler)
     # Don't assign any pool


### PR DESCRIPTION
## Problem

Every test in `tests/v1/multiprocess/test_mq.py` binds a hardcoded loopback port (5556-5567 for the helper-driven tests, 16000-16030 for the in-process ones). Two runs sharing a machine, which is the normal state on a CI runner, race for the same port: the second server's bind fails, and its clients then fail on a timeout that names neither the port nor the cause.

It surfaces as an unrelated-looking failure, for example on `k3-unit-tests`:

```
tests/v1/multiprocess/test_mq.py::test_mq_lookup FAILED
E  Failed: Some clients failed: Client 0: timeout
```

The same lane passed on the immediately preceding build of the same branch, with no Python changed in between, and it fails intermittently across contributors' branches. There is also an earlier `fix(mq): eliminate flaky test in multiprocess message queue` in the history.

## Fix

Ask the OS for a free port rather than hardcoding one. The probe socket only listens, so closing it before the server binds leaves no connection in `TIME_WAIT` to block the bind.

The failure report also now names a dead server before its clients: when the server fails to start, every client fails as a consequence, so naming only the client hides the cause.

## Verification

- Running the file twice concurrently wedges one of the two runs before this change, and passes both after it (22 passed, 1 skipped, each).
- Occupying port 5564 externally fails `test_mq_lookup` before this change and passes after it.
- The file passes on its own, and the pinned pre-commit hooks are clean.