### PR TITLE
[Bugfix][MP] Pass replica config to Mooncake write operations

### DIFF
--- a/csrc/storage_backends/mooncake/connector.cpp
+++ b/csrc/storage_backends/mooncake/connector.cpp
@@ -2,6 +2,7 @@
 
 // Standard
 #include <algorithm>
+#include <charconv>
 #include <cstdint>
 #include <cstdio>
 #include <stdexcept>
@@ -19,6 +20,28 @@ namespace connector {
 
 namespace {
 
+mooncake::ReplicateConfig parse_replicate_config(const ConfigDict& config) {
+  const auto parse_count = [&config](const char* key, size_t& count) {
+    const auto it = config.find(key);
+    if (it == config.end()) {
+      return;
+    }
+
+    const auto& value = it->second;
+    const auto result =
+        std::from_chars(value.data(), value.data() + value.size(), count);
+    if (result.ec != std::errc{} || result.ptr != value.data() + value.size()) {
+      throw std::invalid_argument(std::string(key) +
+                                  " must be a non-negative integer");
+    }
+  };
+
+  mooncake::ReplicateConfig replicate_config;
+  parse_count("replica_num", replicate_config.replica_num);
+  parse_count("nof_replica_num", replicate_config.nof_replica_num);
+  return replicate_config;
+}
+
 template <typename T>
 void ensure_batch_result_size(const std::vector<T>& results, size_t expected,
                               const char* op_name) {
@@ -33,9 +56,11 @@ void ensure_batch_result_size(const std::vector<T>& results, size_t expected,
 
 MooncakeConnector::MooncakeConnector(ConfigDict config, int num_workers,
                                      L1RegistrationConfig l1_registration,
-                                     WorkerPoolConfig worker_pool_config)
+                                     WorkerPoolConfig worker_pool_config,
+                                     ConfigDict replicate_config)
     : ConnectorBase(num_workers, std::move(worker_pool_config)),
       config_(std::move(config)),
+      replicate_config_(parse_replicate_config(replicate_config)),
       l1_registration_(l1_registration) {
   // Create a RealClient via the static factory.
   client_ = mooncake::RealClient::create();
@@ -87,7 +112,8 @@ void MooncakeConnector::do_single_set(WorkerMooncakeConn& conn,
                                       size_t len, size_t chunk_size) {
   (void)chunk_size;
   ensure_registered(buf, len);
-  int rc = conn.client->put_from(key, const_cast<void*>(buf), len);
+  int rc = conn.client->put_from(key, const_cast<void*>(buf), len,
+                                 replicate_config_);
   if (rc != 0) {
     throw std::runtime_error("Mooncake put_from failed for key: " + key);
   }
@@ -169,8 +195,8 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
     ensure_registered(req.buf_ptrs[i], req.buf_lens[i]);
   }
 
-  auto results =
-      conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+  auto results = conn.client->batch_put_from(req.keys, req.buf_ptrs,
+                                             req.buf_lens, replicate_config_);
   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
 
   for (size_t i = 0; i < results.size(); ++i) {

--- a/csrc/storage_backends/mooncake/connector.h
+++ b/csrc/storage_backends/mooncake/connector.h
@@ -43,7 +43,8 @@ class MooncakeConnector : public ConnectorBase<WorkerMooncakeConn> {
  public:
   MooncakeConnector(ConfigDict config, int num_workers,
                     L1RegistrationConfig l1_registration = {},
-                    WorkerPoolConfig worker_pool_config = {});
+                    WorkerPoolConfig worker_pool_config = {},
+                    ConfigDict replicate_config = {});
   ~MooncakeConnector() override;
 
  protected:
@@ -83,6 +84,7 @@ class MooncakeConnector : public ConnectorBase<WorkerMooncakeConn> {
 
   // The original config dict (kept for diagnostics).
   ConfigDict config_;
+  const mooncake::ReplicateConfig replicate_config_;
   L1RegistrationConfig l1_registration_;
   size_t preregistered_block_size_{0};
 };

--- a/csrc/storage_backends/mooncake/pybind.cpp
+++ b/csrc/storage_backends/mooncake/pybind.cpp
@@ -22,15 +22,18 @@ PYBIND11_MODULE(lmcache_mooncake, m) {
   py::class_<lmcache::connector::MooncakeConnector>(m, "LMCacheMooncakeClient")
       .def(py::init([](lmcache::connector::ConfigDict config, int num_workers,
                        lmcache::connector::L1RegistrationConfig l1_registration,
-                       py::object per_op_workers) {
+                       py::object per_op_workers,
+                       lmcache::connector::ConfigDict replicate_config) {
              return new lmcache::connector::MooncakeConnector(
                  std::move(config), num_workers, l1_registration,
                  lmcache::connector::pybind_utils::parse_per_op_workers(
-                     per_op_workers));
+                     per_op_workers),
+                 std::move(replicate_config));
            }),
            py::arg("config"), py::arg("num_workers"),
            py::arg("l1_registration") =
                lmcache::connector::L1RegistrationConfig{},
-           py::arg("per_op_workers") = py::none())
+           py::arg("per_op_workers") = py::none(),
+           py::arg("replicate_config") = lmcache::connector::ConfigDict{})
           LMCACHE_BIND_CONNECTOR_METHODS(lmcache::connector::MooncakeConnector);
 }

--- a/docs/source/mp/l2_storage/mooncake_store.rst
+++ b/docs/source/mp/l2_storage/mooncake_store.rst
@@ -59,12 +59,33 @@ If the Mooncake headers are not installed in the system include path
 **Mooncake fields:**
 
 All other keys in the JSON config (except ``type``, ``num_workers``,
-``per_op_workers``, and ``eviction``) are forwarded **as-is** to Mooncake's
+``per_op_workers``, ``eviction``, ``replica_num``, and ``nof_replica_num``)
+populate ``setup_config`` and are forwarded **as-is** to Mooncake's
 ``setup_internal(ConfigDict)``.  Refer to the
 `Mooncake documentation <https://github.com/kvcache-ai/Mooncake>`_
 for available setup keys (e.g., ``local_hostname``,
 ``metadata_server``, ``master_server_addr``, ``protocol``,
 ``rdma_devices``, ``global_segment_size``).
+
+**Write replica counts:**
+
+``replica_num`` and ``nof_replica_num`` configure the memory and NoF
+replica counts for both single-object and batch writes.  These fields
+populate a separate ``replicate_config`` and are passed to writes through
+Mooncake's ``ReplicateConfig``.  They are not sent to ``setup_internal()``.
+Both values must be non-negative decimal integers.  Omitted values keep
+Mooncake's defaults: one memory replica and zero NoF replicas.
+
+To request one NoF replica and no memory replicas, add the following fields
+to the Mooncake JSON object passed to ``--l2-adapter`` (requires a Mooncake
+deployment with NoF support):
+
+.. code-block:: json
+
+    {
+      "replica_num": "0",
+      "nof_replica_num": "1"
+    }
 
 **Configuration example:**
 

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -41,6 +41,8 @@ _LMCACHE_ONLY_KEYS = {
     "per_op_workers",
 }
 
+_REPLICATE_CONFIG_KEYS = {"replica_num", "nof_replica_num"}
+
 
 class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
     """Config for an L2 adapter backed by the native
@@ -49,13 +51,14 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
     ``setup_config`` is a string-to-string dict forwarded
     **as-is** to mooncake's
     ``RealClient::setup_internal(ConfigDict)``.
-    LMCache does NOT interpret, validate, or fill in
-    defaults for any mooncake keys — that is mooncake's
-    responsibility.
+    ``replicate_config`` supplies the replica counts for writes
+    via Mooncake's ``ReplicateConfig``.
 
     Fields:
         setup_config: Mooncake SDK configuration forwarded
             as-is to ``RealClient::setup_internal()``.
+        replicate_config: ``replica_num`` and ``nof_replica_num`` for
+            single-object and batch writes, as non-negative decimal strings.
         num_workers: Shared worker thread count (default 4,
             must be > 0).  Used for any op whose lane key
             is not present in ``per_op_workers``.
@@ -70,21 +73,24 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
         setup_config: dict[str, str],
         num_workers: int = 4,
         per_op_workers: dict[str, int] | None = None,
-    ):
+        replicate_config: dict[str, str] | None = None,
+    ) -> None:
         super().__init__()
         self.num_workers = L2AdapterConfigBase._validate_num_workers(num_workers)
         self.per_op_workers = L2AdapterConfigBase._validate_per_op_workers(
             per_op_workers
         )
         self.setup_config: dict[str, str] = dict(setup_config)
+        self.replicate_config: dict[str, str] = dict(replicate_config or {})
 
     @classmethod
     def from_dict(cls, d: dict[str, object]) -> "MooncakeStoreL2AdapterConfig":
         """Construct a config from a raw configuration dict.
 
         LMCache-only keys (``type``, ``num_workers``, ``eviction``,
-        ``per_op_workers``) are consumed locally.  All other keys are
-        forwarded to mooncake as string values.
+        ``per_op_workers``) are consumed locally.  ``replica_num`` and
+        ``nof_replica_num`` populate ``replicate_config``; other Mooncake
+        keys populate ``setup_config``.  Values are converted to strings.
 
         Args:
             d: Raw configuration dict (typically from JSON/CLI).
