### PR TITLE
[Bugfix] Clean up aborted async lookups without future traffic

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 import asyncio
 import gc
 import multiprocessing
+import threading
 import time
 
 # Third Party
@@ -167,6 +168,9 @@ class LMCacheEngine:
 
         self.async_loading = config.enable_async_loading
         self.event_manager = EventManager()
+        self._async_lookup_cleanup_lock = threading.Lock()
+        self._active_async_lookups: set[str] = set()
+        self._pending_async_lookup_cleanups: set[str] = set()
 
         self.use_layerwise = config.use_layerwise
 
@@ -327,6 +331,7 @@ class LMCacheEngine:
                     event_manager=self.event_manager,
                     lmcache_worker=self.lmcache_worker,
                     async_lookup_server=async_lookup_server,
+                    async_lookup_done_callback=self.finish_async_lookup,
                 )
                 if self.hidden_state_store is not None:
                     self.hidden_state_store.bind_storage_manager(self.storage_manager)
@@ -1339,6 +1344,10 @@ class LMCacheEngine:
         """
         assert self.storage_manager is not None
 
+        with self._async_lookup_cleanup_lock:
+            self._active_async_lookups.add(lookup_id)
+            self._pending_async_lookup_cleanups.discard(lookup_id)
+
         keys: list[CacheEngineKey] = []
         cum_chunk_lengths = [0]
 
@@ -1379,35 +1388,52 @@ class LMCacheEngine:
 
     def cleanup_memory_objs(self, lookup_id: str) -> None:
         """
-        Cleanup memory objects allocated during prefetch for an aborted lookup.
+        Request cleanup of memory objects allocated by an async lookup.
 
-        Called by the scheduler when it determines that an aborted lookup
-        has finished its prefetch tasks.
+        If prefetch is still running or its event has not been registered,
+        cleanup is deferred until :meth:`finish_async_lookup` is called.
+
+        Args:
+            lookup_id: Identifier of the lookup whose objects should be released.
         """
         try:
-            # Get the completed future from event_manager
-            if (
-                self.event_manager.get_event_status(EventType.LOADING, lookup_id)
-                != EventStatus.DONE
-            ):
-                logger.debug(
-                    "No completed event found for lookup_id=%s to clean up.", lookup_id
+            with self._async_lookup_cleanup_lock:
+                status = self.event_manager.get_event_status(
+                    EventType.LOADING, lookup_id
                 )
-                return
-            future = self.event_manager.pop_event(EventType.LOADING, lookup_id)
+                if (
+                    lookup_id not in self._active_async_lookups
+                    and status == EventStatus.NOT_FOUND
+                ):
+                    logger.debug(
+                        "Ignoring cleanup for inactive lookup_id=%s.", lookup_id
+                    )
+                    return
 
-            # Get memory objects from the future result
+                self._pending_async_lookup_cleanups.add(lookup_id)
+                if status != EventStatus.DONE:
+                    logger.debug(
+                        "Deferring cleanup until lookup_id=%s completes.", lookup_id
+                    )
+                    return
+
+                future = self.event_manager.pop_event(EventType.LOADING, lookup_id)
+                self._pending_async_lookup_cleanups.discard(lookup_id)
+                self._active_async_lookups.discard(lookup_id)
+
+            # Get memory objects from the completed future.
             memory_objs = future.result()
             # Flatten nested lists (each backend returns a list of chunks)
             memory_objs_flat = [mm for m in memory_objs for mm in m]
 
             # Release each memory object
-            for key, memory_obj in memory_objs_flat:
+            for _, memory_obj in memory_objs_flat:
                 try:
                     logger.debug("Releasing memory object for lookup_id=%s", lookup_id)
                     if memory_obj.is_pinned:
                         memory_obj.unpin()
-                    memory_obj.ref_count_down()
+                    if memory_obj.get_ref_count() > 0:
+                        memory_obj.ref_count_down()
                 except Exception as e:
                     logger.error("Error releasing memory object: %s", e)
         except Exception as e:
@@ -1416,6 +1442,28 @@ class LMCacheEngine:
                 lookup_id,
                 e,
             )
+
+    def finish_async_lookup(
+        self, lookup_id: str, event_registered: bool = True
+    ) -> None:
+        """Finish worker-side lifecycle handling for an async lookup.
+
+        Args:
+            lookup_id: Identifier of the completed lookup.
+            event_registered: Whether the lookup registered a loading event.
+                A lookup with no cache hits has no event or memory objects.
+        """
+        if not event_registered:
+            with self._async_lookup_cleanup_lock:
+                self._pending_async_lookup_cleanups.discard(lookup_id)
+                self._active_async_lookups.discard(lookup_id)
+            return
+
+        with self._async_lookup_cleanup_lock:
+            cleanup_requested = lookup_id in self._pending_async_lookup_cleanups
+
+        if cleanup_requested:
+            self.cleanup_memory_objs(lookup_id)
 
     # TODO(Jiayi): Need to handle the case where `tokens=None`.
     # In this case, we compress all tokens.

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -124,7 +124,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         # A lock is needed since we need another thread to pull
         # responses from the lookup_and_prefetch server
         # (e.g., worker process).
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
 
         # map from lookup_id (i.e., req_id) to req's status.
         # None indicates ongoing.
@@ -162,9 +162,6 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         None means ongoing;
         int >= 0 means number of hit tokens
         """
