### PR TITLE
[CI] Configure device environment for AMD MP benchmark

### DIFF
--- a/.buildkite/scripts/amd-vllm-bench-container.sh
+++ b/.buildkite/scripts/amd-vllm-bench-container.sh
@@ -19,6 +19,13 @@ export BUILD_WITH_HIP=1
 export TORCH_DONT_CHECK_COMPILER_ABI=1
 export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE:-0.0.0+ci}"
 
+# This path calls run-single-test.sh directly, bypassing the common run.sh
+# entrypoint that normally configures the shared multiprocess launcher. ROCm
+# still uses the "cuda" torch/vLLM device type, while HIP_VISIBLE_DEVICES owns
+# physical device affinity.
+export VLLM_TARGET_DEVICE="${VLLM_TARGET_DEVICE:-cuda}"
+export DEVICE_AFFINITY_VAR="${DEVICE_AFFINITY_VAR:-HIP_VISIBLE_DEVICES}"
+
 case "${AMD_KERNEL_MODE:?AMD_KERNEL_MODE must be set}" in
     serialized)
         [[ "${AMD_SERIALIZE_KERNEL:-}" == "1" ]]


### PR DESCRIPTION
## Summary

- configure the shared multiprocess launcher for the AMD ROCm benchmark path
- use `cuda` as the torch/vLLM device type and `HIP_VISIBLE_DEVICES` for device affinity
- document why the AMD container entrypoint must provide these values directly

## Why

The AMD benchmark container calls `run-single-test.sh` directly and bypasses the common multiprocess `run.sh` entrypoint. After #4849 made `VLLM_TARGET_DEVICE` and `DEVICE_AFFINITY_VAR` required launcher inputs, both serialized and unserialized AMD jobs exited before starting any processes.

Failed build: https://buildkite.com/lmcache/amd-mp-test/builds/260

## Validation

- `bash -n .buildkite/scripts/amd-vllm-bench-container.sh .buildkite/scripts/amd-vllm-bench.sh`
- `shellcheck -x .buildkite/scripts/amd-vllm-bench-container.sh .buildkite/scripts/amd-vllm-bench.sh`
- `SKIP=rust-fmt,rust-clippy uvx pre-commit run --all-files`