### PR TITLE
[vLLM] Support per-request max offload tokens

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -74,6 +74,7 @@ class LMCacheMPRequestTracker:
 
     cache_salt: str = ""
     request_configs: dict[str, Any] | None = None
+    max_offload_tokens: int | None = None
 
     mm_adjusted_prompt_ids: list[int] = field(default_factory=list)
 
@@ -81,6 +82,9 @@ class LMCacheMPRequestTracker:
         self.request_id = request.request_id
         self.cache_salt: str = request.cache_salt or ""
         self.request_configs = extract_request_configs_from_request(request)
+        self.max_offload_tokens = (self.request_configs or {}).get(
+            "lmcache.max_offload_tokens"
+        )
         self.all_token_ids = request.all_token_ids
         self.allocated_block_ids = {}
         self.num_stored_tokens = 0
@@ -245,6 +249,8 @@ class LMCacheMPRequestMetadata:
             allocated_tokens,
             computed_tokens,
         )
+        if tracker.max_offload_tokens is not None:
+            min_available_tokens = min(min_available_tokens, tracker.max_offload_tokens)
         num_staging_tokens = min_available_tokens - tracker.num_stored_tokens
         num_chunks = num_staging_tokens // lmcache_tokens_per_chunk
 

--- a/tests/v1/test_mp_connector_mm_keys.py
+++ b/tests/v1/test_mp_connector_mm_keys.py
@@ -145,6 +145,7 @@ def test_tracker_extracts_request_configs():
             sampling_params_extra_args={
                 "kv_transfer_params": {
                     "lmcache.skip_save": True,
+                    "lmcache.max_offload_tokens": 4,
                     "lmcache.priority": "high",
                     "temperature": 0.8,
                 }
@@ -154,8 +155,28 @@ def test_tracker_extracts_request_configs():
 
     assert tracker.request_configs == {
         "lmcache.skip_save": True,
+        "lmcache.max_offload_tokens": 4,
         "lmcache.priority": "high",
     }
+    assert tracker.max_offload_tokens == 4
+
+
+def test_tracker_ignores_max_offload_tokens_outside_request_configs():
+    request = _FakeRequest(
+        [1, 2, 3, 4],
+        sampling_params_extra_args={
+            "kv_transfer_params": {
+                "max_offload_tokens": 4,
+                "lmcache.skip_save": True,
+            }
+        },
+    )
+    request.kv_transfer_params = {"lmcache.max_offload_tokens": 4}
+
+    tracker = LMCacheMPRequestTracker(request)
+
+    assert tracker.max_offload_tokens is None
+    assert tracker.request_configs == {"lmcache.skip_save": True}
 
 
 def test_eager_prefetch_forwards_request_configs():
@@ -225,6 +246,32 @@ def test_store_metadata_preserves_request_configs():
 
     assert metadata is not None
     assert metadata.request_configs == {"lmcache.skip_save": True}
+
+
+def test_store_metadata_respects_max_offload_tokens():
+    tracker = _prepare_storable_tracker(
+        _FakeRequest(
+            list(range(8)),
+            sampling_params_extra_args={
+                "kv_transfer_params": {"lmcache.max_offload_tokens": 4}
+            },
+        )
+    )
+
+    metadata = LMCacheMPRequestMetadata.GetStoreMetadata(
+        tracker, lmcache_tokens_per_chunk=4, group_tokens_per_block=[4]
+    )
+
+    assert metadata is not None
+    assert metadata.op.start == 0
+    assert metadata.op.end == 4
+    assert tracker.num_stored_tokens == 4
+    assert (
+        LMCacheMPRequestMetadata.GetStoreMetadata(
+            tracker, lmcache_tokens_per_chunk=4, group_tokens_per_block=[4]
+        )
+        is None
+    )
 
 
 def test_retrieve_metadata_uses_mm_adjusted_token_ids():


### PR DESCRIPTION
## Summary

Adds a per-request `lmcache.max_offload_tokens` cap for the current LMCache MP vLLM integration.

The intended scenario is per-request selective KV offloading. For a request with a reusable prefix—such as a system prompt or shared context—and a long request-specific suffix, the caller can offload only the first N tokens. This reduces runtime transfer traffic and cache usage for tokens unlikely to be reused. Requests without this option remain unchanged

The cap is read directly from the existing LMCache `request_configs` extracted by the tracker. The tracker keeps `request_configs` unchanged, stores the configured value on tracker state, and uses it to cap generated STORE metadata. Other `lmcache.*` request configs continue to be forwarded unchanged.

Covered path:
- current MP connector metadata: caps generated STORE metadata

Intentionally unchanged in this PR:
- `lmcache/integration/vllm/utils.py`
- in-process vLLM connector
- version-pinned MP connector copies for vLLM 0.18.0 and 0.20.1
- bare `max_offload_tokens` or direct request `kv_transfer_params` extraction

## Duplicate-work check

I checked open LMCache PRs for `max_offload_tokens`, `max offload tokens`, `lmcache.max_offload_tokens`, and related request-config/offload keywords. I did not find an open PR implementing this same per-request current-MP offload cap.

## Tests

- `cp /Users/mbl/projects/LMCache/lmcache/lmcache_native.cpython-312-darwin.so lmcache/`
- `/Users/mbl/projects/vllm/.venv/bin/python -m pytest --noconftest tests/v1/test_mp_connector_mm_keys.py -q`
  - 14 passed, 64 warnings
- `rm lmcache/lmcache_native.cpython-312-darwin.so`
- `SKIP=rust-fmt,rust-clippy /Users/mbl/projects/LMCache/.venv/bin/pre-commit run --all-files`
  - passed; Rust hooks skipped for this Python-only macOS validation

No model eval was run; this is a Python-only transfer metadata scheduling change.

AI assistance was used to prepare this PR.
