### PR TITLE
[Bugfix] gpu_connector: always sync the transfer stream in from_gpu, including CUDA destinations

### DIFF
--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -352,6 +352,11 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
              with -1s until the end of the matched prefix. The start and end
              should NEVER overlap with the prefix caching (which means the
              underlying CUDA kernel will never see -1 in slot_mapping)
+          3. This function blocks until the transfer into memory_obj is
+             complete, regardless of the destination device. It is safe for
+             the caller to read or hand off memory_obj as soon as this
+             function returns, including to a non-torch consumer (e.g. a
+             NIXL/UCX RDMA read from another thread).
 
         :raises ValueError: If 'kvcaches' is not provided in kwargs,
         :raises AssertionError: If the memory object does not have a tensor.
@@ -403,11 +408,15 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                 )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.tensor.is_cuda:
-            # Force a synchronize if the target buffer is NOT CUDA device
-            # NOTE: for better performance, we may not want to sync for every
-            # memory object
-            self.store_stream.synchronize()
+        # The D2H/D2D transfer above (and the copy_ in the gpu_buffer branch)
+        # is launched on store_stream with non_blocking=True. Callers read
+        # memory_obj.tensor right after this function returns -- on the CPU
+        # (host offload), on the default CUDA stream (compute), or via a
+        # non-torch consumer such as a NIXL/UCX RDMA read issued from a
+        # background thread (PD disaggregation with a GPU buffer). None of
+        # those wait on store_stream on their own, so we must always
+        # synchronize here regardless of the target device.
+        self.store_stream.synchronize()
 
         if self.use_mla:
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
@@ -587,6 +596,19 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
 
     @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
+        """Load KV data for tokens [start, end) from the engine's paged GPU
+        KV cache into memory_obj, one tensor per layer group.
+
+        This function blocks until the transfer into memory_obj is complete,
+        regardless of the destination device. It is safe for the caller to
+        read or hand off memory_obj as soon as this function returns,
+        including to a non-torch consumer (e.g. a NIXL/UCX RDMA read from
+        another thread).
+
+        :raises AssertionError: If memory_obj has no raw tensor, if
+            'slot_mapping' is missing from kwargs, or if the connector has
+            not been initialized with matching kvcaches.
+        """
         assert memory_obj.raw_tensor is not None
         assert "slot_mapping" in kwargs
 
@@ -638,11 +660,13 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                     assert memory_obj_tensor is not None
                     memory_obj_tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.raw_tensor.is_cuda:
-            # Force a synchronize if the target buffer is NOT CUDA device
-            # NOTE: for better performance, we may not want to sync for every
-            # memory object
-            self.store_stream.synchronize()
+        # See the matching comment in VLLMPagedMemGPUConnectorV2.from_gpu:
+        # the transfer above is async on store_stream, and callers may
+        # consume memory_obj_tensor through a path that never waits on
+        # store_stream (host reads, a different CUDA stream, or a NIXL/UCX
+        # RDMA read from a background thread under PD disaggregation with a
+        # GPU buffer). Always synchronize here, regardless of target device.
+        self.store_stream.synchronize()
 
         if self.use_mla:
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT
@@ -1594,6 +1618,11 @@ class SGLangGPUConnector(GPUConnectorInterface):
              with -1s until the end of the matched prefix. The start and end
              should NEVER overlap with the prefix caching (which means the
              underlying CUDA kernel will never see -1 in slot_mapping)
+          3. This function blocks until the transfer into memory_obj is
+             complete, regardless of the destination device. It is safe for
+             the caller to read or hand off memory_obj as soon as this
+             function returns, including to a non-torch consumer (e.g. a
+             NIXL/UCX RDMA read from another thread).
 
         :raises ValueError: If 'kvcaches' is not provided in kwargs,
         :raises AssertionError: If the memory object does not have a tensor.
@@ -1637,11 +1666,13 @@ class SGLangGPUConnector(GPUConnectorInterface):
             )
             memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.tensor.is_cuda:
-            # Force a synchronize if the target buffer is NOT CUDA device
-            # NOTE: for better performance, we may not want to sync for every
-            # memory object
-            torch.cuda.synchronize()
+        # See the matching comment in VLLMPagedMemGPUConnectorV2.from_gpu:
+        # the transfer above is async, and callers may consume memory_obj.tensor
+        # through a path that never waits on the issuing stream (host reads, a
+        # different CUDA stream, or a NIXL/UCX RDMA read from a background
+        # thread under PD disaggregation with a GPU buffer). Always
+        # synchronize here, regardless of target device.
+        torch.cuda.synchronize()
 
         if self.use_mla:
             memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -219,6 +219,77 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, engine_kv_format):
     allocator.close()
 
 
