### PR TITLE
[good-first-issue] storage: defer HF3FS log formatting (#3372)

### DIFF
--- a/lmcache/v1/storage_backend/connector/hf3fs_connector.py
+++ b/lmcache/v1/storage_backend/connector/hf3fs_connector.py
@@ -94,13 +94,14 @@ class HF3fsConnector(FSConnector):
         try:
             hf3fs_mount_point = extract_mount_point(mount_point)
         except Exception as e:
-            logger.error(f"Failed to extract 3FS mount point: {e}")
+            logger.error("Failed to extract 3FS mount point: %s", e)
             raise Exception(f"Failed to extract 3FS mount point: {e}") from e
 
         if hf3fs_mount_point != mount_point:
             logger.error(
-                f"Invalid 3FS mount point, config:{mount_point},"
-                f" extract:{hf3fs_mount_point}"
+                "Invalid 3FS mount point, config:%s, extract:%s",
+                mount_point,
+                hf3fs_mount_point,
             )
             raise Exception(
                 f"Invalid 3FS mount point, config:{mount_point},"
@@ -121,13 +122,13 @@ class HF3fsConnector(FSConnector):
             try:
                 self.client.close()
             except Exception as e:
-                logger.error(f"Failed to close HF3fsConnector,{e}")
+                logger.error("Failed to close HF3fsConnector,%s", e)
 
         if hasattr(self, "io_executor") and self.io_executor is not None:
             try:
                 self.io_executor.shutdown(wait=True)
             except Exception as e:
-                logger.error(f"Failed to close HF3fsConnector,{e}")
+                logger.error("Failed to close HF3fsConnector,%s", e)
 
     async def close(self):
         await asyncio.to_thread(self._close)
@@ -203,7 +204,7 @@ class HF3fsConnector(FSConnector):
 
         except Exception as e:
             if not isinstance(e, FileNotFoundError):
-                logger.error(f"Failed to read from file {file_path}: {str(e)}")
+                logger.error("Failed to read from file %s: %s", file_path, e)
             if memory_obj is not None:
                 memory_obj.ref_count_down()
             return None
@@ -258,7 +259,7 @@ class HF3fsConnector(FSConnector):
                 # Atomically rename temp file to final destination
                 Hf3fsFile.rename(temp_path, final_path)
         except Exception as e:
-            logger.error(f"Failed to write file {final_path}: {str(e)}")
+            logger.error("Failed to write file %s: %s", final_path, e)
             Hf3fsFile.remove(temp_path)  # Remove corrupted file
             raise
 
@@ -312,11 +313,11 @@ class Hf3fsClient:
             # init the instance
             cls._thread_local._instance = cls(config)
             logger.info(
-                f"Create {cls._thread_local._instance.client_name} instance success"
+                "Create %s instance success", cls._thread_local._instance.client_name
             )
         else:
             logger.debug(
-                f"Hf3fsClient instance already exist in {threading.get_ident()}"
+                "Hf3fsClient instance already exist in %s", threading.get_ident()
             )
         return cls._thread_local._instance
 
@@ -333,10 +334,10 @@ class Hf3fsClient:
                 name=f"{self.client_name}_wt", size=self.config.iov_size, create=True
             )
         except Exception as e:
-            logger.error(f"{self.client_name} failed to create share memory {e}")
+            logger.error("%s failed to create share memory %s", self.client_name, e)
             self.close()
             raise
-        logger.debug(f"{self.client_name} create share memory successfully")
+        logger.debug("%s create share memory successfully", self.client_name)
 
         try:
             self.iov_read = make_iovec(
@@ -350,10 +351,10 @@ class Hf3fsClient:
                 numa=self.config.numa_id,
             )
         except Exception as e:
-            logger.error(f"{self.client_name} failed to create iov: {e}")
+            logger.error("%s failed to create iov: %s", self.client_name, e)
             self.close()
             raise
-        logger.debug(f"{self.client_name} create iov successfully")
+        logger.debug("%s create iov successfully", self.client_name)
 
         # read I/O ring
         try:
@@ -365,10 +366,10 @@ class Hf3fsClient:
                 numa=self.config.numa_id,
             )
         except Exception as e:
-            logger.error(f"{self.client_name} failed to create ior_read: {e}")
+            logger.error("%s failed to create ior_read: %s", self.client_name, e)
             self.close()
             raise
-        logger.debug(f"{self.client_name} create ior_read successfully")
+        logger.debug("%s create ior_read successfully", self.client_name)
 
         # write I/O ring
         try:
@@ -380,21 +381,21 @@ class Hf3fsClient:
                 numa=self.config.numa_id,
             )
         except Exception as e:
-            logger.error(f"{self.client_name} failed to create ior_write: {e}")
+            logger.error("%s failed to create ior_write: %s", self.client_name, e)
             self.close()
             raise
 
-        logger.debug(f"{self.client_name} create ior_write successfully")
+        logger.debug("%s create ior_write successfully", self.client_name)
         # lock for read and write
         self.lock_read = threading.RLock()
         self.lock_write = threading.RLock()
-        logger.debug(f"{self.client_name} initialized end ")
+        logger.debug("%s initialized end ", self.client_name)
 
     def close(self):
         if self._closed:
-            logger.debug(f"{self.client_name} already closed, skip")
+            logger.debug("%s already closed, skip", self.client_name)
             return
-        logger.debug(f"{self.client_name} close begin")
+        logger.debug("%s close begin", self.client_name)
         try:
             #  clear I/O resource first, then share memory
             if hasattr(self, "ior_read") and self.ior_read is not None:
@@ -417,9 +418,9 @@ class Hf3fsClient:
                     self.shm_read.unlink()
                 except FileNotFoundError:
                     # already release, ignore it
-                    logger.debug(f"{self.client_name} shm_read already unlinked")
+                    logger.debug("%s shm_read already unlinked", self.client_name)
                 except Exception as e:
-                    logger.error(f"{self.client_name} error closing shm_read: {e}")
+                    logger.error("%s error closing shm_read: %s", self.client_name, e)
                 finally:
                     self.shm_read = None
             if hasattr(self, "shm_write") and self.shm_write is not None:
@@ -428,25 +429,25 @@ class Hf3fsClient:
                     self.shm_write.unlink()
                 except FileNotFoundError:
                     # already release, ignore it
-                    logger.debug(f"{self.client_name} shm_write already unlinked")
+                    logger.debug("%s shm_write already unlinked", self.client_name)
                 except Exception as e:
-                    logger.error(f"{self.client_name} error closing shm_write: {e}")
+                    logger.error("%s error closing shm_write: %s", self.client_name, e)
                 finally:
                     self.shm_write = None
 
             self._closed = True
-            logger.info(f"{self.client_name} release successfully")
+            logger.info("%s release successfully", self.client_name)
         except Exception as e:
-            logger.error(f"{self.client_name} error during close: {e}")
+            logger.error("%s error during close: %s", self.client_name, e)
             self._closed = True  # Mark this flag even it exception
 
     def __del__(self):
         try:
-            logger.debug(f"{self.client_name} __del__ begin")
+            logger.debug("%s __del__ begin", self.client_name)
             self.close()
         except Exception as e:
             # do not throw exception in __del__
-            logger.error(f"{self.client_name} error in __del__: {e}")
+            logger.error("%s error in __del__: %s", self.client_name, e)
 
     def __enter__(self):
         return self
@@ -466,7 +467,7 @@ class Hf3fsClient:
         try:
             done = self.ior_read.submit().wait(min_results=1)[0]
         except Exception as e:
-            logger.error(f"{self.client_name} read submit failed: {e}")
+            logger.error("%s read submit failed: %s", self.client_name, e)
             raise RuntimeError(f"{self.client_name} read submit failed") from e
 
         total_bytes_read = done.result
@@ -493,8 +494,10 @@ class Hf3fsClient:
                     break
             if total_bytes_read != length:
                 logger.warning(
-                    f"{self.client_name} read: requested {length}, "
-                    f"got {total_bytes_read}"
+                    "%s read: requested %d, got %d",
+                    self.client_name,
+                    length,
+                    total_bytes_read,
                 )
             return total_bytes_read
 
