### PR TITLE
[Bugfix][Operator] Persist RESP auth Secret owner references

### DIFF
--- a/operator/internal/controller/cacheblend_reconcile_helpers.go
+++ b/operator/internal/controller/cacheblend_reconcile_helpers.go
@@ -414,10 +414,10 @@ func (r *CacheBlendEngineReconciler) reconcileRESPAuthSecret(ctx context.Context
 	}
 
 	// Update existing — apply ownerRef, data, and labels.
+	patch := client.MergeFrom(existing.DeepCopy())
 	if err := ctrl.SetControllerReference(engine, existing, r.Scheme); err != nil {
 		return err
 	}
-	patch := client.MergeFrom(existing.DeepCopy())
 	existing.Data = desired.Data
 	existing.Labels = desired.Labels
 	return r.Patch(ctx, existing, patch)

--- a/operator/internal/controller/cacheblendengine_controller_test.go
+++ b/operator/internal/controller/cacheblendengine_controller_test.go
@@ -30,14 +30,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	lmcachev1alpha1 "github.com/LMCache/LMCache/api/v1alpha1"
+	"github.com/LMCache/LMCache/internal/resources"
 )
 
 // cbeResourceName is the name of the CacheBlendEngine fixture reconciled by the
 // controller tests; the owner-reference helper checks against it.
 const cbeResourceName = "test-cbe"
+
+const cbePayloadRepository = "lmcache/cacheblend-plugin"
 
 // argsContainFlagValue reports whether the ["--flag", "value", ...] slice
 // contains the given two-token flag/value pair.