+def test_vllm_paged_connector_v2_from_gpu_syncs_for_cuda_destination():
+    """Regression test for a race where ``from_gpu`` could return before its
+    async transfer into the destination finished.
+
+    ``from_gpu`` launches the KV transfer on ``store_stream`` with
+    ``non_blocking=True`` and used to only call ``store_stream.synchronize()``
+    when the destination ``MemoryObj`` was NOT CUDA. When the destination is
+    itself a CUDA tensor -- e.g. a GPU-resident buffer under PD
+    disaggregation (``pd_buffer_device: "cuda"``) -- that sync was skipped,
+    so a consumer handed the object right after ``from_gpu`` returns (a
+    NIXL/UCX RDMA read issued from a background thread, in the real failure
+    case) could read it while the transfer was still in flight.
+    """
+    num_blocks = 4
+    block_size = 16
+    num_layers = 2
+    num_heads = 2
+    head_size = 8
+    device = torch_device_type
+    hidden_dim = num_heads * head_size
+    num_tokens = 32
+    engine_kv_format = lmcache_native.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+    gpu_kv_src = generate_kv_cache_paged_list_tensors(
+        num_blocks=num_blocks,
+        device=device,
+        block_size=block_size,
+        num_layers=num_layers,
+        head_size=head_size,
+        engine_kv_format=engine_kv_format,
+    )
+    dtype = get_dtype(gpu_kv_src, engine_kv_format)
+    slot_mapping = torch.tensor(
+        random.sample(range(0, num_blocks * block_size), num_tokens),
+        device=device,
+        dtype=torch.int64,
+    )
+
+    connector = VLLMPagedMemGPUConnectorV2(
+        hidden_dim, num_layers, use_gpu=False, dtype=dtype, device=device
+    )
+    gpu_allocator = GPUMemoryAllocator(64 * 1024 * 1024, device=device)
+    memory_obj = gpu_allocator.allocate(connector.get_shape(num_tokens), dtype)
+    assert memory_obj is not None
+    assert memory_obj.tensor is not None
+    assert memory_obj.tensor.is_cuda
+
+    with patch.object(
+        connector.store_stream,
+        "synchronize",
+        wraps=connector.store_stream.synchronize,
+    ) as sync_spy:
+        connector.from_gpu(
+            memory_obj,
+            0,
+            num_tokens,
+            kvcaches=gpu_kv_src,
+            slot_mapping=slot_mapping,
+            offset=0,
+        )
+        assert sync_spy.called, (
+            "from_gpu() must synchronize store_stream before returning even "
+            "when the destination MemoryObj is CUDA-resident, otherwise a "
+            "consumer can read the buffer while the async transfer into it "
+            "is still in flight."
+        )
+
+    gpu_allocator.free(memory_obj)
+    assert gpu_allocator.memcheck()
+
+
 @pytest.mark.parametrize("use_gpu", [True, False])
 @pytest.mark.parametrize("num_groups", [1, 2, 3])
 @pytest.mark.parametrize(
@@ -354,6 +425,73 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(
                 engine_kv_format,
             )
     allocator.close()
+
+
+def test_vllm_paged_connector_v3_from_gpu_syncs_for_cuda_destination():
+    """Regression test for a race where ``from_gpu`` could return before its
+    async transfer into the destination finished.
+
+    See ``test_vllm_paged_connector_v2_from_gpu_syncs_for_cuda_destination``
+    for the full explanation; V3 has the same ``store_stream``-gated-on-
+    ``is_cuda`` pattern.
+    """
+    engine_kv_format = lmcache_native.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+    num_blocks = 4
+    block_size = 16
+    head_size = 8
+    device = torch_device_type
+    num_tokens = 32
+
+    kv_group = generate_kv_cache_paged_list_tensors(
+        num_blocks=num_blocks,
+        device=device,
+        block_size=block_size,
+        dtype=torch.bfloat16,
+        num_layers=2,
+        head_size=head_size,
+        engine_kv_format=engine_kv_format,
+    )
+    kv_caches = {f"0-{j}": layer_tensor for j, layer_tensor in enumerate(kv_group)}
+
+    slot_mapping = torch.tensor(
+        random.sample(range(0, num_blocks * block_size), num_tokens),
+        device=device,
+        dtype=torch.int64,
+    )
+
+    metadata = _create_metadata(False, kv_caches, engine_kv_format)
+    connector = VLLMPagedMemGPUConnectorV3(
+        metadata=metadata, use_gpu=False, device=slot_mapping.device
+    )
+
+    gpu_allocator = GPUMemoryAllocator(64 * 1024 * 1024, device=device)
+    memory_obj = gpu_allocator.allocate(
+        metadata.get_shapes(num_tokens), metadata.get_dtypes()
+    )
+    assert memory_obj is not None
+    assert memory_obj.raw_tensor is not None
+    assert memory_obj.raw_tensor.is_cuda
+
+    with patch.object(
+        connector.store_stream,
+        "synchronize",
+        wraps=connector.store_stream.synchronize,
+    ) as sync_spy:
+        connector.from_gpu(
+            memory_obj,
+            0,
+            num_tokens,
+            kvcaches=list(kv_caches.values()),
+            slot_mapping=slot_mapping,
+            offset=0,
+        )
+        assert sync_spy.called, (
+            "from_gpu() must synchronize store_stream before returning even "
+            "when the destination MemoryObj is CUDA-resident."
+        )
+
+    gpu_allocator.free(memory_obj)
+    assert gpu_allocator.memcheck()
 
 
 @pytest.mark.parametrize("use_gpu", [True])
@@ -902,6 +1040,69 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
         )
 
     allocator.close()
