### PR TITLE
feat: Add DSA (Deepseek Sparse Attention) indexer support for SGLang

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -24,7 +24,6 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
     DEFAULT_MQ_TIMEOUT,
     HeartbeatThread,
     get_lmcache_chunk_size,
-    send_lmcache_request,
 )
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
@@ -34,8 +33,12 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.mq import MessageQueueClient
-from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
+from lmcache.v1.multiprocess.group_view import (
+    EngineGroupInfo,
+    expand_engine_block_ids,
+)
 from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.kv_wrap import wrap_one_kv_cache
 
@@ -50,52 +53,55 @@ logger = init_logger(__name__)
 _WAIT_LOOKUP_RESPONSE_BUFFER_S = 5.0
 
 
-def _validate_sglang_kv_pools(
-    k_pool: list[torch.Tensor],
-    v_pool: list[torch.Tensor],
+def _validate_sglang_kv_caches(
+    kv_caches: list[torch.Tensor],
 ) -> torch.device:
-    """Validate SGLang's split MHA pools and return their shared device.
+    """Validate a flat SGLang KV cache list and return the shared device.
 
     Args:
-        k_pool: Per-layer key-cache tensors.
-        v_pool: Per-layer value-cache tensors.
+        kv_caches: Flat per-layer KV cache tensors. Layout depends on
+            attention type: MHA ``[K..., V...]``, MLA ``[KV...]``,
+            DSA ``[KV..., indexer...]``.
 
     Returns:
-        The device shared by every key and value tensor.
+        The device shared by every tensor.
 
     Raises:
-        ValueError: If either pool is empty, layer counts differ, or tensors
-            span multiple devices.
+        ValueError: If the list is empty or tensors span multiple devices.
     """
-    if not k_pool or not v_pool:
-        raise ValueError("SGLang MP registration requires non-empty K and V pools")
-    if len(k_pool) != len(v_pool):
-        raise ValueError("SGLang MP registration requires matching K and V layers")
-    tensors = [*k_pool, *v_pool]
-    device = tensors[0].device
-    if any(tensor.device != device for tensor in tensors):
-        raise ValueError("SGLang MP K and V pools must use one device")
+    if not kv_caches:
+        raise ValueError("SGLang MP registration requires non-empty KV caches")
+    device = kv_caches[0].device
+    if any(tensor.device != device for tensor in kv_caches):
+        raise ValueError("SGLang MP KV caches must use one device")
     return device
 
 
 def _wrap_sglang_kv_caches(
-    k_pool: list[torch.Tensor],
-    v_pool: list[torch.Tensor],
+    kv_caches: list[torch.Tensor],
 ) -> KVCache:
-    """Flatten SGLang's depth-2 ``[K_layers, V_layers]`` KV layout into a
-    single flat ``KVCache`` so it fits upstream's wire
-    ``KVCache`` payload type. The daemon's
-    :func:`normalize_kv_and_discover_format` recognizes this shape from
-    ``EngineType.SGLANG`` plus a ``tokens_per_block`` ``LayoutHints`` field
-    and splits it back at its midpoint before format detection.
+    """Wrap a flat list of SGLang KV cache tensors for IPC transport.
+
+    The caller (``LMCacheMPConnector.__init__``) supplies a flat
+    ``list[torch.Tensor]`` whose layout depends on the attention type:
+
+    - **MHA**: ``[K_layers..., V_layers...]`` (depth-2 flattened).
+    - **MLA**: ``[KV_layers...]`` -- one fused buffer per layer.
+    - **DSA**: ``[KV_layers..., indexer_layers...]`` -- MLA latent
+      layers followed by DSA indexer layers.
+
+    The daemon's
+    :func:`normalize_and_discover_per_layer_formats` splits this flat
+    list by per-layer tensor shape and assigns each contiguous run of
+    same-shape layers to its own kernel group. The
+    ``engine_group_infos`` sent alongside ``REGISTER_KV_CACHE`` tells
+    the daemon how many groups to expect and which layers each covers.
 
     Raises:
-        ValueError: If the pools are empty, use different devices, or the
-            selected platform cannot provide the complete handle-transfer
-            path.
+        ValueError: If the list is empty or the selected platform
+            cannot provide the complete handle-transfer path.
     """
-    device = _validate_sglang_kv_pools(k_pool, v_pool)
-    tensors = [*k_pool, *v_pool]
+    device = _validate_sglang_kv_caches(kv_caches)
     device_spec = get_device_spec(device.type)
     if device_spec is None or not device_spec.is_handle_transfer_available():
         raise ValueError(
@@ -103,7 +109,7 @@ def _wrap_sglang_kv_caches(
             f"{device.type!r}: required memory IPC, event IPC, cache context, "
             "or block-transfer capabilities are missing"
         )
-    return [wrap_one_kv_cache(tensor) for tensor in tensors]
+    return [wrap_one_kv_cache(tensor) for tensor in kv_caches]
 
 
 def _completed_future(result: bool) -> MessagingFuture[bool]:
@@ -151,7 +157,7 @@ class _PendingLookup:
 class LMCacheMPConnector:
     """SGLang LMCache multi-process connector.
 
-    Talks to a standalone LMCache daemon over ZMQ.
+    Talks to a standalone LMCache daemon through the configured transport.
 
     - ``lookup_kv``: fires LOOKUP. Daemon prefetches missing
       chunks L2→L1 (DRAM), keeps the read locks held, returns the
@@ -175,8 +181,8 @@ class LMCacheMPConnector:
         page_size: int,
         host: str,
         port: int,
-        k_pool: list[torch.Tensor],
-        v_pool: list[torch.Tensor],
+        kv_caches: list[torch.Tensor],
+        
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
@@ -200,9 +206,13 @@ class LMCacheMPConnector:
         self._pending_lookups_lock = threading.Lock()
 
         self.context = zmq.Context.instance()
-        self.mq_client = MessageQueueClient(f"tcp://{host}:{port}", self.context)
+        server_url = f"{host}:{port}"
+        self.req_client: RequestClient = RequestClientFactory.create(
+            server_url,
+            context=self.context,
+        )
 
-        self._lmcache_chunk_size = get_lmcache_chunk_size(self.mq_client)
+        self._lmcache_chunk_size = get_lmcache_chunk_size(self.req_client)
         if self._lmcache_chunk_size % self.page_size != 0:
             raise ValueError(
                 "LMCache chunk size must be a multiple of SGLang page size, got "
@@ -215,22 +225,19 @@ class LMCacheMPConnector:
         # ([K_layers, V_layers]); we flatten it on the wire to fit
         # ``KVCache = list[DeviceIPCWrapper]``. The daemon recognizes the
         # SGLang-MHA flat-of-2NL pattern from ``EngineType.SGLANG`` plus the
-        # ``tokens_per_block`` hint and un-flattens + reshapes per layer.
+        # ``tokens_per_block`` and ``kv_list_layout`` hints, then un-flattens
+        # and reshapes per layer.
         # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the
         # empty list -- which the server treats as one group spanning all layers
         # (matching the vLLM non-hybrid and TensorRT-LLM register paths).
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.REGISTER_KV_CACHE,
-            [
-                self.instance_id,
-                _wrap_sglang_kv_caches(k_pool, v_pool),
-                self.model_name,
-                self.tp_size,
-                EngineType.SGLANG,
-                {"tokens_per_block": self.page_size},
-                [],
-            ],
+        self.req_client.register_kv_cache(
+            self.instance_id,
+            _wrap_sglang_kv_caches(kv_caches),
+            self.model_name,
+            self.tp_size,
+            EngineType.SGLANG,
+            {"tokens_per_block": self.page_size, "kv_list_layout": "k_v"},
+            [],
         ).result(timeout=self._mq_timeout)
         self._registered = True
         self._start_heartbeat()
@@ -239,7 +246,7 @@ class LMCacheMPConnector:
         if self._heartbeat is not None:
             return
         self._heartbeat = HeartbeatThread(
-            mq_client=self.mq_client,
+            req_client=self.req_client,
             health_event=self._health_event,
             interval=self._heartbeat_interval,
             instance_id=self.instance_id,
@@ -272,6 +279,9 @@ class LMCacheMPConnector:
         return IPCCacheServerKey(
             model_name=self.model_name,
             world_size=self.tp_size,
+            # Each worker stores and reads only its own object (no MLA-style
+            # sharing in this adapter yet).
+            num_kv_readers=1,
             worker_id=None if no_worker_id else self.worker_id,
             token_ids=tuple(token_ids),
             start=start,
@@ -311,10 +321,8 @@ class LMCacheMPConnector:
         """
         # The daemon blocks up to ``self._mq_timeout`` for the result, so give
         # the response itself a little longer than that to cover the round trip.
-        matched_chunks = send_lmcache_request(
-            self.mq_client,
-            RequestType.WAIT_PREFETCH_STATUS,
-            [request_id, self._mq_timeout],
+        matched_chunks = self.req_client.wait_prefetch_status(
+            request_id, self._mq_timeout
         ).result(timeout=self._mq_timeout + _WAIT_LOOKUP_RESPONSE_BUFFER_S)
         if matched_chunks is None:
             raise LMCacheTimeoutError(
@@ -332,19 +340,15 @@ class LMCacheMPConnector:
     ) -> None:
         if start >= end or not self.is_healthy:
             return
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.FREE_LOOKUP_LOCKS,
-            [
-                self._create_key(
-                    token_ids,
-                    start=start,
-                    end=end,
-                    request_id=request_id,
-                    no_worker_id=True,
-                ),
-                self.tp_size,
-            ],
+        self.req_client.free_lookup_locks(
+            self._create_key(
+                token_ids,
+                start=start,
+                end=end,
+                request_id=request_id,
+                no_worker_id=True,
+            ),
+            self.tp_size,
         )
 
     def lookup_kv(self, token_ids: list[int], request_id: str) -> int:
@@ -390,11 +394,9 @@ class LMCacheMPConnector:
             request_id=request_id,
             no_worker_id=True,
         )
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.LOOKUP,
-            [lookup_key, self.tp_size],
-        ).result(timeout=self._mq_timeout)
+        self.req_client.lookup(lookup_key, self.tp_size).result(
+            timeout=self._mq_timeout
+        )
         matched = self._wait_for_lookup(request_id)
         matched = self._global_min_tokens(matched)
 
@@ -446,7 +448,7 @@ class LMCacheMPConnector:
             self._free_lookup_locks(
                 pending.token_ids, 0, pending.matched_token_num, request_id
             )
-        send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
+        self.req_client.end_session(request_id)
 
     def _submit_retrieve(
         self,
@@ -456,32 +458,32 @@ class LMCacheMPConnector:
         matched_end: int,
         block_ids: list[int],
         skip_prefix_n_blocks: int = 0,
-    ) -> MessagingFuture[bool]:
+    ) -> tuple[
+        MessagingFuture[tuple[bytes, bool]],
+        MessagingFuture[bool],
+    ]:
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        future = send_lmcache_request(
-            self.mq_client,
-            RequestType.RETRIEVE,
-            [
-                self._create_key(
-                    token_ids,
-                    start=offset,
-                    end=matched_end,
-                    request_id=request_id,
-                ),
-                self.instance_id,
-                # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
-                event.ipc_handle(),
-                skip_prefix_n_blocks,
-            ],
-        ).to_device_future(device=self.device)
+        raw_future: MessagingFuture[tuple[bytes, bool]] = self.req_client.retrieve(
+            self._create_key(
+                token_ids,
+                start=offset,
+                end=matched_end,
+                request_id=request_id,
+            ),
+            self.instance_id,
+            # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
+            # non-hybrid, so wrap the flat list as a single group.
+            [block_ids],
+            event.ipc_handle(),
+            skip_prefix_n_blocks,
+        )
+        future = raw_future.to_device_future(device=self.device)
         # The daemon imports this IPC event after the request crosses the wire.
         # Retain the exporting event until the returned future is released so
         # its underlying handle cannot be destroyed during that interval.
         future.retain_reference(event)
-        return future
+        return raw_future, future
 
     def retrieve_kv(self, load_metadata: LoadMetadata) -> int:
         """Phase 2 of the two-phase load — fires RETRIEVE only.
@@ -493,8 +495,9 @@ class LMCacheMPConnector:
         consumes the held read locks via ``finish_read_prefetched`` —
         we don't separately free them on the success path.
 
-        Failure paths free the still-held trailing read locks
-        explicitly to avoid leaking them in the daemon.
+        Failure paths free the still-held trailing read locks explicitly,
+        except when an event-free terminal response confirms that the daemon
+        already released this worker's share.
 
         Returns ``matched - offset`` (tokens covered by the chunks
         whose RETRIEVE was issued, equivalent to the legacy
@@ -535,12 +538,13 @@ class LMCacheMPConnector:
 
         # Successful RETRIEVE releases the trailing read locks via
         # ``finish_read_prefetched`` inside the daemon. The trailing
-        # ``_free_lookup_locks`` is the failure path's cleanup — calling
-        # it after a successful RETRIEVE would double-release and trigger
-        # "finish read on non-read-locked key".
+        # ``_free_lookup_locks`` is the fallback failure cleanup — calling it
+        # after a successful RETRIEVE or an event-free terminal failure would
+        # double-release locks already consumed by the daemon.
         retrieve_succeeded = False
+        server_released_locks = False
         try:
-            future = self._submit_retrieve(
+            raw_future, future = self._submit_retrieve(
                 request_id=request_id,
                 token_ids=token_ids,
                 offset=offset,
@@ -549,12 +553,17 @@ class LMCacheMPConnector:
                 skip_prefix_n_blocks=prefix_pad_pages,
             )
             if not future.result(timeout=self._mq_timeout):
+                event_handle, _ = raw_future.result(timeout=0)
+                # An event-free False is the missing-registration response.
+                # Its server-side path already released this worker's share;
+                # sending FREE_LOOKUP_LOCKS here would release every rank again.
+                server_released_locks = not event_handle
                 raise RuntimeError(
                     f"LMCache MP retrieve failed for request_id={request_id}"
                 )
             retrieve_succeeded = True
         finally:
-            if not retrieve_succeeded:
+            if not retrieve_succeeded and not server_released_locks:
                 self._free_lookup_locks(
                     token_ids, offset, retrieve_token_num, request_id
                 )
@@ -608,22 +617,18 @@ class LMCacheMPConnector:
         )
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        future = send_lmcache_request(
-            self.mq_client,
-            RequestType.STORE,
-            [
-                self._create_key(
-                    store_metadata.token_ids,
-                    start=0,
-                    end=aligned_end,
-                    request_id=request_id,
-                ),
-                self.instance_id,
-                # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
-                event.ipc_handle(),
-            ],
+        future = self.req_client.store(
+            self._create_key(
+                store_metadata.token_ids,
+                start=0,
+                end=aligned_end,
+                request_id=request_id,
+            ),
+            self.instance_id,
+            # STORE takes per-group block IDs (list[list[int]]); SGLang is
+            # non-hybrid, so wrap the flat list as a single group.
+            [block_ids],
+            event.ipc_handle(),
         ).to_device_future(device=self.device)
         # Keep the exporting device event alive until the caller releases the
         # future. Since we return without blocking, the local ``event`` would
@@ -649,22 +654,18 @@ class LMCacheMPConnector:
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
         success = (
-            send_lmcache_request(
-                self.mq_client,
-                RequestType.STORE,
-                [
-                    self._create_key(
-                        store_metadata.token_ids,
-                        start=0,
-                        end=aligned_end,
-                        request_id=request_id,
-                    ),
-                    self.instance_id,
-                    # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                    # non-hybrid, so wrap the flat list as a single group.
-                    [block_ids],
-                    event.ipc_handle(),
-                ],
+            self.req_client.store(
+                self._create_key(
+                    store_metadata.token_ids,
+                    start=0,
+                    end=aligned_end,
+                    request_id=request_id,
+                ),
+                self.instance_id,
+                # STORE takes per-group block IDs (list[list[int]]); SGLang is
+                # non-hybrid, so wrap the flat list as a single group.
+                [block_ids],
+                event.ipc_handle(),
             )
             .to_device_future(device=self.device)
             .result(timeout=self._mq_timeout)
@@ -685,12 +686,10 @@ class LMCacheMPConnector:
             self._heartbeat = None
         if self._registered:
             try:
-                send_lmcache_request(
-                    self.mq_client,
-                    RequestType.UNREGISTER_KV_CACHE,
-                    [self.instance_id],
-                ).result(timeout=self._mq_timeout)
+                self.req_client.unregister_kv_cache(self.instance_id).result(
+                    timeout=self._mq_timeout
+                )
             except Exception:
                 logger.warning("Failed to unregister SGLang MP KV cache", exc_info=True)
             self._registered = False
-        self.mq_client.close()
+        self.req_client.close()

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -33,19 +33,6 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def _model_uses_mla(model_config: ModelConfig) -> bool:
-    """Return whether SGLang classified the model as MLA.
-
-    Args:
-        model_config: SGLang model metadata containing ``attention_arch``.
-
-    Returns:
-        ``True`` when ``attention_arch`` names the MLA architecture.
-    """
-    attention_arch = getattr(model_config, "attention_arch", None)
-    return getattr(attention_arch, "name", attention_arch) == "MLA"
-
-
 @dataclass
 class StoreMetadata:
     last_node: object
@@ -71,7 +58,9 @@ def init_lmcache_engine(
     global_rank: int,
     kv_dtype: torch.dtype,
     config_file: str,
-    kv_head_dim: int | None = None,
+    use_mla: bool = False,
+    kv_cache_dim: Optional[int] = None,
+    page_size: int = 1,
 ) -> LMCacheEngine:
     """
     Initialize LMCache engine for SGLang integration.
