### PR TITLE
[MUSA]: Add SmartIO muFile backend for MP GDS L1

### DIFF
--- a/.github/workflows/build_musa_artifacts.yml
+++ b/.github/workflows/build_musa_artifacts.yml
@@ -28,7 +28,7 @@ env:
     LC_ALL: en_US.UTF-8
     # The public registry is reachable from GitHub-hosted runners. Keep the
     # image override available for environments that provide their own access.
-    MUSA_IMAGE: ${{ vars.MUSA_IMAGE || 'registry.mthreads.com/mcconline/musa-pytorch-release-public:rc5.2.0-v2.9.1.post1-S5000-py310' }}
+    MUSA_IMAGE: ${{ vars.MUSA_IMAGE || 'registry.mthreads.com/mcconline/musa-pytorch-release-public:rc5.1.0-v2.9.1-S5000-py310_tef' }}
     MUSA_IMAGE_DIGEST: ${{ vars.MUSA_IMAGE_DIGEST || '' }}
     MUSA_HOME: ${{ vars.MUSA_HOME || '/usr/local/musa' }}
     # Leave package installation empty: the public image supplies the build

--- a/.github/workflows/build_musa_artifacts.yml
+++ b/.github/workflows/build_musa_artifacts.yml
@@ -26,11 +26,9 @@ on:
 
 env:
     LC_ALL: en_US.UTF-8
-    # Use the validated CI image by digest. It contains a userspace MUSA
-    # runtime compatible with the bundled Torch build; the public release image
-    # can fail at `import torch` on a GitHub runner without host MUSA drivers.
-    # Organizations can deliberately override it with MUSA_IMAGE.
-    MUSA_IMAGE: ${{ vars.MUSA_IMAGE || 'sh-harbor.mthreads.com/ai-kv/kuae-lmcache-vllm-ci@sha256:75c8c1012cf49caf6dd99dbbfd33931ef100d035647083b999eaf0092d94edba' }}
+    # The public registry is reachable from GitHub-hosted runners. Keep the
+    # image override available for environments that provide their own access.
+    MUSA_IMAGE: ${{ vars.MUSA_IMAGE || 'registry.mthreads.com/mcconline/musa-pytorch-release-public:rc5.2.0-v2.9.1.post1-S5000-py310' }}
     MUSA_IMAGE_DIGEST: ${{ vars.MUSA_IMAGE_DIGEST || '' }}
     MUSA_HOME: ${{ vars.MUSA_HOME || '/usr/local/musa' }}
     # Leave package installation empty: the public image supplies the build

--- a/.github/workflows/build_musa_artifacts.yml
+++ b/.github/workflows/build_musa_artifacts.yml
@@ -26,9 +26,11 @@ on:
 
 env:
     LC_ALL: en_US.UTF-8
-    # The public registry is reachable from GitHub-hosted runners. Keep the
-    # image override available for environments that provide their own access.
-    MUSA_IMAGE: ${{ vars.MUSA_IMAGE || 'registry.mthreads.com/mcconline/musa-pytorch-release-public:rc5.1.0-v2.9.1-S5000-py310_tef' }}
+    # Use the validated CI image by digest. It contains a userspace MUSA
+    # runtime compatible with the bundled Torch build; the public release image
+    # can fail at `import torch` on a GitHub runner without host MUSA drivers.
+    # Organizations can deliberately override it with MUSA_IMAGE.
+    MUSA_IMAGE: ${{ vars.MUSA_IMAGE || 'sh-harbor.mthreads.com/ai-kv/kuae-lmcache-vllm-ci@sha256:75c8c1012cf49caf6dd99dbbfd33931ef100d035647083b999eaf0092d94edba' }}
     MUSA_IMAGE_DIGEST: ${{ vars.MUSA_IMAGE_DIGEST || '' }}
     MUSA_HOME: ${{ vars.MUSA_HOME || '/usr/local/musa' }}
     # Leave package installation empty: the public image supplies the build

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -185,12 +185,13 @@ class GdsL1Config:
     use_direct_io: bool = True
     """Use ``O_DIRECT`` for cuFile/hipFile. Ignored by uGDS."""
 
