### PR TITLE
[Refactor] Let KVFormatSpec own the EngineKVFormat facts (#4063)

### DIFF
--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -178,7 +178,9 @@ enum class EngineKVFormat : int {
 
 // Static layout facts for each format, declared once per format (indexed by the
 // enum value). This mirrors the facts declared on each Python KVFormatSpec so
-// the two sides can never drift; the predicates below are one-line lookups.
+// the two sides can never drift (pinned by
+// tests/v1/gpu_connector/test_kv_format_classification.py, which parses this
+// table); the predicates below are one-line lookups.
 // Exactly one structural shape (cross_layer / kv_list / layer_list) is true per
 // format. The remaining flags are modifiers layered on top of it.
 // Every field defaults to false; the table below only sets the true ones.
@@ -217,6 +219,7 @@ LMC_KV_FORMAT_HD constexpr FormatFacts format_facts(EngineKVFormat f) {
       break;
     case EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS:
       facts.is_kv_list = true;
+      facts.is_pbs_fused = true;
       break;
     case EngineKVFormat::NL_X_NBBS_ONE_HS:
       facts.is_layer_list = true;
@@ -276,20 +279,11 @@ LMC_KV_FORMAT_HD constexpr FormatFacts format_facts(EngineKVFormat f) {
   return facts;
 }
 
-// All layers in one fused tensor.
-LMC_KV_FORMAT_HD constexpr bool is_cross_layer(EngineKVFormat f) {
-  return format_facts(f).is_cross_layer;
-}
-
-// Keys and values in two separate top-level lists: [key_layers, value_layers].
-LMC_KV_FORMAT_HD constexpr bool is_kv_list(EngineKVFormat f) {
-  return format_facts(f).is_kv_list;
-}
-
-// The outermost dimension indexes the list of layers
-LMC_KV_FORMAT_HD constexpr bool is_layer_list(EngineKVFormat f) {
-  return format_facts(f).is_layer_list;
-}
+// Predicates for the facts the device kernels branch on. The remaining fields
+// of FormatFacts are declared above (and kept in sync with the Python
+// KVFormatSpec table) but have no C++ reader, so they get no predicate: Python
+// call sites read every fact from the spec via get_spec_class() rather than
+// through a pybind binding.
 
 // Multi-head Latent Attention: a single latent KV head (no separate K/V split).
 // The blocked-scale indexer cache transfers like MLA (single plane,
@@ -302,9 +296,4 @@ LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
 // separate K/V axis — transferred as one k_or_v == 0 pass (like MLA).
 LMC_KV_FORMAT_HD constexpr bool is_fused_packed(EngineKVFormat f) {
   return format_facts(f).is_fused_packed;
-}
-
-// One list entry per layer, each entry is a tuple of paged tensors.
-LMC_KV_FORMAT_HD constexpr bool is_kv_second_tuple(EngineKVFormat f) {
-  return format_facts(f).is_kv_second_tuple;
 }

--- a/csrc/lmcache_native/pybind.cpp
+++ b/csrc/lmcache_native/pybind.cpp
@@ -84,21 +84,6 @@ PYBIND11_MODULE(lmcache_native, m) {
            py::arg("engine_kv_format"), py::arg("block_ids_base"),
            py::arg("block_ids_capacity"));
 
-  m.def("is_kv_list", &is_kv_list, py::arg("format"),
-        "Return whether the format stores KV as a list of per-token KV "
-        "tensors (kv_size == 2).");
-  m.def("is_layer_list", &is_layer_list, py::arg("format"),
-        "Return whether the format stores one list entry per layer.");
-  m.def("is_cross_layer", &is_cross_layer, py::arg("format"),
-        "Return whether the format stacks KV from different layers into a "
-        "single tensor.");
-  m.def("is_mla", &is_mla, py::arg("format"),
-        "Return whether the format is an MLA variant (single latent KV "
-        "head).");
-  m.def("is_kv_second_tuple", &is_kv_second_tuple, py::arg("format"),
-        "Return whether each per-layer list entry is a (K, V) tuple of "
-        "paged tensors.");
-
   m.def("fold", &lmcache::lmcache_native::fold, py::arg("found"),
         py::arg("num_chunks"), py::arg("num_ranks"), py::arg("group_windows"),
         "Fold per-(group, chunk, rank) presence into a servable-prefix-lengths "

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -109,7 +109,9 @@ kv_format/
 1. Add the enum value in `csrc/kv_transfer_types.h` (the single
    backend-agnostic definition shared by every accelerator backend), then
    register it in the common native pybind module — `csrc/lmcache_native/pybind.cpp`
-   and `csrc/sycl/pybind_sycl.cpp` (SYCL/XPU).
+   and `csrc/sycl/pybind_sycl.cpp` (SYCL/XPU). Add its case to the
+   `format_facts` table in `csrc/engine_kv_format.h` too: the switch has no
+   fall-through default, and the kernels branch on those facts.
 2. Add a branch in the engine's `detectors/<engine>.py` `discover()`. It keys
    off `(list_depth, tensor_ndim)` from `measure_list_depth_until_tensor`,
    returning `(format, kv)`; any reshape-via-hints (e.g. TRT-LLM's 4-D `view`'d
@@ -195,8 +197,15 @@ helper.
 | `get_head_size(kv, fmt, layer_idx=0)` | yes | |
 | `get_hidden_dim_size(kv, fmt, layer_idx=0)` | yes | |
 | `get_dtype(kv, fmt, layer_idx=0)` | yes | |
-| `is_mla(fmt)` | — | Format predicate; the other static facts are read off `get_spec_class(fmt)`. |
 | `get_device(kv)` | — | Format-agnostic (descends to any leaf). |
+
+Static layout facts (`is_mla`, `is_cross_layer`, `is_kv_list`, `is_layer_list`,
+`is_hnd`, `is_fused_packed`, `is_two_major`, `is_pbs_fused`,
+`is_kv_second_tuple`) are not helpers: read them off `get_spec_class(fmt)`.
+`csrc/engine_kv_format.h` keeps a C++ copy of the same table for the device
+kernels, pinned against the specs by
+`tests/v1/gpu_connector/test_kv_format_classification.py`; no fact is exposed to
+Python through a pybind binding.
 
 ### Pointer and descriptor builders
 

--- a/lmcache/lmcache_native.pyi
+++ b/lmcache/lmcache_native.pyi
@@ -67,21 +67,6 @@ class KernelGroupSpec:
         block_ids_capacity: int,
     ) -> None: ...
 
-def is_kv_list(format: EngineKVFormat) -> bool:
-    """Return whether the format stores KV as a list of per-token KV tensors."""
-
-def is_layer_list(format: EngineKVFormat) -> bool:
-    """Return whether the format stores one list entry per layer."""
-
-def is_cross_layer(format: EngineKVFormat) -> bool:
-    """Return whether the format stacks KV from different layers into one tensor."""
-
-def is_mla(format: EngineKVFormat) -> bool:
-    """Return whether the format is an MLA variant (single latent KV head)."""
-
-def is_kv_second_tuple(format: EngineKVFormat) -> bool:
-    """Return whether each per-layer list entry is a (K, V) tuple of paged tensors."""
-
 class TTLLock:
     """
     A thread-safe lock with TTL (Time-To-Live) support.

--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -20,6 +20,7 @@ import zmq
 from lmcache.logging import init_logger
 from lmcache.sdk.cache_kind import LMCacheSDKCacheKind
 from lmcache.sdk.wrapper.contiguous import ContiguousTransferWrapper
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.gpu_connector.utils import (
     DiscoverableKVCache,
     LayoutHints,
@@ -185,7 +186,7 @@ class LMCacheSDKContext:
                 lmcache_native.EngineKVFormat, kernel_group["engine_kv_format"]
             )
             probe: list[DiscoverableKVCache] = [torch.empty(inner, device="meta")]
-            use_mla = lmcache_native.is_mla(fmt)
+            use_mla = get_spec_class(fmt).is_mla
             single_tensor = use_mla or self._kind is LMCacheSDKCacheKind.QUERY
             num_kv_heads = 1 if single_tensor else get_num_heads(probe, fmt)
             block_size = get_block_size(probe, fmt)

--- a/lmcache/v1/gpu_connector/hpu_connector.py
+++ b/lmcache/v1/gpu_connector/hpu_connector.py
@@ -24,6 +24,7 @@ import torch
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import GPUConnectorInterface
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.gpu_connector.utils import (
     get_block_size,
     get_dtype,
@@ -36,7 +37,6 @@ from lmcache.v1.gpu_connector.utils import (
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
-import lmcache.lmcache_native as lmcache_native
 
 if TYPE_CHECKING:
     # First Party
@@ -315,7 +315,7 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
         self.hidden_dim_size = get_hidden_dim_size(kv_caches, self.engine_kv_format)
         self.head_size = get_head_size(kv_caches, self.engine_kv_format)
-        self.use_mla = lmcache_native.is_mla(self.engine_kv_format)
+        self.use_mla = get_spec_class(self.engine_kv_format).is_mla
         self.dtype = get_dtype(kv_caches, self.engine_kv_format)
         self.num_heads = (
             1 if self.use_mla else get_num_heads(kv_caches, self.engine_kv_format)

--- a/lmcache/v1/gpu_connector/musa_connectors.py
+++ b/lmcache/v1/gpu_connector/musa_connectors.py
@@ -13,6 +13,7 @@ from lmcache.v1.gpu_connector.gpu_connectors import (
     GPUConnectorInterface,
     VLLMPagedMemGPUConnectorV2,
 )
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.gpu_connector.utils import (
     DiscoverableKVCache,
     LayoutHints,
@@ -471,7 +472,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             normalized_kv_caches, self.engine_kv_format
         )
         self.head_size = get_head_size(normalized_kv_caches, self.engine_kv_format)
-        self.use_mla = lmcache_native.is_mla(self.engine_kv_format)
+        self.use_mla = get_spec_class(self.engine_kv_format).is_mla
         self.dtype = get_dtype(normalized_kv_caches, self.engine_kv_format)
         self.num_heads = (
             1

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -246,7 +246,7 @@ def normalize_and_discover_per_layer_formats(
         whole_format, whole_normalized = detect_format(
             kv_caches, serving_engine, layout_hints
         )
-        if not lmcache_native.is_layer_list(whole_format):
+        if not get_spec_class(whole_format).is_layer_list:
             return whole_normalized, [whole_format] * get_num_layers(
                 whole_normalized, whole_format
             )
@@ -549,16 +549,17 @@ def resolve_block_stride_and_log_layout(
         # - SGL MHA: outer list is K/V (length 2), inner list is
         #   per-layer; K & V share shape/stride by construction.
         # - Other formats: ``kv_caches`` is already a per-layer list.
-        if lmcache_native.is_cross_layer(engine_kv_format):
+        spec = get_spec_class(engine_kv_format)
+        if spec.is_cross_layer:
             if not isinstance(kv_caches, torch.Tensor):
                 raise TypeError(
                     "Cross-layer EngineKVFormat expects a single backing "
                     f"torch.Tensor, got {type(kv_caches).__name__}."
                 )
             return kv_caches
-        if lmcache_native.is_kv_list(engine_kv_format):
+        if spec.is_kv_list:
             return kv_caches[0][layer_idx]  # type: ignore[index,return-value]
-        if lmcache_native.is_kv_second_tuple(engine_kv_format):
+        if spec.is_kv_second_tuple:
             return kv_caches[layer_idx][0]  # type: ignore[index,return-value]
         return kv_caches[layer_idx]  # type: ignore[index,return-value]
 
@@ -666,7 +667,7 @@ def make_page_buffer_shape_desc(
     desc.bs = block_size
     desc.nh = (
         1
-        if lmcache_native.is_mla(engine_kv_format)
+        if get_spec_class(engine_kv_format).is_mla
         else get_num_heads(kv_caches, engine_kv_format, layer_idx)
     )
     desc.hs = get_head_size(kv_caches, engine_kv_format, layer_idx)

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -104,6 +104,7 @@ def group_layers_by_identity(
             does not match ``engine_kv_formats``.
     """
     # First Party
+    from lmcache.v1.gpu_connector.kv_format import get_spec_class
     from lmcache.v1.gpu_connector.utils import (
         get_block_size,
         get_dtype,
@@ -133,7 +134,7 @@ def group_layers_by_identity(
         if engine_group_idx == EXCLUDED_ENGINE_GROUP:
             continue
         layer_format = engine_kv_formats[idx]
-        mla = lmcache_native.is_mla(layer_format)
+        mla = get_spec_class(layer_format).is_mla
         kv_size = 1 if mla else 2
         nh = 1 if mla else get_num_heads(kv_caches, layer_format, idx)
         hs = get_head_size(kv_caches, layer_format, idx)

--- a/lmcache/v1/platform/base/cache_context.py
+++ b/lmcache/v1/platform/base/cache_context.py
@@ -20,6 +20,7 @@ import array
 import torch
 
 # First Party
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.gpu_connector.utils import (
     get_attention_backend,
     get_concrete_engine_kv_shape_from_shape_desc,
@@ -330,7 +331,7 @@ class BaseCacheContext(ABC):
                     group.shape_desc, engine_kv_format
                 )
             ),
-            "is_mla": lmcache_native.is_mla(engine_kv_format),
+            "is_mla": get_spec_class(engine_kv_format).is_mla,
             "engine_kv_format": engine_kv_format.name,
             "engine_kv_shape": get_engine_kv_shape_description(engine_kv_format),
             "attention_backend": get_attention_backend(engine_kv_format),

--- a/lmcache/v1/platform/musa/device_ops.py
+++ b/lmcache/v1/platform/musa/device_ops.py
@@ -19,7 +19,8 @@ import ctypes
 import torch
 
 # First Party
-from lmcache.lmcache_native import EngineKVFormat, TransferDirection, is_kv_list
+from lmcache.lmcache_native import EngineKVFormat, TransferDirection
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.platform import torch_ops
 from lmcache.v1.platform.base.device_ops import DeviceOps
 from lmcache.v1.platform.musa import native_kv_transfer
@@ -212,7 +213,7 @@ def _reconstruct_paged_layers(
 ) -> _PagedLayers:
     """Normalize pointer-form paged operands to non-owning MUSA views."""
     expected_layers = int(shape_desc.nl)
-    separate_kv_lists = is_kv_list(engine_kv_format)
+    separate_kv_lists = get_spec_class(engine_kv_format).is_kv_list
     if separate_kv_lists:
         nested_layers = _kv_layer_lists(value)
         if nested_layers is not None:

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -26,9 +26,6 @@ from lmcache.lmcache_native import GPUKVFormat  # noqa: F401
 from lmcache.lmcache_native import (
     EngineKVFormat,
     TransferDirection,
-    is_cross_layer,
-    is_kv_list,
-    is_mla,
 )
 from lmcache.logging import init_logger
 from lmcache.v1.platform._device_detect import (
@@ -789,6 +786,21 @@ def _is_kv_second_tuple_format(engine_kv_format: EngineKVFormat) -> bool:
     return _format_spec(engine_kv_format).is_kv_second_tuple
 
 
+def _is_cross_layer_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when all layers live in one fused backing tensor."""
+    return _format_spec(engine_kv_format).is_cross_layer
+
+
+def _is_kv_list_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when keys and values are two separate top-level lists."""
+    return _format_spec(engine_kv_format).is_kv_list
+
+
+def _is_mla_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True for MLA layouts: one latent KV head, no separate K/V split."""
+    return _format_spec(engine_kv_format).is_mla
+
+
 _ELEMENT_SIZE_TO_DTYPE: dict[int, torch.dtype] = {
     # Maps the byte width of a KV-cache element to a representative torch dtype.
     # Only widths that commonly appear in KV caches are listed; 1-byte entries
@@ -928,7 +940,7 @@ def _normalize_paged_layers(
           per-layer tuple format (``NL_X_TWO_X_NB_BS_NH_HS``).
         - ``list[torch.Tensor]`` (per-layer) for all other formats.
     """
-    if is_cross_layer(engine_kv_format):
+    if _is_cross_layer_format(engine_kv_format):
         if isinstance(paged_buffer_ptrs_tensor, torch.Tensor):
             if _is_ptr_tensor(paged_buffer_ptrs_tensor):
                 # 1-D pointer tensor with a single entry → reconstruct full tensor.
@@ -953,7 +965,7 @@ def _normalize_paged_layers(
             "Cross-layer formats require a single torch.Tensor input; "
             "got: " + type(paged_buffer_ptrs_tensor).__name__
         )
-    if is_kv_list(engine_kv_format):
+    if _is_kv_list_format(engine_kv_format):
         if _is_ptr_tensor(paged_buffer_ptrs_tensor):
             # 1-D pointer tensor [K_L0,...,K_LN-1, V_L0,...,V_LN-1] → nested list.
             if shape_desc is None or device is None or dtype is None:
@@ -1096,7 +1108,7 @@ def _normalize_lmcache_objects(
         nh = int(shape_desc.nh)
         hs = int(shape_desc.hs)
         chunk_tokens = lmcache_chunk_size
-        if is_mla(engine_kv_format):
+        if _is_mla_format(engine_kv_format):
             chunk_shape: tuple[int, ...] = (nl, chunk_tokens, hs)
         elif _is_fused_kv_format(engine_kv_format):
             # Single plane: hs is the packed 2 * head_size.
@@ -1196,7 +1208,7 @@ def multi_layer_block_kv_transfer(
     blocks_per_object = lmcache_chunk_size // int(shape_desc.bs)
     block_size = int(shape_desc.bs)
 
-    if is_cross_layer(engine_kv_format):
+    if _is_cross_layer_format(engine_kv_format):
         _transfer_cross_layer(
             normalized,
             object_tensors,
@@ -1208,7 +1220,7 @@ def multi_layer_block_kv_transfer(
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif is_kv_list(engine_kv_format):
+    elif _is_kv_list_format(engine_kv_format):
         _transfer_sglang_mha(
             normalized,
             object_tensors,
@@ -1220,7 +1232,7 @@ def multi_layer_block_kv_transfer(
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif is_mla(engine_kv_format):
+    elif _is_mla_format(engine_kv_format):
         _transfer_per_layer_mla(
             normalized,
             object_tensors,

--- a/tests/v1/gpu_connector/test_blocks_first_cs_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_cs_kv_format.py
@@ -17,6 +17,7 @@ import torch
 from lmcache import device_ops, torch_device_type
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import utils as U
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.multiprocess.transfer_context.base import (
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
@@ -61,7 +62,7 @@ def test_accessors():
     # get_dtype is on the register_kv_caches -> group_layers_by_identity path,
     # so it must recognize this format too.
     assert U.get_dtype(norm, fmt) == _raw_blocks_first_caches()[0].dtype
-    assert not lmcache_native.is_mla(fmt)
+    assert not get_spec_class(fmt).is_mla
 
 
 def test_mp_gather_scatter_roundtrip():

--- a/tests/v1/gpu_connector/test_kv_format_classification.py
+++ b/tests/v1/gpu_connector/test_kv_format_classification.py
@@ -200,13 +200,26 @@ def test_structural_flags_partition_every_format():
 def test_removed_predicates_are_not_rebound():
     # The facts are spec-owned on the Python side; these bindings were dropped
     # from csrc/lmcache_native/pybind.cpp and must not come back.
-    for name in (
+    removed = (
         "is_cross_layer",
         "is_kv_list",
         "is_layer_list",
         "is_mla",
         "is_kv_second_tuple",
-    ):
+    )
+    for name in removed:
         assert not hasattr(lmcache_native, name), (
             f"lmcache_native.{name} is back; read the fact from the spec instead"
         )
+
+    # The .pyi stub is read by type checkers, not by Python at import time, so
+    # the module-level check above can't catch a declaration left behind
+    # there: mypy would keep accepting a call that raises AttributeError at
+    # runtime.
+    pyi_path = Path(lmcache_native.__file__).with_name("lmcache_native.pyi")
+    if pyi_path.is_file():
+        pyi_source = pyi_path.read_text()
+        for name in removed:
+            assert not re.search(rf"^def {name}\(", pyi_source, re.MULTILINE), (
+                f"lmcache_native.pyi still declares {name}; remove its stub too"
+            )

--- a/tests/v1/gpu_connector/test_kv_format_classification.py
+++ b/tests/v1/gpu_connector/test_kv_format_classification.py
@@ -1,15 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Golden tests for the ``EngineKVFormat`` classification predicates.
+"""Golden tests for the ``EngineKVFormat`` classification facts.
 
 The structural shape (``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list``)
 and the ``is_mla`` / ``is_kv_second_tuple`` modifiers are declared once per
-format on its :class:`KVFormatSpec` and mirrored for the device kernels in
-``csrc/engine_kv_format.h`` (reached via ``device_ops``). This file pins each
-format's classification, checks the two sides agree, and enforces that the
-three structural flags partition every format (exactly one is true), so a new
-format or an edit cannot silently break the contract the per-layer detection
-relies on.
+format on its :class:`KVFormatSpec`, which is the single owner every Python call
+site reads. The device kernels need the same facts at compile time, so
+``csrc/engine_kv_format.h`` carries a C++ copy of the table. This file pins each
+format's classification, parses the csrc table to check the two sides agree, and
+enforces that the three structural flags partition every format (exactly one is
+true), so a new format or an edit cannot silently break the contract the
+per-layer detection relies on.
 """
+
+# Standard
+from pathlib import Path
+import re
+
+# Third Party
+import pytest
 
 # First Party
 from lmcache.v1.gpu_connector.kv_format import get_spec_class
@@ -54,8 +62,8 @@ EXPECTED = {
     F.NL_X_NB_BSV_BSS: (False, False, True, True, False),
 }
 
-# Facts that only the spec carries (no native predicate mirrors them):
-# (is_hnd, is_fused_packed, is_two_major, is_pbs_fused) per format.
+# Facts that no device kernel branches on, so csrc declares them without a
+# predicate: (is_hnd, is_fused_packed, is_two_major, is_pbs_fused) per format.
 EXPECTED_SPEC_FACTS = {
     F.NB_NL_TWO_BS_NH_HS: (False, False, False, False),
     F.NB_NL_TWO_NH_BS_HS: (True, False, False, False),
@@ -77,26 +85,62 @@ EXPECTED_SPEC_FACTS = {
 }
 
 
+# Every fact the two sides declare, in FormatFacts / KVFormatSpec order.
+ALL_FACT_NAMES = (
+    "is_cross_layer",
+    "is_kv_list",
+    "is_layer_list",
+    "is_mla",
+    "is_hnd",
+    "is_fused_packed",
+    "is_two_major",
+    "is_pbs_fused",
+    "is_kv_second_tuple",
+)
+
+CSRC_HEADER = Path(__file__).resolve().parents[3] / "csrc" / "engine_kv_format.h"
+
+_CASE_RE = re.compile(r"case EngineKVFormat::(\w+):")
+_SETTER_RE = re.compile(r"facts\.(\w+) = true;")
+
+
 def _all_formats():
     return [v for v in vars(F).values() if isinstance(v, F)]
 
 
+def _csrc_format_facts() -> dict[str, set[str]]:
+    """Parse the ``format_facts`` switch in ``csrc/engine_kv_format.h``.
+
+    Returns:
+        Format enum name -> the set of fact names csrc sets to true for it.
+        A format whose case body sets nothing maps to an empty set.
+    """
+    switch_body = CSRC_HEADER.read_text().split(
+        "constexpr FormatFacts format_facts(", 1
+    )[1]
+    facts: dict[str, set[str]] = {}
+    # One case body may be shared by several fall-through labels.
+    labels: list[str] = []
+    for raw_line in switch_body.splitlines():
+        line = raw_line.strip()
+        case_match = _CASE_RE.fullmatch(line)
+        if case_match:
+            labels.append(case_match.group(1))
+            facts.setdefault(case_match.group(1), set())
+            continue
+        setter_match = _SETTER_RE.fullmatch(line)
+        if setter_match:
+            for label in labels:
+                facts[label].add(setter_match.group(1))
+        elif line == "break;":
+            labels = []
+        elif line.startswith("default:"):
+            break
+    return facts
+
+
 def test_classification_matches_golden():
     for fmt, expected in EXPECTED.items():
-        got = (
-            lmcache_native.is_cross_layer(fmt),
-            lmcache_native.is_kv_list(fmt),
-            lmcache_native.is_layer_list(fmt),
-            lmcache_native.is_mla(fmt),
-            lmcache_native.is_kv_second_tuple(fmt),
-        )
-        assert got == expected, f"{fmt}: got {got}, expected {expected}"
-
-
-def test_spec_facts_match_predicates():
-    # The spec is the Python-side owner of the facts; on a native build the
-    # predicates come from csrc, so this pins the two copies together.
-    for fmt in _all_formats():
         spec = get_spec_class(fmt)
         got = (
             spec.is_cross_layer,
@@ -105,14 +149,31 @@ def test_spec_facts_match_predicates():
             spec.is_mla,
             spec.is_kv_second_tuple,
         )
-        expected = (
-            lmcache_native.is_cross_layer(fmt),
-            lmcache_native.is_kv_list(fmt),
-            lmcache_native.is_layer_list(fmt),
-            lmcache_native.is_mla(fmt),
-            lmcache_native.is_kv_second_tuple(fmt),
+        assert got == expected, f"{fmt}: got {got}, expected {expected}"
+
+
+@pytest.mark.skipif(
+    not CSRC_HEADER.is_file(), reason="csrc sources absent (installed package)"
+)
+def test_spec_facts_match_csrc_table():
+    # The spec owns the facts for Python; csrc keeps a C++ copy the device
+    # kernels compile against. Nothing at runtime crosses the two, so pin them
+    # here: a fact set on one side only would silently split the transfer path
+    # (Python) from the kernel (csrc).
+    csrc_facts = _csrc_format_facts()
+    assert csrc_facts.keys() == {fmt.name for fmt in _all_formats()}, (
+        "csrc format_facts and the EngineKVFormat enum list different formats"
+    )
+    drifted = {
+        fmt.name: (
+            sorted({name for name in ALL_FACT_NAMES if getattr(spec, name)}),
+            sorted(csrc_facts[fmt.name]),
         )
-        assert got == expected, f"{fmt}: spec {got}, native {expected}"
+        for fmt, spec in ((fmt, get_spec_class(fmt)) for fmt in _all_formats())
+        if {name for name in ALL_FACT_NAMES if getattr(spec, name)}
+        != csrc_facts[fmt.name]
+    }
+    assert not drifted, f"spec vs csrc facts drift (spec, csrc): {drifted}"
 
 
 def test_spec_only_facts_match_golden():
@@ -131,9 +192,21 @@ def test_every_format_is_pinned():
 def test_structural_flags_partition_every_format():
     # Exactly one structural shape is true for every format.
     for fmt in _all_formats():
-        structural = (
-            lmcache_native.is_cross_layer(fmt),
-            lmcache_native.is_kv_list(fmt),
-            lmcache_native.is_layer_list(fmt),
-        )
+        spec = get_spec_class(fmt)
+        structural = (spec.is_cross_layer, spec.is_kv_list, spec.is_layer_list)
         assert sum(structural) == 1, f"{fmt}: structural flags {structural}"
+
+
+def test_removed_predicates_are_not_rebound():
+    # The facts are spec-owned on the Python side; these bindings were dropped
+    # from csrc/lmcache_native/pybind.cpp and must not come back.
+    for name in (
+        "is_cross_layer",
+        "is_kv_list",
+        "is_layer_list",
+        "is_mla",
+        "is_kv_second_tuple",
+    ):
+        assert not hasattr(lmcache_native, name), (
+            f"lmcache_native.{name} is back; read the fact from the spec instead"
+        )

--- a/tests/v1/gpu_connector/test_kv_format_specs.py
+++ b/tests/v1/gpu_connector/test_kv_format_specs.py
@@ -321,9 +321,9 @@ def test_data_ptrs_shape(case):
     kv = _build(name)
     spec = get_spec(kv, fmt)
     ptrs = spec.data_ptrs(list(range(NL)))
-    if lmcache_native.is_cross_layer(fmt):
+    if get_spec_class(fmt).is_cross_layer:
         assert len(ptrs) == 1, name  # single base pointer
-    elif lmcache_native.is_kv_list(fmt):
+    elif get_spec_class(fmt).is_kv_list:
         assert len(ptrs) == 2 * NL, name  # K's then V's
     else:
         assert len(ptrs) == NL, name  # one per layer

--- a/tests/v1/gpu_connector/test_per_layer_kv_tuple_format.py
+++ b/tests/v1/gpu_connector/test_per_layer_kv_tuple_format.py
@@ -21,6 +21,7 @@ import torch
 # First Party
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import utils as U
+from lmcache.v1.gpu_connector.kv_format import get_spec_class
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.transfer_context.base import compute_kv_layout
@@ -67,7 +68,7 @@ def test_accessors() -> None:
     assert U.get_tokens_per_layer(norm, fmt) == NB * BS
     assert U.get_elements_per_layer(norm, fmt) == NB * BS * NH * HS * 2
     assert U.get_dtype(norm, fmt) == torch.float32
-    assert not lmc_ops.is_mla(fmt)
+    assert not get_spec_class(fmt).is_mla
 
 
 def test_group_data_ptrs_interleaved_kv_order() -> None:

--- a/tests/v1/platform/test_device_ops.py
+++ b/tests/v1/platform/test_device_ops.py
@@ -287,10 +287,6 @@ def test_package_exports_resolved_device_ops() -> None:
         "TransferDirection",
         "EngineKVFormat",
         "GPUKVFormat",
-        "is_cross_layer",
-        "is_kv_list",
-        "is_layer_list",
-        "is_mla",
     )
     for name in native_only_names:
         assert not hasattr(device_ops, name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4063

A KV format's structural facts lived twice: as predicates in
`csrc/engine_kv_format.h`, mirrored to Python through five `lmcache_native`
pybind bindings. Adding a format meant editing the enum, tagging the new member
in the facts table, *and* hunting down every `lmcache_native.is_*(fmt)` call
site — one format's facts smeared across a central header.

`KVFormatSpec` already declares all nine facts as class attributes and the
registry already maps a format to its spec, so this moves every Python read onto
the spec and drops the bindings:

- **11 call sites** (`gpu_connector/utils.py`, `platform/torch_ops.py`,
  `platform/musa/device_ops.py`, `platform/base/cache_context.py`,
  `gpu_connector/{hpu_connector,musa_connectors}.py`, `kv_layer_groups.py`,
  `sdk/context.py`) now read `get_spec_class(fmt).is_*`. `torch_ops` gains
  `_is_cross_layer_format` / `_is_kv_list_format` / `_is_mla_format` next to its
  existing spec-backed `_is_hnd_format` / `_is_fused_kv_format` / … helpers.
  This also covers the `is_mla` in `describe`'s kernel-group report, which the
  issue called out — it comes from `cache_context.py`.
- **Bindings removed** from `csrc/lmcache_native/pybind.cpp` (all five), and the
  four predicates with **no kernel caller** (`is_cross_layer`, `is_kv_list`,
  `is_layer_list`, `is_kv_second_tuple`) removed from
  `csrc/engine_kv_format.h`. `is_mla` and `is_fused_packed` stay — the CUDA and
  SYCL kernels compile them. The `FormatFacts` fields all stay, so the table
  remains a 1:1 mirror of the specs.

Nothing at runtime crosses the two copies of the table any more, so
`test_kv_format_classification.py` now parses the csrc `format_facts` switch and
pins it against the specs **for all nine facts**. That is a wider guard than the
five-predicate comparison it replaces: a fact set on one side only would
silently split the Python transfer path from the kernel.

**That new guard caught a real drift**: csrc did not set `is_pbs_fused` for
`TWO_X_NL_X_NBBS_NH_HS`, although the spec — and the format name's fused `NBBS`
axis — says it is fused. No C++ reads that field today, so nothing miscomputes
yet; fixed in the same table.

**Special notes for your reviewers**:

- **Deliberately out of scope**: the issue's bonus suggestion to turn the
  `if/elif` chain in `multi_layer_block_kv_transfer` into spec polymorphism.
  That moves transfer behaviour, not just fact ownership — happy to do it as a
  follow-up.
- **The one place I'd like your call**: the issue asked to drop `is_mla`'s
  Python binding too, which removes the old spec-vs-csrc pin. I replaced it with
  the header-parsing test rather than lose the drift guard, since a `is_mla`
  disagreement between the spec (Python transfer path) and the header (kernels)
  would be a silent correctness bug. If you'd rather not parse C++ from a test,
  the alternative is to keep the single `is_mla` binding purely as the test's
  mirror — say the word and I'll switch.
- Unrelated observation while checking kernel callers: `csrc/cuda/mem_kernels.cu`
  defines its own `lmc::is_hnd` listing only `NL_X_TWO_NB_NH_BS_HS` and
  `NL_X_NB_TWO_NH_BS_HS`, while the facts table marks five formats `is_hnd`. Left
  untouched here; flagging in case it is not intentional.
- Verified locally on a CPU-only build (`NO_GPU_EXT=1`, macOS/arm64, Python 3.12,
  torch 2.14): `pytest tests/v1/gpu_connector tests/v1/platform
  tests/v1/lmcache_native tests/sdk tests/v1/cli tests/cli
  tests/v1/test_kv_layer_groups_manager.py tests/v1/test_gpu_connector.py
  tests/v1/test_kv_cache_groups.py tests/v1/test_vllm_kv_cache_groups.py
  tests/v1/test_blocks_first_group_construction.py tests/v1/test_xpu_connector.py`
  → **1588 passed, 98 skipped**. `ruff check` / `ruff format` / `isort` /
  `codespell` clean on the changed files. The C++ extension rebuilds. Two
  pre-existing local failures are unrelated and reproduce on a clean `dev`
  checkout: `test_periodic_event_notifier.py::TestInterval::test_set_interval_ms`
  (timing-sensitive) and 20 `mypy` `list`-invariance errors in
  `hpu_connector.py` / `torch_ops.py` (identical count before and after this
  change). The CUDA/SYCL kernel paths need CI hardware.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
