### PR TITLE
[Bugfix][vLLM] DSA indexer caches: fail fast in-process, validate and document LMCacheMPConnector for GLM-5.3

### DIFF
--- a/docs/source/recipes/glm5_2.rst
+++ b/docs/source/recipes/glm5_2.rst
@@ -1,10 +1,10 @@
 .. _recipe_glm5_2:
 
-GLM 5.1/5.2
-===========
+GLM 5.1/5.2/5.3
+===============
 
 A large Mixture-of-Experts model using **Dynamic Sparse Attention (DSA)**, shared
-by the **GLM-5.1 / GLM-5.2** series. Like DeepSeek-V4-Flash, the sparse-attention path
+by the **GLM-5.1 / GLM-5.2 / GLM-5.3** series. Like DeepSeek-V4-Flash, the sparse-attention path
 splits the model's layers into more than one KV cache group; the
 ``LMCacheMPConnector`` stores and retrieves each group in its own block size, so
 KV reuse works without extra flags.
@@ -13,6 +13,7 @@ Validated models
 ----------------
 
 - `zai-org/GLM-5.2-FP8 <https://huggingface.co/zai-org/GLM-5.2-FP8>`_ (8 GPUs)
+- GLM-5.3 (NVFP4 checkpoint, 8x B200, TP8 + expert parallel, ``--kv-cache-dtype fp8_e4m3``)
 
 .. tab-set::
    :sync-group: engine
@@ -25,7 +26,9 @@ Validated models
       (architecture ``GlmMoeDsaForCausalLM``). See also the
       `vLLM GLM-5.2 recipe <https://recipes.vllm.ai/zai-org/GLM-5.2>`_.
 
-      **Status:** Validated with LMCache (vLLM 0.23.0 + LMCache 0.4.7).
+      **Status:** Validated with LMCache (GLM-5.2: vLLM 0.23.0 + LMCache 0.4.7;
+      GLM-5.3: vLLM 0.28.0 + LMCache 0.5.5rc5, needle retrieval correct at 19k,
+      55k and 92k tokens when the KV is restored from LMCache).
 
       Start the LMCache MP server:
 
@@ -51,7 +54,7 @@ Validated models
              --reasoning-parser glm45 \
              --no-enable-prefix-caching \
              --kv-transfer-config \
-             '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.port":6555}}'
+             '{"kv_connector":"LMCacheMPConnector","kv_connector_module_path":"lmcache.integration.vllm.lmcache_mp_connector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.port":6555}}'
 
       |
 
@@ -110,7 +113,12 @@ LMCache accounts for the MTP draft layer's KV cache automatically.
 Caveats
 -------
 
-- **Dynamic Sparse Attention KV groups.** GLM-5.2's DSA path splits the model's
-  layers into more than one KV cache group with different block geometries.
-  LMCache stores and retrieves each group in its own block size; no extra flags
-  are required beyond the launch commands above.
+- **Dynamic Sparse Attention KV groups.** The DSA path registers a sparse-attention
+  indexer k-cache (uint8, 132 bytes per token) per sparse layer beside the MLA cache.
+  ``LMCacheMPConnector`` stores and restores both (the server log shows two
+  ``KernelGroupInfo`` groups, ``hs=576`` and ``hs=132``); no extra flags are required.
+  ``--chunk-size`` must be a multiple of the engine block size (64 for DSA models).
+- **In-process connector not supported.** ``LMCacheConnectorV1`` /
+  ``LMCacheConnectorV1Dynamic`` cannot carry the indexer caches and refuse to start
+  on DSA models. Restoring only the MLA cache is not an option: every KV hit longer
+  than the indexer top-k (2,048 tokens) then decodes garbage.

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -45,7 +45,7 @@ from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import validate_and_set_config_value
-from lmcache.v1.gpu_connector.kv_format import drop_indexer_caches
+from lmcache.v1.gpu_connector.kv_format import find_indexer_caches
 from lmcache.v1.manager import LMCacheManager
 
 if TYPE_CHECKING:
@@ -740,7 +740,6 @@ class LMCacheConnectorV1Impl:
                 self.kv_caches[layer_name] = attn_layer.kv_cache[
                     forward_context.virtual_engine
                 ]
-        self.kv_caches = drop_indexer_caches(self.kv_caches, EngineType.VLLM)
 
     ####################
     # Worker side APIs
