### PR TITLE
[MP][MC][1/N] Drain admitted transfers before context teardown

### DIFF
--- a/docs/design/v1/multiprocess/transfer_context_lifetime.md
+++ b/docs/design/v1/multiprocess/transfer_context_lifetime.md
@@ -1,0 +1,64 @@
+# MP transfer context lifetime
+
+This shared Device-DAX prerequisite protects registered GPU contexts in the MP
+`LMCacheDrivenTransferModule` during standard STORE/RETRIEVE handlers.
+
+## Role and authority
+
+| Field | Contract |
+| --- | --- |
+| Capability and domain | MP transfer executor; owns local context admission and teardown |
+| Deployment and policy | Existing MP server module; explicit unregister, liveness reaping or shutdown |
+| Resource and scope | One registered GPU context per worker instance in one MP server |
+| Request path | Standard STORE/RETRIEVE handlers and asynchronous lifecycle operations |
+| Inputs/freshness | Current context registry, handler counts and existing heartbeat/grace thresholds |
+| Decisions and state | Module decides whether to admit a handler or begin draining; state is local and ephemeral |
+| Derived state | Context/status snapshots; snapshots do not reserve lifetime |
+| Executor/effects | Module calls context close, layout unregister and device memory collection |
+| Identity/locality | Existing worker instance ID; context entry identifies the registration being used |
+| Consistency | One condition serializes admission; a separate lock serializes registration and cleanup |
+| Durability/recovery | No persistent state; a failed close retains the draining entry for retry |
+| Fencing | Draining entries and a closing module reject standard STORE/RETRIEVE admission and new registrations |
+| Public contracts | Existing register/unregister, STORE/RETRIEVE, reap and close APIs |
+| Failure/readiness | Missing/draining transfers return the existing failure result; cleanup errors propagate |
+| Non-responsibilities | Shared-region ownership, allocation policy, payload visibility, coordinator deployment and fleet placement |
+
+Storage operations and future shared-object authority remain separate from local
+context lifetime. MP messages, normal heartbeat thresholds and storage
+configuration are unchanged. Draining cleanup is retried despite a fresh PING;
+there is no stored state to migrate.
+
+## Ordering
+
+```text
+register -> active -> draining -> closed -> removed
+              |
+       admit STORE/RETRIEVE -> increment active handlers
+              |
+       return or raise -> decrement active handlers -> notify cleanup
+```
+
+Lookup and admission share one condition. Teardown stops admission, then waits
+for handlers with the condition released. Device cleanup runs outside it.
+The cleanup lock serializes registration and teardown. Module close rejects new
+registrations and includes a registration already under construction.
+
+Existing platform context close synchronizes the transfer stream before releasing
+GPU IPC mappings. Completion dispatch stays alive until all contexts close.
+Cleanup retains unfinished entries for retry without repeating a successful close.
+The module drops its handler and registry references before memory collection;
+external snapshots or exception tracebacks may still retain references.
+Checksum context snapshots exclude draining entries; diagnostic entry snapshots
+retain them for retry inspection. Neither snapshot reserves lifetime, and this
+PR does not lease nonstandard Blend or diagnostic operations.
+
+A later MP shutdown change must drain request-queue and lookup/event work before
+closing shared storage. DAX mappings must stay registered through transfer
+completion and visibility barriers; shared-mode activation depends on these steps.
+
+## Verification
+
+Tests race public MP handlers against unregister, reaping and close; check
+admission, reference release, retry after PING and concurrent registration; exclude
+draining checksum contexts; and retain existing transfer and liveness behavior.
+They establish MP lifecycle contracts, not physical DAX sharing or performance.

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -2,6 +2,8 @@
 """LMCache-driven KV cache transfer operations for the MPCacheServer."""
 
 # Standard
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import islice
 from typing import Any, Generator, Sequence
@@ -642,6 +644,9 @@ class ContextEntry:
             PING. Selects the reap window (timeout vs registration grace).
             Latched only by PING, never by traffic.
         event_backend: Cached event backend selected for this context's device.
+        active_operations: Admitted STORE/RETRIEVE handlers using this context.
+        draining: Whether teardown has stopped new transfer admission.
+        context_closed: Whether device cleanup finished, for teardown retries.
     """
 
     cache_context: BaseCacheContext
@@ -650,6 +655,9 @@ class ContextEntry:
     last_seen: float = 0.0
     has_liveness_signal: bool = False
     event_backend: EventIPCBackend | None = None
+    active_operations: int = 0
+    draining: bool = False
+    context_closed: bool = False
 
 
 class LMCacheDrivenTransferModule(InstanceLivenessTarget):
@@ -665,12 +673,11 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
     def __init__(self, ctx: MPCacheServerContext) -> None:
         self._ctx = ctx
         self._cache_contexts: dict[int, ContextEntry] = {}
-        # Guards all reads/writes of _cache_contexts. The reaper mutates it
-        # off the MQ main loop, so register/unregister/store/retrieve and
-        # report_status all serialize through this lock. Held only for dict
-        # ops -- never across context creation, layout-registry calls, or
-        # empty_cache (leaf-lock invariant: no thread holds two locks).
-        self._lock = threading.Lock()
+        # Admission and teardown select entries under the same condition.
+        # Waiting for handlers releases it; device cleanup runs outside it.
+        self._lock = threading.Condition()
+        self._release_lock = threading.Lock()
+        self._closing = False
 
         # Route finish_write / finish_read_prefetched through a C++ host
         # callback so the driver thread doesn't acquire the GIL.
@@ -703,13 +710,18 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             instance_id: The worker instance ID.
 
         Returns:
-            The entry, or None if the instance is not (or no longer) tracked.
+            The entry, or None if absent, draining, or the module is closing.
+
+        Notes:
+            This is a snapshot, not a lifetime reservation. STORE/RETRIEVE
+            hold their own reservation until the handler returns.
         """
         now = time.monotonic()
         with self._lock:
             entry = self._cache_contexts.get(instance_id)