-        # Check if any aborted lookups are finished, send cleanup messages
-        self._cleanup_finished_aborted_lookups()
-
         with self.lock:
             if (req_status := self.reqs_status.get(lookup_id, -1)) == -1:
                 self.reqs_status[lookup_id] = None
@@ -239,11 +236,16 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                     if len(all_res) == self.world_size:
                         self.res_for_each_worker.pop(lookup_id)
 
-                        # NOTE: it is possible that the number of hit
-                        # tokens is different across (TP and PP) ranks, so we
-                        # can use the minimum value as the number of
-                        # hit tokens.
-                        self.reqs_status[lookup_id] = min(all_res)
+                        if lookup_id in self.aborted_lookups:
+                            self.aborted_lookups.discard(lookup_id)
+                            self.reqs_status.pop(lookup_id, None)
+                            self.first_lookup_time.pop(lookup_id, None)
+                        else:
+                            # NOTE: it is possible that the number of hit
+                            # tokens is different across (TP and PP) ranks, so we
+                            # can use the minimum value as the number of
+                            # hit tokens.
+                            self.reqs_status[lookup_id] = min(all_res)
 
             except Exception as e:
                 logger.error("Error processing response from worker: %s", e)
@@ -254,25 +256,24 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             self.first_lookup_time.pop(lookup_id, None)
 
     def cancel_lookup(self, lookup_id: str) -> None:
-        """Mark lookup as aborted. Cleanup will happen after task finishes."""
-        self.aborted_lookups.add(lookup_id)
+        """Cancel a lookup and immediately send cleanup intent to every worker."""
+        with self.lock:
+            if lookup_id in self.aborted_lookups:
+                return
+            self.aborted_lookups.add(lookup_id)
 
-    def _cleanup_finished_aborted_lookups(self) -> None:
-        """Check for finished aborted lookups and send cleanup messages to workers."""
-        # A lookup whose status is None is still loading.
-        # We wait for it to finish before cleanup.
-        finished_lookups = [
-            lookup_id
-            for lookup_id in self.aborted_lookups
-            if self.reqs_status.get(lookup_id) is not None
-        ]
-        if finished_lookups:
-            self.aborted_lookups.difference_update(finished_lookups)
+            if (
+                lookup_id in self.reqs_status
+                and self.reqs_status[lookup_id] is not None
+            ):
+                self.aborted_lookups.discard(lookup_id)
+                self.reqs_status.pop(lookup_id, None)
+                self.res_for_each_worker.pop(lookup_id, None)
+                self.first_lookup_time.pop(lookup_id, None)
 
-        # Tell the server to free the reserved memory buffers for each aborted lookup.
-        for lookup_id in finished_lookups:
-            self._send_cleanup_message(lookup_id)
-            self.clear_lookup_status(lookup_id)
+        # PUSH sockets stay on the Scheduler thread. Workers defer this cleanup
+        # if their loading event has not completed yet.
+        self._send_cleanup_message(lookup_id)
 
     def _send_cleanup_message(self, lookup_id: str) -> None:
         """Send cleanup message to workers to release memory objects."""

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -5,6 +5,7 @@ from concurrent.futures import Future
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Coroutine,
     Dict,
     Generator,
