### PR TITLE
[Bugfix] Use the global worker rank to identify the offload RPC socket

### DIFF
--- a/lmcache/integration/vllm/vllm_service_factory.py
+++ b/lmcache/integration/vllm/vllm_service_factory.py
@@ -280,21 +280,25 @@ class VllmServiceFactory(BaseServiceFactory):
             self.metadata,
         )
 
-    def maybe_create_offload_server(self) -> Optional[ZMQOffloadServer]:
-        # Only worker needs offload server
+    def maybe_create_offload_server(self) -> ZMQOffloadServer | None:
+        """Create this worker's offload RPC server.
+
+        Use ``parallel_config.rank``, matching the lookup service. TP-local
+        ranks repeat across pipeline stages and can collide in a shared IPC
+        namespace.
+
+        Returns:
+            The offload server when this factory serves the ``"worker"``
+            role, ``None`` for every other role.
+        """
         if self.role != "worker":
             return None
-
-        # Third Party
-        from vllm.distributed.parallel_state import (
-            get_tensor_model_parallel_rank,
-        )
 
         self._ensure_engine()
         assert self.lmcache_engine is not None
         return ZMQOffloadServer(
             self.lmcache_engine,
-            get_tensor_model_parallel_rank(),
+            self.vllm_config.parallel_config.rank,
         )
 
     def maybe_create_runtime_plugin_launcher(

--- a/lmcache/v1/offload_server/zmq_server.py
+++ b/lmcache/v1/offload_server/zmq_server.py
@@ -23,14 +23,25 @@ class ZMQOffloadServer(OffloadServerInterface):
     def __init__(
         self,
         lmcache_engine: LMCacheEngine,
-        tp_rank: int,
-    ):
+        rank: int,
+    ) -> None:
+        """Create the worker's offload socket and request thread.
+
+        Args:
+            lmcache_engine: LMCacheEngine receiving the offloaded KV cache.
+            rank: Integer worker rank, unique within the engine's IPC
+                namespace. vLLM callers must pass ``parallel_config.rank``
+                because TP-local ranks repeat across pipeline stages.
+
+        Raises:
+            zmq.ZMQError: If the socket cannot be created or bound.
+        """
         metadata = lmcache_engine.metadata
         self.ctx = get_zmq_context(use_asyncio=False)
         offload_rpc_port = int(os.environ.get("LMCACHE_OFFLOAD_RPC_PORT", 100))
         engine_id = metadata.engine_id or "default"
         socket_path = get_zmq_rpc_path_lmcache(
-            engine_id, "offload", offload_rpc_port, tp_rank
+            engine_id, "offload", offload_rpc_port, rank
         )
         self.socket = get_zmq_socket(
             self.ctx,

--- a/tests/integration/vllm/test_vllm_service_factory.py
+++ b/tests/integration/vllm/test_vllm_service_factory.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only regression tests for vLLM offload endpoint identity.
+
+Worker tests run the real factory, server constructor, and RPC path helper
+with a mocked engine, ZMQ context, and background thread.
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pytest
+import zmq
+
+# First Party
+from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
+from lmcache.v1.cache_engine import LMCacheEngine
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.rpc_utils import get_zmq_rpc_path_lmcache
+
+
+@pytest.mark.parametrize("global_rank", [0, 2, 3])
+def test_worker_offload_server_binds_global_rank_endpoint(
+    global_rank: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each worker must bind the endpoint derived from its own global rank.
+
+    In a PP=2, TP=2 layout, workers 0 and 2 share TP-local rank 0 but must
+    bind different endpoints within the same engine's IPC namespace.
+    """
+    engine_id = "offload-rank-test"
+    rpc_port = 731
+    monkeypatch.setenv("LMCACHE_OFFLOAD_RPC_PORT", str(rpc_port))
+    vllm_config = MagicMock()
+    vllm_config.parallel_config.rank = global_rank
+    engine = MagicMock(spec=LMCacheEngine)
+    engine.metadata = SimpleNamespace(engine_id=engine_id, worker_id=global_rank)
+    factory = VllmServiceFactory(
+        LMCacheEngineConfig.from_defaults(), vllm_config, role="worker"
+    )
+    # Supply an existing engine so this test only exercises service creation.
+    factory.lmcache_engine = engine
+    expected_path = get_zmq_rpc_path_lmcache(
+        engine_id, "offload", rpc_port, global_rank
+    )
+
+    with (
+        patch(
+            "lmcache.v1.offload_server.zmq_server.get_zmq_context"
+        ) as context_factory,
+        patch("lmcache.v1.offload_server.zmq_server.threading.Thread"),
+    ):
+        server = factory.maybe_create_offload_server()
+
+    assert server is not None
+    context = context_factory.return_value
+    context.socket.assert_called_once_with(zmq.REP)
+    context.socket.return_value.bind.assert_called_once_with(f"ipc://{expected_path}")
+
+
+def test_scheduler_does_not_create_offload_server() -> None:
+    """The scheduler must create neither an offload server nor a cache engine."""
+    factory = VllmServiceFactory(
+        LMCacheEngineConfig.from_defaults(), MagicMock(), role="scheduler"
+    )
+
+    with patch(
+        "lmcache.integration.vllm.vllm_service_factory.ZMQOffloadServer"
+    ) as offload_server_cls:
+        offload_server = factory.maybe_create_offload_server()
+
+    offload_server_cls.assert_not_called()
+    assert offload_server is None
+    assert factory.lmcache_engine is None


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4977.

TP-local ranks repeat across pipeline stages. When workers share an engine ID and IPC directory, this makes them bind the same offload endpoint, so new connections can reach the wrong worker.

Use `parallel_config.rank` instead, matching the lookup service, and rename the server parameter from `tp_rank` to `rank`. Add regression tests for the bound worker endpoint and the scheduler's no-server behavior.

**Special notes for your reviewers**:

- The 12 related tests pass, along with Ruff, isort, mypy, and codespell checks for the changed files.
- Verified with four GPUs and real vLLM PP=2 / TP=2 groups on Linux. Before the fix, requests for workers 0 and 1 reached workers 2 and 3. After the fix, each worker received its own request. This used real IPC sockets and a substitute cache engine to record calls; it did not test model inference or GPU KV transfers.
- External clients deriving offload paths from TP-local ranks need to use global worker ranks. Callers using the `tp_rank=` keyword need to use `rank=`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests