### PR TITLE
fix(platform): resolve the HIP copy symbols the ROCm branch loads

### DIFF
--- a/lmcache/v1/platform/torch_ops.py
+++ b/lmcache/v1/platform/torch_ops.py
@@ -53,25 +53,47 @@ _copy_lib_NOT_LOADED = object()
 _copy_lib: Optional[ctypes.CDLL] = _copy_lib_NOT_LOADED  # type: ignore
 
 
+# HIP ships the same runtime entry points as CUDA under ``hip*`` names, so a
+# library loaded from the ROCm branch below answers to none of the ``cuda*``
+# names this module resolves on it. Map each spelling this module uses onto its
+# HIP equivalent. The memcpy-kind values passed alongside these calls (3 for
+# device-to-device, 4 for default) are the same in both runtimes, so only the
+# name differs.
+_HIP_SYMBOL_ALIASES = {"cudaMemcpy": "hipMemcpy"}
+
+
+def _alias_hip_symbols(lib: ctypes.CDLL) -> None:
+    """Expose the CUDA spelling of every runtime call this module resolves.
+
+    Args:
+        lib: A loaded HIP runtime library.
+    """
+    for cuda_name, hip_name in _HIP_SYMBOL_ALIASES.items():
+        if hasattr(lib, cuda_name):
+            continue
+        hip_symbol = getattr(lib, hip_name, None)
+        if hip_symbol is not None:
+            setattr(lib, cuda_name, hip_symbol)
+
+
 def _get_copy_lib() -> Optional[ctypes.CDLL]:
     """Lazily load and cache the CUDA/ROCm runtime library, or None for CPU fallback."""
     global _copy_lib
     if _copy_lib is _copy_lib_NOT_LOADED:
         # Try to load GPU runtime libraries in priority order: CUDA first, then ROCm
-        # TODO: ROCm path to be validated on real device
         for name, fallback in [
             ("cudart", "libcudart.so"),  # NVIDIA CUDA Runtime
             ("amdhip64", "libamdhip64.so"),  # AMD ROCm HIP Runtime
         ]:
             try:
                 path = ctypes.util.find_library(name)
-                if path:
-                    _copy_lib = ctypes.CDLL(path)
-                else:
-                    _copy_lib = ctypes.CDLL(fallback)
-                break  # Successfully loaded, stop trying
+                lib = ctypes.CDLL(path) if path else ctypes.CDLL(fallback)
             except OSError:
                 continue  # Current library not available, try next
+            if name == "amdhip64":
+                _alias_hip_symbols(lib)
+            _copy_lib = lib
+            break  # Successfully loaded, stop trying
         else:
             # All GPU libraries failed to load, fall back to CPU
             _copy_lib = None

--- a/tests/v1/test_torch_ops.py
+++ b/tests/v1/test_torch_ops.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Any, Union
+from typing import Any, Union, cast
 import ctypes
 import os
 import time
