### PR TITLE
Add raw block I/O path metrics

### DIFF
--- a/benchmarks/storage_backend_io/README.md
+++ b/benchmarks/storage_backend_io/README.md
@@ -173,6 +173,11 @@ PY
 ## Output
 
 The script prints a summary and optionally writes JSON results if `--output-json` is provided.
+For `rust_raw_block`, JSON output also includes payload GiB/s and low-level path
+counters. The counters distinguish POSIX, standard io_uring, io_uring command,
+fixed-buffer, and bounce-buffer requests, including bytes copied through bounce
+buffers. This makes optimization results auditable instead of relying on throughput
+alone.
 
 ### Write Benchmark Output
 

--- a/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
+++ b/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
@@ -590,23 +590,71 @@ class StorageBackendBenchmark(ABC):
         return result
 
     def _execute_read_phase(self) -> list[tuple[CacheEngineKey, Optional[MemoryObj]]]:
-        """Execute the read phase and return results.
+        """Execute the read phase and require every requested object to load.
 
-        Override in subclass to customize read behavior.
+        Returns:
+            Read results in request order.
+
+        Raises:
+            RuntimeError: If a worker raises, returns an incomplete result, or
+                returns a missing object. Partial runs are rejected because
+                planned-operation throughput would otherwise be misleading.
         """
         slices = self._get_slices()
         read_results: list[tuple[CacheEngineKey, Optional[MemoryObj]]] = []
-        read_lock = threading.Lock()
+        loaded_objects: list[MemoryObj] = []
+        worker_errors: list[str] = []
+        missing_operations = 0
+        failed_operations = 0
+        unexpected_operations = 0
 
-        def submit_read_slice(start: int, end: int) -> None:
-            batch_keys = self._keys[start:end]
-            loaded = self._backend.batched_get_blocking(batch_keys)
-            with read_lock:
-                read_results.extend(zip(batch_keys, loaded, strict=False))
+        def submit_read_slice(start: int, end: int) -> list[Optional[MemoryObj]]:
+            return self._backend.batched_get_blocking(self._keys[start:end])
 
-        with ThreadPoolExecutor(max_workers=self.concurrency) as ex:
-            for s in slices:
-                ex.submit(submit_read_slice, s[0], s[1])
+        with ThreadPoolExecutor(max_workers=self.concurrency) as executor:
+            futures = [
+                (start, end, executor.submit(submit_read_slice, start, end))
+                for start, end in slices
+            ]
+            for start, end, future in futures:
+                expected_count = end - start
+                try:
+                    loaded = future.result()
+                except Exception as error:
+                    missing_operations += expected_count
+                    worker_errors.append(
+                        f"keys[{start}:{end}]: {type(error).__name__}: {error}"
+                    )
+                    continue
+
+                returned_count = len(loaded)
+                missing_operations += max(0, expected_count - returned_count)
+                unexpected_operations += max(0, returned_count - expected_count)
+                failed_operations += sum(obj is None for obj in loaded[:expected_count])
+                loaded_objects.extend(obj for obj in loaded if obj is not None)
+                read_results.extend(
+                    zip(self._keys[start:end], loaded[:expected_count], strict=False)
+                )
+
+        if (
+            worker_errors
+            or missing_operations
+            or failed_operations
+            or unexpected_operations
+        ):
+            for loaded_obj in loaded_objects:
+                try:
+                    loaded_obj.ref_count_down()
+                except Exception:
+                    pass
+            details = (
+                f"missing_operations={missing_operations}, "
+                f"failed_operations={failed_operations}, "
+                f"unexpected_operations={unexpected_operations}"
+            )
+            if worker_errors:
+                details += f", worker_errors={worker_errors}"
+            raise RuntimeError(f"read benchmark incomplete: {details}")
 
         return read_results
 

--- a/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
+++ b/benchmarks/storage_backend_io/storage_backend_io_benchmark.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 # Standard
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 import argparse
 import asyncio
 import json
@@ -426,6 +426,7 @@ class StorageBackendBenchmark(ABC):
         )
 
         # Run benchmark
+        self._before_benchmark()
         logger.info(f"Start benchmark with {self.backend_name} ...")
         self._start_time = time.perf_counter()
         result = self._execute_benchmark()
@@ -478,14 +479,19 @@ class StorageBackendBenchmark(ABC):
         # Single-phase benchmark (write-only)
         elapsed = self._execute_write_phase()
 
-        return {
+        result = {
             "backend": self.backend_name,
             "num_ops": self.num_ops,
             "concurrency": self.concurrency,
             "write_elapsed_sec": elapsed,
             "write_ops_per_sec": self.num_ops / elapsed if elapsed > 0 else 0.0,
+            "write_gib_per_sec": self._total_payload_bytes() / (1024**3) / elapsed
+            if elapsed > 0
+            else 0.0,
             "use_odirect": self.use_odirect,
         }
+        result.update(self._get_extra_result_fields())
+        return result
 
     def _uses_futures_pattern(self) -> bool:
         """Check if this backend uses futures pattern.
