### PR TITLE
[Bugfix] Prevent duplicate frees in paged allocator

### DIFF
--- a/lmcache/v1/memory_allocators/paged_tensor_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/paged_tensor_memory_allocator.py
@@ -2,6 +2,7 @@
 
 # Standard
 from collections import deque
+import threading
 from typing import List, Optional, Union
 
 # Third Party
@@ -69,10 +70,11 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
 
         self.paged_buffers = torch.split(self.buffer, self.align_bytes, dim=0)
 
-        # NOTE: deque is used since thread-safety is not a concern here as
-        # is implemented in C under the hood (in CPython), and operations
-        # on deque are atomic.
+        # Track both queue order and page membership. The lock makes the
+        # compound queue/set transitions atomic.
         self.free_blocks: deque[TensorMemoryObj] = deque()
+        self._free_blocks_lock = threading.Lock()
+        self._free_page_indices: set[int] = set()
 
         for idx, buf in enumerate(self.paged_buffers):
             # NOTE: idx is the paged index
@@ -95,6 +97,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
                 parent_allocator=self,
             )
             self.free_blocks.append(mem_obj)
+            self._free_page_indices.add(idx)
 
         # Address manager for memory usage tracking
         self.address_manager = PagedAddressManager(self)
@@ -133,9 +136,15 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         """
         shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
 
-        try:
-            free_block = self.free_blocks.popleft()
-        except IndexError:
+        with self._free_blocks_lock:
+            try:
+                free_block = self.free_blocks.popleft()
+            except IndexError:
+                free_block = None
+            if free_block is not None:
+                self._free_page_indices.remove(free_block.meta.address)
+
+        if free_block is None:
             logger.debug(
                 f"Failed to allocate memory for "
                 f"tensor({shapes}, {dtypes}) because "
@@ -185,19 +194,19 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         """
         shapes, dtypes = self._adapt_shapes_and_dtypes(shapes, dtypes)
 
-        allocated_blocks: list[TensorMemoryObj] = []
-        for i in range(batch_size):
-            try:
-                free_block = self.free_blocks.popleft()
-            except IndexError:
+        with self._free_blocks_lock:
+            if len(self.free_blocks) < batch_size:
                 logger.debug(
                     f"Failed to allocate memory for "
                     f"tensor({shapes}, {dtypes}) because "
                     "no free blocks is available"
                 )
-                self.batched_free(allocated_blocks, update_stats=False)
                 return None
+            allocated_blocks = [self.free_blocks.popleft() for _ in range(batch_size)]
+            for free_block in allocated_blocks:
+                self._free_page_indices.remove(free_block.meta.address)
 
+        for free_block in allocated_blocks:
             # FIXME: think about whether parent_allocator
             # should be updated here.
             free_block.meta.shape = shapes[0]
@@ -212,8 +221,6 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
             if shapes != self.shapes:
                 size_in_bytes = get_size_bytes(shapes, dtypes)
                 free_block.raw_data = free_block.raw_data[:size_in_bytes]
-
-            allocated_blocks.append(free_block)
 
         # TODO (Jiayi): need a flag to drop these debug ops
         # NOTE (Jiayi): the following code is not thread-safe but
@@ -237,15 +244,8 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
             memory_obj: Memory object to return to the free-page pool.
             allocator_type: Optional allocator type string.
         """
-        if not memory_obj.is_valid():
+        if not self._return_block(memory_obj):
             return
-        if memory_obj.meta.shapes != self.shapes:
-            page_idx = memory_obj.meta.address
-            memory_obj.raw_data = self.paged_buffers[page_idx]
-
-        self.free_blocks.append(memory_obj)
-
-        # memory_obj.invalidate()
 
         # TODO (Jiayi): need a flag to drop these debug ops
         # NOTE (Jiayi): the following code is not thread-safe but
@@ -276,19 +276,11 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         if not memory_objs:
             return
 
-        for memory_obj in memory_objs:
-            if not memory_obj.is_valid():
-                logger.warning("Trying to free an invalidated MemoryObj")
-                continue
-            # memory_obj.invalidate()
-            if memory_obj.meta.shapes != self.shapes:
-                page_idx = memory_obj.meta.address
-                memory_obj.raw_data = self.paged_buffers[page_idx]
+        num_freed_blocks = sum(
+            self._return_block(memory_obj) for memory_obj in memory_objs
+        )
 
-            self.free_blocks.append(memory_obj)
-
-        if update_stats:
-            num_freed_blocks = len(memory_objs)
+        if update_stats and num_freed_blocks > 0:
             # TODO (Jiayi): need a flag to drop these debug ops
             # NOTE (Jiayi): the following code is not thread-safe but
             # is tolerable as this is only used for debugging purposes.
@@ -338,6 +330,25 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
             for true zero copy operations.
         """
         return self.paged_buffers