+
+
+def test_sglang_connector_from_gpu_syncs_for_cuda_destination():
+    """Regression test for a race where ``from_gpu`` could return before its
+    async transfer into the destination finished.
+
+    ``SGLangGPUConnector`` has no dedicated store stream -- the transfer runs
+    on the ambient current stream -- and used to only call
+    ``torch.cuda.synchronize()`` when the destination ``MemoryObj`` was NOT
+    CUDA. See ``test_vllm_paged_connector_v2_from_gpu_syncs_for_cuda_destination``
+    for why skipping that sync is unsafe for a CUDA-resident destination.
+    """
+    num_blocks = 4
+    block_size = 16
+    num_layers = 2
+    num_heads = 2
+    head_size = 8
+    device = torch_device_type
+    dtype = torch.bfloat16
+    hidden_dim = num_heads * head_size
+    num_tokens = 32
+
+    gpu_kv_src = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        use_mla=False,
+        device=device,
+        dtype=dtype,
+    )
+    slot_mapping = torch.tensor(
+        random.sample(range(0, num_blocks * block_size), num_tokens),
+        device=device,
+        dtype=torch.int64,
+    )
+
+    connector = SGLangGPUConnector(hidden_dim, num_layers, use_gpu=False)
+    gpu_allocator = GPUMemoryAllocator(64 * 1024 * 1024, device=device)
+    memory_obj = gpu_allocator.allocate(
+        connector.get_shape(num_tokens), gpu_kv_src[0][0].dtype
+    )
+    assert memory_obj is not None
+    assert memory_obj.tensor is not None
+    assert memory_obj.tensor.is_cuda
+
+    with patch("torch.cuda.synchronize", wraps=torch.cuda.synchronize) as sync_spy:
+        connector.from_gpu(
+            memory_obj,
+            0,
+            num_tokens,
+            kvcaches=gpu_kv_src,
+            slot_mapping=slot_mapping,
+            offset=0,
+        )
+        assert sync_spy.called, (
+            "from_gpu() must call torch.cuda.synchronize() before returning "
+            "even when the destination MemoryObj is CUDA-resident."
+        )
+
+    gpu_allocator.free(memory_obj)
+    assert gpu_allocator.memcheck()
 
 
 def _create_metadata(use_mla, kv_caches, engine_kv_format):


### PR DESCRIPTION
Fixes #5048

**What this PR does / why we need it**:

Three `from_gpu()` implementations in `lmcache/v1/gpu_connector/gpu_connectors.py` (`VLLMPagedMemGPUConnectorV2`, `VLLMPagedMemGPUConnectorV3`, `SGLangGPUConnector`) launch the KV extraction copy with `non_blocking=True` on a transfer stream and then only synchronize when the destination buffer is *not* CUDA.

That is wrong for PD disaggregation with a GPU-resident buffer (`pd_buffer_device: "cuda"`, the setting in `examples/disagg_prefill/1p1d/configs/lmcache-prefiller-config.yaml`). On that path the PD backend is the engine's allocator backend, so the `MemoryObj`s coming out of `from_gpu()` go straight from `LMCacheEngine.store()` into `batched_submit_put_task` without an intermediate copy, and the NIXL/UCX write is issued from a different thread: the `nixl-worker-tp{N}` thread in `PDBackend._nixl_worker_loop` (sync mode) or the `pd-sender-async` event loop in `PDBackendAsync._async_transfer_task` (async mode, the example default). Neither waits on `store_stream`. RDMA reads registered GPU memory outside CUDA stream ordering, so the transfer can start before the copy into the buffer has finished. The decoder then receives a chunk that is partly stale and partly fresh. Nothing crashes and nothing is logged.

