### PR TITLE
Enable MP io_uring fixed buffer registration

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -561,7 +561,8 @@ class RawBlockL2Adapter(L2AdapterInterface):
         Args:
             config: Validated raw-block adapter configuration.
             l1_memory_desc: Optional L1 allocation descriptor used to validate
-                O_DIRECT alignment compatibility.
+                O_DIRECT alignment compatibility and register the L1 arena for
+                io_uring fixed-buffer I/O.
 
         Raises:
             ValueError: If O_DIRECT is enabled and L1 alignment is insufficient.
@@ -609,11 +610,27 @@ class RawBlockL2Adapter(L2AdapterInterface):
             self._fdp_placement_ids: list[int] = []
             if self._fdp_enabled:
                 self._configure_fdp(config.fdp_placement_ids)
-            if config.io_engine == "io_uring":
+            if (
+                config.io_engine == "io_uring"
+                and config.enable_zero_copy
+                and l1_memory_desc is not None
+            ):
+                try:
+                    self._core.register_fixed_buffer_region(
+                        l1_memory_desc.ptr,
+                        l1_memory_desc.size,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "RawBlockL2Adapter: failed to register the L1 arena as "
+                        "an io_uring fixed buffer: %s. Falling back to "
+                        "non-fixed buffer mode.",
+                        e,
+                    )
+            elif config.io_engine == "io_uring" and config.enable_zero_copy:
                 logger.warning(
-                    "RawBlockL2Adapter: MP raw_block uses io_uring without "
-                    "fixed-buffer registration; zero-copy fixed buffers are "
-                    "disabled unless registered by a future MP allocator path"
+                    "RawBlockL2Adapter: no L1 memory descriptor is available; "
+                    "io_uring fixed-buffer I/O is disabled"
                 )
             self._max_capacity_bytes = int(
                 self._core.report_status().get("usable_capacity_bytes", 0)

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -582,6 +582,30 @@ class RawBlockCore:
             len(buffers),
         )
 
