### PR TITLE
docs: daily drift check — multi-process mode (2026-09-04)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -186,6 +186,14 @@ Source: ``lmcache/v1/multiprocess/config.py``
        independently, and is what allows ``--max-num-batched-tokens`` to exceed
        twice the block size). For a non-hybrid model it makes no difference —
        every layer resolves to one object group. See :doc:`/mp/hybrid_models`.
+   * - ``--enable``
+     - ``[]``
+     - Space-separated list of experimental transfer modules to enable.
+       Currently the only supported value is ``transfer_query`` — the
+       experimental intermediate-tensor (query) transfer path used by the
+       LMCache SDK. See :doc:`/mp/sdk` for the end-to-end configuration and
+       ``lmcache/v1/multiprocess/modules/experimental/__init__.py`` for the
+       registered feature identifiers.
 
 Lookup Hash Logging
 -------------------

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -257,6 +257,19 @@ Kubernetes downward API); an explicit flag wins over the env var.
      - ``LMCACHE_COORDINATOR_EVENT_FLUSH_INTERVAL``
      - Seconds between cache-event batch flushes (must be ``> 0``, default
        ``1``).
+   * - ``--coordinator-blend-timeout``
+     - *(no env fallback)*
+     - Seconds a fleet CacheBlend lookup against the coordinator is
+       allowed to take. Used as both the HTTP timeout and the per-lookup
+       match budget (``match_budget_s``). Default ``1.0``. Applies only
+       when the coordinator was started with ``--enable-blend-lookup``
+       (see `CacheBlend fragment lookup`_).
+   * - ``--coordinator-blend-match-concurrency``
+     - *(no env fallback)*
+     - Maximum number of fleet CacheBlend match round-trips this MP
+       server will keep in flight at once against the coordinator.
+       Default ``8``. Applies only when the coordinator was started with
+       ``--enable-blend-lookup``.
 
 The server registers under its stable identity (``--instance-id`` / OTel
 ``service.instance.id``); if the flag is not passed, the server mints a


### PR DESCRIPTION
## Summary

