### PR TITLE
[Bugfix] Remove per-request async lookup sleeps from the scheduler path

### DIFF
--- a/docs/source/getting_started/quickstart/share_kv_cache.rst
+++ b/docs/source/getting_started/quickstart/share_kv_cache.rst
@@ -124,6 +124,10 @@ Configure LMCache instances
 
 Create two configuration files for the P2P sharing setup. The values that differ between the files are the ``lmcache_instance_id`` and the P2P/controller port assignments.
 
+The old ``extra_config.lookup_backoff_time`` option is deprecated and ignored.
+Async lookup no longer adds a delay per request; the serving engine controls
+idle polling backoff. See :ref:`p2p_sharing` for compatibility notes.
+
 Instance 1 configuration (``p2p_example1.yaml``):
 
 .. code-block:: yaml
@@ -147,9 +151,6 @@ Instance 1 configuration (``p2p_example1.yaml``):
     controller_reply_url: "localhost:8400"
     lmcache_worker_ports: 8500
 
-    extra_config:
-      lookup_backoff_time: 0.001
-
 Instance 2 configuration (``p2p_example2.yaml``):
 
 .. code-block:: yaml
@@ -172,9 +173,6 @@ Instance 2 configuration (``p2p_example2.yaml``):
     controller_pull_url: "localhost:8300"
     controller_reply_url: "localhost:8400"
     lmcache_worker_ports: 8501
-
-    extra_config:
-      lookup_backoff_time: 0.001
 
 Save both files in the directory that you will mount into the container (referenced later as ``$YAML_FILES``).
 

--- a/docs/source/kv_cache/p2p_sharing.rst
+++ b/docs/source/kv_cache/p2p_sharing.rst
@@ -25,7 +25,13 @@ Configuration
 -------------
 
 Create two configuration files for the P2P sharing setup.
- 
+
+Async lookup submission and polling no longer sleep once per request.
+The old ``extra_config.lookup_backoff_time`` option is deprecated and ignored;
+remove it from existing configurations. Idle polling backoff belongs in the
+serving engine, after an empty engine step, so pending lookups do not delay
+runnable requests. Older vLLM versions without an engine-level yield may poll
+more frequently and use more CPU while lookups are pending.
 
 **Instance 1 Configuration (example1.yaml)**:
 
@@ -50,9 +56,6 @@ Create two configuration files for the P2P sharing setup.
     controller_reply_url: "localhost:8400"
     lmcache_worker_ports: 8500
 
-    extra_config:
-      lookup_backoff_time: 0.001
-
 **Instance 2 Configuration (example2.yaml)**:
 
 .. code-block:: yaml
@@ -75,9 +78,6 @@ Create two configuration files for the P2P sharing setup.
     controller_pull_url: "localhost:8300"
     controller_reply_url: "localhost:8400"
     lmcache_worker_ports: 8501
-
-    extra_config:
-      lookup_backoff_time: 0.001
 
 Setup and Usage
 ---------------
@@ -234,4 +234,3 @@ Second instance metrics:
     Query round successful prompt count: 50
 
 In this example, the warm-up round metric in long_doc_qa is used because no existing KV cache is reused within an instance to benefit solely from P2P sharing. With LMCache P2P sharing enabled, the time to first token (TTFT) is reduced by 54.7%, from 2.286 s to 1.036 s, with a 63.6% reduction in total inference time (37.957 s → 13.814 s).
-

--- a/examples/kv_cache_reuse/share_across_instances/p2p_sharing/example1.yaml
+++ b/examples/kv_cache_reuse/share_across_instances/p2p_sharing/example1.yaml
@@ -18,7 +18,6 @@ controller_reply_url: "localhost:8400"
 lmcache_worker_ports: 8500
 
 extra_config:
-  lookup_backoff_time: 0.001
   # P2P backend timeout configurations (optional, defaults shown)
   p2p_socket_recv_timeout_ms: 30000  # Socket receive timeout in milliseconds
   p2p_socket_send_timeout_ms: 10000  # Socket send timeout in milliseconds