@@ -83,15 +72,23 @@ def init_lmcache_engine(
         global_rank: Global tensor parallel rank (for metadata)
         kv_dtype: Data type for KV cache tensors
         config_file: Path to the LMCache YAML configuration file
-        kv_head_dim: Actual width of one MLA cache row. Required for MLA
-            callers because it can differ from the attention head dimension.
+        use_mla: Whether the model uses MLA (fused KV, single buffer).
+            When True, ``kv_cache_dim`` must be provided.
+        kv_cache_dim: The fused KV cache dimension for MLA/DSA models
+            (``kv_lora_rank + qk_rope_head_dim``). Required when
+            ``use_mla`` is True; ignored otherwise.
+        page_size: SGLang page size (tokens per block). Passed as
+            ``tokens_per_block`` in ``layout_hints`` to the GPU connector
+            so that ``KVLayerGroupsManager`` can resolve ``block_size``
+            for fused formats (``NL_X_NBBS_ONE_HS``) whose
+            ``block_size()`` is undefined.
 
     Returns:
         The initialized or existing SGLang LMCache engine.
 
     Raises:
-        ValueError: If an MLA model does not provide a positive cache-row
-            width.
+        ValueError: If ``use_mla=True`` but ``kv_cache_dim`` is not
+            provided.
     """
     if curr_engine := LMCacheEngineBuilder.get(ENGINE_NAME):
         return curr_engine
@@ -104,11 +101,14 @@ def init_lmcache_engine(
     # construct kv shape (for mem pool)
     num_layer = model_config.num_hidden_layers
     chunk_size = config.chunk_size
-    use_mla = _model_uses_mla(model_config)
+
     if use_mla:
-        if kv_head_dim is None or kv_head_dim <= 0:
-            raise ValueError("SGLang MLA requires a positive KV-cache row width")
-        kv_shape = (num_layer, 1, chunk_size, 1, kv_head_dim)
+        if kv_cache_dim is None:
+            raise ValueError(
+                "kv_cache_dim must be provided when use_mla=True"
+            )
+        # MLA/DSA: fused KV, single head, kv_size=1
+        kv_shape = (num_layer, 1, chunk_size, 1, kv_cache_dim)
     else:
         num_kv_head = model_config.get_num_kv_heads(tp_size)
         head_dim = model_config.head_dim
@@ -127,7 +127,10 @@ def init_lmcache_engine(
         use_mla=use_mla,
     )
 
-    gpu_connector = CreateGPUConnector(config, metadata, EngineType.SGLANG)
+    gpu_connector = CreateGPUConnector(
+        config, metadata, EngineType.SGLANG,
+        layout_hints={"tokens_per_block": page_size},
+    )
     engine = LMCacheEngineBuilder.get_or_create(
         ENGINE_NAME,
         config,
@@ -146,19 +149,52 @@ class LMCacheConnector:
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: List[torch.Tensor],
-        v_pool: List[torch.Tensor],
         config_file: str,
+        k_pool: Optional[List[torch.Tensor]] = None,
+        v_pool: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[List[torch.Tensor]] = None,
+        use_mla: bool = False,
+        kv_cache_dim: Optional[int] = None,
+        page_size: int = 1,
     ):
-        if not k_pool:
-            raise ValueError("k_pool cannot be empty during initialization.")
-        use_mla = _model_uses_mla(sgl_config)
-        kv_dtype = k_pool[0].dtype
+        """Initialize the LMCache connector for SGLang.
+
+        Args:
+            sgl_config: SGLang model configuration.
+            tp_size: Tensor parallel size.
+            rank: Global tensor parallel rank.
+            config_file: Path to the LMCache YAML configuration file.
+            k_pool: List of key cache tensors (MHA models). Mutually
+                exclusive with ``kv_caches``.
+            v_pool: List of value cache tensors (MHA models). Mutually
+                exclusive with ``kv_caches``.
+            kv_caches: Flat list of KV cache tensors for MLA/DSA models
+                (fused buffer). When provided, ``k_pool``/``v_pool`` are
+                ignored. For DSA this list includes both the MLA latent
+                layers and the indexer layers appended in order.
+            use_mla: Whether the model uses MLA (fused KV).
+            kv_cache_dim: Fused KV cache dimension for MLA/DSA models.
+            page_size: SGLang page size (tokens per block). Forwarded
+                to ``init_lmcache_engine`` as ``layout_hints`` so the
+                GPU connector can resolve ``block_size`` for fused
+                formats.
+        """
+        if kv_caches is not None:
+            self.kvcaches = kv_caches
+        else:
+            if not k_pool:
+                raise ValueError(
+                    "Either kv_caches or k_pool must be provided."
+                )
+            self.kvcaches = k_pool + v_pool
+        self.use_mla = use_mla
+
+        kv_dtype = self.kvcaches[0].dtype
         if (
-            k_pool[0].device.type == torch_device_type
-            and k_pool[0].device.index is not None
+            self.kvcaches[0].device.type == torch_device_type
+            and self.kvcaches[0].device.index is not None
         ):
-            local_rank = k_pool[0].device.index
+            local_rank = self.kvcaches[0].device.index
         else:
             # Fallback for CPU / odd cases
             local_rank = rank
@@ -172,12 +208,13 @@ class LMCacheConnector:
             rank,  # global_rank (tp_rank) for metadata
             kv_dtype,
             config_file,
-            kv_head_dim=k_pool[0].shape[-1] if use_mla else None,
+            use_mla=use_mla,
+            kv_cache_dim=kv_cache_dim,
+            page_size=page_size,
         )
         self.sgl_config = sgl_config
         self.tp_size = tp_size
         self.rank = local_rank  # Use local_rank for torch.device() calls
-        self.kvcaches = k_pool if use_mla else k_pool + v_pool
         self.num_layer = sgl_config.num_hidden_layers
 
         self.lmcache_engine.post_init(kvcaches=self.kvcaches)
@@ -249,16 +286,34 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: List[torch.Tensor],
-        v_pool: List[torch.Tensor],
         config_file: str,
+        k_pool: Optional[List[torch.Tensor]] = None,
+        v_pool: Optional[List[torch.Tensor]] = None,
+        kv_caches: Optional[List[torch.Tensor]] = None,
+        use_mla: bool = False,
+        kv_cache_dim: Optional[int] = None,
+        page_size: int = 1,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
     ):
-        super().__init__(sgl_config, tp_size, rank, k_pool, v_pool, config_file)
+        super().__init__(
+            sgl_config,
+            tp_size,
+            rank,
+            config_file,
+            k_pool=k_pool,
+            v_pool=v_pool,
+            kv_caches=kv_caches,
+            use_mla=use_mla,
+            kv_cache_dim=kv_cache_dim,
+            page_size=page_size,
+        )
         self._lmcache_chunk_size = self.lmcache_engine.config.chunk_size
         self.layerwise_retrievers: List[Any] = []
         self.layer_load_layer: List[int] = []
-        self.kvcaches = [k_pool, v_pool]
+        if kv_caches is not None:
+            self.kvcaches = [kv_caches]
+        else:
+            self.kvcaches = [k_pool, v_pool]
         self.tp_group = tp_group
         self.lookup_id_list: List[str] = []
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -106,6 +106,11 @@ def round_down(x: int, y: int) -> int:
     return (x // y) * y
 
 
+def round_up(x: int, y: int) -> int:
+    """Round up x to the nearest multiple of y."""
+    return ((x + y - 1) // y) * y
+
+
 def compress_slot_mapping(slots: list[int]) -> list[Union[int, list[int]]]:
     """Compress a list of slot indices into ranges while preserving order.
 
@@ -324,6 +329,12 @@ class DiskCacheMetadata:
     cached_positions: Optional[torch.Tensor] = None
     fmt: Optional[MemoryFormat] = None
     pin_count: int = 0
+    # Plural shapes/dtypes for multi-group memory objects (e.g. DSA
+    # dual-buffer).  When set, the retrieve path allocates with these
+    # instead of the singular shape/dtype so the loaded MemoryObj
+    # preserves the multi-group layout needed by get_tensor(i).
+    shapes: Optional[list[torch.Size]] = None
+    dtypes: Optional[list[torch.dtype]] = None
 
     def pin(self) -> bool:
         self.pin_count += 1

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -330,7 +330,29 @@ class LMCacheEngine:
                 )
                 if self.hidden_state_store is not None:
                     self.hidden_state_store.bind_storage_manager(self.storage_manager)