@@ -498,6 +504,14 @@ class StorageBackendBenchmark(ABC):
         """Wait for all futures to complete."""
         for fut in futures:
             fut.result(timeout=120)
+
+    def _before_benchmark(self) -> None:
+        """Prepare backend-specific state immediately before timing."""
+        return None
+
+    def _total_payload_bytes(self) -> int:
+        """Return the total payload bytes represented by benchmark objects."""
+        return sum(obj.get_size() for obj in self._objs)
 
     def _get_extra_result_fields(self) -> dict:
         """Get extra fields to add to the benchmark result.
@@ -555,8 +569,14 @@ class StorageBackendBenchmark(ABC):
             "write_ops_per_sec": self.num_ops / write_elapsed
             if write_elapsed > 0
             else 0.0,
+            "write_gib_per_sec": self._total_payload_bytes() / (1024**3) / write_elapsed
+            if write_elapsed > 0
+            else 0.0,
             "read_elapsed_sec": read_elapsed,
             "read_ops_per_sec": self.num_ops / read_elapsed
+            if read_elapsed > 0
+            else 0.0,
+            "read_gib_per_sec": self._total_payload_bytes() / (1024**3) / read_elapsed
             if read_elapsed > 0
             else 0.0,
             "total_elapsed_sec": write_elapsed + read_elapsed,
@@ -830,11 +850,29 @@ class RustRawBlockBackendBenchmark(StorageBackendBenchmark):
         if self._backend:
             self._backend.close()
 
+    def _before_benchmark(self) -> None:
+        """Reset path counters so setup I/O is excluded from results."""
+        backend = cast(RustRawBlockBackend, self._backend)
+        backend.reset_io_path_stats()
+
     def _get_extra_result_fields(self) -> dict:
         """Get extra fields for RustRawBlockBackend benchmark results."""
+        backend = cast(RustRawBlockBackend, self._backend)
+        stats = backend.io_path_stats()
+        request_key = "write_requests" if self.write_bench else "read_requests"
+        fixed_key = (
+            "fixed_write_requests" if self.write_bench else "fixed_read_requests"
+        )
+        bounce_key = (
+            "bounce_write_requests" if self.write_bench else "bounce_read_requests"
+        )
+        requests = stats[request_key]
         return {
             "use_uring": self.use_uring,
             "use_uring_cmd": self.use_uring_cmd,
+            "io_path_stats": stats,
+            "fixed_buffer_hit_ratio": stats[fixed_key] / requests if requests else 0.0,
+            "bounce_request_ratio": stats[bounce_key] / requests if requests else 0.0,
         }
 
     def _cleanup_device(self) -> None:
@@ -1228,12 +1266,14 @@ def main() -> None:
             f"{result['backend']}: ops={result['num_ops']} "
             f"concurrency={result['concurrency']} "
             f"write_elapsed={result['write_elapsed_sec']:.3f}s "
-            f"write_ops/sec={result['write_ops_per_sec']:.2f}"
+            f"write_ops/sec={result['write_ops_per_sec']:.2f} "
+            f"write_GiB/sec={result['write_gib_per_sec']:.2f}"
         )
         if not write_bench:
             print(
                 f"read_elapsed={result['read_elapsed_sec']:.3f}s "
                 f"read_ops/sec={result['read_ops_per_sec']:.2f} "
+                f"read_GiB/sec={result['read_gib_per_sec']:.2f} "
                 f"total_elapsed={result['total_elapsed_sec']:.3f}s"
             )
             if args.verify_integrity:

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -701,6 +701,14 @@ class RustRawBlockBackend(StoragePluginInterface):
             raise RuntimeError("RustRawBlockBackend requires local_cpu_backend")
         return self.local_cpu_backend
 
+    def io_path_stats(self) -> dict[str, int]:
+        """Return a snapshot of low-level I/O path counters."""
+        return self._core.io_path_stats()
+
+    def reset_io_path_stats(self) -> None:
+        """Reset all low-level I/O path counters."""
+        self._core.reset_io_path_stats()
+
     def close(self) -> None:
         deadline = time.monotonic() + 10.0
         while True:

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -581,6 +581,14 @@ class RawBlockCore:
             len(buffers),
         )
 
+    def io_path_stats(self) -> dict[str, int]:
+        """Return a snapshot of low-level I/O path counters."""
+        return dict(self._rawdev().io_path_stats())
+
+    def reset_io_path_stats(self) -> None:
+        """Reset all low-level I/O path counters."""
+        self._rawdev().reset_io_path_stats()
+
     def contains_key(self, encoded_key: str, *, lock: bool = False) -> bool:
         """Return whether one encoded key is present in the raw-block index.
 

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -1020,6 +1020,66 @@ struct IoSubmission {
     nvme_cmd_data: Option<NvmeCmdData>, // NVMe command data for io_uring_cmd
 }
 
