### PR TITLE
feat(vllm): publish MP connector KV events

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -8,6 +8,12 @@ import sys
 
 # Third Party
 from vllm.config import VllmConfig
+from vllm.distributed.kv_events import (
+    BlockStored,
+    KVCacheEvent,
+    KVConnectorKVEvents,
+    KVEventAggregator,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
@@ -27,6 +33,7 @@ except ImportError:
 
 # Third Party
 from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import RequestStatus
@@ -93,7 +100,6 @@ except ImportError:
 
 if TYPE_CHECKING:
     # Third Party
-    from vllm.distributed.kv_events import KVCacheEvent
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
         KVConnectorStats,
@@ -110,6 +116,49 @@ logger = lmcache_init_logger(__name__)
 
 _DCP_LAYOUT_NAMESPACE = "##lmcache-dcp-layout-v1-"
 _MAX_LCM_EXPANSION_FACTOR = 4
+
+
+def _convert_kv_event_hash(block_hash: bytes | int | None) -> bytes | int | None:
+    """Convert LMCache event hashes to vLLM's configured external format."""
+    if isinstance(block_hash, bytes):
+        return maybe_convert_block_hash(BlockHash(block_hash))
+    return block_hash
+
+
+class LMCacheMPKVEvents(KVConnectorKVEvents):
+    """KV event container used by LMCache multiprocess workers."""
+
+    def __init__(self, num_workers: int) -> None:
+        self._aggregator = KVEventAggregator(num_workers)
+
+    def add_events(self, events: list[KVCacheEvent]) -> None:
+        """Add events from one worker."""
+        self._aggregator.add_events(events)
+
+    def aggregate(self) -> "LMCacheMPKVEvents":
+        """Retain only events seen from every contributing worker."""
+        common_events = self._aggregator.get_common_events()
+        self._aggregator.clear_events()
+        self._aggregator.add_events(common_events)
+        self._aggregator.reset_workers()
+        return self
+
+    def increment_workers(self, count: int = 1) -> None:
+        """Track an additional worker contribution."""
+        self._aggregator.increment_workers(count)
+
+    def get_all_events(self) -> list[KVCacheEvent]:
+        """Return all buffered events."""
+        return self._aggregator.get_all_events()
+
+    def get_number_of_workers(self) -> int:
+        """Return the number of contributing workers."""
+        return self._aggregator.get_number_of_workers()
+
+    def clear_events(self) -> None:
+        """Clear buffered events and reset the worker count."""
+        self._aggregator.clear_events()
+        self._aggregator.reset_workers()
 
 
 # Helper functions
@@ -491,6 +540,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         assert vllm_config.kv_transfer_config is not None
 
+        self._enable_kv_events = bool(
+            getattr(vllm_config, "kv_events_config", None) is not None
+            and vllm_config.kv_events_config.enable_kv_cache_events
+        )
+
         self._eager_prefetch: bool = bool(
             vllm_config.kv_transfer_config.get_from_extra_config(
                 "lmcache.mp.eager_prefetch", False
@@ -594,6 +648,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+            self._kv_cache_events: LMCacheMPKVEvents | None = None
 
             # GPU block pool reference
             self._gpu_block_pool: "BlockPool | None" = None
@@ -619,6 +674,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
+                enable_kv_events=self._enable_kv_events,
             )
             if self.transfer_intermediate_tensors:
                 # First Party
@@ -943,6 +999,38 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         return self.worker_adapter.get_block_ids_with_load_errors()
 
+    def get_kv_connector_kv_cache_events(self) -> LMCacheMPKVEvents | None:
+        """Return worker-side KV cache events collected since the last step.
+
+        Returns:
+            A vLLM KV event container with completed LMCache store events, or
+            None when disabled or when no store completed.
+        """
+        if not self._enable_kv_events:
+            return None
+        events = self.worker_adapter.get_kv_events()
+        if not events:
+            return None
+
+        blocks = [
+            BlockStored(
+                block_hashes=[
+                    _convert_kv_event_hash(block_hash)
+                    for block_hash in event.block_hashes
+                ],
+                parent_block_hash=_convert_kv_event_hash(event.parent_block_hash),
+                token_ids=event.token_ids,
+                lora_id=event.lora_id,
+                block_size=event.block_size,
+                medium=event.medium,
+                lora_name=event.lora_name,
+            )
+            for event in events
+        ]
+        kv_events = LMCacheMPKVEvents(num_workers=1)
+        kv_events.add_events(blocks)
+        return kv_events
+
     def shutdown(self):
         """
         Shutdown the connector. This is called when the worker process
@@ -1231,6 +1319,16 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             connector_output (KVConnectorOutput): the worker-side
                 connectors output.
         """
+        kv_cache_events = connector_output.kv_cache_events
+        if kv_cache_events and isinstance(kv_cache_events, LMCacheMPKVEvents):
+            if self._kv_cache_events is None:
+                self._kv_cache_events = kv_cache_events
+            else:
+                self._kv_cache_events.add_events(kv_cache_events.get_all_events())
+                self._kv_cache_events.increment_workers(
+                    kv_cache_events.get_number_of_workers()
+                )
+
         if not self.lazy_offload:
             return
         if not self._gpu_block_pool:
@@ -1314,7 +1412,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         Yields:
             New KV cache events since the last call.
         """
-        return ()
+        if self._kv_cache_events is not None:
+            self._kv_cache_events.aggregate()
+            yield from self._kv_cache_events.get_all_events()
+            self._kv_cache_events.clear_events()
+            self._kv_cache_events = None
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -20,7 +20,12 @@ from lmcache import torch_dev
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
 from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.utils import vllm_layout_hints
-from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
+from lmcache.utils import (
+    CacheStoreEvent,
+    EngineType,
+    _lmcache_nvtx_annotate,
+    init_logger,
+)
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
@@ -31,6 +36,7 @@ from lmcache.v1.multiprocess.group_view import (
     expand_engine_block_ids,
 )
 from lmcache.v1.multiprocess.mq import MessagingFuture
+from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.multiprocess.transfer_context import (
     EngineDrivenTransferContext,
     TransferContext,
@@ -75,6 +81,9 @@ class ExtraConfigDefault(enum.Enum):
     # lmcache/v1/platform/isolated_ipc.py. Must match the LMCache server's
     # ``--isolated-ipc`` setting.
     isolated_ipc = False
+    # Must match the MP server's --hash-algorithm setting because KV events
+    # expose the same chunk hashes used by server-side object keys.
+    hash_algorithm = "blake3"
 
 
 # Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
@@ -1149,6 +1158,7 @@ class LMCacheMPWorkerAdapter:
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         extra_config: dict[str, Any] | None = None,
+        enable_kv_events: bool = False,
     ):
         """Initialize the worker adapter for current or legacy vLLM callers.
 
@@ -1169,6 +1179,8 @@ class LMCacheMPWorkerAdapter:
             extra_config: Optional dict with keys starting with
                 ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
                 provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
+            enable_kv_events: Whether to collect completed store operations
+                for vLLM's KV event publisher.
 
         Raises:
             TypeError: If the connector argument shape is unsupported.
@@ -1179,10 +1191,12 @@ class LMCacheMPWorkerAdapter:
             legacy_block_size,
             mq_timeout,
         )
+        hash_algorithm = ExtraConfigDefault.hash_algorithm.value
         if extra_config is not None:
             cfg = _resolve_extra_config(extra_config)
             mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
             heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+            hash_algorithm = cfg[ExtraConfigDefault.hash_algorithm.name]
             # Only treat ``mp_transfer_mode`` as an explicit override when
             # the user actually set it in extra_config; otherwise leave it
             # as ``None`` so ``create_transfer_context`` can still consult
@@ -1256,6 +1270,17 @@ class LMCacheMPWorkerAdapter:
             self.req_client.close()
             _raise_server_unreachable(server_url, self._mq_timeout)
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
+        self._kv_events_enabled = enable_kv_events
+        self._kv_event_hasher = (
+            TokenHasher(
+                chunk_size=lmcache_tokens_per_chunk,
+                hash_algorithm=hash_algorithm,
+            )
+            if enable_kv_events
+            else None
+        )
+        self._pending_store_kv_events: dict[str, list[CacheStoreEvent]] = {}
+        self._kv_events: list[CacheStoreEvent] = []
         if lmcache_tokens_per_chunk % vllm_block_size != 0:
             raise ValueError(
                 f"LMCache chunk size {lmcache_tokens_per_chunk} must be a "
@@ -1588,6 +1613,10 @@ class LMCacheMPWorkerAdapter:
         self.store_futures[request_id] = future
         if event is not None:
             self.store_events[request_id] = event
+        if self._kv_events_enabled:
+            self._pending_store_kv_events.setdefault(request_id, []).extend(
+                self._build_store_kv_events(key)
+            )
 
     @_lmcache_nvtx_annotate
     def submit_retrieve_request(
@@ -1809,6 +1838,7 @@ class LMCacheMPWorkerAdapter:
             self.retrieve_futures.clear()
             self.store_events.clear()
             self.retrieve_events.clear()
+            self._pending_store_kv_events.clear()
 
             # Retrieves dropped at submit time still must be reported,
             # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
@@ -1840,10 +1870,15 @@ class LMCacheMPWorkerAdapter:
             finished_stores.add(request_id)
 
             if not s_result:
+                self._pending_store_kv_events.pop(request_id, None)
                 logger.error(
                     "Something went wrong when processing the "
                     "store request for request_id=%s",
                     request_id,
+                )
+            else:
+                self._kv_events.extend(
+                    self._pending_store_kv_events.pop(request_id, [])
                 )
 
         for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
@@ -1937,6 +1972,7 @@ class LMCacheMPWorkerAdapter:
             self.retrieve_futures.clear()
             self.store_events.clear()
             self.retrieve_events.clear()
+            self._pending_store_kv_events.clear()
 
             # Retrieves dropped at submit time still must be reported,
             # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
@@ -1961,10 +1997,15 @@ class LMCacheMPWorkerAdapter:
             finished_stores.add(request_id)
 
             if not s_result:
+                self._pending_store_kv_events.pop(request_id, None)
                 logger.error(
                     "Something went wrong when processing the "
                     "store request for request_id=%s",
                     request_id,
+                )
+            else:
+                self._kv_events.extend(
+                    self._pending_store_kv_events.pop(request_id, [])
                 )
 
         for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
@@ -2024,6 +2065,20 @@ class LMCacheMPWorkerAdapter:
         self._completed_store_requests = {}
         return completed_store_requests
 
+    def get_kv_events(self) -> list[CacheStoreEvent]:
+        """Return completed store events since the last call.
+
+        Returns:
+            A list of LMCache cache-store events for stores that completed
+            successfully. Returns an empty list when KV events are disabled or
+            no new store completed.
+        """
+        if not self._kv_events_enabled or not self._kv_events:
+            return []
+        events = self._kv_events
+        self._kv_events = []
+        return events
+
     def num_blocks_per_chunk(self) -> int:
         """
         Returns:
@@ -2058,6 +2113,47 @@ class LMCacheMPWorkerAdapter:
         self.transfer_ctx.flush_inflight_stores()
         # Force device sync here, compare to preemption, perf panelty is trivial
         torch_dev.synchronize()
+
+    def _build_store_kv_events(
+        self,
+        key: IPCCacheServerKey,
+    ) -> list[CacheStoreEvent]:
+        """Build LMCache cache-store events for a submitted store key."""
+        if self._kv_event_hasher is None:
+            return []
+
+        token_ids = list(key.token_ids)
+        chunk_size = self.lmcache_tokens_per_chunk
+        hashes = self._kv_event_hasher.compute_chunk_hashes(
+            token_ids,
+            end=key.end,
+        )
+        start_chunk = key.start // chunk_size
+        end_chunk = key.end // chunk_size
+        if start_chunk >= end_chunk:
+            return []
+
+        events = []
+        parent_hash = hashes[start_chunk - 1] if start_chunk > 0 else None
+        for chunk_idx, block_hash in enumerate(
+            hashes[start_chunk:end_chunk],
+            start=start_chunk,
+        ):
+            start = chunk_idx * chunk_size
+            end = start + chunk_size
+            events.append(
+                CacheStoreEvent(
+                    block_hashes=[block_hash],
+                    parent_block_hash=parent_hash,
+                    token_ids=token_ids[start:end],
+                    block_size=chunk_size,
+                    lora_id=None,
+                    medium="cpu",
+                    lora_name=None,
+                )
+            )
+            parent_hash = block_hash
+        return events
 
     def shutdown(self) -> None:
         """

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -658,8 +658,8 @@ class LayerCacheEngineKey(CacheEngineKey):
 
 @dataclass
 class CacheStoreEvent:
-    block_hashes: list[int]
-    parent_block_hash: int | None
+    block_hashes: list[int | bytes]
+    parent_block_hash: int | bytes | None
     token_ids: list[int]
     block_size: int
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -4,7 +4,7 @@ stubbed (see ``fake_adapter``); no GPU or live server needed. End-to-end
 recovery: ``.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh``."""
 
 # Standard
-from typing import Callable, ClassVar
+from typing import Any, Callable, ClassVar
 from unittest.mock import MagicMock
 import gc
 import os
@@ -96,6 +96,7 @@ class FakeHeartbeatThread:
 
 def _make_worker_adapter(
     extra_config: dict[str, object] | None = None,
+    enable_kv_events: bool = False,
 ) -> LMCacheMPWorkerAdapter:
     """Construct a worker adapter with the standard test arguments; the
     network boundary must already be patched (see ``fake_adapter``).
@@ -116,6 +117,7 @@ def _make_worker_adapter(
         parallel_strategy=parallel_strategy,
         mq_timeout=5.0,
         extra_config=extra_config,
+        enable_kv_events=enable_kv_events,
     )
 
 
@@ -335,6 +337,111 @@ def test_submit_store_request_expands_block_ids_to_views(fake_adapter, monkeypat
         [0, 1],
         [10, 11],
     ]
+
+
+def test_store_kv_events_are_reported_after_successful_store(
+    fake_adapter,
+    monkeypatch,
+):
+    """Completed MP stores are exposed once as LMCache cache-store events."""
+    # First Party
+    from lmcache.v1.multiprocess.token_hasher import TokenHasher
+
+    adapter = _make_worker_adapter(enable_kv_events=True)
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    transfer_ctx = MagicMock()
+    store_future = MagicMock()
+    store_future.query.return_value = True
+    store_future.result.return_value = True
+    transfer_ctx.submit_store.return_value = store_future
+    adapter.transfer_ctx = transfer_ctx
+
+    chunk_size = adapter.lmcache_tokens_per_chunk
+    token_ids = list(range(chunk_size * 2))
+    op = LoadStoreOp(
+        token_ids=token_ids,
+        block_ids=[[1]],
+        start=chunk_size,
+        end=chunk_size * 2,
+    )
+    adapter.submit_store_request("req-1", op, event=None)
+
+    assert adapter.get_kv_events() == []
+
+    adapter.get_finished({"req-1"})
+    events = adapter.get_kv_events()
+    expected_hashes = TokenHasher(chunk_size=chunk_size).compute_chunk_hashes(
+        token_ids,
+        end=chunk_size * 2,
+    )
+
+    assert len(events) == 1
+    assert events[0].block_hashes == [expected_hashes[1]]
+    assert events[0].parent_block_hash == expected_hashes[0]
+    assert events[0].token_ids == token_ids[chunk_size : chunk_size * 2]
+    assert events[0].block_size == chunk_size
+    assert events[0].medium == "cpu"
+    assert adapter.get_kv_events() == []
+
+
+def test_store_kv_events_are_discarded_after_failed_store(
+    fake_adapter,
+    monkeypatch,
+):
+    """Failed MP stores must not emit cache-store events."""
+    adapter = _make_worker_adapter(enable_kv_events=True)
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    transfer_ctx = MagicMock()
+    store_future = MagicMock()
+    store_future.query.return_value = True
+    store_future.result.return_value = False
+    transfer_ctx.submit_store.return_value = store_future
+    adapter.transfer_ctx = transfer_ctx
+
+    chunk_size = adapter.lmcache_tokens_per_chunk
+    op = LoadStoreOp(
+        token_ids=list(range(chunk_size)),
+        block_ids=[[0]],
+        start=0,
+        end=chunk_size,
+    )
+    adapter.submit_store_request("req-1", op, event=None)
+
+    adapter.get_finished({"req-1"})
+
+    assert adapter.get_kv_events() == []
+
+
+def test_store_kv_events_use_hash_algorithm_extra_config(
+    fake_adapter,
+    monkeypatch,
+):
+    """KV event hashes use the hash algorithm configured for the MP server."""
+    captured: dict[str, object] = {}
+
+    class FakeTokenHasher:
+        def __init__(self, chunk_size: int, hash_algorithm: str) -> None:
+            captured["chunk_size"] = chunk_size
+            captured["hash_algorithm"] = hash_algorithm
+
+        def compute_chunk_hashes(
+            self,
+            token_ids: list[int],
+            end: int | None = None,
+        ) -> list[bytes]:
+            return [b"hash"]
+
+    monkeypatch.setattr(adapter_mod, "TokenHasher", FakeTokenHasher)
+
+    adapter = _make_worker_adapter(
+        extra_config={"lmcache.mp.hash_algorithm": "builtin"},
+        enable_kv_events=True,
+    )
+
+    assert captured == {
+        "chunk_size": adapter.lmcache_tokens_per_chunk,
+        "hash_algorithm": "builtin",
+    }
 
 
 def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatch):
@@ -631,6 +738,100 @@ def test_failed_full_retrieve_is_recomputed_instead_of_retried_remotely() -> Non
     blocks.get_block_ids.return_value = ([7],)
     connector.update_state_after_alloc(request, blocks, num_external_tokens=0)
     assert tracker.state == LMCacheMPRequestState.READY
+
+
+def test_connector_converts_worker_kv_events_to_vllm_events() -> None:
+    """Worker LMCache events are wrapped in vLLM's KV event container."""
+    kv_events_mod = pytest.importorskip(
+        "vllm.distributed.kv_events",
+        exc_type=ModuleNotFoundError,
+    )
+    BlockStored = kv_events_mod.BlockStored
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector
+    from lmcache.utils import CacheStoreEvent
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector._enable_kv_events = True
+    connector.worker_adapter = MagicMock()
+    connector.worker_adapter.get_kv_events.return_value = [
+        CacheStoreEvent(
+            block_hashes=[b"hash-1"],
+            parent_block_hash=None,
+            token_ids=[1, 2, 3, 4],
+            block_size=4,
+            lora_id=None,
+            medium="cpu",
+            lora_name=None,
+        )
+    ]
+
+    kv_events = connector.get_kv_connector_kv_cache_events()
+
+    assert kv_events is not None
+    events = kv_events.get_all_events()
+    assert len(events) == 1
+    assert isinstance(events[0], BlockStored)
+    assert events[0].token_ids == [1, 2, 3, 4]
+    assert events[0].block_size == 4
+    assert events[0].medium == "cpu"
+
+
+def test_connector_take_events_aggregates_and_drains_once() -> None:
+    """Scheduler-side ``take_events`` publishes common worker events once."""
+    kv_events_mod = pytest.importorskip(
+        "vllm.distributed.kv_events",
+        exc_type=ModuleNotFoundError,
+    )
+    BlockStored = kv_events_mod.BlockStored
+
+    # Third Party
+    from vllm.v1.outputs import KVConnectorOutput
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        LMCacheMPConnector,
+        LMCacheMPKVEvents,
+    )
+
+    def make_container(*events: Any) -> LMCacheMPKVEvents:
+        container = LMCacheMPKVEvents(num_workers=1)
+        container.add_events(list(events))
+        return container
+
+    common = BlockStored(
+        block_hashes=[b"common"],
+        parent_block_hash=None,
+        token_ids=[1, 2, 3, 4],
+        block_size=4,
+        lora_id=None,
+        medium="cpu",
+        lora_name=None,
+    )
+    worker_only = BlockStored(
+        block_hashes=[b"worker-only"],
+        parent_block_hash=None,
+        token_ids=[5, 6, 7, 8],
+        block_size=4,
+        lora_id=None,
+        medium="cpu",
+        lora_name=None,
+    )
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector._kv_cache_events = None
+    connector.lazy_offload = False
+
+    connector.update_connector_output(
+        KVConnectorOutput(kv_cache_events=make_container(common, worker_only))
+    )
+    connector.update_connector_output(
+        KVConnectorOutput(kv_cache_events=make_container(common))
+    )
+
+    assert list(connector.take_events()) == [common]
+    assert list(connector.take_events()) == []
 
 
 def test_instance_id_is_uuid_derived_63_bit_int(fake_adapter) -> None:


### PR DESCRIPTION
**Summary**

vLLM drains connector-side KV cache lifecycle events through `KVConnectorBase_V1.take_events()`. The in-process LMCache connector already feeds that path, but `LMCacheMPConnector.take_events()` returned empty. As a result, when vLLM KV cache events were enabled, LMCache MP store completions were invisible to vLLM's connector event pipeline even though the MP cache itself could still store and retrieve KV correctly.

This PR wires LMCache MP into that existing vLLM path:
- worker adapters collect LMCache `CacheStoreEvent` records only after store futures complete successfully;
- failed stores and degraded-mode drains discard pending event records;
- the connector converts worker events to vLLM `BlockStored` events and respects vLLM's external block-hash format;
- scheduler-side `update_connector_output()` aggregates worker event containers and `take_events()` drains them once;
- `CacheStoreEvent` accepts both `int` and `bytes` hashes, matching current MP `TokenHasher` object-key hashes.

**Benefits / why this is useful**

This is not required for the basic LMCache MP data path: KV store and retrieve can work without these events. It is needed when a deployment enables vLLM KV cache events and expects LMCache MP to participate in the same observability / routing signal path as other connectors.

With this API implemented, downstream consumers can see which prefix chunks were successfully stored by LMCache MP instead of treating the MP connector as an event-silent cache. That helps KV-aware routers, cache-aware debugging, and external observability pipelines make decisions from completed store signals rather than only request logs or LMCache server-side metrics.

**Useful scenarios**

- vLLM deployments using `enable_kv_cache_events` with LMCache MP and a KV-aware router.
- Multi-worker serving where only store events seen by all contributing workers should be published.
- Debugging or tracing cache warmup behavior, especially when distinguishing successful stores from failed or dropped store attempts.
- Aligning LMCache MP with the existing in-process LMCache connector behavior for vLLM's connector event API.

**Scope / non-goals**

This PR emits successful store events (`BlockStored`) only. Eviction / `BlockRemoved` events are still better handled by the MP coordinator or a follow-up server-side signal because the connector does not currently observe server-side eviction decisions.

For non-default MP server hashing, set the connector extra config `lmcache.mp.hash_algorithm` to match the server's `--hash-algorithm`; the default remains `blake3` on both sides.

**Duplicate-work check**

Checked current open PRs for `take_events`, `kv events`, `KVCacheEvent`, `BlockStored`, and `lmcache_mp_connector`.

Related open PRs:
- #4768 and #3938 are coordinator / observability ZMQ event publishers for router ingestion.
- This PR is intentionally narrower and connector-side only: it makes vLLM's own `LMCacheMPConnector.take_events()` path report successful MP stores.

**AI assistance**

AI assistance was used to prepare this change.

**Tests**

```bash
.venv/bin/python -m pytest tests/v1/test_vllm_mp_adapter.py -q
SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files
```

Results:
- `43 passed, 3 skipped` for `tests/v1/test_vllm_mp_adapter.py`; the skipped tests require full vLLM KV-event imports in the local env.
- Full pre-commit passed with Rust hooks skipped on macOS.
- GitHub checks are passing, including Code Quality, Python tests, CPU Device tests, DCO, CodeQL, and Buildkite `k3-unit-tests`.

No model eval was run because this change does not affect model output, decoding, scoring, or serving semantics; it only publishes connector KV cache lifecycle events after successful MP stores.