@@ -512,7 +515,7 @@ class Hf3fsClient:
         try:
             done = self.ior_write.submit().wait(min_results=1)[0]
         except Exception as e:
-            logger.error(f"{self.client_name} write submit failed: {e}")
+            logger.error("%s write submit failed: %s", self.client_name, e)
             raise RuntimeError(f"{self.client_name} write submit failed") from e
 
         total_bytes_written = done.result
@@ -536,8 +539,10 @@ class Hf3fsClient:
                     break
             if total_bytes_written != length:
                 logger.error(
-                    f"{self.client_name} write: requested {length}, "
-                    f"got {total_bytes_written}"
+                    "%s write: requested %d, got %d",
+                    self.client_name,
+                    length,
+                    total_bytes_written,
                 )
                 raise RuntimeError(
                     f"{self.client_name} write: requested {length}, "
@@ -558,9 +563,13 @@ class Hf3fsFile:
         try:
             self.fd = os.open(self.fname, self.flags)
             register_fd(self.fd)
-            logger.debug(f"Open file {self.fname} with flag {self.flags} successfully")
+            logger.debug(
+                "Open file %s with flag %d successfully", self.fname, self.flags
+            )
         except Exception as e:
-            logger.error(f"Open file {self.fname} with flag {self.flags} failed {e}")
+            logger.error(
+                "Open file %s with flag %d failed %s", self.fname, self.flags, e
+            )
             raise
 
     def close(self):
@@ -569,9 +578,9 @@ class Hf3fsFile:
         try:
             deregister_fd(self.fd)
             os.close(self.fd)
-            logger.debug(f"Close file ({self.fname}) successfully")
+            logger.debug("Close file (%s) successfully", self.fname)
         except Exception as e:
-            logger.error(f"Close file {self.fname} failed {e}")
+            logger.error("Close file %s failed %s", self.fname, e)
             raise
         self.fd = -1
         self.fname = ""
@@ -586,7 +595,7 @@ class Hf3fsFile:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
         if exc_type:
-            logger.error(f"Hf3fsFile closed with exception: {exc_val}")
+            logger.error("Hf3fsFile closed with exception: %s", exc_val)
         return False  # False, exceptions are not suppressed
 
     @staticmethod
@@ -600,7 +609,7 @@ class Hf3fsFile:
             os.remove(fname)
             return True
         except OSError as e:
-            logger.error(f"Failed to remove file {fname}: {e}")
+            logger.error("Failed to remove file %s: %s", fname, e)
             return False
 
     @staticmethod
@@ -608,7 +617,7 @@ class Hf3fsFile:
         try:
             os.rename(old_fname, new_fname)
         except OSError as e:
-            logger.warning(f"rename {old_fname} to {new_fname} failed, {e}")
+            logger.warning("rename %s to %s failed, %s", old_fname, new_fname, e)
             raise
         return
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3372, following the maintainer guidance to use lazy log formatting in a small, single-file contribution.

The HF3FS connector eagerly formats 38 log messages, including debug messages on file open/close and client reuse paths even when debug logging is disabled. Convert these calls to parameterized `%s`/`%d` logging and defer exception string conversion to the logger. Rendered messages, log levels, I/O behavior, and exception messages are preserved.

**Special notes for your reviewers**:

- Passed `SKIP=rust-fmt,rust-clippy pre-commit run --all-files` on macOS, including mypy. Rust hooks were explicitly skipped per the repository guidance for non-Rust changes on macOS.
- Passed Ruff 0.11.7 checks, including `G004`, `PLE1205`, and `PLE1206`, and `ruff format --check` on the changed file.
- A local AST comparison verified that non-logging code is unchanged and all 38 converted calls preserve their argument expressions (apart from deferred `str`) and rendered messages across three sample sets.
- Attempted `pytest -xvs tests/v1/storage_backend/test_hf3fs_connector.py`; collection was blocked by missing `numpy` in `tests/conftest.py`. The full runtime suite was not run.
- No new unit tests for this logging-format-only cleanup.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