-    backend: Literal["auto", "cufile", "hipfile", "ugds", "phx"] = "auto"
+    backend: Literal["auto", "cufile", "hipfile", "mufile", "ugds", "phx"] = "auto"
     """GPU storage backend. ``auto`` selects cuFile on CUDA and hipFile on
-    ROCm; ``ugds`` can be used on either platform with a matching
-    ``libugds.so`` and treats ``file_location`` as a character-device path;
-    ``phx`` uses the Phoenix phxfs DMA path with a filesystem slab and a
-    matching ``libphoenix.so``."""
+    ROCm; ``mufile`` uses the SmartIO muFile GDS path on MUSA with a matching
+    ``libmufile.so`` and a filesystem slab; ``ugds`` can be used on either
+    platform with a matching ``libugds.so`` and treats ``file_location`` as a
+    character-device path; ``phx`` uses the Phoenix phxfs DMA path with a
+    filesystem slab and a matching ``libphoenix.so``."""
 
     align_bytes: int = 4096
     """Allocation alignment; cuFile/hipFile and O_DIRECT require 4 KiB."""
@@ -487,12 +488,13 @@ def add_storage_manager_args(
     )
     gds_group.add_argument(
         "--gds-l1-backend",
-        choices=("auto", "cufile", "hipfile", "ugds", "phx"),
+        choices=("auto", "cufile", "hipfile", "mufile", "ugds", "phx"),
         default="auto",
         help="GDS implementation. auto selects cuFile on CUDA or hipFile on ROCm; "
-        "ugds can be used on either platform with a matching libugds.so and "
-        "treats --gds-l1-path as /dev/ugds_drvX; phx uses the Phoenix phxfs "
-        "DMA path with a matching libphoenix.so.",
+        "mufile uses the SmartIO muFile GDS path on MUSA; ugds can be used on "
+        "either platform with a matching libugds.so and treats --gds-l1-path as "
+        "/dev/ugds_drvX; phx uses the Phoenix phxfs DMA path with a matching "
+        "libphoenix.so.",
     )
     # L1 Manager Config (TTL settings)
     ttl_group = parser.add_argument_group(

--- a/lmcache/v1/gpu_connector/_gds_async.py
+++ b/lmcache/v1/gpu_connector/_gds_async.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Literal
 # Third Party
 import torch
 
-BackendName = Literal["auto", "cufile", "hipfile", "ugds", "phx"]
+BackendName = Literal["auto", "cufile", "hipfile", "mufile", "ugds", "phx"]
 _backend: ModuleType
 _selected_backend: str
 _selection_finalized = False
@@ -63,6 +63,11 @@ def _load_backend(name: BackendName) -> tuple[str, ModuleType]:
         from lmcache.v1.gpu_connector import _hipfile_async
 
         backend = _hipfile_async
+    elif selected == "mufile":
+        # First Party
+        from lmcache.v1.gpu_connector import _mufile_async
+
+        backend = _mufile_async
     elif selected == "ugds":
         # First Party
         from lmcache.v1.gpu_connector import _ugds_async
@@ -91,12 +96,25 @@ def _validate_backend_platform(selected: str) -> None:
             raise ValueError("hipfile requires a ROCm PyTorch build")
     elif selected == "cufile" and torch.version.cuda is None:
         raise ValueError(f"{selected} requires a CUDA PyTorch build")
+    elif selected == "mufile" and _torch_device_type() != "musa":
+        raise ValueError(f"{selected} requires a MUSA PyTorch build")
     elif (
         selected == "ugds" and torch.version.hip is None and torch.version.cuda is None
     ):
         raise ValueError(f"{selected} requires a ROCm or CUDA PyTorch build")
     elif selected == "phx" and torch.version.hip is None and torch.version.cuda is None:
         raise ValueError(f"{selected} requires a ROCm or CUDA PyTorch build")
+
+
+def _torch_device_type() -> str:
+    """Return the LMCache platform device type without importing lmcache."""
+    # Imported lazily: the platform detection runs before this shim is used,
+    # and a local import keeps this module importable in CPU-only contexts
+    # (e.g. tests) where the detection stubs the device to ``cpu``.
+    # First Party
+    from lmcache.v1.platform import torch_device_type
+
+    return torch_device_type
 
 
 if TYPE_CHECKING:
@@ -177,3 +195,29 @@ def get_ugds_device_capacity(fd: int, handle: int) -> int:
             "get_ugds_device_capacity requires the selected GDS backend to be 'ugds'"
         )
     return _backend.get_device_capacity(fd, handle)
+
+
+def get_max_registered_region_bytes() -> int:
+    """Return the selected backend's per-registration byte cap.
+
+    GDS buffer registrations (and therefore single DMAs) are capped per
+    backend: 16 MiB for cuFile, hipFile, and muFile alike. GDSContext uses
+    this to split staging buffers and transfers into legal segments.
+
+    Returns:
+        Maximum bytes per buffer registration for the selected backend.
+    """
+    return 16 * 1024 * 1024
+
+
+def get_io_alignment() -> int:
+    """Return the selected backend's async I/O alignment requirement.
+
+    4 KiB for all file-backed backends (cuFile, hipFile, muFile, phx); uGDS
+    does not go through the page cache so it has no alignment requirement
+    beyond the slab's own 4 KiB allocation grid.
+
+    Returns:
+        Alignment in bytes for the selected backend.
+    """
+    return 4096

--- a/lmcache/v1/gpu_connector/_mufile_async.py
+++ b/lmcache/v1/gpu_connector/_mufile_async.py
@@ -1,0 +1,616 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal ctypes wrapper around the muFile async C API (Moore Threads MUSA).
+
+MUSA analog of :mod:`lmcache.v1.gpu_connector._cufile_async`. muFile
+(``SmartIO/mufile``) is the MUSA GPUDirect-Storage library; its async surface
+is similar to cuFile (``muFileReadAsync`` + ``muFileStreamRegister`` + single
+``musaStreamSynchronize``), so this module exposes a compatible set of
+primitives and Python interface -- :class:`GDSContext` talks to either through
+the :mod:`lmcache.v1.gpu_connector._gds_async` dispatch shim.
+
+Surface (similar to ``_hipfile_async`` and ``_cufile_async``):
+
+- :func:`register_buffer` / :func:`deregister_buffer` — wrap
+  ``muFileBufRegister`` / ``muFileBufDeregister`` on a torch tensor.
+- :func:`register_stream` / :func:`deregister_stream` — wrap
+  ``muFileStreamRegister`` / ``muFileStreamDeregister`` on a raw MUSA
+  stream handle.
+- :func:`register_handle` / :func:`deregister_handle` — wrap
+  ``muFileHandleRegister`` / ``muFileHandleDeregister`` on an fd.
+- :class:`AsyncHandle` — opens a file with ``O_DIRECT`` (required by
+  muFile) and registers the muFile handle. ``read_async`` /
+  ``write_async`` enqueue an async IO on a stream and return a
+  :class:`Submission`. Callers run ``musaStreamSynchronize`` once to drain a
+  batch; :meth:`Submission.bytes_done` returns the actual byte count.
+
+Unlike cuFile (which ships an ``nvidia.cufile`` Python binding), muFile has
+no Python package, so every symbol -- driver lifecycle, handle/buffer
+registration, and the ``MUfileError_t`` / ``MUFileDescr_t`` structs -- is
+bound directly from ``libmufile.so`` via ctypes here. Requires SmartIO >=
+the version with the async ABI documented in the LMCache design doc.
+"""
+
+# Standard
+from typing import Any, Optional
+import ctypes
+import os
+import threading
+
+# Third Party
+import torch
+
+# ``libmufile.so`` is dlopened lazily (see ``_lib``) so importing this module
+# on a CPU-only / non-MUSA host -- it is transitively pulled in by the GDS
+# dispatch shim during CLI command discovery -- does not require the MUSA GPU
+# IO driver to be present. This mirrors the lazy ``import cufile`` in the
+# cuFile wrapper.
+
+_LIBMUFILE_SONAME = "libmufile.so"
+
+# muFile handle type for a POSIX fd (mufile.h: ``MU_FILE_HANDLE_TYPE_OPAQUE_FD``).
+_MUFILE_HANDLE_TYPE_OPAQUE_FD = 1
+
+# muFileStreamRegister flags (mufile.h): only MUFILE_STREAM_FIXED_AND_ALIGNED
+# (0x1) is accepted by the library. Other flag values are rejected.
+_STREAM_REGISTER_FLAGS = 0x1
+
+# muFileSuccess (mufile.h ``MU_FILE_SUCCESS``).
+_MUFILE_SUCCESS = 0
+
+# Alignment requirement for muFile async I/O (4 KiB).
+_MUFILE_ALIGNMENT = 4096
+
+
+# --- Error enum mirror ------------------------------------------------------
+
+# Partial mirror of MUfileOpError from mufile.h for diagnostic messages.
+# Full enum is long; we only need the names that appear in common errors.
+_OP_ERROR_NAMES: dict[int, str] = {
+    0: "MU_FILE_SUCCESS",
+    1: "MU_FILE_DRIVER_NOT_INITIALIZED",
+    2: "MU_FILE_DRIVER_INVALID_PROPS",
+    3: "MU_FILE_DRIVER_UNSUPPORTED_LIMIT",
+    4: "MU_FILE_DRIVER_VERSION_MISMATCH",
+    5: "MU_FILE_DRIVER_VERSION_READ_ERROR",
+    6: "MU_FILE_DRIVER_CLOSING",
+    7: "MU_FILE_PLATFORM_NOT_SUPPORTED",
+    8: "MU_FILE_IO_NOT_SUPPORTED",
+    9: "MU_FILE_DEVICE_NOT_SUPPORTED",
+    10: "MU_FILE_MTFS_DRIVER_ERROR",
+    11: "MU_FILE_MUSA_DRIVER_ERROR",
+    12: "MU_FILE_MUSA_POINTER_INVALID",
+    13: "MU_FILE_MUSA_MEMORY_TYPE_INVALID",
+    14: "MU_FILE_MUSA_POINTER_RANGE_ERROR",
+    15: "MU_FILE_MUSA_CONTEXT_MISMATCH",
+    16: "MU_FILE_INVALID_MAPPING_SIZE",
+    17: "MU_FILE_INVALID_MAPPING_RANGE",
+    18: "MU_FILE_INVALID_FILE_TYPE",
+    19: "MU_FILE_INVALID_FILE_OPEN_FLAG",
+    20: "MU_FILE_DIO_NOT_SET",
+    21: "MU_FILE_INVALID_VALUE",
+    22: "MU_FILE_MEMORY_ALREADY_REGISTERED",
+    23: "MU_FILE_MEMORY_NOT_REGISTERED",
+    24: "MU_FILE_PERMISSION_DENIED",
+    25: "MU_FILE_DRIVER_ALREADY_OPEN",
+    26: "MU_FILE_HANDLE_NOT_REGISTERED",
+    27: "MU_FILE_HANDLE_ALREADY_REGISTERED",
+    28: "MU_FILE_DEVICE_NOT_FOUND",
+    29: "MU_FILE_INTERNAL_ERROR",
+}
+
+
+class _MUfileError(ctypes.Structure):
+    """ctypes mirror of ``MUfileError_t`` (mufile.h).
+
+    Single int field: ``err`` is the ``MUfileOpError_t`` status
+    (0 == success).
+    """
+
+    _fields_ = [("err", ctypes.c_int)]
+
+
+class _MUFileHandleUnion(ctypes.Union):
+    """ctypes mirror of the ``MUFileDescr_t.handle`` union (fd or Win32 HANDLE)."""
+
+    _fields_ = [("fd", ctypes.c_int), ("handle", ctypes.c_void_p)]
+
+
+class _MUFileDescr(ctypes.Structure):
+    """ctypes mirror of ``MUFileDescr_t`` (mufile.h).
+
+    Layout on LP64: type (4B) + padding (4B) + union (8B) = 16 bytes.
+    """
+
+    _fields_ = [
+        ("type", ctypes.c_int),
+        # 4 bytes padding here on LP64, ctypes handles it.
+        ("handle", _MUFileHandleUnion),
+    ]
+
+
+# Guards the one-time dlopen + driver open/close below. Only the init/teardown
+# transitions are serialized; the per-DMA fast path (``_lib()`` once loaded)
+# never touches the lock.
+_init_lock = threading.Lock()
+_lib_handle: Optional[ctypes.CDLL] = None
+
+
+def _declare_signatures(lib: ctypes.CDLL) -> None:
+    """Set argtypes/restype on the libmufile symbols. Idempotent."""
+    if getattr(lib.muFileReadAsync, "argtypes", None):
+        return
+
+    lib.muFileDriverOpen.argtypes = []
+    lib.muFileDriverOpen.restype = _MUfileError
+
+    lib.muFileDriverClose.argtypes = []
+    lib.muFileDriverClose.restype = _MUfileError
+
+    lib.muFileHandleRegister.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),  # MUFileHandle_t *fh
+        ctypes.POINTER(_MUFileDescr),  # MUFileDescr_t *descr
+    ]
+    lib.muFileHandleRegister.restype = _MUfileError
+
+    lib.muFileHandleDeregister.argtypes = [ctypes.c_void_p]  # MUFileHandle_t fh
+    lib.muFileHandleDeregister.restype = _MUfileError
+
+    lib.muFileBufRegister.argtypes = [
+        ctypes.c_void_p,  # const void *buffer_base
+        ctypes.c_size_t,  # size_t length
+        ctypes.c_int,  # int flags
+    ]
+    lib.muFileBufRegister.restype = _MUfileError
+
+    lib.muFileBufDeregister.argtypes = [ctypes.c_void_p]  # const void *buffer_base
+    lib.muFileBufDeregister.restype = _MUfileError
+
+    # Async I/O: size_t *bytes_*_p for completion, ssize_t return for status.
+    lib.muFileReadAsync.argtypes = [
+        ctypes.c_void_p,  # MUFileHandle_t fh
+        ctypes.c_void_p,  # void *buffer_base
+        ctypes.POINTER(ctypes.c_size_t),  # size_t *size_p
+        ctypes.POINTER(ctypes.c_int64),  # off_t *file_offset_p
+        ctypes.POINTER(ctypes.c_int64),  # off_t *devPtr_offset_p
+        ctypes.POINTER(ctypes.c_size_t),  # size_t *bytes_read_p
+        ctypes.c_void_p,  # musaStream_t stream
+    ]
+    lib.muFileReadAsync.restype = ctypes.c_ssize_t
+
+    lib.muFileWriteAsync.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_void_p,
+    ]
+    lib.muFileWriteAsync.restype = ctypes.c_ssize_t
+
+    lib.muFileStreamRegister.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    lib.muFileStreamRegister.restype = _MUfileError
+
+    lib.muFileStreamDeregister.argtypes = [ctypes.c_void_p]
+    lib.muFileStreamDeregister.restype = _MUfileError
+
+
+_driver_opened = False
+
+
+def _lib() -> ctypes.CDLL:
+    """dlopen ``libmufile.so`` once and declare signatures. Idempotent.
+
+    Thread-safe via double-checked locking: the common case (already loaded)
+    returns without taking ``_init_lock``, so the per-DMA path stays lock-free.
+
+    Returns:
+        The process-global ``libmufile.so`` handle.
+    """
+    global _lib_handle
+    if _lib_handle is not None:
+        return _lib_handle
+    with _init_lock:
+        if _lib_handle is None:
+            handle = ctypes.CDLL(_LIBMUFILE_SONAME)
+            _declare_signatures(handle)
+            _lib_handle = handle
+    return _lib_handle
+
+
+def _ensure_driver_open() -> None:
+    """Idempotently open the muFile driver (thread-safe).
+
+    Raises:
+        RuntimeError: If ``muFileDriverOpen`` reports a non-success status.
+    """
+    global _driver_opened
+    if _driver_opened:
+        return
+    # ``_lib()`` does its own locking; call it before taking ``_init_lock`` so
+    # the (non-reentrant) lock is never acquired twice on the same thread.
+    lib = _lib()
+    with _init_lock:
+        if _driver_opened:
+            return
+        _check(lib.muFileDriverOpen(), "muFileDriverOpen")
+        _driver_opened = True
+
+
+def close_driver() -> None:
+    """Close the muFile driver (thread-safe). Optional — useful in tests.
+
+    Raises:
+        RuntimeError: If ``muFileDriverClose`` reports a non-success status.
+    """
+    global _driver_opened
+    if not _driver_opened:
+        return
+    lib = _lib()
+    with _init_lock:
+        if not _driver_opened:
+            return
+        try:
+            _check(lib.muFileDriverClose(), "muFileDriverClose")
+        finally:
+            _driver_opened = False
+
+
+def _op_error_name(err_code: int) -> str:
+    """Return the human-readable name for a ``MUfileOpError_t`` value."""
+    return _OP_ERROR_NAMES.get(abs(err_code), f"MU_FILE_ERROR_{abs(err_code)}")
+
+
+def _check(err: "_MUfileError", op: str) -> None:
+    """Convert a non-zero ``MUfileError_t`` into a Python exception."""
+    if err.err != _MUFILE_SUCCESS:
+        raise RuntimeError(
+            f"{op} failed: muFileError(err={err.err} [{_op_error_name(err.err)}])"
+        )
+
+
+# --- Handle registration -------------------------------------------
+
+# muFile's handle points into the caller's MUFileDescr_t, so each descriptor
+# must outlive its handle. Registered descriptors are kept here until
+# muFileHandleDeregister releases them.
+_handle_descr_registry: dict[int, _MUFileDescr] = {}
+_handle_registry_lock = threading.Lock()
+
+
+def register_handle(fd: int) -> int:
+    """Register an open fd with muFile and return the ``MUFileHandle_t``.
+
+    Opens the muFile driver on first use. The returned handle is the raw
+    ``void *`` value (as an int), accepted directly as the first argument of
+    ``muFileReadAsync`` / ``muFileWriteAsync``. The descriptor backing the
+    registration is retained by this module until :func:`deregister_handle`.
+
+    Args:
+        fd: An open file descriptor for the slab (opened with ``O_DIRECT`` for
+            the GDS fast path).
+
+    Returns:
+        The registered ``MUFileHandle_t`` as an integer.
+
+    Raises:
+        RuntimeError: If ``muFileHandleRegister`` reports a non-success status.
+    """
+    _ensure_driver_open()
+    lib = _lib()
+    handle = ctypes.c_void_p()
+    descr = _MUFileDescr()
+    descr.type = _MUFILE_HANDLE_TYPE_OPAQUE_FD
+    descr.handle.fd = fd
+    _check(
+        lib.muFileHandleRegister(ctypes.byref(handle), ctypes.byref(descr)),
+        "muFileHandleRegister",
+    )
+    value = handle.value if handle.value is not None else 0
+    with _handle_registry_lock:
+        _handle_descr_registry[value] = descr
+    return value
+
+
+def deregister_handle(handle: int) -> None:
+    """Reverse of :func:`register_handle` (``muFileHandleDeregister``).
+
+    Also releases the retained descriptor, which may not outlive the handle.
+
+    Args:
+        handle: The ``MUFileHandle_t`` (as an int) from :func:`register_handle`.
+
+    Raises:
+        RuntimeError: If ``muFileHandleDeregister`` reports a non-success status.
+    """
+    with _handle_registry_lock:
+        _handle_descr_registry.pop(handle, None)
+    _check(
+        _lib().muFileHandleDeregister(ctypes.c_void_p(handle)),
+        "muFileHandleDeregister",
+    )
+
+
+# --- Buffer / stream registration ----------------------------------
+
+
+def register_buffer(buf: torch.Tensor) -> None:
+    """Register a device tensor with muFile for GPUDirect Storage DMA.
+
+    Must be called before any ``read_async`` / ``write_async`` whose
+    ``buf_base`` falls inside this tensor's allocation. Implicitly opens the
+    muFile driver on first use.
+
+    Args:
+        buf: A GPU (MUSA device) tensor to register for DMA.
+
+    Raises:
+        ValueError: If ``buf`` is not on the GPU.
+        RuntimeError: If ``muFileBufRegister`` reports a non-success status.
+    """
+    if not getattr(buf, "is_musa", False):
+        raise ValueError("register_buffer: tensor must be on the MUSA device")
+    _ensure_driver_open()
+    lib = _lib()
+    nbytes = buf.numel() * buf.element_size()
+    _check(
+        lib.muFileBufRegister(
+            ctypes.c_void_p(buf.data_ptr()),
+            ctypes.c_size_t(nbytes),
+            ctypes.c_int(0),
+        ),
+        "muFileBufRegister",
+    )
+
+
+def deregister_buffer(buf: torch.Tensor) -> None:
+    """Reverse of :func:`register_buffer`.
+
+    Args:
+        buf: A tensor previously passed to :func:`register_buffer`.
+
+    Raises:
+        RuntimeError: If ``muFileBufDeregister`` reports a non-success status.
+    """
+    _check(
+        _lib().muFileBufDeregister(ctypes.c_void_p(buf.data_ptr())),
+        "muFileBufDeregister",
+    )
+
+
+def register_stream(raw_stream: int) -> None:
+    """Register a MUSA stream with muFile.
+
+    ``raw_stream`` is the integer ``musaStream_t`` handle — get it via
+    ``stream.musa_stream`` or ``stream.ptr`` on MUSA platforms.
+
+    Optional for correctness (``read_async`` / ``write_async`` also take the
+    stream per call). Registered with the FIXED_AND_ALIGNED flag (0x1): muFile
+    still reads the size/offset pointers at stream-execution time -- so their
+    storage must stay alive and unchanged until completion (see ``Submission``)
+    -- but promising the values are fixed at submission lets muFile skip
+    per-op setup.
+
+    Args:
+        raw_stream: The integer ``musaStream_t`` handle to register.
+
+    Raises:
+        RuntimeError: If ``muFileStreamRegister`` reports a non-success status.
+        ValueError: If flags other than 0x1 are requested (muFile only accepts
+            MUFILE_STREAM_FIXED_AND_ALIGNED).
+    """
+    _ensure_driver_open()
+    _check(
+        _lib().muFileStreamRegister(
+            ctypes.c_void_p(raw_stream), _STREAM_REGISTER_FLAGS
+        ),
+        "muFileStreamRegister",
+    )
+
+
+def deregister_stream(raw_stream: int) -> None:
+    """Reverse of :func:`register_stream`.
+
+    Args:
+        raw_stream: The ``musaStream_t`` handle passed to :func:`register_stream`.
+
+    Raises:
+        RuntimeError: If ``muFileStreamDeregister`` reports a non-success status.
+    """
+    _check(
+        _lib().muFileStreamDeregister(ctypes.c_void_p(raw_stream)),
+        "muFileStreamDeregister",
+    )
+
+
+# --- AsyncHandle + Submission --------------------------------------
+
+
+class Submission:
+    """One in-flight ``muFileReadAsync`` / ``muFileWriteAsync``.
+
+    Holds the host-side ``size_p`` / ``file_offset_p`` / ``buf_offset_p`` /
+    ``bytes_done_p`` storage that muFile writes into asynchronously. These
+    ctypes objects MUST stay alive until the stream actually executes the op —
+    keep the :class:`Submission` reference (or stash it in a list) until after
+    the stream sync.
+    """
+
+    __slots__ = ("_size", "_file_offset", "_buf_offset", "_bytes_done")
+
+    def __init__(
+        self,
+        size: int,
+        file_offset: int,
+        buf_offset: int,
+    ) -> None:
+        self._size = ctypes.c_size_t(size)
+        self._file_offset = ctypes.c_int64(file_offset)
+        self._buf_offset = ctypes.c_int64(buf_offset)
+        self._bytes_done = ctypes.c_size_t(0)
+
+    @property
+    def bytes_done(self) -> int:
+        """Bytes actually transferred. Valid only AFTER the stream sync."""
+        return self._bytes_done.value
+
+
+def _check_alignment(
+    buf_base: int, size: int, file_offset: int, buf_offset: int
+) -> None:
+    """Raise ValueError if any async I/O operand is not 4 KiB aligned.
+
+    muFile's async path requires page-aligned base, size, file offset, and
+    device offset. This wrapper enforces that contract before calling the
+    library.
+    """
+    if buf_base % _MUFILE_ALIGNMENT != 0:
+        raise ValueError(
+            f"buf_base 0x{buf_base:x} is not {_MUFILE_ALIGNMENT}-byte aligned"
+        )
+    if size % _MUFILE_ALIGNMENT != 0:
+        raise ValueError(f"size {size} is not {_MUFILE_ALIGNMENT}-byte aligned")
+    if file_offset % _MUFILE_ALIGNMENT != 0:
+        raise ValueError(
+            f"file_offset {file_offset} is not {_MUFILE_ALIGNMENT}-byte aligned"
+        )
+    if buf_offset % _MUFILE_ALIGNMENT != 0:
+        raise ValueError(
+            f"buf_offset {buf_offset} is not {_MUFILE_ALIGNMENT}-byte aligned"
+        )
+
+
+class AsyncHandle:
+    """Open file + muFile handle wrapper.
+
+    Opens with ``O_DIRECT`` (required for muFile's GPUDirect Storage fast
+    path). Optionally pre-allocates the file via ``posix_fallocate``.
+    """
+
+    __slots__ = ("_fd", "_handle", "path", "writable")
+
+    def __init__(
+        self,
+        path: str,
+        writable: bool = False,
+        fallocate_size: Optional[int] = None,
+        mode: int = 0o644,
+    ) -> None:
+        flags = os.O_DIRECT
+        if writable:
+            flags |= os.O_CREAT | os.O_RDWR
+        else:
+            flags |= os.O_RDONLY
+        self.path = path
+        self.writable = writable
+        self._fd = os.open(path, flags, mode)
+        try:
+            if fallocate_size is not None and writable:
+                os.posix_fallocate(self._fd, 0, fallocate_size)
+            self._handle = register_handle(self._fd)
+        except Exception:
+            os.close(self._fd)
+            raise
+
+    @classmethod
+    def from_fd(
+        cls,
+        fd: int,
+        handle: int,
+        path: str,
+        writable: bool = False,
+    ) -> "AsyncHandle":
+        """Wrap an already-opened fd and registered muFile handle.
+
+        For callers that open + register the file themselves (e.g. a slab that
+        must be created, truncated, and ``posix_fallocate``d before
+        ``muFileHandleRegister``) and just need an ``AsyncHandle`` around the
+        result. The descriptor is NOT retained; the caller must keep the fd
+        open until ``close()``.
+        """
+        obj = cls.__new__(cls)
+        obj._fd = fd
+        obj._handle = handle
+        obj.path = path
+        obj.writable = writable
+        return obj
+
+    @property
+    def fd(self) -> int:
+        return self._fd
+
+    def read_async(
+        self,
+        buf_base: int,
+        size: int,
+        file_offset: int,
+        buf_offset: int,
+        raw_stream: int,
+    ) -> Submission:
+        """Enqueue a ``muFileReadAsync`` on the stream.
+
+        ``buf_base`` is the registered base pointer (e.g. ``buf.data_ptr()``).
+        ``buf_offset`` is the byte offset within that registration that the data
+        should land at.
+        """
+        _check_alignment(buf_base, size, file_offset, buf_offset)
+        sub = Submission(size=size, file_offset=file_offset, buf_offset=buf_offset)
+        ret = _lib().muFileReadAsync(
+            ctypes.c_void_p(self._handle),
+            ctypes.c_void_p(buf_base),
+            ctypes.byref(sub._size),
+            ctypes.byref(sub._file_offset),
+            ctypes.byref(sub._buf_offset),
+            ctypes.byref(sub._bytes_done),
+            ctypes.c_void_p(raw_stream),
+        )
+        if ret < 0:
+            raise RuntimeError(f"muFileReadAsync failed: {_op_error_name(int(ret))}")
+        return sub
+
+    def write_async(
+        self,
+        buf_base: int,
+        size: int,
+        file_offset: int,
+        buf_offset: int,
+        raw_stream: int,
+    ) -> Submission:
+        """Enqueue a ``muFileWriteAsync`` on the stream."""
+        _check_alignment(buf_base, size, file_offset, buf_offset)
+        sub = Submission(size=size, file_offset=file_offset, buf_offset=buf_offset)
+        ret = _lib().muFileWriteAsync(
+            ctypes.c_void_p(self._handle),
+            ctypes.c_void_p(buf_base),
+            ctypes.byref(sub._size),
+            ctypes.byref(sub._file_offset),
+            ctypes.byref(sub._buf_offset),
+            ctypes.byref(sub._bytes_done),
+            ctypes.c_void_p(raw_stream),
+        )
+        if ret < 0:
+            raise RuntimeError(f"muFileWriteAsync failed: {_op_error_name(int(ret))}")
+        return sub
+
+    def close(self) -> None:
+        """Deregister the muFile handle and close the fd."""
+        if self._fd < 0:
+            return
+        try:
+            deregister_handle(self._handle)
+        finally:
+            try:
+                os.close(self._fd)
+            finally:
+                self._fd = -1
+
+    def __enter__(self) -> "AsyncHandle":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[Any],
+    ) -> None:
+        self.close()