@@ -3187,3 +3187,109 @@ def test_tensor_from_musa_ptr_fails_without_external_storage(
 
     with pytest.raises(RuntimeError, match="failed to construct"):
         _py_ops._tensor_from_musa_ptr(0x1000, (2, 3), torch.float16, fake_device, 12)
+
+
+class _FakeRuntime:
+    """Stand-in for a loaded runtime whose exported symbols are fixed.
+
+    ``ctypes.CDLL`` resolves an attribute per exported symbol and raises
+    ``AttributeError`` for anything else, which is what this mimics.
+    """
+
+    def __init__(self, name: str, symbols: dict[str, object]) -> None:
+        self._name = name
+        for symbol_name, symbol in symbols.items():
+            setattr(self, symbol_name, symbol)
+
+    def __getattr__(self, symbol_name: str) -> Any:
+        """Fail the way ctypes does for a symbol the library does not export."""
+        raise AttributeError(symbol_name)
+
+
+def _install_fake_runtimes(
+    monkeypatch: pytest.MonkeyPatch, available: dict[str, _FakeRuntime]
+) -> None:
+    """Present *available* as the only loadable runtimes, by soname.
+
+    Args:
+        monkeypatch: Fixture used to restore ``ctypes`` afterwards.
+        available: Maps the ``find_library`` name to the runtime it resolves to.
+            Names absent from the mapping fail to load, as they do on a host
+            without that runtime installed.
+    """
+    monkeypatch.setattr(_py_ops, "_copy_lib", _py_ops._copy_lib_NOT_LOADED)
+
+    def fake_find_library(name: str) -> Union[str, None]:
+        return f"lib{name}.so.fake" if name in available else None
+
+    def fake_cdll(path: str) -> _FakeRuntime:
+        for name, runtime in available.items():
+            if path == f"lib{name}.so.fake":
+                return runtime
+        raise OSError(f"{path}: cannot open shared object file")
+
+    monkeypatch.setattr(_py_ops.ctypes.util, "find_library", fake_find_library)
+    monkeypatch.setattr(_py_ops.ctypes, "CDLL", fake_cdll)
+
+
+def test_get_copy_lib_exposes_the_cuda_spelling_on_rocm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A HIP runtime must answer to the name its callers resolve on it.
+
+    HIP exports ``hipMemcpy``, never ``cudaMemcpy``. Callers here resolve the
+    CUDA spelling, so before aliasing, a ROCm host loaded the HIP runtime and
+    then found no usable copy entry point on it: ``lmcache_memcpy_async`` fell
+    through to the CPU byte copy for device pointers, and ``_tensor_from_ptr``
+    raised AttributeError instead of its documented RuntimeError.
+    """
+    hip_memcpy = object()
+    _install_fake_runtimes(
+        monkeypatch, {"amdhip64": _FakeRuntime("hip", {"hipMemcpy": hip_memcpy})}
+    )
+
+    lib = _py_ops._get_copy_lib()
+
+    assert lib is not None
+    assert lib.cudaMemcpy is hip_memcpy
+
+
+def test_get_copy_lib_prefers_the_cuda_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With both runtimes present, CUDA wins and is handed back untouched."""
+    cuda_memcpy = object()
+    hip_memcpy = object()
+    _install_fake_runtimes(
+        monkeypatch,
+        {
+            "cudart": _FakeRuntime("cuda", {"cudaMemcpy": cuda_memcpy}),
+            "amdhip64": _FakeRuntime("hip", {"hipMemcpy": hip_memcpy}),
+        },
+    )
+
+    lib = _py_ops._get_copy_lib()
+
+    assert lib is not None
+    assert lib.cudaMemcpy is cuda_memcpy
+
+
+def test_get_copy_lib_returns_none_without_a_gpu_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No runtime at all still selects the CPU fallback rather than raising."""
+    _install_fake_runtimes(monkeypatch, {})
+
+    assert _py_ops._get_copy_lib() is None
+
+
+def test_alias_hip_symbols_keeps_an_existing_cuda_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aliasing never overwrites a symbol the runtime already exports."""
+    cuda_memcpy = object()
+    runtime = _FakeRuntime("hip", {"cudaMemcpy": cuda_memcpy, "hipMemcpy": object()})
+
+    _py_ops._alias_hip_symbols(cast("ctypes.CDLL", runtime))
+
+    assert runtime.cudaMemcpy is cuda_memcpy


### PR DESCRIPTION
**What this PR does / why we need it**:

`_get_copy_lib()` in `lmcache/v1/platform/torch_ops.py` tries CUDA first and falls back to `libamdhip64`. It carried a `# TODO: ROCm path to be validated on real device`. I validated it on a real device, and the fallback does not work.

HIP exports `hipMemcpy`, never `cudaMemcpy`, and both consumers resolve the CUDA spelling on whatever `_get_copy_lib()` hands back. So on a ROCm host the HIP runtime loads fine and then answers to none of the names anyone asks it for. Measured on gfx1101 / ROCm 7.2.2:

```
find_library('cudart')   -> None                (no CUDA here, falls through)
find_library('amdhip64') -> libamdhip64.so.7    (loads, fine)
    hasattr(lib, 'cudaMemcpy') -> False
    hasattr(lib, 'hipMemcpy')  -> True
```

Two consequences, and the quiet one is the worse:

- `lmcache_memcpy_async` guards on `hasattr(libcudart, "cudaMemcpy")`, gets `False`, and falls through to `_copy_bytes_with_tensor`, whose own docstring says *"This function only works for CPU-accessible memory. For device memory (CUDA/XPU), use lmcache_memcpy_async with the appropriate runtime library"*. On ROCm, pointer-mode copies of device pointers land there instead.
- `_tensor_from_ptr`'s D2D fallback does `libcudart.cudaMemcpy` directly, so it raises `AttributeError` rather than the `RuntimeError("Failed to load libcudart/libamdhip")` declared two lines above it.

The fix maps the spellings this module resolves onto their HIP equivalents when the ROCm branch is taken, so callers keep asking for one name. The memcpy-kind values passed alongside these calls (3 for device-to-device, 4 for default) are the same in both runtimes, so only the name differs. I checked that rather than assuming it, on the same card:

```
alias cudaMemcpy -> hipMemcpy       : ok
hipMemcpy(kind=4, default)  rc = 0  | data matches
hipMemcpy(kind=3, D2D)      rc = 0  | data matches
```

**Special notes for your reviewers**:

Worth knowing why the suite stayed green through this. The parametrization in `tests/v1/test_torch_ops.py` picks the device variant with `if _py_ops._get_copy_lib() is not None`. On ROCm that is true — the HIP library really does load — so the suite selects the `"cuda"` variant while the code underneath takes the CPU path. The gate is a proxy that stops tracking reality exactly where this bug lives. After the fix the two agree again.

I kept the change inside `_get_copy_lib` rather than touching the two call sites, partly to keep the diff on the bug and partly because #4575 adds a third consumer just below (`getattr(lib, "cudaPointerGetAttributes", None)`) that would inherit the same blind spot; fixing resolution centrally means that one needs no edit from me and the two PRs should not collide.

Only `cudaMemcpy` is resolved on the library today, so the alias table has one entry. `cudaHostRegister`, `cudaHostAlloc` and friends appear in this file only in comments and docstrings.

Verification, all on gfx1101 / ROCm 7.2.2 / torch 2.11.0+rocm7.2.2, built from source with `pip install -e . --no-build-isolation` (the HIP extension builds clean):

- the four new tests against `dev`: 2 fail, `AttributeError: cudaMemcpy` being the one that matters; the other two are regression guards for the CUDA-first and no-runtime paths and pass on both sides
- `pytest tests/v1/test_torch_ops.py` with the fix: **100 passed** (96 before, plus the 4 new)
- `pytest tests/v1/platform/`: **233 passed, 58 skipped**
- `pre-commit run --files` on both changed files: all hooks pass

The tests stub the runtime loader, so they exercise the ROCm branch on a CUDA or CPU host too and need no AMD hardware in CI.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