Daily automated docs-drift check for multi-process (MP) mode against
`LMCache/LMCache:dev` @ [`ceb93b3`](https://github.com/LMCache/LMCache/commit/ceb93b33f1f606036022b0b1915d1821541368f4).

Found two MP-mode CLI flags defined in `lmcache/v1/multiprocess/config.py`
that are missing from the docs pages that promise to cover them.

### `docs/source/` (user-facing)

- **`docs/source/mp/configuration.rst` — MP Server section**
  is missing `--enable`, the flag that turns on experimental transfer
  modules (currently `transfer_query`, used by the LMCache SDK).
- **`docs/source/mp/coordinator.rst` — "Connecting MP servers" table**
  is missing `--coordinator-blend-timeout` and
  `--coordinator-blend-match-concurrency`, both of which gate fleet
  CacheBlend lookups from an MP server to the coordinator.

### `docs/design/`

No new drift found in `docs/design/` for MP mode in this check.

## Evidence

### 1. `--enable` (experimental transfer modules)

- **Code (defines the flag, argparse-visible in `--help`):**
  [`lmcache/v1/multiprocess/config.py#L426-L433`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/lmcache/v1/multiprocess/config.py#L426-L433)

  ```python
  mp_group.add_argument(
      "--enable",
      type=str,
      nargs="*",
      default=[],
      help="List of experimental transfer modules to enable. "
      "Options: transfer_query (see lmcache.v1.multiprocess.modules."
      "experimental.__init___.py).",
  )
  ```

- **Registered feature identifiers:**
  [`lmcache/v1/multiprocess/modules/experimental/__init__.py`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/lmcache/v1/multiprocess/modules/experimental/__init__.py) — only `transfer_query` is currently registered.

- **Only user-facing mention today (an example, not a reference entry):**
  [`docs/source/mp/sdk.rst#L63`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/docs/source/mp/sdk.rst#L63)
  and the example at
  [`#L76`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/docs/source/mp/sdk.rst#L76).

- **Stale doc location:**
  [`docs/source/mp/configuration.rst`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/docs/source/mp/configuration.rst) — the "MP Server" table (starting around L60) opens with "This page documents every CLI argument accepted by the LMCache multiprocess server" but does not list `--enable`.

### 2. `--coordinator-blend-timeout` and `--coordinator-blend-match-concurrency`

- **Code (defines the flags, argparse-visible in `--help`):**
  [`lmcache/v1/multiprocess/config.py#L659-L673`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/lmcache/v1/multiprocess/config.py#L659-L673)

  ```python
  group.add_argument(
      "--coordinator-blend-timeout",
      type=float,
      default=DEFAULT_COORDINATOR_CONFIG.blend_timeout,
      help="Seconds a fleet CacheBlend lookup to the coordinator may take, "
      "used as both the HTTP timeout and the per-lookup match budget "
      f"(default: {DEFAULT_COORDINATOR_CONFIG.blend_timeout}).",
  )
  group.add_argument(
      "--coordinator-blend-match-concurrency",
      type=int,
      default=DEFAULT_COORDINATOR_CONFIG.blend_match_concurrency,
      help="Max fleet CacheBlend match round-trips in flight at once "
      f"(default: {DEFAULT_COORDINATOR_CONFIG.blend_match_concurrency}).",
  )
  ```

- **Defaults (from `CoordinatorConfig`):**
  [`lmcache/v1/multiprocess/config.py#L241-L245`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/lmcache/v1/multiprocess/config.py#L241-L245)
  — `blend_timeout = 1.0`, `blend_match_concurrency = 8`.

- **Consumer (proves the flags are wired up, not dormant):**
  [`docs/design/v1/mp_coordinator/blend_lookup.md#L88`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/docs/design/v1/mp_coordinator/blend_lookup.md#L88)
  documents the per-lookup match budget contract sourced from
  `--coordinator-blend-timeout`.

- **Stale doc location:**
  [`docs/source/mp/coordinator.rst`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/docs/source/mp/coordinator.rst) — the "Connecting MP servers" flag table (around L232-L260) enumerates the coordinator flags an MP server accepts but stops at `--coordinator-event-flush-interval`; the two blend-lookup client flags are absent.

  (For completeness: the hidden deprecated aliases
  `--coordinator-l2-event-reporting` and
  `--coordinator-l2-event-flush-interval` at
  [`lmcache/v1/multiprocess/config.py#L678-L692`](https://github.com/LMCache/LMCache/blob/ceb93b33f1f606036022b0b1915d1821541368f4/lmcache/v1/multiprocess/config.py#L678-L692)
  use `help=argparse.SUPPRESS` and correctly stay out of the docs.)

## Proposed fix (already applied)

- `docs/source/mp/configuration.rst`: add an `--enable` row to the MP Server
  argument table, pointing at `docs/source/mp/sdk.rst` for the SDK
  transfer-query example and at
  `lmcache/v1/multiprocess/modules/experimental/__init__.py` for the
  registered feature identifiers.

- `docs/source/mp/coordinator.rst`: add
  `--coordinator-blend-timeout` and `--coordinator-blend-match-concurrency`
  rows to the "Connecting MP servers" table with the defaults from
  `CoordinatorConfig`, note that they have no `LMCACHE_COORDINATOR_*` env
  fallback, and cross-reference the coordinator-side
  `--enable-blend-lookup` opt-in.

Docs-only. No code files touched. If anything about the wording is off
(especially the semantic gloss on `--enable` vs. the SDK page's example),
please push corrections directly onto this branch or say so in review.

## Notes

- Auto-generated by the daily drift-check routine. **Needs human review
  before merge.**
- Kept as **draft** intentionally.
- Checked prior open drift-check PRs (#4909, #4823, #4799, #4777, …); none
  cover these two items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019udJvAhJB4D98WbKhiTMn5

---
_Generated by [Claude Code](https://claude.ai/code/session_019udJvAhJB4D98WbKhiTMn5)_