--- a/lmcache/v1/gpu_connector/gds_context.py
+++ b/lmcache/v1/gpu_connector/gds_context.py
@@ -39,14 +39,41 @@ from lmcache.v1.memory_management import GDSMemoryObject
 logger = init_logger(__name__)
 
 _SLAB_FILENAME = "lmcache_gds_slab.bin"
-_CUFILE_ALIGNMENT = 4096
-# A single GDS buffer registration / DMA is capped at 16 MiB (both cuFile and
-# hipFile); larger buffers and chunks are registered and transferred in
-# <=16 MiB regions.
-_MAX_CUFILE_REGION = 16 * 1024 * 1024
 # GDS submissions to accumulate before recording a completion event and
 # draining finished ones (keeps the live submission set bounded).
 _SUBMISSION_CHECKPOINT_EVERY = 64
+
+
+def get_raw_stream_handle(stream: object) -> int:
+    """Return the active backend's native stream handle.
+
+    MUSA streams expose ``musa_stream``; CUDA and ROCm use ``cuda_stream``.
+    Falls back to ``ptr`` for streams that expose it directly.
+
+    Args:
+        stream: A ``torch.Stream`` or platform-specific stream object.
+
+    Returns:
+        The raw stream pointer as an integer.
+
+    Raises:
+        RuntimeError: If the stream exposes none of the known attributes.
+    """
+    # MUSA: musa_stream takes precedence.
+    musa_stream = getattr(stream, "musa_stream", None)
+    if musa_stream is not None:
+        return int(musa_stream)
+    # CUDA/ROCm: cuda_stream attribute.
+    cuda_stream = getattr(stream, "cuda_stream", None)
+    if cuda_stream is not None:
+        return int(cuda_stream)
+    # Direct ptr attribute (used by some adapters).
+    ptr = getattr(stream, "ptr", None)
+    if ptr is not None:
+        return int(ptr)
+    raise RuntimeError(
+        f"stream of type {type(stream).__name__} does not expose a stream handle"
+    )
 
 
 def _validate_ugds_device(path: str) -> None:
@@ -131,9 +158,8 @@ class GDSContext:
                 exceeds the backing device capacity.
             Exception: Whatever the GDS library raises if GDS is unavailable.
         """
-        self._slab_size = (config.size_in_bytes + _CUFILE_ALIGNMENT - 1) & ~(
-            _CUFILE_ALIGNMENT - 1
-        )
+        alignment = ca.get_io_alignment()
+        self._slab_size = (config.size_in_bytes + alignment - 1) & ~(alignment - 1)
         self._backend = ca.select_backend(config.backend)
 
         # One shared slab per process (the GDSContext is a process-global
@@ -161,16 +187,17 @@ class GDSContext:
         """
         if not self.initialized:
             return
-        raw_stream = torch_dev.current_stream().cuda_stream
+        raw_stream = get_raw_stream_handle(torch_dev.current_stream())
         buf = buffer.view(torch.uint8)
         nbytes = buf.numel()
+        max_region = ca.get_max_registered_region_bytes()
         with self._registry_lock:
             if raw_stream not in self._registered_streams:
                 ca.register_stream(raw_stream)
                 self._registered_streams.add(raw_stream)
-            for start in range(0, nbytes, _MAX_CUFILE_REGION):
+            for start in range(0, nbytes, max_region):
                 self._register_region_locked(
-                    buf[start : min(start + _MAX_CUFILE_REGION, nbytes)]
+                    buf[start : min(start + max_region, nbytes)]
                 )
 
     def deregister_gpu_buffer(self, buffer: torch.Tensor) -> None:
@@ -182,15 +209,16 @@ class GDSContext:
         if not self.initialized:
             return
         stream = torch_dev.current_stream()
-        raw_stream = stream.cuda_stream
+        raw_stream = get_raw_stream_handle(stream)
         # No in-flight DMA on this stream may still reference the buffer.
         stream.synchronize()
         buf = buffer.view(torch.uint8)
         nbytes = buf.numel()
+        max_region = ca.get_max_registered_region_bytes()
         with self._registry_lock:
-            for start in range(0, nbytes, _MAX_CUFILE_REGION):
+            for start in range(0, nbytes, max_region):
                 self._deregister_region_locked(
-                    buf[start : min(start + _MAX_CUFILE_REGION, nbytes)]
+                    buf[start : min(start + max_region, nbytes)]
                 )
             if raw_stream in self._registered_streams:
                 try:
@@ -236,7 +264,11 @@ class GDSContext:
             pos += seg_len
 
     def close(self) -> None:
-        """Sync the stream, deregister GDS state, and close the slab handle."""
+        """Sync the stream, deregister GDS state, and close the slab handle.
+
+        Finally closes the backend driver (``close_driver``) so the GDS
+        library lifecycle is not left to Python teardown ordering.
+        """
         if self._buffers:
             torch_dev.synchronize(device=self._buffers[0].device)
         with self._submissions_lock:
@@ -265,6 +297,10 @@ class GDSContext:
             except Exception as e:
                 logger.warning("GDSContext.close: slab handle close failed: %s", e)
             self._slab_handle = None
+        try:
+            ca.close_driver()
+        except Exception as e:
+            logger.warning("GDSContext.close: close_driver: %s", e)
 
     # --- Internal -----------------------------------------------------
 
@@ -395,7 +431,7 @@ class GDSContext:
         """Submit one async GDS read against the slab handle (stream-ordered)."""
         if self._slab_handle is None:
             raise RuntimeError("GDSContext._slab_read: slab handle not open")
-        stream_handle = torch_dev.current_stream().cuda_stream
+        stream_handle = get_raw_stream_handle(torch_dev.current_stream())
         sub = self._slab_handle.read_async(
             buf_base, size, slab_offset, dev_offset, stream_handle
         )
@@ -407,7 +443,7 @@ class GDSContext:
         """Submit one async GDS write against the slab handle (stream-ordered)."""
         if self._slab_handle is None:
             raise RuntimeError("GDSContext._slab_write: slab handle not open")
-        stream_handle = torch_dev.current_stream().cuda_stream
+        stream_handle = get_raw_stream_handle(torch_dev.current_stream())
         sub = self._slab_handle.write_async(
             buf_base, size, slab_offset, dev_offset, stream_handle
         )
