### PR TITLE
fix(ci): correct REPO_ROOT depth in xpu unittests run.sh

### DIFF
--- a/.buildkite/k3_tests/xpu/unittests/run.sh
+++ b/.buildkite/k3_tests/xpu/unittests/run.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 
 log() {
   echo "[intel-xpu-unit-tests] $*"


### PR DESCRIPTION
fix the path