@@ -230,6 +231,7 @@ class StorageManager:
         event_manager: EventManager,
         lmcache_worker: Optional["LMCacheWorker"] = None,
         async_lookup_server: Optional["LMCacheAsyncLookupServer"] = None,
+        async_lookup_done_callback: Optional[Callable[[str, bool], None]] = None,
     ):
         self.config = config
         self.metadata = metadata
@@ -269,6 +271,7 @@ class StorageManager:
         self.async_lookup_server: Optional["LMCacheAsyncLookupServer"] = (
             async_lookup_server
         )
+        self.async_lookup_done_callback = async_lookup_done_callback
         self.async_serializer: Optional[AsyncSerializer] = None
 
         # The GPU stream for internal copies during put
@@ -571,9 +574,6 @@ class StorageManager:
             convert each tier's per-key result count back to chunk units.
         """
         assert self.async_lookup_server is not None
-        self.event_manager.update_event_status(
-            EventType.LOADING, lookup_id, status=EventStatus.DONE
-        )
         res = task.result()
 
         # Calculate total retrieved chunks across all tiers based on actual results
@@ -650,7 +650,26 @@ class StorageManager:
             lookup_id,
             retrieved_length,
         )
+        # Publish DONE only after result processing has finished, but before the
+        # response can cause the Scheduler to admit the request.
+        self.mark_async_lookup_done(lookup_id)
         self.async_lookup_server.send_response_to_scheduler(lookup_id, retrieved_length)
+
+    def mark_async_lookup_done(self, lookup_id: str) -> None:
+        """Publish lookup completion and run any deferred cleanup.
+
+        Args:
+            lookup_id: Identifier of the completed asynchronous lookup.
+        """
+        status = self.event_manager.get_event_status(EventType.LOADING, lookup_id)
+        if status == EventStatus.NOT_FOUND:
+            return
+        if status == EventStatus.ONGOING:
+            self.event_manager.update_event_status(
+                EventType.LOADING, lookup_id, status=EventStatus.DONE
+            )
+        if self.async_lookup_done_callback is not None:
+            self.async_lookup_done_callback(lookup_id, True)
 
     async def async_lookup_and_prefetch(
         self,
@@ -791,6 +810,8 @@ class StorageManager:
         if num_total_hit_chunks == 0:
             if self.async_lookup_server is not None:
                 self.async_lookup_server.send_response_to_scheduler(lookup_id, 0)
+            if self.async_lookup_done_callback is not None:
+                self.async_lookup_done_callback(lookup_id, False)
             return
 
         # gather_with_keys() here make a pair of (key, memory_obj) for each chunk
@@ -828,6 +849,7 @@ class StorageManager:
                 keys_per_chunk=keys_per_chunk,
             )
         )
+        all_done.add_done_callback(lambda _: self.mark_async_lookup_done(lookup_id))
 
     def set_hot_cache(self, enabled: bool) -> None:
         """