@@ -420,7 +456,7 @@ class GDSContext:
         ops a GPU event is recorded and completed batches are released.
         """
         stream = torch_dev.current_stream()
-        raw_stream = stream.cuda_stream
+        raw_stream = get_raw_stream_handle(stream)
         with self._submissions_lock:
             st = self._submissions.get(raw_stream)
             if st is None:

--- a/lmcache/v1/platform/musa/cache_context.py
+++ b/lmcache/v1/platform/musa/cache_context.py
@@ -16,6 +16,7 @@ from lmcache import torch_dev
 from lmcache.lmcache_native import EngineKVFormat
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.gds_context import get_gds_context
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
@@ -148,6 +149,11 @@ class _TempMUSABuffer:
     def max_batch_size(self) -> int:
         """Return the number of chunks that fit in the staging buffer."""
         return self._max_batch_size
+
+    @property
+    def buffer(self) -> torch.Tensor:
+        """Return the flat staging tensor (for GDS muFile registration)."""
+        return self._temp_buffer
 
     def get_temp_kernel_group_buffer(
         self,
@@ -360,6 +366,11 @@ class MUSACacheContext(BaseCacheContext):
         self.stream_ = torch_dev.Stream(device=self.device_)
         self.host_callback_stream_ = _MUSAHostCallbackStream(self.stream_)
 
+        # Register the staging buffer with the GDS muFile context on the
+        # context's MUSA stream (mirrors the CUDA cache context).
+        with torch_dev.stream(self.stream_):
+            get_gds_context().register_gpu_buffer(self._temp_buffer.buffer)
+
         logger.debug(
             "MUSACacheContext: %d layers, %d blocks, dtype=%s",
             self.num_layers_,
@@ -369,6 +380,9 @@ class MUSACacheContext(BaseCacheContext):
 
     def close(self) -> None:
         """Synchronize transfers and release receiver-side IPC owners.
+
+        Also deregisters the GDS staging buffer on the context's MUSA stream
+        before releasing IPC wrappers.
 
         Returns:
             None.
@@ -384,6 +398,12 @@ class MUSACacheContext(BaseCacheContext):
         synchronize = getattr(stream, "synchronize", None)
         if callable(synchronize):
             synchronize()
+
+        # Deregister the staging buffer from GDS on the context's stream.
+        temp_buffer = getattr(self, "_temp_buffer", None)
+        if temp_buffer is not None and stream is not None:
+            with torch_dev.stream(stream):
+                get_gds_context().deregister_gpu_buffer(temp_buffer.buffer)
 
         kv_tensors = getattr(self, "kv_caches_", None)
         if isinstance(kv_tensors, list):

