### PR TITLE
fix(mp): preserve and reload KV across preemption

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 import math
 import sys
@@ -429,6 +430,12 @@ def _ensure_transport_scheme(server_url: str) -> str:
     return f"tcp://{server_url}"
 
 
+@dataclass(frozen=True)
+class _PinnedStoreOperation:
+    request_id: str
+    block_ids: tuple[int, ...]
+
+
 class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     """
     The connector for LMCache multi-process mode.
@@ -455,7 +462,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         vllm_config: "VllmConfig",
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig | None" = None,
-    ):
+    ) -> None:
         # Older supported vLLM releases allow connectors to omit this value,
         # while current vLLM's type declaration requires it.
         super().__init__(vllm_config, role, kv_cache_config)  # type: ignore[arg-type]
@@ -581,6 +588,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
             # GPU block pool reference
             self._gpu_block_pool: "BlockPool | None" = None
+            self._next_store_op_id = 0
+            self._pinned_store_operations: dict[int, _PinnedStoreOperation] = {}
 
             # Initialize pending store for lazy offload mode
             if self.lazy_offload:
@@ -603,6 +612,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
+                operation_store_lifetime=True,
             )
             if self.transfer_intermediate_tensors:
                 # First Party
@@ -810,7 +820,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             )
         return
 
-    def wait_for_save(self):
+    def wait_for_save(self) -> None:
         """
         Block until all the save operations is done. This is called
         as the forward context exits to ensure that the async saving
@@ -822,13 +832,17 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(metadata, LMCacheMPConnectorMetadata)
 
         request_ids = []
+        store_op_ids: list[int | None] = []
         ops = []
         cache_salts = []
         request_configs_list = []
         for meta in metadata.requests:
             if meta.direction != "STORE":
                 continue
+            if not self.lazy_offload and meta.store_op_id is None:
+                raise RuntimeError("non-lazy STORE metadata is missing an operation ID")
             request_ids.append(meta.request_id)
+            store_op_ids.append(meta.store_op_id)
             ops.append(meta.op)
             cache_salts.append(meta.cache_salt)
             request_configs_list.append(meta.request_configs)
@@ -846,6 +860,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             event,
             cache_salts=cache_salts,
             request_configs_list=request_configs_list,
+            store_op_ids=store_op_ids,
         )
         if self.dispatcher is not None:
             dispatch(self.dispatcher, "wait_for_save", event=event)
@@ -896,16 +911,31 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # logger.error("Finished req ids: %s, %s", val[0], val[1])
         return val
 
-    def build_connector_worker_meta(self):
-        if not self.lazy_offload:
-            return None
-        completed_store_requests = self.worker_adapter.get_completed_store_requests()
-        if completed_store_requests:
+    def build_connector_worker_meta(self) -> LMCacheMPWorkerMetadata | None:
+        """Drain worker STORE results for scheduler-side block release.
+
+        Returns:
+            New operation terminal reports, legacy lazy-offload request counts,
+            or None when no results are available.
+        """
+        if self.lazy_offload:
+            completed_store_requests = (
+                self.worker_adapter.get_completed_store_requests()
+            )
+            if not completed_store_requests:
+                return None
             return LMCacheMPWorkerMetadata(
                 completed_store_requests=completed_store_requests
             )
-        else:
+
+        result = self.worker_adapter.get_completed_store_operations()
+        if result is None:
             return None
+        terminal, failed = result
+        return LMCacheMPWorkerMetadata(
+            terminal_store_operations=terminal,
+            failed_store_operations=failed,
+        )
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         """
@@ -991,9 +1021,6 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             into account.
         """
         tracker = self._get_or_create_request_tracker(request)
-        # TODO: support loading KV for preempted requests in the future
-        if request.status == RequestStatus.PREEMPTED:
-            return 0, False
 
         # A failed asynchronous load is bypassed until vLLM admits the request
         # for local computation via update_state_after_alloc().  The scheduler
@@ -1207,7 +1234,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         return metadata
 
-    def update_connector_output(self, connector_output: KVConnectorOutput):
+    def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """
         Update KVConnector state from worker-side connectors output.
 
@@ -1215,21 +1242,61 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             connector_output (KVConnectorOutput): the worker-side
                 connectors output.
         """
-        if not self.lazy_offload:
-            return
-        if not self._gpu_block_pool:
-            raise ValueError("Lazy offload is enabled but gpu block pool is not binded")
         meta = connector_output.kv_connector_worker_meta
         if not isinstance(meta, LMCacheMPWorkerMetadata):
             return
