### PR TITLE
[Bugfix][MP] Preserve Valkey sizes on repeated stores

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -134,6 +134,14 @@ Byte accounting is finer-grained. `_notify_keys_stored` is fired with
 into per-`cache_salt` and aggregate totals — so `get_usage()` stays
 accurate even when the task as a whole is marked failed.
 
+The adapter keeps three byte measurements distinct. A successful task's
+`L2StoreResult` reports bytes written on the wire. Process-local usage counts
+each tracked key once, so overwriting a key does not consume capacity twice.
+Store listener and cache-event payloads always carry the object's full size,
+including on an overwrite, because coordinator consumers treat STORE sizes as
+absolute placement values. This also lets a fresh coordinator reconstruct a
+placement from any later successful store event.
+
 ## Cluster vs standalone
 
 | Mode         | glide class            | `database_id` | startup nodes used |
@@ -249,6 +257,10 @@ Custom-certificate setups are a planned follow-up (exposing glide's
 - Per-`cache_salt` quotas operate regardless of `max_capacity_gb` —
   the base class tracks per-salt totals from `_notify_keys_stored` /
   `_notify_keys_deleted` for any quota policy.
+- Repeated writes of the same key retain one object's process-local usage and
+  publish its full size to coordinator-managed accounting. They do not
+  artificially grow local capacity or replace a fleet placement with zero
+  bytes.
 
 `delete(keys)` is synchronous: it submits one DEL per key to the pool,
 waits for each completion (up to `request_timeout`), and fires

--- a/docs/design/v1/mp_coordinator/cache_events.md
+++ b/docs/design/v1/mp_coordinator/cache_events.md
@@ -99,6 +99,9 @@ listener plumbing or a dedicated flush task:
   the pool fleet-wide (one pool per backend type), so the directory
   deduplicates shared-storage placements across emitters (see
   `key_directory.md` — Shared pools).
+  Each L2 STORE size is the object's absolute placement size, rather than an
+  accounting delta. An adapter that stores the same key again must therefore
+  publish its full size so a consumer can upsert or reconstruct that placement.
   The LMCache-driven store path additionally publishes
   `mp.tokens` (parallel `chunk_hashes` + `token_chunks` +
   `token_offsets`) at

--- a/docs/source/mp/l2_storage/valkey.rst
+++ b/docs/source/mp/l2_storage/valkey.rst
@@ -92,6 +92,11 @@ construction fails with::
   **not** combine with ``max_capacity_gb > 0`` (a warning is logged;
   server-side expiry is not reported back to LMCache's byte accounting).
 
+Successful repeated writes of the same key count once toward the adapter's
+logical capacity. Each write still reports the object's full size to the MP
+coordinator, so fleet usage and per-``cache_salt`` quota enforcement retain
+the placement's byte size.
+
 **Configuration examples:**
 
 .. code-block:: bash

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -380,20 +380,54 @@ class L2AdapterInterface(ABC):
         self._backend_name = name
         self._shared = shared
 
-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
-        """Update byte accounting and notify listeners that ``keys`` were
-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+    def _notify_keys_stored(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+        *,
+        accounting_sizes: list[int] | None = None,
+    ) -> None:
+        """Account for and publish a successful store notification.
 
-        Accounting is held under ``_usage_lock``; listener callbacks fire
-        outside the lock so a slow listener cannot stall further notifies.
+        ``sizes[i]`` is the full byte size of ``keys[i]`` and is forwarded
+        unchanged to listeners and cache events. ``accounting_sizes[i]`` is
+        the additive change to this adapter's process-local usage. It defaults
+        to ``sizes``; adapters that overwrite an already-accounted key may pass
+        zero for that key without erasing its full size from notifications.
+
+        All three lists must have equal lengths. They are validated before
+        counters, listeners, or events are touched. Accounting is held under
+        ``_usage_lock``; listener callbacks fire outside the lock so a slow
+        listener cannot stall further notifies.
+
+        Args:
+            keys: Successfully stored object keys.
+            sizes: Full stored-object sizes, in bytes.
+            accounting_sizes: Optional additive local-accounting changes.
+
+        Raises:
+            ValueError: If the input list lengths differ.
         """
+        if len(keys) != len(sizes):
+            raise ValueError(
+                "_notify_keys_stored: keys and sizes length mismatch "
+                f"({len(keys)} vs {len(sizes)})"
+            )
+        if accounting_sizes is None:
+            accounting_sizes = sizes
+        elif len(keys) != len(accounting_sizes):
+            raise ValueError(
+                "_notify_keys_stored: keys and accounting_sizes length mismatch "
+                f"({len(keys)} vs {len(accounting_sizes)})"
+            )
+
         # Aggregate per-salt deltas before touching
         # ``_bytes_by_cache_salt`` — one dict read/write per unique
         # salt instead of one per key. This matters when the registry is
         # large (10k+ salts) and keys/sizes are bulky.
         delta: dict[str, int] = {}
         total_delta = 0
-        for key, size in zip(keys, sizes, strict=True):
+        for key, size in zip(keys, accounting_sizes, strict=True):
             delta[key.cache_salt] = delta.get(key.cache_salt, 0) + size
             total_delta += size
 

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -530,7 +530,8 @@ class ValkeyL2Adapter(L2AdapterInterface):
         worker pool. When the final per-key future completes, the
         adapter publishes an ``L2StoreResult`` whose
         ``bytes_transferred`` reflects only the keys that actually
-        wrote (partial failures are accounted correctly).
+        wrote. A failed batch still exposes zero transferred bytes through
+        ``L2StoreResult`` while successful keys are accounted and published.
 
         If the adapter is closed, or the pool rejects a dispatch, the
         task completes immediately as a failure rather than hanging.
@@ -638,6 +639,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
 
         stored_keys: list[ObjectKey] = []
         stored_sizes: list[int] = []
+        accounting_sizes: list[int] = []
         bytes_transferred = 0
         with self._lock:
             for k, sz, ok in zip(
@@ -646,18 +648,23 @@ class ValkeyL2Adapter(L2AdapterInterface):
                 if not ok:
                     continue
                 stored_keys.append(k)
+                stored_sizes.append(sz)
+                bytes_transferred += sz
                 if k in self._key_sizes:
-                    stored_sizes.append(0)
+                    accounting_sizes.append(0)
                 else:
                     self._key_sizes[k] = sz
-                    stored_sizes.append(sz)
-                    bytes_transferred += sz
+                    accounting_sizes.append(sz)
             self._completed_stores[batch.task_id] = L2StoreResult(
                 all_ok, bytes_transferred
             )
 
         if stored_keys:
-            self._notify_keys_stored(stored_keys, stored_sizes)
+            self._notify_keys_stored(
+                stored_keys,
+                stored_sizes,
+                accounting_sizes=accounting_sizes,
+            )
         self._store_efd.notify()
 
     def pop_completed_store_tasks(

--- a/tests/v1/distributed/test_l2_adapter_base.py
+++ b/tests/v1/distributed/test_l2_adapter_base.py
@@ -36,6 +36,15 @@ class _StubAdapter(L2AdapterInterface):
     """Minimal adapter that satisfies the abstract surface so we can
     exercise base-class behavior in isolation."""
 
+    def __init__(
+        self,
+        max_capacity_bytes: int = 0,
+        accounting_sizes: list[int] | None = None,
+    ) -> None:
+        super().__init__(max_capacity_bytes=max_capacity_bytes)
+        self._accounting_sizes = accounting_sizes
+        self._completed_stores: dict[L2TaskId, L2StoreResult] = {}
+
     def get_store_event_fd(self) -> int:
         return -1
 
@@ -46,10 +55,19 @@ class _StubAdapter(L2AdapterInterface):
         return -1
 
     def submit_store_task(self, keys, objects):
+        sizes = [obj.get_size() for obj in objects]
+        self._notify_keys_stored(
+            keys,
+            sizes,
+            accounting_sizes=self._accounting_sizes,
+        )
+        self._completed_stores[0] = L2StoreResult(True, sum(sizes))
         return 0
 
     def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
-        return {}
+        completed = self._completed_stores
+        self._completed_stores = {}
+        return completed
 
     def submit_lookup_and_lock_task(
         self, keys, group_layout_descs: dict[int, MemoryLayoutDesc]
@@ -70,6 +88,16 @@ class _StubAdapter(L2AdapterInterface):
 
     def close(self) -> None:
         return None
+
+
+class _StubMemoryObj:
+    """Minimal object exposing the size used by the public store method."""
+
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def get_size(self) -> int:
+        return self._size
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +159,41 @@ class TestSupportsGlobalEviction:
 
 
 class TestBaseAccounting:
+    def test_public_store_defaults_to_additive_accounting(self):
+        a = _StubAdapter(max_capacity_bytes=10_000)
+        key = _make_key(1, salt="alice")
+
+        task_id = a.submit_store_task([key], [_StubMemoryObj(100)])
+
+        assert a.pop_completed_store_tasks()[task_id].bytes_transferred() == 100
+        assert a.get_usage().total_bytes_used == 100
+        assert a.get_usage().bytes_by_cache_salt == {"alice": 100}
+
+    def test_explicit_accounting_size_does_not_change_published_size(self):
+        a = _StubAdapter(max_capacity_bytes=10_000, accounting_sizes=[0])
+        listener = _RecordingListener()
+        a.register_listener(listener)
+        key = _make_key(1, salt="alice")
+
+        a.submit_store_task([key], [_StubMemoryObj(100)])
+
+        assert a.get_usage().total_bytes_used == 0
+        assert a.get_usage().bytes_by_cache_salt == {}
+        assert listener.stored == [[key]]
+        assert listener.stored_sizes == [[100]]
+
+    def test_accounting_size_mismatch_has_no_side_effects(self):
+        a = _StubAdapter(max_capacity_bytes=10_000, accounting_sizes=[])
+        listener = _RecordingListener()
+        a.register_listener(listener)
+
+        with pytest.raises(ValueError, match="accounting_sizes length mismatch"):
+            a.submit_store_task([_make_key(1)], [_StubMemoryObj(100)])
+
+        assert a.get_usage().total_bytes_used == 0
+        assert listener.stored == []
+        assert a.pop_completed_store_tasks() == {}
+
     def test_store_increments_aggregate_and_by_cache_salt(self):
         a = _StubAdapter(max_capacity_bytes=10_000)
         k_alice = _make_key(1, salt="alice")
@@ -283,11 +346,13 @@ class _RecordingListener(L2AdapterListener):
 
     def __init__(self) -> None:
         self.stored: list[list[ObjectKey]] = []
+        self.stored_sizes: list[list[int]] = []
         self.accessed: list[list[ObjectKey]] = []
         self.deleted: list[list[ObjectKey]] = []
 
     def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
         self.stored.append(list(keys))
+        self.stored_sizes.append(list(sizes))
 
     def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
         self.accessed.append(list(keys))

--- a/tests/v1/distributed/test_valkey_l2_adapter.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter.py
@@ -192,8 +192,10 @@ def _build_fake_glide_modules() -> dict[str, types.ModuleType]:
 from lmcache.v1.distributed.api import (  # noqa: E402
     MemoryLayoutDesc,
     ObjectKey,
+    Tier,
 )
 from lmcache.v1.distributed.internal_api import L2AdapterListener  # noqa: E402
+from lmcache.v1.distributed.l2_adapters import base as l2_adapter_base  # noqa: E402
 from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (  # noqa: E402
     ValkeyL2Adapter,
     ValkeyL2AdapterConfig,
@@ -203,6 +205,28 @@ from lmcache.v1.memory_management import (  # noqa: E402
     MemoryFormat,
     MemoryObjMetadata,
     TensorMemoryObj,
+)
+from lmcache.v1.mp_coordinator.api import (  # noqa: E402
+    CacheEventBatch,
+    CacheEventType,
+)
+from lmcache.v1.mp_coordinator.cache_events import (  # noqa: E402
+    CacheEventSink,
+    CacheEventSubscriber,
+)
+from lmcache.v1.mp_coordinator.controllers.eviction_controller import (  # noqa: E402
+    FleetEvictionController,
+)
+from lmcache.v1.mp_coordinator.views.instance_registry import (  # noqa: E402
+    InstanceRegistry,
+)
+from lmcache.v1.mp_coordinator.views.key_directory import KeyDirectory  # noqa: E402
+from lmcache.v1.mp_coordinator.views.usage_manager import (  # noqa: E402
+    CacheUsageManager,
+)
+from lmcache.v1.mp_observability.event_bus import (  # noqa: E402
+    EventBus,
+    EventBusConfig,
 )
 from lmcache.v1.platform import consume_fd  # noqa: E402
 
@@ -218,6 +242,7 @@ class _RecordingListener(L2AdapterListener):
 
     def __init__(self) -> None:
         self.stored: list[list[ObjectKey]] = []
+        self.stored_sizes: list[list[int]] = []
         self.accessed: list[list[ObjectKey]] = []
         self.deleted: list[list[ObjectKey]] = []
         self.lock = threading.Lock()
@@ -225,6 +250,7 @@ class _RecordingListener(L2AdapterListener):
     def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
         with self.lock:
             self.stored.append(list(keys))
+            self.stored_sizes.append(list(sizes))
 
     def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
         with self.lock:
@@ -233,6 +259,35 @@ class _RecordingListener(L2AdapterListener):
     def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
         with self.lock:
             self.deleted.append(list(keys))
+
+
+class _ApplyingSink(CacheEventSink):
+    """Apply emitted batches to the coordinator views used in production."""
+
+    def __init__(self) -> None:
+        self.usage = CacheUsageManager()
+        self.directory = KeyDirectory()
+        self.eviction = FleetEvictionController(self.usage, InstanceRegistry())
+        self.batches: list[CacheEventBatch] = []
+        self.condition = threading.Condition()
+
+    def publish(self, batches: list[CacheEventBatch]) -> None:
+        with self.condition:
+            for batch in batches:
+                self.usage.consume(batch)
+                self.directory.consume(batch)
+                self.eviction.consume(batch)
+                self.batches.append(batch)
+            self.condition.notify_all()
+
+    def wait_for_batches(self, count: int, timeout: float = 5.0) -> None:
+        """Wait until at least ``count`` cache-event batches arrive."""
+        with self.condition:
+            arrived = self.condition.wait_for(
+                lambda: len(self.batches) >= count,
+                timeout,
+            )
+        assert arrived, f"only {len(self.batches)} cache-event batches arrived"
 
 
 def create_object_key(
@@ -498,19 +553,145 @@ class TestStore:
         assert result.is_successful()
         assert result.bytes_transferred() == 0
 
-    def test_partial_failure_accounting(self, adapter):
-        """
-        partial batch failure must report the
-        task as NOT successful and  account
-        only the keys that actually wrote in per-salt
-        """
+    def test_repeat_store_keeps_usage_and_reports_full_size(self, adapter):
         listener = _RecordingListener()
         adapter.register_listener(listener)
+        key = create_object_key(1, cache_salt="tenant-a")
+        src = create_memory_obj(size=16, fill_value=0.5)
+
+        first = _wait_for_store(adapter, adapter.submit_store_task([key], [src]))
+        second = _wait_for_store(adapter, adapter.submit_store_task([key], [src]))
+
+        assert first.is_successful()
+        assert second.is_successful()
+        assert first.bytes_transferred() == src.get_size()
+        assert second.bytes_transferred() == src.get_size()
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == src.get_size()
+        assert usage.bytes_by_cache_salt == {"tenant-a": src.get_size()}
+        assert listener.stored == [[key], [key]]
+        assert listener.stored_sizes == [[src.get_size()], [src.get_size()]]
+
+        dst = create_memory_obj(size=16, fill_value=0.0)
+        bitmap = _wait_for_load(adapter, adapter.submit_load_task([key], [dst]))
+        assert bitmap.test(0)
+        assert torch.equal(dst.tensor, src.tensor)
+
+    def test_duplicate_key_in_batch_counts_unique_usage(self, adapter):
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+        key = create_object_key(1, cache_salt="tenant-a")
+        obj = create_memory_obj(size=16)
+
+        result = _wait_for_store(
+            adapter,
+            adapter.submit_store_task([key, key], [obj, obj]),
+        )
+
+        assert result.is_successful()
+        assert result.bytes_transferred() == 2 * obj.get_size()
+        assert adapter.get_usage().total_bytes_used == obj.get_size()
+        assert listener.stored_sizes == [[obj.get_size(), obj.get_size()]]
+
+    def test_mixed_repeat_and_new_store_preserves_bucket_usage(self, adapter):
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+        existing = create_object_key(1, cache_salt="tenant-a")
+        new = create_object_key(2, cache_salt="tenant-b")
+        obj = create_memory_obj(size=16)
+        _wait_for_store(adapter, adapter.submit_store_task([existing], [obj]))
+
+        result = _wait_for_store(
+            adapter,
+            adapter.submit_store_task([existing, new], [obj, obj]),
+        )
+
+        assert result.is_successful()
+        assert result.bytes_transferred() == 2 * obj.get_size()
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == 2 * obj.get_size()
+        assert usage.bytes_by_cache_salt == {
+            "tenant-a": obj.get_size(),
+            "tenant-b": obj.get_size(),
+        }
+        assert listener.stored_sizes[-1] == [obj.get_size(), obj.get_size()]
+
+    def test_repeat_store_preserves_coordinator_placement_and_eviction(
+        self, monkeypatch
+    ):
+        bus = EventBus(EventBusConfig(enabled=True))
+        monkeypatch.setattr(l2_adapter_base, "get_event_bus", lambda: bus)
+        sink = _ApplyingSink()
+        sink.eviction.quota.set_quota("tenant-a", 32)
+        bus.register_subscriber(
+            CacheEventSubscriber(
+                sink,
+                instance_id="test-node",
+                incarnation=1,
+                flush_interval=0,
+            )
+        )
+        bus.start()
+        adapter = ValkeyL2Adapter(_make_config(num_workers=1))
+        adapter.set_backend_identity("valkey", shared=True)
+        key = create_object_key(1, cache_salt="tenant-a")
+        obj = create_memory_obj(size=16)
+        try:
+            for expected_count in (1, 2):
+                result = _wait_for_store(
+                    adapter,
+                    adapter.submit_store_task([key], [obj]),
+                )
+                assert result.is_successful()
+                sink.wait_for_batches(expected_count)
+
+            store_batches = [
+                batch
+                for batch in sink.batches
+                if batch.event_type == CacheEventType.STORE
+            ]
+            assert [batch.entries[0].size_bytes for batch in store_batches] == [
+                obj.get_size(),
+                obj.get_size(),
+            ]
+            assert sink.usage.get_salt_bytes(Tier.L2, "tenant-a") == obj.get_size()
+            assert sink.directory.lookup([key])[0][0].size_bytes == obj.get_size()
+            assert sink.eviction.compute_eviction_plan() == {"tenant-a": [key]}
+
+            # A coordinator that observes only the repeated STORE must still
+            # be able to reconstruct the complete placement.
+            fresh_usage = CacheUsageManager()
+            fresh_directory = KeyDirectory()
+            fresh_usage.consume(store_batches[-1])
+            fresh_directory.consume(store_batches[-1])
+            assert fresh_usage.get_salt_bytes(Tier.L2, "tenant-a") == obj.get_size()
+            assert fresh_directory.lookup([key])[0][0].size_bytes == obj.get_size()
+
+            adapter.delete([key])
+            sink.wait_for_batches(3)
+            assert adapter.get_usage().total_bytes_used == 0
+            assert sink.usage.get_salt_bytes(Tier.L2, "tenant-a") == 0
+            assert sink.directory.lookup([key]) == [[]]
+            bitmap = _wait_for_lookup(
+                adapter,
+                adapter.submit_lookup_and_lock_task([key], {0: _EMPTY_LAYOUT}),
+            )
+            assert not bitmap.test(0)
+        finally:
+            adapter.close()
+            bus.stop()
+
+    def test_partial_failure_accounting(self, adapter):
+        """A partial failure publishes and accounts only successful keys."""
         keys = [create_object_key(i) for i in range(3)]
         objs = [create_memory_obj(size=16) for _ in range(3)]
+        # Seed key 0 so the failing batch includes an overwrite and a new key.
+        _wait_for_store(adapter, adapter.submit_store_task([keys[0]], [objs[0]]))
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
 
-        # Make the SET for key index 1's wire key fail.
-        target_wire = adapter._wire_key(keys[1]).encode()  # noqa: SLF001
+        # Make the SET for key index 2's wire key fail.
+        target_wire = adapter._wire_key(keys[2]).encode()  # noqa: SLF001
 
         def faulty(k: bytes):
             if k == target_wire:
@@ -526,14 +707,12 @@ class TestStore:
         assert not result.is_successful()
         assert result.bytes_transferred() == 0
 
-        # Real accounting: only the 2 successful keys are counted.
+        # Key 0 remains counted once and key 1 is added; the failed key is absent.
         usage = adapter.get_usage()
         assert usage.total_bytes_used == 2 * objs[0].get_size()
-        # verify the failed key is not in the stored-listener notifications.
-        stored_flat = {k for batch in listener.stored for k in batch}
-        assert keys[0] in stored_flat
-        assert keys[2] in stored_flat
-        assert keys[1] not in stored_flat
+        assert usage.bytes_by_cache_salt == {"": 2 * objs[0].get_size()}
+        assert listener.stored == [[keys[0], keys[1]]]
+        assert listener.stored_sizes == [[objs[0].get_size(), objs[1].get_size()]]
 
     def test_length_mismatch_raises(self, adapter):
         with pytest.raises(ValueError, match="length mismatch"):

--- a/tests/v1/distributed/test_valkey_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter_integration.py
@@ -223,6 +223,25 @@ class TestValkeyL2AdapterIntegration:
         assert self._load(adapter, [key], [dst]).test(0) is True
         assert torch.equal(dst.tensor, src.tensor)
 
+    def test_repeat_store_preserves_usage_and_transfer_bytes(self, adapter):
+        """A real repeated SET retains one object's logical usage."""
+        key = create_object_key(1001, cache_salt="repeat-store")
+        src = create_memory_obj(size=128, fill_value=2.5)
+        dst = create_memory_obj(size=128, fill_value=0.0)
+
+        first = self._store(adapter, [key], [src])
+        second = self._store(adapter, [key], [src])
+
+        assert first.is_successful()
+        assert second.is_successful()
+        assert first.bytes_transferred() == src.get_size()
+        assert second.bytes_transferred() == src.get_size()
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == src.get_size()
+        assert usage.bytes_by_cache_salt == {"repeat-store": src.get_size()}
+        assert self._load(adapter, [key], [dst]).test(0) is True
+        assert torch.equal(dst.tensor, src.tensor)
+
     def test_batch_roundtrip_spreads_across_nodes(self, adapter):
         """Many keys round-trip with byte-exact data.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4974.

Repeated successful Valkey stores currently use a zero size to avoid double-counting process-local capacity. That same zero is forwarded as the absolute STORE size to cache-event consumers, so a second write changes coordinator usage and directory placement from the object's real size to zero. Quota eviction then skips an object that remains readable, and the successful repeat SET also reports zero transferred bytes.

This change separates the full stored-object sizes from optional additive local-accounting sizes in the L2 notification helper. Existing callers keep the additive default. Valkey overwrites now add zero to local usage while listeners and coordinator events receive the full object size, and successful `L2StoreResult` values report the bytes actually written.

Regression coverage includes repeated and duplicate stores, mixed cache salts, partial failure, deletion balance, listener payloads, fresh-coordinator reconstruction, and quota eviction. A real Valkey integration case verifies repeated SET/GET behavior and byte-exact loading.

Validation:

- `Buildkite #8855`: `6723 passed, 283 skipped, 1 xpassed`
- `60 passed`: L2 base and Valkey adapter unit suites
- `138 passed`: coordinator usage, directory, cache-event, and eviction suites
- `4 passed, 1 skipped`: live standalone Valkey 8 with `valkey-glide-sync==2.5.2`; the cluster-only status test was skipped in standalone mode
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files` passed; this is a Python/docs-only change and the repository permits those Rust skips on macOS
- The Sphinx build rendered the updated Valkey page. The repository-wide `-W` build remains blocked by 31 pre-existing warnings/errors in unrelated pages, including the malformed YAML directive in `production/observability/chunk_statistics.rst`; no warning references the changed Valkey page.
- `git diff --check` passed

**Special notes for your reviewers**:

`accounting_sizes` is keyword-only and defaults to `sizes`, so all existing adapter callers preserve their behavior. The coordinator protocol remains an absolute-size upsert; a later STORE can therefore reconstruct a placement even if earlier events were dropped.

This keeps the existing fixed-size cache-object behavior. Reconciliation for TTL, external eviction, restart scans, or variable-size same-key replacement remains outside this fix.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
