### PR TITLE
[Bugfix] Keep offload RPC serving after a request fails

### DIFF
--- a/lmcache/v1/offload_server/abstract_server.py
+++ b/lmcache/v1/offload_server/abstract_server.py
@@ -27,7 +27,9 @@ class OffloadServerInterface(metaclass=abc.ABCMeta):
             offsets: Number of tokens in each block.
 
         Returns:
-            Whether the offload was successful.
+            Whether the offload request was processed successfully. This does
+            not guarantee that data was persisted; storage may be skipped or
+            completed asynchronously.
         """
         raise NotImplementedError
 

--- a/lmcache/v1/offload_server/message.py
+++ b/lmcache/v1/offload_server/message.py
@@ -22,7 +22,12 @@ class OffloadMsg(msgspec.Struct):
 
 
 class OffloadRetMsg(msgspec.Struct):
-    """Return message for Offloading"""
+    """Outcome of processing an offload request.
+
+    ``success`` is false if the request is invalid or the engine call raises.
+    True means the engine call returned normally, not that data was persisted.
+    The engine may skip a store or complete it asynchronously.
+    """
 
     success: bool
 

--- a/lmcache/v1/offload_server/zmq_server.py
+++ b/lmcache/v1/offload_server/zmq_server.py
@@ -9,6 +9,7 @@ import msgspec
 import zmq
 
 # First Party
+from lmcache.logging import init_logger
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.offload_server.abstract_server import OffloadServerInterface
 from lmcache.v1.offload_server.message import OffloadMsg, OffloadRetMsg
@@ -18,13 +19,35 @@ from lmcache.v1.rpc_utils import (
     get_zmq_socket,
 )
 
+logger = init_logger(__name__)
+
 
 class ZMQOffloadServer(OffloadServerInterface):
+    """Serve offload requests over a ZMQ REP socket on a background thread.
+
+    Attempt one reply per request: ``success`` is true when the engine call
+    returns normally and false when the request is invalid or the engine
+    raises. A REP socket must reply before receiving another request.
+    Transport errors stop the thread, and ``running`` is cleared on exit.
+    """
+
     def __init__(
         self,
         lmcache_engine: LMCacheEngine,
         tp_rank: int,
-    ):
+    ) -> None:
+        """Bind the offload endpoint and start its request thread.
+
+        Args:
+            lmcache_engine: LMCacheEngine handling offload operations.
+            tp_rank: Integer rank suffix used to construct the IPC endpoint.
+
+        Raises:
+            ValueError: If ``LMCACHE_OFFLOAD_RPC_PORT`` is not an integer, or
+                the base RPC directory cannot fit even a shortened socket name
+                within the IPC path limit.
+            zmq.ZMQError: If the socket cannot be created or bound.
+        """
         metadata = lmcache_engine.metadata
         self.ctx = get_zmq_context(use_asyncio=False)
         offload_rpc_port = int(os.environ.get("LMCACHE_OFFLOAD_RPC_PORT", 100))
@@ -43,35 +66,43 @@ class ZMQOffloadServer(OffloadServerInterface):
         self.lmcache_engine = lmcache_engine
         self.running = True
 
-        def process_request():
-            # First Party
-            from lmcache.logging import init_logger
+        def process_request() -> None:
+            """Complete each REP receive/send cycle, including failed requests."""
+            try:
+                while self.running:
+                    try:
+                        frames = self.socket.recv_multipart(copy=False)
+                        try:
+                            if len(frames) != 1:
+                                raise ValueError(
+                                    "Offload requests must use one frame, "
+                                    f"got {len(frames)}"
+                                )
+                            offload_msg = msgspec.msgpack.decode(
+                                frames[0], type=OffloadMsg
+                            )
+                            result = self.offload(
+                                offload_msg.hashes,
+                                offload_msg.slot_mapping,
+                                offload_msg.offsets,
+                            )
+                        except Exception:
+                            logger.exception("Failed to process offload request")
+                            result = False
 
-            logger = init_logger(__name__)
-
-            while self.running:
-                try:
-                    frame = self.socket.recv(copy=False)
-                    offload_msg = msgspec.msgpack.decode(frame, type=OffloadMsg)
-                    result = self.offload(
-                        offload_msg.hashes,
-                        offload_msg.slot_mapping,
-                        offload_msg.offsets,
-                    )
-                    response = OffloadRetMsg(success=result)
-                    response = msgspec.msgpack.encode(response)
-                    self.socket.send(response)
-                except zmq.ZMQError as e:
-                    # Socket was closed, exit gracefully
-                    if not self.running:
-                        logger.info("ZMQ socket closed, exiting offload server thread")
+                        # REP must reply even when decoding or storing failed.
+                        response = msgspec.msgpack.encode(OffloadRetMsg(success=result))
+                        self.socket.send(response)
+                    except zmq.ZMQError as e:
+                        if not self.running:
+                            logger.info(
+                                "ZMQ socket closed, exiting offload server thread"
+                            )
+                        else:
+                            logger.error("ZMQ error in offload server: %s", e)
                         break
-                    logger.error("ZMQ error in offload server: %s", e)
-                    break
-                except Exception as e:
-                    logger.error("Unexpected error in offload server: %s", e)
-                    if not self.running:
-                        break
+            finally:
+                self.running = False
 
         self.thread = threading.Thread(
             target=process_request, daemon=True, name="offload-server-thread"
@@ -90,11 +121,6 @@ class ZMQOffloadServer(OffloadServerInterface):
         return True
 
     def close(self) -> None:
-        # First Party
-        from lmcache.logging import init_logger
-
-        logger = init_logger(__name__)
-
         logger.info("Closing ZMQOffloadServer...")
         self.running = False
 

--- a/tests/v1/offload_server/test_zmq_server.py
+++ b/tests/v1/offload_server/test_zmq_server.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise offload request recovery with real ZMQ REQ/REP sockets.
+
+In-process transport isolates the protocol from filesystem IPC naming. The
+cache engine is mocked, so these tests need neither vLLM nor a GPU.
+"""
+
+# Standard
+from collections.abc import Iterator
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import msgspec
+import pytest
+import zmq
+
+# First Party
+from lmcache.v1.cache_engine import LMCacheEngine
+from lmcache.v1.offload_server.message import OffloadMsg, OffloadRetMsg
+from lmcache.v1.offload_server.zmq_server import ZMQOffloadServer
+
+
+@pytest.fixture
+def offload_rpc() -> Iterator[tuple[ZMQOffloadServer, zmq.Socket, MagicMock]]:
+    """Provide real REQ/REP sockets and an engine for injecting store errors."""
+    context = zmq.Context()
+    endpoint = "inproc://offload-recovery-test"
+    reply_socket = context.socket(zmq.REP)
+    reply_socket.bind(endpoint)
+    client = context.socket(zmq.REQ)
+    client.setsockopt(zmq.RCVTIMEO, 2000)
+    client.setsockopt(zmq.SNDTIMEO, 2000)
+    client.connect(endpoint)
+    engine = MagicMock(spec=LMCacheEngine)
+    engine.metadata = SimpleNamespace(engine_id="offload-recovery-test")
+
+    with (
+        patch(
+            "lmcache.v1.offload_server.zmq_server.get_zmq_context",
+            return_value=context,
+        ),
+        patch(
+            "lmcache.v1.offload_server.zmq_server.get_zmq_rpc_path_lmcache",
+            return_value="unused",
+        ),
+        patch(
+            "lmcache.v1.offload_server.zmq_server.get_zmq_socket",
+            return_value=reply_socket,
+        ),
+    ):
+        server = ZMQOffloadServer(engine, 0)
+
+    try:
+        yield server, client, engine
+    finally:
+        # Wake the receiver before closing its socket from this thread.
+        server.running = False
+        engine.store.side_effect = None
+        wake_client = context.socket(zmq.REQ)
+        wake_client.setsockopt(zmq.SNDTIMEO, 2000)
+        wake_client.connect(endpoint)
+        try:
+            if server.thread.is_alive():
+                wake_client.send(
+                    msgspec.msgpack.encode(
+                        OffloadMsg(hashes=[], slot_mapping=[], offsets=[])
+                    )
+                )
+                server.thread.join(timeout=5)
+            assert not server.thread.is_alive()
+        finally:
+            client.close(linger=0)
+            wake_client.close(linger=0)
+            server.close()
+            context.term()
+
+
+@pytest.mark.parametrize(
+    "failure", ["decode", "validation", "multipart", "store", "store_zmq"]
+)
+def test_failed_request_is_replied_to_and_next_request_succeeds(
+    offload_rpc: tuple[ZMQOffloadServer, zmq.Socket, MagicMock], failure: str
+) -> None:
+    """A failed request must not prevent the same client from sending another."""
+    server, client, engine = offload_rpc
+    request = OffloadMsg(hashes=[123], slot_mapping=[0], offsets=[1])
+    valid_frame = msgspec.msgpack.encode(request)
+    if failure == "decode":
+        first_frames = [b"\xc1"]  # Reserved MessagePack byte: decoding must fail.
+    elif failure == "validation":
+        first_frames = [
+            msgspec.msgpack.encode(
+                {"hashes": "invalid", "slot_mapping": [0], "offsets": [1]}
+            )
+        ]
+    elif failure == "multipart":
+        first_frames = [valid_frame, valid_frame]
+    else:
+        first_frames = [valid_frame]
+        error = (
+            zmq.ZMQError(zmq.EFSM)
+            if failure == "store_zmq"
+            else ValueError("store failed")
+        )
+        engine.store.side_effect = [error, None]
+
+    client.send_multipart(first_frames)
+    failed_reply = msgspec.msgpack.decode(client.recv(), type=OffloadRetMsg)
+    assert failed_reply.success is False
+
+    client.send(valid_frame)
+    successful_reply = msgspec.msgpack.decode(client.recv(), type=OffloadRetMsg)
+    assert successful_reply.success is True
+    engine.store.assert_called_with(hashes=[123], slot_mapping=[0], offsets=[1])
+    assert engine.store.call_count == (2 if failure in {"store", "store_zmq"} else 1)
+    assert server.running
+    assert server.thread.is_alive()
+
+
+@pytest.mark.parametrize("operation", ["recv_multipart", "send"])
+def test_transport_failure_marks_server_stopped(operation: str) -> None:
+    """A transport error must stop the thread and clear its running flag."""
+    socket = MagicMock(spec=zmq.Socket)
+    frame = msgspec.msgpack.encode(
+        OffloadMsg(hashes=[123], slot_mapping=[0], offsets=[1])
+    )
+    socket.recv_multipart.return_value = [frame]
+    getattr(socket, operation).side_effect = zmq.ZMQError(zmq.ETERM)
+    engine = MagicMock(spec=LMCacheEngine)
+    engine.metadata = SimpleNamespace(engine_id="offload-transport-failure")
+
+    with (
+        patch("lmcache.v1.offload_server.zmq_server.get_zmq_context"),
+        patch(
+            "lmcache.v1.offload_server.zmq_server.get_zmq_rpc_path_lmcache",
+            return_value="unused",
+        ),
+        patch(
+            "lmcache.v1.offload_server.zmq_server.get_zmq_socket",
+            return_value=socket,
+        ),
+    ):
+        server = ZMQOffloadServer(engine, 0)
+
+    try:
+        server.thread.join(timeout=5)
+        assert not server.thread.is_alive()
+        assert server.running is False
+        assert getattr(socket, operation).call_count == 1
+    finally:
+        server.close()


### PR DESCRIPTION
**What this PR does / why we need it**

Fixes #4985.

A failed offload request can stop the server from serving any client. A decoding or ordinary storage exception skips the reply, causing EFSM on the next receive. A `ZMQError` from the engine exits the loop directly. In both cases, even new clients sending valid requests get no reply, while `running` stays true. The server has to be recreated to recover.

Reply with `OffloadRetMsg(success=False)` for invalid requests and engine errors, then continue serving. Consume all frames before rejecting a multipart request so the socket can still reply. Transport errors stop the thread and clear `running`. The reply schema is unchanged.

Recovery tests use real REQ/REP sockets and cover invalid MessagePack, invalid field types, multipart requests, and engine exceptions including `ZMQError`. Each failed request is followed by a successful request on the same client. Separate tests inject socket receive and send errors to check that the thread stops and clears `running`.

**Special notes for your reviewers**

The request loop and `close()` now share a module-level logger instead of initializing their own.

I also clarified the class and return-value docstrings, including `OffloadServerInterface.offload`, to explain the reply behavior and that success does not guarantee persistence. A failure reply does not roll back work already completed by the engine.

**If applicable**

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
