### PR TITLE
feat: add generation-scoped sparse prefetch leases

### DIFF
--- a/docs/design/v1/sparse_prefetch_leases.md
+++ b/docs/design/v1/sparse_prefetch_leases.md
@@ -1,0 +1,72 @@
+# Logical Sparse Prefetch Leases
+
+## Problem
+
+A serving runtime may know which logical KV chunks the next attention layer is
+likely to use. It needs to ask LMCache to stage those chunks without exposing
+the serving engine's physical page IDs, and it must keep the objects protected
+until the GPU copy has finished.
+
+The contract in this document is used by the SGLang adapter, but LMCache itself
+does not depend on SGLang. The public boundary carries `ObjectKey` values,
+request generations, layer IDs, and logical result bitmaps.
+
+## Ownership
+
+- The adapter owns the request/layer mapping from predicted physical pages to
+  logical `ObjectKey` chunks.
+- LMCache owns the prefetch controller request, L1 read locks, L2 load state,
+  and the generation attached to the logical lease.
+- The serving runtime owns GPU destination pages and its page table. It cannot
+  reuse a destination page until the retrieve completion event has been
+  observed.
+
+No component releases a read lock merely because an RPC was submitted. A
+successful release requires the controller operation to have completed, or a
+retrieve copy stream to have been synchronized when the caller already
+consumed the result bitmap.
+
+## Lifecycle
+
+```text
+submit(instance, request, generation, layer, ObjectKeys)
+    -> one active job for the exact four-part identity
+    -> controller lookup/load retains the logical lease
+wait/query
+    -> retrieve(ObjectKeys, destination mapping, producer event)
+    -> copy stream completes
+    -> release consumed logical keys
+```
+
+The identity `(instance_id, request_id, generation, layer_id)` prevents a late
+result from being applied to a reused request row. A second submit for the
+same identity does not replace the first job; its competing handle is cleaned
+up separately, and an uncertain cleanup remains reachable for retry.
+
+Cancellation and release are idempotent. If a request is already gone, the
+operation is a successful no-op. If the controller or connection cannot
+confirm cleanup, the caller receives failure and the adapter keeps its cleanup
+record rather than treating the remote lease as released.
+
+## Retrieve failure ordering
+
+Sparse retrieval may submit one or more H2D copies before a later object fails.
+The read context therefore defers its normal lock release while the retrieve
+is active. On failure, the transfer module first synchronizes the copy stream;
+only then does it release the keys resolved for that job. If synchronization
+cannot be completed, the job and its lease remain live so an explicit cleanup
+can retry safely.
+
+## Integration boundary
+
+LMCache does not receive SGLang block IDs. The SGLang adapter computes logical
+keys with the configured token-hash contract, sends the logical sparse request,
+and supplies the physical destination mapping only to the registered local
+transfer context. The adapter's completion event is retained until the RPC
+future finishes. This keeps logical cache ownership in LMCache and physical
+page ownership in the serving runtime, avoiding a second storage protocol or a
+second owner for the same destination page.
+
+This design covers one-layer lookahead. Multi-layer prediction, pipeline
+parallelism, and speculative decoding require additional identity and
+scheduling rules and are outside this change.

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -13,3 +13,4 @@ commands, and HTTP endpoints.
    extending_lmcache/musa_aiter_integration
    cli
    extending_http_api
+   prefetch_leases

--- a/docs/source/developer_guide/prefetch_leases.rst
+++ b/docs/source/developer_guide/prefetch_leases.rst
@@ -37,7 +37,8 @@ locks in the controller.  A caller has two compatible choices:
 
 When a sparse prediction is no longer valid, call
 ``release_prefetch_task(handle)``.  It is idempotent and cancels the controller
-request with the handle's generation.  If the caller has already consumed the
+request with the handle's generation and waits for controller cleanup before
+releasing manager-owned L1 locks.  If the caller has already consumed the
 result bitmap through the legacy query API, it may pass the consumed keys to
 ``release_prefetch_task(handle, keys)`` so those locks are released as well.
 The existing ``PREFIX`` and ``WARM`` paths keep their historical cleanup

--- a/docs/source/developer_guide/prefetch_leases.rst
+++ b/docs/source/developer_guide/prefetch_leases.rst
@@ -1,0 +1,78 @@
+Prefetch leases and generations
+===============================
+
+The distributed ``PrefetchRequestSpec`` API supports logical sparse
+prefetches without exposing a serving engine's physical block identifiers.
+Callers provide :class:`ObjectKey` chunks and may set
+``policy=TrimPolicy.SPARSE``.  The result bitmap always uses the order of the
+original logical key list.
+
+Request generations
+-------------------
+
+``PrefetchRequestSpec.generation`` is an opaque, non-negative value owned by
+the caller.  A serving adapter should advance it whenever a request slot is
+reused or reordered.  The value is copied to ``PrefetchHandle`` and is
+used as a guard when cancelling an asynchronous request; it does not affect
+key lookup or sparse bitmap selection.
+
+The generation is intentionally separate from ``ObjectKey``.  A key can be
+shared by multiple requests while a stale prefetch operation is still safely
+cancelled.
+
+Lease lifecycle
+---------------
+
+For ``policy=TrimPolicy.SPARSE``, ``submit_prefetch_task`` retains the L1 read
+locks for the keys reported by the handle and coordinates any L2 lookup/load
+locks in the controller.  A caller has two compatible choices:
+
+* Existing integrations can call ``query_prefetch_status(handle)``, read the
+  retained objects, and finish them with ``finish_read_prefetched(keys)``.
+* Lease-oriented integrations can call ``consume_prefetch_task(handle)`` after
+  they have finished using the retained objects and the result bitmap is
+  available.  This releases the retained read locks for that handle.  If the
+  result is not ready, the method returns ``None`` and does not change
+  ownership.
+
+When a sparse prediction is no longer valid, call
+``release_prefetch_task(handle)``.  It is idempotent and cancels the controller
+request with the handle's generation.  If the caller has already consumed the
+result bitmap through the legacy query API, it may pass the consumed keys to
+``release_prefetch_task(handle, keys)`` so those locks are released as well.
+The existing ``PREFIX`` and ``WARM`` paths keep their historical cleanup
+semantics.
+
+Cancellation is completed on the controller thread.  An in-flight adapter
+operation is allowed to return before its L2 locks, L1 write reservation, and
+any retained L1 read locks are released.  This ordering prevents eviction or
+reuse from racing an asynchronous load.  Repeated cancellation/release calls
+are safe, and a generation mismatch cannot cancel a newer operation using the
+same logical request slot.
+
+Minimal example
+---------------
+
+.. code-block:: python
+
+   spec = PrefetchRequestSpec(
+       keys=logical_keys,
+       group_layout_descs={0: layout},
+       policy=TrimPolicy.SPARSE,
+       generation=request_generation,
+   )
+   handle = storage_manager.submit_prefetch_task(spec)
+
+   if not storage_manager.wait_prefetch_status(handle, timeout=1.0):
+       storage_manager.release_prefetch_task(handle)
+   else:
+       found = storage_manager.query_prefetch_status(handle)
+       retained_keys = found.gather(logical_keys)
+       with storage_manager.read_prefetched_results(retained_keys) as objects:
+           consume(objects)
+       storage_manager.release_prefetch_task(handle, retained_keys)
+
+LMCache accepts only logical keys/chunks in this contract.  An adapter that
+uses physical page tables must perform that mapping at its own boundary and
+must not pass physical block IDs as ``ObjectKey`` values.  The contract does
+not require SGLang or any other serving engine as a dependency.

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -27,12 +27,14 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
 )
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
+from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 from lmcache.v1.platform import get_device_spec
@@ -152,6 +154,55 @@ class _PendingLookup:
     locks_held: bool
 
 
+class _SparseLeaseFuture(MessagingFuture):
+    """Forward a sparse RPC result and clean up only after confirmation."""
+
+    def __init__(self, future: MessagingFuture, cleanup, should_cleanup) -> None:
+        super().__init__()
+        self._future = future
+        self._cleanup = cleanup
+        self._should_cleanup = should_cleanup
+        self._cleanup_lock = threading.Lock()
+        self._cleaned = False
+
+    def _observe_result(self, result) -> None:
+        if not self._should_cleanup(result):
+            return
+        with self._cleanup_lock:
+            if self._cleaned:
+                return
+            self._cleanup()
+            self._cleaned = True
+
+    def result(self, timeout=None):
+        result = self._future.result(timeout)
+        self._observe_result(result)
+        return result
+
+    def wait(self, timeout=None) -> bool:
+        if not self._future.wait(timeout):
+            return False
+        try:
+            self._observe_result(self._future.result(timeout=0))
+        except BaseException:
+            # Preserve the underlying exception for the explicit result()
+            # call and keep the cleanup record until it succeeds.
+            pass
+        return True
+
+    def query(self) -> bool:
+        if not self._future.query():
+            return False
+        try:
+            self._observe_result(self._future.result(timeout=0))
+        except BaseException:
+            pass
+        return True
+
+    def retain_reference(self, value: object) -> None:
+        self._future.retain_reference(value)
+
+
 class LMCacheMPConnector:
     """SGLang LMCache multi-process connector.
 
@@ -161,9 +212,9 @@ class LMCacheMPConnector:
       chunks L2→L1 (DRAM), keeps the read locks held, returns the
       matched-token count.
     - ``retrieve_kv``: fires RETRIEVE using the cached LOOKUP result.
-      Daemon copies L1→GPU via ``multi_layer_block_kv_transfer``
-      (one device transfer, all layers) and releases the read locks
-      via ``finish_read_prefetched``.
+      Daemon copies L1→GPU through the registered layer's single-layer
+      transfer path and releases the read locks via the sparse completion
+      callback.
     - ``release_pending``: frees the held locks when no RETRIEVE will
       follow (LMCache had nothing fresh beyond radix).
     - ``end_session``: per-request cleanup. Frees any still-held
@@ -204,6 +255,11 @@ class LMCacheMPConnector:
         self._health_event.set()
         self._pending_lookups: dict[str, _PendingLookup] = {}
         self._pending_lookups_lock = threading.Lock()
+        self._sparse_handles: set[tuple[str, int, int]] = set()
+        self._sparse_handles_lock = threading.Lock()
+        self._sparse_key_cache: dict[tuple, tuple[ObjectKey, ...]] = {}
+        self._sparse_hash_cache: dict[tuple, tuple[bytes, ...]] = {}
+        self._sparse_key_cache_lock = threading.Lock()
 
         self.context = zmq.Context.instance()
         server_url = f"{host}:{port}"
@@ -218,6 +274,10 @@ class LMCacheMPConnector:
                 "LMCache chunk size must be a multiple of SGLang page size, got "
                 f"{self._lmcache_chunk_size} and {self.page_size}"
             )
+        self._sparse_token_hasher = TokenHasher(
+            chunk_size=self._lmcache_chunk_size,
+            hash_algorithm="blake3",
+        )
 
         # Upstream's REGISTER_KV_CACHE protocol takes flat positional args:
         # (instance_id, kv_cache, model_name, world_size, engine_type,
@@ -259,6 +319,243 @@ class LMCacheMPConnector:
 
     def chunk_size(self) -> int:
         return self._lmcache_chunk_size
+
+    def _completed_sparse_future(self, result) -> MessagingFuture:
+        future: MessagingFuture = MessagingFuture()
+        future.set_result(result)
+        return future
+
+    def _sparse_key(self, request_id: str, generation: int, layer_id: int):
+        return request_id, generation, layer_id
+
+    def _forget_sparse_handle(
+        self, request_id: str, generation: int, layer_id: int
+    ) -> None:
+        with self._sparse_handles_lock:
+            self._sparse_handles.discard(
+                self._sparse_key(request_id, generation, layer_id)
+            )
+
+    def _clear_sparse_key_cache(self, request_id: str | None = None) -> None:
+        with self._sparse_key_cache_lock:
+            if request_id is None:
+                self._sparse_key_cache.clear()
+                self._sparse_hash_cache.clear()
+                return
+            self._sparse_key_cache = {
+                key: value
+                for key, value in self._sparse_key_cache.items()
+                if key[0] != request_id
+            }
+            self._sparse_hash_cache = {
+                key: value
+                for key, value in self._sparse_hash_cache.items()
+                if key[0] != request_id
+            }
+
+    def create_sparse_object_keys(
+        self,
+        token_ids: list[int],
+        chunk_indices: list[int],
+        cache_salt: str | None = None,
+        *,
+        request_id: str | None = None,
+        generation: int | None = None,
+        layer_id: int | None = None,
+    ) -> list[ObjectKey]:
+        """Map complete token chunks to LMCache logical object keys.
+
+        The server and this adapter must use the same rolling hash.  The
+        multiprocess SGLang path therefore requires the default ``blake3``
+        token hash; physical SGLang page IDs are deliberately not part of the
+        returned keys.
+        """
+        indices = sorted({int(index) for index in chunk_indices})
+        if not indices:
+            return []
+        if indices[0] < 0:
+            raise ValueError("sparse chunk indices must be non-negative")
+        end = (indices[-1] + 1) * self._lmcache_chunk_size
+        if end > len(token_ids):
+            return []
+
+        normalized_salt = cache_salt or ""
+        cache_key = None
+        hash_cache_key = None
+        if request_id is not None and generation is not None and layer_id is not None:
+            cache_key = (
+                request_id,
+                int(generation),
+                int(layer_id),
+                len(token_ids),
+                normalized_salt,
+                tuple(indices),
+            )
+            hash_cache_key = (
+                request_id,
+                int(generation),
+                len(token_ids),
+                normalized_salt,
+            )
+
+        cache_lock = getattr(self, "_sparse_key_cache_lock", None)
+        if cache_lock is None:
+            cache_lock = threading.Lock()
+            self._sparse_key_cache_lock = cache_lock
+        with cache_lock:
+            if cache_key is not None:
+                cached_keys = getattr(self, "_sparse_key_cache", {}).get(cache_key)
+                if cached_keys is not None:
+                    return list(cached_keys)
+
+            if hash_cache_key is not None:
+                cached_hashes = getattr(self, "_sparse_hash_cache", {}).get(
+                    hash_cache_key
+                )
+            else:
+                cached_hashes = None
+
+            required_hashes = end // self._lmcache_chunk_size
+            if cached_hashes is not None and len(cached_hashes) >= required_hashes:
+                hashes = list(cached_hashes[:required_hashes])
+            else:
+                hasher = getattr(self, "_sparse_token_hasher", None)
+                if hasher is None:
+                    hasher = TokenHasher(
+                        chunk_size=self._lmcache_chunk_size,
+                        hash_algorithm="blake3",
+                    )
+                hashes = hasher.compute_chunk_hashes(list(token_ids), end=end)
+                if hash_cache_key is not None:
+                    self._sparse_hash_cache[hash_cache_key] = tuple(hashes)
+
+        kv_rank = ObjectKey.ComputeKVRank(
+            world_size=self.tp_size,
+            global_rank=self.worker_id,
+            local_world_size=self.tp_size,
+            local_rank=self.worker_id,
+        )
+        result = [
+            ObjectKey(
+                chunk_hash=hashes[index],
+                model_name=self.model_name,
+                kv_rank=kv_rank,
+                object_group_id=0,
+                cache_salt=normalized_salt,
+            )
+            for index in indices
+        ]
+        if cache_key is not None:
+            with self._sparse_key_cache_lock:
+                self._sparse_key_cache[cache_key] = tuple(result)
+        return result
+
+    def sparse_prefetch(
+        self,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[ObjectKey],
+    ) -> MessagingFuture[bool]:
+        """Submit a logical sparse prefetch and retain its server lease."""
+        if (
+            not self.is_healthy
+            or not request_id
+            or generation < 0
+            or layer_id < 0
+            or not keys
+        ):
+            return self._completed_sparse_future(False)
+        with self._sparse_handles_lock:
+            self._sparse_handles.add(self._sparse_key(request_id, generation, layer_id))
+        future = self.req_client.sparse_prefetch(
+            self.instance_id,
+            request_id,
+            generation,
+            layer_id,
+            keys,
+        )
+        return _SparseLeaseFuture(
+            future,
+            lambda: self._forget_sparse_handle(request_id, generation, layer_id),
+            lambda result: result is False,
+        )
+
+    def sparse_query_prefetch(
+        self, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture:
+        """Query retained logical keys without releasing their lease."""
+        if not self.is_healthy:
+            return self._completed_sparse_future(None)
+        return self.req_client.sparse_query_prefetch(
+            self.instance_id, request_id, generation, layer_id
+        )
+
+    def sparse_wait_prefetch(
+        self, request_id: str, generation: int, layer_id: int, timeout: float
+    ) -> MessagingFuture:
+        """Wait for retained logical keys without consuming their lease."""
+        if not self.is_healthy or timeout < 0:
+            return self._completed_sparse_future(None)
+        return self.req_client.sparse_wait_prefetch(
+            self.instance_id, request_id, generation, layer_id, timeout
+        )
+
+    def sparse_retrieve(
+        self,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[ObjectKey],
+        block_ids: list[list[int]],
+    ) -> MessagingFuture:
+        """Load retained logical objects into the supplied GPU pages."""
+        if not self.is_healthy:
+            return self._completed_sparse_future((False, []))
+        event = torch_dev.Event(interprocess=True)
+        event.record(torch_dev.current_stream())
+        raw_future = self.req_client.sparse_retrieve(
+            self.instance_id,
+            request_id,
+            generation,
+            layer_id,
+            keys,
+            block_ids,
+            event.ipc_handle(),
+        )
+        future = raw_future.to_device_future(device=self.device)
+        future.retain_reference(event)
+        return future
+
+    def sparse_cancel_prefetch(
+        self, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture:
+        """Cancel a logical sparse prefetch and release its lease."""
+        if not self.is_healthy:
+            return self._completed_sparse_future(False)
+        future = self.req_client.sparse_cancel_prefetch(
+            self.instance_id, request_id, generation, layer_id
+        )
+        return _SparseLeaseFuture(
+            future,
+            lambda: self._forget_sparse_handle(request_id, generation, layer_id),
+            lambda result: result is True,
+        )
+
+    def sparse_release_prefetch(
+        self, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture:
+        """Release a logical sparse lease after the GPU consumer is done."""
+        if not self.is_healthy:
+            return self._completed_sparse_future(False)
+        future = self.req_client.sparse_release_prefetch(
+            self.instance_id, request_id, generation, layer_id
+        )
+        return _SparseLeaseFuture(
+            future,
+            lambda: self._forget_sparse_handle(request_id, generation, layer_id),
+            lambda result: result is True,
+        )
 
     @torch.no_grad()
     def _global_min_tokens(self, local_tokens: int) -> int:
@@ -438,6 +735,7 @@ class LMCacheMPConnector:
         before sending END_SESSION (covers failure paths where
         retrieve_kv didn't consume the locks).
         """