+#[derive(Default)]
+struct IoPathStats {
+    read_requests: AtomicU64,
+    write_requests: AtomicU64,
+    posix_read_requests: AtomicU64,
+    posix_write_requests: AtomicU64,
+    iouring_read_requests: AtomicU64,
+    iouring_write_requests: AtomicU64,
+    uring_cmd_read_requests: AtomicU64,
+    uring_cmd_write_requests: AtomicU64,
+    fixed_read_requests: AtomicU64,
+    fixed_write_requests: AtomicU64,
+    bounce_read_requests: AtomicU64,
+    bounce_write_requests: AtomicU64,
+    bounce_read_bytes: AtomicU64,
+    bounce_write_bytes: AtomicU64,
+}
+
+impl IoPathStats {
+    fn snapshot(&self) -> HashMap<String, u64> {
+        let counters = [
+            ("read_requests", &self.read_requests),
+            ("write_requests", &self.write_requests),
+            ("posix_read_requests", &self.posix_read_requests),
+            ("posix_write_requests", &self.posix_write_requests),
+            ("iouring_read_requests", &self.iouring_read_requests),
+            ("iouring_write_requests", &self.iouring_write_requests),
+            ("uring_cmd_read_requests", &self.uring_cmd_read_requests),
+            ("uring_cmd_write_requests", &self.uring_cmd_write_requests),
+            ("fixed_read_requests", &self.fixed_read_requests),
+            ("fixed_write_requests", &self.fixed_write_requests),
+            ("bounce_read_requests", &self.bounce_read_requests),
+            ("bounce_write_requests", &self.bounce_write_requests),
+            ("bounce_read_bytes", &self.bounce_read_bytes),
+            ("bounce_write_bytes", &self.bounce_write_bytes),
+        ];
+        counters
+            .into_iter()
+            .map(|(name, counter)| (name.to_string(), counter.load(Ordering::Relaxed)))
+            .collect()
+    }
+
+    fn reset(&self) {
+        self.read_requests.store(0, Ordering::Relaxed);
+        self.write_requests.store(0, Ordering::Relaxed);
+        self.posix_read_requests.store(0, Ordering::Relaxed);
+        self.posix_write_requests.store(0, Ordering::Relaxed);
+        self.iouring_read_requests.store(0, Ordering::Relaxed);
+        self.iouring_write_requests.store(0, Ordering::Relaxed);
+        self.uring_cmd_read_requests.store(0, Ordering::Relaxed);
+        self.uring_cmd_write_requests.store(0, Ordering::Relaxed);
+        self.fixed_read_requests.store(0, Ordering::Relaxed);
+        self.fixed_write_requests.store(0, Ordering::Relaxed);
+        self.bounce_read_requests.store(0, Ordering::Relaxed);
+        self.bounce_write_requests.store(0, Ordering::Relaxed);
+        self.bounce_read_bytes.store(0, Ordering::Relaxed);
+        self.bounce_write_bytes.store(0, Ordering::Relaxed);
+    }
+}
+
 impl Default for IoSubmission {
     fn default() -> Self {
         IoSubmission {
@@ -1092,6 +1152,7 @@ struct RawBlockDevice {
     batched_completions: Arc<Mutex<HashMap<u64, Vec<Arc<IoCompletion>>>>>,
     // Counter for generating unique batch IDs
     next_batch_id: Arc<AtomicU64>,
+    io_path_stats: Arc<IoPathStats>,
 }
 
 /// RAII guard for a raw file descriptor
@@ -1994,6 +2055,7 @@ impl RawBlockDevice {
             next_batch_id: next_batch_id_opt.unwrap_or_else(|| Arc::new(AtomicU64::new(1))),
             batch_in_flight: batch_in_flight_opt
                 .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new()))),
+            io_path_stats: Arc::new(IoPathStats::default()),
         })
     }
 