--- a/examples/kv_cache_reuse/share_across_instances/p2p_sharing/example2.yaml
+++ b/examples/kv_cache_reuse/share_across_instances/p2p_sharing/example2.yaml
@@ -16,6 +16,3 @@ lmcache_instance_id: "lmcache_instance_2"
 controller_pull_url: "localhost:8300"
 controller_reply_url: "localhost:8400"
 lmcache_worker_ports: 8501
-
-extra_config:
-  lookup_backoff_time: 0.001

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -35,6 +35,10 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
     """
     ZMQ-based lookup client that communicates with a lookup server.
 
+    Submission and polling do not add a per-request backoff. The serving
+    engine is responsible for yielding between idle steps when all lookups
+    are pending, so runnable requests are not delayed by lookup polling.
+
     Related extra_config:
     - lookup_server_worker_ids:
         is a config to control create lookup server on some workers.
@@ -50,7 +54,16 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         self,
         config: LMCacheEngineConfig,
         metadata: LMCacheMetadata,
-    ):
+    ) -> None:
+        """Connect to lookup workers and start the response thread.
+
+        Args:
+            config (LMCacheEngineConfig): Lookup and token-database configuration.
+            metadata (LMCacheMetadata): Worker topology and engine RPC identity.
+
+        Raises:
+            AssertionError: If metadata does not specify an engine ID.
+        """
         # lookup_id -> first lookup time
         # this helps us support timeout semantics
         self.first_lookup_time: dict[str, float] = {}
@@ -149,18 +162,24 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         )
         self.thread.start()
 
-        # default backoff time
-        self.lookup_backoff_time = 0.01
-        if config.extra_config is not None:
-            self.lookup_backoff_time = float(
-                config.extra_config.get("lookup_backoff_time", self.lookup_backoff_time)
+        if config.extra_config and "lookup_backoff_time" in config.extra_config:
+            logger.warning(
+                "lookup_backoff_time is deprecated and ignored. Async lookup "
+                "no longer sleeps per request on the scheduler thread; idle "
+                "polling backoff must be handled by the serving engine."
             )
 
     def lookup_cache(self, lookup_id: str) -> Optional[int]:
-        """
-        -1 means not found;
-        None means ongoing;
-        int >= 0 means number of hit tokens
+        """Poll a lookup result without adding a delay while it is pending.
+
+        Args:
+            lookup_id (str): Request identifier to query. The first poll
+                registers the identifier and starts its timeout interval.
+
+        Returns:
+            Optional[int]: -1 for a newly registered lookup, None while pending,
+            or the minimum hit-token count across workers when complete.
+            An expired lookup returns 0 so the caller can recompute its tokens.
         """
         # Check if any aborted lookups are finished, send cleanup messages
         self._cleanup_finished_aborted_lookups()
@@ -170,7 +189,6 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 self.reqs_status[lookup_id] = None
                 self.first_lookup_time[lookup_id] = time.time()
             elif req_status is None:
-                time.sleep(self.lookup_backoff_time)
                 if (
                     time.time() - self.first_lookup_time[lookup_id]
                 ) * 1000 > self.config.lookup_timeout_ms:
@@ -196,6 +214,20 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         lookup_id: str,
         request_configs: Optional[dict] = None,
     ) -> Optional[int]:
+        """Send a lookup to each worker without waiting for its result.
+
+        Args:
+            token_ids (Union[torch.Tensor, list[int]]): Tokens to look up.
+            lookup_id (str): Identifier previously registered by lookup_cache().
+            request_configs (Optional[dict]): Per-request options, including tags.
+
+        Returns:
+            Optional[int]: None; results are obtained through lookup_cache().
+
+        Notes:
+            No polling backoff is added after dispatch. Socket sends retain
+            their existing transport-level blocking behavior.
+        """
         hashes: list[int] = []
         offsets = []
         for start, end, hash_val in self.token_database.process_tokens(
@@ -217,7 +249,6 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
 
         for i in range(self.world_size):
             self.push_sockets[i].send(msg_buf, copy=False)
-        time.sleep(self.lookup_backoff_time)
         return None
 
     def process_responses_from_workers(self):

--- a/tests/v1/lookup_client/test_async_lookup_scheduler_latency.py
+++ b/tests/v1/lookup_client/test_async_lookup_scheduler_latency.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only regressions for scheduler-side asynchronous lookup latency."""
+
+# Standard
+from collections.abc import Iterator
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import Mock
+import threading
+
+# Third Party
+import msgspec
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.lookup_client import lmcache_async_lookup_client as async_lookup
+from lmcache.v1.lookup_client.async_lookup_message import (
+    LookupCleanupMsg,
+    LookupRequestMsg,
+    LookupResponseMsg,
+)
+from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
+    LMCacheAsyncLookupClient,
+)
+from lmcache.v1.metadata import LMCacheMetadata
+
+pytestmark = pytest.mark.no_shared_allocator
+
+
+class FakeClock:
+    """Advance time explicitly so latency assertions do not depend on CPU load."""
+
+    def __init__(self) -> None:
+        self.now = 100.0
+        self.waits: list[float] = []
+
+    def time(self) -> float:
+        """Return the simulated wall-clock time in seconds."""
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        """Record a requested delay in seconds and advance the simulated clock."""
+        self.waits.append(seconds)
+        self.now += seconds
+
+
+class ResponseInbox:
+    """Feed serialized responses through the client's real response thread."""
+
+    def __init__(self) -> None:
+        self.messages: Queue[bytes] = Queue()
+        self.waiting = threading.Event()
+
+    def recv(self, copy: bool = False) -> bytes:
+        """Acknowledge the previous response and wait for the next message.
+
+        Args:
+            copy: Unused ZMQ-compatible argument.
+
+        Returns:
+            The next serialized worker response.
+        """
+        self.waiting.set()
+        return self.messages.get()
+
+    def respond(self, lookup_id: str, hit_tokens: int) -> None:
+        """Publish a worker result and wait until the client has processed it.
+
+        Args:
+            lookup_id: Request identifier to complete.
+            hit_tokens: Number of tokens found by one worker.
+
+        Raises:
+            AssertionError: If the response thread fails to make progress.
+        """
+        self.waiting.clear()
+        self.messages.put(
+            msgspec.msgpack.encode(
+                LookupResponseMsg(lookup_id=lookup_id, num_hit_tokens=hit_tokens)
+            )
+        )
+        assert self.waiting.wait(timeout=5), (
+            "Response thread did not publish the result"
+        )
+
+    def close(self, linger: int = 0) -> None:
+        """Accept the client's close call; no operating-system socket is owned.
+
+        Args:
+            linger: Unused ZMQ-compatible argument.
+        """
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> FakeClock:
+    """Replace only the lookup module's clock, leaving thread waits real."""
+    result = FakeClock()
+    monkeypatch.setattr(async_lookup, "time", result)
+    return result
+
+
+@pytest.fixture
+def lookup_client(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    clock: FakeClock,
+) -> Iterator[tuple[LMCacheAsyncLookupClient, list[Mock], ResponseInbox]]:
+    """Construct a two-worker client with in-memory transport and token hashing."""
+    inbox = ResponseInbox()
+    outgoing = [Mock(), Mock()]
+    monkeypatch.setattr(async_lookup, "get_zmq_context", Mock())
+    monkeypatch.setattr(
+        async_lookup, "get_zmq_rpc_path_lmcache", Mock(return_value="unused")
+    )
+    monkeypatch.setattr(
+        async_lookup, "get_zmq_socket", Mock(side_effect=[*outgoing, inbox])
+    )
+    monkeypatch.setattr(
+        "lmcache.v1.token_database.ChunkedTokenDatabase",
+        Mock(
+            return_value=SimpleNamespace(
+                process_tokens=Mock(return_value=[(0, 4, 11), (4, 8, 22)])
+            )
+        ),
+    )
+    backoff = getattr(request, "param", None)
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={} if backoff is None else {"lookup_backoff_time": backoff},
+        lookup_timeout_ms=3000,
+    )
+    metadata = LMCacheMetadata(
+        model_name="test-model",
+        world_size=2,
+        local_world_size=2,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.float16,
+        kv_shape=(1, 2, 4, 1, 8),
+        engine_id="scheduler-latency-test",
+    )
+    client = LMCacheAsyncLookupClient(config, metadata)
+    assert inbox.waiting.wait(timeout=5)
+    try:
+        yield client, outgoing, inbox
+    finally:
+        # Wake recv so close can join the response thread without a timeout.
+        client.running = False
+        inbox.messages.put(
+            msgspec.msgpack.encode(
+                LookupResponseMsg(lookup_id="shutdown", num_hit_tokens=0)
+            )
+        )
+        client.close()
+
+
+@pytest.mark.parametrize("lookup_client", [None, 0, 0.001, 0.01], indirect=True)
+@pytest.mark.parametrize("num_requests", [1, 8, 32, 128])
+def test_submission_does_not_back_off_per_request(
+    lookup_client: tuple[LMCacheAsyncLookupClient, list[Mock], ResponseInbox],
+    clock: FakeClock,
+    num_requests: int,
+) -> None:
+    """Submit each request to every worker without waiting for a response."""
+    client, outgoing, _ = lookup_client
+    configs = {"lmcache.tag.user": "test-user"}
+    for index in range(num_requests):
+        lookup_id = f"request-{index}"
+        assert client.lookup_cache(lookup_id) == -1
+        assert client.lookup(list(range(8)), lookup_id, configs) is None
+
+    assert clock.waits == []
+    for socket in outgoing:
+        assert socket.send.call_count == num_requests
+        for index, call in enumerate(socket.send.call_args_list):
+            message = msgspec.msgpack.decode(call.args[0], type=LookupRequestMsg)
+            assert message.lookup_id == f"request-{index}"
+            assert message.hashes == [11, 22]
+            assert message.offsets == [4, 4]
+            assert message.request_configs == configs
+
+
+@pytest.mark.parametrize("lookup_client", [None, 0, 0.001, 0.01], indirect=True)
+@pytest.mark.parametrize("num_requests", [1, 8, 32, 128])
+def test_pending_scan_does_not_back_off_per_request(
+    lookup_client: tuple[LMCacheAsyncLookupClient, list[Mock], ResponseInbox],
+    clock: FakeClock,
+    num_requests: int,
+) -> None:
+    """Polling pending requests must not accumulate a delay or resend work."""
+    client, outgoing, _ = lookup_client
+    for index in range(num_requests):
+        assert client.lookup_cache(f"request-{index}") == -1
+
+    for _ in range(2):
+        for index in range(num_requests):
+            assert client.lookup_cache(f"request-{index}") is None
+
+    assert clock.waits == []
+    for socket in outgoing:
+        socket.send.assert_not_called()
+
+
+def test_responses_are_published_between_pending_polls(
+    lookup_client: tuple[LMCacheAsyncLookupClient, list[Mock], ResponseInbox],
+    clock: FakeClock,
+) -> None:
+    """Return pending until all workers respond, then cache their minimum hit count."""
+    client, _, inbox = lookup_client
+    assert client.lookup_cache("request") == -1
+    assert client.lookup(list(range(8)), "request") is None
+    assert client.lookup_cache("request") is None
+    inbox.respond("request", 8)
+    assert client.lookup_cache("request") is None
+    inbox.respond("request", 4)
+    assert client.lookup_cache("request") == 4
+    assert client.lookup_cache("request") == 4
+    assert clock.waits == []
+    client.clear_lookup_status("request")
+    assert client.lookup_cache("request") == -1
+
+
+@pytest.mark.parametrize("cancel", [False, True], ids=["timeout", "cancel"])
+def test_aborted_lookup_waits_for_all_workers_before_cleanup(
+    lookup_client: tuple[LMCacheAsyncLookupClient, list[Mock], ResponseInbox],
+    clock: FakeClock,
+    cancel: bool,
+) -> None:
+    """Preserve timeout boundaries and deferred cleanup for late worker responses."""
+    client, outgoing, inbox = lookup_client
+    assert client.lookup_cache("request") == -1
+    if cancel:
+        client.cancel_lookup("request")
+    else:
+        clock.now += 3
+        assert client.lookup_cache("request") is None
+        clock.now += 0.001
+        assert client.lookup_cache("request") == 0
+
+    inbox.respond("request", 8)
+    client.lookup_cache("another-request")
+    for socket in outgoing:
+        socket.send.assert_not_called()
+
+    inbox.respond("request", 4)
+    assert client.lookup_cache("another-request") is None
+    for socket in outgoing:
+        socket.send.assert_called_once()
+        message = msgspec.msgpack.decode(
+            socket.send.call_args.args[0], type=LookupCleanupMsg
+        )
+        assert message.lookup_id == "request"
+
+    assert client.lookup_cache("request") == -1
+    for socket in outgoing:
+        assert socket.send.call_count == 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #4983.