+
+    def _return_block(self, memory_obj: TensorMemoryObj) -> bool:
+        """Return a page to the free pool exactly once."""
+        if not memory_obj.is_valid():
+            logger.warning("Trying to free an invalidated MemoryObj")
+            return False
+
+        page_idx = memory_obj.meta.address
+        with self._free_blocks_lock:
+            if page_idx in self._free_page_indices:
+                logger.debug("Ignoring duplicate free of page %d", page_idx)
+                return False
+
+            if memory_obj.meta.shapes != self.shapes:
+                memory_obj.raw_data = self.paged_buffers[page_idx]
+
+            self.free_blocks.append(memory_obj)
+            self._free_page_indices.add(page_idx)
+        return True
 
     def __del__(self) -> None:
         # FIXME: NIXL-related memory leak should be handled somewhere (else).

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -150,6 +150,44 @@ def test_tensor_allocator(use_paging):
     allocator.close()
 
 
+@pytest.mark.parametrize("release_mode", ["free", "batched_free", "ref_count"])
+def test_paged_allocator_rejects_duplicate_release(release_mode: str) -> None:
+    """A duplicate release must not alias two live page allocations."""
+    page_count = 4
+    shape = torch.Size([16, 512])
+    dtype = torch.float16
+    page_bytes = shape.numel() * dtype.itemsize
+    allocator = PagedTensorMemoryAllocator(
+        torch.empty(page_count * page_bytes, dtype=torch.uint8),
+        [shape],
+        [dtype],
+        MemoryFormat.KV_2LTD,
+    )
+
+    original = allocator.allocate(shape, dtype)
+    assert original is not None
+    if release_mode == "free":
+        allocator.free(original)
+        allocator.free(original)
+    elif release_mode == "batched_free":
+        allocator.batched_free([original, original])
+    else:
+        original.ref_count_down()
+        original.ref_count_down()
+
+    live = allocator.batched_allocate(shape, dtype, page_count)
+    assert live is not None
+
+    assert len({memory_obj.tensor.data_ptr() for memory_obj in live}) == page_count
+    assert allocator.allocate(shape, dtype) is None
+    assert allocator.memcheck()
+
+    for memory_obj in live:
+        memory_obj.ref_count_down()
+    assert allocator.memcheck()
+    allocator.close()
+
+
 @pytest.mark.parametrize(
     "alloc_cls",
     [


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #5005.

The paged tensor allocator previously allowed the same page-backed `TensorMemoryObj` to be returned to `free_blocks` more than once. Two subsequent allocations could therefore receive the same physical page and silently alias live KV cache data.

This change maintains a locked set of free page indices alongside the deque. Allocation removes a page from both structures atomically, while single, batched, and ref-count-driven release paths only enqueue a page if it is not already free. Batched allocation is also made atomic so a failed batch cannot expose partial allocator state.

A small regression test covers duplicate `free`, duplicate entries in `batched_free`, and repeated `ref_count_down`, then verifies all live pages have distinct data pointers.

**Special notes for your reviewers**:

The original 128 MiB paged allocator behavior test was also run locally with a 30-second hard timeout. The WSL test process reached roughly 9.0 GiB peak RSS despite the explicit tensor being 128 MiB, so broader local memory tests are left to CI.

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Validation:
- `pytest -q tests/v1/test_memory_management.py::test_paged_allocator_rejects_duplicate_release` (3 passed; 64 KiB test buffer)
- `pytest -q tests/v1/test_memory_management.py::test_tensor_allocator[True]` (passed; 128 MiB test buffer; 30-second timeout)
- `ruff check` on both changed files
- `ruff format --check` on both changed files
- `git diff --check`
- Buildkite k3 unit tests passed