--- a/tests/v1/lookup_client/test_lmcache_async_lookup_client.py
+++ b/tests/v1/lookup_client/test_lmcache_async_lookup_client.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for asynchronous lookup cancellation lifecycle handling."""
+
+# Standard
+import threading
+
+# Third Party
+import msgspec
+
+# First Party
+from lmcache.v1.lookup_client.async_lookup_message import LookupCleanupMsg
+from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
+    LMCacheAsyncLookupClient,
+)
+
+
+class RecordingSocket:
+    """Record ZMQ-compatible send calls without opening a real socket."""
+
+    def __init__(self) -> None:
+        self.messages: list[bytes] = []
+
+    def send(self, message: bytes, copy: bool = False) -> None:
+        """Record one serialized message.
+
+        Args:
+            message: Serialized lookup message.
+            copy: Compatibility argument matching ``zmq.Socket.send``.
+        """
+        self.messages.append(message)
+
+
+def test_cancel_lookup_sends_cleanup_immediately_once() -> None:
+    """Cancellation must not wait for another lookup before notifying workers."""
+    socket = RecordingSocket()
+    client = object.__new__(LMCacheAsyncLookupClient)
+    client.lock = threading.RLock()
+    client.world_size = 1
+    client.push_sockets = [socket]
+    client.reqs_status = {"aborted": None}
+    client.res_for_each_worker = {}
+    client.first_lookup_time = {"aborted": 1.0}
+    client.aborted_lookups = set()
+
+    client.cancel_lookup("aborted")
+    client.cancel_lookup("aborted")
+
+    assert len(socket.messages) == 1
+    message = msgspec.msgpack.decode(socket.messages[0], type=LookupCleanupMsg)
+    assert message.lookup_id == "aborted"

--- a/tests/v1/storage_backend/test_storage_manager.py
+++ b/tests/v1/storage_backend/test_storage_manager.py
@@ -32,7 +32,7 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.event_manager import EventManager, EventType
+from lmcache.v1.event_manager import EventManager, EventStatus, EventType
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import AllocatorBackendInterface
@@ -201,6 +201,7 @@ class TestStorageManagerPrefetchCallback:
         storage_manager.prefetch_all_done_callback(
             future, "test_lookup_1", cum_chunk_lengths_total, tier_expected_chunks
         )
+        storage_manager.mark_async_lookup_done("test_lookup_1")
         loop.close()
 
         # Verify: All 5 chunks should be counted, total 1280 tokens
@@ -208,6 +209,12 @@ class TestStorageManagerPrefetchCallback:
         lookup_id, retrieved_length = storage_manager.async_lookup_server.responses[0]
         assert lookup_id == "test_lookup_1"
         assert retrieved_length == 1280
+        assert (
+            storage_manager.event_manager.get_event_status(
+                EventType.LOADING, "test_lookup_1"
+            )
+            == EventStatus.DONE
+        )
 
         # Verify: No memory objects should have ref_count_down called
         for obj in tier0_objs + tier1_objs:

--- a/tests/v1/test_cache_engine_cleanup.py
+++ b/tests/v1/test_cache_engine_cleanup.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 import logging
+import threading
 
 # Third Party
 import pytest
@@ -21,11 +22,21 @@ import pytest
 # First Party
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.event_manager import EventStatus
+from lmcache.v1.event_manager import EventManager, EventStatus, EventType
 from lmcache.v1.pin_monitor import PinMonitor
 
 # Local
 from .utils import create_test_memory_obj
+
+
+def create_cleanup_engine() -> LMCacheEngine:
+    """Create a minimal engine exercising the public cleanup lifecycle."""
+    engine = object.__new__(LMCacheEngine)
+    engine.event_manager = EventManager()
+    engine._async_lookup_cleanup_lock = threading.Lock()
+    engine._active_async_lookups = set()
+    engine._pending_async_lookup_cleanups = set()
+    return engine
 
 
 @pytest.fixture
@@ -60,7 +71,12 @@ def test_cleanup_memory_objs_handles_mixed_pin_state(
         [(None, nonpinned_obj)],
     ]
 
-    engine = SimpleNamespace(event_manager=MagicMock())
+    engine = SimpleNamespace(
+        event_manager=MagicMock(),
+        _async_lookup_cleanup_lock=threading.Lock(),
+        _active_async_lookups={"test_lookup"},
+        _pending_async_lookup_cleanups=set(),
+    )
     engine.event_manager.get_event_status.return_value = EventStatus.DONE
     engine.event_manager.pop_event.return_value = future
 
@@ -74,3 +90,97 @@ def test_cleanup_memory_objs_handles_mixed_pin_state(
     assert "is negative" not in caplog.text
 
     pinned_obj.ref_count_down()
+
+
+def test_cleanup_memory_objs_deferred_until_lookup_finishes() -> None:
+    """An early or duplicate cleanup request must release the result once."""
+    lookup_id = "deferred_lookup"
+    engine = create_cleanup_engine()
+    engine._active_async_lookups.add(lookup_id)
+
+    memory_obj = MagicMock()
+    memory_obj.is_pinned = False
+    memory_obj.get_ref_count.return_value = 1
+    future = MagicMock()
+    future.result.return_value = [[(None, memory_obj)]]
+
+    # Cleanup arrives before event registration, then is repeated while ongoing.
+    engine.cleanup_memory_objs(lookup_id)
+    engine.event_manager.add_event(EventType.LOADING, lookup_id, future)
+    engine.cleanup_memory_objs(lookup_id)
+    memory_obj.ref_count_down.assert_not_called()
+
+    engine.event_manager.update_event_status(
+        EventType.LOADING, lookup_id, EventStatus.DONE
+    )
+    engine.finish_async_lookup(lookup_id)
+
+    memory_obj.ref_count_down.assert_called_once_with()
+    assert (
+        engine.event_manager.get_event_status(EventType.LOADING, lookup_id)
+        == EventStatus.NOT_FOUND
+    )
+
+    # A late duplicate cleanup is ignored after the active event was consumed.
+    engine.cleanup_memory_objs(lookup_id)
+    memory_obj.ref_count_down.assert_called_once_with()
+
+
+def test_cleanup_memory_objs_after_lookup_finishes() -> None:
+    """Cleanup arriving after completion must release immediately."""
+    lookup_id = "completed_lookup"
+    engine = create_cleanup_engine()
+    engine._active_async_lookups.add(lookup_id)
+
+    memory_obj = MagicMock()
+    memory_obj.is_pinned = False
+    memory_obj.get_ref_count.return_value = 1
+    future = MagicMock()
+    future.result.return_value = [[(None, memory_obj)]]
+    engine.event_manager.add_event(EventType.LOADING, lookup_id, future)
+    engine.event_manager.update_event_status(
+        EventType.LOADING, lookup_id, EventStatus.DONE
+    )
+
+    engine.cleanup_memory_objs(lookup_id)
+
+    memory_obj.ref_count_down.assert_called_once_with()
+    assert (
+        engine.event_manager.get_event_status(EventType.LOADING, lookup_id)
+        == EventStatus.NOT_FOUND
+    )
+
+
+def test_finish_async_lookup_without_event_discards_cleanup_request() -> None:
+    """A no-hit lookup must discard an early cleanup tombstone."""
+    lookup_id = "no_hit_lookup"
+    engine = create_cleanup_engine()
+    engine._active_async_lookups.add(lookup_id)
+
+    engine.cleanup_memory_objs(lookup_id)
+    engine.finish_async_lookup(lookup_id, event_registered=False)
+
+    assert lookup_id not in engine._active_async_lookups
+    assert lookup_id not in engine._pending_async_lookup_cleanups
+
+
+def test_cleanup_memory_objs_consumes_failed_lookup_event() -> None:
+    """A failed completed lookup must not retain its future after abort."""
+    lookup_id = "failed_lookup"
+    engine = create_cleanup_engine()
+    engine._active_async_lookups.add(lookup_id)
+
+    future = MagicMock()
+    future.result.side_effect = RuntimeError("prefetch failed")
+    engine.event_manager.add_event(EventType.LOADING, lookup_id, future)
+    engine.cleanup_memory_objs(lookup_id)
+    engine.event_manager.update_event_status(
+        EventType.LOADING, lookup_id, EventStatus.DONE
+    )
+
+    engine.finish_async_lookup(lookup_id)
+
+    assert (
+        engine.event_manager.get_event_status(EventType.LOADING, lookup_id)
+        == EventStatus.NOT_FOUND
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #5006.

Async lookup cancellation previously only added the lookup ID to a Scheduler-side set. Cleanup messages were sent by a later `lookup_cache()` call after completion, so an idle or asymmetrically routed instance could retain the completed event and its prefetched memory indefinitely.

This change sends cleanup intent immediately from `cancel_lookup()`. Each worker tracks active lookups and deferred cleanup requests, including the window before EventManager registration. Result post-processing marks the lookup DONE only after it has finished, then triggers deferred cleanup locally. Cleanup after completion remains immediate, duplicate cleanup is ignored after the event is consumed, and no-hit lookups discard their tombstones.

The client response thread now drops completed responses for canceled lookups directly, so Scheduler-side state also no longer needs a future unrelated lookup to drain it.

**Special notes for your reviewers**:

The completion transition intentionally occurs after prefetch result processing but before the response is sent. A second idempotent done callback covers exceptional result processing, allowing an aborted failed future to be removed as well.

Local validation was limited to small mock/state-machine tests; no model, GPU cache, or large allocator test was run. GitHub CI should run the broader suite.

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Validation:
- `pytest -q tests/v1/test_cache_engine_cleanup.py tests/v1/lookup_client/test_lmcache_async_lookup_client.py tests/v1/storage_backend/test_storage_manager.py::TestStorageManagerPrefetchCallback::test_all_chunks_retrieved_successfully` (7 passed)
- `ruff check` on all six changed files
- `ruff format --check` on all six changed files
- `git diff --check`