@@ -99,27 +105,30 @@ class MooncakeStoreL2AdapterConfig(L2AdapterConfigBase):
         num_workers = cast(int, d.get("num_workers", 4))  # validated in __init__
 
         per_op_workers = L2AdapterConfigBase._parse_per_op_workers_from_dict(d)
-        # Everything except LMCache-only keys is
-        # forwarded to mooncake as str values.
         setup: dict[str, str] = {}
+        replicate: dict[str, str] = {}
         for k, v in d.items():
-            if k in _LMCACHE_ONLY_KEYS:
+            if k in _LMCACHE_ONLY_KEYS or v is None:
                 continue
-            if v is not None:
+            if k in _REPLICATE_CONFIG_KEYS:
+                replicate[k] = str(v)
+            else:
                 setup[k] = str(v)
 
         return cls(
             setup_config=setup,
             num_workers=num_workers,
             per_op_workers=per_op_workers,
+            replicate_config=replicate,
         )
 
     @classmethod
     def help(cls) -> str:
         return (
             "Mooncake Store L2 adapter config.\n"
-            "All keys except LMCache-only keys are "
-            "forwarded as-is to mooncake's "
+            "replica_num and nof_replica_num set the memory and NoF "
+            "replica counts for writes.\n"
+            "Other Mooncake keys are forwarded as-is to "
             "setup_internal(ConfigDict).\n"
             "When protocol=rdma, LMCache must provide "
             "a valid L1 memory descriptor for "
@@ -199,6 +208,7 @@ def _create_mooncake_store_l2_adapter(
         num_workers=config.num_workers,
         l1_registration=l1_registration,
         per_op_workers=config.per_op_workers,
+        replicate_config=config.replicate_config,
     )
     logger.info(
         "Created Mooncake Store L2 adapter "

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -308,6 +308,42 @@ class TestMooncakeStoreL2AdapterConfig:
         assert config.per_op_workers == {"lookup": 4, "retrieve": 16}
         assert "store" not in config.per_op_workers
 
+    @pytest.mark.parametrize(
+        "replica_counts,expected",
+        [
+            ({}, {}),
+            (
+                {"replica_num": 0, "nof_replica_num": 1},
+                {"replica_num": "0", "nof_replica_num": "1"},
+            ),
+            (
+                {"replica_num": "0", "nof_replica_num": "1"},
+                {"replica_num": "0", "nof_replica_num": "1"},
+            ),
+            ({"replica_num": 3}, {"replica_num": "3"}),
+            ({"nof_replica_num": 1}, {"nof_replica_num": "1"}),
+        ],
+    )
+    def test_from_dict_preserves_replica_counts(
+        self, replica_counts: dict[str, object], expected: dict[str, str]
+    ) -> None:
+        """Separate explicit replica counts from connection setup settings.
+
+        Args:
+            replica_counts: User-supplied replica counts, including unset fields.
+            expected: String replica counts forwarded to the native connector.
+        """
+        config = MooncakeStoreL2AdapterConfig.from_dict(
+            {
+                "type": "mooncake_store",
+                "local_hostname": "localhost",
+                **replica_counts,
+            }
+        )
+
+        assert config.setup_config == {"local_hostname": "localhost"}
+        assert config.replicate_config == expected
+
     def test_constructor_copies_setup_config(self):
         """Constructor should copy the setup_config dict."""
         original = {"key": "value"}
@@ -385,7 +421,7 @@ class TestMooncakeStoreL1RegistrationFactory:
 
     def test_factory_passes_disabled_l1_registration_for_tcp(
         self, monkeypatch: pytest.MonkeyPatch
-    ):
+    ) -> None:
         # First Party
         from lmcache.v1.distributed.l2_adapters import native_connector_l2_adapter
 
@@ -396,13 +432,15 @@ class TestMooncakeStoreL1RegistrationFactory:
                 self,
                 config: dict[str, str],
                 num_workers: int,
-                l1_registration,
-                per_op_workers=None,
-            ):
+                l1_registration: Any,
+                per_op_workers: dict[str, int] | None = None,
+                replicate_config: dict[str, str] | None = None,
+            ) -> None:
                 captured["config"] = config
                 captured["num_workers"] = num_workers
                 captured["l1_registration"] = l1_registration
                 captured["per_op_workers"] = per_op_workers
