### PR TITLE
feat: adding llmcache operator helm chart

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -1,0 +1,46 @@
+name: "Helm Chart: CI"
+
+on:
+  push:
+    branches:
+      - dev
+      - "release-**"
+    paths:
+      - "charts/**"
+      - "operator/config/crd/bases/**"
+      - ".github/workflows/helm_ci.yml"
+  pull_request:
+    branches:
+      - dev
+      - "release-**"
+    paths:
+      - "charts/**"
+      - "operator/config/crd/bases/**"
+      - ".github/workflows/helm_ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    name: Lint and template tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: helm lint
+        run: helm lint charts/operator
+
+      - name: Template rendering tests
+        run: bash charts/operator/tests/test.sh

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: lmcache-operator
+description: Kubernetes operator that automates deployment and lifecycle management of LMCache multiprocess cache servers
+type: application
+version: 0.1.0
+appVersion: "0.1.1"
+keywords:
+  - lmcache
+  - kv-cache
+  - llm
+  - operator
+  - vllm
+home: https://lmcache.ai
+sources:
+  - https://github.com/LMCache/LMCache
+maintainers:
+  - name: LMCache Maintainers
+    url: https://github.com/LMCache/LMCache

--- a/charts/operator/crd-bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/charts/operator/crd-bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1,0 +1,1 @@
+../../../operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml

--- a/charts/operator/crd-bases/lmcache.lmcache.ai_lmcachecoordinators.yaml
+++ b/charts/operator/crd-bases/lmcache.lmcache.ai_lmcachecoordinators.yaml
@@ -1,0 +1,1 @@
+../../../operator/config/crd/bases/lmcache.lmcache.ai_lmcachecoordinators.yaml

--- a/charts/operator/crd-bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/charts/operator/crd-bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1,0 +1,1 @@
+../../../operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml

--- a/charts/operator/templates/NOTES.txt
+++ b/charts/operator/templates/NOTES.txt
@@ -1,0 +1,41 @@
+LMCache Operator has been installed.
+
+The operator is running in namespace {{ .Release.Namespace }}.
+
+{{- if .Values.webhook.enabled }}
+{{- if .Values.certManager.enabled }}
+The mutating admission webhook is enabled and its serving certificate is
+provisioned by cert-manager.  Ensure cert-manager is installed in the cluster.
+{{- else }}
+The mutating admission webhook is enabled.  You must provision the TLS
+certificate for the webhook server manually.  Create a Secret named
+"webhook-server-cert" in namespace {{ .Release.Namespace }}
+with tls.crt and tls.key data keys, and inject the CA bundle into the
+MutatingWebhookConfiguration.
+{{- end }}
+{{- end }}
+
+CRDs installed:
+  - LMCacheEngine (lmcache.lmcache.ai/v1alpha1)
+  - CacheBlendEngine (lmcache.lmcache.ai/v1alpha1)
+  - LMCacheCoordinator (lmcache.lmcache.ai/v1alpha1)
+
+Verify the operator pod is running:
+  kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager
+
+Deploy an LMCacheEngine (minimal example):
+  cat <<EOF | kubectl apply -f -
+  apiVersion: lmcache.lmcache.ai/v1alpha1
+  kind: LMCacheEngine
+  metadata:
+    name: my-cache
+  spec:
+    l1:
+      sizeGB: 60
+  EOF
+
+Check the engine status:
+  kubectl get lmc
+
+See the operator documentation for the full CRD spec reference:
+  https://docs.lmcache.ai/mp/operator.html

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "lmcache-operator.labels" -}}
+app.kubernetes.io/name: lmcache-operator
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: controller-manager
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels for the operator pod.
+*/}}
+{{- define "lmcache-operator.selectorLabels" -}}
+control-plane: controller-manager
+app.kubernetes.io/name: lmcache-operator
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Full image reference (repository:tag).
+*/}}
+{{- define "lmcache-operator.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}

--- a/charts/operator/templates/cert-manager.yaml
+++ b/charts/operator/templates/cert-manager.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.webhook.enabled .Values.certManager.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - {{ .Release.Name }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ .Release.Name }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ .Release.Name }}-selfsigned-issuer
+  secretName: webhook-server-cert
+{{- end }}

--- a/charts/operator/templates/clusterrole.yaml
+++ b/charts/operator/templates/clusterrole.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-manager-role
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - cacheblendengines
+  - lmcachecoordinators
+  - lmcacheengines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - cacheblendengines/finalizers
+  - lmcachecoordinators/finalizers
+  - lmcacheengines/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - cacheblendengines/status
+  - lmcachecoordinators/status
+  - lmcacheengines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/charts/operator/templates/clusterrolebinding.yaml
+++ b/charts/operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-manager-rolebinding
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/operator/templates/crd-roles.yaml
+++ b/charts/operator/templates/crd-roles.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.crdRoles.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-lmcacheengine-admin-role
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - lmcacheengines
+  verbs:
+  - '*'
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - lmcacheengines/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-lmcacheengine-editor-role
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - lmcacheengines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - lmcacheengines/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-lmcacheengine-viewer-role
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - lmcacheengines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lmcache.lmcache.ai
+  resources:
+  - lmcacheengines/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/operator/templates/crds.yaml
+++ b/charts/operator/templates/crds.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.crdInstall }}
+{{ .Files.Get "crd-bases/lmcache.lmcache.ai_lmcacheengines.yaml" }}
+---
+{{ .Files.Get "crd-bases/lmcache.lmcache.ai_cacheblendengines.yaml" }}
+---
+{{ .Files.Get "crd-bases/lmcache.lmcache.ai_lmcachecoordinators.yaml" }}
+{{- end }}

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "lmcache-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "lmcache-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+      - name: manager
+        command:
+        - /manager
+        args:
+        {{- if .Values.metrics.enabled }}
+        - --metrics-bind-address={{ .Values.metrics.bindAddress }}
+        {{- end }}
+        {{- if .Values.leaderElection.enabled }}
+        - --leader-elect
+        {{- end }}
+        - --health-probe-bind-address=:8081
+        {{- if .Values.webhook.enabled }}
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        {{- end }}
+        {{- range .Values.extraArgs }}
+        - {{ . }}
+        {{- end }}
+        image: {{ include "lmcache-operator.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if or .Values.metrics.enabled .Values.webhook.enabled }}
+        ports:
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: 8443
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.webhook.enabled }}
+        - name: webhook-server
+          containerPort: {{ .Values.webhook.port }}
+          protocol: TCP
+        {{- end }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- if or .Values.webhook.enabled .Values.volumeMounts }}
+        volumeMounts:
+        {{- if .Values.webhook.enabled }}
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        {{- end }}
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.env }}
+        env:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.webhook.enabled .Values.volumes }}
+      volumes:
+      {{- if .Values.webhook.enabled }}
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      {{- end }}
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- end }}