`LMCacheAsyncLookupClient` currently sleeps once per initial submission and once per pending poll on the vLLM scheduler thread. With the default 10 ms backoff, scanning 128 pending requests adds about 1.3 seconds of delay. The pending-poll sleep also holds the lock needed by the response thread to publish results.

This patch removes both sleeps. It deprecates `extra_config.lookup_backoff_time`: existing configurations remain loadable, but the option is ignored with a warning. The P2P examples and documentation are updated accordingly. Socket sends retain their existing transport-level blocking behavior.

Adds 35 CPU-only regression cases covering submission and repeated polling at 1/8/32/128 requests with default, zero, 1 ms, and 10 ms backoff settings; worker-message contents; response publication through the real response thread; minimum hit counts across two workers; and timeout/cancellation cleanup after late responses.

**Special notes for your reviewers**:

This is a draft for feedback on the compatibility policy:

- The serving engine should handle idle polling backoff after an empty engine step. vLLM 0.27.1 has such a yield; older versions such as 0.10.2 and 0.11.2 lack it and may poll more frequently after this change. Should async loading establish a version floor, or should a separate engine-level fallback be provided? This patch does not add a wait at `build_connector_meta()`, because an empty scheduler output does not imply that the pipelined engine has no executor result to consume.
- Explicit admission/backpressure controls are left for a separate change. Removing the sleeps can make submission burstier.
- The existing timeout-then-repoll `KeyError` is unchanged and overlaps #3722 / #3766. This draft should be coordinated with that fix and the cancellation cleanup work in #5006.

