### PR TITLE
[good-first-issue] vllm: convert f-string log calls in vllm_v1_adapter.py to %-format (#5013)

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -972,7 +972,7 @@ class LMCacheConnectorV1Impl:
             layer_name: the name of that layer
         """
         if self.layerwise_retrievers:
-            logger.debug(f"Waiting for layer {self.current_layer} to be loaded")
+            logger.debug("Waiting for layer %s to be loaded", self.current_layer)
 
         # Wait for the layer to be loaded
         for layerwise_retriever in self.layerwise_retrievers:
@@ -981,7 +981,7 @@ class LMCacheConnectorV1Impl:
             if self.current_layer == self.num_layers - 1:
                 assert ret_token_mask is not None
                 num_retrieved_tokens = ret_token_mask.sum().item()
-                logger.info(f"Retrieved {num_retrieved_tokens} tokens")
+                logger.info("Retrieved %s tokens", num_retrieved_tokens)
 
         if self.layerwise_retrievers:
             self.current_layer += 1
@@ -1395,11 +1395,12 @@ class LMCacheConnectorV1Impl:
             # -1 means no result cached
             # None or int means ongoing (async) or cached result
             logger.debug(
-                f"Found {num_external_hit_tokens} hit tokens for request"
-                f" {req_id} in the lookup cache."
+                "Found %s hit tokens for request %s in the lookup cache.",
+                num_external_hit_tokens,
+                req_id,
             )
         else:
-            logger.debug(f"Looking up cache for the first time for request {req_id}!")
+            logger.debug("Looking up cache for the first time for request %s!", req_id)
             self._requests_priority[req_id] = getattr(request, "priority", 0)
 
             # token_ids = request.prompt_token_ids


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #5013
Refs #3372

`LMCacheConnectorV1Impl` in `lmcache/integration/vllm/vllm_v1_adapter.py` builds four log messages with f-strings, so they are interpolated before the logging call regardless of whether the level is enabled. `wait_for_layer_load()` runs once per layer per forward pass and `get_num_new_matched_tokens()` once per request per scheduler step, so the three `logger.debug` calls pay for string construction on every invocation even with debug logging off.

This converts all four calls to parameterized `%s` logging, following the maintainer guidance in #3372 (see this [discussion](https://github.com/LMCache/LMCache/issues/3372#issuecomment-4543974808)) and the same pattern as #4780 and #4970. Rendered messages, log levels, and control flow are unchanged — f-string interpolation and `%s` both go through `str()`.

**Special notes for your reviewers**:

- This is my first PR to LMCache 🙇 please be gentle.
- Single file, +6/−5, logging format only — no behavioral change.
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files` passes locally — SPDX, isort, ruff, ruff-format, codespell, clang-format and mypy all green. The two Rust hooks were skipped because there is no `cargo` in my environment; this PR touches no Rust.
- Ruff 0.11.7, the version CI pins: `--select G` on this file goes from 4 × G004 to clean, and the repo's configured `ruff check` / `ruff format --check` are clean.
- Placeholder counts were checked against argument counts one call at a time (1↔1, 1↔1, 2↔2, 1↔1), to avoid the `TypeError`-drops-the-record class of bug tracked in #4539.
- I was not able to run the test suite locally — this environment has neither `pytest` nor `vllm` installed. The change touches only the formatting of log calls, so no test behavior should depend on it.
- No new unit tests for this logging-format-only cleanup.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