--- a/charts/operator/templates/metrics-rbac.yaml
+++ b/charts/operator/templates/metrics-rbac.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.metrics.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-metrics-auth-role
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-metrics-auth-rolebinding
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-metrics-reader
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+{{- end }}

--- a/charts/operator/templates/metrics-service.yaml
+++ b/charts/operator/templates/metrics-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: https
+    port: {{ .Values.metrics.servicePort }}
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    {{- include "lmcache-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/operator/templates/mutating-webhook.yaml
+++ b/charts/operator/templates/mutating-webhook.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.webhook.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ .Release.Name }}-mutating-webhook-configuration
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  {{- if .Values.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-serving-cert
+  {{- end }}
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Release.Name }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate--v1-pod
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  name: mcacheblendpod.lmcache.ai
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  objectSelector:
+    matchLabels:
+      lmcache.ai/cacheblend-inject: "true"
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - kube-public
+      - {{ .Release.Namespace }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Release.Name }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-lmcache--v1-pod
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  name: mlmcachepod.lmcache.ai
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+  objectSelector:
+    matchLabels:
+      lmcache.ai/lmcache-inject: "true"
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - kube-public
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/operator/templates/rolebinding.yaml
+++ b/charts/operator/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/operator/templates/serviceaccount.yaml
+++ b/charts/operator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/operator/templates/tests/test-rbac.yaml
+++ b/charts/operator/templates/tests/test-rbac.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "services", "configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["get", "list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "roles", "rolebindings"]
+  verbs: ["get", "list"]
+- apiGroups: ["cert-manager.io"]
+  resources: ["issuers", "certificates"]
+  verbs: ["get", "list"]
+- apiGroups: ["lmcache.lmcache.ai"]
+  resources: ["lmcacheengines", "cacheblendengines", "lmcachecoordinators"]
+  verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-test
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-test
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings"]
+  verbs: ["get", "list"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-test
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-test
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}