Validation on base `21a5db10`:

- New regression module: **35 passed**. Against the original implementation, the same cases produced **34 failed, 1 passed**.
- `PYTHONHASHSEED=0 PYTHONPATH=. pytest -xq tests/v1/lookup_client tests/v1/test_vllm_integration.py`: **60 passed**.
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`: passed. The new test file also passed an explicit `pre-commit run --files` check before staging.
- The standard test suite did not complete: `test_cross_process_round_trip_of_interior_view[torch]` encountered a child-process CUDA `invalid resource handle` error and left the parent waiting. The same error/hang was reproduced on the unmodified base.
- `make clean` followed by `make html SPHINXOPTS='-W --keep-going'` produced 31 Sphinx diagnostics. An unmodified-base build produced the identical diagnostics. The two changed HTML pages, their YAML examples, and the compatibility-note link were checked.

Isolated CPU timing, median of three runs, using the real client with a simulated transport, deterministic token chunks, and the original default 10 ms backoff:

| Requests | Initial submissions before / after (ms) | One pending scan before / after (ms) |
| --- | --- | --- |
| 1 | 10.1511 / 0.0441 | 10.1052 / 0.0017 |
| 8 | 81.2157 / 0.1030 | 80.9744 / 0.0051 |
| 32 | 324.9208 / 0.2865 | 323.4361 / 0.0139 |
| 128 | 1298.9764 / 1.1599 | 1293.5497 / 0.0410 |

These measurements cover client-side dispatch/polling overhead, not backend latency or end-to-end serving performance. Implementation, tests, and this description were prepared with AI assistance.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