@@ -2057,6 +2119,16 @@ impl RawBlockDevice {
     // Expose cached size to Python.
     fn size_bytes(&self) -> PyResult<u64> {
         Ok(self.size)
+    }
+
+    /// Return a snapshot of I/O path counters since construction or last reset.
+    fn io_path_stats(&self) -> HashMap<String, u64> {
+        self.io_path_stats.snapshot()
+    }
+
+    /// Reset all I/O path counters to zero.
+    fn reset_io_path_stats(&self) {
+        self.io_path_stats.reset();
     }
 
     /// Get NVMe namespace ID (only available when use_uring_cmd=true)
@@ -2286,6 +2358,7 @@ impl RawBlockDevice {
         let batch_ready = Arc::clone(self.batch_ready.as_ref().unwrap());
         let batched_completions = Arc::clone(&self.batched_completions);
         let batch_in_flight = Arc::clone(&self.batch_in_flight);
+        let io_path_stats = Arc::clone(&self.io_path_stats);
         // Additional clones for cleanup on error path
         let batch_in_flight_cleanup = Arc::clone(&batch_in_flight);
         let batched_completions_cleanup = Arc::clone(&batched_completions);
@@ -2374,6 +2447,39 @@ impl RawBlockDevice {
 
                 submissions.push((sub, comp));
             }
+
+            io_path_stats
+                .write_requests
+                .fetch_add(n as u64, Ordering::Relaxed);
+            io_path_stats
+                .iouring_write_requests
+                .fetch_add(n as u64, Ordering::Relaxed);
+            if use_uring_cmd {
+                io_path_stats
+                    .uring_cmd_write_requests
+                    .fetch_add(n as u64, Ordering::Relaxed);
+            }
+            let fixed_count = submissions
+                .iter()
+                .filter(|(sub, _)| sub.fixed_buffer_idx.is_some())
+                .count() as u64;
+            let bounce_count = submissions
+                .iter()
+                .filter(|(sub, _)| sub.bounce.is_some())
+                .count() as u64;
+            let bounce_bytes = submissions
+                .iter()
+                .filter_map(|(sub, _)| sub.bounce.as_ref().map(|_| sub.len as u64))
+                .sum::<u64>();
+            io_path_stats
+                .fixed_write_requests
+                .fetch_add(fixed_count, Ordering::Relaxed);
+            io_path_stats
+                .bounce_write_requests
+                .fetch_add(bounce_count, Ordering::Relaxed);
+            io_path_stats
+                .bounce_write_bytes
+                .fetch_add(bounce_bytes, Ordering::Relaxed);
 
             // Queue all submissions atomically. At this point no further errors can
             // occur during queuing.
@@ -2571,6 +2677,31 @@ impl RawBlockDevice {
         // Buffer capacity is less than total_len
         let use_bounce = !ptr_aligned || cap < total_len;
 
+        self.io_path_stats
+            .read_requests
+            .fetch_add(1, Ordering::Relaxed);
+        self.io_path_stats
+            .iouring_read_requests
+            .fetch_add(1, Ordering::Relaxed);
+        if self.use_uring_cmd {
+            self.io_path_stats
+                .uring_cmd_read_requests
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if fixed_idx.is_some() && !use_bounce {
+            self.io_path_stats
+                .fixed_read_requests
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if use_bounce {
+            self.io_path_stats
+                .bounce_read_requests
+                .fetch_add(1, Ordering::Relaxed);
+            self.io_path_stats
+                .bounce_read_bytes
+                .fetch_add(payload_len as u64, Ordering::Relaxed);
+        }
+
         let res = if !use_bounce {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
@@ -2708,6 +2839,31 @@ impl RawBlockDevice {
         // Buffer is not aligned (O_DIRECT requirement)
         // Buffer capacity is less than total_len
         let use_bounce = !ptr_aligned || cap < total_len;
+
+        self.io_path_stats
+            .write_requests
+            .fetch_add(1, Ordering::Relaxed);
+        self.io_path_stats
+            .iouring_write_requests
+            .fetch_add(1, Ordering::Relaxed);
+        if self.use_uring_cmd {
+            self.io_path_stats
+                .uring_cmd_write_requests
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if fixed_idx.is_some() && !use_bounce {
+            self.io_path_stats
+                .fixed_write_requests
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if use_bounce {
+            self.io_path_stats
+                .bounce_write_requests
+                .fetch_add(1, Ordering::Relaxed);
+            self.io_path_stats
+                .bounce_write_bytes
+                .fetch_add(payload_len as u64, Ordering::Relaxed);
+        }
 
         let res = if !use_bounce {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
@@ -2886,6 +3042,7 @@ impl RawBlockDevice {
         let batch_ready = Arc::clone(self.batch_ready.as_ref().unwrap());
         let batched_completions = Arc::clone(&self.batched_completions);
         let batch_in_flight = Arc::clone(&self.batch_in_flight);
+        let io_path_stats = Arc::clone(&self.io_path_stats);
 
         // Additional clones for cleanup on error path
         let batch_in_flight_cleanup = Arc::clone(&batch_in_flight);
@@ -2969,6 +3126,39 @@ impl RawBlockDevice {
 
                 submissions.push((sub, comp));
             }
+
+            io_path_stats
+                .read_requests
+                .fetch_add(n as u64, Ordering::Relaxed);
+            io_path_stats
+                .iouring_read_requests
+                .fetch_add(n as u64, Ordering::Relaxed);
+            if use_uring_cmd {
+                io_path_stats
+                    .uring_cmd_read_requests
+                    .fetch_add(n as u64, Ordering::Relaxed);
+            }
+            let fixed_count = submissions
+                .iter()
+                .filter(|(sub, _)| sub.fixed_buffer_idx.is_some())
+                .count() as u64;
+            let bounce_count = submissions
+                .iter()
+                .filter(|(sub, _)| sub.bounce.is_some())
+                .count() as u64;
+            let bounce_bytes = submissions
+                .iter()
+                .filter_map(|(sub, _)| sub.payload_len.map(|len| len as u64))
+                .sum::<u64>();
+            io_path_stats
+                .fixed_read_requests
+                .fetch_add(fixed_count, Ordering::Relaxed);
+            io_path_stats
+                .bounce_read_requests
+                .fetch_add(bounce_count, Ordering::Relaxed);
+            io_path_stats
+                .bounce_read_bytes
+                .fetch_add(bounce_bytes, Ordering::Relaxed);
 
             // Queue all submissions atomically. At this point no further errors can
             // occur during queuing.
@@ -3076,6 +3266,28 @@ impl RawBlockDevice {
         // to `allow_threads` must own plain data and cannot borrow `view`.
         // We still keep `view` alive until I/O finishes, then release it below.
         let ptr_usize = ptr as usize;
+        let src_aligned = ptr_usize.is_multiple_of(align);
+        let bounce_copy_bytes = if total_len == payload_len && !self.use_odirect {
+            0
+        } else if self.use_odirect && src_aligned {
+            payload_len % align
+        } else {
+            payload_len
+        };
+        self.io_path_stats
+            .write_requests
+            .fetch_add(1, Ordering::Relaxed);
+        self.io_path_stats
+            .posix_write_requests
+            .fetch_add(1, Ordering::Relaxed);
+        if bounce_copy_bytes > 0 {
+            self.io_path_stats
+                .bounce_write_requests
+                .fetch_add(1, Ordering::Relaxed);
+            self.io_path_stats
+                .bounce_write_bytes
+                .fetch_add(bounce_copy_bytes as u64, Ordering::Relaxed);
+        }
         let res = py.allow_threads(move || {
             let src = ptr_usize as *const u8;
             let src_aligned = (src as usize).is_multiple_of(align);
@@ -3216,6 +3428,28 @@ impl RawBlockDevice {
         // Same pattern as write path: move raw address into closure-safe value
         // while retaining `view` lifetime until closure completion.
         let dst_usize = ptr as usize;
+        let dst_aligned = dst_usize.is_multiple_of(align);
+        let bounce_copy_bytes = if total_len == payload_len && !self.use_odirect {
+            0
+        } else if self.use_odirect && dst_aligned {
+            payload_len % align
+        } else {
+            payload_len
+        };
+        self.io_path_stats
+            .read_requests
+            .fetch_add(1, Ordering::Relaxed);
+        self.io_path_stats
+            .posix_read_requests
+            .fetch_add(1, Ordering::Relaxed);
+        if bounce_copy_bytes > 0 {
+            self.io_path_stats
+                .bounce_read_requests
+                .fetch_add(1, Ordering::Relaxed);
+            self.io_path_stats
+                .bounce_read_bytes
+                .fetch_add(bounce_copy_bytes as u64, Ordering::Relaxed);
+        }
         let res = py.allow_threads(move || {
             let dst = dst_usize as *mut u8;
             let dst_aligned = (dst as usize).is_multiple_of(align);

--- a/tests/benchmarks/test_storage_backend_io_benchmark.py
+++ b/tests/benchmarks/test_storage_backend_io_benchmark.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 # Third Party
 import pytest
@@ -82,7 +82,8 @@ def _make_benchmark(num_ops: int, concurrency: int) -> _TestBenchmark:
 def test_read_phase_rejects_empty_or_partial_results(returned_count: int) -> None:
     benchmark = _make_benchmark(num_ops=2, concurrency=1)
     returned = [_LoadedObject() for _ in range(returned_count)]
-    benchmark._backend = _ResultBackend(returned)  # type: ignore[assignment]
+    results = cast(list[Optional[MemoryObj]], returned)
+    benchmark._backend = _ResultBackend(results)  # type: ignore[assignment]
 
     with pytest.raises(
         RuntimeError,

--- a/tests/benchmarks/test_storage_backend_io_benchmark.py
+++ b/tests/benchmarks/test_storage_backend_io_benchmark.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Any, Optional
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from benchmarks.storage_backend_io.storage_backend_io_benchmark import (
+    StorageBackendBenchmark,
+)
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+
+class _TestBenchmark(StorageBackendBenchmark):
+    @property
+    def extra_config_keys(self) -> dict:
+        return {}
+
+    def _create_backend(
+        self,
+        config: LMCacheEngineConfig,
+        metadata: LMCacheMetadata,
+        loop: Any,
+        local_cpu_backend: LocalCPUBackend,
+    ) -> StorageBackendInterface:
+        raise NotImplementedError
+
+    def _close_backend(self) -> None:
+        return None
+
+
+class _LoadedObject:
+    def __init__(self) -> None:
+        self.released = False
+
+    def ref_count_down(self) -> None:
+        self.released = True
+
+
+class _ResultBackend:
+    def __init__(self, results: list[Optional[MemoryObj]]) -> None:
+        self.results = results
+
+    def batched_get_blocking(
+        self, keys: list[CacheEngineKey]
+    ) -> list[Optional[MemoryObj]]:
+        del keys
+        return self.results
+
+
+class _ErrorBackend:
+    def batched_get_blocking(
+        self, keys: list[CacheEngineKey]
+    ) -> list[Optional[MemoryObj]]:
+        raise ValueError(f"worker-{keys[0].chunk_hash}")
+
+
+def _make_benchmark(num_ops: int, concurrency: int) -> _TestBenchmark:
+    benchmark = _TestBenchmark(
+        "test",
+        num_ops=num_ops,
+        concurrency=concurrency,
+        use_odirect=False,
+        alignment=4096,
+        write_bench=False,
+    )
+    benchmark._keys = [
+        CacheEngineKey("model", 1, 0, index, torch.bfloat16) for index in range(num_ops)
+    ]
+    return benchmark
+
+
+@pytest.mark.parametrize("returned_count", [0, 1])
+def test_read_phase_rejects_empty_or_partial_results(returned_count: int) -> None:
+    benchmark = _make_benchmark(num_ops=2, concurrency=1)
+    returned = [_LoadedObject() for _ in range(returned_count)]
+    benchmark._backend = _ResultBackend(returned)  # type: ignore[assignment]
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"missing_operations={2 - returned_count}",
+    ):
+        benchmark._execute_read_phase()
+
+    assert all(obj.released for obj in returned)
+
+
+def test_read_phase_collects_all_worker_exceptions() -> None:
+    benchmark = _make_benchmark(num_ops=4, concurrency=2)
+    benchmark._backend = _ErrorBackend()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        benchmark._execute_read_phase()
+
+    message = str(exc_info.value)
+    assert "missing_operations=4" in message
+    assert "worker-0" in message
+    assert "worker-2" in message

--- a/tests/v1/storage_backend/test_raw_block_device.py
+++ b/tests/v1/storage_backend/test_raw_block_device.py
@@ -95,6 +95,13 @@ def test_raw_block_device_iouring_best_effort_roundtrip(tmp_path):
         assert dev.wait_iouring(batch_id) == ([True], [])
 
         assert out == payload
+        stats = dev.io_path_stats()
+        assert stats["write_requests"] == 1
+        assert stats["read_requests"] == 1
+        assert stats["iouring_write_requests"] == 1
+        assert stats["iouring_read_requests"] == 1
+        assert stats["posix_write_requests"] == 0
+        assert stats["posix_read_requests"] == 0
     except Exception as e:
         if is_skip_safe_io_error(e):
             pytest.skip(f"io_uring is unavailable on this runner: {e}")
@@ -133,3 +140,47 @@ def test_raw_block_device_odirect_optional_smoke(tmp_path):
     finally:
         if dev is not None:
             dev.close()
+
+
+def test_raw_block_device_io_path_stats_posix(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = RawBlockDevice(
+        str(path),
+        writable=True,
+        use_odirect=False,
+        alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+        io_engine="posix",
+        iouring_queue_depth=8,
+    )
+
+    try:
+        assert all(value == 0 for value in dev.io_path_stats().values())
+        payload = bytearray(b"raw-block-path-stats")
+        out = bytearray(len(payload))
+        dev.pwrite_from_buffer(4096, payload, len(payload), len(payload))
+        dev.pread_into(4096, out, len(out), len(out))
+
+        stats = dev.io_path_stats()
+        assert stats["write_requests"] == 1
+        assert stats["read_requests"] == 1
+        assert stats["posix_write_requests"] == 1
+        assert stats["posix_read_requests"] == 1
+        assert stats["iouring_write_requests"] == 0
+        assert stats["iouring_read_requests"] == 0
+        assert stats["bounce_write_requests"] == 0
+        assert stats["bounce_read_requests"] == 0
+
+        padded_payload = bytearray(b"abc")
+        padded_out = bytearray(len(padded_payload))
+        dev.pwrite_from_buffer(8192, padded_payload, len(padded_payload), 4)
+        dev.pread_into(8192, padded_out, len(padded_out), 4)
+        stats = dev.io_path_stats()
+        assert stats["bounce_write_requests"] == 1
+        assert stats["bounce_read_requests"] == 1
+        assert stats["bounce_write_bytes"] == len(padded_payload)
+        assert stats["bounce_read_bytes"] == len(padded_out)
+
+        dev.reset_io_path_stats()
+        assert all(value == 0 for value in dev.io_path_stats().values())
+    finally:
+        dev.close()


### PR DESCRIPTION
## Summary

- add resettable low-overhead counters for POSIX, io_uring, io_uring_cmd, fixed-buffer, and bounce-buffer I/O paths
- expose the counters through `RawBlockCore` and `RustRawBlockBackend`
- include path ratios and payload GiB/s in the raw-block benchmark output
- add coverage for POSIX/io_uring accounting and counter reset

## Validation

- `pre-commit run --all-files`
- `pytest -q tests/v1/storage_backend/test_raw_block_device.py tests/v1/storage_backend/test_raw_block_core.py tests/v1/storage_backend/test_rust_raw_block_backend.py` (75 passed, 1 skipped)
- release extension build via `maturin develop --release`

The repository-wide pytest invocation is currently blocked during collection because the local environment does not have the optional `vllm` package.
