### PR TITLE
feat(vllm): expose LMCache MP lookup latency

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 import math
 import sys
+import time
 
 # Third Party
 from vllm.config import VllmConfig
@@ -53,6 +54,10 @@ from lmcache.integration.vllm.lmcache_mp_metadata import (
     LMCacheMPRequestState,
     LMCacheMPRequestTracker,
     LMCacheMPWorkerMetadata,
+)
+from lmcache.integration.vllm.lmcache_mp_metrics import (
+    LMCacheMPConnectorStats,
+    LMCacheMPPromMetrics,
 )
 from lmcache.integration.vllm.utils import (
     mla_only,
@@ -475,6 +480,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # Older supported vLLM releases allow connectors to omit this value,
         # while current vLLM's type declaration requires it.
         super().__init__(vllm_config, role, kv_cache_config)  # type: ignore[arg-type]
+        self._connector_stats = LMCacheMPConnectorStats()
 
         # Fail fast, before the server handshake below.
         kv_cache_config = getattr(self, "_kv_cache_config", None)
@@ -959,7 +965,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         Get the KV connector stats collected during the last interval.
         """
-        return None
+        stats = self._connector_stats.clone_and_reset()
+        return None if stats.is_empty() else stats
 
     # ==============================
     # Scheduler-side methods
@@ -1045,6 +1052,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             tracker.state = LMCacheMPRequestState.BYPASS_LMCACHE
             return 0, False
 
+        if tracker.lookup_started_at is None:
+            tracker.lookup_started_at = time.monotonic()
         self.scheduler_adapter.maybe_submit_lookup_request(
             request.request_id,
             token_ids=tracker.get_token_ids(),
@@ -1055,6 +1064,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         ret = self.scheduler_adapter.check_lookup_result(request.request_id)
         if ret is None:
             return None, True
+        assert tracker.lookup_started_at is not None
+        self._connector_stats.record_lookup(
+            time.monotonic() - tracker.lookup_started_at
+        )
+        tracker.lookup_started_at = None
 
         if ret == 0:
             return 0, False
@@ -1101,6 +1115,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             return
 
         tracker = self._get_or_create_request_tracker(request)
+        if tracker.lookup_started_at is None:
+            tracker.lookup_started_at = time.monotonic()
         self.scheduler_adapter.maybe_submit_lookup_request(
             request.request_id,
             token_ids=tracker.get_token_ids(),
@@ -1365,7 +1381,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         registered connectors to return their own KVConnectorStats object,
         which can implement custom aggregation logic on the data dict.
         """
-        return None
+        return LMCacheMPConnectorStats(data=data or {})
 
     @classmethod
     def build_prom_metrics(
@@ -1380,7 +1396,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         per-connector Prometheus metrics and implement observe() to
         expose connector transfer stats via Prometheus.
         """
-        return None
+        return LMCacheMPPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
 
     ##############################
     # Helper functions

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -75,6 +75,7 @@ class LMCacheMPRequestTracker:
     cache_salt: str = ""
     request_configs: dict[str, Any] | None = None
     max_offload_tokens: int | None = None
+    lookup_started_at: float | None = None
 
     mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
 
@@ -85,6 +86,7 @@ class LMCacheMPRequestTracker:
         self.max_offload_tokens = (self.request_configs or {}).get(
             "lmcache.max_offload_tokens"
         )
+        self.lookup_started_at = None
         self.all_token_ids = request.all_token_ids
         self.allocated_block_ids = {}
         self.num_stored_tokens = 0

--- a/lmcache/integration/vllm/lmcache_mp_metrics.py
+++ b/lmcache/integration/vllm/lmcache_mp_metrics.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM metrics for the LMCache MP connector."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from typing import Any
+
+# Third Party
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+
+_LOOKUP_DURATION = "lookup_duration_seconds"
+
+
+@dataclass
+class LMCacheMPConnectorStats(KVConnectorStats):
+    """Lookup latency observations collected by the scheduler connector."""
+
+    def __post_init__(self) -> None:
+        self.data.setdefault(_LOOKUP_DURATION, [])
+
+    def record_lookup(self, duration_seconds: float) -> None:
+        self.data[_LOOKUP_DURATION].append(duration_seconds)
+
+    def clone_and_reset(self) -> "LMCacheMPConnectorStats":
+        snapshot = LMCacheMPConnectorStats(
+            data={_LOOKUP_DURATION: self.data[_LOOKUP_DURATION]}
+        )
+        self.reset()
+        return snapshot
+
+    def reset(self) -> None:
+        self.data: dict[str, Any] = {_LOOKUP_DURATION: []}
+
+    def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        if not isinstance(other, LMCacheMPConnectorStats):
+            raise TypeError(f"Cannot aggregate {type(other)}")
+        self.data[_LOOKUP_DURATION].extend(other.data[_LOOKUP_DURATION])
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        durations = self.data[_LOOKUP_DURATION]
+        if not durations:
+            return {}
+        return {
+            "LMCache MP lookup count": len(durations),
+            "LMCache MP lookup avg latency (ms)": round(
+                sum(durations) / len(durations) * 1000, 3
+            ),
+        }
+
+    def is_empty(self) -> bool:
+        return not self.data[_LOOKUP_DURATION]
+
+
+class LMCacheMPPromMetrics(KVConnectorPromMetrics):
+    """Expose LMCache MP lookup latency through vLLM Prometheus metrics."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> None:
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+        histogram = self._histogram_cls(
+            name="vllm:lmcache_mp_lookup_duration_seconds",
+            documentation="LMCache MP lookup latency observed by vLLM.",
+            labelnames=labelnames,
+        )
+        self._lookup_duration = {
+            engine_idx: histogram.labels(*labelvalues)
+            for engine_idx, labelvalues in per_engine_labelvalues.items()
+        }
+
+    def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0) -> None:
+        for duration in transfer_stats_data.get(_LOOKUP_DURATION, []):
+            self._lookup_duration[engine_idx].observe(duration)

--- a/tests/v1/test_mp_connector_metrics.py
+++ b/tests/v1/test_mp_connector_metrics.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for LMCache MP connector metrics."""
+
+# Standard
+from types import SimpleNamespace
+from typing import Any
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector metrics require vLLM")
+
+# Third Party
+from prometheus_client import Counter, Gauge, Histogram  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_metrics import (  # noqa: E402
+    LMCacheMPConnectorStats,
+    LMCacheMPPromMetrics,
+)
+
+
+class _BoundHistogram:
+    def __init__(self) -> None:
+        self.observations: list[float] = []
+
+    def observe(self, value: float) -> None:
+        self.observations.append(value)
+
+
+class _Histogram:
+    instance: "_Histogram"
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.children: dict[tuple[object, ...], _BoundHistogram] = {}
+        _Histogram.instance = self
+
+    def labels(self, *values: object) -> _BoundHistogram:
+        return self.children.setdefault(values, _BoundHistogram())
+
+
+def test_lookup_stats_snapshot_and_aggregation() -> None:
+    stats = LMCacheMPConnectorStats()
+    stats.record_lookup(0.025)
+
+    snapshot = stats.clone_and_reset()
+    aggregate = LMCacheMPConnectorStats()
+    aggregate.aggregate(snapshot)
+
+    assert stats.is_empty()
+    assert aggregate.reduce() == {
+        "LMCache MP lookup count": 1,
+        "LMCache MP lookup avg latency (ms)": 25.0,
+    }
+
+
+def test_prometheus_observes_lookup_duration() -> None:
+    metric_types: dict[Any, Any] = {
+        Counter: _Histogram,
+        Gauge: _Histogram,
+        Histogram: _Histogram,
+    }
+    metrics = LMCacheMPPromMetrics(
+        SimpleNamespace(kv_transfer_config=object()),
+        metric_types,
+        ["model_name", "engine"],
+        {0: ["model", "0"]},
+    )
+
+    metrics.observe({"lookup_duration_seconds": [0.01, 0.02]})
+
+    assert _Histogram.instance.kwargs["name"] == (
+        "vllm:lmcache_mp_lookup_duration_seconds"
+    )
+    assert _Histogram.instance.children[("model", "0")].observations == [0.01, 0.02]

--- a/tests/v1/test_mp_connector_mm_keys.py
+++ b/tests/v1/test_mp_connector_mm_keys.py
@@ -203,6 +203,7 @@ def test_eager_prefetch_forwards_request_configs():
         cache_salt="",
         request_configs={"lmcache.skip_save": True},
     )
+    assert tracker.lookup_started_at is not None
 
 
 def _prepare_storable_tracker(request: _FakeRequest) -> LMCacheMPRequestTracker:


### PR DESCRIPTION
## Summary

- implement `build_kv_connector_stats` and `build_prom_metrics` for `LMCacheMPConnector`
- expose one initial metric: `vllm:lmcache_mp_lookup_duration_seconds`
- record lookup latency from client submission until the scheduler receives a final hit or miss result

In-flight timing is owned by the existing request tracker, so cancellation, request cleanup, and tracker replacement release it with the request lifecycle. The stats payload contains completed observations only.

A Prometheus histogram also provides count, sum, and bucket series, so this single metric gives a useful first validation of the vLLM connector metrics API without adding multiple counters or worker-side instrumentation.

## Follow-up metrics

If this integration proves useful, separate follow-up PRs can add:

- load and store completion latency
- transferred bytes or tokens
- bounded error and timeout counters
- lookup hit/miss or matched-token statistics

Server-side storage and device metrics should remain in LMCache server telemetry rather than being duplicated here.

## Testing

- 55 passed, 7 skipped across the focused MP connector and adapter tests
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`

The skipped tests require a full vLLM runtime that is unavailable in the local macOS environment.