+        self._clear_sparse_key_cache(request_id)
         if not self.is_healthy:
             return
         with self._pending_lookups_lock:
@@ -687,10 +985,44 @@ class LMCacheMPConnector:
             raise RuntimeError("LMCache MP store failed")
 
     def reset(self) -> None:
-        pass
+        self._clear_sparse_key_cache()
 
     def close(self) -> None:
         self.reset()
+        with self._sparse_handles_lock:
+            sparse_handles = list(self._sparse_handles)
+        cleanup_confirmed = True
+        for request_id, generation, layer_id in sparse_handles:
+            try:
+                released = self.req_client.sparse_cancel_prefetch(
+                    self.instance_id,
+                    request_id,
+                    generation,
+                    layer_id,
+                ).result(timeout=self._mq_timeout)
+                if released:
+                    self._forget_sparse_handle(request_id, generation, layer_id)
+                else:
+                    cleanup_confirmed = False
+                    logger.warning(
+                        "LMCache sparse cleanup was not confirmed during close: "
+                        "request_id=%s generation=%d layer=%d",
+                        request_id,
+                        generation,
+                        layer_id,
+                    )
+            except Exception:
+                cleanup_confirmed = False
+                logger.warning(
+                    "Failed to cancel an SGLang sparse prefetch during close",
+                    exc_info=True,
+                )
+        if not cleanup_confirmed:
+            logger.error(
+                "Keeping LMCache connector open because sparse cleanup was not "
+                "confirmed; retry close after the connection recovers"
+            )
+            return
         if self._heartbeat is not None:
             self._heartbeat.stop()
             self._heartbeat = None

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -432,6 +432,9 @@ class PrefetchRequestSpec:
             groups must narrow it to that subset (it drives the fold
             stride).
         mode: Prefetch intent (see :class:`PrefetchMode`).
+        generation: Caller-owned monotonically increasing generation.  A
+            consumer can invalidate an older request without affecting a
+            newer request that reuses the same logical keys.
     """
 
     keys: list[ObjectKey]
@@ -440,12 +443,17 @@ class PrefetchRequestSpec:
     policy: TrimPolicy = TrimPolicy.PREFIX
     attn_desc: AttnWindowDesc = DEFAULT_ATTN_WINDOW_DESC
     mode: PrefetchMode = PrefetchMode.LOOKUP
+    generation: int = 0
 
     def __post_init__(self) -> None:
         if self.num_kv_readers < 1:
             raise ValueError(
                 f"PrefetchRequestSpec: num_kv_readers={self.num_kv_readers} "
                 "must be >= 1 (total read locks per key)"
+            )
+        if self.generation < 0:
+            raise ValueError(
+                f"PrefetchRequestSpec: generation={self.generation} must be >= 0"
             )
         # A caller prefetching a SUBSET of the groups narrows attn_desc, so
         # extra layout entries are harmless; too FEW is the real mistake.
@@ -488,6 +496,13 @@ class PrefetchHandle:
     l2_orig_indices: tuple[int, ...] = ()
     """Original-key index of each key submitted to L2; maps the controller's
     local result bitmap back to original positions."""
+
+    generation: int = 0
+    """Generation captured when this request was submitted.
+
+    Generations are opaque to LMCache.  Adapters use them to cancel an old
+    lookahead request when a request slot is reordered or reused.
+    """
 
 
 def ipc_key_to_object_keys(

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -179,6 +179,7 @@ def trim_load_plan_with_mask(
 PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
 
 PrefetchRequestId = int
+_MISSING = object()
 
 
 class PrefetchPhase(enum.Enum):
@@ -193,6 +194,7 @@ class InFlightPrefetchRequest:
     request_id: PrefetchRequestId
     keys: list[ObjectKey]
     phase: PrefetchPhase
+    generation: int = 0
     num_kv_readers: int = 1
     """Total read locks per key to acquire when transitioning from
     write-locked to read-locked.  Must match the ``num_kv_readers`` of the
@@ -233,6 +235,10 @@ class InFlightPrefetchRequest:
     write_reserved_objs: dict[ObjectKey, "MemoryObj"] = field(default_factory=dict)
     # Key indices found (and read-locked) in L1 when the request starts.
     l1_readlocks: Bitmap = field(default_factory=lambda: Bitmap(0))
+    # Set by the thread-safe cancellation API.  Cancellation is deliberately
+    # completed on the controller thread so adapters that already accepted a
+    # lookup/load task can report their result before locks are returned.
+    cancelled: bool = False
 
     group_layout_descs: dict[int, MemoryLayoutDesc] = field(default_factory=dict)
     """Maps object_group_id to that group's layout (one ``MemoryLayoutDesc``
@@ -318,7 +324,14 @@ class PrefetchController(StorageControllerInterface):
         self._submission_lock = threading.Lock()
         self._submission_queue: list[tuple[PrefetchRequestId, PrefetchRequestSpec]] = []
         self._next_request_id: PrefetchRequestId = 0
+        self._request_generations: dict[PrefetchRequestId, int] = {}
         self._submission_efd = create_event_notifier()
+
+        # Cancellation is a control-plane operation.  The caller only marks a
+        # request here; the background thread owns the actual L1/L2 lock
+        # cleanup, which avoids racing adapter result delivery.
+        self._cancel_lock = threading.Lock()
+        self._cancel_requests: dict[PrefetchRequestId, int | None] = {}
 
         # Thread-safe lookup results (background -> external)
         self._lookup_results_lock = threading.Lock()
@@ -330,6 +343,12 @@ class PrefetchController(StorageControllerInterface):
         self._prefetch_results_lock = threading.Lock()
         self._prefetch_results_cv = threading.Condition(self._prefetch_results_lock)
         self._completed_results: dict[PrefetchRequestId, Bitmap] = {}
+        self._completed_generations: dict[PrefetchRequestId, int] = {}
+        # Request owners may cancel a request and release their lease before
+        # the worker has published the cancellation result.  Remember those
+        # request IDs so the eventual result is cleaned up instead of being
+        # retained forever with no consumer.
+        self._forgotten_results: set[PrefetchRequestId] = set()
 
         # Map eventfds to adapter indices for quick lookup in poll.
         # Relies on the L2AdapterInterface contract that every adapter
@@ -433,8 +452,53 @@ class PrefetchController(StorageControllerInterface):
             request_id = self._next_request_id
             self._next_request_id += 1
             self._submission_queue.append((request_id, spec))
+            self._request_generations[request_id] = spec.generation
         self._submission_efd.notify()
         return request_id
+
+    def cancel_prefetch_request(
+        self,
+        request_id: PrefetchRequestId,
+        generation: int | None = None,
+    ) -> bool:
+        """Cancel a request and release its locks after adapter completion.
+
+        Cancellation is idempotent.  The request remains visible to the
+        background loop until any adapter lookup/load task it already started
+        has returned, so a late result cannot leak an L2 lock or an L1 write
+        reservation.  A zero bitmap is published once cleanup finishes, which
+        also wakes waiters.
+
+        Args:
+            request_id: ID returned by :meth:`submit_prefetch_request`.
+            generation: Optional generation guard.  When supplied, a request
+                with a different generation is left untouched.
+
+        Returns:
+            ``True`` when cancellation was accepted for an active/queued
+            request, ``False`` when the request is unknown or already
+            completed.
+        """
+        with self._prefetch_results_lock:
+            if request_id in self._completed_results:
+                return False
+        with self._submission_lock:
+            request_generation = self._request_generations.get(request_id, _MISSING)
+        if request_generation is _MISSING:
+            return False
+        if generation is not None and generation != request_generation:
+            return False
+        with self._cancel_lock:
+            previous = self._cancel_requests.get(request_id)
+            if (
+                previous is not None
+                and generation is not None
+                and previous != generation
+            ):
+                return False
+            self._cancel_requests[request_id] = generation
+        self._submission_efd.notify()
+        return True
 
     def query_lookup_result(self, request_id: PrefetchRequestId) -> int | None:
         """
@@ -460,7 +524,11 @@ class PrefetchController(StorageControllerInterface):
         with self._lookup_results_lock:
             return self._completed_lookups.get(request_id, None)
 
-    def query_prefetch_result(self, request_id: PrefetchRequestId) -> Bitmap | None:
+    def query_prefetch_result(
+        self,
+        request_id: PrefetchRequestId,
+        generation: int | None = None,
+    ) -> Bitmap | None:
         """
         Query the result of a prefetch request.
 
@@ -481,14 +549,25 @@ class PrefetchController(StorageControllerInterface):
             get None forever.
         """
         with self._prefetch_results_lock:
+            completed_generation = self._completed_generations.get(request_id, _MISSING)
+            if (
+                generation is not None
+                and completed_generation is not _MISSING
+                and completed_generation != generation
+            ):
+                return None
             result = self._completed_results.pop(request_id, None)
+            self._completed_generations.pop(request_id, None)
         if result is not None:
             with self._lookup_results_lock:
                 self._completed_lookups.pop(request_id, None)
         return result
 
     def wait_prefetch_result(
-        self, request_id: PrefetchRequestId, timeout: float
+        self,
+        request_id: PrefetchRequestId,
+        timeout: float,
+        generation: int | None = None,
     ) -> bool:
         """
         Block until a prefetch request's result is published, or until timeout.
@@ -506,9 +585,87 @@ class PrefetchController(StorageControllerInterface):
             the wait timed out.
         """
         with self._prefetch_results_cv:
+            if (
+                generation is not None
+                and request_id in self._completed_results
+                and self._completed_generations.get(request_id) != generation
+            ):
+                return False
             return self._prefetch_results_cv.wait_for(
-                lambda: request_id in self._completed_results, timeout
+                lambda: (
+                    request_id in self._completed_results
+                    and (
+                        generation is None
+                        or self._completed_generations.get(request_id) == generation
+                    )
+                ),
+                timeout,
             )
+
+    def forget_prefetch_result(
+        self,
+        request_id: PrefetchRequestId,
+        generation: int | None = None,
+    ) -> bool:
+        """Forget a completion result or suppress one still in flight.
+
+        This is for an owner that has cancelled or otherwise released a
+        prefetch lease and will not consume the completion bitmap.  If the
+        worker has already published a result, it is removed immediately.  If
+        the request is still active, the worker drops the result after it has
+        released all adapter and L1 resources.  The operation is idempotent.
+
+        Returns:
+            ``True`` if a result was removed or a live request was marked for
+            result suppression, ``False`` if the request is unknown.
+        """
+        with self._prefetch_results_lock:
+            completed_generation = self._completed_generations.get(request_id, _MISSING)
+            if (
+                generation is not None
+                and completed_generation is not _MISSING
+                and completed_generation != generation
+            ):
+                return False
+            removed = self._completed_results.pop(request_id, None) is not None
+            self._completed_generations.pop(request_id, None)
+
+        with self._lookup_results_lock:
+            self._completed_lookups.pop(request_id, None)
+
+        if removed:
+            return True
+
+        with self._submission_lock:
+            request_generation = self._request_generations.get(request_id, _MISSING)
+        known = request_generation is not _MISSING and (
+            generation is None or request_generation == generation
+        )
+        if not known:
+            return False
+
+        with self._prefetch_results_lock:
+            # Re-check under the same lock used by completion publication.  A
+            # completion can race with the first removal attempt, so either
+            # remove that result or install the suppression marker atomically.
+            completed_generation = self._completed_generations.get(request_id, _MISSING)
+            if (
+                generation is not None
+                and completed_generation is not _MISSING
+                and completed_generation != generation
+            ):
+                return False
+            if self._completed_results.pop(request_id, None) is not None:
+                self._completed_generations.pop(request_id, None)
+                removed = True
+            elif known:
+                self._forgotten_results.add(request_id)
+            else:
+                return False
+        if removed:
+            with self._lookup_results_lock:
+                self._completed_lookups.pop(request_id, None)
+        return True
 
     def report_status(self) -> dict:
         """Return a status dict for the prefetch controller."""
@@ -719,6 +876,8 @@ class PrefetchController(StorageControllerInterface):
                         fd,
                     )
 
+            self._drain_cancel_requests()
+
             if any(signaled_adapters.values()):
                 for request in list(self._in_flight_requests.values()):
                     try:
@@ -810,6 +969,138 @@ class PrefetchController(StorageControllerInterface):
         self._pending_queue.extend(items)
         self._status_pending_count += len(items)
 
+    def _drain_cancel_requests(self) -> None:
+        """Apply queued cancellations on the prefetch loop thread."""
+        with self._cancel_lock:
+            requested = dict(self._cancel_requests)
+
+        if not requested:
+            return
+
+        # Requests that have not reached the controller thread yet can be
+        # removed without touching a lock.  Publish an empty result so the
+        # public wait API never hangs on cancellation.
+        with self._submission_lock:
+            queued = self._submission_queue
+            self._submission_queue = []
+        retained_submission: list[tuple[PrefetchRequestId, PrefetchRequestSpec]] = []
+        for request_id, spec in queued:
+            generation = requested.get(request_id, _MISSING)
+            if generation is _MISSING or (
+                generation is not None and generation != spec.generation
+            ):
+                retained_submission.append((request_id, spec))
+                continue
+            self._publish_cancelled(request_id, len(spec.keys), spec.generation)
+
+        if retained_submission:
+            with self._submission_lock:
+                self._submission_queue[0:0] = retained_submission
+
+        retained_pending: list[tuple[PrefetchRequestId, PrefetchRequestSpec]] = []
+        for request_id, spec in self._pending_queue:
+            generation = requested.get(request_id, _MISSING)
+            if generation is _MISSING or (
+                generation is not None and generation != spec.generation
+            ):
+                retained_pending.append((request_id, spec))
+                continue
+            self._status_pending_count -= 1
+            self._publish_cancelled(request_id, len(spec.keys), spec.generation)
+        self._pending_queue = retained_pending
+
+        # In-flight requests are marked first and finalized only after the
+        # adapter task currently in progress has produced its bitmap.
+        for request in list(self._in_flight_requests.values()):
+            generation = requested.get(request.request_id, _MISSING)
+            if generation is _MISSING or (
+                generation is not None and generation != request.generation
+            ):
+                continue
+            request.cancelled = True
+            if request.all_lookups_done() and request.phase is PrefetchPhase.LOOKUP:
+                self._finish_cancelled_request(request)
+            elif (
+                request.all_loads_done()
+                and request.phase is PrefetchPhase.PLAN_AND_LOAD
+            ):
+                self._finish_cancelled_request(request)
+
+        # A generation mismatch is a stale cancel request, not a request that
+        # should remain in the control plane forever.  Drop it after the
+        # current queues/in-flight table have been inspected.
+        known_generations = {
+            request_id: spec.generation for request_id, spec in retained_submission
+        }
+        known_generations.update(
+            {request_id: spec.generation for request_id, spec in retained_pending}
+        )
+        known_generations.update(
+            {
+                request.request_id: request.generation
+                for request in self._in_flight_requests.values()
+            }
+        )
+        with self._cancel_lock:
+            for request_id, requested_generation in list(self._cancel_requests.items()):
+                if (
+                    request_id in known_generations
+                    and requested_generation is not None
+                    and requested_generation != known_generations[request_id]
+                ):
+                    self._cancel_requests.pop(request_id, None)
+
+    def _publish_cancelled(
+        self,
+        request_id: PrefetchRequestId,
+        num_keys: int,
+        generation: int,
+    ) -> None:
+        with self._prefetch_results_lock:
+            forgotten = request_id in self._forgotten_results
+            self._forgotten_results.discard(request_id)
+            if not forgotten:
+                self._completed_results[request_id] = Bitmap(num_keys)
+                self._completed_generations[request_id] = generation
+                self._prefetch_results_cv.notify_all()
+        with self._lookup_results_lock:
+            if forgotten:
+                self._completed_lookups.pop(request_id, None)
+            else:
+                self._completed_lookups[request_id] = 0
+        with self._cancel_lock:
+            self._cancel_requests.pop(request_id, None)
+        with self._submission_lock:
+            self._request_generations.pop(request_id, None)
+
+    def _finish_cancelled_request(self, request: InFlightPrefetchRequest) -> None:
+        """Release every resource held by a cancelled request."""
+        l1_mgr = self._l1_manager
+        if request.write_reserved_keys:
+            l1_mgr.finish_write(request.write_reserved_keys)
+            l1_mgr.delete(request.write_reserved_keys)
+            request.write_reserved_keys.clear()
+            request.write_reserved_objs.clear()
+        self._release_l2_locks(request, keep={})
+        if request.l1_readlocks.popcount() > 0:
+            l1_mgr.finish_read(
+                request.l1_readlocks.gather(request.keys),
+                read_locks=request.num_kv_readers,
+            )
+            request.l1_readlocks = Bitmap(len(request.keys))
+        self._complete_request(
+            request.request_id,
+            Bitmap(len(request.keys)),
+            generation=request.generation,
+        )
+        with self._cancel_lock:
+            self._cancel_requests.pop(request.request_id, None)
+        logger.debug(
+            "Prefetch request %d cancelled (generation=%d)",
+            request.request_id,
+            request.generation,
+        )
+
     def _start_pending_requests(self) -> None:
         """Start pending requests up to the max in-flight limit."""
         while (
@@ -888,6 +1179,7 @@ class PrefetchController(StorageControllerInterface):
             request_id=request_id,
             keys=spec.keys,
             phase=PrefetchPhase.LOOKUP,
+            generation=spec.generation,
             num_kv_readers=spec.num_kv_readers,
             policy=spec.policy,
             attn_desc=spec.attn_desc,
@@ -1226,10 +1518,18 @@ class PrefetchController(StorageControllerInterface):
             return
         if request.phase == PrefetchPhase.LOOKUP:
             self._poll_lookup_results(request, phase_adapters)
+            if request.cancelled:
+                if request.all_lookups_done():
+                    self._finish_cancelled_request(request)
+                return
             if request.all_lookups_done():
                 self._transition_to_load_phase(request)
         elif request.phase == PrefetchPhase.PLAN_AND_LOAD:
             self._poll_load_results(request, phase_adapters)
+            if request.cancelled:
+                if request.all_loads_done():
+                    self._finish_cancelled_request(request)
+                return
             if request.all_loads_done():
                 self._finish_request(request)
 
@@ -1417,7 +1717,11 @@ class PrefetchController(StorageControllerInterface):
         if not request.hit_reported:
             self._report_lookup_hit(request, hit_length)
 
-        self._complete_request(request.request_id, retained)
+        self._complete_request(
+            request.request_id,
+            retained,
+            generation=request.generation,
+        )
 
     # =========================================================================
     # Unlock helpers
@@ -1453,13 +1757,30 @@ class PrefetchController(StorageControllerInterface):
     # Completion and cleanup
     # =========================================================================
 
-    def _complete_request(self, request_id: PrefetchRequestId, result: Bitmap) -> None:
+    def _complete_request(
+        self,
+        request_id: PrefetchRequestId,
+        result: Bitmap,
+        generation: int | None = None,
+    ) -> None:
         """Store the retained-key bitmap and remove from in-flight tracking."""
         with self._prefetch_results_lock:
-            self._completed_results[request_id] = result
-            # Wake any WAIT_PREFETCH_STATUS handler blocked on this result.
-            self._prefetch_results_cv.notify_all()
+            forgotten = request_id in self._forgotten_results
+            self._forgotten_results.discard(request_id)
+            if not forgotten:
+                self._completed_results[request_id] = result
+                if generation is not None:
+                    self._completed_generations[request_id] = generation
+                # Wake any WAIT_PREFETCH_STATUS handler blocked on this result.
+                self._prefetch_results_cv.notify_all()
+        if forgotten:
+            with self._lookup_results_lock:
+                self._completed_lookups.pop(request_id, None)
         removed = self._in_flight_requests.pop(request_id, None)
+        with self._cancel_lock:
+            self._cancel_requests.pop(request_id, None)
+        with self._submission_lock:
+            self._request_generations.pop(request_id, None)
         if removed is not None:
             self._status_in_flight_count -= 1
             if removed.phase == PrefetchPhase.LOOKUP:
@@ -1492,3 +1813,19 @@ class PrefetchController(StorageControllerInterface):
                 len(request.keys),
             )
         self._in_flight_requests.clear()
