### PR TITLE
fix(vllm): start scheduler heartbeats for every MP server

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -693,9 +693,9 @@ class LMCacheMPSchedulerAdapter:
             ev.set()
             self._health_events[url] = ev
 
-        # Heartbeat thread is created but NOT started yet.
-        # It will be lazily started on the first lookup
-        # request, by which time vLLM is fully ready.
+        # Heartbeat threads are not created or started yet.
+        # One per server is lazily created on the first lookup request, by
+        # which time vLLM is fully ready.
         self._heartbeat_interval = heartbeat_interval
         self._heartbeats: dict[str, HeartbeatThread] = {}
         self._heartbeat_lock = threading.Lock()
@@ -721,13 +721,11 @@ class LMCacheMPSchedulerAdapter:
         return all(ev.is_set() for ev in self._health_events.values())
 
     def _ensure_heartbeat_started(self) -> None:
-        """Lazily start the heartbeat thread on first use."""
-        if self._heartbeats is not None:
-            return
+        """Start one heartbeat per configured server, retrying missing heartbeats."""
         with self._heartbeat_lock:
-            if self._heartbeats is not None:
-                return
             for url, client in self.req_clients.items():
+                if url in self._heartbeats:
+                    continue
                 hb = HeartbeatThread(
                     req_client=client,
                     health_event=self._health_events[url],
@@ -967,11 +965,17 @@ class LMCacheMPSchedulerAdapter:
 
     def shutdown(self) -> None:
         """Shutdown the scheduler adapter and its resources."""
+        stop_timeout = max(5.0, self._heartbeat_interval + 1.0)
+        with self._heartbeat_lock:
+            heartbeats = tuple(self._heartbeats.values())
+            for hb in heartbeats:
+                hb.stop(timeout=stop_timeout)
+            for hb in heartbeats:
+                # ``stop`` has a bounded join timeout. Keep request clients
+                # open until any heartbeat that outlived that timeout exits.
+                hb.wait_for_stop()
         for client in self.req_clients.values():
             client.close()
-        with self._heartbeat_lock:
-            for hb in self._heartbeats.values():
-                hb.stop()
 
     def free_lookup_locks(
         self,

--- a/lmcache/v1/periodic_thread.py
+++ b/lmcache/v1/periodic_thread.py
@@ -279,6 +279,23 @@ class PeriodicThread(ABC):
                     timeout,
                 )
 
+    def wait_for_stop(self, timeout: float | None = None) -> bool:
+        """Wait for the periodic thread to terminate.
+
+        Args:
+            timeout: Maximum time to wait in seconds. If ``None``, wait until
+                the thread terminates.
+
+        Returns:
+            ``True`` if the periodic thread has terminated, otherwise ``False``
+            when the timeout expires first.
+        """
+        thread = self._thread
+        if thread is None:
+            return True
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
+
     def wake(self) -> None:
         """Trigger one execution now instead of waiting for the next tick.
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -64,6 +64,10 @@ class FakeHeartbeatThread:
         # "start", "stop") for call-order assertions.
         self.calls: list[str] = []
         self.stop_requested = False
+        self.stop_timeouts: list[float] = []
+        self.wait_for_stop_calls = 0
+        self.in_flight_ping_duration = 0.0
+        self.in_flight_ping = False
         FakeHeartbeatThread.instances.append(self)
 
     def register_recover_callback(self, callback: Callable[[], bool]) -> None:
@@ -80,7 +84,17 @@ class FakeHeartbeatThread:
 
     def stop(self, timeout: float = 5.0) -> None:
         self.calls.append("stop")
+        self.stop_timeouts.append(timeout)
+        if timeout < self.in_flight_ping_duration:
+            return
         self.stop_requested = True
+        self.in_flight_ping = False
+
+    def wait_for_stop(self, timeout: float | None = None) -> bool:
+        self.wait_for_stop_calls += 1
+        self.stop_requested = True
+        self.in_flight_ping = False
+        return True
 
     def simulate_successful_ping(self) -> None:
         """Mimic one successful heartbeat cycle: on the unhealthy->healthy
@@ -116,6 +130,44 @@ def _make_worker_adapter(
         parallel_strategy=parallel_strategy,
         mq_timeout=5.0,
         extra_config=extra_config,
+    )
+
+
+def _make_scheduler_adapter_for_heartbeat_test(
+    monkeypatch: pytest.MonkeyPatch,
+    heartbeat_interval: float = 10.0,
+) -> tuple[adapter_mod.LMCacheMPSchedulerAdapter, dict[str, MagicMock]]:
+    """Build a scheduler adapter with recorded request clients."""
+    server_urls = ["tcp://server-a:5555", "tcp://server-b:5555"]
+    clients = {
+        url: MagicMock(name=f"{url}_client", spec=RequestClient) for url in server_urls
+    }
+    for client in clients.values():
+        client.get_chunk_size.return_value.result.return_value = 256
+        client.lookup.return_value.result.return_value = None
+
+    request_client_factory = MagicMock()
+    request_client_factory.create.side_effect = lambda url, **_kwargs: clients[url]
+    monkeypatch.setattr(adapter_mod, "RequestClientFactory", request_client_factory)
+
+    return (
+        adapter_mod.LMCacheMPSchedulerAdapter(
+            server_urls=server_urls,
+            context=MagicMock(name="zmq_context"),
+            model_name="test-model",
+            vllm_block_size=16,
+            parallel_strategy=ParallelStrategy(
+                mla_only=False,
+                vllm_world_size=2,
+                vllm_worker_id=0,
+                tp_size=2,
+                pp_size=1,
+                n_servers=2,
+            ),
+            mq_timeout=5.0,
+            heartbeat_interval=heartbeat_interval,
+        ),
+        clients,
     )
 
 
@@ -687,6 +739,87 @@ def test_heartbeat_lazy_start_wires_callback_before_start(fake_adapter) -> None:
     adapter.submit_store_request("req-2", _op([[1]]), MagicMock())
     assert len(FakeHeartbeatThread.instances) == 1
     assert adapter.transfer_ctx.submit_store.call_count == 2
+
+
+def test_scheduler_heartbeat_startup_starts_missing_servers_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lookups start, backfill, and retain one heartbeat per server."""
+    FakeHeartbeatThread.instances.clear()
+    monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
+    adapter, clients = _make_scheduler_adapter_for_heartbeat_test(monkeypatch)
+    failed_client = clients["tcp://server-b:5555"]
+
+    def fail_one_start(heartbeat: FakeHeartbeatThread) -> None:
+        if heartbeat.req_client is failed_client:
+            FakeHeartbeatThread.start_hook = None
+            raise RuntimeError("simulated heartbeat start failure")
+
+    monkeypatch.setattr(FakeHeartbeatThread, "start_hook", fail_one_start)
+
+    with pytest.raises(RuntimeError, match="simulated heartbeat start failure"):
+        adapter.maybe_submit_lookup_request("first", list(range(256)))
+
+    adapter.maybe_submit_lookup_request("second", list(range(256)))
+    adapter.maybe_submit_lookup_request("third", list(range(256)))
+
+    server_a_heartbeats = [
+        heartbeat
+        for heartbeat in FakeHeartbeatThread.instances
+        if heartbeat.req_client is clients["tcp://server-a:5555"]
+    ]
+    server_b_heartbeats = [
+        heartbeat
+        for heartbeat in FakeHeartbeatThread.instances
+        if heartbeat.req_client is failed_client
+    ]
+    assert len(server_a_heartbeats) == 1
+    assert len(server_b_heartbeats) == 2
+    assert server_a_heartbeats[0].calls == ["start"]
+    assert server_b_heartbeats[-1].calls == ["start"]
+    assert clients["tcp://server-a:5555"].lookup.call_count == 2
+    assert failed_client.lookup.call_count == 2
+
+
+def test_scheduler_shutdown_waits_for_in_flight_heartbeats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown waits for every in-flight heartbeat before closing clients."""
+    FakeHeartbeatThread.instances.clear()
+    monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
+    adapter, clients = _make_scheduler_adapter_for_heartbeat_test(
+        monkeypatch, heartbeat_interval=2.0
+    )
+
+    adapter.maybe_submit_lookup_request("request", list(range(256)))
+
+    for heartbeat in FakeHeartbeatThread.instances:
+        heartbeat.in_flight_ping_duration = 6.0
+        heartbeat.in_flight_ping = True
+
+    heartbeat_stopped_at_close: list[bool] = []
+    for client in clients.values():
+        client.close.side_effect = lambda: heartbeat_stopped_at_close.append(
+            all(heartbeat.stop_requested for heartbeat in FakeHeartbeatThread.instances)
+        )
+
+    adapter.shutdown()
+
+    assert all(
+        heartbeat.in_flight_ping_duration > 5.0
+        for heartbeat in FakeHeartbeatThread.instances
+    )
+    assert all(
+        heartbeat.stop_timeouts == [5.0] for heartbeat in FakeHeartbeatThread.instances
+    )
+    assert all(
+        heartbeat.wait_for_stop_calls == 1
+        for heartbeat in FakeHeartbeatThread.instances
+    )
+    assert all(
+        not heartbeat.in_flight_ping for heartbeat in FakeHeartbeatThread.instances
+    )
+    assert heartbeat_stopped_at_close == [True] * len(clients)
 
 
 def test_heartbeat_first_ping_runs_callback_before_setting_event(


### PR DESCRIPTION
## Summary

- Correct the scheduler heartbeat lifecycle: the first lookup now starts one heartbeat for every configured LMCache server, and later lookups backfill only servers missing a successful heartbeat.
- Preserve heartbeats that already started when another server fails during startup; a later lookup retries only the failed server.
- Stop all scheduler heartbeats before closing request clients, waiting `heartbeat_interval + 1` seconds so an in-flight `send_ping()` using that same interval as its timeout can complete.

## Regression coverage

- Drives scheduler heartbeat startup and idempotence through `maybe_submit_lookup_request()`.
- Simulates a partial start failure and verifies that only the missing server heartbeat is retried.
- Exercises public `shutdown()` with deterministic fake in-flight pings longer than the former 5-second stop timeout; verifies every heartbeat stops before any request client closes.

## Tests

- `pytest -xvs tests/v1/test_vllm_mp_adapter.py::test_scheduler_heartbeat_startup_starts_missing_servers_once tests/v1/test_vllm_mp_adapter.py::test_scheduler_shutdown_waits_for_in_flight_heartbeats` — 2 passed
- `pytest -xvs tests/v1/test_vllm_mp_adapter.py` — 42 passed, 1 skipped
- `ruff format --check lmcache/integration/vllm/vllm_multi_process_adapter.py tests/v1/test_vllm_mp_adapter.py`
- `ruff check lmcache/integration/vllm/vllm_multi_process_adapter.py tests/v1/test_vllm_mp_adapter.py`
- `mypy --config-file=pyproject.toml lmcache/integration/vllm/vllm_multi_process_adapter.py tests/v1/test_vllm_mp_adapter.py`
- `python -m py_compile lmcache/integration/vllm/vllm_multi_process_adapter.py tests/v1/test_vllm_mp_adapter.py`
- `git diff --check`

Closes #4963