+                captured["replicate_config"] = replicate_config
 
         _install_fake_mooncake_extension(monkeypatch, FakeClient)
         monkeypatch.setattr(
@@ -418,6 +456,8 @@ class TestMooncakeStoreL1RegistrationFactory:
                 "metadata_server": "P2PHANDSHAKE",
                 "num_workers": 3,
                 "protocol": "tcp",
+                "replica_num": 0,
+                "nof_replica_num": 1,
             }
         )
         l1_desc = L1MemoryDesc(ptr=123456, size=65536, align_bytes=4096)
@@ -430,6 +470,10 @@ class TestMooncakeStoreL1RegistrationFactory:
 
         assert wrapped_adapter[0] == "wrapped"
         assert captured["config"] == config.setup_config
+        assert captured["replicate_config"] == {
+            "replica_num": "0",
+            "nof_replica_num": "1",
+        }
         assert captured["num_workers"] == 3
         registration = captured["l1_registration"]
         assert registration.enabled is False
@@ -449,9 +493,10 @@ class TestMooncakeStoreL1RegistrationFactory:
                 self,
                 config: dict[str, str],
                 num_workers: int,
-                l1_registration,
-                per_op_workers=None,
-            ):
+                l1_registration: Any,
+                per_op_workers: dict[str, int] | None = None,
+                replicate_config: dict[str, str] | None = None,
+            ) -> None:
                 captured["config"] = config
                 captured["num_workers"] = num_workers
                 captured["l1_registration"] = l1_registration
@@ -500,9 +545,10 @@ class TestMooncakeStoreL1RegistrationFactory:
                 self,
                 config: dict[str, str],
                 num_workers: int,
-                l1_registration,
-                per_op_workers=None,
-            ):
+                l1_registration: Any,
+                per_op_workers: dict[str, int] | None = None,
+                replicate_config: dict[str, str] | None = None,
+            ) -> None:
                 captured["config"] = config
                 captured["num_workers"] = num_workers
                 captured["l1_registration"] = l1_registration


### PR DESCRIPTION
**What this PR does / why we need it**:

Mooncake's setup_internal() does not set the replica policy for writes, so configured replica counts were ignored by the MP connector.

Separate replica settings from setup configuration and pass them to put_from() and batch_put_from() through 
ReplicateConfig. Preserve SDK defaults for omitted counts and reject invalid values.

Fixes #4952

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
