### PR TITLE
fix(mp-connector): timeout stuck retrieves instead of hanging requests in WAITING_FOR_REMOTE_KVS forever

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -76,6 +76,12 @@ class ExtraConfigDefault(enum.Enum):
     # Interval (seconds) between periodic heartbeat pings
     # to the server.
     heartbeat_interval = 10.0
+    # Max age (seconds) of a pending retrieve (KV load) before it is
+    # treated as failed: the request is reported finished with its blocks
+    # marked for recompute, instead of hanging in WAITING_FOR_REMOTE_KVS
+    # forever when a transfer result is lost. Healthy transfers complete
+    # in milliseconds; 0 disables the timeout.
+    retrieve_timeout = 30.0
     # Routing mode for ``create_transfer_context``: ``auto`` keeps the
     # historical CUDA -> lmcache_driven / others -> engine_driven dispatch;
     # ``lmcache_driven`` forces the IPC / SHM zero-copy path where the
@@ -1215,8 +1221,10 @@ class LMCacheMPWorkerAdapter:
                 self._mp_transfer_mode = None
             set_isolated_ipc(cfg[ExtraConfigDefault.isolated_ipc.name])
             set_use_vmm_api(cfg[ExtraConfigDefault.use_vmm_api.name])
+            self._retrieve_timeout = cfg[ExtraConfigDefault.retrieve_timeout.name]
         else:
             self._mp_transfer_mode = None
+            self._retrieve_timeout = ExtraConfigDefault.retrieve_timeout.default
         self.req_client = RequestClientFactory.create(server_url, context=context)
         self._mq_timeout = mq_timeout
 
@@ -1238,9 +1246,9 @@ class LMCacheMPWorkerAdapter:
 
         # Request futures
         self.store_futures: dict[str, MessagingFuture[StoreResult]] = {}
-        # request_id -> (future, block_ids)
+        # request_id -> (future, block_ids, submitted_at monotonic)
         self.retrieve_futures: dict[
-            str, tuple[MessagingFuture[RetrieveResult], list[int]]
+            str, tuple[MessagingFuture[RetrieveResult], list[int], float]
         ] = {}
         # The IPC handle is not enough by itself; CUDA needs the exporting
         # event object to stay alive until the consumer is done with it.
@@ -1665,7 +1673,11 @@ class LMCacheMPWorkerAdapter:
             self.blocks_in_chunk,
             skip_first_n_tokens=op.skip_first_n_tokens,
         )
-        self.retrieve_futures[request_id] = (future, op.flat_block_ids)
+        self.retrieve_futures[request_id] = (
+            future,
+            op.flat_block_ids,
+            time.monotonic(),
+        )
         if event is not None:
             self.retrieve_events[request_id] = event
 
@@ -1786,6 +1798,41 @@ class LMCacheMPWorkerAdapter:
         self._returned_finished.update(ret_stores)
         return ret_stores
 
+    def _expire_timed_out_retrieves(self, finished_retrieves: set[str]) -> None:
+        """Force-fail retrieve futures pending past ``retrieve_timeout``.
+
+        A retrieve whose result never arrives would otherwise leave the
+        request parked in WAITING_FOR_REMOTE_KVS forever: the scheduler only
+        promotes out of that state when the id comes back in
+        finished_recving. Mirror the unhealthy-drain path for exactly that
+        request: report it finished here and mark its blocks so vLLM
+        recomputes them. ``0`` disables the timeout.
+        """
+        if self._retrieve_timeout <= 0:
+            return
+        now = time.monotonic()
+        for request_id, (r_future, r_block_ids, submitted_at) in list(
+            self.retrieve_futures.items()
+        ):
+            if r_future.query():
+                continue
+            age_s = now - submitted_at
+            if age_s < self._retrieve_timeout:
+                continue
+            self.retrieve_futures.pop(request_id, None)
+            self.retrieve_events.pop(request_id, None)
+            self.error_block_ids.update(r_block_ids)
+            finished_retrieves.add(request_id)
+            logger.warning(
+                "Retrieve for request_id=%s timed out after %.1fs "
+                "(limit %.1fs); marking %d blocks as failed so vLLM "
+                "recomputes them",
+                request_id,
+                age_s,
+                self._retrieve_timeout,
+                len(r_block_ids),
+            )
+
     @_lmcache_nvtx_annotate
     def get_finished(
         self, finished_req_ids_from_engine: set[str]
@@ -1822,6 +1869,7 @@ class LMCacheMPWorkerAdapter:
             for request_id, (
                 _r_future,
                 r_block_ids,
+                _submitted_at,
             ) in self.retrieve_futures.items():
                 finished_retrieves.add(request_id)
                 self.error_block_ids.update(r_block_ids)
@@ -1852,6 +1900,7 @@ class LMCacheMPWorkerAdapter:
 
         finished_stores = set()
         finished_retrieves = set()
+        self._expire_timed_out_retrieves(finished_retrieves)
         for request_id, s_future in self.store_futures.items():
             if not s_future.query():
                 continue
@@ -1866,7 +1915,9 @@ class LMCacheMPWorkerAdapter:
                     request_id,
                 )
 
