### PR TITLE
[Bugfix][MP] Hold the transfer context across a transfer, retire the one it replaces

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Protocol
 import enum
@@ -1215,6 +1216,11 @@ class LMCacheMPWorkerAdapter:
         self.engine_group_infos: list[EngineGroupInfo] = []
         # Transport context for transfer operations.
         self.transfer_ctx: TransferContext | None = None
+        # Guards the context swap against transfers already running on the
+        # context being replaced. Transfers hold a count; the swap waits for
+        # it to fall to zero before publishing and retiring.
+        self._ctx_cond = threading.Condition()
+        self._ctx_inflight = 0
 
         # Request futures
         self.store_futures: dict[str, MessagingFuture[StoreResult]] = {}
@@ -1388,6 +1394,94 @@ class LMCacheMPWorkerAdapter:
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
         return expand_engine_block_ids(self.engine_group_infos, op.block_ids)
 
+    @contextmanager
+    def _held_transfer_ctx(self) -> "Iterator[TransferContext | None]":
+        """Hold the published transfer context for the duration of a transfer.
+
+        The context is read once and pinned for the block: a server restart
+        re-registers on the heartbeat thread, and the transfer paths
+        dereference views into the pool the context owns. Reading the
+        attribute again mid-transfer, or letting the swap retire the context
+        while a copy is in flight, touches memory the replacement has already
+        unmapped.
+
+        Yields:
+            The published context, held until the block exits, or ``None``
+            when nothing is registered.
+        """
+        with self._ctx_cond:
+            ctx = self.transfer_ctx
+            if ctx is None:
+                yield None
+                return
+            self._ctx_inflight += 1
+        try:
+            yield ctx
+        finally:
+            with self._ctx_cond:
+                self._ctx_inflight -= 1
+                if not self._ctx_inflight:
+                    self._ctx_cond.notify_all()
+
+    def _publish_transfer_ctx(
+        self, new_ctx: TransferContext
+    ) -> "TransferContext | None":
+        """Publish a registered context once no transfer is using the old one.
+
+        The wait is bounded: this runs on the heartbeat thread, and blocking
+        it for an unbounded time would stop the pings that keep the worker
+        from being reaped.
+
+        Args:
+            new_ctx: The context to publish; must already be registered.
+
+        Returns:
+            The context that was replaced, for the caller to retire. ``None``
+            on the first registration, and also when transfers were still
+            running at the deadline: such a context is leaked rather than
+            closed under a live copy, which is the behaviour this replaces
+            and is still preferable to faulting the rank.
+        """
+        deadline = time.monotonic() + self._mq_timeout
+        with self._ctx_cond:
+            while self._ctx_inflight:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._ctx_cond.wait(remaining)
+            old_ctx = self.transfer_ctx
+            self.transfer_ctx = new_ctx
+            if self._ctx_inflight:
+                logger.warning(
+                    "Transfers still in flight after %ss; leaving the replaced "
+                    "transfer context open instead of closing it under them",
+                    self._mq_timeout,
+                )
+                return None
+            return old_ctx
+
+    @staticmethod
+    def _retire_transfer_ctx(old_ctx: "TransferContext | None") -> None:
+        """Drain and close a context that is no longer published.
+
+        Closing is what unpins the SHM pool and unmaps it. Left to the
+        garbage collector, the unpin never runs at all, so the device keeps a
+        host registration over an address range that is unmapped later, at a
+        moment nothing orders against the copies still reading it.
+
+        Args:
+            old_ctx: The replaced context, or ``None`` on first registration.
+        """
+        if old_ctx is None:
+            return
+        try:
+            old_ctx.flush_inflight_stores()
+            torch_dev.synchronize()
+        except Exception:
+            logger.exception("Failed to drain the replaced transfer context")
+        finally:
+            old_ctx.close()
+
     def _send_register_kv_caches_request(
         self,
         kv_caches: dict[str, torch.Tensor],
@@ -1407,11 +1501,11 @@ class LMCacheMPWorkerAdapter:
         self.kv_caches = kv_caches
         transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
         layout_hints = self._layout_hints
-        self.transfer_ctx = transfer_ctx
         try:
-            # Register on the local, not self.transfer_ctx: a concurrent
-            # shutdown() may null self.transfer_ctx between publish and this
-            # call. The local is always non-None.
+            # Register before publishing: a context is visible to the transfer
+            # paths only once its transport exists, so a store arriving during
+            # a re-registration keeps using the context it replaces rather
+            # than failing against a half-built one.
             transfer_ctx.register(
                 self.instance_id,
                 kv_caches,
@@ -1430,6 +1524,7 @@ class LMCacheMPWorkerAdapter:
                 "register_kv_caches within "
                 f"{self._mq_timeout}s. Is the server running?"
             ) from None
+        self._retire_transfer_ctx(self._publish_transfer_ctx(transfer_ctx))
 
     def _ensure_heartbeat_started(self) -> None:
         """Lazily start the heartbeat thread on first store/retrieve.
@@ -1571,20 +1666,21 @@ class LMCacheMPWorkerAdapter:
             cache_salt=cache_salt,
             request_configs=request_configs,
         )
-        if self.transfer_ctx is None:
-            raise RuntimeError(
-                "Transfer context is not initialized. "
-                "Call register_kv_caches() before submitting store requests."
+        with self._held_transfer_ctx() as transfer_ctx:
+            if transfer_ctx is None:
+                raise RuntimeError(
+                    "Transfer context is not initialized. "
+                    "Call register_kv_caches() before submitting store requests."
+                )
+            future = transfer_ctx.submit_store(
+                request_id,
+                key,
+                self.instance_id,
+                self.kv_caches,
+                self._block_ids_per_group(op),
+                event,
+                self.blocks_in_chunk,
             )
-        future = self.transfer_ctx.submit_store(
-            request_id,
-            key,
-            self.instance_id,
-            self.kv_caches,
-            self._block_ids_per_group(op),
-            event,
-            self.blocks_in_chunk,
-        )
         self.store_futures[request_id] = future
         if event is not None:
             self.store_events[request_id] = event
@@ -1630,21 +1726,22 @@ class LMCacheMPWorkerAdapter:
             cache_salt=cache_salt,
             request_configs=request_configs,
         )
-        if self.transfer_ctx is None:
-            raise RuntimeError(
-                "Transfer context is not initialized. "
-                "Call register_kv_caches() before submitting retrieve requests."
+        with self._held_transfer_ctx() as transfer_ctx:
+            if transfer_ctx is None:
+                raise RuntimeError(
+                    "Transfer context is not initialized. "
+                    "Call register_kv_caches() before submitting retrieve requests."
+                )
+            future = transfer_ctx.submit_retrieve(
+                request_id,
+                key,
+                self.instance_id,
+                self.kv_caches,
+                self._block_ids_per_group(op),
+                event,
+                self.blocks_in_chunk,
+                skip_first_n_tokens=op.skip_first_n_tokens,
             )
-        future = self.transfer_ctx.submit_retrieve(
-            request_id,
-            key,
-            self.instance_id,
-            self.kv_caches,
-            self._block_ids_per_group(op),
-            event,
-            self.blocks_in_chunk,
-            skip_first_n_tokens=op.skip_first_n_tokens,
-        )
         self.retrieve_futures[request_id] = (future, op.flat_block_ids)
         if event is not None:
             self.retrieve_events[request_id] = event
@@ -2053,11 +2150,14 @@ class LMCacheMPWorkerAdapter:
         """
         if not need_flush_before_forward:
             return
-        if not self.is_healthy or self.transfer_ctx is None:
+        if not self.is_healthy:
             return
-        self.transfer_ctx.flush_inflight_stores()
-        # Force device sync here, compare to preemption, perf panelty is trivial
-        torch_dev.synchronize()
+        with self._held_transfer_ctx() as transfer_ctx:
+            if transfer_ctx is None:
+                return
+            transfer_ctx.flush_inflight_stores()
+            # Force device sync here, compare to preemption, perf panelty is trivial
+            torch_dev.synchronize()
 
     def shutdown(self) -> None:
         """

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -976,12 +976,12 @@ def test_startup_does_not_warn_for_default_heartbeat_interval(
     assert not any("reap" in msg for msg in warnings)
 
 
-def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+def test_recover_callback_rebuilds_and_retires_transfer_ctx(
     fake_adapter, monkeypatch
 ) -> None:
-    """Pin current behavior: every recover-callback invocation rebuilds
-    ``transfer_ctx`` without closing the previous context (known IPC leak;
-    in-flight submissions may still hold a reference to the old context)."""
+    """Every recover-callback invocation rebuilds ``transfer_ctx`` and retires
+    the context it replaces, draining it first. This used to leave the old
+    context to the garbage collector, which never runs the unpin at all."""
     adapter, _send_mock, _ = fake_adapter
     contexts = _patch_transfer_context_factory(monkeypatch)
 
@@ -995,18 +995,16 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
     assert len(contexts) == 1
     assert adapter.transfer_ctx is contexts[0]
 
-    # Each recover-callback invocation rebuilds transfer_ctx without closing
-    # the previous context (known IPC leak; in-flight submissions may still
-    # hold a reference to the old context).
     assert heartbeat.recover_callback() is True
     assert len(contexts) == 2
     assert adapter.transfer_ctx is contexts[1]
-    contexts[0].close.assert_not_called()
+    contexts[0].flush_inflight_stores.assert_called_once_with()
+    contexts[0].close.assert_called_once_with()
 
     assert heartbeat.recover_callback() is True
     assert len(contexts) == 3
     assert adapter.transfer_ctx is contexts[2]
-    contexts[1].close.assert_not_called()
+    contexts[1].close.assert_called_once_with()
 
 
 # For the experimental dispatcher
@@ -1040,3 +1038,132 @@ def test_recovery_reports_the_ring_re_registration_result(fake_adapter, ring_ok)
     adapter.register_kv_caches({"layer.0": fake_tensor})
 
     assert adapter._reregister_kv_caches_callback() is ring_ok
+
+
+def _registered_adapter(fake_adapter, monkeypatch) -> tuple:
+    """Register one KV cache and return ``(adapter, first_context, contexts)``."""
+    adapter, _send_mock, _future = fake_adapter
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    contexts = _patch_transfer_context_factory(monkeypatch)
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    adapter.register_kv_caches({"layer.0": fake_tensor})
+    assert len(contexts) == 1
+    return adapter, contexts[0], contexts
+
+
+def test_failed_reregistration_keeps_serving_the_previous_context(
+    fake_adapter, monkeypatch
+):
+    """A context is published only once it has registered.
+
+    Publishing before ``register`` returns exposes a context whose transport
+    is not built yet, so a store landing in that window fails against a
+    half-built context instead of the working one it replaced.
+    """
+    adapter, old_ctx, _contexts = _registered_adapter(fake_adapter, monkeypatch)
+    failing_ctx = MagicMock(name="failing_ctx")
+    failing_ctx.register.side_effect = ConnectionError("server still down")
+    monkeypatch.setattr(
+        adapter_mod, "create_transfer_context", lambda *a, **kw: failing_ctx
+    )
+
+    assert adapter._reregister_kv_caches_callback() is False
+
+    assert adapter.transfer_ctx is old_ctx
+    old_ctx.close.assert_not_called()
+
+
+def test_context_swap_waits_for_an_inflight_submit(fake_adapter, monkeypatch):
+    """The swap must not retire a context a store is still transferring into.
+
+    ``submit_store`` gathers into slot views over the old pool. Retiring that
+    context while the gather is in flight unmaps the pages the copy is
+    writing, which faults in native code and takes the whole engine down with
+    the rank.
+    """
+    adapter, old_ctx, contexts = _registered_adapter(fake_adapter, monkeypatch)
+    second_created = threading.Event()
+    inner_factory = adapter_mod.create_transfer_context
+
+    def counting_factory(*args, **kwargs):
+        ctx = inner_factory(*args, **kwargs)
+        second_created.set()
+        return ctx
+
+    monkeypatch.setattr(adapter_mod, "create_transfer_context", counting_factory)
+
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+    closed_during_submit: list[bool] = []
+
+    def blocking_submit(*_args, **_kwargs):
+        submit_entered.set()
+        assert release_submit.wait(timeout=10)
+        closed_during_submit.append(bool(old_ctx.close.call_args_list))
+        return MagicMock(name="store_future")
+
+    old_ctx.submit_store.side_effect = blocking_submit
+
+    storer = threading.Thread(
+        target=adapter.submit_store_request, args=("store", _op([[0]]), None)
+    )
+    storer.start()
+    assert submit_entered.wait(timeout=10)
+
+    swapper = threading.Thread(target=adapter._reregister_kv_caches_callback)
+    swapper.start()
+    try:
+        # The replacement is built before the swap, so this only says the
+        # re-registration is under way, not that it has taken effect.
+        assert second_created.wait(timeout=10)
+        published_during_submit = adapter.transfer_ctx
+    finally:
+        # Always release, so a failed assertion here does not also hang the
+        # store thread and bury the real reason.
+        release_submit.set()
+    storer.join(timeout=10)
+    swapper.join(timeout=10)
+    assert published_during_submit is old_ctx, "swapped while a store was in flight"
+    assert not storer.is_alive() and not swapper.is_alive()
+
+    assert closed_during_submit == [False], "old context closed under a live store"
+    assert adapter.transfer_ctx is contexts[1]
+    old_ctx.close.assert_called_once_with()
+
+
+def test_swap_leaves_a_wedged_context_open_rather_than_stalling_recovery(
+    fake_adapter, monkeypatch
+):
+    """A transfer outliving the drain deadline must not stall recovery.
+
+    The swap runs on the heartbeat thread, so blocking it without bound would
+    stop the pings that keep the worker from being reaped. Past the deadline
+    the replacement is published anyway and the old context is left open,
+    which leaks it but never closes a pool a copy is still writing into.
+    """
+    adapter, old_ctx, contexts = _registered_adapter(fake_adapter, monkeypatch)
+    adapter._mq_timeout = 0.05
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+
+    def blocking_submit(*_args, **_kwargs):
+        submit_entered.set()
+        assert release_submit.wait(timeout=10)
+        return MagicMock(name="store_future")
+
+    old_ctx.submit_store.side_effect = blocking_submit
+    storer = threading.Thread(
+        target=adapter.submit_store_request, args=("store", _op([[0]]), None)
+    )
+    storer.start()
+    assert submit_entered.wait(timeout=10)
+
+    try:
+        assert adapter._reregister_kv_caches_callback() is True
+        assert adapter.transfer_ctx is contexts[1]
+        old_ctx.close.assert_not_called()
+    finally:
+        release_submit.set()
+        storer.join(timeout=10)
+    assert not storer.is_alive()


### PR DESCRIPTION
Fixes #4069.

## Problem

A server restart re-registers KV caches on the heartbeat thread while the model runner is still transferring. In `engine_driven` SHM mode the transfer paths dereference `torch.frombuffer` views into the pool the context owns, so anything that retires that context mid-transfer reaches native code: the reporter saw a TP rank die with no Python traceback, which took the executor and then EngineCore down with it.

Three separate windows:

1. `submit_store_request` and `submit_retrieve_request` read `self.transfer_ctx` twice, once to null-check and once to call, so the swap could land between the two reads.
2. The replaced context was dropped rather than closed. Only `close()` runs `_unpin_shm_buffer`, so the `cudaHostUnregister` never happened at all and the unmap was left to `SharedMemory.__del__`: the device kept a host registration over an address range that was unmapped later, at a moment nothing ordered against the copies still reading it.
3. The new context was published before `register()` ran, so a store arriving mid-recovery met a context whose transport did not exist yet.

## Fix

- Transfers take the context once and hold it for their duration (`_held_transfer_ctx`), which also covers `flush_before_forward`.
- The swap waits for in-flight transfers, then drains (`flush_inflight_stores` + device sync) and closes the context it replaces.
- A context is published only once `register()` has returned; a failed re-registration leaves the working context in place.

The drain wait is bounded by `mq_timeout`, because it runs on the heartbeat thread and stalling it would stop the pings that keep the worker from being reaped. Past that deadline the old context is leaked rather than closed under a live copy, which is exactly what happened before this change.

## A pinned behaviour changes

`test_recover_callback_rebuilds_transfer_ctx_without_closing_previous` asserted the old context is never closed, describing it as a "known IPC leak; in-flight submissions may still hold a reference to the old context". That is this bug, so the test now asserts the context is drained and retired instead.

## Verification

All CPU-only, no hardware needed. Each new test fails on `dev` and passes with the fix (checked by reverting just the adapter change):

- `test_context_swap_waits_for_an_inflight_submit`: on `dev` the swap lands mid-store ("swapped while a store was in flight") and the old context is never closed.
- `test_failed_reregistration_keeps_serving_the_previous_context`: on `dev` the half-built context is published even though `register()` raised.
- `test_recover_callback_rebuilds_and_retires_transfer_ctx`: on `dev` `flush_inflight_stores` and `close` are never called.
- `test_swap_leaves_a_wedged_context_open_rather_than_stalling_recovery`: pins the bounded-wait tradeoff.

`tests/v1/test_vllm_mp_adapter.py`, `tests/v1/test_vllm_dcp_support.py` and `tests/v1/multiprocess/` are green, with the same result on `dev` and on this branch. Pinned pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
