### PR TITLE
[Doc] zh_CN: fix inline literal escaping before fullwidth parens

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/mp/index.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/mp/index.po
@@ -232,7 +232,7 @@ msgid ""
 "state.  The ZMQ server runs as part of the same process, and any "
 "configured runtime plugins are spawned by ``MPRuntimePluginLauncher`` "
 "during FastAPI startup."
-msgstr "**``http_server.py``** -- 将 ``run_cache_server()``（来自 ``server.py``）封装在 FastAPI 应用程序中。端点由 ``http_apis/`` 下的模块贡献，并通过 ``HTTPAPIRegistry`` 自动注册：``GET /``（基本存活检查）、``GET /healthcheck`` 用于 Kubernetes 探针、``POST /cache/clear`` 用于清除 L1（CPU）内存中的所有 KV Cache 数据，以及 ``GET /status`` 用于检查详细的内部状态。ZMQ 服务器作为同一进程的一部分运行，任何配置的运行时插件在 FastAPI 启动期间由 ``MPRuntimePluginLauncher`` 生成。"
+msgstr "**``http_server.py``** -- 将 ``run_cache_server()``\ （来自 ``server.py``）封装在 FastAPI 应用程序中。端点由 ``http_apis/`` 下的模块贡献，并通过 ``HTTPAPIRegistry`` 自动注册：``GET /``\ （基本存活检查）、``GET /healthcheck`` 用于 Kubernetes 探针、``POST /cache/clear`` 用于清除 L1（CPU）内存中的所有 KV Cache 数据，以及 ``GET /status`` 用于检查详细的内部状态。ZMQ 服务器作为同一进程的一部分运行，任何配置的运行时插件在 FastAPI 启动期间由 ``MPRuntimePluginLauncher`` 生成。"
 
 #: ../../source/mp/index.rst:143
 msgid "ZMQ Protocol"
@@ -774,7 +774,7 @@ msgid ""
 "-- cuFile (``libcufile.so``) on NVIDIA and hipFile (``libhipfile.so``) on"
 " AMD ROCm; see the *GDS L1 Tier* section of :doc:`configuration` for the "
 "vendor-specific requirements. The CPU tier is disabled in this mode."
-msgstr "``GDSL1MemoryManager`` -- 当设置了 ``--gds-l1-path`` 时，使用 NVMe 块文件。字节存储在磁盘上；读/写通过 DMA 直接在 GPU 暂存缓冲区和块之间进行，由进程全局的 ``GDSContext``（``gpu_connector/gds_context.py``）驱动，并从 ``gpu_ops`` 派发。DMA 后端由平台通过 ``gpu_connector/_gds_async.py`` 选择 -- NVIDIA 使用 cuFile（``libcufile.so``），AMD ROCm 使用 hipFile（``libhipfile.so``）；有关特定于供应商的要求，请参见 :doc:`configuration` 的 *GDS L1 Tier* 部分。在此模式下，CPU 层被禁用。"
+msgstr "``GDSL1MemoryManager`` -- 当设置了 ``--gds-l1-path`` 时，使用 NVMe 块文件。字节存储在磁盘上；读/写通过 DMA 直接在 GPU 暂存缓冲区和块之间进行，由进程全局的 ``GDSContext``\ （``gpu_connector/gds_context.py``）驱动，并从 ``gpu_ops`` 派发。DMA 后端由平台通过 ``gpu_connector/_gds_async.py`` 选择 -- NVIDIA 使用 cuFile（``libcufile.so``），AMD ROCm 使用 hipFile（``libhipfile.so``）；有关特定于供应商的要求，请参见 :doc:`configuration` 的 *GDS L1 Tier* 部分。在此模式下，CPU 层被禁用。"
 
 #: ../../source/mp/index.rst:401
 msgid "L2 Adapters"


### PR DESCRIPTION
**What this PR does / why we need it**:

Three inline literals in the zh_CN catalog for `docs/source/mp/index.rst` are followed immediately by a fullwidth left parenthesis (U+FF08). docutils only closes an inline-markup span when the end-string is followed by whitespace or closing/final punctuation, so the span is never recognised and the raw backticks leak into the rendered page. The unmatched backticks then mis-pair with the next span, so the rest of the sentence loses its markup as well.

Rendered today on https://docs.lmcache.ai/zh_CN/mp/index.html

```
将 run_cache_server()``（来自 ``server.py）封装在 FastAPI 应用程序中
...由进程全局的 GDSContext``（``gpu_connector/gds_context.py）驱动
```

Expected:

```
将 run_cache_server()（来自 server.py）封装在 FastAPI 应用程序中
...由进程全局的 GDSContext（gpu_connector/gds_context.py）驱动
```

The fix inserts the escaped-space separator (a backslash followed by a space) before the fullwidth parenthesis. This is the convention the same file already uses in 58 other places, and that `kv_cache/storage_backends/s3.po`, `kv_cache/storage_backends/hfbucket.po` and `mp/l2_storage/index.po` already use for exactly this fullwidth-parenthesis case — those pages render with no stray backticks.

**Special notes for your reviewers**:

Only `msgstr` lines change and no `msgid` is touched, so the catalog mapping is unaffected. Three spans are fixed across two entries (source refs `mp/index.rst:143` and `mp/index.rst:401`).

The same pattern appears in roughly 17 other zh_CN catalogs, e.g. `cli/tool.po`, `cli/bench.po`, `mp/http_api.po`, `mp/coordinator.po`. For scale, the rendered `zh_CN/cli/tool.html` currently shows 20 stray backtick pairs. I am happy to send follow-up PRs per directory if this approach looks right.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