@@ -79,7 +83,7 @@ var _ = Describe("CacheBlendEngine Controller", func() {
 			if err != nil && errors.IsNotFound(err) {
 				// injection.payloadImage.repository is required by ValidateSpec
 				// (the webhook needs it to inject a valid init container).
-				payloadRepo := "lmcache/cacheblend-plugin"
+				payloadRepo := cbePayloadRepository
 				resource := &lmcachev1alpha1.CacheBlendEngine{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
@@ -209,4 +213,111 @@ var _ = Describe("CacheBlendEngine Controller", func() {
 			Expect(updated.Status.Phase).To(Equal(lmcachev1alpha1.PhasePending))
 		})
 	})
+})
+
+var _ = Describe("CacheBlend RESP auth secret ownership", func() {
+	var nsName string
+	const engineName = "test-engine"
+	BeforeEach(func() {
+		nsName = mustCreateNS(uniqueNS("cacheblend-resp-auth"))
+	})
+
+	It("restores the CacheBlend managed secret owner reference and cleans up when auth is removed", func() {
+		payloadRepo := cbePayloadRepository
+		engine := &lmcachev1alpha1.CacheBlendEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: engineName, Namespace: nsName},
+			Spec: lmcachev1alpha1.CacheBlendEngineSpec{
+				L1: lmcachev1alpha1.L1BackendSpec{SizeGB: 10},
+				Injection: &lmcachev1alpha1.InjectionSpec{
+					PayloadImage: &lmcachev1alpha1.ImageSpec{Repository: &payloadRepo},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, engine)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, engine) })
+		r := &CacheBlendEngineReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		source := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "restore-auth", Namespace: nsName},
+			Data:       map[string][]byte{"password": []byte("test-password")}, // pragma: allowlist secret
+		}
+		Expect(k8sClient.Create(ctx, source)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, source) })
+		engine.Spec.L2Backend = &lmcachev1alpha1.L2BackendSpec{
+			RESP: &lmcachev1alpha1.RESPL2AdapterSpec{
+				Host: "redis", Port: 6379,
+				AuthSecretRef: &lmcachev1alpha1.SecretReference{Name: source.Name},
+			},
+		}
+		Expect(k8sClient.Update(ctx, engine)).To(Succeed())
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: engineName, Namespace: nsName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		key := types.NamespacedName{Name: resources.RESPAuthSecretName(engineName), Namespace: nsName}
+		managed := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, key, managed)).To(Succeed())
+		Expect(metav1.IsControlledBy(managed, engine)).To(BeTrue())
+		// Simulate metadata drift without changing the mirrored credentials.
+		managed.OwnerReferences = nil
+		Expect(k8sClient.Update(ctx, managed)).To(Succeed())
+
+		for range 2 {
+			_, err = r.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, key, managed)).To(Succeed())
+			Expect(metav1.IsControlledBy(managed, engine)).To(BeTrue())
+			Expect(managed.Data).To(Equal(source.Data))
+		}
+
+		Expect(k8sClient.Get(ctx, req.NamespacedName, engine)).To(Succeed())
+		engine.Spec.L2Backend.RESP.AuthSecretRef = nil
+		Expect(k8sClient.Update(ctx, engine)).To(Succeed())
+		_, err = r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(errors.IsNotFound(k8sClient.Get(ctx, key, managed))).To(BeTrue())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: source.Name, Namespace: nsName}, source)).To(Succeed())
+	})
+
+	It("does not change a CacheBlend RESP secret controlled by another engine", func() {
+		payloadRepo := cbePayloadRepository
+		engine := &lmcachev1alpha1.CacheBlendEngine{
+			ObjectMeta: metav1.ObjectMeta{Name: engineName, Namespace: nsName},
+			Spec: lmcachev1alpha1.CacheBlendEngineSpec{
+				L1: lmcachev1alpha1.L1BackendSpec{SizeGB: 10},
+				Injection: &lmcachev1alpha1.InjectionSpec{
+					PayloadImage: &lmcachev1alpha1.ImageSpec{Repository: &payloadRepo},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, engine)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, engine) })
+		r := &CacheBlendEngineReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		other := newEngine(nsName, "other-engine")
+		source := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "conflict-auth", Namespace: nsName},
+			Data:       map[string][]byte{"password": []byte("new-password")}, // pragma: allowlist secret
+		}
+		Expect(k8sClient.Create(ctx, source)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, source) })
+		managed := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: resources.RESPAuthSecretName(engineName), Namespace: nsName},
+			Data:       map[string][]byte{"password": []byte("old-password")}, // pragma: allowlist secret
+		}
+		Expect(controllerutil.SetControllerReference(other, managed, r.Scheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, managed)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, managed) })
+		original := managed.DeepCopy()
+		engine.Spec.L2Backend = &lmcachev1alpha1.L2BackendSpec{
+			RESP: &lmcachev1alpha1.RESPL2AdapterSpec{
+				Host: "redis", Port: 6379,
+				AuthSecretRef: &lmcachev1alpha1.SecretReference{Name: source.Name},
+			},
+		}
+		Expect(k8sClient.Update(ctx, engine)).To(Succeed())
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: engineName, Namespace: nsName}})
+		Expect(err).To(BeAssignableToTypeOf(&controllerutil.AlreadyOwnedError{}))
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: managed.Name, Namespace: nsName}, managed)).To(Succeed())
+		Expect(managed).To(Equal(original))
+	})
+
 })

--- a/operator/internal/controller/reconcile_helpers.go
+++ b/operator/internal/controller/reconcile_helpers.go
@@ -479,10 +479,10 @@ func (r *LMCacheEngineReconciler) reconcileRESPAuthSecret(ctx context.Context, e
 	}
 
 	// Update existing — apply ownerRef, data, and labels.
+	patch := client.MergeFrom(existing.DeepCopy())
 	if err := ctrl.SetControllerReference(engine, existing, r.Scheme); err != nil {
 		return err
 	}
-	patch := client.MergeFrom(existing.DeepCopy())
 	existing.Data = desired.Data
 	existing.Labels = desired.Labels
 	return r.Patch(ctx, existing, patch)

--- a/operator/internal/controller/reconcile_helpers_test.go
+++ b/operator/internal/controller/reconcile_helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	lmcachev1alpha1 "github.com/LMCache/LMCache/api/v1alpha1"
@@ -288,6 +289,80 @@ var _ = Describe("reconcileRESPAuthSecret", func() {
 			Namespace: nsName,
 		}, got)).To(Succeed())
 		Expect(got.Data).To(HaveKeyWithValue("password", []byte("v2")))
