### PR TITLE
[Fix][MP] Don't store MTP's speculative scratch block as a Mamba state

### DIFF
--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -174,15 +174,21 @@ logical-block granularity. See
 limits (notably: edited groups are byte-opaque — no content-aware processing,
 no cross-backend cache sharing).
 
-In `mamba_cache_mode="align"` a Mamba group's block list is sparse: a step
-writes one state, into the slot of its last token, and vLLM nulls the slots a
-multi-block step skips (EAGLE-family speculative decoding merges the prompt's
-last full block with its tail, so this is common). vLLM reports only appended
-blocks, and a speculative scratch block relocated from a skipped slot to the
-tail is reported again. `LMCacheMPRequestTracker.append_block_ids` nulls the
-old slot of a re-reported block; `all_null_chunk_masks` then drops that
-chunk's recurrent object and the next hit fails closed one chunk earlier.
-Requires `--separate-object-groups`.
+### MTP and the last prompt block
+
+With MTP, vLLM's scheduler runs the prompt's last full block and its tail in
+one prefill step, so no Mamba state is ever written for that block's
+boundary. In vLLM's own block list that position becomes the null block
+(id 0), and the speculative block that used to sit there is moved to the
+end. The connector only receives the blocks added at the end, so the tracker
+would still show the moved block at its old position and store it as the
+chunk's Mamba state, which no kernel ever wrote.
+
+A block is never listed twice for one request, so when a reported id is
+already in the tracker's list, `append_block_ids` sets the old position to 0.
+The server then sees an all-zero chunk for the Mamba group and skips it, and
+the next hit ends one chunk earlier. Needs `--separate-object-groups` and
+chunk size equal to the Mamba block size.
 
 ## Code map
 

--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -174,6 +174,16 @@ logical-block granularity. See
 limits (notably: edited groups are byte-opaque — no content-aware processing,
 no cross-backend cache sharing).
 