@@ -748,10 +747,16 @@ class LMCacheConnectorV1Impl:
     @_lmcache_nvtx_annotate
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         logger.info("Registering KV caches")
-        # DSA models also register an indexer cache per sparse layer; vLLM
-        # manages those itself and the connectors here are sized to the
-        # attention layer count, so keep only the attention KV caches.
-        kv_caches = drop_indexer_caches(kv_caches, EngineType.VLLM)
+        indexer_caches = find_indexer_caches(kv_caches, EngineType.VLLM)
+        if indexer_caches:
+            # The connectors here are sized to the attention layers and cannot
+            # carry these. Dropping them boots, but every KV hit longer than the
+            # indexer top-k then decodes garbage (LMCache/LMCache#5002).
+            raise NotImplementedError(
+                f"{len(indexer_caches)} DSA indexer KV caches registered (e.g. "
+                f"{indexer_caches[0]}); this connector cannot offload them yet. "
+                "See https://github.com/LMCache/LMCache/issues/5002."
+            )
         # TODO(chunxiaozheng): `_init_kv_caches_from_forward_context` is
         #  not called, we should consider removing it.
         assert len(self.kv_caches) == 0 and len(kv_caches) > 0

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -754,8 +754,9 @@ class LMCacheConnectorV1Impl:
             # indexer top-k then decodes garbage (LMCache/LMCache#5002).
             raise NotImplementedError(
                 f"{len(indexer_caches)} DSA indexer KV caches registered (e.g. "
-                f"{indexer_caches[0]}); this connector cannot offload them yet. "
-                "See https://github.com/LMCache/LMCache/issues/5002."
+                f"{indexer_caches[0]}); this connector cannot offload them. Use "
+                "LMCacheMPConnector, which stores and restores them (see the GLM "
+                "recipe and https://github.com/LMCache/LMCache/issues/5002)."
             )
         # TODO(chunxiaozheng): `_init_kv_caches_from_forward_context` is
         #  not called, we should consider removing it.

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -40,11 +40,12 @@ from lmcache.integration.vllm.utils import (
 from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor, PrometheusLogger
-from lmcache.utils import CacheStoreEvent, _lmcache_nvtx_annotate, cdiv
+from lmcache.utils import CacheStoreEvent, EngineType, _lmcache_nvtx_annotate, cdiv
 from lmcache.v1.cache_engine import LMCacheEngine
 from lmcache.v1.compute.blend import LMCBlenderBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import validate_and_set_config_value
+from lmcache.v1.gpu_connector.kv_format import drop_indexer_caches
 from lmcache.v1.manager import LMCacheManager
 
 if TYPE_CHECKING:
@@ -739,6 +740,7 @@ class LMCacheConnectorV1Impl:
                 self.kv_caches[layer_name] = attn_layer.kv_cache[
                     forward_context.virtual_engine
                 ]
+        self.kv_caches = drop_indexer_caches(self.kv_caches, EngineType.VLLM)
 
     ####################
     # Worker side APIs
@@ -746,6 +748,10 @@ class LMCacheConnectorV1Impl:
     @_lmcache_nvtx_annotate
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         logger.info("Registering KV caches")
+        # DSA models also register an indexer cache per sparse layer; vLLM
+        # manages those itself and the connectors here are sized to the
+        # attention layer count, so keep only the attention KV caches.
+        kv_caches = drop_indexer_caches(kv_caches, EngineType.VLLM)
         # TODO(chunxiaozheng): `_init_kv_caches_from_forward_context` is
         #  not called, we should consider removing it.
         assert len(self.kv_caches) == 0 and len(kv_caches) > 0

--- a/lmcache/v1/gpu_connector/kv_format/__init__.py
+++ b/lmcache/v1/gpu_connector/kv_format/__init__.py
@@ -6,6 +6,8 @@ Public surface:
 - :class:`KVFormatSpec` -- per-format geometry interface.
 - :func:`get_spec` / :func:`get_spec_class` -- look up the spec for a format.
 - :func:`detect_format` -- normalize a raw ``kv_caches`` and discover its format.
+- :func:`is_indexer_cache` / :func:`drop_indexer_caches` -- keep sparse-attention
+  indexer caches (spec fact ``is_indexer``) away from attention-KV connectors.
 - :func:`describe_shape` / :func:`concrete_shape` -- render a format's symbolic /
   numeric shape string.
 """
@@ -13,7 +15,9 @@ Public surface:
 # First Party
 from lmcache.v1.gpu_connector.kv_format.detection import (
     detect_format,
+    drop_indexer_caches,
     extract_kv_cache_shapes,
+    is_indexer_cache,
 )
 from lmcache.v1.gpu_connector.kv_format.specs import (
     KVFormatSpec,
@@ -28,7 +32,9 @@ __all__ = [
     "concrete_shape",
     "describe_shape",
     "detect_format",
+    "drop_indexer_caches",
     "extract_kv_cache_shapes",
     "get_spec",
     "get_spec_class",
+    "is_indexer_cache",
 ]

--- a/lmcache/v1/gpu_connector/kv_format/__init__.py
+++ b/lmcache/v1/gpu_connector/kv_format/__init__.py
@@ -6,8 +6,7 @@ Public surface:
 - :class:`KVFormatSpec` -- per-format geometry interface.
 - :func:`get_spec` / :func:`get_spec_class` -- look up the spec for a format.
 - :func:`detect_format` -- normalize a raw ``kv_caches`` and discover its format.
-- :func:`is_indexer_cache` / :func:`drop_indexer_caches` -- keep sparse-attention
-  indexer caches (spec fact ``is_indexer``) away from attention-KV connectors.
+- :func:`find_indexer_caches` -- names of indexer caches (spec fact ``is_indexer``).
 - :func:`describe_shape` / :func:`concrete_shape` -- render a format's symbolic /
   numeric shape string.
 """
@@ -15,9 +14,8 @@ Public surface:
 # First Party
 from lmcache.v1.gpu_connector.kv_format.detection import (
     detect_format,
-    drop_indexer_caches,
     extract_kv_cache_shapes,
-    is_indexer_cache,
+    find_indexer_caches,
 )
 from lmcache.v1.gpu_connector.kv_format.specs import (
     KVFormatSpec,
@@ -32,9 +30,8 @@ __all__ = [
     "concrete_shape",
     "describe_shape",
     "detect_format",
-    "drop_indexer_caches",
+    "find_indexer_caches",
     "extract_kv_cache_shapes",
     "get_spec",
     "get_spec_class",
-    "is_indexer_cache",
 ]

--- a/lmcache/v1/gpu_connector/kv_format/detection.py
+++ b/lmcache/v1/gpu_connector/kv_format/detection.py
@@ -5,6 +5,9 @@
 off to the engine's :class:`EngineDetector` to reshape and identify the format.
 """
 
+# Standard
+from collections.abc import Mapping
+
 # Third Party
 import torch
 
@@ -15,7 +18,7 @@ from lmcache.v1.gpu_connector.kv_format.contiguity import (
     attempt_permute_to_contiguous_view,
 )
 from lmcache.v1.gpu_connector.kv_format.detectors import get_detector
-from lmcache.v1.gpu_connector.kv_format.specs import describe_shape
+from lmcache.v1.gpu_connector.kv_format.specs import describe_shape, get_spec_class
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache, LayoutHints
 import lmcache.lmcache_native as lmcache_native
 
@@ -70,3 +73,51 @@ def detect_format(
         "Engine KV Format: %s %s", engine_kv_format, describe_shape(engine_kv_format)
     )
     return engine_kv_format, kv_caches
+
+
+def is_indexer_cache(
+    kv_cache: torch.Tensor,
+    serving_engine: EngineType,
+    layout_hints: "LayoutHints | None" = None,
+) -> bool:
+    """Return whether one per-layer tensor is a sparse-attention indexer cache.
+
+    Detects the tensor's format as a single-layer registration and reads the
+    ``is_indexer`` fact off its spec, so the answer follows the format table
+    rather than any engine layer class. Unrecognized layouts are not indexers.
+    """
+    kv_caches = attempt_permute_to_contiguous_view([kv_cache])
+    detector = get_detector(serving_engine)
+    if detector is None:
+        return False
+    engine_kv_format, _ = detector.discover(kv_caches, layout_hints or {})
+    return engine_kv_format is not None and get_spec_class(engine_kv_format).is_indexer
+
+
+def drop_indexer_caches(
+    kv_caches: Mapping[str, torch.Tensor],
+    serving_engine: EngineType,
+    layout_hints: "LayoutHints | None" = None,
+) -> dict[str, torch.Tensor]:
+    """Return *kv_caches* without its indexer caches, in registration order.
+
+    DSA models (DeepSeek-V3.2, GLM-5.3) register an indexer k-cache per sparse
+    layer beside the attention KV caches. The engine manages those itself, and
+    connectors that size themselves to the attention layer count cannot carry
+    them, so registration paths call this before handing the caches on. Tensors
+    are returned as-is (no copies); a summary is logged only when something was
+    dropped.
+    """
+    kept = {
+        name: kv_cache
+        for name, kv_cache in kv_caches.items()
+        if not is_indexer_cache(kv_cache, serving_engine, layout_hints)
+    }
+    dropped = len(kv_caches) - len(kept)
+    if dropped:
+        logger.info(
+            "Skipping %d indexer KV caches, registering %d attention KV caches",
+            dropped,
+            len(kept),
+        )
+    return kept

--- a/lmcache/v1/gpu_connector/kv_format/detection.py
+++ b/lmcache/v1/gpu_connector/kv_format/detection.py
@@ -5,9 +5,6 @@
 off to the engine's :class:`EngineDetector` to reshape and identify the format.
 """
 
-# Standard
-from collections.abc import Mapping
-
 # Third Party
 import torch
 
@@ -75,49 +72,25 @@ def detect_format(
     return engine_kv_format, kv_caches
 
 
-def is_indexer_cache(
-    kv_cache: torch.Tensor,
-    serving_engine: EngineType,
-    layout_hints: "LayoutHints | None" = None,
-) -> bool:
-    """Return whether one per-layer tensor is a sparse-attention indexer cache.
+def find_indexer_caches(
+    kv_caches: dict[str, torch.Tensor], serving_engine: EngineType
+) -> list[str]:
+    """Return the names in *kv_caches* whose format spec declares ``is_indexer``.
 
-    Detects the tensor's format as a single-layer registration and reads the
-    ``is_indexer`` fact off its spec, so the answer follows the format table
-    rather than any engine layer class. Unrecognized layouts are not indexers.
+    DSA models (DeepSeek-V3.2, GLM-5.3) register a sparse-attention indexer
+    k-cache per sparse layer beside the attention KV. Each tensor is detected on
+    its own; layouts detection rejects are not indexers.
     """
-    kv_caches = attempt_permute_to_contiguous_view([kv_cache])
     detector = get_detector(serving_engine)
     if detector is None:
-        return False
-    engine_kv_format, _ = detector.discover(kv_caches, layout_hints or {})
-    return engine_kv_format is not None and get_spec_class(engine_kv_format).is_indexer
+        return []
 
+    def is_indexer(kv_cache: torch.Tensor) -> bool:
+        try:
+            view = attempt_permute_to_contiguous_view([kv_cache])
+            fmt, _ = detector.discover(view, {})
+        except ValueError:
+            return False
+        return fmt is not None and get_spec_class(fmt).is_indexer
 
-def drop_indexer_caches(
-    kv_caches: Mapping[str, torch.Tensor],
-    serving_engine: EngineType,
-    layout_hints: "LayoutHints | None" = None,
-) -> dict[str, torch.Tensor]:
-    """Return *kv_caches* without its indexer caches, in registration order.
-
-    DSA models (DeepSeek-V3.2, GLM-5.3) register an indexer k-cache per sparse
-    layer beside the attention KV caches. The engine manages those itself, and
-    connectors that size themselves to the attention layer count cannot carry
-    them, so registration paths call this before handing the caches on. Tensors
-    are returned as-is (no copies); a summary is logged only when something was
-    dropped.
-    """
-    kept = {
-        name: kv_cache
-        for name, kv_cache in kv_caches.items()
-        if not is_indexer_cache(kv_cache, serving_engine, layout_hints)
-    }
-    dropped = len(kv_caches) - len(kept)
-    if dropped:
-        logger.info(
-            "Skipping %d indexer KV caches, registering %d attention KV caches",
-            dropped,
-            len(kept),
-        )
-    return kept
+    return [name for name, t in kv_caches.items() if is_indexer(t)]

--- a/lmcache/v1/gpu_connector/kv_format/specs/base.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/base.py
@@ -101,10 +101,10 @@ class KVFormatSpec(ABC):
     representative) and the format's **static layout facts** -- the structural
     shape (``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list``, exactly one
     true) plus the ``is_mla`` / ``is_hnd`` / ``is_fused_packed`` /
-    ``is_two_major`` / ``is_pbs_fused`` modifiers. They default to ``False``, so
-    a spec only declares what applies to it, and every consumer reads them
-    through ``get_spec_class(fmt)`` -- no format lists at call sites. The device
-    kernels keep their own copy in ``csrc/engine_kv_format.h``.
+    ``is_two_major`` / ``is_pbs_fused`` / ``is_indexer`` modifiers. They default
+    to ``False``, so a spec only declares what applies to it, and every consumer
+    reads them through ``get_spec_class(fmt)`` -- no format lists at call sites.
+    The device kernels keep their own copy in ``csrc/engine_kv_format.h``.
 
     Method usage by mode -- every spec is consumed through the ``get_*``
     facade in ``gpu_connector.utils``:
@@ -153,6 +153,11 @@ class KVFormatSpec(ABC):
     # Each per-layer list entry is a ``(K, V)`` tuple of paged tensors, rather
     # than a single stacked per-layer tensor.
     is_kv_second_tuple: ClassVar[bool] = False
+    # A sparse-attention indexer cache (DSA: DeepSeek-V3.2, GLM-5.3), not
+    # attention K/V. The engine registers it beside the attention caches and
+    # manages it itself; ``drop_indexer_caches`` keeps it away from connectors
+    # sized to the attention layer count.
+    is_indexer: ClassVar[bool] = False
 
     def __init__(self, kv_caches: DiscoverableKVCache) -> None:
         # Borrowed, not owned: see the class docstring's "Lifetime" note. The

--- a/lmcache/v1/gpu_connector/kv_format/specs/base.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/base.py
@@ -153,10 +153,8 @@ class KVFormatSpec(ABC):
     # Each per-layer list entry is a ``(K, V)`` tuple of paged tensors, rather
     # than a single stacked per-layer tensor.
     is_kv_second_tuple: ClassVar[bool] = False
-    # A sparse-attention indexer cache (DSA: DeepSeek-V3.2, GLM-5.3), not
-    # attention K/V. The engine registers it beside the attention caches and
-    # manages it itself; ``drop_indexer_caches`` keeps it away from connectors
-    # sized to the attention layer count.
+    # Sparse-attention (DSA) indexer cache, not attention K/V; see
+    # ``find_indexer_caches``.
     is_indexer: ClassVar[bool] = False
 
     def __init__(self, kv_caches: DiscoverableKVCache) -> None:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bsv_bss.py
@@ -23,3 +23,4 @@ class NL_X_NB_BSV_BSS_Spec(NL_X_NB_BS_HS_Spec):
     attention_backends = ("vLLM MLA",)
     is_layer_list = True
     is_mla = True
+    is_indexer = True

--- a/tests/v1/gpu_connector/test_kv_format_specs.py
+++ b/tests/v1/gpu_connector/test_kv_format_specs.py
@@ -13,12 +13,17 @@ import pytest
 import torch
 
 # First Party
+from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.kv_format import (
     describe_shape,
+    drop_indexer_caches,
     get_spec,
     get_spec_class,
+    is_indexer_cache,
 )
 import lmcache.lmcache_native as lmcache_native
+
+F = lmcache_native.EngineKVFormat
 
 # Distinct dims so a wrong axis surfaces as a wrong number.
 NB, NL, BS, NH, HS = 7, 5, 3, 2, 4
@@ -360,3 +365,51 @@ def test_facade_diagnostic_labels(case):
     # get_attention_backend is a diagnostic-only representative label.
     label = utils.get_attention_backend(fmt)
     assert isinstance(label, str) and not label.startswith("Unknown"), name
+
+
+# ── Indexer-cache fact ──────────────────────────────────────────────────────
+# vLLM's DSA indexer k-cache: uint8 [NB, BS, 132] (128 fp8 values + a 4-byte
+# fp32 scale per token), registered per sparse layer beside the MLA cache.
+INDEXER_HS = 132
+
+
+def _indexer_layer() -> torch.Tensor:
+    return torch.zeros(NB, BS, INDEXER_HS, dtype=torch.uint8)
+
+
+def test_is_indexer_fact_pinned():
+    # Only the DSA indexer k-cache is an indexer; every other format is
+    # attention K/V. A new indexer format must be declared here deliberately.
+    formats = [f for f in vars(F).values() if isinstance(f, F)]
+    indexer = {f for f in formats if get_spec_class(f).is_indexer}
+    assert indexer == {F.NL_X_NB_BSV_BSS}
+
+
+def test_is_indexer_cache_reads_the_spec_fact():
+    assert is_indexer_cache(_indexer_layer(), EngineType.VLLM)
+    # The MLA main cache shares the indexer's rank and list depth.
+    assert not is_indexer_cache(_t(NB, BS, HS), EngineType.VLLM)
+    # Same trailing dim in a real dtype is still MLA, not an indexer cache.
+    assert not is_indexer_cache(_t(NB, BS, INDEXER_HS), EngineType.VLLM)
+    assert not is_indexer_cache(_t(2, NB, BS, NH, HS), EngineType.VLLM)
+
+
+def test_drop_indexer_caches_keeps_attention_layers_in_order():
+    # A DSA registration: one MLA cache per layer plus an indexer k-cache on
+    # the sparse layers, interleaved in one dict as vLLM hands it over.
+    kv = {}
+    for i in range(NL):
+        kv[f"model.layers.{i}.self_attn.attn"] = _t(NB, BS, HS)
+        if i % 2 == 0:
+            kv[f"model.layers.{i}.self_attn.indexer.k_cache"] = _indexer_layer()
+    kept = drop_indexer_caches(kv, EngineType.VLLM)
+    assert list(kept) == [f"model.layers.{i}.self_attn.attn" for i in range(NL)]
+    # Same tensor objects: the filter never copies or re-views.
+    assert all(kept[name] is kv[name] for name in kept)
+
+
+def test_drop_indexer_caches_is_identity_without_indexers():
+    kv = {f"model.layers.{i}.self_attn.attn": _t(2, NB, BS, NH, HS) for i in range(NL)}
+    kept = drop_indexer_caches(kv, EngineType.VLLM)
+    assert list(kept) == list(kv)
+    assert all(kept[name] is kv[name] for name in kv)

--- a/tests/v1/gpu_connector/test_kv_format_specs.py
+++ b/tests/v1/gpu_connector/test_kv_format_specs.py
@@ -16,10 +16,9 @@ import torch
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.kv_format import (
     describe_shape,
-    drop_indexer_caches,
+    find_indexer_caches,
     get_spec,
     get_spec_class,
-    is_indexer_cache,
 )
 import lmcache.lmcache_native as lmcache_native
 
@@ -385,16 +384,7 @@ def test_is_indexer_fact_pinned():
     assert indexer == {F.NL_X_NB_BSV_BSS}
 
 
-def test_is_indexer_cache_reads_the_spec_fact():
-    assert is_indexer_cache(_indexer_layer(), EngineType.VLLM)
-    # The MLA main cache shares the indexer's rank and list depth.
-    assert not is_indexer_cache(_t(NB, BS, HS), EngineType.VLLM)
-    # Same trailing dim in a real dtype is still MLA, not an indexer cache.
-    assert not is_indexer_cache(_t(NB, BS, INDEXER_HS), EngineType.VLLM)
-    assert not is_indexer_cache(_t(2, NB, BS, NH, HS), EngineType.VLLM)
-
-
-def test_drop_indexer_caches_keeps_attention_layers_in_order():
+def test_find_indexer_caches_names_only_the_indexer_layers():
     # A DSA registration: one MLA cache per layer plus an indexer k-cache on
     # the sparse layers, interleaved in one dict as vLLM hands it over.
     kv = {}
@@ -402,14 +392,17 @@ def test_drop_indexer_caches_keeps_attention_layers_in_order():
         kv[f"model.layers.{i}.self_attn.attn"] = _t(NB, BS, HS)
         if i % 2 == 0:
             kv[f"model.layers.{i}.self_attn.indexer.k_cache"] = _indexer_layer()
-    kept = drop_indexer_caches(kv, EngineType.VLLM)
-    assert list(kept) == [f"model.layers.{i}.self_attn.attn" for i in range(NL)]
-    # Same tensor objects: the filter never copies or re-views.
-    assert all(kept[name] is kv[name] for name in kept)
+    found = find_indexer_caches(kv, EngineType.VLLM)
+    assert found == [f"model.layers.{i}.self_attn.indexer.k_cache" for i in (0, 2, 4)]
 
 
-def test_drop_indexer_caches_is_identity_without_indexers():
-    kv = {f"model.layers.{i}.self_attn.attn": _t(2, NB, BS, NH, HS) for i in range(NL)}
-    kept = drop_indexer_caches(kv, EngineType.VLLM)
-    assert list(kept) == list(kv)
-    assert all(kept[name] is kv[name] for name in kv)
+def test_find_indexer_caches_ignores_every_attention_format():
+    kv = {
+        "mha": _t(2, NB, BS, NH, HS),
+        "mla": _t(NB, BS, HS),
+        # The indexer's trailing dim in a real dtype is still MLA.
+        "mla132": _t(NB, BS, INDEXER_HS),
+        # A strided view detection rejects is not classified as an indexer.
+        "strided": torch.zeros(NB, 2 * BS, HS, dtype=DT)[:, ::2, :],
+    }
+    assert find_indexer_caches(kv, EngineType.VLLM) == []

--- a/tests/v1/gpu_connector/test_normalize_per_layer_formats.py
+++ b/tests/v1/gpu_connector/test_normalize_per_layer_formats.py
@@ -84,3 +84,14 @@ def test_vllm_mixed_rank4_fused_groups():
     assert tuple(normalized[0].shape) == (NB, BS, NH, 2 * HS)
     assert tuple(normalized[3].shape) == (NB, BS, NH, 4 * HS)
     assert formats == [F.NL_X_NB_NH_BS_CS] * 5
+
+
+def test_vllm_dsa_mla_plus_indexer_groups():
+    # DSA (GLM-5.3, DeepSeek-V3.2): fp8 MLA caches beside uint8 [NB, BS, 132]
+    # indexer k-caches, one vLLM group. Each layer must get its own format.
+    mla = [torch.zeros(NB, BS, 576, dtype=torch.float8_e4m3fn) for _ in range(3)]
+    indexer = [torch.zeros(NB, BS, 132, dtype=torch.uint8) for _ in range(2)]
+    _, formats = normalize_and_discover_per_layer_formats(
+        mla + indexer, [range(5)], EngineType.VLLM, {}
+    )
+    assert formats == [F.NL_X_NB_BS_HS] * 3 + [F.NL_X_NB_BSV_BSS] * 2

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -308,6 +308,38 @@ def test_conversion_mixed_kv_and_mla_groups():
     assert [group.tokens_per_block for group in spec] == [16, 128]
 
 
+def _indexer_caches(names: list[str]) -> dict[str, torch.Tensor]:
+    """DSA indexer k-caches as vLLM registers them: uint8 [NB, BS, 132]."""
+    return {n: torch.zeros(32, 16, 132, dtype=torch.uint8) for n in names}
+
+
+def test_conversion_uniform_group_splits_dsa_indexer_from_mla():
+    """GLM-5.3 / DeepSeek-V3.2: fp8 MLA caches and uint8 [NB, BS, 132] indexer
+    k-caches arrive in ONE ``UniformTypeKVCacheSpecs`` group with identical rank
+    and block size. They must still land in two LMCache groups sharing one
+    block-id space, or the indexer would be transferred with the MLA layout."""
+    caches = {
+        "attn.0": torch.zeros(32, 16, 576, dtype=torch.float8_e4m3fn),
+        "attn.1": torch.zeros(32, 16, 576, dtype=torch.float8_e4m3fn),
+        **_indexer_caches(["idx.0", "idx.1"]),
+    }
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={name: MLAAttentionSpec(block_size=16) for name in caches},
+    )
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[MockKVCacheGroup(list(caches), uniform_spec)]
+        ),
+        caches,
+    )
+
+    assert num_engine_groups(spec) == 1
+    assert [group.engine_group_id for group in spec] == [0, 0]
+    assert [group.layer_indices for group in spec] == [(0, 1), (2, 3)]
+    assert [group.tokens_per_block for group in spec] == [16, 16]
+
+
 def test_conversion_uniform_group_mixes_kv_and_mla_layouts():
     """vLLM can coalesce a rank-5 K+V group and a rank-3 key-only indexer group
     into ONE ``UniformTypeKVCacheSpecs`` group, not two. Detection must split it


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #5002. `VLLMPagedMemGPUConnectorV2` crashed at engine init on DSA models (DeepSeek-V3.2, GLM-5.3) with `could not broadcast input array from shape (99,) into shape (78,)`: vLLM registers a uint8 `[NB, BS, 132]` indexer k-cache per sparse layer beside the MLA cache, and the in-process vLLM adapter handed all of them to connectors sized to the attention layer count.

The first version of this PR dropped the indexer caches at registration, as the issue proposed. Testing that on hardware showed it is unsafe (details in the issue): the model boots, but every LMCache hit longer than the indexer top-k (2048 tokens) decodes garbage, because vLLM only writes the indexer k-cache while prefilling those tokens and tokens loaded from LMCache are never prefilled. So this PR now:

- **`KVFormatSpec.is_indexer`**: new static layout fact (default `False`), declared `True` by `NL_X_NB_BSV_BSS`, the spec that already models vLLM's DSA indexer k-cache. The fact lives in the spec layer as suggested in the thread.
- **`find_indexer_caches()`** in `kv_format.detection`: detects each registered tensor on its own and returns the names whose spec declares `is_indexer`. Layouts that detection rejects are not classified.
- **vLLM v1 adapter** raises `NotImplementedError` in `register_kv_caches` naming the indexer caches, instead of dropping them or failing later on the numpy broadcast. Silent corruption is worse than a clear refusal.
- **MP path untouched**: it keeps offloading indexer groups through the `NL_X_NB_BSV_BSS` kernels.

**The working path: `LMCacheMPConnector`.** Validated on GLM-5.3 (8x B200, vLLM 0.28.0, LMCache 0.5.5rc5 unmodified, TP8 + EP, fp8 KV, `lmcache server --chunk-size 256`): the server forms two kernel groups (78 MLA layers `hs=576`, 21 indexer layers `hs=132` uint8) and restores both. The E1 needle gate run twice, second pass served from LMCache (`Retrieved 19200 / 55040 / 91648 tokens` on all 8 ranks), passes at 19,335 / 55,061 / 91,743 tokens, with vLLM prefix caching off and on (`/reset_prefix_cache` between passes). This PR therefore also:

- updates the GLM recipe (`docs/source/recipes/glm5_2.rst`) with GLM-5.3, the `kv_connector_module_path`, the 64-token block / chunk-size rule, and the "in-process connector not supported" caveat;
- adds regression tests pinning the uint8/132 indexer split into its own group in `normalize_and_discover_per_layer_formats` and `create_engine_group_infos_from_vllm` (no existing test covered that layout);
- makes the in-process error message point at `LMCacheMPConnector`.

**Special notes for your reviewers**:

- Hardware probe behind the fail-fast decision (GLM-5.3, pool capped at 49,152 tokens so filler prompts evict the needle prompt):

| Needle prompt | Fresh prefill | After LMCache hit with indexer caches dropped |
|---|---|---|
| 19,365 tokens | correct | `1111111111...`, logprobs near -2.3 |
| 5,852 tokens | correct | garbage |
| 1,491 tokens (below top-k) | correct | correct |

- The 1,491-token control shows the main MLA KV restore is fine; the indexer is the cause. vLLM's own NIXL connector transfers the indexer regions rather than skipping them.
- Offloading the indexer caches on the in-process path would need per-group formats in `VLLMPagedMemGPUConnectorV3` (today it forwards group 0's format and geometry to every group) and per-group metadata shapes; out of scope here, but the spec fact and helper are the hook for it.
- One unexplained event during MP testing: with prefix caching on and the pool capped to 768 blocks, one vLLM worker died silently during a 41,906-token prompt at 85% pool usage. Four further eviction cycles on the same config did not reproduce it. Noted, not attributed.
- While probing we hit the builtin-hash `PYTHONHASHSEED` warning for real on the in-process path: without it, scheduler and worker keys differ and lookups never hit. MP hashes with blake3 and is unaffected.

Verification, branch on 8x B200 with vLLM 0.28.0 and torch 2.13 cu130:

| Check | Result |
|---|---|
| `tests/v1/gpu_connector` + `tests/v1/test_vllm_kv_cache_groups.py` (5 new tests) | 281 passed, 4 skipped |
| `tests/v1/test_v1_adapter_*`, `test_vllm_layerwise_wait_for_save`, `test_decode_save_and_preemption` | 29 passed |
| ruff, ruff format, isort, codespell on changed files | clean |
| mypy on the adapter with real vLLM types | 20 errors, identical set to `dev` baseline |

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

This work was done by Daniel Dubinsky for [Pearl Research Labs](https://pearlresearch.ai/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