--- a/tests/v1/gpu_connector/test_mufile_async.py
+++ b/tests/v1/gpu_connector/test_mufile_async.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the muFile async wrapper (``_mufile_async``).
+
+These are pure: ``libmufile.so`` is never dlopened. A fake lib (see
+:class:`_FakeLib`) is substituted at the ``_lib`` seam, so the tests exercise
+the Python logic of the ctypes wrapper -- ``MUFileDescr_t`` construction and
+ownership, the stream-register flag value, error decoding, :class:`Submission`
+lifetime, 4 KiB submit alignment enforcement, and which symbol each call
+dispatches to -- without a GPU or the SmartIO GPU IO driver. The ctypes ABI
+itself (struct field offsets, argtype marshalling) is covered by the
+on-hardware roundtrip tests in ``test_gds_context.py``.
+"""
+
+# Standard
+from types import SimpleNamespace
+import ctypes
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.gpu_connector import _mufile_async as ma
+
+
+def _ok() -> ma._MUfileError:
+    """A success ``MUfileError_t`` (err == MU_FILE_SUCCESS)."""
+    return ma._MUfileError(err=ma._MUFILE_SUCCESS)
+
+
+def _err(code: int = 2) -> ma._MUfileError:
+    """A failure ``MUfileError_t``."""
+    return ma._MUfileError(err=code)
+
+
+class _FakeLib:
+    """Stand-in for the ``libmufile.so`` CDLL.
+
+    Each muFile symbol records its positional args in :attr:`calls` and returns
+    a success ``MUfileError_t`` by default. Tests override individual symbols
+    (e.g. to populate an out-param or force an error) by assigning attributes.
+    """
+
+    def __init__(self) -> None:
+        self.calls: dict[str, tuple] = {}
+
+    def __getattr__(self, name: str):
+        # Any muFile* symbol not explicitly overridden records its args and
+        # succeeds. ``__getattr__`` only fires for names not set in __dict__.
+        # Async IO returns a plain ``ssize_t`` submit status per the ABI; every
+        # other symbol returns a ``MUfileError_t`` struct.
+        def _record(*args):
+            self.calls[name] = args
+            if name in ("muFileReadAsync", "muFileWriteAsync"):
+                return 0
+            return _ok()
+
+        return _record
+
+
+@pytest.fixture(autouse=True)
+def _fake_lib(monkeypatch: pytest.MonkeyPatch) -> _FakeLib:
+    """Replace the ``_lib`` seam with a fake and reset module driver state."""
+    lib = _FakeLib()
+    monkeypatch.setattr(ma, "_lib", lambda: lib)
+    monkeypatch.setattr(ma, "_driver_opened", False)
+    return lib
+
+
+def _fake_gpu_tensor(ptr: int = 0x1000, nbytes: int = 4096):
+    """A duck-typed stand-in for a MUSA ``torch.Tensor`` (no GPU needed)."""
+    return SimpleNamespace(
+        is_musa=True,
+        data_ptr=lambda: ptr,
+        numel=lambda: nbytes,
+        element_size=lambda: 1,
+    )
+
+
+class TestCheck:
+    def test_success_is_noop(self):
+        ma._check(_ok(), "op")
+
+    def test_nonzero_raises_with_code(self, _fake_lib):
+        with pytest.raises(RuntimeError) as exc:
+            ma._check(_err(5), "muFileDriverOpen")
+        msg = str(exc.value)
+        assert "muFileDriverOpen" in msg
+        assert "5" in msg
+
+
+class TestDriverLifecycle:
+    def test_ensure_open_calls_driver_open_once(self, _fake_lib):
+        ma._ensure_driver_open()
+        ma._ensure_driver_open()
+        assert "muFileDriverOpen" in _fake_lib.calls
+        assert ma._driver_opened is True
+
+    def test_close_driver_when_open(self, _fake_lib):
+        ma._ensure_driver_open()
+        ma.close_driver()
+        assert "muFileDriverClose" in _fake_lib.calls
+        assert ma._driver_opened is False
+
+    def test_close_driver_noop_when_closed(self, _fake_lib):
+        ma.close_driver()
+        assert "muFileDriverClose" not in _fake_lib.calls
+
+
+class TestRegisterHandle:
+    def test_builds_opaque_fd_descr_and_returns_handle_and_keeps_descr(self, _fake_lib):
+        captured = {}
+
+        def _register(fh_ref, descr_ref):
+            descr = descr_ref._obj
+            captured["type"] = descr.type
+            captured["fd"] = descr.handle.fd
+            # Populate the out-param like the real driver would.
+            fh_ref._obj.value = 0xDEADBEEF
+            return _ok()
+
+        _fake_lib.muFileHandleRegister = _register
+        handle = ma.register_handle(42)
+        assert handle == 0xDEADBEEF
+        assert captured["type"] == ma._MUFILE_HANDLE_TYPE_OPAQUE_FD
+        assert captured["fd"] == 42
+        # The descriptor stays module-owned until deregister_handle.
+        assert 0xDEADBEEF in ma._handle_descr_registry
+
+    def test_register_handle_opens_driver(self, _fake_lib):
+        ma.register_handle(7)
+        assert "muFileDriverOpen" in _fake_lib.calls
+
+    def test_deregister_handle_dispatches_and_releases_descr(self, _fake_lib):
+        # Set up a register that actually populates the handle out-param.
+        def _register(fh_ref, descr_ref):
+            fh_ref._obj.value = 0x1234
+            return _ok()
+
+        _fake_lib.muFileHandleRegister = _register
+        handle = ma.register_handle(99)
+        assert handle == 0x1234
+        ma.deregister_handle(handle)
+        assert "muFileHandleDeregister" in _fake_lib.calls
+        (fh,) = _fake_lib.calls["muFileHandleDeregister"]
+        assert fh.value == 0x1234
+        assert handle not in ma._handle_descr_registry
+
+
+class TestBufferRegistration:
+    def test_rejects_non_musa_tensor(self):
+        cpu = SimpleNamespace(is_musa=False)
+        with pytest.raises(ValueError):
+            ma.register_buffer(cpu)
+
+    def test_register_buffer_passes_size(self, _fake_lib):
+        ma.register_buffer(_fake_gpu_tensor(ptr=0x2000, nbytes=8192))
+        base, length, flags = _fake_lib.calls["muFileBufRegister"]
+        assert base.value == 0x2000
+        assert length.value == 8192
+        assert flags.value == 0
+
+    def test_deregister_buffer_dispatches(self, _fake_lib):
+        ma.deregister_buffer(_fake_gpu_tensor(ptr=0x2000))
+        (base,) = _fake_lib.calls["muFileBufDeregister"]
+        assert base.value == 0x2000
+
+
+class TestStreamRegistration:
+    def test_register_stream_uses_fixed_and_aligned_flag(self, _fake_lib):
+        ma.register_stream(0xABC)
+        stream, flags = _fake_lib.calls["muFileStreamRegister"]
+        assert stream.value == 0xABC
+        # MUFILE_STREAM_FIXED_AND_ALIGNED: the only flag muFile accepts.
+        assert flags == 0x1
+
+    def test_deregister_stream_dispatches(self, _fake_lib):
+        ma.register_stream(0xABC)
+        ma.deregister_stream(0xABC)
+        (stream,) = _fake_lib.calls["muFileStreamDeregister"]
+        assert stream.value == 0xABC
+
+
+class TestSubmission:
+    def test_bytes_done_defaults_zero_then_reflects_driver(self):
+        sub = ma.Submission(size=4096, file_offset=0, buf_offset=0)
+        assert sub.bytes_done == 0
+        sub._bytes_done.value = 4096
+        assert sub.bytes_done == 4096
+
+    def test_completion_is_size_t(self):
+        sub = ma.Submission(size=4096, file_offset=0, buf_offset=0)
+        assert isinstance(sub._bytes_done, ctypes.c_size_t)
+
+
+class TestAsyncHandleIO:
+    def _handle(self) -> ma.AsyncHandle:
+        return ma.AsyncHandle.from_fd(fd=5, handle=0xFEED, path="/slab", writable=True)
+
+    def test_read_async_dispatches_and_returns_submission(self, _fake_lib):
+        def _read(fh, buf, size_p, foff_p, boff_p, bytes_p, stream):
+            # Driver reports the byte count into the caller's storage.
+            bytes_p._obj.value = 4096
+            _fake_lib.calls["muFileReadAsync"] = (fh, buf, stream)
+            return 0
+
+        _fake_lib.muFileReadAsync = _read
+        h = self._handle()
+        sub = h.read_async(
+            buf_base=0x3000, size=4096, file_offset=0, buf_offset=0, raw_stream=0x9
+        )
+        fh, buf, stream = _fake_lib.calls["muFileReadAsync"]
+        assert fh.value == 0xFEED
+        assert buf.value == 0x3000
+        assert stream.value == 0x9
+        assert sub.bytes_done == 4096
+
+    def test_write_async_dispatches(self, _fake_lib):
+        h = self._handle()
+        sub = h.write_async(
+            buf_base=0x3000, size=4096, file_offset=4096, buf_offset=0, raw_stream=0x9
+        )
+        assert "muFileWriteAsync" in _fake_lib.calls
+        assert isinstance(sub, ma.Submission)
+
+    def test_submit_error_raises(self, _fake_lib):
+        _fake_lib.muFileWriteAsync = lambda *a: -5  # -MU_FILE_DRIVER_NOT_INITIALIZED
+        h = self._handle()
+        with pytest.raises(RuntimeError) as exc:
+            h.write_async(
+                buf_base=0x3000, size=4096, file_offset=0, buf_offset=0, raw_stream=0x9
+            )
+        assert "muFileWriteAsync" in str(exc.value)
+
+    def test_unaligned_submit_raises_before_calling_lib(self, _fake_lib):
+        h = self._handle()
+        with pytest.raises(ValueError, match="4096"):
+            h.write_async(
+                buf_base=0x3001,
+                size=4096,
+                file_offset=0,
+                buf_offset=0,
+                raw_stream=0x9,
+            )
+        assert "muFileWriteAsync" not in _fake_lib.calls
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"buf_base": 0x3001, "size": 4096, "file_offset": 0, "buf_offset": 0},
+            {"buf_base": 0x3000, "size": 4097, "file_offset": 0, "buf_offset": 0},
+            {"buf_base": 0x3000, "size": 4096, "file_offset": 512, "buf_offset": 0},
+            {"buf_base": 0x3000, "size": 4096, "file_offset": 0, "buf_offset": 256},
+        ],
+    )
+    def test_misaligned_any_operand_rejects(self, _fake_lib, kwargs):
+        h = self._handle()
+        with pytest.raises(ValueError):
+            h.write_async(raw_stream=0x9, **kwargs)
+        assert "muFileWriteAsync" not in _fake_lib.calls
+
+
+class TestCloseDriverIdempotency:
+    def test_close_driver_twice_is_safe(self, _fake_lib):
+        ma._ensure_driver_open()
+        ma.close_driver()
+        calls_after_first = dict(_fake_lib.calls)
+        ma.close_driver()
+        assert _fake_lib.calls == calls_after_first
+
+
+class TestStructLayout:
+    """Guard the ctypes structs against the mufile.h C ABI (LP64)."""
+
+    def test_error_struct_size(self):
+        assert ctypes.sizeof(ma._MUfileError) == 4
+
+    def test_descr_struct_layout(self):
+        assert ctypes.sizeof(ma._MUFileDescr) == 16
+        assert ma._MUFileDescr.type.offset == 0
+        assert ma._MUFileDescr.handle.offset == 8
+
+
+class TestErrorMapping:
+    def test_op_error_names_are_stable(self):
+        # Spot-check the MUfileOpError enum mirror: success and two errors.
+        assert ma._MUFILE_SUCCESS == 0
+        assert ma._OP_ERROR_NAMES[0] == "MU_FILE_SUCCESS"
+        assert ma._OP_ERROR_NAMES[26] == "MU_FILE_HANDLE_NOT_REGISTERED"
+        assert ma._OP_ERROR_NAMES[29] == "MU_FILE_INTERNAL_ERROR"
+
+
+class TestPartialCompletion:
+    def test_submit_ok_but_bytes_zero_is_reported_not_faked(self, _fake_lib):
+        """Completion reflects the driver-written value, never fabricated."""
+        _fake_lib.muFileReadAsync = lambda *a: 0  # submit OK, completion stays 0
+        h = ma.AsyncHandle.from_fd(fd=5, handle=0xFEED, path="/slab", writable=True)
+        sub = h.read_async(
+            buf_base=0x3000, size=4096, file_offset=0, buf_offset=0, raw_stream=0x9
+        )
+        assert sub.bytes_done == 0
+
+
+class TestBackendDispatch:
+    """``mufile`` selection and platform validation in the ``_gds_async`` shim.
+
+    These are host-independent (no CUDA gate): they monkeypatch the platform
+    detection the shim consults, never dlopen any library.
+    """
+
+    def test_mufile_rejected_off_musa(self, monkeypatch: pytest.MonkeyPatch):
+        # First Party
+        from lmcache.v1.gpu_connector import _gds_async
+
+        monkeypatch.setattr(_gds_async, "_torch_device_type", lambda: "cuda")
+        with pytest.raises(ValueError, match="MUSA"):
+            _gds_async.select_backend("mufile")
+
+    def test_mufile_accepted_on_musa(self, monkeypatch: pytest.MonkeyPatch):
+        # First Party
+        from lmcache.v1.gpu_connector import _gds_async
+
+        monkeypatch.setattr(_gds_async, "_torch_device_type", lambda: "musa")
+        assert _gds_async.select_backend("mufile") == "mufile"
+        # The re-bound surface must be the mufile wrapper.
+        assert _gds_async.AsyncHandle is ma.AsyncHandle
+
+    def test_backend_capability_queries(self):
+        # First Party
+        from lmcache.v1.gpu_connector import _gds_async
+
+        assert _gds_async.get_max_registered_region_bytes() == 16 * 1024 * 1024
+        assert _gds_async.get_io_alignment() == 4096
+
+
+class TestGetRawStreamHandle:
+    """Platform stream-handle extraction (gds_context.get_raw_stream_handle)."""
+
+    def test_prefers_musa_stream(self):
+        # First Party
+        from lmcache.v1.gpu_connector.gds_context import get_raw_stream_handle
+
+        stream = SimpleNamespace(musa_stream=0xA1, cuda_stream=0xB2)
+        assert get_raw_stream_handle(stream) == 0xA1
+
+    def test_cuda_stream_fallback(self):
+        # First Party
+        from lmcache.v1.gpu_connector.gds_context import get_raw_stream_handle
+
+        stream = SimpleNamespace(cuda_stream=0xB2)
+        assert get_raw_stream_handle(stream) == 0xB2
+
+    def test_ptr_fallback(self):
+        # First Party
+        from lmcache.v1.gpu_connector.gds_context import get_raw_stream_handle
+
+        stream = SimpleNamespace(ptr=0xC3)
+        assert get_raw_stream_handle(stream) == 0xC3
+
+    def test_raises_when_no_handle_attribute(self):
+        # First Party
+        from lmcache.v1.gpu_connector.gds_context import get_raw_stream_handle
+
+        with pytest.raises(RuntimeError, match="stream handle"):
+            get_raw_stream_handle(SimpleNamespace())

--- a/tests/v1/platform/musa/test_musa_cache_context.py
+++ b/tests/v1/platform/musa/test_musa_cache_context.py
@@ -2,6 +2,10 @@
 
 """Tests for MUSA cache-context IPC owner lifetime."""
 
+# Standard
+from types import SimpleNamespace
+from typing import Any
+
 # First Party
 from lmcache.v1.platform.musa.cache_context import MUSACacheContext
 
@@ -35,3 +39,47 @@ def test_close_synchronizes_before_releasing_ipc_owners() -> None:
     context.close()
 
     assert calls == ["synchronize", "first", "second"]
+
+
+def test_close_deregisters_gds_staging_buffer(monkeypatch: Any) -> None:
+    """Close deregisters the staging buffer from GDS before IPC release."""
+    # First Party
+    import lmcache.v1.platform.musa.cache_context as musa_ctx_mod
+
+    calls: list[str] = []
+
+    class _Stream:
+        def synchronize(self) -> None:
+            calls.append("synchronize")
+
+    class _Wrapper:
+        def close(self) -> None:
+            calls.append("wrapper.close")
+
+    class _FakeGDSContext:
+        def deregister_gpu_buffer(self, buffer: Any) -> None:
+            calls.append(f"deregister:{buffer}")
+
+    class _TestContext(MUSACacheContext):
+        def __init__(self) -> None:
+            self.stream_ = _Stream()  # type: ignore[assignment]
+            self._ipc_wrappers = (_Wrapper(),)  # type: ignore[assignment]
+            self._temp_buffer = SimpleNamespace(  # type: ignore[assignment]
+                buffer="STAGING"
+            )
+
+    monkeypatch.setattr(musa_ctx_mod, "get_gds_context", lambda: _FakeGDSContext())
+    # torch_dev.stream must be usable as a context manager for the
+    # deregistration block.
+    # Standard
+    import contextlib
+
+    monkeypatch.setattr(
+        musa_ctx_mod.torch_dev, "stream", lambda s: contextlib.nullcontext()
+    )
+
+    context = _TestContext()
+    context.close()
+
+    # Order: sync first, then GDS deregister, then IPC wrapper release.
+    assert calls == ["synchronize", "deregister:STAGING", "wrapper.close"]

--- a/tests/v1/platform/musa/test_musa_wheel_workflow.py
+++ b/tests/v1/platform/musa/test_musa_wheel_workflow.py
@@ -45,7 +45,7 @@ def test_musa_reusable_workflow_exposes_version_and_artifact_contract() -> None:
     assert workflow["env"]["MUSA_IMAGE"] == (
         "${{ vars.MUSA_IMAGE || "
         "'registry.mthreads.com/mcconline/musa-pytorch-release-public:"
-        "rc5.2.0-v2.9.1.post1-S5000-py310' }}"
+        "rc5.1.0-v2.9.1-S5000-py310_tef' }}"
     )
     assert workflow["env"]["TORCH_DEVICE_BACKEND_AUTOLOAD"] == "0"
     assert workflow["env"]["SKIP_AUDITWHEEL_REPAIR"] == "0"

--- a/tests/v1/platform/musa/test_musa_wheel_workflow.py
+++ b/tests/v1/platform/musa/test_musa_wheel_workflow.py
@@ -44,8 +44,8 @@ def test_musa_reusable_workflow_exposes_version_and_artifact_contract() -> None:
     workflow = _load_workflow(".github/workflows/build_musa_artifacts.yml")
     assert workflow["env"]["MUSA_IMAGE"] == (
         "${{ vars.MUSA_IMAGE || "
-        "'sh-harbor.mthreads.com/ai-kv/kuae-lmcache-vllm-ci@sha256:"
-        "75c8c1012cf49caf6dd99dbbfd33931ef100d035647083b999eaf0092d94edba' }}"
+        "'registry.mthreads.com/mcconline/musa-pytorch-release-public:"
+        "rc5.2.0-v2.9.1.post1-S5000-py310' }}"
     )
     assert workflow["env"]["MUSA_REQUIRE_TORCH_MUSA"] == (
         "${{ vars.MUSA_REQUIRE_TORCH_MUSA || '0' }}"

--- a/tests/v1/platform/musa/test_musa_wheel_workflow.py
+++ b/tests/v1/platform/musa/test_musa_wheel_workflow.py
@@ -44,8 +44,11 @@ def test_musa_reusable_workflow_exposes_version_and_artifact_contract() -> None:
     workflow = _load_workflow(".github/workflows/build_musa_artifacts.yml")
     assert workflow["env"]["MUSA_IMAGE"] == (
         "${{ vars.MUSA_IMAGE || "
-        "'registry.mthreads.com/mcconline/musa-pytorch-release-public:"
-        "rc5.1.0-v2.9.1-S5000-py310_tef' }}"
+        "'sh-harbor.mthreads.com/ai-kv/kuae-lmcache-vllm-ci@sha256:"
+        "75c8c1012cf49caf6dd99dbbfd33931ef100d035647083b999eaf0092d94edba' }}"
+    )
+    assert workflow["env"]["MUSA_REQUIRE_TORCH_MUSA"] == (
+        "${{ vars.MUSA_REQUIRE_TORCH_MUSA || '0' }}"
     )
     assert workflow["env"]["TORCH_DEVICE_BACKEND_AUTOLOAD"] == "0"
     assert workflow["env"]["SKIP_AUDITWHEEL_REPAIR"] == "0"

--- a/tests/v1/platform/musa/test_musa_wheel_workflow.py
+++ b/tests/v1/platform/musa/test_musa_wheel_workflow.py
@@ -47,9 +47,6 @@ def test_musa_reusable_workflow_exposes_version_and_artifact_contract() -> None:
         "'registry.mthreads.com/mcconline/musa-pytorch-release-public:"
         "rc5.2.0-v2.9.1.post1-S5000-py310' }}"
     )
-    assert workflow["env"]["MUSA_REQUIRE_TORCH_MUSA"] == (
-        "${{ vars.MUSA_REQUIRE_TORCH_MUSA || '0' }}"
-    )
     assert workflow["env"]["TORCH_DEVICE_BACKEND_AUTOLOAD"] == "0"
     assert workflow["env"]["SKIP_AUDITWHEEL_REPAIR"] == "0"
     assert workflow["env"]["MAX_JOBS"] == "2"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Add SmartIO muFile backend for MP GDS L1

**Special notes for your reviewers**:
1. Why modify the common file gds_context.py:
lmcache/v1/gpu_connector/gds_context.py is the common MP GDS lifecycle owner. It currently contained CUDA-specific assumptions:
- It directly accessed torch_dev.current_stream().cuda_stream.
- It used constants named _CUFILE_ALIGNMENT and _MAX_CUFILE_REGION.
- It did not explicitly close the selected backend driver during GDSContext.close().
Those assumptions prevent a MUSA backend from integrating cleanly. 

2.  The changes:
- Add get_raw_stream_handle(stream), which resolves handles in this order:musa_stream,cuda_stream,ptr
- Replace direct .cuda_stream access in registration, deregistration, read, write, and submission-checkpoint paths with the helper.
- Move alignment and registration-region limits behind "_gds_async" capability queries: get_io_alignment(),
get_max_registered_region_bytes().
- Call the selected backend’s close_driver() during context teardown.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests - tests added