-            if entry is not None:
-                entry.last_seen = now
+            if self._closing or entry is None or entry.draining:
+                return None
+            entry.last_seen = now
             return entry
 
     def _release_failed_retrieve_locks(
@@ -760,6 +772,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
     def context_entries_snapshot(self) -> dict[int, ContextEntry]:
         """Return a shallow copy of the registry for iteration or status.
 
+        Includes draining entries for cleanup diagnostics; does not reserve
+        their lifetime or authorize further device access.
+
         Returns:
             A new dict mapping instance ID to entry; does not refresh
             last-seen times.
@@ -794,6 +809,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
 
         A ping-proven instance is judged against ``reap_timeout_s``; one
         that has never pinged against the larger ``registration_grace_s``.
+        Stops transfer admission and waits for admitted handlers before cleanup.
+        Retries draining entries even if a later heartbeat refreshed liveness.
 
         Args:
             reap_timeout_s: Silence budget for ping-proven instances.
@@ -803,60 +820,20 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             The instance IDs reaped this scan.
         """
         now = time.monotonic()
-        reaped: list[tuple[int, ContextEntry]] = []
-        with self._lock:
-            stale_ids = [
-                iid
-                for iid, entry in self._cache_contexts.items()
-                if now - entry.last_seen
+        reaped_ids = self._release_entries(
+            lambda _iid, entry: (
+                entry.draining
+                or now - entry.last_seen
                 > (
                     reap_timeout_s
                     if entry.has_liveness_signal
                     else registration_grace_s
                 )
-            ]
-            for iid in stale_ids:
-                reaped.append((iid, self._cache_contexts.pop(iid)))
-        reaped_ids: list[int] = []
-        entries: list[ContextEntry] = []
-        for iid, e in reaped:
-            logger.warning(
-                "Reaped GPU instance %d: silent for %.1fs (pinged=%s)",
-                iid,
-                now - e.last_seen,
-                e.has_liveness_signal,
             )
-            reaped_ids.append(iid)
-            entries.append(e)
-        if reaped:
-            del e  # a bound name would pin the final entry (see _release_entries)
-            reaped.clear()
-            self._release_entries(entries)
+        )
+        for instance_id in reaped_ids:
+            logger.warning("Reaped GPU instance %d", instance_id)
         return reaped_ids
-
-    def _release_entries(self, entries: list[ContextEntry]) -> None:
-        """Release a batch of entries and reclaim their device memory.
-
-        Args:
-            entries: The only remaining references to the released entries.
-                The list is cleared before memory is reclaimed.
-        """
-        if not entries:
-            return
-        for entry in entries:
-            entry.cache_context.close()
-            self._ctx.layout_desc_registry.unregister(
-                entry.model_name, entry.world_size
-            )
-        del entry
-        entries.clear()
-        # ipc_collect() only unmaps a CUDA-IPC-imported segment once its last
-        # tensor reference is gone (LMCache#4014), hence the clear() above.
-        torch_dev.empty_cache()
-        ipc_collect = getattr(torch_dev, "ipc_collect", None)
-        if ipc_collect is not None:
-            # Backends without IPC collection omit this optional operation.
-            ipc_collect()
 
     def get_handlers(self) -> list[HandlerSpec]:
         """Return handler specs for all request types this module serves.
@@ -913,15 +890,16 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         }
 
     def close(self) -> None:
-        """Release GPU resources owned by this module."""
-        # Stop the drain thread before storage_manager.close() so any
-        # in-flight completions reach a live storage manager.
-        self._device_host_func_dispatcher.stop()
+        """Stop admission and wait for handlers before releasing GPU contexts.
 
+        Device cleanup errors propagate, leaving unreleased contexts draining
+        for a later retry. The completion dispatcher stays live until every
+        context has closed.
+        """
         with self._lock:
-            entries = list(self._cache_contexts.values())
-            self._cache_contexts.clear()
-        self._release_entries(entries)
+            self._closing = True
+        self._release_entries(lambda _iid, _entry: True)
+        self._device_host_func_dispatcher.stop()
 
     def register_kv_cache(
         self,
@@ -947,15 +925,160 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 GPUCacheContext for GPU KV format detection.
             engine_group_infos: Engine-neutral KV cache group metadata
                 (already msgspec-decoded by the message queue).
+
+        Raises:
+            RuntimeError: The module is closing or the instance is draining.
         """
+        with self._lock:
+            if self._closing:
+                raise RuntimeError("KV cache module is closing")
+            existing = self._cache_contexts.get(instance_id)
+            if existing is not None and existing.draining:
+                raise RuntimeError("KV cache context is draining")
+        with self._release_lock:
+            self._register_kv_cache(
+                instance_id,
+                kv_caches,
+                model_name,
+                world_size,
+                engine_type,
+                layout_hints,
+                engine_group_infos,
+            )
+
+    def unregister_kv_cache(self, instance_id: int) -> None:
+        """Stop transfer admission and release one instance after its handlers.
+
+        Args:
+            instance_id: The GPU instance ID (such as PID).
+
+        Notes:
+            Missing instances are a no-op. Device cleanup errors propagate;
+            a failed context remains draining until cleanup is retried.
+        """
+        released = self._release_entries(lambda iid, _entry: iid == instance_id)
+        if released:
+            logger.info("Unregistered KV cache for GPU ID %d", instance_id)
+        else:
+            logger.warning(
+                "No registered GPU context found for instance ID %d", instance_id
+            )
+
+    @_lmcache_nvtx_annotate
+    def store(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+    ) -> tuple[bytes, bool]:
+        """Store the GPU KV cache blocks to CPU.
+
+        Args:
+            key: The IPC key for the KV cache blocks.
+                Must have worker_id != None (worker store operation).
+            instance_id: The GPU instance ID (such as PID).
+            gpu_block_ids: GPU block IDs to store, indexed by LMCache KV
+                group index.
+            event_ipc_handle: The IPC handle of the event to wait on.
+
+        Returns:
+            A tuple where the first element is the IPC handle of the event
+            that signals the completion of the store operation, and the second
+            element indicates whether the store operation completed without a
+            fatal error (not whether every requested chunk was stored; see
+            Notes). The event handle is empty when no device work was submitted.
+            Unregistered or draining instances return ``(b"", False)``.
+
+        Raises:
+            RuntimeError: If the backend does not support IPC event handles.
+
+        Notes:
+            All-or-nothing. If ``gpu_block_ids`` do not fully cover every chunk
+            ``key`` resolves to for every LMCache group (e.g. a caller/protocol
+            bug), or a copy fails, the whole store is skipped and nothing is
+            committed (logged at WARNING); a subsequent retrieve simply misses
+            and the engine recomputes. The boolean result reports whether the
+            store completed without such a failure.
+        """
+        with self._context_operation(instance_id) as entry:
+            try:
+                return self._store(
+                    key, instance_id, gpu_block_ids, event_ipc_handle, entry
+                )
+            finally:
+                # Drop the handler's reference before waking teardown.
+                del entry
+
+    @_lmcache_nvtx_annotate
+    def retrieve(
+        self,
+        key: IPCCacheServerKey,
+        instance_id: int,
+        gpu_block_ids: list[list[int]],
+        event_ipc_handle: bytes,
+        skip_first_n_tokens: int = 0,
+    ) -> tuple[bytes, bool]:
+        """Retrieve the CPU KV cache and put into GPU blocks.
+
+        Args:
+            key: The IPC key for the KV cache blocks.
+                Must have worker_id != None (worker retrieve operation).
+            instance_id: The GPU instance ID (such as PID).
+            gpu_block_ids: GPU block IDs to retrieve into, indexed by LMCache
+                KV group index.
+            event_ipc_handle: The IPC handle of the event to wait on.
+            skip_first_n_tokens: Number of tokens to skip writing at
+                the start of the retrieve range. This avoids overwriting
+                APC-shared GPU blocks that may be read concurrently by other
+                requests.
+
+        Returns:
+            A tuple where the first element is the IPC handle of the event
+            that signals the completion of the retrieve operation, and the
+            second element indicates whether the key was successfully retrieved.
+            The event handle is empty when no device work was submitted.
+            Unregistered or draining instances return ``(b"", False)``.
+
+        Raises:
+            RuntimeError: If the backend does not support IPC event handles.
+        """
+        with self._context_operation(instance_id) as entry:
+            try:
+                return self._retrieve(
+                    key,
+                    instance_id,
+                    gpu_block_ids,
+                    event_ipc_handle,
+                    skip_first_n_tokens,
+                    entry,
+                )
+            finally:
+                del entry
+
+    def _register_kv_cache(
+        self,
+        instance_id: int,
+        kv_caches: KVCache,
+        model_name: str,
+        world_size: int,
+        engine_type: EngineType,
+        layout_hints: LayoutHints,
+        engine_group_infos: list[EngineGroupInfo],
+    ) -> None:
+        """Construct and publish a context while teardown is serialized."""
         now = time.monotonic()
         # NOOP-register: an already-registered instance (e.g. a recovering
         # worker re-registering on its first ping) refreshes its last-seen
         # time so a stale entry is not reaped right after recovery. REGISTER
         # is SYNC-serialized on the MQ main loop, so it is the sole inserter.
         with self._lock:
+            if self._closing:
+                raise RuntimeError("KV cache module is closing")
             existing = self._cache_contexts.get(instance_id)
             if existing is not None:
+                if existing.draining:
+                    raise RuntimeError("KV cache context is draining")
                 existing.last_seen = now
                 logger.info(
                     "Instance %d already registered; refreshing liveness",
@@ -1013,68 +1136,76 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             cache_context.num_layers,
         )
 
-    def unregister_kv_cache(self, instance_id: int) -> None:
-        """Unregister the KV cache tensors for a given GPU instance ID.
-
-        Args:
-            instance_id: The GPU instance ID (such as PID).
-        """
+    @contextmanager
+    def _context_operation(self, instance_id: int) -> Iterator[ContextEntry | None]:
+        """Keep an admitted context alive until the handler exits."""
         with self._lock:
-            popped = [
-                e
-                for e in (self._cache_contexts.pop(instance_id, None),)
-                if e is not None
-            ]
-        if not popped:
-            logger.warning(
-                "No registered GPU context found for instance ID %d", instance_id
-            )
-            return
+            entry = self.get_and_touch_context_entry(instance_id)
+            if entry is not None:
+                entry.active_operations += 1
+        try:
+            yield entry
+        finally:
+            with self._lock:
+                if entry is not None:
+                    entry.active_operations -= 1
+                    del entry
+                    self._lock.notify_all()
 
-        # No scalar binding: `popped` must stay the only reference so
-        # _release_entries' reclaim actually unmaps the IPC segments.
-        self._release_entries(popped)
-        logger.info("Unregistered KV cache for GPU ID %d", instance_id)
+    def _release_entries(
+        self, selected: Callable[[int, ContextEntry], bool]
+    ) -> list[int]:
+        """Drain selected contexts, retaining failed cleanup for retry."""
+        # Serialize cleanup and registration across the selected batch.
+        with self._release_lock:
+            with self._lock:
+                entries = {
+                    iid: entry
+                    for iid, entry in self._cache_contexts.items()
+                    if selected(iid, entry)
+                }
+                for entry in entries.values():
+                    entry.draining = True
+                self._lock.wait_for(
+                    lambda: all(
+                        entry.active_operations == 0 for entry in entries.values()
+                    )
+                )
+            released: list[int] = []
+            try:
+                for iid, entry in entries.items():
+                    if not entry.context_closed:
+                        entry.cache_context.close()
+                        entry.context_closed = True
+                    self._ctx.layout_desc_registry.unregister(
+                        entry.model_name, entry.world_size
+                    )
+                    with self._lock:
+                        del self._cache_contexts[iid]
+                    released.append(iid)
+            finally:
+                # Drop entry references before collecting CUDA IPC mappings.
+                if entries:
+                    del entry
+                entries.clear()
+                if released:
+                    torch_dev.empty_cache()
+                    ipc_collect = getattr(torch_dev, "ipc_collect", None)
+                    if ipc_collect is not None:
+                        ipc_collect()
+            return released
 
-    @_lmcache_nvtx_annotate
-    def store(
+    def _store(
         self,
         key: IPCCacheServerKey,
         instance_id: int,
         gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
+        entry: ContextEntry | None,
     ) -> tuple[bytes, bool]:
-        """Store the GPU KV cache blocks to CPU.
-
-        Args:
-            key: The IPC key for the KV cache blocks.
-                Must have worker_id != None (worker store operation).
-            instance_id: The GPU instance ID (such as PID).
-            gpu_block_ids: GPU block IDs to store, indexed by LMCache KV
-                group index.
-            event_ipc_handle: The IPC handle of the event to wait on.
-
-        Returns:
-            A tuple where the first element is the IPC handle of the event
-            that signals the completion of the store operation, and the second
-            element indicates whether the store operation completed without a
-            fatal error (not whether every requested chunk was stored; see
-            Notes). The event handle is empty when no device work was submitted.
-
-        Raises:
-            RuntimeError: If the backend does not support IPC event handles.
-
-        Notes:
-            All-or-nothing. If ``gpu_block_ids`` do not fully cover every chunk
-            ``key`` resolves to for every LMCache group (e.g. a caller/protocol
-            bug), or a copy fails, the whole store is skipped and nothing is
-            committed (logged at WARNING); a subsequent retrieve simply misses
-            and the engine recomputes. The boolean result reports whether the
-            store completed without such a failure.
-        """
+        """Execute STORE while its context lifetime is reserved."""
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
         if entry is None:
             # The worker can reconnect to a replacement server before its next
             # registration probe. No device work was submitted in that window,
@@ -1280,41 +1411,18 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             store_succeeded,
         )
 
-    @_lmcache_nvtx_annotate
-    def retrieve(
+    def _retrieve(
         self,
         key: IPCCacheServerKey,
         instance_id: int,
         gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
-        skip_first_n_tokens: int = 0,
+        skip_first_n_tokens: int,
+        entry: ContextEntry | None,
     ) -> tuple[bytes, bool]:
-        """Retrieve the CPU KV cache and put into GPU blocks.
-
-        Args:
-            key: The IPC key for the KV cache blocks.
-                Must have worker_id != None (worker retrieve operation).
-            instance_id: The GPU instance ID (such as PID).
-            gpu_block_ids: GPU block IDs to retrieve into, indexed by LMCache
-                KV group index.
-            event_ipc_handle: The IPC handle of the event to wait on.
-            skip_first_n_tokens: Number of tokens to skip writing at
-                the start of the retrieve range. This avoids overwriting
-                APC-shared GPU blocks that may be read concurrently by other
-                requests.
-
-        Returns:
-            A tuple where the first element is the IPC handle of the event
-            that signals the completion of the retrieve operation, and the
-            second element indicates whether the key was successfully retrieved.
-            The event handle is empty when no device work was submitted.
-
-        Raises:
-            RuntimeError: If the backend does not support IPC event handles.
-        """
+        """Execute RETRIEVE while its context lifetime is reserved."""
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
         if entry is None:
             # See store(): there is no completion event because no device work
             # was submitted. The False result lets the caller recover or

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -135,12 +135,16 @@ class MPCacheServer:
 
     @property
     def cache_contexts(self) -> dict[int, BaseCacheContext] | None:
-        """Used by ``/cache/checksums``; unwraps :class:`ContextEntry`."""
+        """Return non-draining contexts for ``/cache/checksums``.
+
+        The snapshot does not reserve their lifetime.
+        """
         for module in self._modules:
             if isinstance(module, LMCacheDrivenTransferModule):
                 return {
                     i: e.cache_context
                     for i, e in module.context_entries_snapshot().items()
+                    if not e.draining
                 }
         return None
 

--- a/tests/v1/multiprocess/test_ipc_memory_reclaim.py
+++ b/tests/v1/multiprocess/test_ipc_memory_reclaim.py
@@ -16,15 +16,24 @@ module (``torch_dev``).
 
 # Standard
 # Standard Library
-from types import SimpleNamespace
+from concurrent.futures import ThreadPoolExecutor
+from types import FrameType, SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
+import sys
+import threading
 import time
 import weakref
 
+# Third Party
+import pytest
+
 # First Party
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     LMCacheDrivenTransferModule,
 )
+from lmcache.v1.multiprocess.server import MPCacheServer
 import lmcache.v1.multiprocess.modules.lmcache_driven_transfer as gpu_mod
 
 
@@ -234,3 +243,228 @@ def test_close_with_empty_registry_does_not_reclaim(monkeypatch) -> None:
     module.close()
 
     assert dev.calls == []
+
+
+@pytest.mark.parametrize("operation", ["store", "retrieve"])
+def test_returning_transfer_drops_entry_before_memory_collection(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    """A completed handler must not pin its entry while teardown collects IPC."""
+    dev = MagicMock()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    cache_context = _register(module, monkeypatch, 1)
+    cache_context.kv_layer_groups_manager.num_object_groups = 1
+    cache_context.kv_layer_groups_manager.num_kernel_groups = 1
+    cache_context.calculate_num_blocks.return_value = 1
+    cast(MagicMock, module.context).resolve_obj_keys.return_value = [[object()]]
+    ref = weakref.ref(module.context_entries_snapshot()[1])
+    entry_alive: list[bool] = []
+    dev.ipc_collect.side_effect = lambda: entry_alive.append(ref() is not None)
+    returning = threading.Event()
+    resume = threading.Event()
+
+    def pause_return(frame: FrameType, event: str, arg: object) -> None:
+        # Pause the public handler after its body finishes, while its frame
+        # still exists. This makes a retained local reference deterministic.
+        if (
+            event == "return"
+            and frame.f_code.co_name == operation
+            and frame.f_globals.get("__name__") == gpu_mod.__name__
+        ):
+            returning.set()
+            assert resume.wait(5), "test did not release the returning handler"
+
+    def transfer() -> None:
+        sys.setprofile(pause_return)
+        try:
+            key = IPCCacheServerKey("m", 1, 0, (1,), 0, 1, "request")
+            # An underfilled block list returns before any transfer is submitted.
+            assert getattr(module, operation)(key, 1, [[]], b"evt")[1] is False
+        finally:
+            sys.setprofile(None)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(transfer)
+        try:
+            assert returning.wait(5), "transfer did not reach its return"
+            module.unregister_kv_cache(1)
+            assert entry_alive == [False]
+        finally:
+            resume.set()
+        pending.result(timeout=5)
+
+
+@pytest.mark.parametrize(
+    ("operation", "release"),
+    [
+        ("store", "unregister"),
+        ("retrieve", "unregister"),
+        ("store", "reap"),
+        ("retrieve", "close"),
+    ],
+)
+def test_release_waits_for_admitted_transfer(
+    monkeypatch: pytest.MonkeyPatch, operation: str, release: str
+) -> None:
+    """An admitted handler survives draining; later requests submit no work."""
+    monkeypatch.setattr(gpu_mod, "torch_dev", _FakeTorchDev())
+    module = _module(monkeypatch)
+    cache_context = _register(module, monkeypatch, 1)
+    cache_context.kv_layer_groups_manager.num_object_groups = 1
+    context = cast(MagicMock, module.context)
+    engine = MPCacheServer(module.context, [module])
+    context.session_manager.get.return_value = None
+    key = IPCCacheServerKey("m", 1, 0, (1,), 0, 1, "request")
+    entered = threading.Event()
+    resume = threading.Event()
+
+    def resolve_keys(*args: object) -> None:
+        entered.set()
+        assert resume.wait(5), "test did not release the transfer"
+        raise RuntimeError("transfer interrupted")
+
+    context.resolve_obj_keys.side_effect = resolve_keys
+    clock = [1000.0]
+    monkeypatch.setattr(gpu_mod.time, "monotonic", lambda: clock[0])
+
+    def release_context() -> None:
+        if release == "unregister":
+            module.unregister_kv_cache(1)
+        elif release == "reap":
+            assert module.reap_stale_instances(60.0, 60.0) == [1]
+        else:
+            module.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        transfer = executor.submit(getattr(module, operation), key, 1, [[1]], b"evt")
+        assert entered.wait(5), "transfer did not reach key resolution"
+        clock[0] += 1000.0
+        cleanup = executor.submit(release_context)
+        try:
+            deadline = time.perf_counter() + 5
+            while not module.context_entries_snapshot()[1].draining:
+                assert time.perf_counter() < deadline, "release did not start"
+                time.sleep(0.001)
+            cache_context.close.assert_not_called()
+            assert engine.cache_contexts == {}
+            assert not cleanup.done()
+            assert module.get_and_touch_context_entry(1) is None
+            assert getattr(module, operation)(key, 1, [[1]], b"evt") == (b"", False)
+            assert context.resolve_obj_keys.call_count == 1
+            with pytest.raises(RuntimeError):
+                _register(module, monkeypatch, 1)
+        finally:
+            resume.set()
+        with pytest.raises(RuntimeError, match="transfer interrupted"):
+            transfer.result(timeout=5)
+        cleanup.result(timeout=5)
+
+    cache_context.close.assert_called_once()
+    assert module.context_entries_snapshot() == {}
+
+
+@pytest.mark.parametrize("failure_at", ["context", "layout"])
+def test_failed_batch_close_keeps_only_unreleased_entries_for_retry(
+    monkeypatch: pytest.MonkeyPatch, failure_at: str
+) -> None:
+    """Retry cannot admit a failed entry or restore an already closed one."""
+    monkeypatch.setattr(gpu_mod, "torch_dev", _FakeTorchDev())
+    module = _module(monkeypatch)
+    engine = MPCacheServer(module.context, [module])
+    first = _register(module, monkeypatch, 1, model="a")
+    second = _register(module, monkeypatch, 2, model="b")
+    if failure_at == "context":
+        second.close.side_effect = RuntimeError("release failed")
+    else:
+        cast(MagicMock, module.context.layout_desc_registry.unregister).side_effect = [
+            None,
+            RuntimeError("release failed"),
+            None,
+        ]
+    dispatcher = cast(MagicMock, gpu_mod.DeviceHostFuncDispatcher).return_value
+
+    with pytest.raises(RuntimeError, match="release failed"):
+        module.close()
+
+    first.close.assert_called_once()
+    assert set(module.context_entries_snapshot()) == {2}
+    assert engine.cache_contexts == {}
+    assert module.get_and_touch_context_entry(2) is None
+    dispatcher.stop.assert_not_called()
+    with pytest.raises(RuntimeError):
+        _register(module, monkeypatch, 3)
+
+    second.close.side_effect = None
+    module.close()
+
+    first.close.assert_called_once()
+    assert second.close.call_count == (2 if failure_at == "context" else 1)
+    assert module.context_entries_snapshot() == {}
+    dispatcher.stop.assert_called_once()
+
+
+def test_reaper_retries_draining_context_after_fresh_ping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A heartbeat cannot cancel cleanup already owed by a draining context."""
+    monkeypatch.setattr(gpu_mod, "torch_dev", _FakeTorchDev())
+    module = _module(monkeypatch)
+    context = _register(module, monkeypatch, 1, age_s=120.0)
+    context.close.side_effect = [RuntimeError("release failed"), None]
+    _register(module, monkeypatch, 2)
+
+    with pytest.raises(RuntimeError, match="release failed"):
+        module.reap_stale_instances(60.0, 60.0)
+    module.touch_instance(1)
+
+    assert module.reap_stale_instances(60.0, 60.0) == [1]
+    assert context.close.call_count == 2
+    assert set(module.context_entries_snapshot()) == {2}
+
+
+def test_close_waits_for_registration_being_constructed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration already admitted when close starts is also released."""
+    monkeypatch.setattr(gpu_mod, "torch_dev", _FakeTorchDev())
+    module = _module(monkeypatch)
+    first = _register(module, monkeypatch, 1)
+    second = MagicMock(num_layers=1)
+    entered = threading.Event()
+    resume = threading.Event()
+
+    def create_context(*args: object, **kwargs: object) -> MagicMock:
+        entered.set()
+        assert resume.wait(5), "test did not release registration"
+        return second
+
+    monkeypatch.setattr(gpu_mod, "create_cache_context", create_context)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        registration = executor.submit(
+            module.register_kv_cache,
+            2,
+            MagicMock(),
+            "m",
+            1,
+            MagicMock(),
+            MagicMock(),
+            [],
+        )
+        assert entered.wait(5), "registration did not reach context construction"
+        cleanup = executor.submit(module.close)
+        try:
+            deadline = time.perf_counter() + 5
+            while module.get_and_touch_context_entry(1) is not None:
+                assert time.perf_counter() < deadline, "close did not start"
+                time.sleep(0.001)
+            assert not cleanup.done()
+            first.close.assert_not_called()
+        finally:
+            resume.set()
+        registration.result(timeout=5)
+        cleanup.result(timeout=5)
+
+    first.close.assert_called_once()
+    second.close.assert_called_once()
+    assert module.context_entries_snapshot() == {}

--- a/tests/v1/multiprocess/test_lmcache_driven_missing_registration.py
+++ b/tests/v1/multiprocess/test_lmcache_driven_missing_registration.py
@@ -3,7 +3,6 @@
 
 # Standard
 from collections import Counter
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 # Third Party
@@ -15,10 +14,16 @@ from lmcache.v1.distributed.api import (
     ipc_key_to_object_keys,
 )
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as gpu_mod
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     LMCacheDrivenTransferModule,
 )
 from lmcache.v1.multiprocess.session import SessionManager
+
+
+@pytest.fixture(autouse=True)
+def _mock_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gpu_mod, "DeviceHostFuncDispatcher", MagicMock())
 
 
 class _TestTokenHasher:
@@ -88,12 +93,9 @@ def test_missing_registration_returns_terminal_false(method_name: str) -> None:
     a terminal state during the restart-before-registration window. The empty
     handle indicates that the server submitted no device work.
     """
-    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
-    module.get_and_touch_context_entry = MagicMock(  # type: ignore[method-assign]
-        return_value=None
-    )
-    module._ctx = MagicMock()
-    module._ctx.session_manager.get.return_value = None
+    ctx = MagicMock()
+    ctx.session_manager.get.return_value = None
+    module = LMCacheDrivenTransferModule(ctx)
     producer_event = b"worker-producer-event"
     key = _cache_key(world_size=1, worker_id=0, request_id="request")
 
@@ -105,7 +107,7 @@ def test_missing_registration_returns_terminal_false(method_name: str) -> None:
     )
 
     assert result == (b"", False)
-    module.get_and_touch_context_entry.assert_called_once_with(42)
+    assert module.context_entries_snapshot() == {}
 
 
 @pytest.mark.parametrize("mla", [False, True], ids=["sharded-kv", "mla-shared-kv"])
@@ -138,12 +140,14 @@ def test_tp_failed_worker_releases_only_its_reader_share_once(mla: bool) -> None
     layout_registry.find_attn_desc.side_effect = AssertionError(
         "failed-retrieve cleanup must use the lookup session's layout"
     )
-    ctx = SimpleNamespace(
+    ctx = MagicMock(
         chunk_size=hasher.chunk_size,
         token_hasher=hasher,
         session_manager=sessions,
         layout_desc_registry=layout_registry,
-        storage_manager=storage,
+        storage_manager=MagicMock(
+            finish_read_prefetched=storage.finish_read_prefetched
+        ),
     )
 
     hashes = hasher.compute_chunk_hashes(list(lookup_key.token_ids), end=lookup_key.end)
@@ -159,11 +163,7 @@ def test_tp_failed_worker_releases_only_its_reader_share_once(mla: bool) -> None
     request_prefix_keys = ipc_key_to_object_keys(lookup_key, hashes[:1], [0])[0]
     storage.finish_read_prefetched(request_prefix_keys, read_locks=lookup_read_locks)
 
-    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
-    module._ctx = ctx  # type: ignore[assignment]
-    module.get_and_touch_context_entry = MagicMock(  # type: ignore[method-assign]
-        return_value=None
-    )
+    module = LMCacheDrivenTransferModule(ctx)
     failed_key = _cache_key(
         world_size=world_size,
         worker_id=failed_worker,
@@ -207,17 +207,12 @@ def test_tp_failed_worker_releases_only_its_reader_share_once(mla: bool) -> None
 
 def test_cleanup_exception_does_not_suppress_terminal_false() -> None:
     """A resolution failure must not consume the claim or strand the caller."""
-    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
-    module.get_and_touch_context_entry = MagicMock(  # type: ignore[method-assign]
-        return_value=None
-    )
-    module._ctx = MagicMock()
+    ctx = MagicMock()
+    module = LMCacheDrivenTransferModule(ctx)
     session = MagicMock()
     session.prepare_failed_retrieve_release.return_value = (2, (0,), (-1,), 7)
-    module._ctx.session_manager.get.return_value = session
-    module._ctx.token_hasher.compute_chunk_hashes.side_effect = RuntimeError(
-        "cleanup failed"
-    )
+    ctx.session_manager.get.return_value = session
+    ctx.token_hasher.compute_chunk_hashes.side_effect = RuntimeError("cleanup failed")
 
     result = module.retrieve(
         _cache_key(world_size=1, worker_id=0, request_id="request"),

--- a/tests/v1/multiprocess/test_lmcache_driven_transfer_skip.py
+++ b/tests/v1/multiprocess/test_lmcache_driven_transfer_skip.py
@@ -13,10 +13,14 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+# Third Party
+import pytest
+
 # First Party
 from lmcache.v1.kv_layer_groups import ObjectGroupInfo
 from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as mod
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    ContextEntry,
     LMCacheDrivenTransferModule,
     all_null_chunk_masks,
 )
@@ -95,13 +99,16 @@ def test_object_group_null_only_when_all_its_kernel_groups_null():
 # ------------------------------------------------------------------ #
 
 
-def _make_module(monkeypatch, num_chunks, num_chunks_in_sw, group_kinds=()):
+def _make_module(
+    monkeypatch: pytest.MonkeyPatch,
+    num_chunks: int,
+    num_chunks_in_sw: list[int],
+    group_kinds: tuple[str, ...] = (),
+) -> tuple[LMCacheDrivenTransferModule, list[list[str]], list[tuple[int, list]]]:
     """Build an LMCacheDrivenTransferModule with its collaborators mocked, and
     return (module, read_calls, transfer_calls) capturing what retrieve reads
     and transfers per object group."""
     num_object_groups = len(num_chunks_in_sw)
-
-    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
 
     kvlgm = SimpleNamespace(
         num_object_groups=num_object_groups,
@@ -116,10 +123,12 @@ def _make_module(monkeypatch, num_chunks, num_chunks_in_sw, group_kinds=()):
     cache_context.max_batch_size = 8
 
     event_backend = MagicMock()
-    entry = SimpleNamespace(
-        cache_context=cache_context, model_name="m", event_backend=event_backend
+    entry = ContextEntry(
+        cache_context=cache_context,
+        model_name="m",
+        world_size=1,
+        event_backend=event_backend,
     )
-    module.get_and_touch_context_entry = MagicMock(return_value=entry)
 
     # Object keys: one distinct key per (group, chunk).
     obj_keys = [
@@ -137,7 +146,9 @@ def _make_module(monkeypatch, num_chunks, num_chunks_in_sw, group_kinds=()):
         yield [MagicMock(get_size=MagicMock(return_value=10)) for _ in keys]
 
     ctx.storage_manager.read_prefetched_results = MagicMock(side_effect=fake_read)
-    module._ctx = ctx
+    monkeypatch.setattr(mod, "DeviceHostFuncDispatcher", MagicMock())
+    module = LMCacheDrivenTransferModule(ctx)
+    monkeypatch.setattr(module, "get_and_touch_context_entry", lambda _: entry)
 
     transfer_calls: list[tuple[int, list]] = []
 

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -40,7 +40,9 @@ def _bare_gpu_module() -> LMCacheDrivenTransferModule:
     module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
     module._ctx = MagicMock(name="ctx")
     module._cache_contexts = {}
-    module._lock = threading.Lock()
+    module._lock = threading.Condition()
+    module._release_lock = threading.Lock()
+    module._closing = False
     return module
 
 


### PR DESCRIPTION
  **What this PR does / why we need it**:

ref https://github.com/LMCache/LMCache/issues/5030.

Series of PR for memory sharing among mp server via cxl memory.

  An MP STORE/RETRIEVE handler can still be using a registered GPU context when unregister, worker reaping, or module shutdown closes it. Protecting the initial lookup with a lock does not protect the context for the rest of the handler.

  This PR reserves context lifetime when a standard `lmcache_driven` transfer is admitted. Teardown stops new admission and waits for active handlers before closing contexts. It also:

  - Serializes registration with teardown and retains failed cleanup for retry.
  - Keeps completion dispatch alive until context cleanup finishes.
  - Releases completed handlers' admission references before IPC collection.
  - Excludes draining contexts from checksum access and retries their cleanup even after a fresh heartbeat.

  Validation:

  - **181 MP tests passed, no skips**, covering transfer/reclaim races, liveness, events, existing engine-driven paths and HTTP/checksum behavior.
  - Regression tests reproduce the teardown, reference-retention, checksum-access and heartbeat-retry failures before their fixes.
  - All applicable pre-commit hooks passed; Rust hooks were explicitly skipped.
  - Sphinx builds reproduce the same 31 existing upstream diagnostics, with no new diagnostics. The Markdown design note was rendered and inspected.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