-            self.post_inited = True
+
+        # Eagerly initialize the GPU connector's kvcaches pointers and
+        # KVLayerGroupsManager so that metadata.get_shapes() returns
+        # per-group shapes before the first store()/retrieve() call.
+        # Without this, the lazy _initialize_pointers() in
+        # SGLangGPUConnector runs only inside from_gpu/to_gpu — which is
+        # *after* get_shapes() is called in store() — causing a
+        # single-group fallback that crashes with IndexError when
+        # from_gpu tries to access the second group (DSA indexer).
+        if self.gpu_connector is not None and "kvcaches" in kwargs:
+            self.gpu_connector.initialize_kvcaches_ptr(**kwargs)
+            # SGLangGPUConnector needs _initialize_pointers called to build
+            # the KVLayerGroupsManager on metadata; other connectors are
+            # unaffected (no _initialize_pointers method or already built).
+            init_ptrs = getattr(
+                self.gpu_connector, "_initialize_pointers", None
+            )
+            if init_ptrs is not None:
+                kvcaches = getattr(self.gpu_connector, "kvcaches", None)
+                if kvcaches is not None:
+                    init_ptrs(kvcaches)
+
+        self.post_inited = True
 
     def freeze(self, enabled: bool) -> None:
         """

--- a/lmcache/v1/gpu_connector/__init__.py
+++ b/lmcache/v1/gpu_connector/__init__.py
@@ -123,6 +123,18 @@ def CreateGPUConnector(
             )
 
             if config.use_layerwise:
+                if metadata.use_mla:
+                    raise ValueError(
+                        "Layerwise mode (use_layerwise=True) is not yet "
+                        "supported for MLA/DSA models. The layerwise "
+                        "store_layer/retrieve_layer path in cache_engine "
+                        "iterates per-layer with a single uniform shape and "
+                        "has no awareness of layer groups — incompatible "
+                        "with MLA's fused single-buffer layout and DSA's "
+                        "dual-buffer layout. Set use_layerwise=False (the "
+                        "default) to use the fully-supported non-layerwise "
+                        "MP path."
+                    )
                 return SGLangLayerwiseGPUConnector(
                     hidden_dim_size,
                     num_layer,
@@ -139,6 +151,9 @@ def CreateGPUConnector(
                     chunk_size=chunk_size,
                     dtype=kv_dtype,
                     device=device,
+                    use_mla=metadata.use_mla,
+                    metadata=metadata,
+                    layout_hints=layout_hints,
                 )
     elif engine == EngineType.VLLM:
         _validate_vllm_device_features(config)

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -25,8 +25,6 @@ from lmcache.v1.gpu_connector.utils import (
     get_group_data_ptrs,
     get_head_size,
     get_num_blocks,
-    get_num_layers,
-    get_page_buffer_size,
     get_tokens_per_layer,
     normalize_and_discover_per_layer_formats,
     normalize_kv_and_discover_format,
@@ -481,6 +479,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 engine_kv_formats=engine_kv_formats,
             )
         klg_manager = self.metadata.kv_layer_groups_manager
+        assert klg_manager is not None
 
         # Heterogeneous-block_size sanity check.
         #
@@ -519,7 +518,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.group_kv_cache_pointers_on_gpu = []
         for group in klg_manager.kernel_groups:
             ptrs = get_group_data_ptrs(
-                self.kvcaches, self.engine_kv_format, group.layer_indices
+                self.kvcaches, group.engine_kv_format, group.layer_indices
             )
             cpu = torch.empty(len(ptrs), dtype=torch.int64, device="cpu")
             cpu.numpy()[:] = ptrs
@@ -545,6 +544,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         assert self.kvcaches[0].device == self.device
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
+        klg_manager = self.metadata.kv_layer_groups_manager
+        assert klg_manager is not None
 
         # avoid read/write stream race condition for shared block
         # this will only be potentially non-zero for the first
@@ -553,6 +554,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
+            group = klg_manager.kernel_groups[i]
             memory_obj_tensor = memory_obj.get_tensor(i)
             assert memory_obj_tensor is not None
             device_ops.multi_layer_kv_transfer(
@@ -560,11 +562,11 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 kv_cache_pointer,
                 slot_mapping[start:end],
                 self.device,
-                self.page_buffer_size,
+                group.shape_desc.nb * group.shape_desc.bs,
                 lmcache_native.TransferDirection.H2D,
-                self.engine_kv_format,
-                block_size=self.block_size,
-                head_size=self.head_size,
+                group.engine_kv_format,
+                block_size=group.shape_desc.bs,
+                head_size=group.shape_desc.hs,
                 skip_prefix_n_tokens=skip_prefix_n_tokens,
             )
 
@@ -579,11 +581,14 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         assert self.kvcaches[0].device == self.device
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
+        klg_manager = self.metadata.kv_layer_groups_manager
+        assert klg_manager is not None
         with torch.cuda.stream(self.store_stream):
             if not self.use_gpu or end - start != self.chunk_size:
                 for i, kv_cache_pointer in enumerate(
                     self.group_kv_cache_pointers_on_gpu
                 ):
+                    group = klg_manager.kernel_groups[i]
                     memory_obj_tensor = memory_obj.get_tensor(i)
                     assert memory_obj_tensor is not None
                     device_ops.multi_layer_kv_transfer(
@@ -591,11 +596,11 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         kv_cache_pointer,
                         slot_mapping[start:end],
                         self.device,
-                        self.page_buffer_size,
+                        group.shape_desc.nb * group.shape_desc.bs,
                         lmcache_native.TransferDirection.D2H,
-                        self.engine_kv_format,
-                        block_size=self.block_size,
-                        head_size=self.head_size,
+                        group.engine_kv_format,
+                        block_size=group.shape_desc.bs,
+                        head_size=group.shape_desc.hs,
                     )
             else:
                 # kvcaches -> gpu_buffer -> memobj
@@ -603,17 +608,18 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 for i, kv_cache_pointer in enumerate(
                     self.group_kv_cache_pointers_on_gpu
                 ):
+                    group = klg_manager.kernel_groups[i]
                     tmp_gpu_buffer = self.group_tmp_buffer[i][:, :, : end - start, :]
                     device_ops.multi_layer_kv_transfer(
                         tmp_gpu_buffer,
                         kv_cache_pointer,
                         slot_mapping[start:end],
                         self.device,
-                        self.page_buffer_size,
+                        group.shape_desc.nb * group.shape_desc.bs,
                         lmcache_native.TransferDirection.D2H,
-                        self.engine_kv_format,
-                        block_size=self.block_size,
-                        head_size=self.head_size,
+                        group.engine_kv_format,
+                        block_size=group.shape_desc.bs,
+                        head_size=group.shape_desc.hs,
                     )
                     memory_obj_tensor = memory_obj.get_tensor(i)
                     assert memory_obj_tensor is not None
@@ -1436,18 +1442,25 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
 
 
 class SGLangGPUConnector(GPUConnectorInterface):
-    """
-    The GPU KV cache should be a list of tensors, one for each layer,
-    with separate key and value pointers.
-    More specifically, we have:
-    - kvcaches: Tuple[List[Tensor], List[Tensor]]
-      - The first element is a list of key tensors, one per layer.
-      - The second element is a list of value tensors, one per layer.
-    - Each tensor: [page_buffer_size, head_num, head_size]
+    """SGLang GPU connector with per-layer-group transfer support.
 
-    The connector manages the transfer of KV cache data between CPU and GPU
-    memory for SGLang using pointer arrays for efficient access.
-    It will produce/consume memory objects with KV_2LTD format.
+    For MHA models the KV cache is a flat ``list[2*NL]`` of per-layer
+    tensors (K layers then V layers), each ``[page_buffer_size, num_heads,
+    head_size]``.  The connector discovers a single format and transfers
+    all layers in one kernel launch.
+
+    For MLA/DSA models the KV cache is a flat ``list[NL]`` (MLA) or
+    ``list[2*NL]`` (DSA: NL latent layers + NL indexer layers).  The
+    connector uses :func:`normalize_and_discover_per_layer_formats` to
+    split the list into kernel groups by tensor identity, builds a
+    :class:`KVLayerGroupsManager`, and dispatches one
+    ``multi_layer_kv_transfer`` per group — each with its own
+    ``engine_kv_format``, ``page_buffer_size``, ``block_size`` and
+    ``head_size`` from the group's ``PageBufferShapeDesc``.
+
+    Memory objects are multi-group: ``metadata.get_shapes()`` returns one
+    shape per group, and ``memory_obj.get_tensor(i)`` slices the flat
+    buffer into a per-group view via ``group_prefix_sum``.
     """
 
     def __init__(
@@ -1456,75 +1469,177 @@ class SGLangGPUConnector(GPUConnectorInterface):
         self.hidden_dim_size = hidden_dim_size
         self.num_layers = num_layers
 
-        self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
-        self.page_buffer_size = 0
-
-        self.gpu_buffer: Optional[torch.Tensor] = None
         self.use_mla = "use_mla" in kwargs and kwargs["use_mla"]
+        self.metadata: Optional[LMCacheMetadata] = kwargs.get("metadata", None)
+        self.layout_hints: LayoutHints = kwargs.get("layout_hints", None) or {}
 
-        self.num_kv_cache = num_layers if self.use_mla else num_layers * 2
-        self.kv_cache_pointers = torch.empty(
-            self.num_kv_cache, dtype=torch.int64, device="cpu"
-        )
+        # Per-group GPU pointer tensors, built lazily in _initialize_pointers.
+        self.group_kv_cache_pointers_on_gpu: list[torch.Tensor] = []
+        self._layer_groups_initialized = False
+        # Legacy single-pointer dict kept for backward-compatible callers.
+        self.kv_cache_pointers_on_gpu: dict[int, torch.Tensor] = {}
 
-        if use_gpu:
-            assert "chunk_size" in kwargs, (
-                "chunk_size should be provided to create a GPU buffer."
-            )
-            assert "device" in kwargs, (
-                "device should be provided to create a GPU buffer."
-            )
+        self.use_gpu = use_gpu
+        self.chunk_size: Optional[int] = kwargs.get("chunk_size", None)
+
+        # MHA (single group): allocate the legacy single GPU staging buffer
+        # at construction time.  MLA/DSA (multi-group): per-group staging
+        # buffers are allocated lazily in _initialize_pointers after the
+        # layer-groups manager is built, because the per-group shapes and
+        # dtypes are not known until then.
+        self.gpu_buffer: Optional[torch.Tensor] = None
+        self.group_tmp_buffer: Optional[list[torch.Tensor]] = None
+        if use_gpu and not self.use_mla:
+            if "chunk_size" not in kwargs:
+                raise ValueError(
+                    "chunk_size should be provided to create a GPU buffer."
+                )
+            if "device" not in kwargs:
+                raise ValueError("device should be provided to create a GPU buffer.")
             shape = self.get_shape(kwargs["chunk_size"])
             self.gpu_buffer = torch.empty(
                 shape, dtype=kwargs["dtype"], device=kwargs["device"]
             )
             logger.info("GPU buffer: %s", self.gpu_buffer.shape)
 
-    def _initialize_pointers(self, kv_caches: DiscoverableKVCache) -> torch.Tensor:
-        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
-            kv_caches, EngineType.SGLANG
+        # CUDA stream isolation: store_stream for D2H (from_gpu), load_stream
+        # for H2D (batched_to_gpu).  Keeps transfers from serializing with
+        # compute on the default stream, mirroring V2/V3 connectors.
+        self.store_stream = torch.cuda.Stream()
+        self.load_stream = torch.cuda.Stream()
+
+        self.kvcaches: Optional[List[torch.Tensor]] = None
+
+    def _initialize_pointers(
+        self, kv_caches: DiscoverableKVCache
+    ) -> list[torch.Tensor]:
+        """Discover per-layer formats, build the layer-groups manager, and
+        capture per-group GPU pointer tensors.
+
+        For MHA (single group) this is equivalent to the legacy single-format
+        path.  For MLA/DSA the flat ``kv_caches`` list is split into one or
+        two kernel groups by :func:`normalize_and_discover_per_layer_formats`
+        — DSA's indexer tensors (uint8, last-dim 132) have a different
+        identity from the MLA latent tensors and naturally form their own
+        group.
+
+        Like ``VLLMPagedMemGPUConnectorV3``, this connector dispatches each
+        group with its own ``group.engine_kv_format``.  The difference is
+        that this connector also builds ``engine_group_infos`` from the
+        detected formats and passes them to ``KVLayerGroupsManager`` so that
+        fused formats (``NL_X_NBBS_ONE_HS``) whose ``block_size()`` is
+        undefined can fall back to ``tokens_per_block`` from the layout
+        hints — V3 omits ``engine_group_infos`` because vLLM does not use
+        SGLang's fused PBS layout.
+        """
+        if self._layer_groups_initialized:
+            return self.group_kv_cache_pointers_on_gpu
+
+        empty_layer_index_groups: list[list[int]] = []
+        kv_caches, engine_kv_formats = normalize_and_discover_per_layer_formats(
+            kv_caches, empty_layer_index_groups, EngineType.SGLANG, self.layout_hints
         )
-        num_layers = get_num_layers(kv_caches, self.engine_kv_format)
-        # SGLang registers every layer as one group; pass all indices in order.
-        ptrs = get_group_data_ptrs(
-            kv_caches, self.engine_kv_format, list(range(num_layers))
-        )
-        assert len(ptrs) == self.num_kv_cache, (
-            f"Expected {self.num_kv_cache} KV cache pointers, got {len(ptrs)}"
-        )
-        self.kv_cache_pointers.numpy()[:] = ptrs
+
+        # Build engine_group_infos from detected formats so that
+        # KVLayerGroupsManager can fall back to tokens_per_block for
+        # fused formats (NL_X_NBBS_ONE_HS) whose block_size() is undefined.
+        # One EngineGroupInfo per distinct format — this matches the kernel
+        # group split because engine_kv_format is part of LayerGroupIdentity.
+        # First Party
+        from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+        tokens_per_block = self.layout_hints.get("tokens_per_block", 0)
+        if tokens_per_block:
+            format_to_layers: dict[lmcache_native.EngineKVFormat, list[int]] = {}
+            for idx, fmt in enumerate(engine_kv_formats):
+                format_to_layers.setdefault(fmt, []).append(idx)
+            engine_group_infos: list[EngineGroupInfo] = [
+                EngineGroupInfo(
+                    engine_group_id=0,
+                    layer_indices=tuple(indices),
+                    tokens_per_block=tokens_per_block,
+                )
+                for indices in format_to_layers.values()
+            ]
+        else:
+            engine_group_infos = []
+
+        if self.metadata is not None and self.metadata.kv_layer_groups_manager is None:
+            self.metadata.kv_layer_groups_manager = KVLayerGroupsManager(
+                kv_caches,
+                engine_kv_formats=engine_kv_formats,
+                engine_group_infos=engine_group_infos,
+            )
+        if self.metadata is not None:
+            klg_manager = self.metadata.kv_layer_groups_manager
+        else:
+            klg_manager = None
+        if klg_manager is None:
+            raise RuntimeError(
+                "SGLangGPUConnector requires metadata with a KVLayerGroupsManager"
+            )
 
         device = get_device(kv_caches)
-        assert device.type == "cuda", "The device should be CUDA."
-        idx = device.index
-        if idx not in self.kv_cache_pointers_on_gpu:
-            self.kv_cache_pointers_on_gpu[idx] = torch.empty(
-                self.num_kv_cache, dtype=torch.int64, device=device
+        if device.type != "cuda":
+            raise ValueError(
+                f"SGLangGPUConnector requires a CUDA device, got {device.type}."
             )
-        self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
 
-        self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
-        return self.kv_cache_pointers_on_gpu[idx]
+        # Allocate per-group GPU staging buffers for MLA/DSA (multi-group).
+        # MHA uses the legacy single self.gpu_buffer allocated in __init__.
+        if self.use_gpu and self.use_mla and self.group_tmp_buffer is None:
+            tmp_buf_shapes = self.metadata.get_shapes(self.chunk_size)
+            tmp_buf_dtypes = self.metadata.get_dtypes()
+            if len(tmp_buf_shapes) != len(tmp_buf_dtypes):
+                raise ValueError(
+                    f"Shape count ({len(tmp_buf_shapes)}) != dtype count "
+                    f"({len(tmp_buf_dtypes)}) from metadata."
+                )
+            self.group_tmp_buffer = [
+                torch.empty(shape, dtype=dtype, device=device)
+                for shape, dtype in zip(tmp_buf_shapes, tmp_buf_dtypes, strict=True)
+            ]
+
+        self.group_kv_cache_pointers_on_gpu = []
+        for group in klg_manager.kernel_groups:
+            ptrs = get_group_data_ptrs(
+                kv_caches, group.engine_kv_format, group.layer_indices
+            )
+            cpu = torch.empty(len(ptrs), dtype=torch.int64, device="cpu")
+            cpu.numpy()[:] = ptrs
+            gpu = torch.empty(len(ptrs), dtype=torch.int64, device=device)
+            gpu.copy_(cpu)
+            self.group_kv_cache_pointers_on_gpu.append(gpu)
+
+        # Keep the legacy dict populated for any caller that still reads it.
+        self.kv_cache_pointers_on_gpu[device.index] = (
+            self.group_kv_cache_pointers_on_gpu[0]
+        )
+
+        self._layer_groups_initialized = True
+        logger.debug(
+            "SGLangGPUConnector initialized %d layer group(s): %s",
+            len(klg_manager.kernel_groups),
+            [g.engine_kv_format for g in klg_manager.kernel_groups],
+        )
+        return self.group_kv_cache_pointers_on_gpu
 
     @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
-        The kvcaches should correspond to the "WHOLE token sequence".
+        """Transfer a memory object from CPU to GPU KV cache slots.
 
-        Note:
-          1. This function expects the 'slot_mapping' is a "partial slot mapping"
-             where its length is the same as the uncached token sequence.
-          2. In the case that there is prefix caching, slot_mapping will starts
-             with -1s until the end of the matched prefix. The start and end
-             should NEVER overlap with the prefix caching (which means the
-             underlying CUDA kernel will never see -1 in slot_mapping)
+        For MLA/DSA the memory object is multi-group (``meta.shapes`` is a
+        list); each group is dispatched with its own ``engine_kv_format``,
+        ``page_buffer_size``, ``block_size`` and ``head_size`` derived from
+        the group's ``shape_desc``.  For MHA the single-group path is
+        equivalent to the legacy ``multi_layer_kv_transfer_unilateral`` call.
 
-
-        :raises ValueError: If 'kvcaches' is not provided in kwargs.
-        :raises AssertionError: If the memory object does not have a tensor.
-        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        :raises ValueError: If 'kvcaches' or 'slot_mapping' is missing.
+        :raises ValueError: If the memory object format does not match the
+            connector's MLA/MHA mode.
         """
-        assert memory_obj.tensor is not None
+        if memory_obj.raw_tensor is None:
+            raise ValueError("Memory object has no raw tensor.")
 
         if self.use_mla:
             if memory_obj.metadata.fmt != MemoryFormat.KV_MLA_FMT:
@@ -1541,99 +1656,180 @@ class SGLangGPUConnector(GPUConnectorInterface):
 
         if "kvcaches" not in kwargs:
             raise ValueError("'kvcaches' should be provided in kwargs.")
-
         if "slot_mapping" not in kwargs:
             raise ValueError("'slot_mapping' should be provided in kwargs.")
 
         offset = kwargs.get("offset", 0)
-
         kvcaches: DiscoverableKVCache = kwargs["kvcaches"]
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
 
-        kv_cache_pointers = self._initialize_pointers(kvcaches)
-        device_ops.multi_layer_kv_transfer_unilateral(
-            memory_obj.tensor,
-            kv_cache_pointers,
-            slot_mapping[start - offset : end - offset],
-            get_device(kvcaches),
-            self.page_buffer_size,
-            lmcache_native.TransferDirection.H2D,
-            self.engine_kv_format,
-        )
+        self.initialize_kvcaches_ptr(**kwargs)
+        group_pointers = self._initialize_pointers(self.kvcaches)
+        klg_manager = self.metadata.kv_layer_groups_manager
+        assert klg_manager is not None
+        device = get_device(kvcaches)
+
+        for i, group in enumerate(klg_manager.kernel_groups):
+            group_tensor = memory_obj.get_tensor(i)
+            if group_tensor is None:
+                raise ValueError(
+                    f"Memory object has no tensor for group {i} of "
+                    f"{len(klg_manager.kernel_groups)} groups."
+                )
+            page_buffer_size = group.shape_desc.nb * group.shape_desc.bs
+            if lmcache_native.is_mla(group.engine_kv_format):
+                # MLA/DSA: layer-list formats handled by multi_layer_kv_transfer
+                device_ops.multi_layer_kv_transfer(
+                    group_tensor,
+                    group_pointers[i],
+                    slot_mapping[start - offset : end - offset],
+                    device,
+                    page_buffer_size,
+                    lmcache_native.TransferDirection.H2D,
+                    group.engine_kv_format,
+                    block_size=group.shape_desc.bs,
+                    head_size=group.shape_desc.hs,
+                )
+            else:
+                # MHA: K/V-split (KV-list) formats handled by unilateral
+                device_ops.multi_layer_kv_transfer_unilateral(
+                    group_tensor,
+                    group_pointers[i],
+                    slot_mapping[start - offset : end - offset],
+                    device,
+                    page_buffer_size,
+                    lmcache_native.TransferDirection.H2D,
+                    group.engine_kv_format,
+                )
 
     @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        """Expect a kwarg 'kvcaches' which is a nested tuple of K and V tensors.
-        The kvcaches should correspond to the "WHOLE token sequence".
+        """Transfer KV cache from GPU slots into the memory object.
 
-        Will set the memory_obj.metadata.fmt to MemoryFormat.KV_2LTD.
+        For MLA/DSA each group is dispatched with its own format and geometry.
+        When ``use_gpu`` is True and the transfer size matches ``chunk_size``,
+        a per-group GPU staging buffer (``group_tmp_buffer``) is used as an
+        intermediate stop to keep the D2H copy off the default stream.  For
+        MHA the legacy single ``gpu_buffer`` is used instead.
 
-        Note:
-          1. This function expects the 'slot_mapping' is a "partial slot mapping"
-             where its length is the same as the uncached token sequence.
-          2. In the case that there is prefix caching, slot_mapping will starts
-             with -1s until the end of the matched prefix. The start and end
-             should NEVER overlap with the prefix caching (which means the
-             underlying CUDA kernel will never see -1 in slot_mapping)
-
-        :raises ValueError: If 'kvcaches' is not provided in kwargs,
-        :raises AssertionError: If the memory object does not have a tensor.
-        :raises ValueError: If 'slot_mapping' is not provided in kwargs.
+        :raises ValueError: If 'kvcaches' or 'slot_mapping' is missing.
         """
-        assert memory_obj.tensor is not None
+        if memory_obj.raw_tensor is None:
+            raise ValueError("Memory object has no raw tensor.")
 
         if "kvcaches" not in kwargs:
             raise ValueError("'kvcaches' should be provided in kwargs.")
-
         if "slot_mapping" not in kwargs:
             raise ValueError("'slot_mapping' should be provided in kwargs.")
 
         kvcaches: DiscoverableKVCache = kwargs["kvcaches"]
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
 
-        kv_cache_pointers = self._initialize_pointers(kvcaches)
+        self.initialize_kvcaches_ptr(**kwargs)
+        group_pointers = self._initialize_pointers(self.kvcaches)
+        klg_manager = self.metadata.kv_layer_groups_manager
+        assert klg_manager is not None
+        device = get_device(kvcaches)
 
-        if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
-            device_ops.multi_layer_kv_transfer_unilateral(
-                memory_obj.tensor,
-                kv_cache_pointers,
-                slot_mapping[start:end],
-                get_device(kvcaches),
-                self.page_buffer_size,
-                lmcache_native.TransferDirection.D2H,
-                self.engine_kv_format,
-            )
-        else:
-            # kvcaches -> gpu_buffer -> memobj
-            assert self.gpu_buffer.device == get_device(kvcaches)
-            tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
-            device_ops.multi_layer_kv_transfer_unilateral(
-                tmp_gpu_buffer,
-                kv_cache_pointers,
-                slot_mapping[start:end],
-                get_device(kvcaches),
-                self.page_buffer_size,
-                lmcache_native.TransferDirection.D2H,
-                self.engine_kv_format,
-            )
-            memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
+        with torch.cuda.stream(self.store_stream):
+            for i, group in enumerate(klg_manager.kernel_groups):
+                group_tensor = memory_obj.get_tensor(i)
+                if group_tensor is None:
+                    raise ValueError(
+                        f"Memory object has no tensor for group {i} of "
+                        f"{len(klg_manager.kernel_groups)} groups."
+                    )
+                page_buffer_size = group.shape_desc.nb * group.shape_desc.bs
 
-        if not memory_obj.tensor.is_cuda:
+                if (
+                    self.use_mla
+                    and self.use_gpu
+                    and self.group_tmp_buffer is not None
+                    and end - start == self.chunk_size
+                ):
+                    # MLA/DSA: per-group staging buffer (full chunks only).
+                    # Partial chunks would slice a non-contiguous view from
+                    # the chunk_size-sized buffer, corrupting the transfer.
+                    tmp = self.group_tmp_buffer[i][:, :, : end - start, :]
+                    device_ops.multi_layer_kv_transfer(
+                        tmp,
+                        group_pointers[i],
+                        slot_mapping[start:end],
+                        device,
+                        page_buffer_size,
+                        lmcache_native.TransferDirection.D2H,
+                        group.engine_kv_format,
+                        block_size=group.shape_desc.bs,
+                        head_size=group.shape_desc.hs,
+                    )
+                    group_tensor.copy_(tmp, non_blocking=True)
+                elif (
+                    not self.use_mla
+                    and self.gpu_buffer is not None
+                    and end - start == self.gpu_buffer.shape[2]
+                ):
+                    # MHA: single legacy staging buffer (full chunks only)
+                    if self.gpu_buffer.device != device:
+                        raise ValueError(
+                            f"GPU buffer device {self.gpu_buffer.device} "
+                            f"!= transfer device {device}."
+                        )
+                    tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
+                    device_ops.multi_layer_kv_transfer_unilateral(
+                        tmp_gpu_buffer,
+                        group_pointers[i],
+                        slot_mapping[start:end],
+                        device,
+                        page_buffer_size,
+                        lmcache_native.TransferDirection.D2H,
+                        group.engine_kv_format,
+                    )
+                    group_tensor.copy_(tmp_gpu_buffer, non_blocking=True)
+                elif lmcache_native.is_mla(group.engine_kv_format):
+                    # MLA/DSA direct transfer (partial chunks or no GPU buffer)
+                    device_ops.multi_layer_kv_transfer(
+                        group_tensor,
+                        group_pointers[i],
+                        slot_mapping[start:end],
+                        device,
+                        page_buffer_size,
+                        lmcache_native.TransferDirection.D2H,
+                        group.engine_kv_format,
+                        block_size=group.shape_desc.bs,
+                        head_size=group.shape_desc.hs,
+                    )
+                else:
+                    # MHA direct transfer (partial chunks or no GPU buffer)
+                    device_ops.multi_layer_kv_transfer_unilateral(
+                        group_tensor,
+                        group_pointers[i],
+                        slot_mapping[start:end],
+                        device,
+                        page_buffer_size,
+                        lmcache_native.TransferDirection.D2H,
+                        group.engine_kv_format,
+                    )
+
+        if not memory_obj.raw_tensor.is_cuda:
             # Force a synchronize if the target buffer is NOT CUDA device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
-            torch.cuda.synchronize()
+            self.store_stream.synchronize()
 
         if self.use_mla:
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
 
     def get_shape(self, num_tokens: int) -> torch.Size:
+        if self.use_mla:
+            return torch.Size([1, self.num_layers, num_tokens, self.hidden_dim_size])
         return torch.Size([2, self.num_layers, num_tokens, self.hidden_dim_size])
 
     # TODO(Jiayi): need to optimize to enable real batching
     def batched_to_gpu(self, memory_objs, starts, ends, **kwargs):
-        for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
-            self.to_gpu(memory_obj, start, end, **kwargs)
+        with torch.cuda.stream(self.load_stream):
+            for memory_obj, start, end in zip(memory_objs, starts, ends, strict=False):
+                self.to_gpu(memory_obj, start, end, **kwargs)
+        self.load_stream.synchronize()
 
     # TODO(Yuwei): need to optimize to enable real batching
     def batched_from_gpu(self, memory_objs, starts, ends, **kwargs):
@@ -1641,9 +1837,21 @@ class SGLangGPUConnector(GPUConnectorInterface):
             self.from_gpu(memory_obj, start, end, **kwargs)
 
 
-# TODO: support MLA
 class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
-    """
+    """Layerwise GPU connector for SGLang MHA models.
+
+    .. warning::
+
+        This connector does **not** support MLA/DSA models.
+        :func:`CreateGPUConnector` rejects ``use_layerwise=True`` when
+        ``metadata.use_mla`` is set, and ``lmc_radix_cache.py`` forces
+        MP mode for MLA/DSA.  The layerwise ``store_layer`` /
+        ``retrieve_layer`` path in ``cache_engine.py`` iterates
+        ``for layer_id in range(self.num_layers)`` with a single uniform
+        shape from ``gpu_connector.get_shape()`` — it has no awareness of
+        layer groups, which is incompatible with MLA's fused single-buffer
+        layout and DSA's dual-buffer layout.
+
     The GPU KV cache should be a list of tensors, one for each layer,
     with separate key and value pointers.
     More specifically, we have:
@@ -1660,9 +1868,11 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
     def __init__(
         self, hidden_dim_size: int, num_layers: int, use_gpu: bool = False, **kwargs
     ):
-        assert "dtype" in kwargs, "dtype should be provided to create a GPU buffer."
+        if "dtype" not in kwargs:
+            raise ValueError("dtype should be provided to create a GPU buffer.")
         self.dtype = kwargs["dtype"]
-        assert "device" in kwargs, "device should be provided to create a GPU buffer."
+        if "device" not in kwargs:
+            raise ValueError("device should be provided to create a GPU buffer.")
         self.device = kwargs["device"]
 
         self.hidden_dim_size = hidden_dim_size
@@ -1936,7 +2146,7 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
         yield
 
     def get_shape(self, num_tokens: int) -> torch.Size:
-        # TODO: support MLA
+        # MLA/DSA is not supported in the layerwise path — see class docstring.
         return torch.Size([num_tokens, 2, self.hidden_dim_size])
 
 

--- a/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
@@ -22,18 +22,23 @@ class SGLANG_Detector(EngineDetector):
     engine_type = EngineType.SGLANG
 
     def discover(
-        self, kv_caches: DiscoverableKVCache, layout_hints: LayoutHints
+        self,
+        kv_caches: DiscoverableKVCache,
+        layout_hints: LayoutHints,
     ) -> "tuple[Optional[lmcache_native.EngineKVFormat], DiscoverableKVCache]":
-        # MP path: a flat list[2*NL] of 3-D tensors (K layers then V layers)
-        # plus a tokens_per_block hint. Regroup into [K_layers, V_layers] and
-        # reshape each (PBS, NH, HS) -> (NB, BS, NH, HS).
+        # MP non-MLA path: a flat list[2*NL] of 3-D tensors (K layers then V layers)
+        # plus explicit K/V-list-layout and tokens-per-block hints. Regroup
+        # into [K_layers, V_layers] and reshape each
+        # (PBS, NH, HS) -> (NB, BS, NH, HS). The explicit layout hint is
+        # required because NH can be 1 after tensor parallelism, which is
+        # otherwise indistinguishable by shape from SGLang MLA.
         if (
             isinstance(kv_caches, list)
             and len(kv_caches) > 0
             and len(kv_caches) % 2 == 0
             and isinstance(kv_caches[0], torch.Tensor)
             and kv_caches[0].dim() == 3
-            and kv_caches[0].shape[1] > 1
+            and layout_hints.get("kv_list_layout") == "k_v"
             and "tokens_per_block" in layout_hints
         ):
             block_size = layout_hints["tokens_per_block"]
@@ -54,12 +59,65 @@ class SGLANG_Detector(EngineDetector):
                     )
                 regrouped.append(reshaped)
             kv_caches = regrouped
+        # MP MLA path: each layer arrives as (PBS, 1, HS), where PBS folds
+        # num_blocks and block_size together. Unlike the in-process path, MP
+        # registration supplies tokens_per_block, so restore the explicit
+        # (NB, BS, HS) geometry required by the block-oriented cache context.
+        elif (
+            isinstance(kv_caches, list)
+            and len(kv_caches) > 0
+            and isinstance(kv_caches[0], torch.Tensor)
+            and kv_caches[0].dim() == 3
+            and kv_caches[0].shape[1] == 1
+            and "tokens_per_block" in layout_hints
+        ):
+            block_size = layout_hints["tokens_per_block"]
+            reshaped = []
+            for layer in kv_caches:
+                page_buffer_size = layer.shape[0]
+                if page_buffer_size % block_size != 0:
+                    raise ValueError(
+                        f"SGLang MLA page_buffer_size {page_buffer_size} not "
+                        f"divisible by tokens_per_block {block_size}"
+                    )
+                num_blocks = page_buffer_size // block_size
+                reshaped.append(layer.view(num_blocks, block_size, layer.shape[2]))
+            kv_caches = reshaped
 
         list_depth, tensor_ndim, first_tensor = measure_list_depth_until_tensor(
             kv_caches
         )
-        if list_depth == 1 and first_tensor.shape[1] == 1:  # MLA, fused PBS
-            return lmcache_native.EngineKVFormat.NL_X_NBBS_ONE_HS, kv_caches
+        # DSA indexer cache: list[NL] of 2-D uint8 tensors. Each tensor is
+        # (num_pages, page_size * 132) where 132 = 128B fp8 key + 4B fp32 scale
+        # per token. SGLang packs the page dimension into the last axis (unlike
+        # vLLM which keeps a 3-D (NB, BS, 132) layout), so we check divisibility
+        # by 132 rather than equality. Detected before MLA since the indexer is
+        # 2-D while MLA latent is 3-D with a singleton head axis.
+        #
+        # Reshape (num_pages, page_size * 132) -> (num_pages, page_size, 132)
+        # so the tensor matches the 3-D (NB, BS, HS) layout that the
+        # NL_X_NB_BSV_BSS spec (inheriting NL_X_NB_BS_HS_Spec) expects. The
+        # spec's geometry accessors only read shape/dtype/data_ptr, so the view
+        # is safe even though the physical per-block layout interleaves values
+        # and scales differently ([BS x 128 vals][BS x 4B scales]); the
+        # transfer kernels address values and scales separately via raw ptrs.
+        if (
+            list_depth == 1
+            and tensor_ndim == 2
+            and first_tensor.dtype == torch.uint8
+            and int(first_tensor.shape[-1]) % 132 == 0
+        ):
+            bs = int(first_tensor.shape[-1]) // 132
+            kv_caches = [t.view(t.shape[0], bs, 132) for t in kv_caches]
+            return lmcache_native.EngineKVFormat.NL_X_NB_BSV_BSS, kv_caches
+
+        if list_depth == 1:
+            if "tokens_per_block" in layout_hints:
+                # MP MLA, non-fused PBS
+                return lmcache_native.EngineKVFormat.NL_X_NB_BS_HS, kv_caches
+            else:
+                # IP MLA, fused PBS
+                return lmcache_native.EngineKVFormat.NL_X_NBBS_ONE_HS, kv_caches
         if list_depth == 2:
             if tensor_ndim == 4:  # MP daemon: NB/BS split into separate axes
                 return lmcache_native.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS, kv_caches

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py
@@ -20,6 +20,6 @@ import lmcache.lmcache_native as lmcache_native
 
 class NL_X_NB_BSV_BSS_Spec(NL_X_NB_BS_HS_Spec):
     engine_kv_format = lmcache_native.EngineKVFormat.NL_X_NB_BSV_BSS
-    attention_backends = ("vLLM MLA",)
+    attention_backends = ("vLLM MLA", "SGLang MLA")
     is_layer_list = True
     is_mla = True

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -78,6 +78,7 @@ def group_layers_by_identity(
     kv_caches: "DiscoverableKVCache",
     engine_kv_formats: "Sequence[lmcache_native.EngineKVFormat]",
     per_layer_engine_group_idx: Sequence[int] | None = None,
+    per_layer_tokens_per_block: Sequence[int] | None = None,
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
     """Partition layer indices by :data:`LayerGroupIdentity`.
 
@@ -94,6 +95,11 @@ def group_layers_by_identity(
             identity even if their tensor shapes match. Layers whose value is
             ``EXCLUDED_ENGINE_GROUP`` are left out of all groups (e.g. cross-layer
             KV-sharing layers whose KV lives in their target owner's blocks).
+        per_layer_tokens_per_block: Optional logical tokens-per-block per layer,
+            as declared by the engine (``EngineGroupInfo.tokens_per_block``).
+            Used as a fallback for ``block_size`` when the format's spec raises
+            ``ValueError`` — i.e. for NBBS-fused formats (SGLang MLA) where the
+            block axis is folded into PBS and ``block_size()`` is undefined.
 
     Returns:
         A list of ``(identity, layer_indices)`` pairs sorted by each group's
@@ -138,7 +144,16 @@ def group_layers_by_identity(
         nh = 1 if mla else get_num_heads(kv_caches, layer_format, idx)
         hs = get_head_size(kv_caches, layer_format, idx)
         dt = get_dtype(kv_caches, layer_format, idx)
-        bs = get_block_size(kv_caches, layer_format, idx)
+        try:
+            bs = get_block_size(kv_caches, layer_format, idx)
+        except ValueError:
+            # NBBS-fused formats (e.g. SGLang MLA NL_X_NBBS_ONE_HS) fold the
+            # block axis into PBS, so block_size() is undefined. Fall back to
+            # the engine-declared tokens_per_block from EngineGroupInfo.
+            if per_layer_tokens_per_block is not None:
+                bs = per_layer_tokens_per_block[idx]
+            else:
+                raise
 
         identity = LayerGroupIdentity(
             kv_size=kv_size,
@@ -332,6 +347,7 @@ class KVLayerGroupsManager:
         # First Party
         from lmcache.v1.gpu_connector.utils import (
             get_num_blocks,
+            get_page_buffer_size,
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
@@ -348,8 +364,20 @@ class KVLayerGroupsManager:
         per_layer_engine_group_idx = get_engine_group_indices(
             engine_group_infos, num_layers
         )
+        # Build a per-layer tokens_per_block mapping from engine_group_infos so
+        # that group_layers_by_identity can fall back to it for NBBS-fused
+        # formats (SGLang MLA) where block_size() is undefined.
+        per_layer_tokens_per_block: list[int] | None = None
+        if engine_group_infos:
+            per_layer_tokens_per_block = [0] * num_layers
+            for info in engine_group_infos:
+                for layer_idx in info.layer_indices:
+                    per_layer_tokens_per_block[layer_idx] = info.tokens_per_block
         groups_by_identity = group_layers_by_identity(
-            kv_caches, engine_kv_formats, per_layer_engine_group_idx
+            kv_caches,
+            engine_kv_formats,
+            per_layer_engine_group_idx,
+            per_layer_tokens_per_block=per_layer_tokens_per_block,
         )
 
         # Engine group infos are produced by the same group_layers_by_identity
@@ -373,7 +401,14 @@ class KVLayerGroupsManager:
             group_format = identity.engine_kv_format
             # Block count is per engine group (each is its own block-id space), so
             # read it from this group's own tensor rather than a context-wide value.
-            group_num_blocks = get_num_blocks([kv_caches[indices[0]]], group_format)
+            try:
+                group_num_blocks = get_num_blocks([kv_caches[indices[0]]], group_format)
+            except ValueError:
+                # NBBS-fused formats have no separate block axis; derive
+                # num_blocks from page_buffer_size // block_size.
+                group_num_blocks = (
+                    get_page_buffer_size([kv_caches[indices[0]]], group_format) // bs
+                )
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
                 group_format,
@@ -390,7 +425,9 @@ class KVLayerGroupsManager:
                 block_stride_elems=block_stride_elems,
             )
 
-            info = engine_group_infos[group_idx] if engine_group_infos else None
+            info: "EngineGroupInfo | None" = (
+                engine_group_infos[group_idx] if engine_group_infos else None
+            )
             if info is not None and tuple(indices) != tuple(info.layer_indices):
                 raise ValueError(
                     f"group {group_idx}: engine group info covers layers "

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -846,6 +846,12 @@ class TensorMemoryObj(MemoryObj):
             # transport slots from ``tensor.shape`` and
             # ``shm_byte_length`` then stay self-consistent.
             return self.raw_data[: self._used_size_override].view(torch.uint8)
+        # Multi-group objects (e.g. DSA dual-buffer): the raw_data buffer
+        # contains multiple groups concatenated, but meta.shape/dtype only
+        # describe group 0.  Return group 0's properly shaped tensor via
+        # get_tensor(0), which uses group_prefix_sum to slice correctly.
+        if self.meta.shapes is not None and self.meta.dtypes is not None:
+            return self.get_tensor(0)
         # TODO(Jiayi): consider caching the `get_size()`
         return (
             self.raw_data[: self.get_size()].view(self.meta.dtype).view(self.meta.shape)

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -828,7 +828,15 @@ def _per_layer_paged_shape(
     fmt = int(engine_kv_format)
     if fmt == int(EngineKVFormat.NL_X_NBBS_ONE_HS):
         return (nb * bs, 1, hs)
-    if fmt == int(EngineKVFormat.NL_X_NB_BS_HS):
+    if fmt in (
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NB_BSV_BSS),
+    ):
+        # NL_X_NB_BSV_BSS (DSA indexer) is logically identical to
+        # NL_X_NB_BS_HS: a 3-D (NB, BS, HS) per-layer tensor with nh=1.
+        # The physical per-block layout interleaves values and scales
+        # differently, but the transfer kernels address them via raw
+        # ptrs, so the logical shape matches.
         return (nb, bs, hs)
     if fmt == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
         return (2, nb, nh, bs, hs)

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -98,12 +98,25 @@ def get_fstype(path):
     return best_fstype
 
 
-def pack_metadata(tensor, fmt: MemoryFormat, **extra_metadata) -> bytes:
+def pack_metadata(
+    tensor,
+    fmt: MemoryFormat,
+    shapes: Optional[list[torch.Size]] = None,
+    dtypes: Optional[list[torch.dtype]] = None,
+    **extra_metadata,
+) -> bytes:
     if tensor.dtype not in torch_dtypes:
         raise RuntimeError(f"unhandled dtype {tensor.dtype}")
 
     # Metadata
-    data_size = tensor.numel() * tensor.element_size()
+    if shapes is not None and dtypes is not None:
+        # Multi-group: data_size covers all groups' raw bytes so that
+        # data_offsets[1] - data_offsets[0] matches the on-disk blob.
+        data_size = sum(
+            s.numel() * d.element_size() for s, d in zip(shapes, dtypes, strict=True)
+        )
+    else:
+        data_size = tensor.numel() * tensor.element_size()
     tensor_meta = {
         "dtype": torch_dtypes[tensor.dtype],
         "shape": list(tensor.size()),
@@ -111,6 +124,12 @@ def pack_metadata(tensor, fmt: MemoryFormat, **extra_metadata) -> bytes:
         "fmt": fmt.value,
         "__metadata__": extra_metadata,
     }
+    # Record per-group shapes/dtypes for multi-group memory objects (e.g.
+    # DSA dual-buffer) so the retrieve path can reconstruct the multi-group
+    # MemoryObj with the correct group_prefix_sum.
+    if shapes is not None and dtypes is not None:
+        tensor_meta["shapes"] = [list(s) for s in shapes]
+        tensor_meta["dtypes"] = [torch_dtypes[d] for d in dtypes]
     meta = {"kvcache": tensor_meta}
     str_meta = json.dumps(meta).encode("utf-8")
     meta_len = len(str_meta)
@@ -140,7 +159,25 @@ def unpack_metadata(buffer: bytes):
     nbytes = data_offsets[1] - data_offsets[0]
     dtype = torch_dtypes_inverse[dtype_str]
 
-    return torch.Size(shape), dtype, nbytes, fmt, tensor_meta["__metadata__"]
+    # Reconstruct per-group shapes/dtypes for multi-group memory objects.
+    multi_shapes = tensor_meta.get("shapes")
+    multi_dtypes_str = tensor_meta.get("dtypes")
+    if multi_shapes is not None and multi_dtypes_str is not None:
+        shapes = [torch.Size(s) for s in multi_shapes]
+        dtypes = [torch_dtypes_inverse[d] for d in multi_dtypes_str]
+    else:
+        shapes = None
+        dtypes = None
+
+    return (
+        torch.Size(shape),
+        dtype,
+        nbytes,
+        fmt,
+        tensor_meta["__metadata__"],
+        shapes,
+        dtypes,
+    )
 
 
 def rand_suffix(n: int):
@@ -490,7 +527,9 @@ class GdsBackend(AllocatorBackendInterface):
         filename: str,
         subdir_key: str,
     ):
-        shape, dtype, size, fmt, extra_metadata = self._read_metadata_info(filename)
+        shape, dtype, size, fmt, extra_metadata, shapes, dtypes = (
+            self._read_metadata_info(filename)
+        )
         if extra_metadata["lmcache_version"] != str(_METADATA_VERSION):
             raise UnsupportedMetadataVersion("unhandled lmcache metadata")
         logger.debug(
@@ -508,6 +547,8 @@ class GdsBackend(AllocatorBackendInterface):
             dtype,
             None,
             fmt,
+            shapes=shapes,
+            dtypes=dtypes,
         )
         with self.hot_lock:
             self.metadata_dirs.add(subdir_key)
@@ -666,6 +707,8 @@ class GdsBackend(AllocatorBackendInterface):
                     fmt,
                     self.gds_base_pointer,
                     memory_obj.metadata.address,
+                    memory_obj.metadata.shapes,
+                    memory_obj.metadata.dtypes,
                 )
             except Exception as e:
                 logger.error(
@@ -748,9 +791,20 @@ class GdsBackend(AllocatorBackendInterface):
         shape = memory_obj.metadata.shape
         dtype = memory_obj.metadata.dtype
         fmt = memory_obj.metadata.fmt
+        shapes = memory_obj.metadata.shapes
+        dtypes = memory_obj.metadata.dtypes
         with self.hot_lock:
             # TODO(Jiayi): need to support `cached_positions`.
-            self.hot_cache[key] = DiskCacheMetadata(path, size, shape, dtype, None, fmt)
+            self.hot_cache[key] = DiskCacheMetadata(
+                path,
+                size,
+                shape,
+                dtype,
+                None,
+                fmt,
+                shapes=shapes,
+                dtypes=dtypes,
+            )
 
     def submit_prefetch_task(
         self,
@@ -802,10 +856,22 @@ class GdsBackend(AllocatorBackendInterface):
         dtype = entry.dtype
         shape = entry.shape
         fmt = entry.fmt
-        logger.warning(entry)
         assert dtype is not None
         assert shape is not None
         assert fmt is not None
+        # Multi-group memory objects (e.g. DSA dual-buffer) need the
+        # per-group shapes/dtypes so the allocated MemoryObj has the
+        # correct group_prefix_sum for get_tensor(i).
+        if entry.shapes is not None and entry.dtypes is not None:
+            return self._load_bytes_from_disk_with_allocation(
+                key,
+                path,
+                dtype=dtype,
+                shape=shape,
+                fmt=fmt,
+                shapes=entry.shapes,
+                dtypes=entry.dtypes,
+            )
         return self._load_bytes_from_disk_with_allocation(
             key, path, dtype=dtype, shape=shape, fmt=fmt
         )
@@ -817,6 +883,8 @@ class GdsBackend(AllocatorBackendInterface):
         dtype: torch.dtype,
         shape: torch.Size,
         fmt: MemoryFormat,
+        shapes: Optional[list[torch.Size]] = None,
+        dtypes: Optional[list[torch.dtype]] = None,
     ) -> Optional[MemoryObj]:
         """
         Load byte array from disk by first allocating memory, then loading.
@@ -826,12 +894,19 @@ class GdsBackend(AllocatorBackendInterface):
             path: File path to load from
             dtype: Data type for memory allocation
             shape: Shape for memory allocation
+            shapes: Per-group shapes for multi-group memory objects.
+                When provided, the allocator receives the full list so
+                the resulting MemoryObj has the correct group_prefix_sum.
+            dtypes: Per-group dtypes, paired with ``shapes``.
 
         Returns:
             A new memory object with loaded data, or None if allocation or
             loading failed
         """
-        memory_obj = self.memory_allocator.allocate(shape, dtype, fmt=fmt)
+        if shapes is not None and dtypes is not None:
+            memory_obj = self.memory_allocator.allocate(shapes, dtypes, fmt=fmt)
+        else:
+            memory_obj = self.memory_allocator.allocate(shape, dtype, fmt=fmt)
         if memory_obj is None:
             logger.error("Memory allocation failed during sync disk load.")
             return None
@@ -923,6 +998,8 @@ class GdsBackend(AllocatorBackendInterface):
         dtypes: list[torch.dtype | None] = []
         shapes: list[torch.Size | None] = []
         fmts: list[MemoryFormat | None] = []
+        multi_shapes: list[Optional[list[torch.Size]]] = []
+        multi_dtypes: list[Optional[list[torch.dtype]]] = []
         with self.hot_lock:
             for key in keys:
                 entry = self.hot_cache.get(key)
@@ -932,19 +1009,28 @@ class GdsBackend(AllocatorBackendInterface):
                     dtypes.append(None)
                     shapes.append(None)
                     fmts.append(None)
+                    multi_shapes.append(None)
+                    multi_dtypes.append(None)
                     continue
                 paths.append(entry.path)
                 dtypes.append(entry.dtype)
                 shapes.append(entry.shape)
                 fmts.append(entry.fmt)
+                multi_shapes.append(entry.shapes)
+                multi_dtypes.append(entry.dtypes)
 
         memory_objs: list[MemoryObj | None] = []
         gds_reads, gds_read_bytes = 0, 0
-        for dtype, shape, path, fmt in zip(dtypes, shapes, paths, fmts, strict=True):
+        for dtype, shape, path, fmt, m_shapes, m_dtypes in zip(
+            dtypes, shapes, paths, fmts, multi_shapes, multi_dtypes, strict=True
+        ):
             if path is None:
                 memory_objs.append(None)
                 continue
-            memory_obj = self.memory_allocator.allocate(shape, dtype, fmt=fmt)
+            if m_shapes is not None and m_dtypes is not None:
+                memory_obj = self.memory_allocator.allocate(m_shapes, m_dtypes, fmt=fmt)
+            else:
+                memory_obj = self.memory_allocator.allocate(shape, dtype, fmt=fmt)
             if memory_obj is None:
                 logger.error(f"Memory allocation failed during get_blocking for {path}")
             else:
@@ -976,7 +1062,24 @@ class GdsBackend(AllocatorBackendInterface):
         fmt: MemoryFormat,
         base_pointer: int,
         device_offset: int,
+        shapes: Optional[list[torch.Size]] = None,
+        dtypes: Optional[list[torch.dtype]] = None,
     ):
+        # For multi-group memory objects (e.g. DSA dual-buffer), kv_chunk
+        # is only group 0's tensor (via memory_obj.tensor → get_tensor(0)).
+        # The full raw_data buffer contains all groups concatenated, so we
+        # must write get_size() bytes — not kv_chunk.nbytes — to persist
+        # every group.  The write address is the raw_data base pointer
+        # (or the pre-computed base_pointer + device_offset for pinned
+        # allocator paths).
+        if shapes is not None and dtypes is not None:
+            write_nbytes = sum(
+                s.numel() * d.element_size()
+                for s, d in zip(shapes, dtypes, strict=True)
+            )
+        else:
+            write_nbytes = kv_chunk.nbytes
+
         if base_pointer is None:
             addr = ctypes.c_void_p(kv_chunk.data_ptr())
             dev_offset = 0
@@ -988,7 +1091,11 @@ class GdsBackend(AllocatorBackendInterface):
         # TODO: We can add the chunk's metadata here, e.g. Tensor parallelism shard
         # and pipeline parallelism index.
         metadata = pack_metadata(
-            kv_chunk, fmt=fmt, lmcache_version=str(_METADATA_VERSION)
+            kv_chunk,
+            fmt=fmt,
+            shapes=shapes,
+            dtypes=dtypes,
+            lmcache_version=str(_METADATA_VERSION),
         )
         try:
             with open(tmp_path, "wb") as f:
@@ -998,12 +1105,12 @@ class GdsBackend(AllocatorBackendInterface):
                     tmp_path, "r+", use_direct_io=self.use_direct_io
                 ) as f:
                     f.write(
-                        addr, kv_chunk.nbytes, file_offset=offset, dev_offset=dev_offset
+                        addr, write_nbytes, file_offset=offset, dev_offset=dev_offset
                     )
             elif self._gpu_memcpy:
                 # mmap the file
                 fd = os.open(tmp_path, os.O_RDWR)
-                nbytes = kv_chunk.nbytes
+                nbytes = write_nbytes
                 os.ftruncate(fd, nbytes + offset)
                 mm = mmap.mmap(
                     fd, nbytes + offset, prot=mmap.PROT_WRITE, flags=mmap.MAP_SHARED
@@ -1017,7 +1124,7 @@ class GdsBackend(AllocatorBackendInterface):
                 assert addr.value is not None
                 res = self._gpu_memcpy(
                     ctypes.c_void_p(buf_addr + offset),
-                    ctypes.c_void_p(int(addr.value) + device_offset),
+                    ctypes.c_void_p(int(addr.value) + dev_offset),
                     ctypes.c_size_t(nbytes),
                     ctypes.c_int(2),
                 )

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -293,6 +293,8 @@ class LocalDiskBackend(StorageBackendInterface):
         dtype: torch.dtype,
         fmt: MemoryFormat,
         cached_positions: Optional[torch.Tensor] = None,
+        shapes: Optional[list[torch.Size]] = None,
+        dtypes: Optional[list[torch.dtype]] = None,
     ) -> None:
         path = self._key_to_path(key)
 
@@ -304,7 +306,15 @@ class LocalDiskBackend(StorageBackendInterface):
                 has_stored = True
             else:
                 self.dict[key] = DiskCacheMetadata(
-                    path, size, shape, dtype, cached_positions, fmt, 0
+                    path,
+                    size,
+                    shape,
+                    dtype,
+                    cached_positions,
+                    fmt,
+                    0,
+                    shapes=shapes,
+                    dtypes=dtypes,
                 )
 
         # Push kv admit msg with batching
@@ -328,8 +338,15 @@ class LocalDiskBackend(StorageBackendInterface):
         :param on_complete_callback: Optional callback invoked once per key
             after the disk write completes. Callback exceptions are caught
             and logged.
+        :returns: Always ``None``. The task is skipped when a write for this
+            key is already in flight or when the key is already on disk.
         """
         assert memory_obj.tensor is not None
+
+        with self.disk_lock:
+            if key in self.dict:
+                self.cache_policy.update_on_hit(key, self.dict)
+                return None
 
         # skip repeated save
         if self.exists_in_put_tasks(key):
@@ -427,6 +444,8 @@ class LocalDiskBackend(StorageBackendInterface):
             dtype = disk_meta.dtype
             shape = disk_meta.shape
             fmt = disk_meta.fmt
+            shapes = disk_meta.shapes
+            dtypes = disk_meta.dtypes
             assert dtype is not None
             assert shape is not None
 
@@ -435,7 +454,13 @@ class LocalDiskBackend(StorageBackendInterface):
         # must not hold disk_lock while waiting, or concurrent insert/evict
         # operations would deadlock.
         memory_obj = self.load_bytes_from_disk(
-            key, path, dtype=dtype, shape=shape, fmt=fmt
+            key,
+            path,
+            dtype=dtype,
+            shape=shape,
+            fmt=fmt,
+            shapes=shapes,
+            dtypes=dtypes,
         )
 
         if memory_obj is not None:
@@ -474,9 +499,15 @@ class LocalDiskBackend(StorageBackendInterface):
 
         # --- 2. Pre-allocate staging buffers (sequential) -----------------
         memory_objs = [
-            self.local_cpu_backend.allocate(m.shape, m.dtype, m.fmt)
-            if m is not None
-            else None
+            (
+                self.local_cpu_backend.allocate(
+                    m.shapes, m.dtypes, m.fmt
+                )
+                if m is not None and m.shapes is not None and m.dtypes is not None
+                else self.local_cpu_backend.allocate(m.shape, m.dtype, m.fmt)
+                if m is not None
+                else None
+            )
             for m in metas
         ]
 
@@ -551,10 +582,13 @@ class LocalDiskBackend(StorageBackendInterface):
             self.disk_lock.acquire()
             assert key in self.dict, f"Key {key} not found in disk cache after pinning"
 
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
+            disk_meta = self.dict[key]
+            path = disk_meta.path
+            dtype = disk_meta.dtype
+            shape = disk_meta.shape
+            fmt = disk_meta.fmt
+            shapes = disk_meta.shapes
+            dtypes = disk_meta.dtypes
 
             assert dtype is not None
             assert shape is not None
@@ -562,12 +596,20 @@ class LocalDiskBackend(StorageBackendInterface):
             # busy_loop=False prevents spinning on the event loop thread;
             # if staging memory is exhausted the caller will get a logged
             # error rather than a silent deadlock.
-            memory_obj = self.local_cpu_backend.allocate(
-                shape,
-                dtype,
-                fmt,
-                busy_loop=False,
-            )
+            if shapes is not None and dtypes is not None:
+                memory_obj = self.local_cpu_backend.allocate(
+                    shapes,
+                    dtypes,
+                    fmt,
+                    busy_loop=False,
+                )
+            else:
+                memory_obj = self.local_cpu_backend.allocate(
+                    shape,
+                    dtype,
+                    fmt,
+                    busy_loop=False,
+                )
 
             if memory_obj is None:
                 logger.error(
@@ -655,7 +697,18 @@ class LocalDiskBackend(StorageBackendInterface):
         cached_positions = memory_obj.metadata.cached_positions
         memory_obj.ref_count_down()
 
-        self.insert_key(key, size, shape, dtype, fmt, cached_positions=cached_positions)
+        shapes = memory_obj.metadata.shapes
+        dtypes = memory_obj.metadata.dtypes
+        self.insert_key(
+            key,
+            size,
+            shape,
+            dtype,
+            fmt,
+            cached_positions=cached_positions,
+            shapes=shapes,
+            dtypes=dtypes,
+        )
 
         self.disk_worker.remove_put_task(key)
 
@@ -701,12 +754,21 @@ class LocalDiskBackend(StorageBackendInterface):
         dtype: torch.dtype,
         shape: torch.Size,
         fmt: MemoryFormat,
+        shapes: Optional[list[torch.Size]] = None,
+        dtypes: Optional[list[torch.dtype]] = None,
     ) -> Optional[MemoryObj]:
         """
         Load bytearray from disk.
-        """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
+        When ``shapes`` and ``dtypes`` are provided (multi-group memory
+        objects such as DSA dual-buffer), the allocator receives the
+        plural shapes/dtypes so the loaded MemoryObj preserves the
+        multi-group layout needed by get_tensor(i).
+        """
+        if shapes is not None and dtypes is not None:
+            memory_obj = self.local_cpu_backend.allocate(shapes, dtypes, fmt)
+        else:
+            memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
         assert memory_obj is not None, "Memory allocation failed during disk load."
 
         buffer = memory_obj.byte_array

--- a/tests/v1/gpu_connector/test_dsa_support.py
+++ b/tests/v1/gpu_connector/test_dsa_support.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DSA (Deepseek Sparse Attention) indexer support.
+
+These tests cover the SGLang DSA detection path: the indexer buffer is a
+flat list of 2-D uint8 tensors whose last axis is a multiple of 132
+(128 B fp8 key + 4 B fp32 scale per token).  Detection reshapes each
+tensor to 3-D ``(NB, BS, 132)`` and reports ``NL_X_NB_BSV_BSS``.
+
+The mixed-list tests verify that ``normalize_and_discover_per_layer_formats``
+splits a DSA dual-buffer ``kv_caches`` list (NL MLA latent + NL DSA indexer)
+into two format groups.  The ``_build_engine_group_infos`` tests verify the
+daemon-side engine-group metadata for the same split.  The
+``get_shapes`` tests verify per-group shape reporting through
+``KVLayerGroupsManager``.
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.kv_format import detect_format
+from lmcache.v1.gpu_connector.utils import normalize_and_discover_per_layer_formats
+import lmcache.c_ops as lmc_ops
+
+NB, NL, BS, NH, HS = 7, 5, 4, 2, 4
+DT = torch.float16
+F = lmc_ops.EngineKVFormat
+
+# DSA indexer constants
+INDEX_DIM = 132  # 128 B fp8 key + 4 B fp32 scale per token
+
+
+def _t(*shape: int) -> torch.Tensor:
+    return torch.zeros(shape, dtype=DT)
+
+
+def _dsa_t(num_pages: int, page_size: int = BS) -> torch.Tensor:
+    """Create a DSA indexer tensor: 2-D uint8 (num_pages, page_size * 132)."""
+    return torch.zeros(num_pages, page_size * INDEX_DIM, dtype=torch.uint8)
+
+
+# ---------------------------------------------------------------------------
+# SGLang DSA detector
+# ---------------------------------------------------------------------------
+
+
+class TestSGLangDSADetection:
+    """SGLang DSA indexer format detection via ``detect_format``."""
+
+    def test_dsa_indexer_detected(self):
+        """A flat list of 2-D uint8 tensors with last axis % 132 == 0 is
+        detected as ``NL_X_NB_BSV_BSS`` and reshaped to 3-D."""
+        kv = [_dsa_t(NB) for _ in range(NL)]
+        fmt, out = detect_format(kv, EngineType.SGLANG, {"tokens_per_block": BS})
+        assert fmt == F.NL_X_NB_BSV_BSS
+        assert len(out) == NL
+        for t in out:
+            assert t.dim() == 3
+            assert tuple(t.shape) == (NB, BS, INDEX_DIM)
+
+    def test_dsa_indexer_preserves_data_ptr(self):
+        """The reshape is a view -- the data pointer must not change."""
+        kv = [_dsa_t(NB) for _ in range(NL)]
+        _, out = detect_format(kv, EngineType.SGLANG, {"tokens_per_block": BS})
+        assert out[0].data_ptr() == kv[0].data_ptr()
+
+    def test_dsa_indexer_larger_multiple_of_132(self):
+        """A last axis that is a larger multiple of 132 (e.g. 2 * 132) is
+        also valid -- the detector infers page_size from the quotient."""
+        kv = [torch.zeros(NB, 2 * INDEX_DIM, dtype=torch.uint8) for _ in range(NL)]
+        fmt, out = detect_format(kv, EngineType.SGLANG, {"tokens_per_block": BS})
+        assert fmt == F.NL_X_NB_BSV_BSS
+        assert tuple(out[0].shape) == (NB, 2, INDEX_DIM)
+
+    def test_dsa_not_confused_with_mla(self):
+        """A 2-D uint8 tensor must not match the MLA branch (which expects
+        3-D with shape[1] == 1).  DSA detection runs first and catches it."""
+        kv = [_dsa_t(NB) for _ in range(NL)]
+        fmt, _ = detect_format(kv, EngineType.SGLANG, {})
+        assert fmt == F.NL_X_NB_BSV_BSS
+
+    def test_dsa_does_not_require_tokens_per_block_hint(self):
+        """DSA detection works without the ``tokens_per_block`` layout hint
+        -- it infers page_size from ``shape[-1] // 132``."""
+        kv = [_dsa_t(NB) for _ in range(NL)]
+        fmt, out = detect_format(kv, EngineType.SGLANG, {})
+        assert fmt == F.NL_X_NB_BSV_BSS
+        assert tuple(out[0].shape) == (NB, BS, INDEX_DIM)
+
+
+# ---------------------------------------------------------------------------
+# normalize_and_discover_per_layer_formats: mixed DSA dual-buffer
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMixedDSA:
+    """``normalize_and_discover_per_layer_formats`` splits a DSA dual-buffer
+    list (NL MLA latent + NL DSA indexer) into two format groups."""
+
+    def test_mixed_mla_dsa_with_explicit_groups(self):
+        """A flat list of NL MLA latent tensors followed by NL DSA indexer
+        tensors is split into two groups with distinct formats."""
+        mla = [_t(NB * BS, 1, HS) for _ in range(NL)]
+        dsa = [_dsa_t(NB) for _ in range(NL)]
+        kv = mla + dsa
+        normalized, formats = normalize_and_discover_per_layer_formats(
+            kv,
+            [list(range(NL)), list(range(NL, 2 * NL))],
+            EngineType.SGLANG,
+            {"tokens_per_block": BS},
+        )
+        assert len(normalized) == 2 * NL
+        assert len(formats) == 2 * NL
+        # First NL layers: MLA latent
+        assert formats[:NL] == [F.NL_X_NBBS_ONE_HS] * NL
+        # Last NL layers: DSA indexer
+        assert formats[NL:] == [F.NL_X_NB_BSV_BSS] * NL
+        # DSA tensors are reshaped to 3-D
+        for t in normalized[NL:]:
+            assert t.dim() == 3
+            assert tuple(t.shape) == (NB, BS, INDEX_DIM)
+
+    def test_mixed_mla_dsa_no_explicit_groups(self):
+        """Without explicit ``layer_index_groups``, the function still
+        splits by tensor shape -- MLA and DSA have different shapes."""
+        mla = [_t(NB * BS, 1, HS) for _ in range(NL)]
+        dsa = [_dsa_t(NB) for _ in range(NL)]
+        kv = mla + dsa
+        normalized, formats = normalize_and_discover_per_layer_formats(
+            kv, (), EngineType.SGLANG, {"tokens_per_block": BS}
+        )
+        assert formats[:NL] == [F.NL_X_NBBS_ONE_HS] * NL
+        assert formats[NL:] == [F.NL_X_NB_BSV_BSS] * NL
+
+
+# ---------------------------------------------------------------------------
+# _build_engine_group_infos
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEngineGroupInfos:
+    """``LMCacheMPConnector._build_engine_group_infos`` returns two groups
+    for DSA (MLA latent + DSA indexer) and empty for MLA/MHA."""
+
+    @staticmethod
+    def _make_connector(kvcaches, use_mla, num_layers, page_size):
+        """Create an ``LMCacheMPConnector`` without calling ``__init__``."""
+        # First Party
+        from lmcache.integration.sglang.multi_process_adapter import (
+            LMCacheMPConnector,
+        )
+
+        conn = LMCacheMPConnector.__new__(LMCacheMPConnector)
+        conn.kvcaches = kvcaches
+        conn.use_mla = use_mla
+        conn.num_layers = num_layers
+        conn.page_size = page_size
+        return conn
+
+    def test_dsa_returns_two_groups(self):
+        """DSA (use_mla=True, num_kv_tensors > num_layers) returns two
+        ``EngineGroupInfo`` entries, both with ``engine_group_id=0``."""
+        kv = [_t(NB * BS, 1, HS) for _ in range(NL)] + [_dsa_t(NB) for _ in range(NL)]
+        conn = self._make_connector(kv, use_mla=True, num_layers=NL, page_size=BS)
+        infos = conn._build_engine_group_infos()
+        assert len(infos) == 2
+        # Both share engine_group_id=0 (same page address space)
+        assert all(info.engine_group_id == 0 for info in infos)
+        # First group: MLA latent layers [0, NL)
+        assert tuple(infos[0].layer_indices) == tuple(range(NL))
+        assert infos[0].tokens_per_block == BS
+        # Second group: DSA indexer layers [NL, 2*NL)
+        assert tuple(infos[1].layer_indices) == tuple(range(NL, 2 * NL))
+        assert infos[1].tokens_per_block == BS
+
+    def test_mla_returns_empty(self):
+        """MLA (use_mla=True, num_kv_tensors == num_layers) returns empty."""
+        kv = [_t(NB * BS, 1, HS) for _ in range(NL)]
+        conn = self._make_connector(kv, use_mla=True, num_layers=NL, page_size=BS)
+        infos = conn._build_engine_group_infos()
+        assert infos == []
+
+    def test_mha_returns_empty(self):
+        """MHA (use_mla=False) returns empty regardless of tensor count."""
+        kv = [_t(NB * BS, NH, HS) for _ in range(2 * NL)]
+        conn = self._make_connector(kv, use_mla=False, num_layers=NL, page_size=BS)
+        infos = conn._build_engine_group_infos()
+        assert infos == []
+
+
+# ---------------------------------------------------------------------------
+# metadata.get_shapes()
+# ---------------------------------------------------------------------------
+
+
+class TestGetShapes:
+    """``LMCacheMetadata.get_shapes`` returns per-group shapes when a
+    ``KVLayerGroupsManager`` is attached."""
+
+    def test_fallback_single_shape(self):
+        """Without a ``KVLayerGroupsManager``, ``get_shapes`` returns a
+        single shape derived from the legacy ``kv_shape`` field."""
+        # First Party
+        from lmcache.v1.metadata import LMCacheMetadata
+
+        meta = LMCacheMetadata(
+            model_name="test",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.float16,
+            kv_shape=(NL, 2, 256, NH, HS),
+        )
+        shapes = meta.get_shapes()
+        assert len(shapes) == 1
+        assert tuple(shapes[0]) == (2, NL, 256, NH * HS)
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="KVLayerGroupsManager requires CUDA build",
+    )
+    def test_dsa_two_group_shapes(self):
+        """With a ``KVLayerGroupsManager`` for DSA, ``get_shapes`` returns
+        two shapes: one for MLA latent and one for DSA indexer."""
+        # First Party
+        from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+        from lmcache.v1.metadata import LMCacheMetadata
+        from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+        mla = [_t(NB * BS, 1, HS) for _ in range(NL)]
+        dsa = [_dsa_t(NB) for _ in range(NL)]
+        kv = mla + dsa
+        normalized, formats = normalize_and_discover_per_layer_formats(
+            kv,
+            [list(range(NL)), list(range(NL, 2 * NL))],
+            EngineType.SGLANG,
+            {"tokens_per_block": BS},
+        )
+        # engine_group_infos provides tokens_per_block so that
+        # group_layers_by_identity can fall back to it for fused formats
+        # (NL_X_NBBS_ONE_HS) whose block_size() is undefined.
+        engine_group_infos = [
+            EngineGroupInfo(
+                engine_group_id=0,
+                layer_indices=tuple(range(NL)),
+                tokens_per_block=BS,
+            ),
+            EngineGroupInfo(
+                engine_group_id=0,
+                layer_indices=tuple(range(NL, 2 * NL)),
+                tokens_per_block=BS,
+            ),
+        ]
+        manager = KVLayerGroupsManager(
+            normalized,
+            engine_kv_formats=formats,
+            engine_group_infos=engine_group_infos,
+        )
+        meta = LMCacheMetadata(
+            model_name="test",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.float16,
+            kv_shape=(NL, 1, 256, 1, HS),
+            use_mla=True,
+            kv_layer_groups_manager=manager,
+        )
+        shapes = meta.get_shapes(num_tokens=256)
+        assert len(shapes) == 2
+        # Group 0: MLA latent (kv_size=1, NL layers, 256 tokens, HS hidden)
+        assert tuple(shapes[0]) == (1, NL, 256, HS)
+        # Group 1: DSA indexer (kv_size=1, NL layers, 256 tokens, 132 hidden)
+        assert tuple(shapes[1]) == (1, NL, 256, INDEX_DIM)
+
+
+# ---------------------------------------------------------------------------
+# Layerwise MLA/DSA guard
+# ---------------------------------------------------------------------------
+
+
+class TestLayerwiseMLAGuard:
+    """``CreateGPUConnector`` rejects ``use_layerwise=True`` for MLA/DSA."""
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="CreateGPUConnector calls torch_dev.set_device (requires CUDA)",
+    )
+    def test_layerwise_mla_raises(self):
+        """When ``metadata.use_mla`` is True and ``config.use_layerwise``
+        is True, ``CreateGPUConnector`` raises ``ValueError``."""
+        # First Party
+        from lmcache.v1.config import LMCacheEngineConfig
+        from lmcache.v1.gpu_connector import CreateGPUConnector
+        from lmcache.v1.metadata import LMCacheMetadata
+
+        config = LMCacheEngineConfig.from_defaults(use_layerwise=True)
+        metadata = LMCacheMetadata(
+            model_name="test",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.float16,
+            kv_shape=(NL, 1, 256, 1, HS),
+            use_mla=True,
+        )
+        with pytest.raises(
+            ValueError,
+            match="Layerwise mode.*not yet supported.*MLA/DSA",
+        ):
+            CreateGPUConnector(
+                config=config,
+                metadata=metadata,
+                engine=EngineType.SGLANG,
+                layout_hints={"tokens_per_block": BS},
+            )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="CreateGPUConnector calls torch_dev.set_device (requires CUDA)",
+    )
+    def test_layerwise_mha_allowed(self):
+        """When ``metadata.use_mla`` is False, ``use_layerwise=True`` is
+        allowed (the layerwise connector is constructed for MHA)."""
+        # First Party
+        from lmcache.v1.config import LMCacheEngineConfig
+        from lmcache.v1.gpu_connector import CreateGPUConnector
+        from lmcache.v1.gpu_connector.gpu_connectors import (
+            SGLangLayerwiseGPUConnector,
+        )
+        from lmcache.v1.metadata import LMCacheMetadata
+
+        config = LMCacheEngineConfig.from_defaults(use_layerwise=True)
+        metadata = LMCacheMetadata(
+            model_name="test",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.float16,
+            kv_shape=(NL, 2, 256, NH, HS),
+            use_mla=False,
+        )
+        connector = CreateGPUConnector(
+            config=config,
+            metadata=metadata,
+            engine=EngineType.SGLANG,
+            layout_hints={"tokens_per_block": BS},
+        )
+        assert isinstance(connector, SGLangLayerwiseGPUConnector)

--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -30,12 +30,14 @@ def test_gds_backend_metadata():
     # more tensor types to be sure.
     for [tensor, expected_nbytes] in [(torch.randn(3, 10), 120)]:
         r = pack_metadata(tensor, fmt=MemoryFormat.KV_2LTD, version="test")
-        size, dtype, nbytes, fmt, meta = unpack_metadata(r)
+        size, dtype, nbytes, fmt, meta, shapes, dtypes = unpack_metadata(r)
         assert size == tensor.size()
         assert dtype == tensor.dtype
         assert expected_nbytes == nbytes
         assert fmt == MemoryFormat.KV_2LTD
         assert meta["version"] == "test"
+        assert shapes is None
+        assert dtypes is None
 
         # Make sure that safetensors can load this
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -865,6 +865,27 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
                 gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size
             )
 
+    metadata = LMCacheMetadata(
+        model_name="test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=dtype,
+        kv_shape=(num_layers, 1 if use_mla else 2, chunk_size, num_heads, head_size),
+        use_mla=use_mla,
+    )
+    metadata2 = LMCacheMetadata(
+        model_name="test",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=dtype,
+        kv_shape=(num_layers, 1 if use_mla else 2, chunk_size, num_heads, head_size),
+        use_mla=use_mla,
+    )
+
     connector = SGLangGPUConnector(
         hidden_dim,
         num_layers,
@@ -873,6 +894,8 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
         dtype=dtype,
         device=device,
         use_mla=use_mla,
+        metadata=metadata,
+        layout_hints={"tokens_per_block": block_size},
     )
     connector2 = SGLangGPUConnector(
         hidden_dim,
@@ -882,13 +905,16 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
         dtype=dtype,
         device=device,
         use_mla=use_mla,
+        metadata=metadata2,
+        layout_hints={"tokens_per_block": block_size},
     )
     assert connector.use_mla == use_mla
     assert connector2.use_mla == use_mla
     for start in range(0, num_tokens, chunk_size):
         end = min(start + chunk_size, num_tokens)
-        shape = connector.get_shape(end - start)
-        memory_obj = allocator.allocate(shape, gpu_kv_src[0][0].dtype)
+        memory_obj = allocator.allocate(
+            metadata.get_shapes(end - start), metadata.get_dtypes()
+        )
         connector.from_gpu(
             memory_obj,
             start,

--- a/tests/v1/test_sglang_adapter.py
+++ b/tests/v1/test_sglang_adapter.py
@@ -16,7 +16,7 @@ from lmcache.v1.metadata import LMCacheMetadata
 
 
 @pytest.mark.parametrize(
-    ("attention_arch", "kv_head_dim", "expected_shape", "expected_use_mla"),
+    ("attention_arch", "kv_cache_dim", "expected_shape", "expected_use_mla"),
     [
         ("MHA", None, (2, 2, 16, 4, 128), False),
         ("MLA", 576, (2, 1, 16, 1, 576), True),
@@ -25,7 +25,7 @@ from lmcache.v1.metadata import LMCacheMetadata
 def test_init_lmcache_engine_propagates_sglang_attention_arch(
     monkeypatch: pytest.MonkeyPatch,
     attention_arch: str,
-    kv_head_dim: int | None,
+    kv_cache_dim: int | None,
     expected_shape: tuple[int, int, int, int, int],
     expected_use_mla: bool,
 ) -> None:
@@ -40,6 +40,7 @@ def test_init_lmcache_engine_propagates_sglang_attention_arch(
         _connector_config: LMCacheEngineConfig,
         metadata: object,
         engine_type: EngineType,
+        **_kwargs: object,
     ) -> object:
         captured["metadata"] = metadata
         captured["engine_type"] = engine_type
@@ -67,7 +68,9 @@ def test_init_lmcache_engine_propagates_sglang_attention_arch(
         global_rank=0,
         kv_dtype=torch.float16,
         config_file="",
-        kv_head_dim=kv_head_dim,
+        use_mla=expected_use_mla,
+        kv_cache_dim=kv_cache_dim,
+        page_size=1,
     )
 
     metadata = cast(LMCacheMetadata, captured["metadata"])
@@ -90,7 +93,10 @@ def test_init_lmcache_engine_rejects_mla_without_pool_width(
         model_path="test-model",
     )
 
-    with pytest.raises(ValueError, match="positive KV-cache row width"):
+    with pytest.raises(
+        ValueError,
+        match="kv_cache_dim must be provided when use_mla=True",
+    ):
         adapter_mod.init_lmcache_engine(
             model_config,
             tp_size=1,
@@ -98,6 +104,7 @@ def test_init_lmcache_engine_rejects_mla_without_pool_width(
             global_rank=0,
             kv_dtype=torch.float16,
             config_file="",
+            use_mla=True,
         )
 
 
@@ -132,6 +139,7 @@ def test_connector_registers_only_the_model_kv_layout(
         num_hidden_layers=2,
     )
 
+    use_mla = attention_arch == "MLA"
     connector = adapter_mod.LMCacheConnector(
         model_config,
         tp_size=1,
@@ -139,9 +147,13 @@ def test_connector_registers_only_the_model_kv_layout(
         k_pool=k_pool,
         v_pool=v_pool,
         config_file="",
+        use_mla=use_mla,
+        kv_cache_dim=width if use_mla else None,
+        page_size=1,
     )
 
     assert len(connector.kvcaches) == expected_cache_count
     init_kwargs = cast(dict[str, object], captured["kwargs"])
-    assert init_kwargs["kv_head_dim"] == expected_width
+    assert init_kwargs["use_mla"] is use_mla
+    assert init_kwargs["kv_cache_dim"] == expected_width
     engine.post_init.assert_called_once_with(kvcaches=connector.kvcaches)

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -145,8 +145,12 @@ def test_wrap_sglang_kv_caches_uses_platform_wrapper_in_kv_order(
 ) -> None:
     """Registration dispatches each tensor through the platform wrapper."""
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
-    k_pool = [torch.tensor([1]), torch.tensor([2])]
-    v_pool = [torch.tensor([3]), torch.tensor([4])]
+    kv_caches = [
+        torch.tensor([1]),
+        torch.tensor([2]),
+        torch.tensor([3]),
+        torch.tensor([4]),
+    ]
     wrapped_tensors: list[torch.Tensor] = []
 
     def wrap_one(tensor: torch.Tensor) -> object:
@@ -160,11 +164,11 @@ def test_wrap_sglang_kv_caches_uses_platform_wrapper_in_kv_order(
         raising=False,
     )
 
-    wrapped = adapter_mod._wrap_sglang_kv_caches(k_pool, v_pool)
+    wrapped = adapter_mod._wrap_sglang_kv_caches(kv_caches)
     wrapped_namespaces = cast(list[SimpleNamespace], wrapped)
 
-    assert wrapped_tensors == [*k_pool, *v_pool]
-    assert [wrapper.tensor for wrapper in wrapped_namespaces] == [*k_pool, *v_pool]
+    assert wrapped_tensors == kv_caches
+    assert [wrapper.tensor for wrapper in wrapped_namespaces] == kv_caches
 
 
 def test_wrap_sglang_kv_caches_requires_full_handle_capability(
@@ -187,14 +191,71 @@ def test_wrap_sglang_kv_caches_requires_full_handle_capability(
         )
 
 
-def test_wrap_sglang_kv_caches_rejects_mismatched_layers() -> None:
-    """Registration rejects a wire payload that cannot split into K/V pairs."""
+def test_wrap_sglang_kv_caches_rejects_empty_list() -> None:
+    """Registration rejects an empty KV cache list."""
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
-    with pytest.raises(ValueError, match="matching K and V layers"):
-        adapter_mod._wrap_sglang_kv_caches(
-            [torch.tensor([1]), torch.tensor([2])],
-            [torch.tensor([3])],
-        )
+    with pytest.raises(ValueError, match="non-empty KV caches"):
+        adapter_mod._wrap_sglang_kv_caches([])
+
+
+def test_mp_connector_registration_marks_kv_list_layout(monkeypatch) -> None:
+    """Registration identifies flat single-head pools as split K/V MHA."""
+    adapter_mod, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
+    req_client = MagicMock(name="rpc_client")
+    req_client.register_kv_cache.return_value = SimpleNamespace(
+        result=MagicMock(return_value=None)
+    )
+
+    class FakeHeartbeatThread:
+        def __init__(
+            self,
+            req_client: object,
+            health_event: threading.Event,
+            interval: float,
+            instance_id: int | None,
+        ) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "zmq",
+        SimpleNamespace(Context=SimpleNamespace(instance=lambda: object())),
+    )
+    request_client_factory = MagicMock(name="request_client_factory")
+    request_client_factory.create.return_value = req_client
+    monkeypatch.setattr(
+        adapter_mod,
+        "RequestClientFactory",
+        request_client_factory,
+    )
+    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda _client: 4)
+    monkeypatch.setattr(adapter_mod, "HeartbeatThread", FakeHeartbeatThread)
+    monkeypatch.setattr(
+        adapter_mod,
+        "get_device_spec",
+        lambda _device_type: SimpleNamespace(is_handle_transfer_available=lambda: True),
+    )
+    monkeypatch.setattr(adapter_mod, "wrap_one_kv_cache", lambda tensor: tensor)
+
+    kv_caches = [torch.empty(4, 1, 8) for _ in range(4)]
+    LMCacheMPConnector(
+        sgl_config=SimpleNamespace(model_path="test-model"),
+        tp_size=1,
+        rank=0,
+        page_size=2,
+        host="127.0.0.1",
+        port=5556,
+        kv_caches=kv_caches,
+    )
+
+    req_client.register_kv_cache.assert_called_once()
+    assert req_client.register_kv_cache.call_args.args[5] == {
+        "tokens_per_block": 2,
+        "kv_list_layout": "k_v",
+    }
 
 
 @pytest.mark.parametrize(
@@ -230,13 +291,10 @@ def test_mp_connector_validates_pools_before_opening_mq(
 
 
 def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> None:
-    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    _, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=False)
-
-    def _fail_send(*args, **kwargs):
-        pytest.fail("send_lmcache_request must not be called when unhealthy")
-
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", _fail_send)
+    conn.req_client = MagicMock(name="rpc_client")
+    conn.engine_group_infos = []
 
     future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
 
@@ -244,24 +302,22 @@ def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> 
     assert future.query() is True
     # Unhealthy connector stored nothing -> the future must report failure.
     assert future.result(timeout=0) is False
+    conn.req_client.store.assert_not_called()
 
 
 def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(
     monkeypatch,
 ) -> None:
-    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    _, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=True)
-
-    def _fail_send(*args, **kwargs):
-        pytest.fail("send_lmcache_request must not be called with no aligned range")
-
-    monkeypatch.setattr(adapter_mod, "send_lmcache_request", _fail_send)
+    conn.req_client = MagicMock(name="rpc_client")
 
     # Fewer tokens than one chunk -> aligned_end == 0 -> no wire send.
     future = conn.store_kv_async(_store_metadata(num_tokens=_CHUNK_SIZE - 1))
 
     assert isinstance(future, MessagingFuture)
     assert future.result(timeout=0) is True
+    conn.req_client.store.assert_not_called()
 
 
 def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
@@ -269,7 +325,7 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
 ) -> None:
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
     conn = _make_connector(healthy=True)
-    conn.mq_client = object()  # type: ignore[assignment]
+    conn.req_client = MagicMock(name="rpc_client")
     conn.instance_id = 123
     conn.device = "cpu"
     # Stub the helpers store_kv_async calls so we exercise only its own logic.
@@ -278,11 +334,7 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
 
     sentinel = _SpyFuture()
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
-    monkeypatch.setattr(
-        adapter_mod,
-        "send_lmcache_request",
-        lambda mq_client, request_type, payload: _FakeRaw(sentinel),
-    )
+    conn.req_client.store.return_value = _FakeRaw(sentinel)
 
     future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
 
@@ -299,21 +351,18 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
     """The producer event outlives daemon import through the returned future."""
     adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
     connector = _make_connector(healthy=True)
-    connector.mq_client = object()  # type: ignore[assignment]
+    connector.req_client = MagicMock(name="rpc_client")
     connector.instance_id = 123
     connector.device = "cpu"
     connector.model_name = "test-model"
     connector.tp_size = 1
     connector.worker_id = 0
     sentinel = _SpyFuture()
+    raw = _FakeRaw(sentinel)
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
-    monkeypatch.setattr(
-        adapter_mod,
-        "send_lmcache_request",
-        lambda mq_client, request_type, payload: _FakeRaw(sentinel),
-    )
+    connector.req_client.retrieve.return_value = raw
 
-    future = connector._submit_retrieve(
+    raw_future, future = connector._submit_retrieve(
         request_id="request-1",
         token_ids=[1, 2],
         offset=0,
@@ -321,9 +370,71 @@ def test_submit_retrieve_retains_exported_device_event(monkeypatch) -> None:
         block_ids=[0],
     )
 
+    assert raw_future is raw
     assert future is sentinel
     assert len(sentinel.retained_references) == 1
     assert isinstance(sentinel.retained_references[0], _FakeEvent)
+
+
+@pytest.mark.parametrize(
+    ("event_handle", "expected_free_ranges"),
+    [
+        (b"", [(0, _CHUNK_SIZE)]),
+        (
+            b"completion-event",
+            [(0, _CHUNK_SIZE), (_CHUNK_SIZE, 2 * _CHUNK_SIZE)],
+        ),
+    ],
+)
+def test_retrieve_failure_uses_single_cleanup_owner(
+    event_handle: bytes,
+    expected_free_ranges: list[tuple[int, int]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An event-free failure must not repeat server-side lock cleanup."""
+    adapter_mod, _, _completed_future, _, LoadMetadata, _ = _import_adapter_symbols()
+    connector = _make_connector(healthy=True)
+    connector.req_client = MagicMock(name="rpc_client")
+    connector.model_name = "test-model"
+    connector.tp_size = 2
+    connector.worker_id = 0
+    connector.page_size = _CHUNK_SIZE
+    connector._pending_lookups = {
+        "request-1": SimpleNamespace(
+            token_ids=list(range(2 * _CHUNK_SIZE)),
+            matched_token_num=2 * _CHUNK_SIZE,
+            locks_held=True,
+        )
+    }
+    connector._pending_lookups_lock = threading.Lock()
+    connector._slot_mapping_to_block_ids = MagicMock(return_value=[1])
+
+    free_ranges: list[tuple[int, int]] = []
+
+    def record_free_request(key: Any, _tp_size: int) -> MessagingFuture[bool]:
+        free_ranges.append((key.start, key.end))
+        return _completed_future(True)
+
+    connector.req_client.free_lookup_locks.side_effect = record_free_request
+
+    raw_future: MessagingFuture[tuple[bytes, bool]] = MessagingFuture()
+    raw_future.set_result((event_handle, False))
+    connector._submit_retrieve = MagicMock(
+        return_value=(raw_future, _completed_future(False))
+    )
+    token_ids = connector._pending_lookups["request-1"].token_ids
+    metadata = LoadMetadata(
+        token_ids=token_ids,
+        slot_mapping=torch.arange(2 * _CHUNK_SIZE),
+        offset=_CHUNK_SIZE,
+        request_id="request-1",
+    )
+
+    with pytest.raises(RuntimeError, match="LMCache MP retrieve failed"):
+        connector.retrieve_kv(metadata)
+
+    assert free_ranges == expected_free_ranges
+    assert connector._pending_lookups["request-1"].locks_held is False
 
 
 def test_layerwise_load_forwards_partial_slot_mapping_offset() -> None:

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -137,6 +137,12 @@ def recover_engine_states(engine):
 
 def recover_gpu_connector_states(gpu_connector):
     gpu_connector.kv_cache_pointers_on_gpu = {}
+    # SGLangGPUConnector keeps per-group state that must also be reset
+    # so a fresh _initialize_pointers runs on the next store/retrieve.
+    if hasattr(gpu_connector, "_layer_groups_initialized"):
+        gpu_connector._layer_groups_initialized = False
+    if hasattr(gpu_connector, "group_kv_cache_pointers_on_gpu"):
+        gpu_connector.group_kv_cache_pointers_on_gpu = []
 
 
 def dumb_metadata(kv_shape=(32, 2, 256, 8, 128)):


### PR DESCRIPTION
## Summary

This PR adds DSA (Deepseek Sparse Attention) indexer support for SGLang integration, enabling LMCache to correctly handle, store, and retrieve DSA-format KV caches used by GLM-5.2/5.3 and similar models with MLA+DSA attention.

## Changes

### DSA Indexer Detection (`lmcache/v1/gpu_connector/kv_format/detectors/sglang.py`)
- Add detection for DSA indexer tensors: 2-D `uint8` tensors where `shape[-1] % 132 == 0` (132 = 128B fp8 key + 4B fp32 scale per token)
- Reshape to `(num_pages, page_size, 132)` and return `NL_X_NB_BSV_BSS` format

### Disk Cache Metadata (`lmcache/utils.py`)
- Add `shapes: Optional[list[torch.Size]]` and `dtypes: Optional[list[torch.dtype]]` fields to `DiskCacheMetadata` for multi-group memory objects

### Local Disk Backend (`lmcache/v1/storage_backend/local_disk_backend.py`)
- Pass `shapes`/`dtypes` through `get_blocking`, `load_bytes_from_disk`, `insert_key`
- Extract `shapes`/`dtypes` from `disk_meta` when available
- Add shapes/dtypes-aware allocate paths for multi-group tensors

### Multi-Process Adapter (`lmcache/integration/sglang/multi_process_adapter.py`)
- Replace `_validate_sglang_kv_pools(k_pool, v_pool)` with `_validate_sglang_kv_caches(kv_caches)`
- Update `_wrap_sglang_kv_caches` to take `kv_caches` instead of `k_pool`/`v_pool`
- Add `EngineGroupInfo`/`expand_engine_block_ids` import and `engine_group_infos` attribute
- Compatible with new `RequestClient`/`RequestClientFactory` transport

### DSA KV Format Spec (`lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py`)
- Add `NL_X_NB_BSV_BSS` format spec for DSA indexer tensors

### Tests
- `tests/v1/gpu_connector/test_dsa_support.py`: Comprehensive DSA detection and format tests
- `tests/v1/test_sglang_mp_adapter.py`: Updated tests for `kv_caches` API
- `tests/v1/test_gds.py`, `tests/v1/test_gpu_connector.py`, `tests/v1/test_sglang_adapter.py`: Updated for new APIs

## Testing

All tests pass on MI350X (gfx950) and MI308X (gfx942) hardware with GLM-5.2/5.3 models.

## Related

Supersedes the closed PR #4586 (which had a stale base tree). This is a clean rebase against current `dev`.