### PR TITLE
[MP][Observability] Prometheus counters for L1/L2 hit attribution and early exits

### DIFF
--- a/docs/design/v1/mp_observability/DEBUG.md
+++ b/docs/design/v1/mp_observability/DEBUG.md
@@ -37,19 +37,22 @@ L2_hit_rate         = L2_hit_tokens_total
 
 The keys-to-tokens conversion is exact — every L2 hit is a full chunk.
 
-## L1-only hit rate (derived)
+## L1-only / L2-only hit rate (direct)
 
-Total minus L2:
+`MP_LOOKUP_PREFETCH_END` attributes each lookup's hit prefix by tier
+(`l1_hit_tokens + l2_hit_tokens == hit_tokens`, following each object
+group's attention-window rule), so the split is a direct read:
 
 ```
-L1_hit_tokens_total = increase(lmcache_mp_lookup_hit_tokens_total)
-                    - increase(lmcache_mp_l2_prefetch_hit_chunks_total) * chunk_size
+L1_hit_tokens_total = increase(lmcache_mp_lookup_hit_l1_tokens_total)
+L2_hit_tokens_total = increase(lmcache_mp_lookup_hit_l2_tokens_total)
 L1_hit_rate         = L1_hit_tokens_total
                     / increase(lmcache_mp_lookup_requested_tokens_total)
 ```
 
-Sanity check: `L1_hit_tokens_total >= 0`.  A sustained negative value
-indicates a metric-emission bug.
+The older recipe `lookup_hit - l2_prefetch_hit_chunks * chunk_size` counts
+keys found in L2 rather than the window-rule remainder, so the two differ
+on hybrid-attention or TP>1 deployments; prefer the direct counters.
 
 ## Blend total hit rate
 

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -202,7 +202,7 @@ ratio is the fraction of tokens requested by a lookup that were served from
 either L1 or L2.  L0 (GPU prefix cache) is intentionally excluded — it is
 vLLM-owned and not observable from LMCache.
 
-Both counters carry `model_name` and `cache_salt` OTel attributes (captured
+All of these counters carry `model_name` and `cache_salt` OTel attributes (captured
 at lookup time from `IPCCacheServerKey`), enabling per-model and per-tenant
 slicing of the hit rate.  `cache_salt` can be high-cardinality; drop it at
 scrape time with `metric_relabel_configs` if storage cost matters.
@@ -211,6 +211,10 @@ scrape time with `metric_relabel_configs` if storage cost matters.
 |---|---|---|---|---|
 | `lmcache_mp.lookup_requested` | `lmcache_mp_lookup_requested_tokens_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+requested_tokens` |
 | `lmcache_mp.lookup_hit` | `lmcache_mp_lookup_hit_tokens_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+hit_tokens` |
+| `lmcache_mp.lookup_hit_l1` | `lmcache_mp_lookup_hit_l1_tokens_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+l1_hit_tokens` (0 if absent) |
+| `lmcache_mp.lookup_hit_l2` | `lmcache_mp_lookup_hit_l2_tokens_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+l2_hit_tokens` (0 if absent); `l1 + l2 == lookup_hit` per event |
+| `lmcache_mp.lookups` | `lmcache_mp_lookups_requests_total` | Counter (attrs: `model_name`, `cache_salt`) | `MP_LOOKUP_PREFETCH_END` | `+1` per completed lookup |
+| `lmcache_mp.lookup_early_exit` | `lmcache_mp_lookup_early_exit_requests_total` | Counter (attrs: `model_name`, `cache_salt`, `reason` ∈ {`no_gpu_context`, `empty_chunk_hashes`, `no_group_layout_descs`}) | `MP_LOOKUP_PREFETCH_END` | `+1` when `early_exit_reason != ""` |
 
 **What it answers:** What fraction of tokens requested by a lookup were served from cache (L1 or L2)?
 
@@ -224,9 +228,22 @@ sum(rate(lmcache_mp_lookup_hit_tokens_total[5m])) by (model_name)
 / sum(rate(lmcache_mp_lookup_requested_tokens_total[5m])) by (model_name)
 ```
 
-> **Note:** Both counters are driven by the *same* event, so they always
+**Per-tier split and early exits:**
+
+```promql
+# Share of hit tokens that L1 could serve on its own:
+rate(lmcache_mp_lookup_hit_l1_tokens_total[5m])
+/ rate(lmcache_mp_lookup_hit_tokens_total[5m])
+
+# Fraction of lookups that early-exited, by reason:
+sum(rate(lmcache_mp_lookup_early_exit_requests_total[5m])) by (reason)
+/ sum(rate(lmcache_mp_lookups_requests_total[5m]))
+```
+
+> **Note:** All lookup counters are driven by the *same* event, so they always
 > advance together per completed lookup.  Early-exit lookups (no GPU
-> context matches, empty `chunk_hashes`) contribute `0` to both, and
+> context matches, empty `chunk_hashes`) contribute `0` tokens to all four
+> token counters and `+1` to `lookups` and `lookup_early_exit{reason}`, and
 > abandoned lookups (client never polls `query_prefetch_status`)
 > contribute to neither.  See
 > [L1_L2_HIT_RATE_PLAN.md](L1_L2_HIT_RATE_PLAN.md) for the full rationale.

--- a/docs/source/mp/observability/metrics.rst
+++ b/docs/source/mp/observability/metrics.rst
@@ -287,10 +287,26 @@ intentionally excluded — it is vLLM-owned and not observable from LMCache.
      - Counter (attrs: ``model_name``, ``cache_salt``)
      - Total tokens found in L1 or L2 during lookup (numerator of the
        L1+L2 token-level hit rate). Counts the contiguous prefix hit only.
+   * - ``lmcache_mp.lookup_hit_l1``
+     - Counter (attrs: ``model_name``, ``cache_salt``)
+     - Of ``lookup_hit``: tokens L1 could serve on its own under each
+       object group's attention-window rule.
+   * - ``lmcache_mp.lookup_hit_l2``
+     - Counter (attrs: ``model_name``, ``cache_salt``)
+     - Of ``lookup_hit``: tokens L2 added beyond the L1-servable prefix.
+       ``l1 + l2 == lookup_hit`` per event.
+   * - ``lmcache_mp.lookups``
+     - Counter (attrs: ``model_name``, ``cache_salt``)
+     - Completed lookups (denominator for ``lookup_early_exit``).
+   * - ``lmcache_mp.lookup_early_exit``
+     - Counter (attrs: ``model_name``, ``cache_salt``, ``reason``)
+     - Lookups that exited before a cache probe; ``reason`` is one of
+       ``no_gpu_context``, ``empty_chunk_hashes``, ``no_group_layout_descs``.
 
-Both counters are driven by the same event (``MP_LOOKUP_PREFETCH_END``),
+All lookup counters are driven by the same event (``MP_LOOKUP_PREFETCH_END``),
 so they always advance together per completed lookup. Early-exit lookups
-contribute ``0`` to both, and abandoned lookups contribute to neither.
+contribute ``0`` tokens to all four token counters and ``+1`` to
+``lookups`` / ``lookup_early_exit``, and abandoned lookups contribute to neither.
 
 The ``model_name`` and ``cache_salt`` attributes are captured at lookup
 time from ``IPCCacheServerKey`` so dashboards can compute per-model or
@@ -309,6 +325,14 @@ per tenant or isolation domain); drop it at scrape time with
     # Per-model:
     sum(rate(lmcache_mp_lookup_hit_tokens_total[5m])) by (model_name)
     / sum(rate(lmcache_mp_lookup_requested_tokens_total[5m])) by (model_name)
+
+    # Share of hit tokens L1 could serve on its own:
+    rate(lmcache_mp_lookup_hit_l1_tokens_total[5m])
+    / rate(lmcache_mp_lookup_hit_tokens_total[5m])
+
+    # Fraction of lookups that early-exited, by reason:
+    sum(rate(lmcache_mp_lookup_early_exit_requests_total[5m])) by (reason)
+    / sum(rate(lmcache_mp_lookups_requests_total[5m]))
 
 L0 (GPU) Block Lifecycle Histograms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmcache/v1/mp_observability/subscribers/metrics/lookup.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/lookup.py
@@ -2,17 +2,21 @@
 
 """Lookup metrics subscriber — OTel counters for L1+L2 token-level hit rate.
 
-Exposes two counters driven by the ``MP_LOOKUP_PREFETCH_END`` event.  Their
-ratio is the fraction of tokens requested by a lookup that were served from
-the L1 or L2 caches (L0/GPU prefix cache is vLLM-owned and not observable
-here):
+Exposes counters driven by the ``MP_LOOKUP_PREFETCH_END`` event.  The
+combined pair ``lookup_requested`` / ``lookup_hit`` gives the fraction of
+tokens requested by a lookup that were served from the L1 or L2 caches
+(L0/GPU prefix cache is vLLM-owned and not observable here):
 
     rate(lmcache_mp_lookup_hit_tokens_total[5m])
     / rate(lmcache_mp_lookup_requested_tokens_total[5m])
 
-Both counters carry ``model_name`` and ``cache_salt`` attributes so the
-ratio can be sliced per model and per tenant / isolation domain on the
-dashboard.
+``lookup_hit_l1`` / ``lookup_hit_l2`` split ``lookup_hit`` by tier
+(``l1 + l2 == hit`` per event); ``lookups`` counts completed lookups and
+``lookup_early_exit`` those that short-circuited before a cache probe,
+labeled by ``reason``.
+
+All counters carry ``model_name`` and ``cache_salt`` attributes so they can
+be sliced per model and per tenant / isolation domain on the dashboard.
 
 See ``docs/design/v1/mp_observability/L1_L2_HIT_RATE_PLAN.md`` for the full
 rationale behind co-locating numerator and denominator on a single event.
@@ -52,12 +56,21 @@ def _lookup_attrs(event: Event) -> dict[str, Any]:
 class LookupMetricsSubscriber(EventSubscriber):
     """Maintains OTel counters for L1+L2 token-level cache hit rate.
 
-    Metrics (both labeled by ``model_name`` and ``cache_salt``):
+    Metrics (all labeled by ``model_name`` and ``cache_salt``):
     - ``lmcache_mp.lookup_requested`` — tokens submitted for lookup
       (denominator).  Counts only the chunk-aligned portion; sub-chunk
       trailing tokens are excluded because they cannot hit by design.
     - ``lmcache_mp.lookup_hit`` — tokens found in L1+L2 during the
       lookup (numerator).  Counts the contiguous prefix hit only.
+    - ``lmcache_mp.lookup_hit_l1`` — of lookup_hit, tokens L1 could serve
+      on its own under each object group's attention-window rule.
+    - ``lmcache_mp.lookup_hit_l2`` — of lookup_hit, tokens L2 added beyond
+      the L1-servable prefix.  ``l1 + l2 == lookup_hit`` per event.
+    - ``lmcache_mp.lookups`` — completed lookups (denominator for
+      ``lookup_early_exit``).
+    - ``lmcache_mp.lookup_early_exit`` — lookups that exited before a
+      cache probe; extra ``reason`` label (``no_gpu_context``,
+      ``empty_chunk_hashes``, ``no_group_layout_descs``).
     """
 
     def __init__(self) -> None:
@@ -81,6 +94,37 @@ class LookupMetricsSubscriber(EventSubscriber):
             ),
             unit="tokens",
         )
+        self._l1_hit_tokens = meter.create_counter(
+            "lmcache_mp.lookup_hit_l1",
+            description=(
+                "Of lookup_hit: tokens L1 could serve on its own under each "
+                "object group's attention-window rule (from "
+                "PrefetchHandle.l1_hit_chunks)."
+            ),
+            unit="tokens",
+        )
+        self._l2_hit_tokens = meter.create_counter(
+            "lmcache_mp.lookup_hit_l2",
+            description=(
+                "Of lookup_hit: tokens L2 added beyond the L1-servable "
+                "prefix. lookup_hit_l1 + lookup_hit_l2 == lookup_hit."
+            ),
+            unit="tokens",
+        )
+        self._lookups = meter.create_counter(
+            "lmcache_mp.lookups",
+            description="Completed lookups (denominator for lookup_early_exit).",
+            unit="requests",
+        )
+        self._early_exits = meter.create_counter(
+            "lmcache_mp.lookup_early_exit",
+            description=(
+                "Lookups that exited before a normal cache probe, labeled "
+                "by reason (no_gpu_context, empty_chunk_hashes, "
+                "no_group_layout_descs)."
+            ),
+            unit="requests",
+        )
 
     def get_subscriptions(self) -> dict[EventType, EventCallback]:
         return {
@@ -91,3 +135,15 @@ class LookupMetricsSubscriber(EventSubscriber):
         attrs = _lookup_attrs(event)
         self._requested_tokens.add(event.metadata["requested_tokens"], attributes=attrs)
         self._hit_tokens.add(event.metadata["hit_tokens"], attributes=attrs)
+        self._lookups.add(1, attributes=attrs)
+        # .get(): tolerate events from emitters predating the attribution
+        # fields; they simply do not move the split counters.
+        self._l1_hit_tokens.add(
+            event.metadata.get("l1_hit_tokens", 0), attributes=attrs
+        )
+        self._l2_hit_tokens.add(
+            event.metadata.get("l2_hit_tokens", 0), attributes=attrs
+        )
+        early_exit_reason = event.metadata.get("early_exit_reason", "")
+        if early_exit_reason:
+            self._early_exits.add(1, attributes={**attrs, "reason": early_exit_reason})

--- a/tests/v1/mp_observability/subscribers/metrics/test_lookup.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_lookup.py
@@ -358,3 +358,100 @@ class TestLookupAttributeLabels:
             after.get(req, {}).get(empty_key, 0)
             == before.get(req, {}).get(empty_key, 0) + 128
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-tier attribution and early-exit counters
+# ---------------------------------------------------------------------------
+
+
+class TestAttributionCounters:
+    def test_l1_l2_split(self, bus, subscriber, snapshot):
+        """l1/l2 hit tokens land in their dedicated counters."""
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id="req-attr-1",
+                metadata={
+                    "found_count": 4,
+                    "requested_tokens": 2048,
+                    "hit_tokens": 1024,
+                    "l1_hit_tokens": 768,
+                    "l2_hit_tokens": 256,
+                    "early_exit_reason": "",
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert delta["lmcache_mp.lookup_hit_l1"] == 768
+        assert delta["lmcache_mp.lookup_hit_l2"] == 256
+        assert delta["lmcache_mp.lookups"] == 1
+        assert delta.get("lmcache_mp.lookup_early_exit", 0) == 0
+
+    def test_early_exit_labeled_by_reason(self, bus, subscriber):
+        """Early exits count once on the reason-labeled series (with the
+        model/salt attrs preserved) and still count as a completed lookup."""
+        bus.start()
+        before = _read_counters_by_attrs()
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id="req-attr-2",
+                metadata={
+                    "found_count": 0,
+                    "requested_tokens": 0,
+                    "hit_tokens": 0,
+                    "l1_hit_tokens": 0,
+                    "l2_hit_tokens": 0,
+                    "early_exit_reason": "no_gpu_context",
+                    "model_name": "llama-3.1-8b",
+                    "cache_salt": "tenant-A",
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        after = _read_counters_by_attrs()
+        base_key = (
+            ("cache_salt", "tenant-A"),
+            ("model_name", "llama-3.1-8b"),
+        )
+        reason_key = base_key + (("reason", "no_gpu_context"),)
+        ee_before = before.get("lmcache_mp.lookup_early_exit", {})
+        ee_after = after.get("lmcache_mp.lookup_early_exit", {})
+        assert ee_after.get(reason_key, 0) == ee_before.get(reason_key, 0) + 1
+        # The reason label is additive: no unlabeled / base-only series moves.
+        assert ee_after.get(base_key, 0) == ee_before.get(base_key, 0)
+        assert ee_after.get((), 0) == ee_before.get((), 0)
+        # An early exit is still a completed lookup for the denominator.
+        lk_before = before.get("lmcache_mp.lookups", {}).get(base_key, 0)
+        lk_after = after.get("lmcache_mp.lookups", {}).get(base_key, 0)
+        assert lk_after == lk_before + 1
+
+    def test_missing_attribution_fields_are_tolerated(self, bus, subscriber, snapshot):
+        """Events from emitters without the new fields move nothing."""
+        bus.start()
+        bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id="req-attr-3",
+                metadata={
+                    "found_count": 4,
+                    "requested_tokens": 1024,
+                    "hit_tokens": 1024,
+                },
+            )
+        )
+        time.sleep(_DRAIN_WAIT)
+        bus.stop()
+
+        delta = snapshot()
+        assert delta.get("lmcache_mp.lookup_hit_l1", 0) == 0
+        assert delta.get("lmcache_mp.lookup_hit_l2", 0) == 0
+        assert delta["lmcache_mp.lookups"] == 1
+        assert delta.get("lmcache_mp.lookup_early_exit", 0) == 0


### PR DESCRIPTION
Follow-up to #4734, which added `l1_hit_tokens` / `l2_hit_tokens` / `early_exit_reason` to `MP_LOOKUP_PREFETCH_END` and explicitly deferred Prometheus aggregation until the event semantics settled. This PR does that aggregation.

## What it does

`LookupMetricsSubscriber` gains four counters next to the existing `lookup_requested` / `lookup_hit` pair, on the same event and with the same `model_name` / `cache_salt` labels:

- `lmcache_mp.lookup_hit_l1` — tokens L1 could serve on its own under each object group's window rule
- `lmcache_mp.lookup_hit_l2` — the remainder; `lookup_hit_l1 + lookup_hit_l2 == lookup_hit` per event (the emitter clamps `l1 <= found` before computing `l2`)
- `lmcache_mp.lookups` — completed lookups, so early-exit and per-lookup rates have a denominator
- `lmcache_mp.lookup_early_exit` — lookups that exited before a normal probe, with an extra `reason` label (`no_gpu_context`, `empty_chunk_hashes`, `no_group_layout_descs` — the three values the emitter produces)

Events from emitters that predate the attribution fields are tolerated: the split counters simply don't move.

Scraped names follow the exporter's unit splice: `lmcache_mp_lookup_hit_l1_tokens_total`, `lmcache_mp_lookup_hit_l2_tokens_total`, `lmcache_mp_lookups_requests_total`, `lmcache_mp_lookup_early_exit_requests_total`.

## Why

With only the combined `lookup_hit`, a fleet dashboard can't tell whether external hits are being held in RAM or only on disk — and on interleaved sliding-window models that distinction is the whole story. #4734 made the split observable per request via tracing; this makes it scrapeable as rates. Note these are lookup-time (what each tier holds), not serve-time attribution.

## Docs

`METRICS.md` and `metrics.rst` gain the four rows plus PromQL for the L1 share and early-exit rate; `DEBUG.md`'s L1/L2 derivation (previously `lookup_hit − l2_prefetch_hit_chunks × chunk_size`, which counts L2-found keys rather than the window-rule remainder) now points at the direct counters.

## Testing

- `ruff format --check` / `ruff check` clean.
- `tests/v1/mp_observability/subscribers/metrics/test_lookup.py`: 12 passed locally (3 new: tier split sums + lookups denominator, early-exit counted on the reason-labeled series with model/salt attrs preserved, tolerance of pre-attribution events).

## Scope

Counters and their docs only. Dashboard panels (incl. the example Grafana dashboard) are left as a follow-up; no changes to the event or the lookup path.
