### PR TITLE
[Bugfix] Enable ZMQ IPv6 support in multiprocess transport

### DIFF
--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -282,6 +282,10 @@ class MessageQueueClient:
         # Socket
         self.ctx = context
         self.socket = self.ctx.socket(zmq.DEALER)
+        # ZMQ sockets default to IPv4-only. Enable IPv6 so endpoints can be
+        # IPv6 literals (tcp://[::1]:6555) or hostnames resolving to IPv6.
+        # Additive for IPv4 users.
+        self.socket.setsockopt(zmq.IPV6, 1)
         self.socket.connect(server_url)
 
         # Input queue
@@ -507,6 +511,10 @@ class MessageQueueServer:
         # Socket
         self.ctx = context
         self.socket = self.ctx.socket(zmq.ROUTER)
+        # ZMQ sockets default to IPv4-only. Enable IPv6 so endpoints can be
+        # IPv6 literals (tcp://[::1]:6555) or hostnames resolving to IPv6.
+        # Additive for IPv4 users.
+        self.socket.setsockopt(zmq.IPV6, 1)
         self.socket.bind(bind_url)
         # Use a cross-platform Notifier instead of zmq PUSH/PULL sockets
         # because blocking handler callbacks run on ThreadPoolExecutor

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -3,6 +3,7 @@
 from multiprocessing.synchronize import Event as EventClass
 from typing import Any, Callable
 import multiprocessing as mp
+import socket
 import sys
 import threading
 import time
@@ -959,3 +960,58 @@ def test_start_fails_without_pool_assignment():
         server.start()
 
     server.close()
+
+
+# ==============================================================================
+# IPv6 endpoint tests
+# ==============================================================================
+
+
+def _free_ipv6_port() -> int:
+    """
+    Reserve an ephemeral port on IPv6 loopback and return it.
+    """
+    s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    s.bind(("::1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_mq_ipv6_sockopt_set():
+    """
+    Server and client sockets enable zmq.IPV6 when created.
+    """
+    if not socket.has_ipv6:
+        pytest.skip("IPv6 not supported on this host")
+    port = _free_ipv6_port()
+    context = zmq.Context.instance()
+    server = MessageQueueServer(f"tcp://[::1]:{port}", context)
+    try:
+        assert server.socket.getsockopt(zmq.IPV6) == 1
+    finally:
+        server.close()
+
+    context = zmq.Context.instance()
+    client = MessageQueueClient(f"tcp://[::1]:{port}", context)
+    try:
+        assert client.socket.getsockopt(zmq.IPV6) == 1
+    finally:
+        client.close()
+
+
+def test_mq_ipv6_end_to_end():
+    """
+    NOOP round-trip between server and client over an IPv6 endpoint.
+    """
+    if not socket.has_ipv6:
+        pytest.skip("IPv6 not supported on this host")
+    port = _free_ipv6_port()
+    helper = MessageQueueTestHelper(server_url=f"tcp://[::1]:{port}")
+    helper.register_handler(RequestType.NOOP, test_mq_handler_helpers.noop_handler)
+    helper.run_test(
+        request_type=RequestType.NOOP,
+        payloads=[],
+        expected_response="NOOP_OK",
+        num_requests=3,
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #5043

Sets the `zmq.IPV6` socket option on the two MP transport sockets in `lmcache/v1/multiprocess/mq.py` (server `ROUTER` bind, client `DEALER` connect). ZMQ sockets default to IPv4-only, so on an IPv6-only host the MP server either fails to bind an IPv6 literal ("No such device") or silently binds IPv4-only when the user passes `tcp://*`, and the vLLM-side connector cannot reach an off-node server. Setting the option unconditionally is additive for IPv4 users and requires no new flag — the existing `--host` / `lmcache.mp.host` values flow into the `tcp://host:port` URL verbatim.

**Special notes for your reviewers**:

- Two lines of behavior change (one `setsockopt` per socket) plus a comment; the rest is tests.
- `setsockopt(zmq.IPV6, 1)` before `bind`/`connect` is the documented ZMQ requirement; no other sockopt is touched.
- `tcp://0.0.0.0` still binds IPv4-only with the option set, so existing IPv4 deployments are unaffected. The only visible behavior change is that a wildcard endpoint (`tcp://*`) becomes dual-stack.
- `get_ip()` in `rpc_utils.py` (heartbeat/P2P discovery) remains IPv4-only; out of scope here.

Validation (local, CPU-only env built the same way as CI: `NO_GPU_EXT=1 pip install -e . --no-build-isolation`):
- `MessageQueueServer` on `tcp://[::1]:<port>` binds and reports `zmq.IPV6 == 1`
- `MessageQueueClient` on the same endpoint connects with `zmq.IPV6 == 1`
- NOOP round-trip end-to-end over IPv6 loopback passes
- Full `tests/v1/multiprocess/test_mq.py` suite: 25 passed, 1 pre-existing skip
- `pre-commit run --all-files`: all Python hooks pass

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