+    def register_fixed_buffer_region(self, buffer_ptr: int, buffer_size: int) -> None:
+        """Register one contiguous memory region for io_uring fixed I/O.
+
+        Args:
+            buffer_ptr: Base address of the memory region.
+            buffer_size: Size of the memory region in bytes.
+
+        Raises:
+            ValueError: If the pointer or size is not positive.
+            Exception: Propagates Rust registration errors.
+        """
+        if self.io_engine != "io_uring":
+            return
+        if buffer_ptr <= 0:
+            raise ValueError("fixed buffer pointer must be positive")
+        if buffer_size <= 0:
+            raise ValueError("fixed buffer size must be positive")
+
+        self._rawdev().register_fixed_buffers([buffer_ptr], [buffer_size])
+        logger.info(
+            "RawBlockCore: registered one %d-byte region for io_uring fixed I/O",
+            buffer_size,
+        )
+
     def contains_key(self, encoded_key: str, *, lock: bool = False) -> bool:
         """Return whether one encoded key is present in the raw-block index.
 

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -13,7 +13,7 @@ import torch
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import EvictionConfig
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
     RawBlockL2Adapter,
     RawBlockL2AdapterConfig,
@@ -26,6 +26,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.storage_backend.raw_block.core import RawBlockCore
 
 _EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 
@@ -202,6 +203,58 @@ def test_raw_block_l2_adapter_config_explicit_io_engine_wins_over_legacy_flag():
 def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
     with pytest.raises(ValueError, match="iouring_queue_depth"):
         RawBlockL2AdapterConfig.from_dict(_config_dict(iouring_queue_depth=0))
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_registers_l1_arena_for_iouring(tmp_path) -> None:
+    dev_path = tmp_path / "dev.bin"
+    dev_path.write_bytes(b"\x00" * (8 * 1024 * 1024))
+    l1_memory_desc = L1MemoryDesc(ptr=0x1000, size=2 * 1024 * 1024, align_bytes=4096)
+
+    with patch.object(
+        RawBlockCore,
+        "register_fixed_buffer_region",
+        autospec=True,
+    ) as register_fixed_buffer_region:
+        adapter = RawBlockL2Adapter(
+            _make_config(str(dev_path), io_engine="io_uring"),
+            l1_memory_desc,
+        )
+        try:
+            register_fixed_buffer_region.assert_called_once()
+            _, buffer_ptr, buffer_size = register_fixed_buffer_region.call_args.args
+            assert buffer_ptr == l1_memory_desc.ptr
+            assert buffer_size == l1_memory_desc.size
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_fixed_buffer_failure_falls_back(tmp_path) -> None:
+    dev_path = tmp_path / "dev.bin"
+    dev_path.write_bytes(b"\x00" * (8 * 1024 * 1024))
+    l1_memory_desc = L1MemoryDesc(ptr=0x1000, size=2 * 1024 * 1024, align_bytes=4096)
+
+    with (
+        patch.object(
+            RawBlockCore,
+            "register_fixed_buffer_region",
+            autospec=True,
+            side_effect=RuntimeError("registration failed"),
+        ),
+        patch(
+            "lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter.logger.warning"
+        ) as warning,
+    ):
+        adapter = RawBlockL2Adapter(
+            _make_config(str(dev_path), io_engine="io_uring"),
+            l1_memory_desc,
+        )
+        try:
+            warning.assert_called_once()
+            assert "Falling back to non-fixed buffer mode" in warning.call_args.args[0]
+        finally:
+            adapter.close()
 
 
 @pytest.mark.parametrize("block_align", [0, -1, 3, 4095])

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -949,6 +949,7 @@ def test_raw_block_core_rebuilds_missing_free_slots_from_checkpoint(tmp_path):
 class _FakeRawDevice:
     def __init__(self, size_bytes: int = RAW_BLOCK_CI_CAPACITY_BYTES) -> None:
         self._size_bytes = int(size_bytes)
+        self.registered_fixed_buffers: list[tuple[list[int], list[int]]] = []
         self.batched_write_calls: list[
             tuple[list[int], list[int], list[int | None] | None]
         ] = []
@@ -957,6 +958,11 @@ class _FakeRawDevice:
 
     def size_bytes(self) -> int:
         return self._size_bytes
+
+    def register_fixed_buffers(
+        self, buffer_ptrs: list[int], buffer_sizes: list[int]
+    ) -> None:
+        self.registered_fixed_buffers.append((buffer_ptrs, buffer_sizes))
 
     def pread_into(self, offset, out, payload_len, total_len=None):
         del offset, total_len
@@ -994,6 +1000,31 @@ class _FakeRawDevice:
 
     def close(self) -> None:
         return None
+
+
+def test_register_fixed_buffer_region_uses_l1_arena(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core, raw_device = _make_fake_io_uring_core(tmp_path, monkeypatch)
+    try:
+        core.register_fixed_buffer_region(0x1000, 0x20000)
+
+        assert raw_device.registered_fixed_buffers == [([0x1000], [0x20000])]
+    finally:
+        core.close()
+
+
+def test_register_fixed_buffer_region_is_noop_for_posix(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core, raw_device = _make_fake_io_uring_core(tmp_path, monkeypatch)
+    core.io_engine = "posix"
+    try:
+        core.register_fixed_buffer_region(0x1000, 0x20000)
+
+        assert raw_device.registered_fixed_buffers == []
+    finally:
+        core.close()
 
 
 def _make_fake_io_uring_core(


### PR DESCRIPTION
## Summary

- register the MP L1 memory arena with the raw-block io_uring backend
- add a `RawBlockCore` API for registering one contiguous fixed-buffer region
- fall back to normal io_uring I/O when registration is unavailable
- preserve adapter/core shutdown ordering so buffers are unregistered before L1 memory is released

## Why

The legacy raw-block backend registers allocator memory for `ReadFixed`/`WriteFixed`, but the MP `RawBlockL2Adapter` previously only emitted a warning and always used ordinary io_uring operations. The MP storage manager already provides an `L1MemoryDesc`, so the adapter can register that arena without accessing allocator internals.

A follow-up PR will extend fixed-buffer lookup from exact base-address matching to subranges within the registered L1 arena.

## Validation

- release extension build: `maturin develop --release`
- raw-block tests: `116 passed, 1 skipped`
- `pre-commit run --all-files`
- MP adapter fixed-buffer end-to-end smoke passed in a privileged container with unlimited memlock
- no physical NVMe namespace was accessed

## Benchmark

4 KiB O_DIRECT random reads against a temporary regular file, queue depth 128, 640,000 operations per run, 7 runs. The benchmark ran in a privileged container because the host blocks io_uring fixed-buffer registration with `ENOMEM`.

| Mode | Median IOPS | Median wall latency/op | Median CPU/op |
|---|---:|---:|---:|
| Unregistered | 721,115 | 1,386.7 ns | 1,341.5 ns |
| Fixed buffer | 778,931 | 1,283.8 ns | 1,248.5 ns |

Measured change: **+8.0% IOPS**, **-7.4% wall latency/op**, and **-6.9% CPU/op**.

An independent fio cross-check on the same host measured **+7.0% IOPS** and **-6.6% average latency** with fixed buffers enabled.
