### PR TITLE
[Bugfix][CLI] Freeze engine benchmark timing before cleanup and reporting

### DIFF
--- a/lmcache/cli/commands/bench/engine_bench/stats.py
+++ b/lmcache/cli/commands/bench/engine_bench/stats.py
@@ -79,6 +79,7 @@ class StatsCollector:
         self._lock = threading.Lock()
         self._results: list[RequestResult] = []
         self._start_time: float = time.monotonic()
+        self._end_time: float | None = None
 
         # Running accumulators (updated under lock)
         self._successful: int = 0
@@ -108,6 +109,20 @@ class StatsCollector:
             result.successful,
         )
 
+    def finish(self) -> None:
+        """Stop the elapsed-time clock for the measured run. Thread-safe.
+
+        Call after all measured requests and their callbacks finish, before
+        client/display cleanup or reporting. Repeated calls preserve the
+        first end time. Call :meth:`reset` before recording another run.
+
+        Returns:
+            None.
+        """
+        with self._lock:
+            if self._end_time is None:
+                self._end_time = time.monotonic()
+
     def reset(self) -> None:
         """Clear all accumulated results and restart the timer.
 
@@ -117,6 +132,7 @@ class StatsCollector:
         with self._lock:
             self._results.clear()
             self._start_time = time.monotonic()
+            self._end_time = None
             self._successful = 0
             self._failed = 0
             self._sum_ttft = 0.0
@@ -127,11 +143,18 @@ class StatsCollector:
         logger.debug("Stats collector reset")
 
     def get_current_stats(self) -> AggregatedStats:
-        """Return current aggregated stats snapshot. Thread-safe."""
+        """Return running statistics, using the fixed end time after finish.
+
+        Returns:
+            AggregatedStats: A thread-safe snapshot of the recorded results.
+        """
         with self._lock:
             successful = self._successful
             failed = self._failed
-            elapsed = time.monotonic() - self._start_time
+            end_time = (
+                self._end_time if self._end_time is not None else time.monotonic()
+            )
+            elapsed = end_time - self._start_time
             sum_ttft = self._sum_ttft
             sum_decode = self._sum_decode_speed
             sum_latency = self._sum_request_latency
@@ -157,8 +180,15 @@ class StatsCollector:
     def get_final_stats(self) -> FinalStats:
         """Compute and return final stats with percentiles.
 
-        Should be called once after the benchmark completes.
+        Stops the timer if :meth:`finish` has not already been called.
+        Call only after all measured requests finish; use
+        :meth:`get_current_stats` for running statistics. Subsequent calls
+        and JSON exports use the same measured interval until :meth:`reset`.
+
+        Returns:
+            FinalStats: The completed run's aggregate and percentile metrics.
         """
+        self.finish()
         with self._lock:
             results = list(self._results)
 

--- a/lmcache/cli/commands/bench/engine_bench/workloads/base.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/base.py
@@ -155,6 +155,7 @@ class BaseWorkload(ABC):
                 await asyncio.sleep(sleep_duration)
 
         self._drain_finished_queue()  # final drain
+        self._stats_collector.finish()
         self._progress_monitor.log_message("Benchmark complete")
 
     def request_finished(self, result, response_text: str) -> None:

--- a/tests/cli/commands/bench/engine_bench/test_stats.py
+++ b/tests/cli/commands/bench/engine_bench/test_stats.py
@@ -2,6 +2,9 @@
 """Tests for bench engine stats module."""
 
 # Standard
+from dataclasses import asdict
+from pathlib import Path
+from unittest.mock import patch
 import csv
 import json
 import threading
@@ -329,6 +332,72 @@ class TestStatsCollectorExport:
         assert "p50_ttft_ms" in data["results"]
         assert "p90_ttft_ms" in data["results"]
         assert data["results"]["total_requests"] == 2
+
+
+# ---------------------------------------------------------------------------
+# StatsCollector — finished timing
+# ---------------------------------------------------------------------------
+
+
+class TestFinishedTiming:
+    def test_final_stats_and_json_keep_the_same_elapsed_time(
+        self, tmp_path: Path
+    ) -> None:
+        """Reporting delays must not change a completed run's metrics."""
+        with patch("time.monotonic", return_value=100.0) as clock:
+            collector = StatsCollector()
+            collector.on_request_finished(
+                _make_result(num_input_tokens=1000, num_output_tokens=100)
+            )
+            clock.return_value = 101.0
+            final = collector.get_final_stats()
+
+            clock.return_value = 110.0
+            assert collector.get_final_stats() == final
+            path = tmp_path / "summary.json"
+            collector.export_json(str(path), _make_config())
+
+        assert final.elapsed_time == 1.0
+        assert final.input_throughput == 1000.0
+        assert final.output_throughput == 100.0
+        assert json.loads(path.read_text())["results"] == asdict(final)
+
+    def test_finish_is_idempotent(self) -> None:
+        """Repeated finish calls preserve the original measured interval."""
+        with patch("time.monotonic", return_value=0.0) as clock:
+            collector = StatsCollector()
+            collector.on_request_finished(_make_result())
+            clock.return_value = 1.0
+            collector.finish()
+            clock.return_value = 10.0
+            collector.finish()
+            assert collector.get_current_stats().elapsed_time == 1.0
+
+    def test_empty_run_can_finish_at_zero(self) -> None:
+        """A zero timestamp and zero-duration run remain valid after finish."""
+        with patch("time.monotonic", return_value=0.0) as clock:
+            collector = StatsCollector()
+            collector.finish()
+            clock.return_value = 10.0
+            final = collector.get_final_stats()
+        assert final.elapsed_time == 0.0
+        assert final.input_throughput == final.output_throughput == 0.0
+
+    def test_reset_restarts_a_finished_timer(self) -> None:
+        """Reset clears finalization so running metrics advance again."""
+        with patch("time.monotonic", return_value=100.0) as clock:
+            collector = StatsCollector()
+            collector.on_request_finished(_make_result())
+            clock.return_value = 101.0
+            collector.finish()
+
+            clock.return_value = 200.0
+            collector.reset()
+            clock.return_value = 202.0
+            assert collector.get_current_stats().elapsed_time == 2.0
+            clock.return_value = 203.0
+            assert collector.get_current_stats().elapsed_time == 3.0
+            assert collector.get_all_results() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/commands/bench/engine_bench/workloads/test_base_workload.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_base_workload.py
@@ -2,12 +2,12 @@
 """Tests for the BaseWorkload abstract class."""
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import queue
 
 # First Party
 from lmcache.cli.commands.bench.engine_bench.config import WarmupPolicy