-        for req_id, count in meta.completed_store_requests.items():
-            if self.scheduler_adapter.update_pending_store_count(req_id, count):
-                gpu_block_ids = self._pending_store.get_request_gpu_block_ids(req_id)
-                self._gpu_block_pool.free_blocks(
-                    [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+        if self._gpu_block_pool is None:
+            raise RuntimeError("GPU block pool is not bound")
+
+        if self.lazy_offload:
+            for req_id, count in meta.completed_store_requests.items():
+                if self.scheduler_adapter.update_pending_store_count(req_id, count):
+                    gpu_block_ids = self._pending_store.get_request_gpu_block_ids(
+                        req_id
+                    )
+                    self._gpu_block_pool.free_blocks(
+                        [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
+                    )
+                    self._pending_store.remove_request_gpu_block_ids(req_id)
+                    self.scheduler_adapter.end_session(req_id)
+            return
+
+        unknown_failures = set(meta.failed_store_operations).difference(
+            meta.terminal_store_operations
+        )
+        if unknown_failures:
+            raise RuntimeError(
+                "STORE failures lack matching terminal worker IDs: "
+                f"{sorted(unknown_failures)}"
+            )
+
+        for store_op_id, terminal_workers in meta.terminal_store_operations.items():
+            pinned = self._pinned_store_operations.get(store_op_id)
+            if pinned is None:
+                raise RuntimeError(
+                    f"unknown or already released STORE operation {store_op_id}"
                 )
-                self._pending_store.remove_request_gpu_block_ids(req_id)
-                self.scheduler_adapter.end_session(req_id)
+            failed_workers = meta.failed_store_operations.get(store_op_id, set())
+            all_failed_workers = self.scheduler_adapter.update_pending_store_workers(
+                store_op_id,
+                terminal_workers,
+                failed_workers,
+            )
+            if all_failed_workers is None:
+                continue
+
+            del self._pinned_store_operations[store_op_id]
+            self._gpu_block_pool.free_blocks(
+                self._gpu_block_pool.blocks[block_id]
+                for block_id in reversed(pinned.block_ids)
+            )
+            if all_failed_workers:
+                logger.error(
+                    "STORE operation %d for request %s failed on workers %s",
+                    store_op_id,
+                    pinned.request_id,
+                    sorted(all_failed_workers),
+                )
 
     def request_finished(
         self,
@@ -1277,8 +1344,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         if self.lazy_offload:
             self._pending_store.mark_req_finished(request.request_id)
-            return False, (return_params or None)
-        return True, (return_params or None)
+        return False, (return_params or None)
 
     def request_finished_all_groups(
         self,
@@ -1320,6 +1386,14 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             int: expected sending or receiving completion count.
         """
         return None
+
+    def has_pending_push_work(self) -> bool:
+        """Keep polling while non-lazy STORE operations own block references."""
+        return bool(
+            self.role == KVConnectorRole.SCHEDULER
+            and not self.lazy_offload
+            and self._pinned_store_operations
+        )
 
     @classmethod
     def build_kv_connector_stats(
@@ -1391,7 +1465,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 if self.lazy_offload:
                     self._pending_store.add(r_meta)
                 else:
-                    metadata.add_request_metadata(r_meta)
+                    self._add_store_metadata(metadata, r_meta)
         # if scheduler_output.total_num_scheduled_tokens is 0,
         # vllm `gpu_model_runner` will call `kv_connector_no_forward`
         # in `execute_model`, which will result in lose some store ops.
@@ -1432,7 +1506,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 if self.lazy_offload:
                     self._pending_store.add(r_meta)
                 else:
-                    metadata.add_request_metadata(r_meta)
+                    self._add_store_metadata(metadata, r_meta)
         # if scheduler_output.total_num_scheduled_tokens is 0,
         # vllm `gpu_model_runner` will call `kv_connector_no_forward`
         # in `execute_model`, which will result in lose some store ops.
@@ -1585,3 +1659,34 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 "[KVConnector] Cleaned up request_tracker for request %s",
                 request_id,
             )
+
+    def _add_store_metadata(
+        self,
+        connector_metadata: LMCacheMPConnectorMetadata,
+        store_metadata: LMCacheMPRequestMetadata,
+    ) -> None:
+        """Pin the blocks referenced by one non-lazy STORE operation."""
+        if self.lazy_offload:
+            raise RuntimeError("operation-level STORE tracking excludes lazy offload")
+        if store_metadata.direction != "STORE":
+            raise ValueError("only STORE metadata can own GPU block references")
+        if store_metadata.store_op_id is not None:
+            raise ValueError("STORE metadata already has an operation ID")
+        if self._gpu_block_pool is None:
+            raise RuntimeError("GPU block pool must be bound before storing KV")
+
+        block_ids = tuple(dict.fromkeys(store_metadata.op.flat_block_ids))
+        if not block_ids:
+            raise ValueError("STORE metadata must reference at least one GPU block")
+        self._gpu_block_pool.touch(
+            [self._gpu_block_pool.blocks[block_id] for block_id in block_ids]
+        )
+
+        store_op_id = self._next_store_op_id
+        self._next_store_op_id += 1
+        store_metadata.store_op_id = store_op_id
+        self._pinned_store_operations[store_op_id] = _PinnedStoreOperation(
+            request_id=store_metadata.request_id,
+            block_ids=block_ids,
+        )
+        connector_metadata.add_request_metadata(store_metadata)

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -183,6 +183,7 @@ class LMCacheMPRequestMetadata:
     op: LoadStoreOp
     cache_salt: str = ""
     request_configs: dict[str, Any] | None = None
+    store_op_id: int | None = None
 
     @staticmethod
     def GetStoreMetadata(
@@ -367,12 +368,13 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
         return len(self.requests)
 
     # For debugging
-    def __str__(self):
+    def __str__(self) -> str:
         request_strs = []
         for req_meta in self.requests:
             request_strs.append(
                 f"RequestMetadata(request_id={req_meta.request_id}, "
                 f"direction={req_meta.direction}, "
+                f"store_op_id={req_meta.store_op_id}, "
                 f"num_blocks={len(req_meta.op.flat_block_ids)}, "
                 f"block_ids={req_meta.op.block_ids})"
             )
@@ -388,21 +390,36 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
 
 @dataclass
 class LMCacheMPWorkerMetadata(KVConnectorWorkerMetadata):
-    """Worker -> Scheduler metadata for completed store events.
+    """Worker results for request- and operation-level STORE tracking."""
 
-    Each worker reports {req_id: 1} for newly completed stores.
-    ``aggregate()`` sums counts across workers within a step.
-    The scheduler-side manager accumulates across steps and processes
-    a store completion only when count reaches ``world_size``.
-    """
-
-    completed_store_requests: dict[str, int]
+    completed_store_requests: dict[str, int] = field(default_factory=dict)
+    terminal_store_operations: dict[int, set[int]] = field(default_factory=dict)
+    failed_store_operations: dict[int, set[int]] = field(default_factory=dict)
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
     ) -> "KVConnectorWorkerMetadata":
         assert isinstance(other, LMCacheMPWorkerMetadata)
-        merged = dict(self.completed_store_requests)
+        merged_requests = dict(self.completed_store_requests)
         for k, v in other.completed_store_requests.items():
-            merged[k] = merged.get(k, 0) + v
-        return LMCacheMPWorkerMetadata(completed_store_requests=merged)
+            merged_requests[k] = merged_requests.get(k, 0) + v
+
+        merged_terminals = {
+            store_op_id: set(worker_ids)
+            for store_op_id, worker_ids in self.terminal_store_operations.items()
+        }
+        for store_op_id, worker_ids in other.terminal_store_operations.items():
+            merged_terminals.setdefault(store_op_id, set()).update(worker_ids)
+
+        merged_failures = {
+            store_op_id: set(worker_ids)
+            for store_op_id, worker_ids in self.failed_store_operations.items()
+        }
+        for store_op_id, worker_ids in other.failed_store_operations.items():
+            merged_failures.setdefault(store_op_id, set()).update(worker_ids)
+
+        return LMCacheMPWorkerMetadata(
+            completed_store_requests=merged_requests,
+            terminal_store_operations=merged_terminals,
+            failed_store_operations=merged_failures,
+        )

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -562,6 +562,12 @@ RetrieveResult = bool
 LookupResult = int
 
 
+@dataclass
+class _PendingStoreFuture:
+    request_id: str
+    future: MessagingFuture[StoreResult]
+
+
 class LMCacheMPSchedulerAdapter:
     def __init__(
         self,
@@ -575,7 +581,7 @@ class LMCacheMPSchedulerAdapter:
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         extra_config: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """
         Args:
             server_urls: LMCache multiprocess request server URLs.
@@ -681,6 +687,8 @@ class LMCacheMPSchedulerAdapter:
         # Events must be reported by all world_size workers before considered complete.
         self._expected_worker_count = parallel_strategy.vllm_world_size
         self._store_request_pending_counts: dict[str, int] = {}
+        self._store_operation_terminal_workers: dict[int, set[int]] = {}
+        self._store_operation_failed_workers: dict[int, set[int]] = {}
 
     @property
     def world_size(self) -> int:
@@ -1066,6 +1074,54 @@ class LMCacheMPSchedulerAdapter:
             self._store_request_pending_counts[req_id] = total
             return False
 
+    def update_pending_store_workers(
+        self,
+        store_op_id: int,
+        terminal_workers: set[int],
+        failed_workers: set[int],
+    ) -> set[int] | None:
+        """Accumulate one STORE operation until every worker is terminal.
+
+        Args:
+            store_op_id: Scheduler-assigned STORE identity.
+            terminal_workers: Worker ranks that have finished reading the source.
+            failed_workers: Terminal ranks that did not durably store the KV.
+
+        Returns:
+            Failed ranks once all workers are terminal, or None while pending.
+            Repeated ranks do not count as additional completions.
+
+        Raises:
+            ValueError: If ranks are invalid, the terminal set is empty, or a
+                failed rank is absent from the terminal report.
+        """
+        if not terminal_workers:
+            raise ValueError("terminal_workers must not be empty")
+        if not failed_workers.issubset(terminal_workers):
+            raise ValueError("failed_workers must be a subset of terminal_workers")
+
+        invalid_workers = {
+            worker_id
+            for worker_id in terminal_workers
+            if worker_id < 0 or worker_id >= self._expected_worker_count
+        }
+        if invalid_workers:
+            raise ValueError(
+                "STORE operation reported invalid worker IDs: "
+                f"{sorted(invalid_workers)}"
+            )
+
+        terminal = self._store_operation_terminal_workers.setdefault(store_op_id, set())
+        failures = self._store_operation_failed_workers.setdefault(store_op_id, set())
+        terminal.update(terminal_workers)
+        failures.update(failed_workers)
+        if len(terminal) != self._expected_worker_count:
+            return None
+
+        self._store_operation_terminal_workers.pop(store_op_id, None)
+        self._store_operation_failed_workers.pop(store_op_id, None)
+        return failures
+
 
 class LMCacheMPWorkerAdapter:
     def __init__(
@@ -1080,7 +1136,8 @@ class LMCacheMPWorkerAdapter:
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         extra_config: dict[str, Any] | None = None,
-    ):
+        operation_store_lifetime: bool = False,
+    ) -> None:
         """Initialize the worker adapter for current or legacy vLLM callers.
 
         Args:
@@ -1100,6 +1157,9 @@ class LMCacheMPWorkerAdapter:
             extra_config: Optional dict with keys starting with
                 ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
                 provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
+            operation_store_lifetime: Use scheduler-assigned STORE operation
+                IDs and worker metadata for completion. Legacy connectors leave
+                this disabled and keep request-level completion semantics.
 
         Raises:
             TypeError: If the connector argument shape is unsupported.
@@ -1130,6 +1190,7 @@ class LMCacheMPWorkerAdapter:
             self._mp_transfer_mode = None
         self.req_client = RequestClientFactory.create(server_url, context=context)
         self._mq_timeout = mq_timeout
+        self.operation_store_lifetime = operation_store_lifetime
 
         # Instance id for GPU worker. uuid4-derived (OS entropy) rather
         # than os.getpid() to avoid collision in containerized deployments.
@@ -1149,6 +1210,7 @@ class LMCacheMPWorkerAdapter:
 
         # Request futures
         self.store_futures: dict[str, MessagingFuture[StoreResult]] = {}
+        self._store_operation_futures: dict[int, _PendingStoreFuture] = {}
         # request_id -> (future, block_ids)
         self.retrieve_futures: dict[
             str, tuple[MessagingFuture[RetrieveResult], list[int]]
@@ -1156,6 +1218,7 @@ class LMCacheMPWorkerAdapter:
         # The IPC handle is not enough by itself; CUDA needs the exporting
         # event object to stay alive until the consumer is done with it.
         self.store_events: dict[str, _IpcEvent] = {}
+        self._store_operation_events: dict[int, _IpcEvent] = {}
         self.retrieve_events: dict[str, _IpcEvent] = {}
 
         # Block IDs that failed due to retrieve timeout
@@ -1166,14 +1229,14 @@ class LMCacheMPWorkerAdapter:
         # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
         self._dropped_retrieves: set[str] = set()
 
-        # The store requests that have finished execution in LMCache
+        # Request-level STORE completion state used by legacy connectors.
         self.finished_stores: set[str] = set()
-        # The finished request ids that are passed via vLLM and also
-        # have corresponding store requests submitted to LMCache before
         self.previously_finished: set[str] = set()
-        # Request IDs already returned as finished_sending to the scheduler.
-        # Prevents re-reporting the same ID after drain clears tracking sets.
         self._returned_finished: set[str] = set()
+
+        self._pending_store_ops_by_request: dict[str, set[int]] = {}
+        self._engine_finished_store_requests: set[str] = set()
+        self._indeterminate_store_operations: dict[int, str] = {}
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
@@ -1247,6 +1310,8 @@ class LMCacheMPWorkerAdapter:
 
         # Completed store requests to report via build_connector_worker_meta
         self._completed_store_requests: dict[str, int] = {}
+        self._terminal_store_operations: dict[int, set[int]] = {}
+        self._failed_store_operations: dict[int, set[int]] = {}
 
     @property
     def is_healthy(self) -> bool:
@@ -1472,7 +1537,9 @@ class LMCacheMPWorkerAdapter:
         event: _IpcEvent | None,
         cache_salt: str = "",
         request_configs: dict[str, Any] | None = None,
-    ):
+        *,
+        store_op_id: int | None = None,
+    ) -> None:
         """
         Submit a KV cache store request to LMCache
 
@@ -1484,13 +1551,64 @@ class LMCacheMPWorkerAdapter:
             cache_salt: Per-user isolation salt.
             request_configs: Optional LMCache request configs to include in
                 the IPC key.
+            store_op_id: Scheduler-assigned identity for a non-lazy STORE.
+
+        Raises:
+            ValueError: If an operation identity is missing or already pending.
+            RuntimeError: If a legacy caller has no transfer context. Submission
+                errors also propagate; operation-owned references remain held
+                when submission may have reached the server.
         """
         self._ensure_heartbeat_started()
 
+        if self.lazy_offload or not self.operation_store_lifetime:
+            if not self.is_kv_writer or not self.is_healthy:
+                return
+            assert op.token_ids is not None
+            key = self._create_key(
+                op.token_ids,
+                op.start,
+                op.end,
+                request_id=request_id,
+                cache_salt=cache_salt,
+                request_configs=request_configs,
+            )
+            if self.transfer_ctx is None:
+                raise RuntimeError(
+                    "Transfer context is not initialized. "
+                    "Call register_kv_caches() before submitting store requests."
+                )
+            future = self.transfer_ctx.submit_store(
+                request_id,
+                key,
+                self.instance_id,
+                self.kv_caches,
+                self._block_ids_per_group(op),
+                event,
+                self.blocks_in_chunk,
+            )
+            self.store_futures[request_id] = future
+            if event is not None:
+                self.store_events[request_id] = event
+            return
+
+        if store_op_id is None:
+            raise ValueError("operation-level STORE requires store_op_id")
+        if (
+            store_op_id in self._store_operation_futures
+            or store_op_id in self._indeterminate_store_operations
+        ):
+            raise ValueError(f"duplicate pending store_op_id {store_op_id}")
+        self._pending_store_ops_by_request.setdefault(request_id, set()).add(
+            store_op_id
+        )
+
         if not self.is_kv_writer:
+            self._record_store_terminal(store_op_id, request_id, succeeded=True)
             return
 
         if not self.is_healthy:
+            self._record_store_terminal(store_op_id, request_id, succeeded=False)
             return
 
         assert op.token_ids is not None
@@ -1503,22 +1621,39 @@ class LMCacheMPWorkerAdapter:
             request_configs=request_configs,
         )
         if self.transfer_ctx is None:
-            raise RuntimeError(
-                "Transfer context is not initialized. "
-                "Call register_kv_caches() before submitting store requests."
+            logger.error(
+                "STORE operation %d cannot start for request_id=%s because "
+                "the transfer context is not initialized",
+                store_op_id,
+                request_id,
             )
-        future = self.transfer_ctx.submit_store(
-            request_id,
-            key,
-            self.instance_id,
-            self.kv_caches,
-            self._block_ids_per_group(op),
-            event,
-            self.blocks_in_chunk,
-        )
-        self.store_futures[request_id] = future
+            self._record_store_terminal(store_op_id, request_id, succeeded=False)
+            return
         if event is not None:
-            self.store_events[request_id] = event
+            self._store_operation_events[store_op_id] = event
+        try:
+            future = self.transfer_ctx.submit_store(
+                request_id,
+                key,
+                self.instance_id,
+                self.kv_caches,
+                self._block_ids_per_group(op),
+                event,
+                self.blocks_in_chunk,
+            )
+        except Exception:
+            logger.exception(
+                "STORE operation %d for request_id=%s has indeterminate "
+                "submission state; retaining its GPU block references",
+                store_op_id,
+                request_id,
+            )
+            self._indeterminate_store_operations[store_op_id] = request_id
+            raise
+        self._store_operation_futures[store_op_id] = _PendingStoreFuture(
+            request_id,
+            future,
+        )
 
     @_lmcache_nvtx_annotate
     def submit_retrieve_request(
@@ -1588,7 +1723,9 @@ class LMCacheMPWorkerAdapter:
         event: _IpcEvent | None,
         cache_salts: list[str] | None = None,
         request_configs_list: list[dict[str, Any] | None] | None = None,
-    ):
+        *,
+        store_op_ids: list[int | None] | None = None,
+    ) -> None:
         """
         Submit a batched store request to LMCache
 
@@ -1603,9 +1740,16 @@ class LMCacheMPWorkerAdapter:
                 request_ids.
             request_configs_list: Optional LMCache request configs, one per
                 request.
+            store_op_ids: Scheduler-assigned identities, one per STORE.
+
+        Raises:
+            ValueError: If list lengths differ. No requests are submitted in
+                that case. Individual submission errors propagate to the caller.
         """
         if cache_salts is None:
             cache_salts = [""] * len(request_ids)
+        if store_op_ids is None:
+            store_op_ids = [None] * len(request_ids)
         if request_configs_list is None:
             request_configs_list = [None] * len(request_ids)
         if not (
@@ -1613,13 +1757,19 @@ class LMCacheMPWorkerAdapter:
             == len(ops)
             == len(cache_salts)
             == len(request_configs_list)
+            == len(store_op_ids)
         ):
             raise ValueError(
-                "request_ids, ops, cache_salts, and request_configs_list "
+                "request_ids, ops, cache_salts, request_configs_list, and store_op_ids "
                 "must have the same length"
             )
-        for request_id, op, salt, request_configs in zip(
-            request_ids, ops, cache_salts, request_configs_list, strict=True
+        for request_id, op, salt, request_configs, store_op_id in zip(
+            request_ids,
+            ops,
+            cache_salts,
+            request_configs_list,
+            store_op_ids,
+            strict=True,
         ):
             self.submit_store_request(
                 request_id,
@@ -1627,6 +1777,7 @@ class LMCacheMPWorkerAdapter:
                 event,
                 cache_salt=salt,
                 request_configs=request_configs,
+                store_op_id=store_op_id,
             )
 
     @_lmcache_nvtx_annotate
@@ -1683,7 +1834,7 @@ class LMCacheMPWorkerAdapter:
         finished_req_ids_from_lmcache: set[str],
         finished_req_ids_from_engine: set[str],
     ) -> set[str]:
-        """Merge LMCache-side and engine-side finished store info."""
+        """Merge request-level completion state for legacy connectors."""
         self.finished_stores.update(finished_req_ids_from_lmcache)
         ret_stores = set()
         for req_id in finished_req_ids_from_engine:
@@ -1701,133 +1852,62 @@ class LMCacheMPWorkerAdapter:
     def get_finished(
         self, finished_req_ids_from_engine: set[str]
     ) -> tuple[set[str] | None, set[str] | None]:
-        """
-        Check and get the finished store and retrieve requests.
+        """Poll non-lazy STORE work and asynchronous retrieves.
+
+        Operation-aware callers receive STORE completion through worker
+        metadata, while legacy callers retain request-level
+        ``finished_sending`` semantics. Retrieve completion continues to use
+        the vLLM connector contract in both modes.
 
         Args:
-            finished_req_ids_from_engine: the set of request ids that are
-                reported as finished from the vLLM engine side.
+            finished_req_ids_from_engine: Request IDs finished in this scheduler
+                step. vLLM sends each finished request in one step only.
 
         Returns:
-            A tuple of two sets:
-            - The first set contains the finished store request ids. The returned
-                store request ids MUST be seen before in the
-                `finished_req_ids_from_engine`.
-            - The second set contains the finished retrieve request ids,
-                including retrieves dropped at submit time while unhealthy
-                (reported exactly once; blocks already in error_block_ids).
-
-        Notes:
-            When enabling async scheduling in vLLM, the same request ID may appear
-            multiple times in `finished_req_ids_from_engine`. The adapter should
-            take care of deduplicating the request IDs and only return the request
-            IDs that have not been returned before.
+            Finished STORE and RETRIEVE request IDs. Operation-aware callers
+            receive an empty STORE set and drain STORE worker metadata instead.
         """
+        if self.lazy_offload:
+            raise ValueError("use get_finished_with_lazy_offload in lazy mode")
         if self.dispatcher is not None:
             dispatch(self.dispatcher, "reclaim")
+        if not self.operation_store_lifetime:
+            return self._get_finished_request_level(finished_req_ids_from_engine)
 
-        # If unhealthy, drain all pending futures immediately
+        self._engine_finished_store_requests.update(finished_req_ids_from_engine)
+        self._poll_store_operations()
+
+        finished_retrieves: set[str] = set()
         if not self.is_healthy:
-            finished_stores = set(self.store_futures.keys())
-            finished_retrieves = set()
             for request_id, (
                 _r_future,
                 r_block_ids,
             ) in self.retrieve_futures.items():
                 finished_retrieves.add(request_id)
                 self.error_block_ids.update(r_block_ids)
-            self.store_futures.clear()
             self.retrieve_futures.clear()
-            self.store_events.clear()
             self.retrieve_events.clear()
+        else:
+            for request_id, (future, block_ids) in self.retrieve_futures.items():
+                if not future.query():
+                    continue
+                succeeded = bool(future.result(timeout=60))
+                finished_retrieves.add(request_id)
+                if not succeeded:
+                    self.error_block_ids.update(block_ids)
+                    logger.error(
+                        "RETRIEVE was not successful for request_id=%s",
+                        request_id,
+                    )
+            for request_id in finished_retrieves:
+                self.retrieve_futures.pop(request_id, None)
+                self.retrieve_events.pop(request_id, None)
 
-            # Retrieves dropped at submit time still must be reported,
-            # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
-            # Swap-drain (not update-then-clear): a concurrent
-            # submit_retrieve_request add lands in the old set (reported now)
-            # or the fresh set (reported next call), never lost.
-            dropped = self._dropped_retrieves
-            self._dropped_retrieves = set()
-            finished_retrieves.update(dropped)
-
-            ret_stores = self._process_finished_stores(
-                finished_stores, finished_req_ids_from_engine
-            )
-            # A request may have a pending retrieve AND appear in
-            # finished_req_ids_from_engine (it ran without loading KV after
-            # the server died).  The scheduler processes finished_recving
-            # first and deletes the request, so we must not also report it
-            # in finished_sending.
-            ret_stores -= finished_retrieves
-            return ret_stores, finished_retrieves
-
-        finished_stores = set()
-        finished_retrieves = set()
-        for request_id, s_future in self.store_futures.items():
-            if not s_future.query():
-                continue
-
-            s_result = s_future.result(timeout=60)
-            finished_stores.add(request_id)
-
-            if not s_result:
-                logger.error(
-                    "Something went wrong when processing the "
-                    "store request for request_id=%s",
-                    request_id,
-                )
-
-        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
-            if not r_future.query():
-                continue
-
-            r_result = r_future.result(timeout=60)
-            finished_retrieves.add(request_id)
-
-            if not r_result:
-                self.error_block_ids.update(r_block_ids)
-                logger.error(
-                    "Something went wrong when processing the "
-                    "retrieve request for request_id=%s, result=%s",
-                    request_id,
-                    r_result,
-                )
-
-        # Remove the finished requests from the tracking dicts
-        for request_id in finished_stores:
-            self.store_futures.pop(request_id, None)
-            self.store_events.pop(request_id, None)
-        for request_id in finished_retrieves:
-            self.retrieve_futures.pop(request_id, None)
-            self.retrieve_events.pop(request_id, None)
-
-        # Retrieves dropped while unhealthy still must be reported,
-        # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS. No
-        # finished_sending dedup is needed (unlike the unhealthy branch): a
-        # dropped retrieve's request is parked in WAITING_FOR_REMOTE_KVS until
-        # this report, so it cannot also be engine-finished in the same call.
-        # Swap-drain so a concurrent submit_retrieve_request add is never lost.
         dropped = self._dropped_retrieves
         self._dropped_retrieves = set()
         finished_retrieves.update(dropped)
-
-        # Update the internal states
-        ret_stores = self._process_finished_stores(
-            finished_stores, finished_req_ids_from_engine
-        )
-
-        # the invocation of `get_finished` means that
-        # these requests' KV caches are already fully stored.
-        # or the requests normally ends without any store.
-        if ret_stores:
-            self.request_telemetry.on_request_store_finished(
-                request_ids_set=ret_stores,
-                model_name=self.model_name,
-                world_size=self.world_size,
-                kv_rank=self.worker_id,
-            )
-
-        return ret_stores, finished_retrieves
+        self._finish_operation_store_telemetry()
+        return set(), finished_retrieves
 
     # TODO(chunxiaozheng): There are some duplicated codes
     #  with `get_finished`, optimize it later.
@@ -1955,6 +2035,25 @@ class LMCacheMPWorkerAdapter:
         self._completed_store_requests = {}
         return completed_store_requests
 
+    def get_completed_store_operations(
+        self,
+    ) -> tuple[dict[int, set[int]], dict[int, set[int]]] | None:
+        """Drain non-lazy STORE terminal results since the previous call.
+
+        Returns:
+            Terminal and failed worker ranks keyed by STORE identity, or None
+            when no operation is terminal. Query failures retain the operation
+            because completion has not been established.
+        """
+        self._poll_store_operations()
+        if not self._terminal_store_operations:
+            return None
+        terminal = self._terminal_store_operations
+        failed = self._failed_store_operations
+        self._terminal_store_operations = {}
+        self._failed_store_operations = {}
+        return terminal, failed
+
     def num_blocks_per_chunk(self) -> int:
         """
         Returns:
@@ -2029,17 +2128,12 @@ class LMCacheMPWorkerAdapter:
         self.request_telemetry.close()
 
     # Helper functions
-    def _update_and_get_finished_store(
-        self,
-    ) -> set[str]:
-        """Converge the internal states about finished stores
-        and returns the 'safe finished store request ids' back
-        """
-        safe_finished_s = self.finished_stores.intersection(self.previously_finished)
+    def _update_and_get_finished_store(self) -> set[str]:
+        """Return request IDs terminal on both engine and LMCache sides."""
+        safe_finished = self.finished_stores.intersection(self.previously_finished)
         self.finished_stores.difference_update(self.previously_finished)
-        self.previously_finished.difference_update(safe_finished_s)
-
-        return safe_finished_s
+        self.previously_finished.difference_update(safe_finished)
+        return safe_finished
 
     def _create_key(
         self,
@@ -2076,3 +2170,158 @@ class LMCacheMPWorkerAdapter:
             cache_salt=cache_salt,
             request_configs=request_configs,
         )
+
+    def _record_store_terminal(
+        self,
+        store_op_id: int,
+        request_id: str,
+        *,
+        succeeded: bool,
+    ) -> None:
+        if store_op_id in self._terminal_store_operations:
+            raise RuntimeError(f"STORE operation {store_op_id} completed twice")
+
+        worker_id = self.parallel_strategy.vllm_worker_id
+        self._terminal_store_operations[store_op_id] = {worker_id}
+        if not succeeded:
+            self._failed_store_operations[store_op_id] = {worker_id}
+
+        request_operations = self._pending_store_ops_by_request.get(request_id)
+        if request_operations is not None:
+            request_operations.discard(store_op_id)
+            if not request_operations:
+                self._pending_store_ops_by_request.pop(request_id, None)
+
+    def _poll_store_operations(self) -> None:
+        finished: set[int] = set()
+        for store_op_id, pending in list(self._store_operation_futures.items()):
+            try:
+                is_terminal = pending.future.query()
+            except Exception:
+                logger.exception(
+                    "Cannot prove STORE operation %d terminal for request_id=%s; "
+                    "retaining its GPU block references",
+                    store_op_id,
+                    pending.request_id,
+                )
+                continue
+            if not is_terminal:
+                continue
+
+            try:
+                succeeded = bool(pending.future.result(timeout=60))
+            except Exception:
+                logger.exception(
+                    "Terminal STORE operation %d failed for request_id=%s",
+                    store_op_id,
+                    pending.request_id,
+                )
+                succeeded = False
+            if not succeeded:
+                logger.error(
+                    "STORE operation %d was not durable for request_id=%s",
+                    store_op_id,
+                    pending.request_id,
+                )
+            self._record_store_terminal(
+                store_op_id,
+                pending.request_id,
+                succeeded=succeeded,
+            )
+            finished.add(store_op_id)
+
+        for store_op_id in finished:
+            self._store_operation_futures.pop(store_op_id, None)
+            self._store_operation_events.pop(store_op_id, None)
+
+    def _finish_operation_store_telemetry(self) -> None:
+        finished = {
+            request_id
+            for request_id in self._engine_finished_store_requests
+            if request_id not in self._pending_store_ops_by_request
+        }
+        if not finished:
+            return
+        self._engine_finished_store_requests.difference_update(finished)
+        self.request_telemetry.on_request_store_finished(
+            request_ids_set=finished,
+            model_name=self.model_name,
+            world_size=self.world_size,
+            kv_rank=self.worker_id,
+        )
+
+    def _get_finished_request_level(
+        self,
+        finished_req_ids_from_engine: set[str],
+    ) -> tuple[set[str], set[str]]:
+        """Preserve request-level completion for legacy MP connectors."""
+        if not self.is_healthy:
+            finished_stores = set(self.store_futures)
+            finished_retrieves = set()
+            for request_id, (_future, block_ids) in self.retrieve_futures.items():
+                finished_retrieves.add(request_id)
+                self.error_block_ids.update(block_ids)
+            self.store_futures.clear()
+            self.retrieve_futures.clear()
+            self.store_events.clear()
+            self.retrieve_events.clear()
+
+            dropped = self._dropped_retrieves
+            self._dropped_retrieves = set()
+            finished_retrieves.update(dropped)
+
+            ret_stores = self._process_finished_stores(
+                finished_stores,
+                finished_req_ids_from_engine,
+            )
+            ret_stores.difference_update(finished_retrieves)
+            return ret_stores, finished_retrieves
+
+        finished_stores = set()
+        finished_retrieves = set()
+        for request_id, future in self.store_futures.items():
+            if not future.query():
+                continue
+            succeeded = bool(future.result(timeout=60))
+            finished_stores.add(request_id)
+            if not succeeded:
+                logger.error(
+                    "STORE was not successful for request_id=%s",
+                    request_id,
+                )
+
+        for request_id, (future, block_ids) in self.retrieve_futures.items():
+            if not future.query():
+                continue
+            succeeded = bool(future.result(timeout=60))
+            finished_retrieves.add(request_id)
+            if not succeeded:
+                self.error_block_ids.update(block_ids)
+                logger.error(
+                    "RETRIEVE was not successful for request_id=%s",
+                    request_id,
+                )
+
+        for request_id in finished_stores:
+            self.store_futures.pop(request_id, None)
+            self.store_events.pop(request_id, None)
+        for request_id in finished_retrieves:
+            self.retrieve_futures.pop(request_id, None)
+            self.retrieve_events.pop(request_id, None)
+
+        dropped = self._dropped_retrieves
+        self._dropped_retrieves = set()
+        finished_retrieves.update(dropped)
+
+        ret_stores = self._process_finished_stores(
+            finished_stores,
+            finished_req_ids_from_engine,
+        )
+        if ret_stores:
+            self.request_telemetry.on_request_store_finished(
+                request_ids_set=ret_stores,
+                model_name=self.model_name,
+                world_size=self.world_size,
+                kv_rank=self.worker_id,
+            )
+        return ret_stores, finished_retrieves

--- a/tests/v1/test_mp_preemption_loading.py
+++ b/tests/v1/test_mp_preemption_loading.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler-side tests for MP connector preemption loading."""
+
+# Standard
+from types import SimpleNamespace
+from typing import Any
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
+
+# Third Party
+from vllm.v1.request import RequestStatus  # noqa: E402
+from vllm.v1.utils import ConstantList  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+)
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
+    LMCacheMPRequestState,
+    LMCacheMPRequestTracker,
+)
+
+
+class _FakeRequest:
+    def __init__(self, token_ids: list[int]) -> None:
+        self.request_id = "req-0"
+        self.cache_salt = ""
+        self.prompt_token_ids = list(token_ids[:4])
+        self._token_ids = list(token_ids)
+        self.all_token_ids = ConstantList(self._token_ids)
+        self.mm_features = []
+        self.status = RequestStatus.PREEMPTED
+        self.num_computed_tokens = 0
+
+    @property
+    def num_tokens(self) -> int:
+        return len(self._token_ids)
+
+
+class _FakeSchedulerAdapter:
+    lmcache_tokens_per_chunk = 4
+
+    def __init__(self, results: list[int | None]) -> None:
+        self._results = iter(results)
+        self.lookup_token_ids: list[list[int]] = []
+        self.lookup_configs: list[dict[str, Any] | None] = []
+
+    def maybe_submit_lookup_request(
+        self,
+        request_id: str,
+        token_ids: list[int],
+        cache_salt: str,
+        request_configs: dict[str, Any] | None = None,
+    ) -> None:
+        del request_id, cache_salt
+        self.lookup_token_ids.append(list(token_ids))
+        self.lookup_configs.append(request_configs)
+
+    def check_lookup_result(self, request_id: str) -> int | None:
+        del request_id
+        return next(self._results)
+
+
+def _make_connector(
+    adapter: _FakeSchedulerAdapter,
+) -> LMCacheMPConnector:
+    connector = object.__new__(LMCacheMPConnector)
+    connector.request_trackers = {}
+    connector.scheduler_adapter = adapter
+    connector._hit_alignment_tokens = 4
+    return connector
+
+
+def test_preempted_request_reloads_cached_output_prefix() -> None:
+    request = _FakeRequest(list(range(12)))
+    adapter = _FakeSchedulerAdapter([8])
+    connector = _make_connector(adapter)
+
+    old_tracker = LMCacheMPRequestTracker(request)
+    old_tracker.allocated_block_ids = {0: [10, 11, 12]}
+    old_tracker.state = LMCacheMPRequestState.READY
+    connector.request_trackers[request.request_id] = old_tracker
+
+    result = connector.get_num_new_matched_tokens(request, num_computed_tokens=0)
+
+    assert result == (8, True)
+    assert adapter.lookup_token_ids == [list(range(12))]
+    new_tracker = connector.request_trackers[request.request_id]
+    assert new_tracker is not old_tracker
+    assert new_tracker.allocated_block_ids == {}
+
+
+def test_preemption_lookup_polling_keeps_fresh_tracker() -> None:
+    request = _FakeRequest(list(range(12)))
+    adapter = _FakeSchedulerAdapter([None, 8])
+    connector = _make_connector(adapter)
+
+    old_tracker = LMCacheMPRequestTracker(request)
+    old_tracker.state = LMCacheMPRequestState.READY
+    connector.request_trackers[request.request_id] = old_tracker
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (None, True)
+    fresh_tracker = connector.request_trackers[request.request_id]
+    assert fresh_tracker is not old_tracker
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (8, True)
+    assert connector.request_trackers[request.request_id] is fresh_tracker
+
+
+def test_preempted_full_hit_recomputes_last_token() -> None:
+    request = _FakeRequest(list(range(8)))
+    adapter = _FakeSchedulerAdapter([8])
+    connector = _make_connector(adapter)
+
+    result = connector.get_num_new_matched_tokens(request, num_computed_tokens=0)
+
+    assert result == (7, True)
+
+
+def test_preemption_reload_preserves_request_configs() -> None:
+    request = _FakeRequest(list(range(12)))
+    request.sampling_params = SimpleNamespace(
+        extra_args={"kv_transfer_params": {"lmcache.priority": 2}}
+    )
+    adapter = _FakeSchedulerAdapter([8])
+    connector = _make_connector(adapter)
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (8, True)
+    assert adapter.lookup_configs == [{"lmcache.priority": 2}]

--- a/tests/v1/test_mp_store_lifetime.py
+++ b/tests/v1/test_mp_store_lifetime.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Operation-level lifetime tests for LMCache MP STORE operations."""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Third Party
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector
+from lmcache.integration.vllm.lmcache_mp_metadata import (
+    LMCacheMPConnectorMetadata,
+    LMCacheMPRequestMetadata,
+    LMCacheMPWorkerMetadata,
+)
+from lmcache.integration.vllm.vllm_multi_process_adapter import (
+    LMCacheMPSchedulerAdapter,
+    LoadStoreOp,
+)
+
+
+def _store_metadata(request_id: str, block_ids: list[int]) -> LMCacheMPRequestMetadata:
+    return LMCacheMPRequestMetadata(
+        request_id=request_id,
+        direction="STORE",
+        op=LoadStoreOp(
+            token_ids=list(range(256)),
+            block_ids=[block_ids],
+            start=0,
+            end=256,
+        ),
+    )
+
+
+def _bare_scheduler_adapter(expected_workers: int) -> LMCacheMPSchedulerAdapter:
+    adapter = object.__new__(LMCacheMPSchedulerAdapter)
+    adapter._expected_worker_count = expected_workers
+    adapter._store_operation_terminal_workers = {}
+    adapter._store_operation_failed_workers = {}
+    return adapter
+
+
+def _bare_connector(expected_workers: int = 2) -> tuple[LMCacheMPConnector, MagicMock]:
+    connector = object.__new__(LMCacheMPConnector)
+    connector._role = KVConnectorRole.SCHEDULER
+    connector.lazy_offload = False
+    connector._next_store_op_id = 0
+    connector._pinned_store_operations = {}
+    connector.scheduler_adapter = _bare_scheduler_adapter(expected_workers)
+    pool = MagicMock(name="block_pool")
+    pool.blocks = {index: MagicMock(name=f"block_{index}") for index in range(8)}
+    connector._gpu_block_pool = pool
+    return connector, pool
+
+
+def test_worker_metadata_aggregates_terminals_and_failures() -> None:
+    merged = LMCacheMPWorkerMetadata(
+        completed_store_requests={"lazy": 1},
+        terminal_store_operations={1: {0}, 2: {0}},
+        failed_store_operations={2: {0}},
+    ).aggregate(
+        LMCacheMPWorkerMetadata(
+            completed_store_requests={"lazy": 1},
+            terminal_store_operations={1: {1}, 3: {1}},
+            failed_store_operations={3: {1}},
+        )
+    )
+
+    assert isinstance(merged, LMCacheMPWorkerMetadata)
+    assert merged.completed_store_requests == {"lazy": 2}
+    assert merged.terminal_store_operations == {1: {0, 1}, 2: {0}, 3: {1}}
+    assert merged.failed_store_operations == {2: {0}, 3: {1}}
+
+
+def test_scheduler_aggregates_operation_across_steps() -> None:
+    adapter = _bare_scheduler_adapter(expected_workers=2)
+
+    assert adapter.update_pending_store_workers(4, {1}, {1}) is None
+    assert adapter.update_pending_store_workers(4, {0}, set()) == {1}
+    assert adapter._store_operation_terminal_workers == {}
+    assert adapter._store_operation_failed_workers == {}
+
+
+def test_scheduler_rejects_invalid_worker_id() -> None:
+    adapter = _bare_scheduler_adapter(expected_workers=2)
+
+    try:
+        adapter.update_pending_store_workers(5, {0, 2}, set())
+    except ValueError as exc:
+        assert "invalid worker IDs" in str(exc)
+    else:
+        raise AssertionError("an invalid worker ID was accepted")
+
+
+def test_scheduler_rejects_failure_without_terminal_report() -> None:
+    adapter = _bare_scheduler_adapter(expected_workers=2)
+
+    try:
+        adapter.update_pending_store_workers(5, {0}, {1})
+    except ValueError as exc:
+        assert "subset" in str(exc)
+    else:
+        raise AssertionError("a failure without a terminal report was accepted")
+
+
+def test_duplicate_worker_report_does_not_replace_delayed_rank() -> None:
+    adapter = _bare_scheduler_adapter(expected_workers=2)
+
+    assert adapter.update_pending_store_workers(6, {0}, set()) is None
+    assert adapter.update_pending_store_workers(6, {0}, set()) is None
+    assert adapter._store_operation_terminal_workers[6] == {0}
+    assert adapter.update_pending_store_workers(6, {1}, set()) == set()
+
+
+def test_store_pins_unique_blocks_and_releases_after_all_ranks() -> None:
+    connector, pool = _bare_connector(expected_workers=2)
+    connector_metadata = LMCacheMPConnectorMetadata()
+    store_metadata = _store_metadata("same-request", [1, 2, 1, 2])
+
+    connector._add_store_metadata(connector_metadata, store_metadata)
+
+    assert store_metadata.store_op_id == 0
+    pool.touch.assert_called_once_with([pool.blocks[1], pool.blocks[2]])
+    assert connector.has_pending_push_work() is True
+
+    connector.update_connector_output(
+        SimpleNamespace(
+            kv_connector_worker_meta=LMCacheMPWorkerMetadata(
+                terminal_store_operations={0: {0}},
+            )
+        )
+    )
+    pool.free_blocks.assert_not_called()
+
+    connector.update_connector_output(
+        SimpleNamespace(
+            kv_connector_worker_meta=LMCacheMPWorkerMetadata(
+                terminal_store_operations={0: {1}},
+            )
+        )
+    )
+    assert list(pool.free_blocks.call_args.args[0]) == [
+        pool.blocks[2],
+        pool.blocks[1],
+    ]
+    assert pool.free_blocks.call_count == 1
+    assert connector.has_pending_push_work() is False
+
+
+def test_same_request_gets_independent_operation_ids() -> None:
+    connector, _pool = _bare_connector(expected_workers=1)
+    connector_metadata = LMCacheMPConnectorMetadata()
+    first = _store_metadata("same-request", [1])
+    second = _store_metadata("same-request", [2])
+
+    connector._add_store_metadata(connector_metadata, first)
+    connector._add_store_metadata(connector_metadata, second)
+
+    assert first.store_op_id == 0
+    assert second.store_op_id == 1
+    assert set(connector._pinned_store_operations) == {0, 1}
+
+
+def test_failed_rank_is_terminal_and_releases_after_all_ranks() -> None:
+    connector, pool = _bare_connector(expected_workers=2)
+    connector_metadata = LMCacheMPConnectorMetadata()
+    connector._add_store_metadata(
+        connector_metadata,
+        _store_metadata("req-failure", [3]),
+    )
+
+    connector.update_connector_output(
+        SimpleNamespace(
+            kv_connector_worker_meta=LMCacheMPWorkerMetadata(
+                terminal_store_operations={0: {0, 1}},
+                failed_store_operations={0: {1}},
+            )
+        )
+    )
+
+    assert list(pool.free_blocks.call_args.args[0]) == [pool.blocks[3]]
+    assert pool.free_blocks.call_count == 1
+    assert connector.has_pending_push_work() is False
+
+
+def test_request_finish_uses_operation_owned_block_references() -> None:
+    connector, pool = _bare_connector(expected_workers=1)
+    connector._cleanup_request_tracker = MagicMock()
+    connector.scheduler_adapter.end_session = MagicMock()
+    request = SimpleNamespace(request_id="req-finished", kv_transfer_params=None)
+
+    delay_free, return_params = connector.request_finished(request, [1, 2])
+
+    assert delay_free is False
+    assert return_params is None
+    pool.free_blocks.assert_not_called()
+    connector._cleanup_request_tracker.assert_called_once_with("req-finished")
+    connector.scheduler_adapter.end_session.assert_called_once_with("req-finished")
+
+
+def test_worker_metadata_drains_operation_results() -> None:
+    connector = object.__new__(LMCacheMPConnector)
+    connector.lazy_offload = False
+    connector.worker_adapter = MagicMock()
+    connector.worker_adapter.get_completed_store_operations.return_value = (
+        {7: {0, 1}},
+        {7: {1}},
+    )
+
+    metadata = connector.build_connector_worker_meta()
+
+    assert metadata == LMCacheMPWorkerMetadata(
+        terminal_store_operations={7: {0, 1}},
+        failed_store_operations={7: {1}},
+    )

--- a/tests/v1/test_mp_store_lifetime.py
+++ b/tests/v1/test_mp_store_lifetime.py
@@ -6,16 +6,25 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 # Third Party
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
+
+# Third Party
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (  # noqa: E402
+    KVConnectorRole,
+)
 
 # First Party
-from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector
-from lmcache.integration.vllm.lmcache_mp_metadata import (
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+)
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
     LMCacheMPConnectorMetadata,
     LMCacheMPRequestMetadata,
     LMCacheMPWorkerMetadata,
 )
-from lmcache.integration.vllm.vllm_multi_process_adapter import (
+from lmcache.integration.vllm.vllm_multi_process_adapter import (  # noqa: E402
     LMCacheMPSchedulerAdapter,
     LoadStoreOp,
 )

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -96,6 +96,8 @@ class FakeHeartbeatThread:
 
 def _make_worker_adapter(
     extra_config: dict[str, object] | None = None,
+    *,
+    operation_store_lifetime: bool = True,
 ) -> LMCacheMPWorkerAdapter:
     """Construct a worker adapter with the standard test arguments; the
     network boundary must already be patched (see ``fake_adapter``).
@@ -116,6 +118,7 @@ def _make_worker_adapter(
         parallel_strategy=parallel_strategy,
         mq_timeout=5.0,
         extra_config=extra_config,
+        operation_store_lifetime=operation_store_lifetime,
     )
 
 
@@ -277,8 +280,11 @@ def test_register_kv_caches_tuple_caches_use_engine_driven_context(
     assert adapter.create_recorded_event() is None
 
 
-def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
-    """submit_store_request stores the returned future in store_futures."""
+def test_submit_store_request_tracks_returned_future(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """submit_store_request tracks the future by STORE operation ID."""
     adapter, _send_mock, _ = fake_adapter
     monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
     fake_tensor = MagicMock()
@@ -295,6 +301,7 @@ def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
         op,
         event=MagicMock(),
         request_configs={"lmcache.skip_save": True},
+        store_op_id=17,
     )
 
     assert transfer_ctx.submit_store.called
@@ -303,10 +310,123 @@ def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
         "lmcache.skip_save": True
     }
     assert transfer_ctx.submit_store.call_args.args[4] == [[0]]
-    assert adapter.store_futures["req-1"] is fake_future
+    assert adapter._store_operation_futures[17].request_id == "req-1"
+    assert adapter._store_operation_futures[17].future is fake_future
 
 
-def test_submit_store_request_expands_block_ids_to_views(fake_adapter, monkeypatch):
+def test_legacy_connector_keeps_request_level_store_completion(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
+    legacy = _make_worker_adapter(operation_store_lifetime=False)
+    future = MagicMock()
+    future.query.return_value = True
+    future.result.return_value = True
+    legacy.transfer_ctx = MagicMock()
+    legacy.transfer_ctx.submit_store.return_value = future
+
+    legacy.submit_store_request("legacy-request", _op([[0]]), MagicMock())
+
+    assert legacy.store_futures == {"legacy-request": future}
+    assert legacy.get_finished({"legacy-request"}) == ({"legacy-request"}, set())
+
+
+def test_operation_store_requires_scheduler_identity(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+
+    with pytest.raises(ValueError, match="requires store_op_id"):
+        adapter.submit_store_request("missing-id", _op([[0]]), MagicMock())
+
+
+def test_operation_completion_releases_finished_request_id(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
+    class RequestId(str):
+        pass
+
+    adapter, _, _ = fake_adapter
+    adapter.request_telemetry = MagicMock()
+    request_id = RequestId("finished-request")
+    reference = weakref.ref(request_id)
+
+    assert adapter.get_finished({request_id}) == (set(), set())
+    adapter.get_finished(set())
+    adapter.request_telemetry.on_request_store_finished.assert_called_once()
+    adapter.request_telemetry.reset_mock()
+    del request_id
+    gc.collect()
+
+    assert reference() is None
+
+
+def test_operation_telemetry_waits_for_last_store(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.request_telemetry = MagicMock()
+    future = MagicMock()
+    future.query.return_value = False
+    future.result.return_value = True
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.return_value = future
+    adapter.submit_store_request("delayed", _op([[1]]), MagicMock(), store_op_id=301)
+
+    adapter.get_finished({"delayed"})
+    adapter.get_finished(set())
+    adapter.request_telemetry.on_request_store_finished.assert_not_called()
+    future.query.return_value = True
+    adapter.get_finished(set())
+    adapter.get_finished(set())
+
+    adapter.request_telemetry.on_request_store_finished.assert_called_once_with(
+        request_ids_set={"delayed"}, model_name="test-model", world_size=1, kv_rank=0
+    )
+    assert adapter.get_completed_store_operations() == ({301: {0}}, {})
+
+
+def test_operation_store_accepts_context_without_event(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    future = MagicMock()
+    future.query.return_value = True
+    future.result.return_value = True
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.return_value = future
+
+    adapter.submit_store_request("sync-store", _op([[1]]), None, store_op_id=302)
+
+    assert adapter.transfer_ctx.submit_store.call_args.args[5] is None
+    assert adapter.get_completed_store_operations() == ({302: {0}}, {})
+
+
+def test_store_batch_rejects_operation_count_before_submission(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _, _ = fake_adapter
+    submit = MagicMock()
+    monkeypatch.setattr(adapter, "submit_store_request", submit)
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        adapter.batched_submit_store_requests(
+            ["first", "second"], [_op([[1]]), _op([[2]])], None, store_op_ids=[303]
+        )
+
+    submit.assert_not_called()
+
+
+def test_submit_store_request_expands_block_ids_to_views(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     adapter, _send_mock, _ = fake_adapter
     monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
     fake_tensor = MagicMock()
@@ -328,13 +448,208 @@ def test_submit_store_request_expands_block_ids_to_views(fake_adapter, monkeypat
         end=4,
     )
 
-    adapter.submit_store_request("req-1", op, event=MagicMock())
+    adapter.submit_store_request("req-1", op, event=MagicMock(), store_op_id=18)
 
     assert transfer_ctx.submit_store.call_args.args[4] == [
         [0, 1],
         [0, 1],
         [10, 11],
     ]
+
+
+def test_same_request_store_operations_do_not_overwrite_each_other(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.kv_caches = {"layer.0": MagicMock()}
+    first_future = MagicMock(name="first_future")
+    second_future = MagicMock(name="second_future")
+    first_future.query.return_value = True
+    first_future.result.return_value = True
+    second_future.query.return_value = False
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.side_effect = [first_future, second_future]
+
+    adapter.submit_store_request(
+        "same-request", _op([[1]]), MagicMock(), store_op_id=101
+    )
+    adapter.submit_store_request(
+        "same-request", _op([[2]]), MagicMock(), store_op_id=102
+    )
+
+    assert set(adapter._store_operation_futures) == {101, 102}
+    assert adapter.get_finished({"same-request"})[0] == set()
+    assert set(adapter._store_operation_futures) == {102}
+    assert adapter.get_completed_store_operations() == ({101: {0}}, {})
+
+    second_future.query.return_value = True
+    second_future.result.return_value = True
+    assert adapter.get_finished({"same-request"})[0] == set()
+    assert adapter._store_operation_futures == {}
+    assert adapter.get_completed_store_operations() == ({102: {0}}, {})
+
+
+def test_false_store_result_reports_failed_terminal(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.kv_caches = {"layer.0": MagicMock()}
+    future = MagicMock()
+    future.query.return_value = True
+    future.result.return_value = False
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.return_value = future
+
+    adapter.submit_store_request("req-failed", _op([[3]]), MagicMock(), store_op_id=103)
+    adapter.get_finished(set())
+
+    assert adapter.get_completed_store_operations() == ({103: {0}}, {103: {0}})
+
+
+def test_terminal_store_exception_reports_failed_terminal(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.kv_caches = {"layer.0": MagicMock()}
+    future = MagicMock()
+    future.query.return_value = True
+    future.result.side_effect = RuntimeError("store failed")
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.return_value = future
+
+    adapter.submit_store_request(
+        "req-terminal-error", _op([[3]]), MagicMock(), store_op_id=109
+    )
+
+    assert adapter.get_completed_store_operations() == ({109: {0}}, {109: {0}})
+    assert 109 not in adapter._store_operation_futures
+
+
+def test_unknown_store_state_retains_operation(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.kv_caches = {"layer.0": MagicMock()}
+    future = MagicMock()
+    future.query.side_effect = RuntimeError("query failed")
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.return_value = future
+
+    adapter.submit_store_request(
+        "req-query-error", _op([[3]]), MagicMock(), store_op_id=110
+    )
+
+    assert adapter.get_completed_store_operations() is None
+    assert 110 in adapter._store_operation_futures
+    assert 110 in adapter._store_operation_events
+
+
+def test_store_submit_exception_is_indeterminate_and_propagates(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.kv_caches = {"layer.0": MagicMock()}
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.side_effect = RuntimeError("submit failed")
+
+    event = MagicMock()
+    with pytest.raises(RuntimeError, match="submit failed"):
+        adapter.submit_store_request(
+            "req-submit-failed", _op([[4]]), event, store_op_id=104
+        )
+
+    assert adapter._store_operation_futures == {}
+    assert adapter._indeterminate_store_operations == {104: "req-submit-failed"}
+    assert adapter._store_operation_events == {104: event}
+    assert adapter.get_completed_store_operations() is None
+
+
+def test_unhealthy_store_reports_failed_terminal(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter._health_event.clear()
+    adapter.transfer_ctx = MagicMock()
+
+    adapter.submit_store_request(
+        "req-unhealthy", _op([[5]]), MagicMock(), store_op_id=105
+    )
+
+    adapter.transfer_ctx.submit_store.assert_not_called()
+    assert adapter.get_completed_store_operations() == ({105: {0}}, {105: {0}})
+
+
+def test_missing_transfer_context_reports_failed_terminal(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.transfer_ctx = None
+
+    adapter.submit_store_request(
+        "req-no-context", _op([[5]]), MagicMock(), store_op_id=108
+    )
+
+    assert adapter.get_completed_store_operations() == ({108: {0}}, {108: {0}})
+
+
+def test_unhealthy_heartbeat_keeps_inflight_store_pending(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.kv_caches = {"layer.0": MagicMock()}
+    future = MagicMock()
+    future.query.return_value = False
+    adapter.transfer_ctx = MagicMock()
+    adapter.transfer_ctx.submit_store.return_value = future
+
+    adapter.submit_store_request(
+        "req-inflight", _op([[5]]), MagicMock(), store_op_id=107
+    )
+    adapter._health_event.clear()
+    adapter.get_finished(set())
+
+    assert 107 in adapter._store_operation_futures
+    assert adapter.get_completed_store_operations() is None
+
+
+def test_non_writer_store_reports_successful_terminal(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter, _send_mock, _ = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    adapter.parallel_strategy = ParallelStrategy(
+        mla_only=True,
+        vllm_world_size=2,
+        vllm_worker_id=1,
+        tp_size=2,
+        pp_size=1,
+        n_servers=1,
+    )
+    adapter.transfer_ctx = MagicMock()
+
+    adapter.submit_store_request(
+        "req-non-writer", _op([[6]]), MagicMock(), store_op_id=106
+    )
+
+    adapter.transfer_ctx.submit_store.assert_not_called()
+    assert adapter.get_completed_store_operations() == ({106: {1}}, {})
 
 
 def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatch):
@@ -479,14 +794,16 @@ def test_none_event_is_not_retained(fake_adapter, monkeypatch):
     transfer_ctx.submit_retrieve.return_value = MagicMock()
     adapter.transfer_ctx = transfer_ctx
 
-    adapter.submit_store_request("store", _op([[0]]), None)
+    adapter.submit_store_request("store", _op([[0]]), None, store_op_id=304)
     adapter.submit_retrieve_request("retrieve", _op([[1]]), None)
 
-    assert "store" not in adapter.store_events
+    assert 304 not in adapter._store_operation_events
     assert "retrieve" not in adapter.retrieve_events
 
 
-def test_store_keeps_event_until_future_finishes(fake_adapter):
+def test_store_keeps_event_until_future_finishes(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
     """Store requests keep the exported CUDA event alive while pending."""
     adapter, _send_mock, _future = fake_adapter
     cuda_future = MagicMock(name="cuda_future")
@@ -499,7 +816,7 @@ def test_store_keeps_event_until_future_finishes(fake_adapter):
     event_ref = weakref.ref(event)
     op = LoadStoreOp(token_ids=[1, 2], block_ids=[[7]], start=0, end=2)
 
-    adapter.submit_store_request("req-1", op, event)
+    adapter.submit_store_request("req-1", op, event, store_op_id=23)
     del event
     gc.collect()
     assert event_ref() is not None
@@ -508,9 +825,10 @@ def test_store_keeps_event_until_future_finishes(fake_adapter):
     cuda_future.result.return_value = True
     finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
 
-    assert finished_stores == {"req-1"}
+    assert finished_stores == set()
     assert finished_retrieves == set()
-    assert "req-1" not in adapter.store_events
+    assert 23 not in adapter._store_operation_events
+    assert adapter.get_completed_store_operations() == ({23: {0}}, {})
     transfer_ctx.reset_mock()
     gc.collect()
     assert event_ref() is None
@@ -663,7 +981,9 @@ def test_instance_id_logged_at_info_on_construction(fake_adapter, monkeypatch) -
     assert any(str(adapter.instance_id) in msg for msg in messages)
 
 
-def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
+def test_heartbeat_lazy_start_wires_callback_before_start(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
     """The lazy create path starts the heartbeat healthy (no pessimistic
     clear) and wires the recover callback before ``start()``; the first
     store is not gated. Idempotent on re-entry (no second thread)."""
@@ -671,7 +991,7 @@ def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
     adapter.transfer_ctx = MagicMock()
     assert adapter.is_healthy  # the constructor leaves the event set
 
-    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    adapter.submit_store_request("req-1", _op([[0]]), MagicMock(), store_op_id=201)
 
     assert len(FakeHeartbeatThread.instances) == 1
     heartbeat = FakeHeartbeatThread.instances[0]
@@ -684,7 +1004,7 @@ def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
     assert adapter.transfer_ctx.submit_store.call_count == 1
 
     # Re-entry is idempotent: no new thread.
-    adapter.submit_store_request("req-2", _op([[1]]), MagicMock())
+    adapter.submit_store_request("req-2", _op([[1]]), MagicMock(), store_op_id=202)
     assert len(FakeHeartbeatThread.instances) == 1
     assert adapter.transfer_ctx.submit_store.call_count == 2
 
@@ -773,12 +1093,14 @@ def test_dropped_retrieve_reported_once_via_healthy_get_finished(
     assert finished_retrieves == set()
 
 
-def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
+def test_shutdown_stops_heartbeat_before_unregister(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
     """shutdown() stops the heartbeat before sending UNREGISTER, so no
     stray heartbeat ping can race the closing req_client."""
     adapter, req_client, future = fake_adapter
     adapter.transfer_ctx = MagicMock()
-    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    adapter.submit_store_request("req-1", _op([[0]]), MagicMock(), store_op_id=203)
     heartbeat = FakeHeartbeatThread.instances[0]
 
     stop_state_at_unregister: list[bool] = []
@@ -848,7 +1170,8 @@ def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> Non
 
 
 def test_recover_callback_skips_register_after_stop_requested(
-    fake_adapter, monkeypatch
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A recover callback that observes a requested stop bails out before
     submitting REGISTER: a REGISTER submitted after UNREGISTER would
@@ -859,7 +1182,7 @@ def test_recover_callback_skips_register_after_stop_requested(
     fake_tensor = MagicMock()
     fake_tensor.device.type = "cuda"
     adapter.register_kv_caches({"layer.0": fake_tensor})
-    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    adapter.submit_store_request("req-1", _op([[0]]), MagicMock(), store_op_id=204)
     heartbeat = FakeHeartbeatThread.instances[0]
     assert heartbeat.recover_callback is not None
     rebuilds_before = len(contexts)
@@ -977,7 +1300,8 @@ def test_startup_does_not_warn_for_default_heartbeat_interval(
 
 
 def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
-    fake_adapter, monkeypatch
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Pin current behavior: every recover-callback invocation rebuilds
     ``transfer_ctx`` without closing the previous context (known IPC leak;
@@ -989,7 +1313,7 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
     fake_tensor.device.type = "cuda"
     adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[0]
     # Start the heartbeat (healthy, no recover) so the callback is wired.
-    adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
+    adapter.submit_store_request("req-1", _op([[0]]), MagicMock(), store_op_id=205)
     heartbeat = FakeHeartbeatThread.instances[0]
     assert heartbeat.recover_callback is not None
     assert len(contexts) == 1


### PR DESCRIPTION
**What this PR does / why we need it**:

A non-lazy MP STORE may still be reading its source GPU blocks when vLLM preempts the request. If those blocks are released and reused, LMCache can save KV data that already belongs to another request.

This change assigns an operation ID to every non-lazy STORE and takes an extra reference on the exact source blocks before vLLM releases the request's references. Completion is tracked separately for each operation and worker rank. The extra references are released only after every rank reports a terminal result, so multiple STOREs from the same request cannot overwrite each other's tracking state. If submission or completion cannot be determined, the references are retained and an error is reported.

Preempted requests now use the existing lookup and load path to restore their cached prompt and generated prefix. On a full cache hit, the final token is left for recomputation so vLLM can produce logits normally. Lazy offload and legacy adapter callers keep their existing request-level completion behavior.

**Special notes for your reviewers**:

This overlaps with #4836 on the source-block lifetime problem, but uses a different completion boundary: #4836 drains worker-local STORE futures when preemption is handled, while this change holds the exact blocks in the scheduler until every worker reports the operation as terminal. The non-lazy path also takes its own block references before request completion, so it does not use the request-level `finished_sending` signal introduced by #4826 to release them. #4939 touches the same connector state and may require a small rebase if it lands first.

Validation:

- Qwen3-8B with vLLM `687db597` on 4×A800, TP=4.
- All 448 requests across 14 formal cases produced 512 output tokens.
- With a 750 ms injected STORE delay, the baseline logged 248 source-block reuse correlations before the related STORE completed; the candidate logged 0 under the same workload.
- The TP4 candidate runs covered 665 STORE operations and 2,660 worker terminal reports, with no observed early block release, held-block reassignment, sampled KV changes, or leaked block references.
- The A800-tested candidate passed 113 focused tests. After rebasing onto `dev` at `59a56a2c`, the current patch also passes 31 focused source-level regression checks together with Ruff, isort, codespell, SPDX, syntax, and diff checks.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