-        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+        for request_id, (r_future, r_block_ids, _submitted_at) in list(
+            self.retrieve_futures.items()
+        ):
             if not r_future.query():
                 continue
 
@@ -1950,6 +2001,7 @@ class LMCacheMPWorkerAdapter:
             for request_id, (
                 _r_future,
                 r_block_ids,
+                _submitted_at,
             ) in self.retrieve_futures.items():
                 finished_retrieves.add(request_id)
                 self.error_block_ids.update(r_block_ids)
@@ -1987,7 +2039,10 @@ class LMCacheMPWorkerAdapter:
                     request_id,
                 )
 
-        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+        self._expire_timed_out_retrieves(finished_retrieves)
+        for request_id, (r_future, r_block_ids, _submitted_at) in list(
+            self.retrieve_futures.items()
+        ):
             if not r_future.query():
                 continue
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -370,7 +370,8 @@ def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatc
         "lmcache.skip_save": True
     }
     assert transfer_ctx.submit_retrieve.call_args.args[4] == [[0]]
-    assert adapter.retrieve_futures["req-1"] == (fake_future, [0])
+    tracked_future, tracked_blocks, _submitted_at = adapter.retrieve_futures["req-1"]
+    assert (tracked_future, tracked_blocks) == (fake_future, [0])
 
 
 @pytest.mark.parametrize(
@@ -579,7 +580,11 @@ def test_failed_retrieve_marks_blocks_for_recompute(
     retrieve_future = MagicMock(name="retrieve_future")
     retrieve_future.query.return_value = True
     retrieve_future.result.return_value = False
-    adapter.retrieve_futures["req-1"] = (retrieve_future, [7, 8])
+    adapter.retrieve_futures["req-1"] = (
+        retrieve_future,
+        [7, 8],
+        time.monotonic(),
+    )
 
     if lazy_offload:
         finished_stores, finished_retrieves = adapter.get_finished_with_lazy_offload()
@@ -1062,3 +1067,88 @@ def test_recovery_reports_the_ring_re_registration_result(fake_adapter, ring_ok)
     adapter.register_kv_caches({"layer.0": fake_tensor})
 
     assert adapter._reregister_kv_caches_callback() is ring_ok
+
+
+@pytest.mark.parametrize("lazy_offload", [False, True])
+def test_timed_out_retrieve_is_reported_and_recomputed(
+    fake_adapter,
+    lazy_offload: bool,
+) -> None:
+    """A retrieve future that never resolves must not hang the request in
+    WAITING_FOR_REMOTE_KVS forever: past ``retrieve_timeout`` it is reported
+    finished exactly once and its blocks are marked for recompute."""
+    adapter, _send_mock, _future = fake_adapter
+    adapter.lazy_offload = lazy_offload
+    adapter._retrieve_timeout = 30.0
+    stuck_future = MagicMock(name="stuck_future")
+    stuck_future.query.return_value = False
+    # Submitted 31s ago: past the 30s timeout.
+    adapter.retrieve_futures["req-stuck"] = (
+        stuck_future,
+        [7, 8],
+        time.monotonic() - 31.0,
+    )
+    adapter.retrieve_events["req-stuck"] = MagicMock()
+
+    if lazy_offload:
+        _stores, finished_retrieves = adapter.get_finished_with_lazy_offload()
+    else:
+        _stores, finished_retrieves = adapter.get_finished(set())
+
+    assert finished_retrieves == {"req-stuck"}
+    assert adapter.get_block_ids_with_load_errors() == {7, 8}
+    assert "req-stuck" not in adapter.retrieve_futures
+    assert "req-stuck" not in adapter.retrieve_events
+
+    # Reported exactly once: the next pass returns nothing for it.
+    if lazy_offload:
+        _s2, second = adapter.get_finished_with_lazy_offload()
+    else:
+        _s2, second = adapter.get_finished(set())
+    assert not second
+
+
+@pytest.mark.parametrize("lazy_offload", [False, True])
+def test_pending_retrieve_within_timeout_is_left_alone(
+    fake_adapter,
+    lazy_offload: bool,
+) -> None:
+    """A retrieve younger than ``retrieve_timeout`` keeps waiting normally."""
+    adapter, _send_mock, _future = fake_adapter
+    adapter.lazy_offload = lazy_offload
+    adapter._retrieve_timeout = 30.0
+    pending = MagicMock(name="pending_future")
+    pending.query.return_value = False
+    adapter.retrieve_futures["req-wait"] = (
+        pending,
+        [9],
+        time.monotonic(),
+    )
+
+    if lazy_offload:
+        _s, finished_retrieves = adapter.get_finished_with_lazy_offload()
+    else:
+        _s, finished_retrieves = adapter.get_finished(set())
+
+    assert not finished_retrieves
+    assert "req-wait" in adapter.retrieve_futures
+    assert adapter.get_block_ids_with_load_errors() == set()
+
+
+def test_retrieve_timeout_extra_config_wiring(fake_adapter, monkeypatch):
+    """``lmcache.mp.retrieve_timeout`` overrides the default; 0 disables."""
+    adapter, _send_mock, _future = fake_adapter
+    adapter._retrieve_timeout = 0.0
+    stuck_future = MagicMock(name="stuck_future")
+    stuck_future.query.return_value = False
+    adapter.retrieve_futures["req-forever"] = (
+        stuck_future,
+        [3],
+        time.monotonic() - 3600.0,
+    )
+
+    _stores, finished_retrieves = adapter.get_finished(set())
+
+    # Disabled timeout: even a 1h-old pending retrieve is left alone.
+    assert not finished_retrieves
+    assert "req-forever" in adapter.retrieve_futures


### PR DESCRIPTION
## Problem

A retrieve (KV load) whose result never arrives leaves the request parked in `WAITING_FOR_REMOTE_KVS` **indefinitely**. `LMCacheMPWorkerAdapter.get_finished()` only reports a retrieve once its future resolves (`r_future.query()`), and there is no timeout anywhere on the path — the vLLM scheduler promotes out of `WAITING_FOR_REMOTE_KVS` only when the id comes back in `finished_recving`. The engine stays healthy and serves other traffic while the wedged request waits for the client's own timeout.

**Production incident** (vLLM 0.28.0 + LMCache 0.5.4, DeepSeek-V4-Flash, TP=1, `lmcache_driven`): requests admitted at 12:32:01, LMCache prefetch completed *partially* (`58/184 retained keys` in 0.5 ms), then nothing for 600 s while the same engine completed hundreds of other requests per minute. At 600 s the API-side sync timeout cancelled them (504s to clients); at cleanup the LMCache session was already gone (`Session … not found, skipping touch`). Four occurrences in one day across two workers.

## Fix

Track the submit time of each retrieve future and expire pending retrieves past a new `lmcache.mp.retrieve_timeout` (default **30 s**, `0` disables). Expiry mirrors the existing *unhealthy-drain* path for exactly that request:

- report the request finished, exactly once (so the scheduler promotes it out of `WAITING_FOR_REMOTE_KVS`), and
- mark its block ids via `error_block_ids`, so vLLM's invalid-blocks path truncates to the longest valid prefix and **recomputes** — never exposing unloaded KV.

Healthy transfers complete in milliseconds (~0.5–1.3 ms in our logs), so a 30 s default carries no false-positive risk for IPC/SHM deployments and is still generous for slower L2 backends; operators can tighten (`lmcache.mp.retrieve_timeout: 5`) or disable (`0`).

A `WARNING` is logged at fire time with the request id and age — previously the wedge left no log line until the client's own timeout.

## Tests

`tests/v1/test_vllm_mp_adapter.py` (49 passed, 1 skipped):

- `test_timed_out_retrieve_is_reported_and_recomputed` (parametrized over `lazy_offload`): an expired stuck retrieve is reported finished exactly once, blocks land in `get_block_ids_with_load_errors()`, tracking dicts are cleaned.
- `test_pending_retrieve_within_timeout_is_left_alone`: a young pending retrieve is untouched.
- `test_retrieve_timeout_extra_config_wiring`: `0` disables the timeout.

## Notes

- The healthy-path `get_finished` loop already marks `error_block_ids` on a *failed* retrieve result on `dev`; this PR extends the same semantics to *never-completing* retrieves.
- Root cause of the lost result (server-side session evaporating mid-transfer) is a separate investigation; this change is containment that works regardless of cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)