+	})
+
+	It("restores the managed secret owner reference and cleans up when auth is removed", func() {
+		engine := newEngine(nsName, engineName)
+		source := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "restore-auth", Namespace: nsName},
+			Data:       map[string][]byte{"password": []byte("test-password")}, // pragma: allowlist secret
+		}
+		Expect(k8sClient.Create(ctx, source)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, source) })
+		engine.Spec.L2Backend = &lmcachev1alpha1.L2BackendSpec{
+			RESP: &lmcachev1alpha1.RESPL2AdapterSpec{
+				Host: "redis", Port: 6379,
+				AuthSecretRef: &lmcachev1alpha1.SecretReference{Name: source.Name},
+			},
+		}
+		Expect(k8sClient.Update(ctx, engine)).To(Succeed())
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: engineName, Namespace: nsName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		key := types.NamespacedName{Name: resources.RESPAuthSecretName(engineName), Namespace: nsName}
+		managed := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, key, managed)).To(Succeed())
+		Expect(metav1.IsControlledBy(managed, engine)).To(BeTrue())
+		// Simulate metadata drift without changing the mirrored credentials.
+		managed.OwnerReferences = nil
+		Expect(k8sClient.Update(ctx, managed)).To(Succeed())
+
+		for range 2 {
+			_, err = r.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, key, managed)).To(Succeed())
+			Expect(metav1.IsControlledBy(managed, engine)).To(BeTrue())
+			Expect(managed.Data).To(Equal(source.Data))
+		}
+
+		Expect(k8sClient.Get(ctx, req.NamespacedName, engine)).To(Succeed())
+		engine.Spec.L2Backend.RESP.AuthSecretRef = nil
+		Expect(k8sClient.Update(ctx, engine)).To(Succeed())
+		_, err = r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apierrors.IsNotFound(k8sClient.Get(ctx, key, managed))).To(BeTrue())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: source.Name, Namespace: nsName}, source)).To(Succeed())
+	})
+
+	It("does not change a RESP secret controlled by another engine", func() {
+		engine := newEngine(nsName, engineName)
+		other := newEngine(nsName, "other-engine")
+		source := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "conflict-auth", Namespace: nsName},
+			Data:       map[string][]byte{"password": []byte("new-password")}, // pragma: allowlist secret
+		}
+		Expect(k8sClient.Create(ctx, source)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, source) })
+		managed := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: resources.RESPAuthSecretName(engineName), Namespace: nsName},
+			Data:       map[string][]byte{"password": []byte("old-password")}, // pragma: allowlist secret
+		}
+		Expect(controllerutil.SetControllerReference(other, managed, r.Scheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, managed)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, managed) })
+		original := managed.DeepCopy()
+		engine.Spec.L2Backend = &lmcachev1alpha1.L2BackendSpec{
+			RESP: &lmcachev1alpha1.RESPL2AdapterSpec{
+				Host: "redis", Port: 6379,
+				AuthSecretRef: &lmcachev1alpha1.SecretReference{Name: source.Name},
+			},
+		}
+		Expect(k8sClient.Update(ctx, engine)).To(Succeed())
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: engineName, Namespace: nsName}})
+		Expect(err).To(BeAssignableToTypeOf(&controllerutil.AlreadyOwnedError{}))
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: managed.Name, Namespace: nsName}, managed)).To(Succeed())
+		Expect(managed).To(Equal(original))
 	})
 
 	It("errors when the source secret is missing", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

When an existing RESP auth mirror loses its owner reference, both engine controllers return success from reconciliation but leave the Secret unowned. Removing `authSecretRef` then leaves the mirrored credentials behind because cleanup only deletes owned Secrets.

Take the merge-patch snapshot before setting the controller reference in both LMCacheEngine and CacheBlendEngine, so the ownership change is persisted along with the data and labels.

**Special notes for your reviewers**:

The regression tests use the public `Reconcile` entry points against envtest. They cover restoring ownership when credentials are unchanged, repeated reconciliation, cleanup after removing auth, and preserving Secrets controlled by another engine. Each ownership-restoration test fails on the original implementation.

Validation: `make test` and `make lint` in `operator/`. The controller suite also passes with #4876 applied.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