This is the same bug shape as #4830 (`00db3ce`), which fixed an async copy handed off before completion in the multiprocess transfer path. That fix did not cover the single-process `gpu_connector.py` path.

**The fix**: remove the `is_cuda` guard in all three methods and synchronize unconditionally before returning (`store_stream.synchronize()` for the two vLLM connectors; `torch.cuda.synchronize()` for `SGLangGPUConnector`, which has no dedicated stream). Each method's docstring now states the guarantee explicitly. `VLLMPagedMemGPUConnectorV3.from_gpu` had no docstring, so it gained one.

**Why a full sync rather than an event or `wait_stream`**: the consumer in the failing case is a non-torch RDMA engine on another thread. There is no stream on that side to order against, so `wait_stream()` cannot help. A CUDA event that the PD sender thread waits on before issuing the RDMA op would be cheaper, but it changes the PD backends' threading model and is out of scope for a bugfix. Happy to follow up separately if maintainers prefer that design.

**Blast radius**: only `enable_pd: true` senders with a GPU-backed buffer. The CPU-offload path already synchronized and is unchanged. Expect a small store-path throughput cost on the PD/GPU-buffer path from the now-mandatory sync.

**Special notes for your reviewers**:

Verified on a rented single-GPU CUDA instance (NVIDIA RTX A6000, driver 610.43.02, torch 2.12.1+cu130, LMCache built from source with the CUDA extensions) against `dev` at `5eebe0d`. The three new tests fail on the synchronize assertion when run against the unfixed `gpu_connectors.py`, and pass against this branch:

```
$ python3 -c "import torch; print(torch.__version__, torch.version.cuda)"
2.12.1+cu130 13.0

# new tests against the UNFIXED source (gpu_connectors.py reverted to 5eebe0d)
$ python3 -m pytest -q tests/v1/test_gpu_connector.py -k syncs_for_cuda_destination
E   AssertionError: from_gpu() must synchronize store_stream before returning even when the destination MemoryObj is CUDA-resident, ...
E   AssertionError: from_gpu() must synchronize store_stream before returning even when the destination MemoryObj is CUDA-resident, ...
E   AssertionError: from_gpu() must call torch.cuda.synchronize() before returning even when the destination MemoryObj is CUDA-resident, ...
======================= 3 failed, 33 deselected in 0.69s =======================

# same tests against this branch
$ python3 -m pytest -v tests/v1/test_gpu_connector.py -k syncs_for_cuda_destination
test_vllm_paged_connector_v2_from_gpu_syncs_for_cuda_destination PASSED
test_vllm_paged_connector_v3_from_gpu_syncs_for_cuda_destination PASSED
test_sglang_connector_from_gpu_syncs_for_cuda_destination PASSED
======================= 3 passed, 33 deselected in 0.62s =======================
```

What this does and does not prove: the tests exercise the public `from_gpu()` API with a GPU-resident `MemoryObj` from `GPUMemoryAllocator` and assert that the synchronize call happens before the function returns, which is exactly the call the `is_cuda` guard was skipping. I did not run the full 1P1D NIXL reproduction, so the RDMA race itself was not observed directly. The claim rests on the call-chain trace (`cache_engine.store` -> `batched_from_gpu` -> `from_gpu` -> `storage_manager.batched_put` -> `PDBackend[Async].batched_submit_put_task` -> NIXL write thread) plus the unit-level before/after above. If anyone can run a 1P1D NIXL setup, a concurrent-load run with a deterministic eval before and after this patch would be the strongest confirmation.

One caveat about the existing `*_with_gpu_and_mla` tests for the same three connectors: on that rented instance they fail identically with and without this change (14x `Host tensor not registered/pinned`, 14x `CUDA error: invalid argument`) because pinned host memory cannot be registered on the provider's virtualized GPU, so I could not use them as a no-regression signal there. Please rely on GPU CI for that; the change only replaces a conditional synchronize with an unconditional one, so those tests are not expected to be affected.

`ruff check` and `ruff format --check` pass on the changed files; mypy reports no new findings.

**If applicable**:

- [ ] this PR contains user facing changes - docs added (not applicable: internal correctness fix, no config or API change)
- [x] this PR contains unit tests