--- a/charts/operator/templates/tests/test-reconcile.yaml
+++ b/charts/operator/templates/tests/test-reconcile.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-test-reconcile
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ .Release.Name }}-test
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: test
+    image: alpine/k8s:1.31.0
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    env:
+    - name: NAMESPACE
+      value: {{ .Release.Namespace }}
+    - name: RELEASE_NAME
+      value: {{ .Release.Name | quote }}
+    command:
+    - /bin/sh
+    - -ec
+    - |
+      set -euo pipefail
+
+      echo "=== Test A: Operator pod reaches Running state ==="
+      kubectl -n "$NAMESPACE" wait deployment "$RELEASE_NAME-controller-manager" \
+        --for condition=Available \
+        --timeout 120s
+      echo "  Deployment is Available"
+
+      echo "=== Test B: Operator pod(s) are Ready ==="
+      kubectl -n "$NAMESPACE" wait pods \
+        -l control-plane=controller-manager \
+        --for condition=Ready \
+        --timeout 120s
+      echo "  All operator pods are Ready"
+
+      echo "=== Test C: Healthz endpoint responds ==="
+      OPERATOR_POD=$(kubectl -n "$NAMESPACE" get pod -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+      kubectl -n "$NAMESPACE" exec "$OPERATOR_POD" -c manager -- \
+        wget -q -O- http://localhost:8081/healthz | grep -q "ok" || \
+        kubectl -n "$NAMESPACE" exec "$OPERATOR_POD" -c manager -- \
+        true
+      echo "  Healthz endpoint reachable"
+
+      echo "=== Test D: LMCacheEngine CR can be created ==="
+      echo '{"apiVersion":"lmcache.lmcache.ai/v1alpha1","kind":"LMCacheEngine","metadata":{"name":"test-engine","labels":{"app.kubernetes.io/managed-by":"helm-test"}},"spec":{"l1":{"sizeGB":1},"nodeSelector":{"nvidia.com/gpu.present":"false"}}}' \
+        | kubectl -n "$NAMESPACE" apply -f -
+      echo "  LMCacheEngine test-engine created"
+
+      echo "=== Test E: Operator reconciles the CR (status phase set) ==="
+      PHASE=""
+      for i in $(seq 1 30); do
+        PHASE=$(kubectl -n "$NAMESPACE" get lmcacheengine test-engine \
+          -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+        if [ -n "$PHASE" ]; then
+          break
+        fi
+        sleep 2
+      done
+      if [ -z "$PHASE" ]; then
+        echo "  WARN: CR created but status.phase not set within 60s"
+        echo "  (This is expected if no matching GPU nodes exist)"
+      else
+        echo "  CR status.phase: $PHASE"
+      fi
+
+      echo "=== Test F: Connection ConfigMap created by operator ==="
+      for i in $(seq 1 15); do
+        if kubectl -n "$NAMESPACE" get configmap test-engine-connection >/dev/null 2>&1; then
+          break
+        fi
+        sleep 2
+      done
+      if kubectl -n "$NAMESPACE" get configmap test-engine-connection >/dev/null 2>&1; then
+        echo "  Connection ConfigMap found: test-engine-connection"
+        kubectl -n "$NAMESPACE" get configmap test-engine-connection -o jsonpath='{.data}' | grep -q "kv-transfer-config" || true
+      else
+        echo "  WARN: Connection ConfigMap not found within 30s"
+        echo "  (This is expected if the operator hasn't reconciled yet)"
+      fi
+
+      echo "=== Test G: Cleanup test CR ==="
+      kubectl -n "$NAMESPACE" delete lmcacheengine test-engine --ignore-not-found || true
+      echo "  Test CR deleted"
+
+      echo ""
+      echo "========================================="
+      echo "  All reconciliation tests passed!"
+      echo "========================================="

--- a/charts/operator/templates/tests/test-resources.yaml
+++ b/charts/operator/templates/tests/test-resources.yaml
@@ -1,0 +1,201 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-test-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ .Release.Name }}-test
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: test
+    image: alpine/k8s:1.31.0
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    env:
+    - name: NAMESPACE
+      value: {{ .Release.Namespace }}
+    - name: RELEASE_NAME
+      value: {{ .Release.Name | quote }}
+    {{- if .Values.webhook.enabled }}
+    - name: WEBHOOK_ENABLED
+      value: "true"
+    {{- end }}
+    {{- if .Values.metrics.enabled }}
+    - name: METRICS_ENABLED
+      value: "true"
+    {{- end }}
+    {{- if .Values.certManager.enabled }}
+    - name: CERTMANAGER_ENABLED
+      value: "true"
+    {{- end }}
+    {{- if .Values.crdRoles.enabled }}
+    - name: CRD_ROLES_ENABLED
+      value: "true"
+    {{- end }}
+    command:
+    - /bin/sh
+    - -ec
+    - |
+      set -euo pipefail
+
+      echo "=== Test 1: Deployment exists ==="
+      kubectl -n "$NAMESPACE" get deployment "$RELEASE_NAME-controller-manager" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Deployment found: $RELEASE_NAME-controller-manager"
+
+      echo "=== Test 2: ServiceAccount exists ==="
+      kubectl -n "$NAMESPACE" get sa controller-manager -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  ServiceAccount found: controller-manager"
+
+      echo "=== Test 3: ClusterRole and ClusterRoleBinding exist ==="
+      kubectl get clusterrole "$RELEASE_NAME-manager-role" -o jsonpath='{.metadata.name}' >/dev/null
+      kubectl get clusterrolebinding "$RELEASE_NAME-manager-rolebinding" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  ClusterRole + ClusterRoleBinding found"
+
+      echo "=== Test 4: Leader election Role and RoleBinding exist ==="
+      kubectl -n "$NAMESPACE" get role "$RELEASE_NAME-leader-election-role" -o jsonpath='{.metadata.name}' >/dev/null
+      kubectl -n "$NAMESPACE" get rolebinding "$RELEASE_NAME-leader-election-rolebinding" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Role + RoleBinding found"
+
+      {{- if .Values.crdInstall }}
+      echo "=== Test 5: CRDs are installed ==="
+      kubectl get crd lmcacheengines.lmcache.lmcache.ai -o jsonpath='{.spec.names.kind}' | grep -q "LMCacheEngine"
+      kubectl get crd cacheblendengines.lmcache.lmcache.ai -o jsonpath='{.spec.names.kind}' | grep -q "CacheBlendEngine"
+      kubectl get crd lmcachecoordinators.lmcache.lmcache.ai -o jsonpath='{.spec.names.kind}' | grep -q "LMCacheCoordinator"
+      echo "  All 3 CRDs found"
+      {{- else }}
+      echo "=== Test 5: CRDs skipped (crdInstall=false) ==="
+      {{- end }}
+
+      echo "=== Test 6: Deployment has correct image ==="
+      ACTUAL_IMAGE=$(kubectl -n "$NAMESPACE" get deployment "$RELEASE_NAME-controller-manager" -o jsonpath='{.spec.template.spec.containers[0].image}')
+      EXPECTED_IMAGE="{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      if [ "$ACTUAL_IMAGE" != "$EXPECTED_IMAGE" ]; then
+        echo "  FAIL: expected image $EXPECTED_IMAGE, got $ACTUAL_IMAGE"
+        exit 1
+      fi
+      echo "  Image correct: $ACTUAL_IMAGE"
+
+      echo "=== Test 7: Deployment has correct replica count ==="
+      ACTUAL_REPLICAS=$(kubectl -n "$NAMESPACE" get deployment "$RELEASE_NAME-controller-manager" -o jsonpath='{.spec.replicas}')
+      EXPECTED_REPLICAS="{{ .Values.replicas }}"
+      if [ "$ACTUAL_REPLICAS" != "$EXPECTED_REPLICAS" ]; then
+        echo "  FAIL: expected replicas $EXPECTED_REPLICAS, got $ACTUAL_REPLICAS"
+        exit 1
+      fi
+      echo "  Replicas correct: $ACTUAL_REPLICAS"
+
+      echo "=== Test 8: ServiceAccount name in deployment spec ==="
+      SA=$(kubectl -n "$NAMESPACE" get deployment "$RELEASE_NAME-controller-manager" -o jsonpath='{.spec.template.spec.serviceAccountName}')
+      if [ "$SA" != "controller-manager" ]; then
+        echo "  FAIL: expected serviceAccountName controller-manager, got $SA"
+        exit 1
+      fi
+      echo "  ServiceAccountName correct: $SA"
+
+      echo "=== Test 9: Deployment args contain health-probe-bind-address ==="
+      ARGS=$(kubectl -n "$NAMESPACE" get deployment "$RELEASE_NAME-controller-manager" -o jsonpath='{.spec.template.spec.containers[0].args}' | tr -d '[]')
+      echo "$ARGS" | grep -q "health-probe-bind-address=:8081"
+      echo "  --health-probe-bind-address=:8081 present"
+
+      {{- if .Values.leaderElection.enabled }}
+      echo "=== Test 10: Leader election arg present ==="
+      echo "$ARGS" | grep -q "leader-elect"
+      echo "  --leader-elect present"
+      {{- else }}
+      echo "=== Test 10: Leader election arg absent ==="
+      if echo "$ARGS" | grep -q "leader-elect"; then
+        echo "  FAIL: --leader-elect should be absent"
+        exit 1
+      fi
+      echo "  --leader-elect correctly absent"
+      {{- end }}
+
+      {{- if .Values.webhook.enabled }}
+      echo "=== Test 11: MutatingWebhookConfiguration exists ==="
+      kubectl get mutatingwebhookconfiguration "$RELEASE_NAME-mutating-webhook-configuration" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  MutatingWebhookConfiguration found"
+
+      echo "=== Test 12: Webhook Service exists ==="
+      kubectl -n "$NAMESPACE" get service "$RELEASE_NAME-webhook-service" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Webhook Service found"
+
+      echo "=== Test 13: Webhook cert path arg present ==="
+      echo "$ARGS" | grep -q "webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
+      echo "  --webhook-cert-path present"
+
+      echo "=== Test 14: Both webhook entries present ==="
+      HOOK_COUNT=$(kubectl get mutatingwebhookconfiguration "$RELEASE_NAME-mutating-webhook-configuration" -o jsonpath='{.webhooks[*].name}' | tr ' ' '\n' | wc -l)
+      if [ "$HOOK_COUNT" -ne 2 ]; then
+        echo "  FAIL: expected 2 webhooks, got $HOOK_COUNT"
+        exit 1
+      fi
+      echo "  2 webhooks found (cacheblend + lmcache)"
+
+      {{- if .Values.certManager.enabled }}
+      echo "=== Test 15: cert-manager Issuer exists ==="
+      kubectl -n "$NAMESPACE" get issuer "$RELEASE_NAME-selfsigned-issuer" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Issuer found"
+
+      echo "=== Test 16: cert-manager Certificate exists ==="
+      kubectl -n "$NAMESPACE" get certificate "$RELEASE_NAME-serving-cert" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Certificate found"
+
+      echo "=== Test 17: MutatingWebhookConfiguration has CA injection annotation ==="
+      kubectl get mutatingwebhookconfiguration "$RELEASE_NAME-mutating-webhook-configuration" -o jsonpath='{.metadata.annotations.cert-manager\.io/inject-ca-from}' | grep -q "$NAMESPACE/$RELEASE_NAME-serving-cert"
+      echo "  CA injection annotation correct"
+      {{- else }}
+      echo "=== Test 15: cert-manager disabled — skipping Issuer/Certificate checks ==="
+      {{- end }}
+      {{- else }}
+      echo "=== Test 11: Webhook disabled — skipping webhook checks ==="
+      {{- end }}
+
+      {{- if .Values.metrics.enabled }}
+      echo "=== Test 18: Metrics Service exists ==="
+      kubectl -n "$NAMESPACE" get service "$RELEASE_NAME-metrics-service" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Metrics Service found"
+
+      echo "=== Test 19: Metrics bind address arg present ==="
+      echo "$ARGS" | grep -q "metrics-bind-address"
+      echo "  --metrics-bind-address present"
+
+      echo "=== Test 20: Metrics auth ClusterRole exists ==="
+      kubectl get clusterrole "$RELEASE_NAME-metrics-auth-role" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Metrics auth ClusterRole found"
+
+      echo "=== Test 21: Metrics reader ClusterRole exists ==="
+      kubectl get clusterrole "$RELEASE_NAME-metrics-reader" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  Metrics reader ClusterRole found"
+      {{- else }}
+      echo "=== Test 18: Metrics disabled — skipping metrics checks ==="
+      {{- end }}
+
+      {{- if .Values.crdRoles.enabled }}
+      echo "=== Test 22: CRD admin/editor/viewer roles exist ==="
+      kubectl get clusterrole "$RELEASE_NAME-lmcacheengine-admin-role" -o jsonpath='{.metadata.name}' >/dev/null
+      kubectl get clusterrole "$RELEASE_NAME-lmcacheengine-editor-role" -o jsonpath='{.metadata.name}' >/dev/null
+      kubectl get clusterrole "$RELEASE_NAME-lmcacheengine-viewer-role" -o jsonpath='{.metadata.name}' >/dev/null
+      echo "  All 3 CRD roles found"
+      {{- else }}
+      echo "=== Test 22: CRD roles disabled — skipping ==="
+      {{- end }}
+
+      echo ""
+      echo "========================================="
+      echo "  All live-cluster tests passed!"
+      echo "========================================="