+In `mamba_cache_mode="align"` a Mamba group's block list is sparse: a step
+writes one state, into the slot of its last token, and vLLM nulls the slots a
+multi-block step skips (EAGLE-family speculative decoding merges the prompt's
+last full block with its tail, so this is common). vLLM reports only appended
+blocks, and a speculative scratch block relocated from a skipped slot to the
+tail is reported again. `LMCacheMPRequestTracker.append_block_ids` nulls the
+old slot of a re-reported block; `all_null_chunk_masks` then drops that
+chunk's recurrent object and the next hit fails closed one chunk earlier.
+Requires `--separate-object-groups`.
+
 ## Code map
 
 | Area | File |

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -292,7 +292,8 @@ def validate_mamba_step_alignment(
     the end of each scheduler step, on the last block the step advanced. A step
     advancing more than one block fills the skipped block-table positions with
     the null block (``MambaManager.allocate_new_blocks``); LMCache handles those
-    safely -- ``store`` never commits an all-null-block chunk and ``retrieve``
+    safely -- the request tracker nulls the slot of a relocated speculative
+    block, ``store`` never commits an all-null-block chunk and ``retrieve``
     loads only each object group's sliding-window suffix -- so
     ``max_num_batched_tokens`` may exceed ``2 * block_size`` (with
     ``--separate-object-groups``). Only the lower bound remains: a step must

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -132,15 +132,26 @@ class LMCacheMPRequestTracker:
     def append_block_ids(
         self,
         new_block_ids: tuple[list[int], ...],
-    ):
-        """Update the block ids for the current request
-        This function will be called when processing the cached requests.
+    ) -> None:
+        """Append the block ids vLLM reported for this request in one step.
+
+        A block occupies one slot per request, so an id already in the list
+        means vLLM moved it (align-mode Mamba relocates a speculative block
+        past a skipped boundary) or freed and reallocated it. vLLM nulls the
+        old slot in place without reporting it; mirror that here.
+
+        Args:
+            new_block_ids: Block ids appended this step, one list per engine
+                group.
         """
         for engine_group_idx, group_block_ids in enumerate(new_block_ids):
-            if group_block_ids:
-                self.allocated_block_ids.setdefault(engine_group_idx, []).extend(
-                    group_block_ids
-                )
+            if not group_block_ids:
+                continue
+            block_ids = self.allocated_block_ids.setdefault(engine_group_idx, [])
+            for block_id in group_block_ids:
+                if block_id != 0 and block_id in block_ids:
+                    block_ids[block_ids.index(block_id)] = 0
+                block_ids.append(block_id)
 
     def num_allocated_blocks(self) -> dict[int, int]:
         return {

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -135,10 +135,11 @@ class LMCacheMPRequestTracker:
     ) -> None:
         """Append the block ids vLLM reported for this request in one step.
 
-        A block occupies one slot per request, so an id already in the list
-        means vLLM moved it (align-mode Mamba relocates a speculative block
-        past a skipped boundary) or freed and reallocated it. vLLM nulls the
-        old slot in place without reporting it; mirror that here.
+        vLLM never lists the same block at two slots of a request. An id that
+        is already in the list therefore means vLLM took it out of its old
+        slot (relocated an align-mode Mamba speculative block, or freed and
+        reallocated it) and wrote the null block there without reporting it.
+        Do the same here.
 
         Args:
             new_block_ids: Block ids appended this step, one list per engine

--- a/tests/v1/test_mp_tracker_mamba_skipped_slots.py
+++ b/tests/v1/test_mp_tracker_mamba_skipped_slots.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The MP tracker nulls the old slot of a block vLLM relocated to the tail."""
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
+
+# Third Party
+from vllm.v1.utils import ConstantList  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
+    LMCacheMPRequestMetadata,
+    LMCacheMPRequestTracker,
+)
+
+BLOCK = 100
+ATTN, MAMBA = 0, 1
+
+
+def _tracker() -> LMCacheMPRequestTracker:
+    request = SimpleNamespace(
+        request_id="req-0",
+        cache_salt="",
+        prompt_token_ids=list(range(337)),
+        all_token_ids=ConstantList(list(range(337))),
+        mm_features=[],
+        sampling_params=SimpleNamespace(extra_args=None),
+    )
+    return LMCacheMPRequestTracker(request)
+
+
+def _store_blocks(tracker: LMCacheMPRequestTracker) -> list[list[int]]:
+    meta = LMCacheMPRequestMetadata.GetStoreMetadata(tracker, BLOCK, [BLOCK, BLOCK])
+    assert meta is not None
+    return meta.op.block_ids
+
+
+def test_relocated_speculative_block_is_nulled():
+    """MTP prefill of 337 tokens, block 100, 4 speculative blocks.
+
+    Step 3 spans [200, 337); vLLM nulls Mamba slot 2, moves block 12 to the
+    tail and reports [12, 16]. Chunk 2 must not be stored from block 12.
+    """
+    tracker = _tracker()
+    tracker.append_block_ids(([50, 51], [10, 11, 12, 13, 14]))
+    tracker.increase_num_scheduled_tokens(100)
+    tracker.append_block_ids(([52], [15]))
+    tracker.increase_num_scheduled_tokens(100)
+    assert _store_blocks(tracker) == [[50, 51], [10, 11]]
+    tracker.append_block_ids(([53, 54], [12, 16]))
+    tracker.increase_num_scheduled_tokens(137)
+    assert tracker.allocated_block_ids[MAMBA] == [10, 11, 0, 13, 14, 15, 12, 16]
+    assert tracker.allocated_block_ids[ATTN] == [50, 51, 52, 53, 54]
+    assert _store_blocks(tracker) == [[52], [0]]
+
+
+def test_padded_nulls_are_appended_as_is():
+    tracker = _tracker()
+    tracker.append_block_ids(([50, 51, 52], [0, 0, 20, 21, 22, 23, 24]))
+    tracker.append_block_ids(([53], [0, 25]))
+    assert tracker.allocated_block_ids[MAMBA] == [0, 0, 20, 21, 22, 23, 24, 0, 25]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4984

`LMCacheMPConnector` stores a garbage recurrent state for the last full chunk of a prompt when a Mamba/GDN hybrid runs with MTP, so every later hit on that prefix resumes from a bogus state. Root cause (details in https://github.com/LMCache/LMCache/issues/4984#issuecomment-5569045977):

- With MTP, vLLM's `_mamba_block_aligned_split` merges the prompt's last full block and its tail into one prefill step, so no Mamba state is ever written for that block boundary. Without MTP these are two steps with a stop at the boundary.
- vLLM handles this in its own block list: it writes the null block into that slot and moves the speculative scratch block that sat there to the tail. But `new_block_ids` only carries the tail, so the connector's tracker keeps the moved block at its old slot and hands it to the server as that chunk's recurrent state. No kernel ever wrote that block.

```
    tokens      0        1616       3232       4538
                |----------|--------------------|
    MTP on      [ step 1  ][       step 2       ]
    state slot       0                     2       <- slot 1 never written
    Mamba list  [ A ,      NULL ,      C , ...]  (vLLM's own list)
    tracker     [ A ,       S1 ,       C , ...]  (LMCache's copy, before this PR)
```

The fix is in `LMCacheMPRequestTracker.append_block_ids`: a block is never listed at two slots of one request, so a reported id that is already in the list means vLLM moved it. The tracker sets the old slot to 0 before appending. The server's existing `all_null_chunk_masks` then skips that chunk's recurrent object, and because a chunk hit needs every object group, the next lookup stops one chunk earlier instead of loading a bogus state. Models without speculative decoding never re-report a block, so this is a no-op for them.

Verified on 2x RTX 5090, vLLM 0.28.0, FlashAttention, `Qwen/Qwen3.5-0.8B`, `--mamba-cache-mode align --separate-object-groups`, 2408-token prompt, store -> `reset_prefix_cache` -> identical request at temperature 0:

| MTP | block = chunk | `--max-num-batched-tokens` | before | after |
|---|---|---|---|---|
| on, 4 draft tokens | 560 | 1119 | output differs, hit 2240 | output identical, hit 1680 |
| off | 544 | 1087 | output identical, hit 2176 | output identical, hit 2176 |

**Special notes for your reviewers**:

- Attention backend independent; #4253 is a separate attention-side issue.
- This issue only happens when MTP enabled for hybrid models, and it's across attention backends

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

https://claude.ai/code/session_01KkHmV1o9xSqrCTyjuGACp2
