### PR TITLE
fix(build): make the hipify guard reachable in the ROCm profile

### DIFF
--- a/setup_extensions/build_profiles/rocm.py
+++ b/setup_extensions/build_profiles/rocm.py
@@ -60,24 +60,25 @@ def _hipify_wrapper(source_names: list[str]) -> list[str]:
         hipify_extra_files_only=True,
     )
     hipified_sources: list[str] = []
+    unhipified: list[str] = []
     for source_name in source_names:
         s_abs = os.path.abspath(os.path.join(HIPIFY_OUT_DIR, source_name))
-        hipified_s_abs = (
-            hipify_result[s_abs].hipified_path
-            if (
-                s_abs in hipify_result
-                and hipify_result[s_abs].hipified_path is not None
-            )
-            else s_abs
-        )
+        result = hipify_result.get(s_abs)
+        hipified_s_abs = result.hipified_path if result is not None else None
+        if hipified_s_abs is None:
+            unhipified.append(source_name)
+            continue
         hipified_sources.append(
             os.path.relpath(hipified_s_abs, ROOT_DIR).replace(os.sep, "/")
         )
 
-    if len(hipified_sources) != len(source_names):
+    if unhipified:
+        # Returning the input path instead would hand setuptools the original
+        # CUDA source, so the ROCm build would compile CUDA under hipcc. The
+        # count check this replaces could never fire: the list gains exactly one
+        # entry per requested source, so the two lengths always matched.
         raise RuntimeError(
-            "Hipify failed: expected %d sources, got %d"
-            % (len(source_names), len(hipified_sources))
+            "Hipify did not yield a path for: %s" % ", ".join(unhipified)
         )
     return hipified_sources
 

--- a/tests/test_build_profiles_rocm.py
+++ b/tests/test_build_profiles_rocm.py
@@ -85,3 +85,62 @@ def test_hipify_wrapper_copies_headers_into_the_output_tree(
     rocm._hipify_wrapper(["ac_dec.cu"])
 
     assert (hipify_sandbox / "csrc_hip" / "cuda" / "utils.h").is_file()
+
+
+def _install_hipify_stub_skipping(
+    monkeypatch: pytest.MonkeyPatch, skipped: set[str]
+) -> None:
+    """Stub hipify so it yields no entry for the base names in ``skipped``.
+
+    Models hipify declining to process a file: the real one omits a source from
+    its result rather than reporting an error.
+    """
+
+    def fake_hipify(
+        project_directory: str,
+        output_directory: str,
+        extra_files: list[str],
+        **kwargs: object,
+    ) -> dict[str, _HipifyResult]:
+        result: dict[str, _HipifyResult] = {}
+        for abs_path in extra_files:
+            if os.path.basename(abs_path) in skipped:
+                continue
+            root, ext = os.path.splitext(abs_path)
+            hipified = root + ".hip" if ext == ".cu" else abs_path
+            result[abs_path] = _HipifyResult(hipified_path=hipified)
+        return result
+
+    stub = ModuleType("torch.utils.hipify.hipify_python")
+    stub.hipify = fake_hipify  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch.utils.hipify.hipify_python", stub)
+
+
+def test_hipify_wrapper_rejects_a_source_hipify_did_not_process(
+    hipify_sandbox: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source hipify skipped must fail the build, not fall back to the CUDA path.
+
+    Falling back hands setuptools the original ``.cu``, so the ROCm build
+    compiles CUDA sources under hipcc. The count check this replaces could not
+    catch it: the result list gained exactly one entry per requested source, so
+    its length always matched and the guard was unreachable.
+    """
+    _install_hipify_stub_skipping(monkeypatch, {"ac_dec.cu"})
+
+    with pytest.raises(RuntimeError, match="ac_dec.cu"):
+        rocm._hipify_wrapper(["ac_dec.cu", "pybind.cpp"])
+
+
+def test_hipify_wrapper_names_every_unhipified_source(
+    hipify_sandbox: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The error names all of them, so one build reports the whole problem."""
+    _install_hipify_stub_skipping(monkeypatch, {"ac_dec.cu", "pybind.cpp"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        rocm._hipify_wrapper(["ac_dec.cu", "pybind.cpp"])
+
+    message = str(excinfo.value)
+    assert "ac_dec.cu" in message
+    assert "pybind.cpp" in message


### PR DESCRIPTION
**What this PR does / why we need it**:

`_hipify_wrapper()` in `setup_extensions/build_profiles/rocm.py` documents:

```
    Raises:
        RuntimeError: If hipify did not yield a path for every requested source.
```

That check can never fire. `hipified_sources` gains exactly one entry per iteration over `source_names`, so `len(hipified_sources) != len(source_names)` is never true. The case the docstring describes is handled a few lines earlier, silently, by falling back to the input path:

```python
        hipified_s_abs = (
            hipify_result[s_abs].hipified_path
            if (s_abs in hipify_result and ...)
            else s_abs          # <- the original, un-hipified source
        )
```

So when hipify does not process a source, the profile hands setuptools the original CUDA file and the ROCm build compiles it under hipcc, with no diagnostic pointing at hipify.

Running the repository's own function with a hipify that returns nothing:

```
docstring says: RuntimeError: If hipify did not yield a path for every requested source.

hipify behaves (control)        -> ['csrc_hip/cuda/ac_dec.hip', 'csrc_hip/cuda/pybind.cpp']
hipify yields an empty result   -> ['csrc_hip/cuda/ac_dec.cu',  'csrc_hip/cuda/pybind.cpp']
hipify silently skips the .cu   -> ['csrc_hip/cuda/ac_dec.cu',  'csrc_hip/cuda/pybind.cpp']
```

The `.cu` comes back un-hipified and nothing is raised.

This PR raises on the sources hipify did not process, naming all of them so one build reports the whole problem, which is what the docstring already promised.

**Special notes for your reviewers**:

The fair question is whether tightening this can fail a build that works today. It cannot, and I checked rather than argued it. Running the patched wrapper against the real `csrc/cuda` tree with the real `torch.utils.hipify`, on gfx1101 / ROCm 7.2.2:

```
patched _hipify_wrapper on the real tree -> 12 sources, no raise
    csrc_hip/cuda/pybind_hip.cpp
    csrc_hip/cuda/mem_kernels.hip
    ... (all 12 requested sources resolved)
Successfully preprocessed all matching files.
```

Every requested source is present in hipify's result with a non-None path, including the `.cpp` ones — real hipify renames those too (`pybind.cpp` → `pybind_hip.cpp`), which is worth noting because the stub in the existing tests models hipify as leaving non-`.cu` names untouched. That difference does not affect production code, since it reads `hipified_path` rather than reconstructing the name, so I left the stub alone rather than widen this PR.

Verification:

- the two new tests against `dev`: both fail with `Failed: DID NOT RAISE <class 'RuntimeError'>`, which is the dead guard
- `pytest tests/test_build_profiles_rocm.py` with the fix: **4 passed** (the 2 existing ones still pass, so the honest path is unchanged)
- `pre-commit run --files` on both changed files: all hooks pass

The tests stub hipify, as the existing ones do, so they need neither torch nor ROCm.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