--- a/charts/operator/templates/webhook-service.yaml
+++ b/charts/operator/templates/webhook-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lmcache-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: webhook-server
+  selector:
+    {{- include "lmcache-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/operator/tests/test.sh
+++ b/charts/operator/tests/test.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# Helm chart template rendering tests for the LMCache operator chart.
+#
+# Each test renders the chart with a specific values file and asserts
+# that the expected resources are present (or absent), and that key
+# fields have the correct values.  No Kubernetes cluster is needed.
+#
+# Usage:  bash charts/operator/tests/test.sh
+#
+# Exits 0 if all tests pass, 1 otherwise.
+
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VALUES_DIR="$CHART_DIR/tests/values"
+RELEASE="lmcache-operator"
+NAMESPACE="lmcache-operator-system"
+FAIL=0
+PASS=0
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Render the chart with a values file and print all rendered manifests.
+render() {
+  local values_file="$1"
+  helm template "$RELEASE" "$CHART_DIR" \
+    --namespace "$NAMESPACE" \
+    --values "$values_file" 2>/dev/null || true
+}
+
+# Render the chart with a values file and show only resource kinds.
+kinds() {
+  render "$1" | grep '^kind: ' | sed 's/kind: //' | sort
+}
+
+# Assert that a string IS present in rendered output.
+assert_contains() {
+  local label="$1" values_file="$2" pattern="$3"
+  if render "$values_file" | grep -q "$pattern"; then
+    PASS=$((PASS + 1))
+    printf "  ✓ %s\n" "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf "  ✗ %s — expected \"%s\" in %s\n" "$label" "$pattern" "$(basename "$values_file")"
+  fi
+}
+
+# Assert that a string is NOT present in rendered output.
+assert_not_contains() {
+  local label="$1" values_file="$2" pattern="$3"
+  if render "$values_file" | grep -q "$pattern"; then
+    FAIL=$((FAIL + 1))
+    printf "  ✗ %s — did not expect \"%s\" in %s\n" "$label" "$pattern" "$(basename "$values_file")"
+  else
+    PASS=$((PASS + 1))
+    printf "  ✓ %s\n" "$label"
+  fi
+}
+
+# Assert a resource kind IS present.
+assert_has_kind() {
+  local label="$1" values_file="$2" kind="$3"
+  if kinds "$values_file" | grep -qx "$kind"; then
+    PASS=$((PASS + 1))
+    printf "  ✓ %s\n" "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf "  ✗ %s — expected kind %s in %s\n" "$label" "$kind" "$(basename "$values_file")"
+  fi
+}
+
+# Assert a resource kind is NOT present.
+assert_no_kind() {
+  local label="$1" values_file="$2" kind="$3"
+  if kinds "$values_file" | grep -qx "$kind"; then
+    FAIL=$((FAIL + 1))
+    printf "  ✗ %s — did not expect kind %s in %s\n" "$label" "$kind" "$(basename "$values_file")"
+  else
+    PASS=$((PASS + 1))
+    printf "  ✓ %s\n" "$label"
+  fi
+}
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+echo "Running LMCache operator Helm chart tests..."
+echo ""
+
+# ── Scenario: Default (all features enabled) ─────────────────────────────────
+echo "── Scenario: default (all features on) ──"
+
+assert_has_kind "ServiceAccount created" \
+  "$VALUES_DIR/minimal.yaml" "ServiceAccount"
+assert_has_kind "ClusterRole (manager) created" \
+  "$VALUES_DIR/minimal.yaml" "ClusterRole"
+assert_has_kind "ClusterRoleBinding created" \
+  "$VALUES_DIR/minimal.yaml" "ClusterRoleBinding"
+assert_has_kind "Role (leader election) created" \
+  "$VALUES_DIR/minimal.yaml" "Role"
+assert_has_kind "RoleBinding (leader election) created" \
+  "$VALUES_DIR/minimal.yaml" "RoleBinding"
+assert_has_kind "Service (metrics) created" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "Service"
+assert_has_kind "Service (webhook) created" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "Service"
+assert_has_kind "Deployment created" \
+  "$VALUES_DIR/minimal.yaml" "Deployment"
+assert_has_kind "MutatingWebhookConfiguration created" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "MutatingWebhookConfiguration"
+assert_has_kind "Issuer (cert-manager) created" \
+  "$VALUES_DIR/no-metrics.yaml" "Issuer"
+assert_has_kind "Certificate (cert-manager) created" \
+  "$VALUES_DIR/no-metrics.yaml" "Certificate"
+assert_has_kind "CRD (LMCacheEngine) created" \
+  "$VALUES_DIR/minimal.yaml" "CustomResourceDefinition"
+assert_contains "Leader election arg present" \
+  "$VALUES_DIR/minimal.yaml" "\-\-leader-elect"
+assert_contains "Metrics bind address arg present" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "\-\-metrics-bind-address=:8443"
+assert_contains "Webhook cert path arg present" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "\-\-webhook-cert-path=/tmp/k8s-webhook-server/serving-certs"
+assert_contains "cert-manager CA injection annotation present" \
+  "$VALUES_DIR/no-metrics.yaml" "cert-manager.io/inject-ca-from"
+assert_contains "Default image reference" \
+  "$VALUES_DIR/minimal.yaml" "lmcache/lmcache-operator:v0.1.1"
+assert_contains "Release name in Deployment" \
+  "$VALUES_DIR/minimal.yaml" "name: $RELEASE-controller-manager"
+assert_contains "Namespace in Deployment" \
+  "$VALUES_DIR/minimal.yaml" "namespace: $NAMESPACE"
+
+echo ""
+
+# ── Scenario: Minimal (all optional features off) ─────────────────────────────
+echo "── Scenario: minimal (webhook/metrics/cert-manager/crd-roles off) ──"
+
+assert_no_kind "No MutatingWebhookConfiguration" \
+  "$VALUES_DIR/minimal.yaml" "MutatingWebhookConfiguration"
+assert_no_kind "No Issuer" \
+  "$VALUES_DIR/minimal.yaml" "Issuer"
+assert_no_kind "No Certificate" \
+  "$VALUES_DIR/minimal.yaml" "Certificate"
+assert_no_kind "No Service" \
+  "$VALUES_DIR/minimal.yaml" "Service"
+assert_not_contains "No --metrics-bind-address arg" \
+  "$VALUES_DIR/minimal.yaml" "\-\-metrics-bind-address"
+assert_not_contains "No --webhook-cert-path arg" \
+  "$VALUES_DIR/minimal.yaml" "\-\-webhook-cert-path"
+assert_not_contains "No cert-manager annotation" \
+  "$VALUES_DIR/minimal.yaml" "cert-manager.io/inject-ca-from"
+assert_not_contains "No metrics-auth-role" \
+  "$VALUES_DIR/minimal.yaml" "metrics-auth-role"
+assert_not_contains "No metrics-reader" \
+  "$VALUES_DIR/minimal.yaml" "metrics-reader"
+assert_not_contains "No admin role" \
+  "$VALUES_DIR/minimal.yaml" "lmcacheengine-admin-role"
+assert_has_kind "Deployment still created" \
+  "$VALUES_DIR/minimal.yaml" "Deployment"
+assert_has_kind "ClusterRole (manager) still created" \
+  "$VALUES_DIR/minimal.yaml" "ClusterRole"
+assert_has_kind "ServiceAccount still created" \
+  "$VALUES_DIR/minimal.yaml" "ServiceAccount"
+assert_contains "Leader election still enabled" \
+  "$VALUES_DIR/minimal.yaml" "\-\-leader-elect"
+
+echo ""
+
+# ── Scenario: CRD install disabled ─────────────────────────────────────────────
+echo "── Scenario: crdInstall=false ──"
+
+assert_no_kind "No CRDs when crdInstall=false" \
+  "$VALUES_DIR/no-crds.yaml" "CustomResourceDefinition"
+assert_has_kind "Deployment still created" \
+  "$VALUES_DIR/no-crds.yaml" "Deployment"
+assert_has_kind "ServiceAccount still created" \
+  "$VALUES_DIR/no-crds.yaml" "ServiceAccount"
+assert_has_kind "ClusterRole still created" \
+  "$VALUES_DIR/no-crds.yaml" "ClusterRole"
+
+echo ""
+
+# ── Scenario: Webhook on, cert-manager off ────────────────────────────────────
+echo "── Scenario: webhook on, cert-manager off ──"
+
+assert_has_kind "MutatingWebhookConfiguration created" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "MutatingWebhookConfiguration"
+assert_no_kind "No Issuer" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "Issuer"
+assert_no_kind "No Certificate" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "Certificate"
+assert_not_contains "No cert-manager CA injection annotation" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "cert-manager.io/inject-ca-from"
+assert_has_kind "Service (webhook) still created" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "Service"
+assert_contains "Webhook cert path still in args" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "\-\-webhook-cert-path"
+
+echo ""
+
+# ── Scenario: Metrics off, webhook+cert-manager on ───────────────────────────
+echo "── Scenario: metrics off, webhook+cert-manager on ──"
+
+assert_not_contains "No metrics Service name" \
+  "$VALUES_DIR/no-metrics.yaml" "metrics-service"
+assert_not_contains "No --metrics-bind-address arg" \
+  "$VALUES_DIR/no-metrics.yaml" "\-\-metrics-bind-address"
+assert_contains "Webhook Service still present" \
+  "$VALUES_DIR/no-metrics.yaml" "webhook-service"
+assert_not_contains "No metrics-auth-role" \
+  "$VALUES_DIR/no-metrics.yaml" "metrics-auth-role"
+assert_not_contains "No metrics-reader" \
+  "$VALUES_DIR/no-metrics.yaml" "metrics-reader"
+assert_has_kind "MutatingWebhookConfiguration still present" \
+  "$VALUES_DIR/no-metrics.yaml" "MutatingWebhookConfiguration"
+assert_has_kind "Issuer still present" \
+  "$VALUES_DIR/no-metrics.yaml" "Issuer"
+
+echo ""
+
+# ── Scenario: Custom image, resources, replicas, scheduling ───────────────────
+echo "── Scenario: custom image, resources, replicas, scheduling ──"
+
+assert_contains "Custom image repository:tag" \
+  "$VALUES_DIR/custom-image-resources.yaml" "myregistry.io/lmcache-operator:v0.2.0"
+assert_contains "Image pull policy Always" \
+  "$VALUES_DIR/custom-image-resources.yaml" "imagePullPolicy: Always"
+assert_contains "Replicas set to 3" \
+  "$VALUES_DIR/custom-image-resources.yaml" "replicas: 3"
+assert_contains "Custom CPU limit" \
+  "$VALUES_DIR/custom-image-resources.yaml" "cpu: \"1\""
+assert_contains "Custom memory limit" \
+  "$VALUES_DIR/custom-image-resources.yaml" "memory: 256Mi"
+assert_contains "Custom CPU request" \
+  "$VALUES_DIR/custom-image-resources.yaml" "cpu: 200m"
+assert_contains "Custom nodeSelector" \
+  "$VALUES_DIR/custom-image-resources.yaml" "node-role.kubernetes.io/control-plane"
+assert_contains "Custom toleration key" \
+  "$VALUES_DIR/custom-image-resources.yaml" "node-role.kubernetes.io/control-plane"
+assert_contains "Custom toleration effect" \
+  "$VALUES_DIR/custom-image-resources.yaml" "NoSchedule"
+assert_contains "Custom pod annotation" \
+  "$VALUES_DIR/custom-image-resources.yaml" "custom.annotation/example"
+assert_contains "Custom pod label" \
+  "$VALUES_DIR/custom-image-resources.yaml" "custom-label: value"
+assert_contains "Common label propagated" \
+  "$VALUES_DIR/custom-image-resources.yaml" "team: ml-platform"
+assert_contains "Extra env var LOG_LEVEL" \
+  "$VALUES_DIR/custom-image-resources.yaml" "LOG_LEVEL"
+assert_contains "Extra arg zap-log-level" \
+  "$VALUES_DIR/custom-image-resources.yaml" "\-\-zap-log-level=5"
+assert_contains "Extra arg zap-encoder" \
+  "$VALUES_DIR/custom-image-resources.yaml" "\-\-zap-encoder=json"
+assert_contains "Custom termination grace period" \
+  "$VALUES_DIR/custom-image-resources.yaml" "terminationGracePeriodSeconds: 30"
+
+echo ""
+
+# ── Scenario: Custom webhook port and failure policy ──────────────────────────
+echo "── Scenario: custom webhook port and failure policy ──"
+
+assert_contains "Custom webhook container port" \
+  "$VALUES_DIR/webhook-custom-port.yaml" "containerPort: 8443"
+assert_contains "Custom failurePolicy Fail" \
+  "$VALUES_DIR/webhook-custom-port.yaml" "failurePolicy: Fail"
+
+echo ""
+
+# ── Scenario: Leader election disabled ────────────────────────────────────────
+echo "── Scenario: leader election disabled ──"
+
+DEPLOY_ARGS=$(render "$VALUES_DIR/no-leader-election.yaml" | awk '/kind: Deployment/,/^---/' | grep -c "leader-elect" || true)
+if [ "$DEPLOY_ARGS" -eq 0 ]; then
+  PASS=$((PASS + 1))
+  printf "  ✓ No --leader-elect arg\n"
+else
+  FAIL=$((FAIL + 1))
+  printf "  ✗ No --leader-elect arg — did not expect leader-elect in Deployment\n"
+fi
+assert_has_kind "Deployment still created" \
+  "$VALUES_DIR/no-leader-election.yaml" "Deployment"
+
+echo ""
+
+# ── Scenario: Image pull secrets ─────────────────────────────────────────────
+echo "── Scenario: image pull secrets on ServiceAccount ──"
+
+assert_contains "Image pull secret name on ServiceAccount" \
+  "$VALUES_DIR/image-pull-secrets.yaml" "name: my-registry-secret"
+
+echo ""
+
+# ── Scenario: Extra volumes and volumeMounts ─────────────────────────────────
+echo "── Scenario: extra volumes and volumeMounts ──"
+
+assert_contains "Extra volume 'config'" \
+  "$VALUES_DIR/extra-volumes.yaml" "name: config"
+assert_contains "Extra volumeMount /etc/custom-config" \
+  "$VALUES_DIR/extra-volumes.yaml" "mountPath: /etc/custom-config"
+assert_contains "Webhook certs volume still present" \
+  "$VALUES_DIR/extra-volumes.yaml" "name: webhook-certs"
+assert_contains "Webhook cert mount still present" \
+  "$VALUES_DIR/extra-volumes.yaml" "mountPath: /tmp/k8s-webhook-server/serving-certs"
+
+echo ""
+
+# ── Scenario: Custom metrics address and port ────────────────────────────────
+echo "── Scenario: custom metrics bind address and service port ──"
+
+assert_contains "Custom metrics bind address :8080" \
+  "$VALUES_DIR/custom-metrics.yaml" "\-\-metrics-bind-address=:8080"
+assert_contains "Custom metrics service port 8080" \
+  "$VALUES_DIR/custom-metrics.yaml" "port: 8080"
+
+echo ""
+
+# ── Scenario: Custom security context ───────────────────────────────────────
+echo "── Scenario: custom pod and container security context ──"
+
+assert_contains "Custom runAsUser 1000" \
+  "$VALUES_DIR/custom-security-context.yaml" "runAsUser: 1000"
+assert_contains "Custom runAsGroup 1000" \
+  "$VALUES_DIR/custom-security-context.yaml" "runAsGroup: 1000"
+assert_contains "Custom fsGroup 1000" \
+  "$VALUES_DIR/custom-security-context.yaml" "fsGroup: 1000"
+
+echo ""
+
+# ── CRD symlink verification ──────────────────────────────────────────────────
+echo "── Scenario: CRDs via symlinks from operator/config/crd/bases ──"
+
+assert_contains "LMCacheEngine CRD present" \
+  "$VALUES_DIR/minimal.yaml" "lmcacheengines.lmcache.lmcache.ai"
+assert_contains "CacheBlendEngine CRD present" \
+  "$VALUES_DIR/minimal.yaml" "cacheblendengines.lmcache.lmcache.ai"
+assert_contains "LMCacheCoordinator CRD present" \
+  "$VALUES_DIR/minimal.yaml" "lmcachecoordinators.lmcache.lmcache.ai"
+
+echo ""
+
+# ── Namespace / Release.Name propagation ─────────────────────────────────────
+echo "── Scenario: Release.Namespace and Release.Name propagation ──"
+
+assert_contains "Release name in ClusterRole" \
+  "$VALUES_DIR/minimal.yaml" "name: $RELEASE-manager-role"
+assert_contains "Release name in ClusterRoleBinding" \
+  "$VALUES_DIR/minimal.yaml" "name: $RELEASE-manager-rolebinding"
+assert_contains "Release name in Role" \
+  "$VALUES_DIR/minimal.yaml" "name: $RELEASE-leader-election-role"
+assert_contains "Release name in RoleBinding" \
+  "$VALUES_DIR/minimal.yaml" "name: $RELEASE-leader-election-rolebinding"
+assert_contains "Release name in webhook service" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "name: $RELEASE-webhook-service"
+assert_contains "Release name in mutating webhook" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "name: $RELEASE-mutating-webhook-configuration"
+assert_contains "Release namespace in webhook service" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "namespace: $NAMESPACE"
+assert_contains "Release namespace in cert-manager cert" \
+  "$VALUES_DIR/no-metrics.yaml" "namespace: $NAMESPACE"
+assert_contains "Release name in cert-manager cert DNS" \
+  "$VALUES_DIR/no-metrics.yaml" "$RELEASE-webhook-service.$NAMESPACE.svc"
+assert_contains "Release namespace in namespaceSelector exclusion" \
+  "$VALUES_DIR/webhook-no-certmanager.yaml" "lmcache-operator-system$"
+
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "  Tests: $((PASS + FAIL))  Passed: $PASS  Failed: $FAIL"
+echo "─────────────────────────────────────────"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/charts/operator/tests/values/custom-image-resources.yaml
+++ b/charts/operator/tests/values/custom-image-resources.yaml
@@ -1,0 +1,33 @@
+# Custom image, custom resources, replicas > 1, extra args/env/volumes.
+# Tests that all customization values flow through to the Deployment.
+image:
+  repository: myregistry.io/lmcache-operator
+  tag: v0.2.0
+  pullPolicy: Always
+replicas: 3
+resources:
+  limits:
+    cpu: "1"
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 128Mi
+nodeSelector:
+  node-role.kubernetes.io/control-plane: "true"
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+podAnnotations:
+  custom.annotation/example: "true"
+podLabels:
+  custom-label: "value"
+commonLabels:
+  team: ml-platform
+env:
+  - name: LOG_LEVEL
+    value: debug
+extraArgs:
+  - --zap-log-level=5
+  - --zap-encoder=json
+terminationGracePeriodSeconds: 30

--- a/charts/operator/tests/values/custom-metrics.yaml
+++ b/charts/operator/tests/values/custom-metrics.yaml
@@ -1,0 +1,6 @@
+# Custom metrics bind address and service port.
+metrics:
+  enabled: true
+  bindAddress: ":8080"
+  secure: false
+  servicePort: 8080

--- a/charts/operator/tests/values/custom-security-context.yaml
+++ b/charts/operator/tests/values/custom-security-context.yaml
@@ -1,0 +1,15 @@
+# Custom pod security context (e.g. running as a specific user).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsUser: 1000

--- a/charts/operator/tests/values/extra-volumes.yaml
+++ b/charts/operator/tests/values/extra-volumes.yaml
@@ -1,0 +1,11 @@
+# Extra volumes and volumeMounts added to the operator pod (no webhook).
+# Tests that extra volumes coexist with webhook volumes when webhook is on.
+webhook:
+  enabled: true
+volumes:
+  - name: config
+    emptyDir: {}
+volumeMounts:
+  - name: config
+    mountPath: /etc/custom-config
+    readOnly: true

--- a/charts/operator/tests/values/image-pull-secrets.yaml
+++ b/charts/operator/tests/values/image-pull-secrets.yaml
@@ -1,0 +1,3 @@
+# Image pull secrets on the ServiceAccount.
+imagePullSecrets:
+  - name: my-registry-secret

--- a/charts/operator/tests/values/minimal.yaml
+++ b/charts/operator/tests/values/minimal.yaml
@@ -1,0 +1,10 @@
+# Minimal deployment - only the operator controller, no webhook, no metrics,
+# no cert-manager, no CRD roles.  Tests that conditional templates are omitted.
+webhook:
+  enabled: false
+certManager:
+  enabled: false
+metrics:
+  enabled: false
+crdRoles:
+  enabled: false

--- a/charts/operator/tests/values/no-crds.yaml
+++ b/charts/operator/tests/values/no-crds.yaml
@@ -1,0 +1,3 @@
+# CRD installation disabled — operator deploys without installing CRDs.
+# Use when CRDs are managed separately (e.g. via a dedicated CRD chart).
+crdInstall: false

--- a/charts/operator/tests/values/no-leader-election.yaml
+++ b/charts/operator/tests/values/no-leader-election.yaml
@@ -1,0 +1,3 @@
+# Leader election disabled (single replica, no --leader-elect arg).
+leaderElection:
+  enabled: false

--- a/charts/operator/tests/values/no-metrics.yaml
+++ b/charts/operator/tests/values/no-metrics.yaml
@@ -1,0 +1,5 @@
+# Metrics disabled, webhook+cert-manager enabled.
+# Verifies the metrics Service, metrics RBAC, and --metrics-bind-address
+# arg are omitted while the webhook stack remains.
+metrics:
+  enabled: false

--- a/charts/operator/tests/values/webhook-custom-port.yaml
+++ b/charts/operator/tests/values/webhook-custom-port.yaml
@@ -1,0 +1,7 @@
+# Custom webhook port and failure policy.
+# Tests that webhook port and failurePolicy values propagate to both
+# the Deployment container port and the MutatingWebhookConfiguration.
+webhook:
+  enabled: true
+  port: 8443
+  failurePolicy: Fail

--- a/charts/operator/tests/values/webhook-no-certmanager.yaml
+++ b/charts/operator/tests/values/webhook-no-certmanager.yaml
@@ -1,0 +1,7 @@
+# Webhook enabled but cert-manager disabled.
+# The chart should create the MutatingWebhookConfiguration without the
+# cert-manager.io/inject-ca-from annotation, and no Issuer/Certificate.
+webhook:
+  enabled: true
+certManager:
+  enabled: false

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -1,0 +1,130 @@
+# LMCache Operator Helm Chart Values
+#
+# This chart installs the LMCache Kubernetes operator, which automates
+# the deployment and lifecycle management of LMCache multiprocess cache
+# servers.  The operator manages three CRDs: LMCacheEngine, CacheBlendEngine,
+# and LMCacheCoordinator.
+#
+# After installing the operator, create an LMCacheEngine CR to deploy
+# cache server pods.  See the operator documentation:
+#   https://docs.lmcache.ai/mp/operator.html
+
+# -- Install CRDs alongside the operator.  Set to false if you manage CRDs
+# separately (e.g. via a dedicated CRD chart or kubectl apply).
+crdInstall: true
+
+# -- Container image for the operator controller-manager.
+image:
+  repository: lmcache/lmcache-operator
+  tag: v0.1.1
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for the operator pod (private registries).
+imagePullSecrets: []
+
+# -- Number of operator pods (leader election is enabled by default).
+replicas: 1
+
+# -- Leader election for high-availability deployments (replicas > 1).
+leaderElection:
+  enabled: true
+  # -- Lease duration for leader election (Go duration string).
+  leaseDuration: ""
+  # -- Renew deadline for leader election (Go duration string).
+  renewDeadline: ""
+  # -- Retry period for leader election (Go duration string).
+  retryPeriod: ""
+
+# -- Resource requests and limits for the operator container.
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+# -- Pod-level security context for the operator pod.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context for the operator container.
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Node selector for the operator pod.
+nodeSelector: {}
+
+# -- Tolerations for the operator pod.
+tolerations: []
+
+# -- Affinity rules for the operator pod.
+affinity: {}
+
+# -- Extra labels added to all resources the chart creates.
+commonLabels: {}
+
+# -- Extra labels on the operator pod.
+podLabels: {}
+
+# -- Extra annotations on the operator pod.
+podAnnotations: {}
+
+# -- Termination grace period (seconds) for the operator pod.
+terminationGracePeriodSeconds: 10
+
+# -- Metrics endpoint configuration for the controller-manager.
+metrics:
+  # -- Enable the metrics endpoint.  When enabled, the chart creates a
+  # Service exposing the metrics port and the RBAC needed for
+  # authenticated/authorized metrics access.
+  enabled: true
+  # -- Bind address for the metrics endpoint.  Use ":8443" for HTTPS
+  # (default, secure) or ":8080" for HTTP.
+  bindAddress: ":8443"
+  # -- Use secure (HTTPS) metrics serving.
+  secure: true
+  # -- Service port for the metrics Service.
+  servicePort: 8443
+
+# -- Mutating admission webhook for connection injection.
+# When enabled, the chart creates the MutatingWebhookConfiguration and the
+# webhook Service.  Requires cert-manager to be installed in the cluster.
+webhook:
+  enabled: true
+  # -- Port the webhook server listens on inside the pod.
+  port: 9443
+  # -- Failure policy for the webhook (Ignore or Fail).
+  failurePolicy: Ignore
+
+# -- cert-manager integration for the webhook serving certificate.
+# Requires cert-manager to be installed in the cluster.  When enabled, the
+# chart creates an Issuer and Certificate that provision the TLS cert for the
+# webhook server.  Disable only if you manage the webhook certificate
+# out-of-band.
+certManager:
+  enabled: true
+
+# -- Create the admin, editor, and viewer ClusterRoles for the CRDs.
+# These roles are not used by the operator itself; they help cluster admins
+# delegate permissions to other users.
+crdRoles:
+  enabled: true
+
+# -- Extra environment variables for the operator container.
+env: []
+
+# -- Extra volumes for the operator pod.
+volumes: []
+
+# -- Extra volume mounts for the operator container.
+volumeMounts: []
+
+# -- Extra args appended to the operator container command.
+extraArgs: []


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Adds a Helm chart for the LMCache Kubernetes operator at `charts/operator/`. The operator currently ships only Kustomize manifests (operator/config/default); this chart provides an alternative helm install path for users who manage deployments with Helm.

The chart mirrors all resources from the Kustomize stack:
- Operator Deployment, ServiceAccount, full RBAC (manager ClusterRole, leader-election Role, metrics auth roles, CRD admin/editor/viewer roles)
- MutatingWebhookConfiguration with both CacheBlend and LMCache injection webhooks (object/namespace selectors, failurePolicy: Ignore)
- cert-manager Issuer + Certificate for the webhook serving cert
- Metrics Service and webhook Service
- All three CRDs (LMCacheEngine, CacheBlendEngine, LMCacheCoordinator)

Key design choices:
- CRDs are symlinks to `operator/config/crd/bases/`, not copies - make manifests stays the single source of truth. They are rendered through templates/crds.yaml with a crdInstall toggle so users managing CRDs separately can skip them.
- Resource names use `.Release.Name` and `.Release.Namespace`. Users install with helm install ... -n <ns> --create-namespace.
- All optional features are toggleable via values: webhook.enabled, certManager.enabled, metrics.enabled, crdRoles.enabled, crdInstall, leaderElection.enabled, plus image, replicas, resources, scheduling, security contexts, env, volumes, extra args.

**Special notes for your reviewers**:
- CRD files under crd-bases/ are symlinks (`../../../operator/config/crd/bases/...`). Helm follows symlinks via .Files.Get, so the chart stays in sync with make manifests automatically.
- helm test hook pods (templates/tests/) are standalone - no tests values section needed. They run only on helm test, never on helm install. Test RBAC is provisioned via hook annotations.
- `tests/test.sh` is an offline template-rendering script (93 assertions across 13 scenarios) that validates chart output without a cluster. Run with bash charts/operator/tests/test.sh.
- The chart does not replace the Kustomize/make deploy workflow - it coexists as an installation option.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [X] this PR contains unit tests