+        self._pending_queue.clear()
+        self._status_in_flight_count = 0
+        self._status_pending_count = 0
+        self._status_lookup_phase_count = 0
+        self._status_load_phase_count = 0
+        with self._submission_lock:
+            self._submission_queue.clear()
+            self._request_generations.clear()
+        with self._cancel_lock:
+            self._cancel_requests.clear()
+        with self._lookup_results_lock:
+            self._completed_lookups.clear()
+        with self._prefetch_results_lock:
+            self._completed_results.clear()
+            self._completed_generations.clear()
+            self._forgotten_results.clear()

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -566,7 +566,7 @@ class PrefetchController(StorageControllerInterface):
     def wait_prefetch_result(
         self,
         request_id: PrefetchRequestId,
-        timeout: float,
+        timeout: float | None,
         generation: int | None = None,
     ) -> bool:
         """
@@ -578,7 +578,8 @@ class PrefetchController(StorageControllerInterface):
 
         Args:
             request_id: The request ID from submit_prefetch_request.
-            timeout: Maximum number of seconds to wait for the result.
+            timeout: Maximum number of seconds to wait for the result. Pass
+                ``None`` to wait until the result is published.
 
         Returns:
             True if the result became available within the timeout, False if

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -187,6 +187,7 @@ class StorageManager:
             int, weakref.ReferenceType[PrefetchHandle]
         ] = {}
         self._prefetch_handle_metadata: dict[int, _PrefetchLeaseState] = {}
+        self._prefetch_release_inflight: set[int] = set()
 
         # L2 usage gauge — one observation per adapter, tagged by
         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
@@ -288,6 +289,8 @@ class StorageManager:
     def read_prefetched_results(
         self,
         keys: list[ObjectKey],
+        *,
+        release_on_exit: bool = True,
     ) -> Iterator[list[MemoryObj] | None]:
         """
         Read the memory objects from L1 storage that has been prefetched beforehand.
@@ -296,6 +299,10 @@ class StorageManager:
 
         Args:
             keys (list[ObjectKey]): List of object keys to reserve for reading.
+            release_on_exit (bool): Release read locks when the context exits.
+                Set to ``False`` when the caller has enqueued an asynchronous
+                device copy and will call :meth:`finish_read_prefetched` only
+                after that copy is known to be complete.
 
         Returns:
             Iterator[list[MemoryObj] | None]: An iterator yielding an optional list of
@@ -372,11 +379,8 @@ class StorageManager:
                 )
             )
 
-        successfully_yielded = False
-
         try:
             yield good_objs if all_good else None