-from lmcache.cli.commands.bench.engine_bench.stats import RequestResult
+from lmcache.cli.commands.bench.engine_bench.stats import RequestResult, StatsCollector
 from lmcache.cli.commands.bench.engine_bench.workloads.base import BaseWorkload
 
 # ---------------------------------------------------------------------------
@@ -116,6 +116,62 @@ class TestBaseWorkloadDrainQueue:
 
 
 class TestBaseWorkloadRunLoop:
+    def test_run_excludes_cleanup_and_reporting_from_elapsed_time(self) -> None:
+        """Freeze timing after final callbacks but before reporting/client cleanup."""
+        with patch("time.monotonic", return_value=100.0) as clock:
+            collector = StatsCollector()
+            sender = MagicMock()
+            monitor = MagicMock()
+            workload = StubWorkload(sender, collector, monitor)
+            result = RequestResult(
+                request_id="r0",
+                successful=True,
+                ttft=0.1,
+                request_latency=1.0,
+                num_input_tokens=1000,
+                num_output_tokens=100,
+                decode_speed=100 / 0.9,
+                submit_time=100.0,
+                first_token_time=100.1,
+                finish_time=101.0,
+                error="",
+            )
+
+            async def step(time_offset: float) -> float:
+                clock.return_value = 101.0
+                collector.on_request_finished(result)
+                workload.request_finished(result, "answer")
+                return -1.0
+
+            def finished(request_id: str, output: str) -> None:
+                workload.finished_calls.append((request_id, output))
+                clock.return_value = 102.0
+
+            def log_message(message: str) -> None:
+                if message == "Benchmark complete":
+                    clock.return_value = 110.0
+
+            async def close() -> None:
+                clock.return_value = 120.0
+
+            sender.close = AsyncMock(side_effect=close)
+            monitor.log_message.side_effect = log_message
+            with (
+                patch.object(workload, "step", side_effect=step),
+                patch.object(workload, "on_request_finished", side_effect=finished),
+            ):
+                workload.run(WarmupPolicy.SKIP)
+
+            # Model the additional display-thread join after workload.run().
+            clock.return_value = 130.0
+            final = collector.get_final_stats()
+
+        assert workload.finished_calls == [("r0", "answer")]
+        sender.close.assert_awaited_once()
+        assert final.elapsed_time == 2.0
+        assert final.input_throughput == 500.0
+        assert final.output_throughput == 50.0
+
     def test_run_calls_warmup(self) -> None:
         w = _make_stub()
         w.run()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4981.

`bench engine` kept its elapsed-time clock running through HTTP client cleanup, progress-display shutdown, and reporting. JSON export then recomputed the final metrics after terminal/CSV output, producing lower throughput for the same completed requests.

Stop the clock after the workload's final callbacks, before cleanup and reporting. `StatsCollector.finish()` preserves the first end time, `get_final_stats()` also finalizes standalone collectors, and `reset()` starts a fresh interval. Terminal and JSON results now use the same measured interval.

**Special notes for your reviewers**:

The issue's controlled reproduction now reports `1.0 s / 100.0 tok/s` for both the initial summary and the later JSON export (previously `1.0 / 100.0` versus `10.0 / 10.0`). Per-request latency and decode-speed definitions are unchanged.

Validation:

- The two regression tests for delayed export and workload cleanup both failed on unmodified `dev`, then passed with this change.
- `pytest -q tests/cli/commands/bench/engine_bench`: 475 passed (98 OpenTelemetry deprecation warnings).
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`: passed, including mypy. Rust hooks were explicitly skipped for this Python-only change.
- No model-serving/GPU benchmark was needed; timing assertions use a controlled clock.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