-            successfully_yielded = True
         except Exception:
             logger.exception(
                 "Exception occurred while processing read prefetched results",
@@ -384,8 +388,13 @@ class StorageManager:
             raise
         finally:
             # Decrease the read lock for all successfully read memory objects
-            # if None is yielded or exception occurs during caller's processing
-            if not all_good or not successfully_yielded:
+            # on ordinary callers.  An async device-copy caller can defer this
+            # until its completion event.  A failed read before the caller
+            # receives a complete object list has not enqueued a copy, so its
+            # successfully reserved objects can still be released here.  If
+            # the caller raises after receiving the complete list, keep the
+            # locks until the caller's copy-completion cleanup runs.
+            if release_on_exit or not all_good:
                 self._l1_manager.finish_read(good_keys)
                 self._event_bus.publish(
                     Event(
@@ -695,11 +704,16 @@ class StorageManager:
                     self._released_prefetch_handles.pop(handle_id, None)
             if handle_id in self._released_prefetch_handles:
                 return
-            self._released_prefetch_handles[handle_id] = weakref.ref(handle)
-            state = self._prefetch_handle_metadata.pop(handle_id, None)
-
-        if state is None:
-            return
+            release_inflight = getattr(self, "_prefetch_release_inflight", None)
+            if release_inflight is None:
+                release_inflight = set()
+                self._prefetch_release_inflight = release_inflight
+            if handle_id in release_inflight:
+                return
+            state = self._prefetch_handle_metadata.get(handle_id)
+            if state is None:
+                return
+            release_inflight.add(handle_id)
 
         release_keys = [
             state.keys[index]
@@ -714,10 +728,33 @@ class StorageManager:
         # A bitmap can contain the L1 keys as well as newly loaded L2 keys.
         # Deduplicate so the initial L1 reservation is not released twice.
         release_keys = list(dict.fromkeys(release_keys))
-        if release_keys and state.num_kv_readers > 0:
-            self.finish_read_prefetched(
-                release_keys,
-                read_locks=state.num_kv_readers,
+        try:
+            if release_keys and state.num_kv_readers > 0:
+                self.finish_read_prefetched(
+                    release_keys,
+                    read_locks=state.num_kv_readers,
+                )
+        except Exception:
+            with self._prefetch_release_lock:
+                self._prefetch_release_inflight.discard(handle_id)
+            raise
+
+        with self._prefetch_release_lock:
+            if self._prefetch_handle_metadata.get(handle_id) is state:
+                self._prefetch_handle_metadata.pop(handle_id, None)
+            self._prefetch_release_inflight.discard(handle_id)
+            manager_ref = weakref.ref(self)
+
+            def forget_released_handle(ref, handle_id=handle_id):
+                manager = manager_ref()
+                if manager is None:
+                    return
+                with manager._prefetch_release_lock:
+                    if manager._released_prefetch_handles.get(handle_id) is ref:
+                        manager._released_prefetch_handles.pop(handle_id, None)
+
+            self._released_prefetch_handles[handle_id] = weakref.ref(
+                handle, forget_released_handle
             )
 
     def _combine_found(
@@ -776,7 +813,7 @@ class StorageManager:
     def wait_prefetch_status(
         self,
         handle: PrefetchHandle,
-        timeout: float,
+        timeout: float | None,
     ) -> bool:
         """
         Block until the prefetch task for ``handle`` has a result, or timeout.
@@ -788,7 +825,8 @@ class StorageManager:
 
         Args:
             handle (PrefetchHandle): The handle of the prefetch task.
-            timeout: Maximum number of seconds to wait for the L2 result.
+            timeout: Maximum number of seconds to wait for the L2 result. Pass
+                ``None`` to wait until the controller publishes a result.
 
         Returns:
             True if a result is available within the timeout (always True for
@@ -801,6 +839,37 @@ class StorageManager:
             timeout,
             generation=handle.generation,
         )
+
+    def _cancel_prefetch_and_wait(
+        self, handle: PrefetchHandle
+    ) -> tuple[bool, Bitmap | None]:
+        """Cancel a controller request and wait before releasing L1 locks."""
+        if handle.prefetch_request_id == -1:
+            return False, self._combine_found(handle, None)
+
+        cancelled = self._prefetch_controller.cancel_prefetch_request(
+            handle.prefetch_request_id,
+            generation=handle.generation,
+        )
+        if cancelled and not self.wait_prefetch_status(handle, timeout=None):
+            raise RuntimeError(
+                "LMCache prefetch cancellation did not complete; "
+                "retaining the prefetch lease"
+            )
+
+        # If cancellation was accepted, the controller has now released its
+        # L2 locks and any L1 write reservations before publishing the empty
+        # result.  Querying it also clears the controller's bookkeeping.
+        found = self.query_prefetch_status(handle)
+        if found is None:
+            # The result may have been consumed by a legacy caller already.
+            # Suppress any late publication, but do not release caller-owned
+            # keys here unless the caller supplied them below.
+            self._prefetch_controller.forget_prefetch_result(
+                handle.prefetch_request_id,
+                generation=handle.generation,
+            )
+        return cancelled, found
 
     @enable_tracing()
     def cancel_prefetch_task(self, handle: PrefetchHandle) -> None:
@@ -823,26 +892,7 @@ class StorageManager:
             if released is not None and released() is handle:
                 return
 
-        found = None
-        if handle.prefetch_request_id != -1:
-            self._prefetch_controller.cancel_prefetch_request(
-                handle.prefetch_request_id,
-                generation=handle.generation,
-            )
-            # If the request had already completed, this also consumes the
-            # completion bitmap so the loaded read locks can be released.
-            found = self.query_prefetch_status(handle)
-            if found is None:
-                # Cancellation may finish asynchronously after the query, or
-                # the request may already be outside the manager's active set.
-                # The generation guard makes this cleanup safe for a reused
-                # request ID, and the controller operation is idempotent.
-                self._prefetch_controller.forget_prefetch_result(
-                    handle.prefetch_request_id,
-                    generation=handle.generation,
-                )
-        else:
-            found = self._combine_found(handle, None)
+        _, found = self._cancel_prefetch_and_wait(handle)
         self._release_prefetch_lease(handle, found=found)
 
     @enable_tracing()
@@ -864,20 +914,7 @@ class StorageManager:
             if released is not None and released() is handle:
                 return
 
-        found = None
-        if handle.prefetch_request_id != -1:
-            cancelled = self._prefetch_controller.cancel_prefetch_request(
-                handle.prefetch_request_id,
-                generation=handle.generation,
-            )
-            found = self.query_prefetch_status(handle)
-            if found is None:
-                self._prefetch_controller.forget_prefetch_result(
-                    handle.prefetch_request_id,
-                    generation=handle.generation,
-                )
-        else:
-            found = self._combine_found(handle, None)
+        cancelled, found = self._cancel_prefetch_and_wait(handle)
         # ``keys`` is a compatibility escape hatch for callers that already
         # consumed the controller bitmap through the legacy query API.  When
         # cancellation is still active, the controller owns cleanup of any

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -825,16 +825,18 @@ class StorageManager:
 
         found = None
         if handle.prefetch_request_id != -1:
-            cancelled = self._prefetch_controller.cancel_prefetch_request(
+            self._prefetch_controller.cancel_prefetch_request(
                 handle.prefetch_request_id,
                 generation=handle.generation,
             )
             # If the request had already completed, this also consumes the
             # completion bitmap so the loaded read locks can be released.
             found = self.query_prefetch_status(handle)
-            if found is None and cancelled:
-                # Cancellation may finish asynchronously after the query.  Do
-                # not leave an unconsumed empty completion in the controller.
+            if found is None:
+                # Cancellation may finish asynchronously after the query, or
+                # the request may already be outside the manager's active set.
+                # The generation guard makes this cleanup safe for a reused
+                # request ID, and the controller operation is idempotent.
                 self._prefetch_controller.forget_prefetch_result(
                     handle.prefetch_request_id,
                     generation=handle.generation,
@@ -869,7 +871,7 @@ class StorageManager:
                 generation=handle.generation,
             )
             found = self.query_prefetch_status(handle)
-            if found is None and cancelled:
+            if found is None:
                 self._prefetch_controller.forget_prefetch_result(
                     handle.prefetch_request_id,
                     generation=handle.generation,

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -5,10 +5,11 @@ Distributed multi-tier storage manager for MP mode
 
 # Standard
 from contextlib import contextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Iterator, Literal, Optional
 import threading
 import time
+import weakref
 
 # First Party
 from lmcache.lmcache_native import Bitmap, PeriodicEventNotifier
@@ -70,6 +71,16 @@ from lmcache.v1.mp_observability.trace.decorator import (
 from lmcache.v1.platform import HAS_EVENTFD
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class _PrefetchLeaseState:
+    """Manager-owned read-lock state for one opaque prefetch handle."""
+
+    handle: PrefetchHandle
+    keys: tuple[ObjectKey, ...]
+    l1_found_indices: tuple[int, ...]
+    num_kv_readers: int
 
 
 class StorageManager:
@@ -164,6 +175,18 @@ class StorageManager:
             max_in_flight=config.prefetch_max_in_flight,
         )
         self._prefetch_controller.start()
+        self._prefetch_release_lock = threading.Lock()
+        # Handle identity is intentional here.  L1-only handles use the
+        # sentinel request id -1 and may all have generation 0; using the
+        # request id as a key would make unrelated leases cancel each other.
+        # Keep a weak reference to released handles alongside their object IDs
+        # so an ID cannot be mistaken for a still-live lease.  Value-based
+        # dataclass equality is not sufficient: two independent handles may
+        # carry identical fields.
+        self._released_prefetch_handles: dict[
+            int, weakref.ReferenceType[PrefetchHandle]
+        ] = {}
+        self._prefetch_handle_metadata: dict[int, _PrefetchLeaseState] = {}
 
         # L2 usage gauge — one observation per adapter, tagged by
         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
@@ -434,7 +457,7 @@ class StorageManager:
                 prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
                     spec
                 )
-            return PrefetchHandle(
+            handle = PrefetchHandle(
                 prefetch_request_id=prefetch_request_id,
                 external_request_id=external_request_id,
                 l1_found_indices=(),
@@ -444,7 +467,12 @@ class StorageManager:
                 l2_orig_indices=(
                     tuple(range(len(keys))) if prefetch_request_id != -1 else ()
                 ),
+                generation=spec.generation,
             )
+            # WARM does not acquire L1 read locks.  Keep it on the legacy
+            # bookkeeping path even when it has an asynchronous L2 request.
+            self._remember_prefetch_handle(handle, keys, 0, track_lease=False)
+            return handle
 
         # NOTE: now we only have L1, so the prefetch is essentially checking how many
         # objects are already in L1, and adding read locks to them.
@@ -486,7 +514,7 @@ class StorageManager:
                 prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
                     replace(spec, keys=remaining_keys)
                 )
-            return PrefetchHandle(
+            handle = PrefetchHandle(
                 prefetch_request_id=prefetch_request_id,
                 external_request_id=external_request_id,
                 l1_found_indices=tuple(l1_found_indices),
@@ -496,7 +524,15 @@ class StorageManager:
                 l2_orig_indices=(
                     tuple(sparse_l2_indices) if prefetch_request_id != -1 else ()
                 ),
+                generation=spec.generation,
             )
+            self._remember_prefetch_handle(
+                handle,
+                keys,
+                spec.num_kv_readers,
+                track_lease=True,
+            )
+            return handle
 
         # PREFIX: fold the per-(group, chunk, rank) L1 presence into the
         # model-wide hit and the per-object-group retain set (sliding-window
@@ -600,7 +636,7 @@ class StorageManager:
             prefetch_request_id,
         )
 
-        return PrefetchHandle(
+        handle = PrefetchHandle(
             prefetch_request_id=prefetch_request_id,
             external_request_id=external_request_id,
             l1_found_indices=tuple(retained_indices),
@@ -608,7 +644,81 @@ class StorageManager:
             total_requested_keys=len(keys),
             submit_time=submit_time,
             l2_orig_indices=l2_orig_indices,
+            generation=spec.generation,
         )
+        # Existing PREFIX callers own the read-lock lifecycle through
+        # finish_read_prefetched.  The explicit lease contract is reserved for
+        # SPARSE requests, whose scattered result cannot be represented by the
+        # legacy prefix cleanup path.
+        self._remember_prefetch_handle(
+            handle,
+            keys,
+            spec.num_kv_readers,
+            track_lease=False,
+        )
+        return handle
+
+    def _remember_prefetch_handle(
+        self,
+        handle: PrefetchHandle,
+        keys: list[ObjectKey],
+        num_kv_readers: int,
+        *,
+        track_lease: bool = True,
+    ) -> None:
+        """Keep the small amount of state needed for explicit cancellation."""
+        if not track_lease:
+            return
+        with self._prefetch_release_lock:
+            handle_id = id(handle)
+            self._prefetch_handle_metadata[handle_id] = _PrefetchLeaseState(
+                handle=handle,
+                keys=tuple(keys),
+                l1_found_indices=handle.l1_found_indices,
+                num_kv_readers=num_kv_readers,
+            )
+
+    def _release_prefetch_lease(
+        self,
+        handle: PrefetchHandle,
+        found: Optional["Bitmap"] = None,
+        extra_keys: Optional[list[ObjectKey]] = None,
+    ) -> None:
+        """Release one handle's manager-owned locks at most once."""
+        handle_id = id(handle)
+        with self._prefetch_release_lock:
+            released = self._released_prefetch_handles.get(handle_id)
+            if released is not None:
+                if released() is handle:
+                    return
+                if released() is None:
+                    self._released_prefetch_handles.pop(handle_id, None)
+            if handle_id in self._released_prefetch_handles:
+                return
+            self._released_prefetch_handles[handle_id] = weakref.ref(handle)
+            state = self._prefetch_handle_metadata.pop(handle_id, None)
+
+        if state is None:
+            return
+
+        release_keys = [
+            state.keys[index]
+            for index in state.l1_found_indices
+            if 0 <= index < len(state.keys)
+        ]
+        if found is not None:
+            release_keys.extend(found.gather(state.keys))
+        if extra_keys:
+            release_keys.extend(extra_keys)
+
+        # A bitmap can contain the L1 keys as well as newly loaded L2 keys.
+        # Deduplicate so the initial L1 reservation is not released twice.
+        release_keys = list(dict.fromkeys(release_keys))
+        if release_keys and state.num_kv_readers > 0:
+            self.finish_read_prefetched(
+                release_keys,
+                read_locks=state.num_kv_readers,
+            )
 
     def _combine_found(
         self, handle: PrefetchHandle, l2_local: "Bitmap | None"
@@ -687,8 +797,119 @@ class StorageManager:
         if handle.prefetch_request_id == -1:
             return True
         return self._prefetch_controller.wait_prefetch_result(
-            handle.prefetch_request_id, timeout
+            handle.prefetch_request_id,
+            timeout,
+            generation=handle.generation,
         )
+
+    @enable_tracing()
+    def cancel_prefetch_task(self, handle: PrefetchHandle) -> None:
+        """Cancel a prefetch and release any locks owned by this manager.
+
+        The controller performs cancellation on its worker thread.  This
+        method also releases the L1 read locks retained by the initial
+        ``StorageManager`` lookup, once and only once.  If an adapter has
+        already accepted an asynchronous task, the controller waits for that
+        task's result before releasing its L2 lock or L1 write reservation.
+
+        Calling this method repeatedly is safe.  The generation carried by
+        ``handle`` prevents a reused request slot from cancelling a newer
+        request when the adapter forwards the handle across an integration
+        boundary.
+        """
+        handle_id = id(handle)
+        with self._prefetch_release_lock:
+            released = self._released_prefetch_handles.get(handle_id)
+            if released is not None and released() is handle:
+                return
+
+        found = None
+        if handle.prefetch_request_id != -1:
+            cancelled = self._prefetch_controller.cancel_prefetch_request(
+                handle.prefetch_request_id,
+                generation=handle.generation,
+            )
+            # If the request had already completed, this also consumes the
+            # completion bitmap so the loaded read locks can be released.
+            found = self.query_prefetch_status(handle)
+            if found is None and cancelled:
+                # Cancellation may finish asynchronously after the query.  Do
+                # not leave an unconsumed empty completion in the controller.
+                self._prefetch_controller.forget_prefetch_result(
+                    handle.prefetch_request_id,
+                    generation=handle.generation,
+                )
+        else:
+            found = self._combine_found(handle, None)
+        self._release_prefetch_lease(handle, found=found)
+
+    @enable_tracing()
+    def release_prefetch_task(
+        self,
+        handle: PrefetchHandle,
+        keys: Optional[list[ObjectKey]] = None,
+    ) -> None:
+        """Release a prefetch lease, optionally releasing consumed keys.
+
+        ``keys`` should be supplied when the caller has consumed the retained
+        objects and wants to drop their read locks.  When omitted, the method
+        cancels the request and performs all cleanup that can be identified by
+        the opaque handle.  This is intentionally idempotent.
+        """
+        handle_id = id(handle)
+        with self._prefetch_release_lock:
+            released = self._released_prefetch_handles.get(handle_id)
+            if released is not None and released() is handle:
+                return
+
+        found = None
+        if handle.prefetch_request_id != -1:
+            cancelled = self._prefetch_controller.cancel_prefetch_request(
+                handle.prefetch_request_id,
+                generation=handle.generation,
+            )
+            found = self.query_prefetch_status(handle)
+            if found is None and cancelled:
+                self._prefetch_controller.forget_prefetch_result(
+                    handle.prefetch_request_id,
+                    generation=handle.generation,
+                )
+        else:
+            found = self._combine_found(handle, None)
+        # ``keys`` is a compatibility escape hatch for callers that already
+        # consumed the controller bitmap through the legacy query API.  When
+        # cancellation is still active, the controller owns cleanup of any
+        # in-flight L2 reservation; releasing caller-supplied keys here could
+        # race that asynchronous operation.
+        extra_keys = None
+        if handle.prefetch_request_id == -1:
+            extra_keys = keys
+        elif found is None and not cancelled:
+            extra_keys = keys
+        self._release_prefetch_lease(
+            handle,
+            found=found,
+            extra_keys=extra_keys,
+        )
+
+    def consume_prefetch_task(self, handle: PrefetchHandle) -> Bitmap | None:
+        """Consume a completed prefetch and release its read-lock lease.
+
+        The returned bitmap is indexed over the original logical key list.
+        This is the lease-oriented counterpart to
+        :meth:`query_prefetch_status`: once a bitmap is returned, all retained
+        keys owned by this handle are released.  Existing callers can keep
+        using ``query_prefetch_status`` plus ``finish_read_prefetched``.
+        """
+        handle_id = id(handle)
+        with self._prefetch_release_lock:
+            released = self._released_prefetch_handles.get(handle_id)
+            if released is not None and released() is handle:
+                return None
+        found = self.query_prefetch_status(handle)
+        if found is not None:
+            self._release_prefetch_lease(handle, found=found)
+        return found
 
     def query_prefetch_status(
         self,
@@ -708,7 +929,8 @@ class StorageManager:
         l2_r: Bitmap | None = None
         if handle.prefetch_request_id != -1:
             l2_r = self._prefetch_controller.query_prefetch_result(
-                handle.prefetch_request_id
+                handle.prefetch_request_id,
+                generation=handle.generation,
             )
             if l2_r is None:
                 return None
@@ -1113,6 +1335,12 @@ class StorageManager:
         """
         Close the storage manager and release all resources.
         """
+        with self._prefetch_release_lock:
+            outstanding_handles = tuple(
+                state.handle for state in self._prefetch_handle_metadata.values()
+            )
+        for handle in outstanding_handles:
+            self.cancel_prefetch_task(handle)
         self._prefetch_controller.stop()
         self._store_controller.stop()
         self._eviction_controller.stop()
@@ -1124,6 +1352,9 @@ class StorageManager:
             adapter.close()
 
         self._l1_manager.close()
+        with self._prefetch_release_lock:
+            self._prefetch_handle_metadata.clear()
+            self._released_prefetch_handles.clear()
 
     def report_status(self) -> dict:
         """Return a status dict aggregating all sub-component statuses."""

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -914,16 +914,16 @@ class StorageManager:
             if released is not None and released() is handle:
                 return
 
-        cancelled, found = self._cancel_prefetch_and_wait(handle)
+        _, found = self._cancel_prefetch_and_wait(handle)
         # ``keys`` is a compatibility escape hatch for callers that already
-        # consumed the controller bitmap through the legacy query API.  When
-        # cancellation is still active, the controller owns cleanup of any
-        # in-flight L2 reservation; releasing caller-supplied keys here could
-        # race that asynchronous operation.
+        # consumed the controller bitmap through the legacy query API.  The
+        # helper above waits for an accepted cancellation before returning, so
+        # explicit keys are safe to release even when cancellation was the
+        # operation that completed the controller request.
         extra_keys = None
         if handle.prefetch_request_id == -1:
             extra_keys = keys
-        elif found is None and not cancelled:
+        elif found is None:
             extra_keys = keys
         self._release_prefetch_lease(
             handle,

--- a/lmcache/v1/mp_observability/trace/codecs.py
+++ b/lmcache/v1/mp_observability/trace/codecs.py
@@ -210,6 +210,7 @@ def _enc_prefetch_handle(h: PrefetchHandle) -> dict[str, Any]:
         "total_requested_keys": h.total_requested_keys,
         "submit_time": h.submit_time,
         "l2_orig_indices": list(h.l2_orig_indices),
+        "generation": h.generation,
     }
 
 
@@ -222,6 +223,7 @@ def _dec_prefetch_handle(d: dict[str, Any]) -> PrefetchHandle:
         total_requested_keys=d["total_requested_keys"],
         submit_time=d["submit_time"],
         l2_orig_indices=tuple(d.get("l2_orig_indices", ())),
+        generation=d.get("generation", 0),
     )
 
 
@@ -285,6 +287,7 @@ def _enc_prefetch_request_spec(s: PrefetchRequestSpec) -> dict[str, Any]:
             str(gid): encode_value(ld) for gid, ld in s.group_layout_descs.items()
         },
         "mode": encode_value(s.mode),
+        "generation": s.generation,
     }
 
 
@@ -311,6 +314,7 @@ def _dec_prefetch_request_spec(d: dict[str, Any]) -> PrefetchRequestSpec:
         policy=decode_value(d["policy"]),
         attn_desc=decode_value(d["attn_desc"]),
         mode=decode_value(d["mode"]),
+        generation=d.get("generation", 0),
     )
 
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -2,7 +2,7 @@
 """LMCache-driven KV cache transfer operations for the MPCacheServer."""
 
 # Standard
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import islice
 from typing import Any, Generator, Sequence
 import threading
@@ -21,6 +21,9 @@ from lmcache.utils import (
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
+    PrefetchHandle,
+    PrefetchRequestSpec,
+    TrimPolicy,
 )
 from lmcache.v1.gpu_connector.gpu_ops import (
     build_staging_copies,
@@ -249,6 +252,108 @@ def downsample_and_stage_block_ids(
     # Stage the cut block ids into GPU tensors
     block_ids_gpu = cache_context.stage_block_ids(block_ids)
     return block_ids_gpu
+
+
+def _stage_sparse_layer(
+    cache_context: BaseCacheContext,
+    memory_objs: Sequence[MemoryObj],
+    selected_block_ids: list[list[int]],
+    object_group_id: int,
+    layer_id: int,
+) -> None:
+    """Copy one logical layer from sparse objects into SGLang pages.
+
+    The regular object-group transfer is intentionally multi-layer: one
+    ``MemoryObj`` contains all layers in an object group.  A lookahead ticket
+    has a narrower contract, so using that helper here would transfer every
+    layer and make ``layer_id`` only bookkeeping.  The SGLang MP layout has
+    separate K/V page tensors and can use the existing single-layer device
+    primitive instead.
+
+    This first adapter is deliberately strict.  Other engine layouts keep the
+    normal sparse fallback until they provide an equivalent layer view.
+    """
+    manager = cache_context.kv_layer_groups_manager
+    object_group = manager.object_groups[object_group_id]
+    target_group_id = next(
+        (
+            kernel_group_id
+            for kernel_group_id in object_group.kernel_group_indices
+            if layer_id in manager.kernel_groups[kernel_group_id].layer_indices
+        ),
+        None,
+    )
+    if target_group_id is None:
+        raise ValueError(
+            f"layer {layer_id} is not part of object group {object_group_id}"
+        )
+
+    target_group = manager.kernel_groups[target_group_id]
+    group_position = object_group.kernel_group_indices.index(target_group_id)
+    local_layer_id = target_group.layer_indices.index(layer_id)
+    expected_format = lmcache_native.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS
+    if cache_context.get_engine_kv_format(target_group_id) != expected_format:
+        raise ValueError(
+            "sparse layer transfer currently requires the SGLang split-K/V "
+            f"layout, got {cache_context.get_engine_kv_format(target_group_id)}"
+        )
+
+    kv_tensors = cache_context.kv_tensors
+    if (
+        not isinstance(kv_tensors, list)
+        or len(kv_tensors) != 2
+        or not isinstance(kv_tensors[0], list)
+        or not isinstance(kv_tensors[1], list)
+    ):
+        raise ValueError("SGLang sparse layer transfer requires split K/V tensors")
+    key_cache = kv_tensors[0][layer_id]
+    value_cache = kv_tensors[1][layer_id]
+    blocks_per_key = cache_context.calculate_num_blocks(
+        cache_context.lmcache_tokens_per_chunk, target_group_id
+    )
+    block_size = target_group.shape_desc.bs
+    if block_size <= 0:
+        raise ValueError("sparse layer transfer requires a positive page size")
+
+    destination_blocks = selected_block_ids[target_group_id]
+    expected_blocks = len(memory_objs) * blocks_per_key
+    if len(destination_blocks) != expected_blocks:
+        raise ValueError(
+            "sparse layer transfer block mapping has wrong length: "
+            f"expected {expected_blocks}, got {len(destination_blocks)}"
+        )
+
+    offsets = torch.arange(block_size, dtype=torch.int64, device=key_cache.device)
+    for object_index, memory_obj in enumerate(memory_objs):
+        source_group = memory_obj.get_tensor(group_position)
+        if source_group is None:
+            raise ValueError("sparse layer transfer received a non-tensor object")
+        if source_group.ndim != 4 or source_group.shape[0] != 2:
+            raise ValueError(
+                "sparse layer transfer expected [2, layers, tokens, hidden] "
+                f"source, got {tuple(source_group.shape)}"
+            )
+        if local_layer_id >= source_group.shape[1]:
+            raise ValueError(
+                f"source object has {source_group.shape[1]} layers, "
+                f"cannot read local layer {local_layer_id}"
+            )
+        source_layer = source_group[:, local_layer_id]
+        start = object_index * blocks_per_key
+        blocks = torch.tensor(
+            destination_blocks[start : start + blocks_per_key],
+            dtype=torch.int64,
+            device=key_cache.device,
+        )
+        slot_mapping = (blocks[:, None] * block_size + offsets).reshape(-1)
+        device_ops.single_layer_kv_transfer_sgl(
+            source_layer,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            lmcache_native.TransferDirection.H2D,
+            token_major=False,
+        )
 
 
 def _recalculate_blocks_to_skip(
@@ -675,6 +780,32 @@ class ContextEntry:
     event_backend: EventIPCBackend | None = None
 
 
+@dataclass
+class _SparsePrefetchJob:
+    """Server-side state for one logical sparse prefetch lease."""
+
+    handle: PrefetchHandle
+    keys: tuple[ObjectKey, ...]
+    instance_id: int
+    request_id: str
+    generation: int
+    layer_id: int
+    condition: threading.Condition = field(
+        default_factory=threading.Condition, repr=False
+    )
+    found_indices: tuple[int, ...] | None = None
+    status_inflight: bool = False
+    retrieving: bool = False
+    completion_submitted: bool = False
+    completed: bool = False
+    copy_submitted: bool = False
+    copy_synchronized: bool = False
+    copy_sync_inflight: bool = False
+    copy_stream: Any = field(default=None, repr=False)
+    last_error: BaseException | None = field(default=None, repr=False)
+    cancel_requested: bool = False
+
+
 class LMCacheDrivenTransferModule(InstanceLivenessTarget):
     """Handles LMCache-driven KV cache transfer operations.
 
@@ -694,6 +825,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         # ops -- never across context creation, layout-registry calls, or
         # empty_cache (leaf-lock invariant: no thread holds two locks).
         self._lock = threading.Lock()
+        self._sparse_jobs: dict[tuple[int, str, int, int], _SparsePrefetchJob] = {}
+        self._sparse_jobs_lock = threading.Lock()
+        self._sparse_orphan_handles: dict[tuple[int, int], PrefetchHandle] = {}
 
         # Route finish_write / finish_read_prefetched through a C++ host
         # callback so the driver thread doesn't acquire the GIL.
@@ -707,6 +841,11 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             "finish_read_prefetched",
             self._ctx.storage_manager.finish_read_prefetched,
             payload_type=list[ObjectKey],
+        )
+        self._device_host_func_dispatcher.register(
+            "complete_sparse_prefetch",
+            self._complete_sparse_prefetch,
+            payload_type=tuple[int, str, int, int],
         )
         self._device_host_func_dispatcher.start()
 
@@ -832,7 +971,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             The instance IDs reaped this scan.
         """
         now = time.monotonic()
-        reaped: list[tuple[int, ContextEntry]] = []
+        stale_candidates: list[tuple[int, ContextEntry]] = []
         with self._lock:
             stale_ids = [
                 iid
@@ -845,10 +984,29 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 )
             ]
             for iid in stale_ids:
-                reaped.append((iid, self._cache_contexts.pop(iid)))
+                stale_candidates.append((iid, self._cache_contexts[iid]))
         reaped_ids: list[int] = []
         entries: list[ContextEntry] = []
-        for iid, e in reaped:
+        for iid, candidate in stale_candidates:
+            if not self._cleanup_sparse_instance(iid):
+                logger.error(
+                    "Keeping stale GPU instance %d registered because sparse "
+                    "prefetch cleanup did not complete",
+                    iid,
+                )
+                continue
+            with self._lock:
+                current = self._cache_contexts.get(iid)
+                if current is not candidate:
+                    continue
+                timeout = (
+                    reap_timeout_s
+                    if current.has_liveness_signal
+                    else registration_grace_s
+                )
+                if time.monotonic() - current.last_seen <= timeout:
+                    continue
+                e = self._cache_contexts.pop(iid)
             logger.warning(
                 "Reaped GPU instance %d: silent for %.1fs (pinged=%s)",
                 iid,
@@ -857,9 +1015,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             )
             reaped_ids.append(iid)
             entries.append(e)
-        if reaped:
+        if entries:
             del e  # a bound name would pin the final entry (see _release_entries)
-            reaped.clear()
             self._release_entries(entries)
         return reaped_ids
 
@@ -909,10 +1066,559 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         return {
             "registered_gpu_ids": registered_gpu_ids,
             "cache_context_meta": cache_context_meta,
+            "active_sparse_prefetches": self._active_sparse_count(),
         }
+
+    def _active_sparse_count(self) -> int:
+        with self._sparse_jobs_lock:
+            return len(self._sparse_jobs) + len(
+                getattr(self, "_sparse_orphan_handles", {})
+            )
+
+    def _sparse_job_key(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> tuple[int, str, int, int]:
+        return instance_id, request_id, generation, layer_id
+
+    def _get_sparse_job(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> _SparsePrefetchJob | None:
+        with self._sparse_jobs_lock:
+            return self._sparse_jobs.get(
+                self._sparse_job_key(instance_id, request_id, generation, layer_id)
+            )
+
+    def _remove_sparse_job(self, job: _SparsePrefetchJob) -> None:
+        key = self._sparse_job_key(
+            job.instance_id, job.request_id, job.generation, job.layer_id
+        )
+        with self._sparse_jobs_lock:
+            if self._sparse_jobs.get(key) is job:
+                self._sparse_jobs.pop(key, None)
+
+    def _remember_sparse_orphan_handle(
+        self, instance_id: int, handle: PrefetchHandle
+    ) -> None:
+        """Retain a losing storage handle when its first cleanup fails."""
+        with self._sparse_jobs_lock:
+            orphan_handles = getattr(self, "_sparse_orphan_handles", None)
+            if orphan_handles is None:
+                orphan_handles = {}
+                self._sparse_orphan_handles = orphan_handles
+            orphan_handles[(instance_id, id(handle))] = handle
+
+    def _cancel_or_remember_sparse_handle(
+        self, instance_id: int, handle: PrefetchHandle
+    ) -> bool:
+        """Cancel a handle, retaining it when success is not confirmed."""
+        try:
+            result = self._ctx.storage_manager.cancel_prefetch_task(handle)
+        except Exception:
+            self._remember_sparse_orphan_handle(instance_id, handle)
+            logger.exception("Failed to cancel a losing sparse prefetch handle")
+            return False
+        if result is False:
+            self._remember_sparse_orphan_handle(instance_id, handle)
+            logger.error("Sparse prefetch handle cancellation was not confirmed")
+            return False
+        return True
+
+    def _cleanup_sparse_orphan_handles(self, instance_id: int | None = None) -> bool:
+        """Retry cleanup for handles whose first cancellation was uncertain."""
+        with self._sparse_jobs_lock:
+            orphan_handles = {
+                key: handle
+                for key, handle in getattr(self, "_sparse_orphan_handles", {}).items()
+                if instance_id is None or key[0] == instance_id
+            }
+        all_clean = True
+        for handle_key, handle in orphan_handles.items():
+            if not self._cancel_or_remember_sparse_handle(handle_key[0], handle):
+                all_clean = False
+                continue
+            with self._sparse_jobs_lock:
+                current = getattr(self, "_sparse_orphan_handles", {}).get(handle_key)
+                if current is handle:
+                    self._sparse_orphan_handles.pop(handle_key, None)
+        return all_clean
+
+    def _finish_sparse_job(self, job: _SparsePrefetchJob) -> None:
+        with job.condition:
+            job.completed = True
+            job.retrieving = False
+            job.condition.notify_all()
+        self._remove_sparse_job(job)
+
+    def _complete_sparse_prefetch(self, payload: tuple[int, str, int, int]) -> None:
+        """Release a sparse lease after the GPU transfer stream completes."""
+        instance_id, request_id, generation, layer_id = payload
+        job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
+        if job is None:
+            return
+        with job.condition:
+            found_indices = job.found_indices
+            retrieving = job.retrieving
+        if not retrieving or found_indices is None:
+            return
+        found_keys = [job.keys[index] for index in found_indices]
+        with job.condition:
+            # This callback runs on the copy stream, so all H2D work is
+            # complete before releasing the host read locks.
+            job.copy_synchronized = True
+            job.copy_sync_inflight = False
+            job.condition.notify_all()
+        try:
+            # The PrefetchHandle owns the storage-manager read lease. Release
+            # it only from this completion callback, after the copy stream has
+            # synchronized; releasing the same keys separately here would
+            # double-decrement the handle's read locks.
+            self._ctx.storage_manager.release_prefetch_task(job.handle, keys=found_keys)
+        except Exception:
+            logger.exception(
+                "Failed to release sparse prefetch lease after transfer: "
+                "request_id=%s generation=%d",
+                request_id,
+                generation,
+            )
+            with job.condition:
+                # The device callback already proves the copy is finished.
+                # Leave the job reachable, but allow an explicit cancel or
+                # release to retry the logical lease without waiting for a
+                # completion callback that will never run again.
+                job.retrieving = False
+                job.condition.notify_all()
+            return
+        self._finish_sparse_job(job)
+
+    def _cleanup_sparse_job(self, job: _SparsePrefetchJob) -> bool:
+        """Cancel/release one job, waiting for an in-flight GPU copy."""
+        deadline = time.monotonic() + 60.0
+        with job.condition:
+            if job.completed:
+                return True
+            job.cancel_requested = True
+            while job.retrieving and not job.completed:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.error(
+                        "Timed out waiting for sparse prefetch transfer cleanup: "
+                        "request_id=%s generation=%d",
+                        job.request_id,
+                        job.generation,
+                    )
+                    return False
+                job.condition.wait(timeout=min(remaining, 0.5))
+            if job.completed:
+                return True
+
+        if not self._synchronize_sparse_copy(job):
+            logger.error(
+                "Cannot prove sparse retrieve copy completion; retaining "
+                "request resources: request_id=%s generation=%d",
+                job.request_id,
+                job.generation,
+            )
+            return False
+
+        try:
+            self._ctx.storage_manager.release_prefetch_task(job.handle)
+        except Exception:
+            logger.exception(
+                "Failed to release sparse prefetch job: request_id=%s generation=%d",
+                job.request_id,
+                job.generation,
+            )
+            return False
+        self._finish_sparse_job(job)
+        return True
+
+    def _synchronize_sparse_copy(self, job: _SparsePrefetchJob) -> bool:
+        """Synchronize a partially submitted copy before releasing its lease."""
+        with job.condition:
+            if not job.copy_submitted or job.copy_synchronized:
+                return True
+            while job.copy_sync_inflight:
+                job.condition.wait()
+                if job.copy_synchronized:
+                    return True
+            job.copy_sync_inflight = True
+            copy_stream = job.copy_stream
+
+        try:
+            synchronize = getattr(copy_stream, "synchronize", None)
+            if synchronize is None:
+                raise RuntimeError("sparse retrieve copy stream has no synchronize()")
+            synchronize()
+        except Exception as exc:
+            with job.condition:
+                job.copy_sync_inflight = False
+                job.last_error = exc
+                job.condition.notify_all()
+            logger.exception(
+                "Could not confirm sparse retrieve copy completion; "
+                "resources remain leased: request_id=%s generation=%d",
+                job.request_id,
+                job.generation,
+            )
+            return False
+
+        with job.condition:
+            job.copy_sync_inflight = False
+            job.copy_synchronized = True
+            job.condition.notify_all()
+        return True
+
+    def _cleanup_sparse_instance(self, instance_id: int) -> bool:
+        with self._sparse_jobs_lock:
+            jobs = [
+                job
+                for job in self._sparse_jobs.values()
+                if job.instance_id == instance_id
+            ]
+        all_clean = True
+        for job in jobs:
+            all_clean = self._cleanup_sparse_job(job) and all_clean
+        all_clean = self._cleanup_sparse_orphan_handles(instance_id) and all_clean
+        return all_clean
+
+    def _cleanup_all_sparse_jobs(self) -> bool:
+        with self._sparse_jobs_lock:
+            jobs = list(self._sparse_jobs.values())
+        all_clean = True
+        for job in jobs:
+            all_clean = self._cleanup_sparse_job(job) and all_clean
+        all_clean = self._cleanup_sparse_orphan_handles() and all_clean
+        return all_clean
+
+    def _resolve_sparse_status(
+        self, job: _SparsePrefetchJob, timeout: float | None
+    ) -> list[int] | None:
+        """Return a stable found-index list without consuming it twice."""
+        with job.condition:
+            if job.found_indices is not None:
+                return list(job.found_indices)
+            if job.status_inflight:
+                deadline = None if timeout is None else time.monotonic() + timeout
+                while job.status_inflight and job.found_indices is None:
+                    remaining = (
+                        None if deadline is None else deadline - time.monotonic()
+                    )
+                    if remaining is not None and remaining <= 0:
+                        return None
+                    job.condition.wait(timeout=remaining)
+                return None if job.found_indices is None else list(job.found_indices)
+            job.status_inflight = True
+
+        found = None
+        try:
+            if not self._ctx.storage_manager.wait_prefetch_status(job.handle, timeout):
+                return None
+            bitmap = self._ctx.storage_manager.query_prefetch_status(job.handle)
+            if bitmap is not None:
+                found = tuple(bitmap.get_indices_list())
+        finally:
+            with job.condition:
+                if found is not None:
+                    job.found_indices = found
+                job.status_inflight = False
+                job.condition.notify_all()
+        return None if found is None else list(found)
+
+    def sparse_prefetch(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[ObjectKey],
+    ) -> bool:
+        """Submit a logical SPARSE prefetch and retain its read lease."""
+        if generation < 0 or layer_id < 0 or not request_id:
+            return False
+        entry = self.get_and_touch_context_entry(instance_id)
+        if entry is None or not keys:
+            return False
+        if any(key.model_name != entry.model_name for key in keys):
+            logger.warning(
+                "Rejecting sparse prefetch with a mismatched model name: request_id=%s",
+                request_id,
+            )
+            return False
+        if any(key.object_group_id < 0 for key in keys):
+            return False
+        job_key = self._sparse_job_key(instance_id, request_id, generation, layer_id)
+        with self._sparse_jobs_lock:
+            existing = self._sparse_jobs.get(job_key)
+            if existing is not None:
+                return existing.keys == tuple(keys)
+            if any(
+                job.instance_id == instance_id
+                and job.request_id == request_id
+                and job.generation != generation
+                for job in self._sparse_jobs.values()
+            ):
+                # The caller must explicitly cancel the old generation before
+                # reusing a request id. This makes stale slot reuse visible
+                # instead of silently sharing a lease between generations.
+                return False
+
+        group_layout_descs = self._ctx.layout_desc_registry.find_group_layout_descs(
+            entry.model_name, entry.world_size
+        )
+        attn_desc = self._ctx.layout_desc_registry.find_attn_desc(
+            entry.model_name, entry.world_size
+        )
+        if not group_layout_descs or attn_desc is None:
+            return False
+        if any(key.object_group_id >= attn_desc.num_object_groups for key in keys):
+            return False
+
+        handle = self._ctx.storage_manager.submit_prefetch_task(
+            PrefetchRequestSpec(
+                keys=list(keys),
+                group_layout_descs=group_layout_descs,
+                policy=TrimPolicy.SPARSE,
+                attn_desc=attn_desc,
+                generation=generation,
+            ),
+            external_request_id=f"{request_id}:{generation}:{layer_id}",
+        )
+        job = _SparsePrefetchJob(
+            handle=handle,
+            keys=tuple(keys),
+            instance_id=instance_id,
+            request_id=request_id,
+            generation=generation,
+            layer_id=layer_id,
+        )
+        duplicate = False
+        conflict = False
+        generation_conflict = False
+        with self._sparse_jobs_lock:
+            existing = self._sparse_jobs.get(job_key)
+            if existing is not None:
+                duplicate = existing.keys == job.keys
+                conflict = not duplicate
+            elif any(
+                other.instance_id == instance_id
+                and other.request_id == request_id
+                and other.generation != generation
+                for other in self._sparse_jobs.values()
+            ):
+                generation_conflict = True
+            else:
+                self._sparse_jobs[job_key] = job
+
+        if generation_conflict:
+            # The caller must explicitly cancel the old generation before
+            # reusing a request id. This makes stale slot reuse visible
+            # instead of silently sharing a lease between generations.
+            self._cancel_or_remember_sparse_handle(instance_id, handle)
+            return False
+
+        if duplicate or conflict:
+            # The first submitter owns the logical job. This caller still
+            # owns a real storage-manager handle, so release that losing
+            # handle before reporting a duplicate or conflicting submit.
+            self._cancel_or_remember_sparse_handle(instance_id, handle)
+            return duplicate
+        return True
+
+    def sparse_query_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> list[int] | None:
+        """Query a sparse prefetch without releasing its lease."""
+        job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
+        if job is None:
+            return None
+        return self._resolve_sparse_status(job, timeout=0.0)
+
+    def sparse_wait_prefetch(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        timeout: float,
+    ) -> list[int] | None:
+        """Wait for a sparse prefetch without releasing its lease."""
+        if timeout < 0:
+            return None
+        job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
+        if job is None:
+            return None
+        return self._resolve_sparse_status(job, timeout=timeout)
+
+    def sparse_retrieve(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[ObjectKey],
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, tuple[bool, list[int]]]:
+        """Copy retained sparse objects into the supplied GPU page mapping."""
+        entry = self.get_and_touch_context_entry(instance_id)
+        job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
+        if entry is None or job is None or tuple(keys) != job.keys:
+            if job is not None:
+                self._cleanup_sparse_job(job)
+            return b"", (False, [])
+
+        found_indices = self._resolve_sparse_status(job, timeout=None)
+        if found_indices is None or not found_indices:
+            self._cleanup_sparse_job(job)
+            return b"", (False, [])
+
+        cache_context = entry.cache_context
+        event_backend = entry.event_backend
+        if event_backend is None:
+            self._cleanup_sparse_job(job)
+            return b"", (False, found_indices)
+        object_groups = cache_context.kv_layer_groups_manager.object_groups
+        group_ids = {key.object_group_id for key in keys}
+        if len(group_ids) != 1:
+            logger.warning(
+                "Sparse retrieve currently accepts one object group per request"
+            )
+            self._cleanup_sparse_job(job)
+            return b"", (False, found_indices)
+        object_group_id = next(iter(group_ids))
+        object_group = object_groups[object_group_id]
+        num_kernel_groups = cache_context.kv_layer_groups_manager.num_kernel_groups
+        if len(gpu_block_ids) != num_kernel_groups:
+            self._cleanup_sparse_job(job)
+            return b"", (False, found_indices)
+
+        blocks_per_chunk = {
+            kernel_group_id: cache_context.calculate_num_blocks(
+                self._ctx.chunk_size, kernel_group_id
+            )
+            for kernel_group_id in object_group.kernel_group_indices
+        }
+        for kernel_group_id, blocks_per_key in blocks_per_chunk.items():
+            if len(gpu_block_ids[kernel_group_id]) != len(keys) * blocks_per_key:
+                logger.warning(
+                    "Sparse retrieve block mapping has wrong length: "
+                    "request_id=%s group=%d",
+                    request_id,
+                    object_group_id,
+                )
+                self._cleanup_sparse_job(job)
+                return b"", (False, found_indices)
+
+        with job.condition:
+            if job.retrieving or job.completed or job.cancel_requested:
+                return b"", (False, found_indices)
+            job.retrieving = True
+            job.copy_stream = cache_context.stream
+
+        found_keys = [keys[index] for index in found_indices]
+        selected_block_ids: list[list[int]] = [[] for _ in range(num_kernel_groups)]
+        for kernel_group_id, blocks_per_key in blocks_per_chunk.items():
+            source_ids = gpu_block_ids[kernel_group_id]
+            selected_block_ids[kernel_group_id] = [
+                block_id
+                for index in found_indices
+                for block_id in source_ids[
+                    index * blocks_per_key : (index + 1) * blocks_per_key
+                ]
+            ]
+
+        try:
+            with (
+                torch_dev.device(cache_context.device),
+                torch_dev.stream(cache_context.stream),
+            ):
+                event = event_backend.create_event(cache_context.device)
+                producer_event = event_backend.import_event(
+                    event_ipc_handle, cache_context.device
+                )
+                event_backend.wait_event(producer_event, cache_context.stream)
+                stage_error: BaseException | None = None
+                with self._ctx.storage_manager.read_prefetched_results(
+                    found_keys, release_on_exit=False
+                ) as memory_objs:
+                    if memory_objs is None or len(memory_objs) != len(found_keys):
+                        raise RuntimeError(
+                            "Sparse retrieve found keys changed before read"
+                        )
+                    with job.condition:
+                        # Mark conservatively before entering the layer
+                        # transfer. A native call can enqueue an H2D copy and
+                        # then raise while processing a later object.
+                        job.copy_submitted = True
+                    try:
+                        _stage_sparse_layer(
+                            cache_context,
+                            memory_objs,
+                            selected_block_ids,
+                            object_group_id=object_group_id,
+                            layer_id=layer_id,
+                        )
+                    except BaseException as exc:
+                        # Keep the context manager on its normal-exit path so
+                        # deferred read locks are not released before the
+                        # partially submitted copy is synchronized below.
+                        stage_error = exc
+                if stage_error is not None:
+                    raise stage_error
+                submit_callback_to_stream(
+                    cache_context.cupy_stream,
+                    "complete_sparse_prefetch",
+                    (instance_id, request_id, generation, layer_id),
+                )
+                with job.condition:
+                    job.completion_submitted = True
+                    job.condition.notify_all()
+                event_backend.record_event(event, cache_context.stream)
+                return event_backend.export_event(event, cache_context.device), (
+                    True,
+                    found_indices,
+                )
+        except Exception:
+            logger.exception(
+                "Sparse retrieve failed: request_id=%s generation=%d",
+                request_id,
+                generation,
+            )
+            with job.condition:
+                if not job.completion_submitted:
+                    job.retrieving = False
+                job.condition.notify_all()
+            if not job.completion_submitted and self._synchronize_sparse_copy(job):
+                self._cleanup_sparse_job(job)
+            return b"", (False, found_indices)
+
+    def sparse_cancel_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> bool:
+        """Cancel one generation and release its logical cache lease."""
+        job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
+        if job is None:
+            return False
+        return self._cleanup_sparse_job(job)
+
+    def sparse_release_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> bool:
+        """Release one generation after its destination pages are consumed."""
+        job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
+        if job is None:
+            # The stream callback may already have performed the idempotent
+            # release; an absent exact-generation job is terminal success.
+            return True
+        return self._cleanup_sparse_job(job)
 
     def close(self) -> None:
         """Release GPU resources owned by this module."""
+        if not self._cleanup_all_sparse_jobs():
+            raise RuntimeError(
+                "Cannot close LMCache transfer module while sparse prefetch "
+                "resources are still in flight"
+            )
         # Stop the drain thread before storage_manager.close() so any
         # in-flight completions reach a live storage manager.
         self._device_host_func_dispatcher.stop()
@@ -1018,6 +1724,11 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         Args:
             instance_id: The GPU instance ID (such as PID).
         """
+        if not self._cleanup_sparse_instance(instance_id):
+            raise RuntimeError(
+                "Cannot unregister GPU context while sparse prefetch resources "
+                "are still in flight"
+            )
         with self._lock:
             popped = [
                 e
@@ -1442,6 +2153,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             )
 
             prefetched_keys: list[ObjectKey] = []
+            read_locked_keys: list[ObjectKey] = []
             total_bytes = 0
             retrieve_succeeded = True
             try:
@@ -1451,7 +2163,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     skip = group_skips[obj_group_id]
                     in_window_keys = obj_keys_per_obj_group[obj_group_id][skip:]
                     with self._ctx.storage_manager.read_prefetched_results(
-                        in_window_keys
+                        in_window_keys, release_on_exit=False
                     ) as window_objs:
                         if not window_objs or len(window_objs) != len(in_window_keys):
                             logger.error("Some keys not found during retrieve!")
@@ -1467,6 +2179,13 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                             window_objs
                         )
 
+                        # Keep these locks owned by this retrieve until the
+                        # stream copy is known to have completed.  If the
+                        # native transfer submits one object and fails on the
+                        # next, the deferred read context must not release
+                        # these keys before the failure cleanup synchronizes
+                        # the copy stream.
+                        read_locked_keys.extend(in_window_keys)
                         transfer_kv_per_object_group(
                             cache_context,
                             block_ids_per_group_gpu,
@@ -1477,21 +2196,30 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                             direction=lmcache_native.TransferDirection.H2D,
                             transfer_key=transfer_key,
                         )
-                        # Extend only after the copy is enqueued: on exception,
-                        # read_prefetched_results releases this group's locks
-                        # itself, and a key must not be released twice.
-                        prefetched_keys.extend(in_window_keys)
+                    prefetched_keys.extend(in_window_keys)
             except Exception:
                 logger.exception("Cannot retrieve keys due to exception")
                 retrieve_succeeded = False
             finally:
                 event_backend.record_event(event, cache_context.stream)
-                if prefetched_keys:
+                if retrieve_succeeded and prefetched_keys:
                     submit_callback_to_stream(
                         cache_context.cupy_stream,
                         "finish_read_prefetched",
                         prefetched_keys,
                     )
+                elif read_locked_keys:
+                    try:
+                        cache_context.stream.synchronize()
+                    except Exception:
+                        logger.exception(
+                            "Cannot confirm failed retrieve copy completion; "
+                            "retaining read locks"
+                        )
+                    else:
+                        self._ctx.storage_manager.finish_read_prefetched(
+                            read_locked_keys
+                        )
                 num_tokens = (
                     num_chunks * self._ctx.chunk_size
                     if len(prefetched_keys) == expected_retained

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -1220,8 +1220,18 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             )
             return False
 
+        with job.condition:
+            found_indices = job.found_indices
+        found_keys = (
+            None
+            if found_indices is None
+            else [job.keys[index] for index in found_indices]
+        )
         try:
-            self._ctx.storage_manager.release_prefetch_task(job.handle)
+            # A sparse retrieve may have acquired an L2 read lease after the
+            # initial prefetch response.  Pass the resolved keys through so
+            # cleanup releases both the original L1 lease and those L2 locks.
+            self._ctx.storage_manager.release_prefetch_task(job.handle, keys=found_keys)
         except Exception:
             logger.exception(
                 "Failed to release sparse prefetch job: request_id=%s generation=%d",
@@ -1598,7 +1608,10 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         """Cancel one generation and release its logical cache lease."""
         job = self._get_sparse_job(instance_id, request_id, generation, layer_id)
         if job is None:
-            return False
+            # Cancellation is an idempotent cleanup operation.  The stream
+            # completion callback or an earlier cancel may already have
+            # removed this exact-generation job.
+            return True
         return self._cleanup_sparse_job(job)
 
     def sparse_release_prefetch(

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -62,6 +62,16 @@ class RequestType(enum.Enum):
     PREPARE_RETRIEVE = enum.auto()
     COMMIT_RETRIEVE = enum.auto()
 
+    # Sparse lookahead operations. These keep logical ObjectKey ownership in
+    # the storage manager while allowing a registered GPU client to provide a
+    # destination page mapping for one asynchronous retrieve.
+    SPARSE_PREFETCH = enum.auto()
+    SPARSE_QUERY_PREFETCH = enum.auto()
+    SPARSE_WAIT_PREFETCH = enum.auto()
+    SPARSE_RETRIEVE = enum.auto()
+    SPARSE_CANCEL_PREFETCH = enum.auto()
+    SPARSE_RELEASE_PREFETCH = enum.auto()
+
     # Controller operations
     CLEAR = enum.auto()
     GET_CHUNK_SIZE = enum.auto()

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -15,6 +15,7 @@ This module defines the protocol for:
 
 # First Party
 from lmcache.utils import EngineType
+from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
@@ -48,6 +49,12 @@ REQUEST_NAMES = [
     "COMMIT_STORE",
     "PREPARE_RETRIEVE",
     "COMMIT_RETRIEVE",
+    "SPARSE_PREFETCH",
+    "SPARSE_QUERY_PREFETCH",
+    "SPARSE_WAIT_PREFETCH",
+    "SPARSE_RETRIEVE",
+    "SPARSE_CANCEL_PREFETCH",
+    "SPARSE_RELEASE_PREFETCH",
 ]
 
 # Type alias for cache keys
@@ -255,6 +262,56 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         ),
         "COMMIT_RETRIEVE": ProtocolDefinition(
             payload_classes=[KeyType, int],
+            response_class=bool,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Submit a logical sparse prefetch. The registered GPU context supplies
+        # the memory layouts; physical destination pages are not part of this
+        # request and are sent only with SPARSE_RETRIEVE.
+        "SPARSE_PREFETCH": ProtocolDefinition(
+            payload_classes=[int, str, int, int, list[ObjectKey]],
+            response_class=bool,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Return the retained-key indices over the original sparse request.
+        "SPARSE_QUERY_PREFETCH": ProtocolDefinition(
+            payload_classes=[int, str, int, int],
+            response_class=list[int] | None,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Block until the logical prefetch is complete, without consuming the
+        # retained-key lease.
+        "SPARSE_WAIT_PREFETCH": ProtocolDefinition(
+            payload_classes=[int, str, int, int, float],
+            response_class=list[int] | None,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Read the retained logical objects into the supplied physical pages.
+        # The response is (device-event-ipc-handle, (success, found-indices)).
+        "SPARSE_RETRIEVE": ProtocolDefinition(
+            payload_classes=[
+                int,
+                str,
+                int,
+                int,
+                list[ObjectKey],
+                list[list[int]],
+                bytes,
+            ],
+            response_class=tuple[bytes, tuple[bool, list[int]]],
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Cancel a pending logical prefetch and release its lease.
+        "SPARSE_CANCEL_PREFETCH": ProtocolDefinition(
+            payload_classes=[int, str, int, int],
+            response_class=bool,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        # Explicitly release a completed or pending sparse lease. This is
+        # intentionally separate from cancellation for adapters that expose
+        # consume/release as distinct lifecycle operations.
+        "SPARSE_RELEASE_PREFETCH": ProtocolDefinition(
+            payload_classes=[int, str, int, int],
             response_class=bool,
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/transport/base.py
+++ b/lmcache/v1/multiprocess/transport/base.py
@@ -94,6 +94,47 @@ class RequestClient(Protocol):
 
     def commit_retrieve(self, key: Any, instance_id: int) -> MessagingFuture[Any]: ...
 
+    def sparse_prefetch(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[Any],
+    ) -> MessagingFuture[Any]: ...
+
+    def sparse_query_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture[Any]: ...
+
+    def sparse_wait_prefetch(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        timeout: float,
+    ) -> MessagingFuture[Any]: ...
+
+    def sparse_retrieve(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[Any],
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]: ...
+
+    def sparse_cancel_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture[Any]: ...
+
+    def sparse_release_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture[Any]: ...
+
     def clear(self) -> MessagingFuture[Any]: ...
 
     def get_chunk_size(self) -> MessagingFuture[Any]: ...

--- a/lmcache/v1/multiprocess/transport/zmq_impl/client.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/client.py
@@ -180,6 +180,100 @@ class ZmqMultiprocessClient(RequestClient):
         """Commit an engine-driven retrieve."""
         return self._call(RequestType.COMMIT_RETRIEVE, key, instance_id)
 
+    def sparse_prefetch(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[Any],
+    ) -> MessagingFuture[Any]:
+        """Submit a logical sparse prefetch lease."""
+        return self._call(
+            RequestType.SPARSE_PREFETCH,
+            instance_id,
+            request_id,
+            generation,
+            layer_id,
+            keys,
+        )
+
+    def sparse_query_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture[Any]:
+        """Query a sparse prefetch without waiting for completion."""
+        return self._call(
+            RequestType.SPARSE_QUERY_PREFETCH,
+            instance_id,
+            request_id,
+            generation,
+            layer_id,
+        )
+
+    def sparse_wait_prefetch(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        timeout: float,
+    ) -> MessagingFuture[Any]:
+        """Wait for a sparse prefetch without consuming its lease."""
+        return self._call(
+            RequestType.SPARSE_WAIT_PREFETCH,
+            instance_id,
+            request_id,
+            generation,
+            layer_id,
+            timeout,
+        )
+
+    def sparse_retrieve(
+        self,
+        instance_id: int,
+        request_id: str,
+        generation: int,
+        layer_id: int,
+        keys: list[Any],
+        block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> MessagingFuture[Any]:
+        """Retrieve the retained sparse objects into physical GPU pages."""
+        return self._call(
+            RequestType.SPARSE_RETRIEVE,
+            instance_id,
+            request_id,
+            generation,
+            layer_id,
+            keys,
+            block_ids,
+            event_ipc_handle,
+        )
+
+    def sparse_cancel_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture[Any]:
+        """Cancel a sparse prefetch and release its lease."""
+        return self._call(
+            RequestType.SPARSE_CANCEL_PREFETCH,
+            instance_id,
+            request_id,
+            generation,
+            layer_id,
+        )
+
+    def sparse_release_prefetch(
+        self, instance_id: int, request_id: str, generation: int, layer_id: int
+    ) -> MessagingFuture[Any]:
+        """Release a sparse prefetch lease after consumption."""
+        return self._call(
+            RequestType.SPARSE_RELEASE_PREFETCH,
+            instance_id,
+            request_id,
+            generation,
+            layer_id,
+        )
+
     def clear(self) -> MessagingFuture[Any]:
         """Clear all server caches."""
         return self._call(RequestType.CLEAR)

--- a/lmcache/v1/multiprocess/transport/zmq_impl/server.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/server.py
@@ -174,6 +174,36 @@ def get_zmq_handler_specs(module: EngineModule) -> list[HandlerSpec]:
                 module.retrieve,
                 ThreadPoolType.AFFINITY,
             ),
+            HandlerSpec(
+                RequestType.SPARSE_PREFETCH,
+                module.sparse_prefetch,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.SPARSE_QUERY_PREFETCH,
+                module.sparse_query_prefetch,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.SPARSE_WAIT_PREFETCH,
+                module.sparse_wait_prefetch,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.SPARSE_RETRIEVE,
+                module.sparse_retrieve,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.SPARSE_CANCEL_PREFETCH,
+                module.sparse_cancel_prefetch,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.SPARSE_RELEASE_PREFETCH,
+                module.sparse_release_prefetch,
+                ThreadPoolType.NORMAL,
+            ),
         ]
     if isinstance(module, EngineDrivenTransferModule):
         return [

--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -2302,7 +2302,15 @@ def lmcache_memcpy_async(
         try:
             # Synchronous cudaMemcpy handles cross-cudaHostRegister boundaries
             # internally — no manual alignment splitting needed.
-            ret = libcudart.cudaMemcpy(
+            cuda_memcpy = libcudart.cudaMemcpy
+            cuda_memcpy.restype = ctypes.c_int
+            cuda_memcpy.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_size_t,
+                ctypes.c_int,
+            ]
+            ret = cuda_memcpy(
                 ctypes.c_void_p(dest),
                 ctypes.c_void_p(src),
                 ctypes.c_size_t(nbytes),

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -241,6 +241,60 @@ class TestPrefetchControllerLifecycle:
         ctrl.start()
         ctrl.stop()
 
+    def test_cancel_queued_request_publishes_empty_result(self, l1_manager):
+        """A queued generation can be cancelled before any adapter work starts."""
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=DefaultPrefetchPolicy(),
+            max_in_flight=0,
+        )
+        ctrl.start()
+
+        try:
+            req_id = ctrl.submit_prefetch_request(
+                PrefetchRequestSpec(keys, {0: layout}, generation=7)
+            )
+            assert not ctrl.cancel_prefetch_request(req_id, generation=8)
+            assert ctrl.cancel_prefetch_request(req_id, generation=7)
+            result = wait_for_prefetch_result_bitmap(ctrl, req_id)
+            assert result is not None
+            assert result.popcount() == 0
+            assert not ctrl.cancel_prefetch_request(req_id, generation=7)
+        finally:
+            ctrl.stop()
+
+    def test_forget_cancelled_result_does_not_retain_completion(self, l1_manager):
+        """A released cancellation suppresses its eventual result bitmap."""
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=DefaultPrefetchPolicy(),
+            max_in_flight=0,
+        )
+        ctrl.start()
+
+        try:
+            req_id = ctrl.submit_prefetch_request(
+                PrefetchRequestSpec(keys, {0: layout}, generation=7)
+            )
+            assert ctrl.cancel_prefetch_request(req_id, generation=7)
+            assert ctrl.forget_prefetch_result(req_id)
+            assert wait_for_condition(
+                lambda: req_id not in ctrl._request_generations,
+            )
+            assert ctrl.query_prefetch_result(req_id) is None
+            assert ctrl.query_lookup_result(req_id) is None
+            assert not ctrl.forget_prefetch_result(req_id)
+        finally:
+            ctrl.stop()
+
 
 # =============================================================================
 # Single Adapter Prefetch

--- a/tests/v1/distributed/test_sparda_prefetch_contract.py
+++ b/tests/v1/distributed/test_sparda_prefetch_contract.py
@@ -3,8 +3,8 @@
 """Contract tests for generation-scoped logical prefetch leases."""
 
 # Standard
-import threading
 from unittest.mock import Mock
+import threading
 
 # Third Party
 import pytest

--- a/tests/v1/distributed/test_sparda_prefetch_contract.py
+++ b/tests/v1/distributed/test_sparda_prefetch_contract.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for generation-scoped logical prefetch leases."""
+
+# Standard
+import threading
+from unittest.mock import Mock
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+    PrefetchHandle,
+    PrefetchRequestSpec,
+    TrimPolicy,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
+
+
+def _key(name: bytes = b"key") -> ObjectKey:
+    return ObjectKey(chunk_hash=name, model_name="contract-test", kv_rank=0)
+
+
+def _layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc([torch.Size([1])], [torch.float16])
+
+
+def test_generation_is_validated_and_carried_by_spec_and_handle():
+    spec = PrefetchRequestSpec(
+        keys=[_key()],
+        group_layout_descs={0: _layout()},
+        policy=TrimPolicy.SPARSE,
+        generation=4,
+    )
+    handle = PrefetchHandle(
+        prefetch_request_id=3,
+        external_request_id="request",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=spec.generation,
+    )
+
+    assert spec.generation == 4
+    assert handle.generation == 4
+    with pytest.raises(ValueError, match="generation"):
+        PrefetchRequestSpec(
+            keys=[_key()],
+            group_layout_descs={0: _layout()},
+            generation=-1,
+        )
+
+
+def test_l1_only_handles_have_independent_idempotent_cleanup():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage.finish_read_prefetched = Mock()
+
+    first = PrefetchHandle(
+        prefetch_request_id=-1,
+        external_request_id="first",
+        l1_found_indices=(0,),
+        l1_hit_chunks=1,
+        total_requested_keys=1,
+        submit_time=0.0,
+    )
+    second = PrefetchHandle(
+        prefetch_request_id=-1,
+        external_request_id="second",
+        l1_found_indices=(0,),
+        l1_hit_chunks=1,
+        total_requested_keys=1,
+        submit_time=0.0,
+    )
+    first_key = _key(b"first")
+    second_key = _key(b"second")
+    storage._remember_prefetch_handle(first, [first_key], 1)
+    storage._remember_prefetch_handle(second, [second_key], 1)
+
+    storage._release_prefetch_lease(first)
+    storage._release_prefetch_lease(first)
+
+    assert id(second) in storage._prefetch_handle_metadata
+    storage._release_prefetch_lease(second)
+    assert storage.finish_read_prefetched.call_count == 2
+    assert id(first) in storage._released_prefetch_handles
+    assert id(second) in storage._released_prefetch_handles
+
+
+def test_warm_handle_release_does_not_drop_nonexistent_read_locks():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage.finish_read_prefetched = Mock()
+
+    handle = PrefetchHandle(
+        prefetch_request_id=-1,
+        external_request_id="warm",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+    )
+    storage._remember_prefetch_handle(handle, [_key(b"warm")], 0)
+
+    storage.release_prefetch_task(handle)
+
+    assert storage.finish_read_prefetched.call_count == 0
+
+
+def test_release_uses_generation_guard_and_is_idempotent():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage._prefetch_controller = Mock()
+    storage._prefetch_controller.cancel_prefetch_request.return_value = False
+    storage.query_prefetch_status = Mock(return_value=None)
+    storage.finish_read_prefetched = Mock()
+
+    key = _key(b"release")
+    handle = PrefetchHandle(
+        prefetch_request_id=8,
+        external_request_id="request",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=12,
+    )
+    storage._remember_prefetch_handle(handle, [key], 2)
+
+    storage.release_prefetch_task(handle, [key])
+    storage.release_prefetch_task(handle, [key])
+
+    storage._prefetch_controller.cancel_prefetch_request.assert_called_once_with(
+        8, generation=12
+    )
+    storage._prefetch_controller.forget_prefetch_result.assert_called_once_with(
+        8, generation=12
+    )
+    storage.finish_read_prefetched.assert_called_once_with([key], read_locks=2)

--- a/tests/v1/distributed/test_sparda_prefetch_contract.py
+++ b/tests/v1/distributed/test_sparda_prefetch_contract.py
@@ -3,8 +3,12 @@
 """Contract tests for generation-scoped logical prefetch leases."""
 
 # Standard
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 from unittest.mock import Mock
+import gc
 import threading
+import weakref
 
 # Third Party
 import pytest
@@ -18,7 +22,12 @@ from lmcache.v1.distributed.api import (
     PrefetchRequestSpec,
     TrimPolicy,
 )
+from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.storage_manager import StorageManager
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    LMCacheDrivenTransferModule,
+    _SparsePrefetchJob,
+)
 
 
 def _key(name: bytes = b"key") -> ObjectKey:
@@ -27,6 +36,45 @@ def _key(name: bytes = b"key") -> ObjectKey:
 
 def _layout() -> MemoryLayoutDesc:
     return MemoryLayoutDesc([torch.Size([1])], [torch.float16])
+
+
+def test_read_prefetched_results_can_defer_release_until_copy_completion():
+    storage = StorageManager.__new__(StorageManager)
+    key = _key(b"deferred-read")
+    memory_obj = object()
+    finish_read = Mock(return_value={key: L1Error.SUCCESS})
+    storage._l1_manager = SimpleNamespace(
+        unsafe_read=Mock(return_value={key: (L1Error.SUCCESS, memory_obj)}),
+        finish_read=finish_read,
+    )
+    storage._event_bus = Mock()
+
+    with storage.read_prefetched_results([key], release_on_exit=False) as objs:
+        assert objs == [memory_obj]
+    finish_read.assert_not_called()
+
+    storage.finish_read_prefetched([key])
+    finish_read.assert_called_once_with([key], read_locks=1)
+
+
+def test_deferred_read_does_not_release_on_copy_exception():
+    storage = StorageManager.__new__(StorageManager)
+    key = _key(b"deferred-copy-error")
+    memory_obj = object()
+    finish_read = Mock(return_value={key: L1Error.SUCCESS})
+    storage._l1_manager = SimpleNamespace(
+        unsafe_read=Mock(return_value={key: (L1Error.SUCCESS, memory_obj)}),
+        finish_read=finish_read,
+    )
+    storage._event_bus = Mock()
+
+    with pytest.raises(RuntimeError, match="copy failed"):
+        with storage.read_prefetched_results([key], release_on_exit=False):
+            raise RuntimeError("copy failed")
+
+    finish_read.assert_not_called()
+    storage.finish_read_prefetched([key])
+    finish_read.assert_called_once_with([key], read_locks=1)
 
 
 def test_generation_is_validated_and_carried_by_spec_and_handle():
@@ -148,3 +196,504 @@ def test_release_uses_generation_guard_and_is_idempotent():
         8, generation=12
     )
     storage.finish_read_prefetched.assert_called_once_with([key], read_locks=2)
+
+
+def test_release_waits_for_controller_cleanup_before_releasing_l1_lock():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage._prefetch_controller = Mock()
+    storage._prefetch_controller.cancel_prefetch_request.return_value = True
+    storage.wait_prefetch_status = Mock(return_value=True)
+    storage.query_prefetch_status = Mock(return_value=None)
+    storage.finish_read_prefetched = Mock()
+
+    key = _key(b"wait-before-release")
+    handle = PrefetchHandle(
+        prefetch_request_id=9,
+        external_request_id="request",
+        l1_found_indices=(0,),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=13,
+    )
+    storage._remember_prefetch_handle(handle, [key], 1)
+
+    storage.release_prefetch_task(handle)
+
+    storage.wait_prefetch_status.assert_called_once_with(handle, timeout=None)
+    storage.finish_read_prefetched.assert_called_once_with([key], read_locks=1)
+
+
+def test_release_failure_keeps_lease_metadata_for_retry():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage.finish_read_prefetched = Mock(
+        side_effect=[RuntimeError("read lock release failed"), None]
+    )
+
+    key = _key(b"retry-release")
+    handle = PrefetchHandle(
+        prefetch_request_id=-1,
+        external_request_id="retry",
+        l1_found_indices=(0,),
+        l1_hit_chunks=1,
+        total_requested_keys=1,
+        submit_time=0.0,
+    )
+    storage._remember_prefetch_handle(handle, [key], 1)
+
+    with pytest.raises(RuntimeError, match="read lock release failed"):
+        storage._release_prefetch_lease(handle)
+
+    assert id(handle) in storage._prefetch_handle_metadata
+    assert id(handle) not in storage._released_prefetch_handles
+
+    storage._release_prefetch_lease(handle)
+
+    assert id(handle) not in storage._prefetch_handle_metadata
+    assert storage.finish_read_prefetched.call_count == 2
+
+
+def test_released_handle_bookkeeping_does_not_keep_handles_alive():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage.finish_read_prefetched = Mock()
+
+    handle = PrefetchHandle(
+        prefetch_request_id=-1,
+        external_request_id="weakref",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=0,
+        submit_time=0.0,
+    )
+    handle_id = id(handle)
+    storage._remember_prefetch_handle(handle, [], 0)
+    storage._release_prefetch_lease(handle)
+    handle_ref = weakref.ref(handle)
+
+    del handle
+    gc.collect()
+
+    assert handle_ref() is None
+    assert handle_id not in storage._released_prefetch_handles
+
+
+def test_concurrent_sparse_submit_keeps_one_job_and_releases_loser():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+    module.get_and_touch_context_entry = Mock(
+        return_value=SimpleNamespace(model_name="contract-test", world_size=1)
+    )
+    module._ctx = SimpleNamespace(
+        layout_desc_registry=SimpleNamespace(
+            find_group_layout_descs=Mock(return_value={0: _layout()}),
+            find_attn_desc=Mock(return_value=SimpleNamespace(num_object_groups=1)),
+        )
+    )
+
+    handles = []
+    submit_barrier = threading.Barrier(2)
+
+    def submit_prefetch_task(*_args, **_kwargs):
+        submit_barrier.wait(timeout=5)
+        handle = PrefetchHandle(
+            prefetch_request_id=len(handles),
+            external_request_id="request:0:1",
+            l1_found_indices=(),
+            l1_hit_chunks=0,
+            total_requested_keys=1,
+            submit_time=0.0,
+            generation=0,
+        )
+        handles.append(handle)
+        return handle
+
+    module._ctx.storage_manager = SimpleNamespace(
+        submit_prefetch_task=Mock(side_effect=submit_prefetch_task),
+        cancel_prefetch_task=Mock(),
+    )
+
+    results = []
+
+    def submit():
+        results.append(module.sparse_prefetch(0, "request", 0, 1, [_key()]))
+
+    threads = [threading.Thread(target=submit) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert sorted(results) == [True, True]
+    assert len(module._sparse_jobs) == 1
+    module._ctx.storage_manager.cancel_prefetch_task.assert_called_once()
+
+
+def test_duplicate_sparse_submit_retries_loser_cleanup_after_failure():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+    module.get_and_touch_context_entry = Mock(
+        return_value=SimpleNamespace(model_name="contract-test", world_size=1)
+    )
+    module._ctx = SimpleNamespace(
+        layout_desc_registry=SimpleNamespace(
+            find_group_layout_descs=Mock(return_value={0: _layout()}),
+            find_attn_desc=Mock(return_value=SimpleNamespace(num_object_groups=1)),
+        )
+    )
+
+    handles = []
+    submit_barrier = threading.Barrier(2)
+
+    def submit_prefetch_task(*_args, **_kwargs):
+        submit_barrier.wait(timeout=5)
+        handle = PrefetchHandle(
+            prefetch_request_id=len(handles),
+            external_request_id="request:0:1",
+            l1_found_indices=(),
+            l1_hit_chunks=0,
+            total_requested_keys=1,
+            submit_time=0.0,
+            generation=0,
+        )
+        handles.append(handle)
+        return handle
+
+    cancel = Mock(side_effect=[RuntimeError("temporary cleanup failure"), None])
+    module._ctx.storage_manager = SimpleNamespace(
+        submit_prefetch_task=Mock(side_effect=submit_prefetch_task),
+        cancel_prefetch_task=cancel,
+        release_prefetch_task=Mock(),
+    )
+
+    results = []
+
+    def submit():
+        results.append(module.sparse_prefetch(0, "request", 0, 1, [_key()]))
+
+    threads = [threading.Thread(target=submit) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert sorted(results) == [True, True]
+    assert len(module._sparse_jobs) == 1
+    assert len(module._sparse_orphan_handles) == 1
+
+    assert module._cleanup_sparse_instance(0) is True
+    assert module._sparse_orphan_handles == {}
+    assert cancel.call_count == 2
+
+
+def test_sparse_retrieve_waits_for_submitted_copy_before_release(monkeypatch):
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+
+    key = _key(b"retrieve")
+    handle = PrefetchHandle(
+        prefetch_request_id=11,
+        external_request_id="request:0:1",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=0,
+    )
+    job = _SparsePrefetchJob(
+        handle=handle,
+        keys=(key,),
+        instance_id=0,
+        request_id="request",
+        generation=0,
+        layer_id=1,
+        found_indices=(0,),
+    )
+    module._sparse_jobs[(0, "request", 0, 1)] = job
+
+    order = []
+
+    class _Stream:
+        def synchronize(self):
+            order.append("stream_synchronize")
+
+    cache_context = SimpleNamespace(
+        device=torch.device("cpu"),
+        stream=_Stream(),
+        cupy_stream=object(),
+        kv_layer_groups_manager=SimpleNamespace(
+            object_groups=[SimpleNamespace(kernel_group_indices=[0])],
+            num_kernel_groups=1,
+        ),
+        calculate_num_blocks=lambda *_args: 1,
+    )
+    event_backend = Mock()
+    event_backend.create_event.return_value = object()
+    event_backend.import_event.return_value = object()
+    entry = SimpleNamespace(
+        cache_context=cache_context,
+        model_name="contract-test",
+        world_size=1,
+        event_backend=event_backend,
+    )
+    module.get_and_touch_context_entry = Mock(return_value=entry)
+
+    @contextmanager
+    def read_prefetched_results(_keys, **_kwargs):
+        yield [object()]
+
+    def release_prefetch_task(_handle, **_kwargs):
+        order.append("release")
+
+    module._ctx = SimpleNamespace(
+        chunk_size=1,
+        storage_manager=SimpleNamespace(
+            read_prefetched_results=read_prefetched_results,
+            release_prefetch_task=release_prefetch_task,
+        ),
+    )
+
+    def stage_after_copy(*_args, **_kwargs):
+        order.append("copy_submitted")
+        raise RuntimeError("next object failed after the first H2D submit")
+
+    # First Party
+    from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as mod
+
+    monkeypatch.setattr(mod, "_stage_sparse_layer", stage_after_copy)
+    monkeypatch.setattr(mod, "submit_callback_to_stream", Mock())
+    monkeypatch.setattr(mod.torch_dev, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(mod.torch_dev, "stream", lambda _stream: nullcontext())
+
+    _event, result = module.sparse_retrieve(
+        0,
+        "request",
+        0,
+        1,
+        [key],
+        [[7]],
+        b"producer-event",
+    )
+
+    assert result == (False, [0])
+    assert order == [
+        "copy_submitted",
+        "stream_synchronize",
+        "release",
+    ]
+    assert module._sparse_jobs == {}
+
+
+def test_sparse_copy_sync_failure_retains_job_and_lease():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+
+    class _FailingStream:
+        def synchronize(self):
+            raise RuntimeError("stream is unavailable")
+
+    handle = PrefetchHandle(
+        prefetch_request_id=12,
+        external_request_id="request:0:1",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=0,
+    )
+    job = _SparsePrefetchJob(
+        handle=handle,
+        keys=(_key(b"retain"),),
+        instance_id=0,
+        request_id="request",
+        generation=0,
+        layer_id=1,
+        copy_submitted=True,
+        copy_stream=_FailingStream(),
+    )
+    module._sparse_jobs[(0, "request", 0, 1)] = job
+    module._ctx = SimpleNamespace(
+        storage_manager=SimpleNamespace(release_prefetch_task=Mock())
+    )
+
+    assert module._cleanup_sparse_job(job) is False
+    assert module._sparse_jobs[(0, "request", 0, 1)] is job
+    module._ctx.storage_manager.release_prefetch_task.assert_not_called()
+    assert isinstance(job.last_error, RuntimeError)
+
+
+def test_sparse_cancel_marks_job_before_releasing_lease():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+    handle = PrefetchHandle(
+        prefetch_request_id=13,
+        external_request_id="request:0:1",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=0,
+    )
+    job = _SparsePrefetchJob(
+        handle=handle,
+        keys=(_key(b"cancel"),),
+        instance_id=0,
+        request_id="request",
+        generation=0,
+        layer_id=1,
+    )
+    module._sparse_jobs[(0, "request", 0, 1)] = job
+    release_started = threading.Event()
+    allow_release = threading.Event()
+
+    def release_prefetch_task(_handle, **_kwargs):
+        release_started.set()
+        assert allow_release.wait(timeout=5)
+
+    module._ctx = SimpleNamespace(
+        storage_manager=SimpleNamespace(release_prefetch_task=release_prefetch_task)
+    )
+    cancel_thread = threading.Thread(
+        target=lambda: module.sparse_cancel_prefetch(0, "request", 0, 1)
+    )
+    cancel_thread.start()
+    assert release_started.wait(timeout=5)
+    with job.condition:
+        assert job.cancel_requested is True
+    allow_release.set()
+    cancel_thread.join(timeout=5)
+    assert not cancel_thread.is_alive()
+    assert module._sparse_jobs == {}
+
+
+def test_sparse_retrieve_rejects_job_marked_for_cancel(monkeypatch):
+    # First Party
+    from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as mod
+
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+    key = _key(b"cancel-before-retrieve")
+    handle = PrefetchHandle(
+        prefetch_request_id=14,
+        external_request_id="request:0:1",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=0,
+    )
+    job = _SparsePrefetchJob(
+        handle=handle,
+        keys=(key,),
+        instance_id=0,
+        request_id="request",
+        generation=0,
+        layer_id=1,
+        found_indices=(0,),
+        cancel_requested=True,
+    )
+    module._sparse_jobs[(0, "request", 0, 1)] = job
+
+    cache_context = SimpleNamespace(
+        device=torch.device("cpu"),
+        stream=object(),
+        cupy_stream=object(),
+        kv_layer_groups_manager=SimpleNamespace(
+            object_groups=[SimpleNamespace(kernel_group_indices=[0])],
+            num_kernel_groups=1,
+        ),
+        calculate_num_blocks=lambda *_args: 1,
+    )
+    event_backend = Mock()
+    event_backend.create_event.return_value = object()
+    event_backend.import_event.return_value = object()
+    event_backend.export_event.return_value = b"completion"
+    entry = SimpleNamespace(
+        cache_context=cache_context,
+        model_name="contract-test",
+        world_size=1,
+        event_backend=event_backend,
+    )
+    module.get_and_touch_context_entry = Mock(return_value=entry)
+    module._resolve_sparse_status = Mock(return_value=[0])
+
+    @contextmanager
+    def read_prefetched_results(_keys, **_kwargs):
+        yield [object()]
+
+    module._ctx = SimpleNamespace(
+        chunk_size=1,
+        storage_manager=SimpleNamespace(
+            read_prefetched_results=read_prefetched_results,
+        ),
+    )
+    stage = Mock()
+    monkeypatch.setattr(mod, "_stage_sparse_layer", stage)
+    monkeypatch.setattr(mod, "submit_callback_to_stream", Mock())
+    monkeypatch.setattr(mod.torch_dev, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(mod.torch_dev, "stream", lambda _stream: nullcontext())
+
+    _event, result = module.sparse_retrieve(
+        0,
+        "request",
+        0,
+        1,
+        [key],
+        [[7]],
+        b"producer-event",
+    )
+
+    assert result == (False, [0])
+    stage.assert_not_called()
+
+
+def test_sparse_completion_release_failure_leaves_job_retryable():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+    key = _key(b"completion-release")
+    handle = PrefetchHandle(
+        prefetch_request_id=15,
+        external_request_id="request:0:1",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=0,
+    )
+    job = _SparsePrefetchJob(
+        handle=handle,
+        keys=(key,),
+        instance_id=0,
+        request_id="request",
+        generation=0,
+        layer_id=1,
+        found_indices=(0,),
+        retrieving=True,
+        completion_submitted=True,
+    )
+    module._sparse_jobs[(0, "request", 0, 1)] = job
+    release = Mock(side_effect=RuntimeError("lease still busy"))
+    module._ctx = SimpleNamespace(
+        storage_manager=SimpleNamespace(release_prefetch_task=release)
+    )
+
+    module._complete_sparse_prefetch((0, "request", 0, 1))
+
+    assert module._sparse_jobs[(0, "request", 0, 1)] is job
+    assert job.retrieving is False
+    assert job.completed is False

--- a/tests/v1/distributed/test_sparda_prefetch_contract.py
+++ b/tests/v1/distributed/test_sparda_prefetch_contract.py
@@ -227,6 +227,34 @@ def test_release_waits_for_controller_cleanup_before_releasing_l1_lock():
     storage.finish_read_prefetched.assert_called_once_with([key], read_locks=1)
 
 
+def test_release_keeps_explicit_keys_after_controller_result_was_consumed():
+    storage = StorageManager.__new__(StorageManager)
+    storage._prefetch_release_lock = threading.Lock()
+    storage._released_prefetch_handles = {}
+    storage._prefetch_handle_metadata = {}
+    storage._prefetch_controller = Mock()
+    storage._prefetch_controller.cancel_prefetch_request.return_value = True
+    storage.wait_prefetch_status = Mock(return_value=True)
+    storage.query_prefetch_status = Mock(return_value=None)
+    storage.finish_read_prefetched = Mock()
+
+    key = _key(b"consumed-result")
+    handle = PrefetchHandle(
+        prefetch_request_id=10,
+        external_request_id="request",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=1,
+        submit_time=0.0,
+        generation=14,
+    )
+    storage._remember_prefetch_handle(handle, [key], 1)
+
+    storage.release_prefetch_task(handle, [key])
+
+    storage.finish_read_prefetched.assert_called_once_with([key], read_locks=1)
+
+
 def test_release_failure_keeps_lease_metadata_for_retry():
     storage = StorageManager.__new__(StorageManager)
     storage._prefetch_release_lock = threading.Lock()
@@ -534,6 +562,44 @@ def test_sparse_copy_sync_failure_retains_job_and_lease():
     assert isinstance(job.last_error, RuntimeError)
 
 
+def test_sparse_cleanup_releases_all_retrieved_keys_after_copy_sync():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+    keys = (_key(b"miss"), _key(b"hit"))
+    handle = PrefetchHandle(
+        prefetch_request_id=16,
+        external_request_id="request:0:1",
+        l1_found_indices=(),
+        l1_hit_chunks=0,
+        total_requested_keys=2,
+        submit_time=0.0,
+        generation=0,
+    )
+    job = _SparsePrefetchJob(
+        handle=handle,
+        keys=keys,
+        instance_id=0,
+        request_id="request",
+        generation=0,
+        layer_id=1,
+        found_indices=(1,),
+        copy_submitted=True,
+        copy_synchronized=True,
+    )
+    module._sparse_jobs[(0, "request", 0, 1)] = job
+    module._ctx = SimpleNamespace(
+        storage_manager=SimpleNamespace(release_prefetch_task=Mock())
+    )
+
+    assert module._cleanup_sparse_job(job) is True
+
+    module._ctx.storage_manager.release_prefetch_task.assert_called_once_with(
+        handle, keys=[keys[1]]
+    )
+    assert module._sparse_jobs == {}
+
+
 def test_sparse_cancel_marks_job_before_releasing_lease():
     module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
     module._sparse_jobs = {}
@@ -659,6 +725,14 @@ def test_sparse_retrieve_rejects_job_marked_for_cancel(monkeypatch):
 
     assert result == (False, [0])
     stage.assert_not_called()
+
+
+def test_sparse_cancel_missing_job_is_idempotent():
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+    module._sparse_jobs = {}
+    module._sparse_jobs_lock = threading.Lock()
+
+    assert module.sparse_cancel_prefetch(0, "missing", 0, 1) is True
 
 
 def test_sparse_completion_release_failure_leaves_job_retryable():

--- a/tests/v1/mp_observability/trace/test_codecs.py
+++ b/tests/v1/mp_observability/trace/test_codecs.py
@@ -12,6 +12,7 @@ from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
     PrefetchHandle,
+    PrefetchRequestSpec,
     TrimPolicy,
 )
 from lmcache.v1.mp_observability.trace import codecs
@@ -90,9 +91,35 @@ class TestPrefetchHandle:
             total_requested_keys=10,
             submit_time=12345.6,
             l2_orig_indices=(3, 4, 5),
+            generation=9,
         )
         out = _roundtrip(h)
         assert out == h
+
+    def test_legacy_trace_defaults_generation_to_zero(self):
+        h = PrefetchHandle(
+            prefetch_request_id=7,
+            external_request_id="req-1",
+            l1_found_indices=(),
+            l1_hit_chunks=0,
+            total_requested_keys=1,
+            submit_time=12345.6,
+        )
+        encoded = codecs._enc_prefetch_handle(h)
+        encoded.pop("generation")
+        assert codecs._dec_prefetch_handle(encoded).generation == 0
+
+
+class TestPrefetchRequestSpec:
+    def test_generation_roundtrip(self):
+        spec = PrefetchRequestSpec(
+            keys=[ObjectKey(chunk_hash=b"a", model_name="m", kv_rank=0)],
+            group_layout_descs={
+                0: MemoryLayoutDesc([torch.Size([1])], [torch.float16])
+            },
+            generation=11,
+        )
+        assert _roundtrip(spec) == spec
 
 
 class TestTrimPolicy:

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -22,10 +22,10 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     LMCacheDrivenTransferModule,
 )
+from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
 from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -23,6 +23,9 @@ from lmcache.v1.multiprocess.custom_types import (
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    LMCacheDrivenTransferModule,
+)
 from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,
@@ -73,6 +76,22 @@ def test_zmq_handler_specs_cover_all_p2p_request_types() -> None:
         RequestType.P2P_LOOKUP_AND_LOCK,
         RequestType.P2P_QUERY_LOOKUP_RESULTS,
         RequestType.P2P_UNLOCK_OBJECTS,
+    }
+
+
+def test_zmq_handler_specs_cover_sparse_prefetch_request_types() -> None:
+    """The LMCache transfer adapter exposes every sparse RPC handler."""
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
+
+    request_types = {spec.request_type for spec in get_zmq_handler_specs(module)}
+
+    assert request_types >= {
+        RequestType.SPARSE_PREFETCH,
+        RequestType.SPARSE_QUERY_PREFETCH,
+        RequestType.SPARSE_WAIT_PREFETCH,
+        RequestType.SPARSE_RETRIEVE,
+        RequestType.SPARSE_CANCEL_PREFETCH,
+        RequestType.SPARSE_RELEASE_PREFETCH,
     }
 
 

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -70,6 +70,12 @@ def _make_connector(healthy: bool = True) -> Any:
     conn._lmcache_chunk_size = _CHUNK_SIZE
     conn._mq_timeout = 5.0
     conn._event_backend = _FakeEventBackend()
+    conn.instance_id = 1
+    conn._sparse_handles = set()
+    conn._sparse_handles_lock = threading.Lock()
+    conn._sparse_key_cache = {}
+    conn._sparse_hash_cache = {}
+    conn._sparse_key_cache_lock = threading.Lock()
     return conn
 
 
@@ -335,6 +341,150 @@ def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> 
     # Unhealthy connector stored nothing -> the future must report failure.
     assert future.result(timeout=0) is False
     conn.req_client.store.assert_not_called()
+
+
+def test_sparse_release_keeps_cleanup_record_until_remote_success() -> None:
+    _, _, _, _, _, _ = _import_adapter_symbols()
+    conn = _make_connector(healthy=True)
+    conn.req_client = MagicMock(name="rpc_client")
+    key = ("request", 2, 3)
+    conn._sparse_handles = {key}
+
+    failed: MessagingFuture = MessagingFuture()
+    failed.set_result(False)
+    conn.req_client.sparse_release_prefetch.return_value = failed
+
+    future = conn.sparse_release_prefetch(*key)
+    assert future.result(timeout=0) is False
+    assert key in conn._sparse_handles
+
+    succeeded: MessagingFuture = MessagingFuture()
+    succeeded.set_result(True)
+    conn.req_client.sparse_release_prefetch.return_value = succeeded
+    future = conn.sparse_release_prefetch(*key)
+    assert future.result(timeout=0) is True
+    assert key not in conn._sparse_handles
+
+
+def test_sparse_object_keys_reuse_hashes_with_request_scoped_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated layer lookups reuse hashes without crossing generations."""
+    _, LMCacheMPConnector, _, _, _, _ = _import_adapter_symbols()
+    conn: Any = object.__new__(LMCacheMPConnector)
+    conn._lmcache_chunk_size = _CHUNK_SIZE
+    conn.model_name = "test-model"
+    conn.tp_size = 1
+    conn.worker_id = 0
+    conn._sparse_key_cache = {}
+    conn._sparse_hash_cache = {}
+    conn._sparse_key_cache_lock = threading.Lock()
+
+    class _Hasher:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def compute_chunk_hashes(self, token_ids, end):
+            self.calls += 1
+            return [bytes([index]) * 32 for index in range(end // _CHUNK_SIZE)]
+
+    hasher = _Hasher()
+    conn._sparse_token_hasher = hasher
+    token_ids = list(range(2 * _CHUNK_SIZE))
+
+    first = conn.create_sparse_object_keys(
+        token_ids,
+        [0],
+        cache_salt="salt-a",
+        request_id="request-1",
+        generation=3,
+        layer_id=0,
+    )
+    second = conn.create_sparse_object_keys(
+        token_ids,
+        [0],
+        cache_salt="salt-a",
+        request_id="request-1",
+        generation=3,
+        layer_id=1,
+    )
+    assert first == second
+    assert hasher.calls == 1
+
+    conn.create_sparse_object_keys(
+        token_ids,
+        [0],
+        cache_salt="salt-a",
+        request_id="request-1",
+        generation=4,
+        layer_id=0,
+    )
+    assert hasher.calls == 2
+
+
+def test_sparse_lease_future_retries_local_cleanup_after_failure() -> None:
+    adapter_mod, _, _, _, _, _ = _import_adapter_symbols()
+    raw_future: MessagingFuture = MessagingFuture()
+    raw_future.set_result(True)
+    cleanup_calls = []
+
+    def cleanup() -> None:
+        cleanup_calls.append(True)
+        if len(cleanup_calls) == 1:
+            raise RuntimeError("local cleanup failed")
+
+    future = adapter_mod._SparseLeaseFuture(
+        raw_future,
+        cleanup,
+        lambda result: result is True,
+    )
+
+    with pytest.raises(RuntimeError, match="local cleanup failed"):
+        future.result(timeout=0)
+    assert future.result(timeout=0) is True
+    assert len(cleanup_calls) == 2
+
+
+def test_unhealthy_sparse_cleanup_is_not_reported_as_remote_success() -> None:
+    _, _, _, _, _, _ = _import_adapter_symbols()
+    conn = _make_connector(healthy=False)
+    conn.req_client = MagicMock(name="rpc_client")
+    key = ("request", 4, 5)
+    conn._sparse_handles = {key}
+
+    cancel_future = conn.sparse_cancel_prefetch(*key)
+    release_future = conn.sparse_release_prefetch(*key)
+
+    assert cancel_future.result(timeout=0) is False
+    assert release_future.result(timeout=0) is False
+    assert key in conn._sparse_handles
+    conn.req_client.sparse_cancel_prefetch.assert_not_called()
+    conn.req_client.sparse_release_prefetch.assert_not_called()
+
+
+def test_close_keeps_sparse_cleanup_record_until_cancel_succeeds() -> None:
+    _, _, _, _, _, _ = _import_adapter_symbols()
+    conn = _make_connector(healthy=True)
+    conn.req_client = MagicMock(name="rpc_client")
+    conn._heartbeat = None
+    conn._registered = False
+    key = ("request", 5, 6)
+    conn._sparse_handles = {key}
+
+    failed: MessagingFuture = MessagingFuture()
+    failed.set_result(False)
+    succeeded: MessagingFuture = MessagingFuture()
+    succeeded.set_result(True)
+    conn.req_client.sparse_cancel_prefetch.side_effect = [failed, succeeded]
+
+    conn.close()
+    assert key in conn._sparse_handles
+    conn.req_client.close.assert_not_called()
+
+    conn.close()
+    assert key not in conn._sparse_handles
+    assert conn.req_client.sparse_cancel_prefetch.call_count == 2
+    conn.req_client.close.assert_called_once()
 
 
 def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(


### PR DESCRIPTION
**What this PR does / why we need it**:

SparDA can predict logical KV chunks before the next attention layer needs them. LMCache needs to keep those chunks protected until the asynchronous load and the consumer copy are finished. This PR adds a generation-scoped sparse-prefetch lease contract without exposing serving-engine physical block IDs to LMCache.

- Keep `ObjectKey` and `PrefetchRequestSpec(policy=TrimPolicy.SPARSE)` as the public boundary.
- Track one active job per `(instance, request, generation, layer)` and clean up competing handles safely.
- Keep L1 read locks and L2 load state alive until retrieve/copy completion; partial retrieve failures synchronize already-submitted copies before releasing keys.
- Make cancel/release idempotent and keep cleanup records reachable when the connector cannot confirm remote release.
- Add the SGLang adapter path, lifecycle tests, developer documentation, and a design note describing ownership and failure ordering.

The implementation has no SGLang dependency in LMCache and accepts logical keys/chunks only. Existing `PREFIX` and `WARM` behavior is unchanged.

**Special notes for your reviewers**:

- The lease is generation-scoped so a late result cannot be applied to a reused request slot.
- The serving adapter owns physical staging pages and page-table mapping; LMCache owns logical objects, controller state, and read locks.
- The contract covers one-layer lookahead. Multi-layer prediction, pipeline parallelism, and speculative decoding need additional scheduling rules.

**Tests**:

- The dependency-complete sparse contract and SGLang adapter targeted suite previously passed with 37 tests.
- The latest focused lifecycle regressions passed 3/3: consumed-result cleanup, release after sparse-copy synchronization, and idempotent cancellation.
- A copied sparse-contract run passed 19 tests with a temporary native-less shim. That run checks the Python contract only and is not being presented as native-extension or daemon proof.
- `git diff --check`, SPDX, isort, ruff, codespell, clang-format, mypy, and Rust format checks passed. Rust clippy is blocked on the current macOS toolchain by an existing Linux-only `io-uring` dependency issue; this PR does not change Rust code.

**Documentation and checklist**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
