### PR TITLE
refactor(multiprocess): isolate ZMQ request handling

### DIFF
--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -539,9 +539,10 @@ Adding a new request type
    or ``p2p``) and add the request name to that module's ``REQUEST_NAMES``.
 3. Implement the handler method on the appropriate ``EngineModule``
    (e.g. ``LookupModule``, ``LMCacheDrivenTransferModule``, ``BlendModule``) and
-   expose it as a ``HandlerSpec`` from that module's ``get_handlers()``.
-4. ``run_cache_server()`` registers every ``HandlerSpec`` returned by the
-   loaded modules via ``add_handler_helper()`` — no manual registration
+   add its ``HandlerSpec`` to ``get_zmq_handler_specs()`` in the ZMQ transport
+   adapter.
+4. ``build_zmq_request_server()`` registers every ``HandlerSpec`` returned for
+   the loaded modules via ``add_handler_helper()`` — no manual registration
    step is needed.
 
 Key Source Files
@@ -560,8 +561,12 @@ Key Source Files
    * - ``lmcache/v1/multiprocess/engine_context.py``
      - MPCacheServerContext (shared state passed to every EngineModule)
    * - ``lmcache/v1/multiprocess/engine_module.py``
-     - ``EngineModule`` protocol, ``HandlerSpec``, ``ThreadPoolType``
-       (per-module handler registration)
+     - Transport-neutral ``EngineModule`` protocol
+   * - ``lmcache/v1/multiprocess/transport/server_factory.py``
+     - Transport-neutral request-server construction boundary
+   * - ``lmcache/v1/multiprocess/transport/zmq_impl/server.py``
+     - ZMQ ``HandlerSpec`` and ``ThreadPoolType`` definitions, per-module
+       handler adapters, and message queue server construction
    * - ``lmcache/v1/multiprocess/modules/``
      - Engine module implementations: ``lookup.py`` (``LookupModule``),
        ``management.py`` (``ManagementModule``), ``lmcache_driven_transfer.py``

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -541,9 +541,9 @@ Adding a new request type
    (e.g. ``LookupModule``, ``LMCacheDrivenTransferModule``, ``BlendModule``) and
    add its ``HandlerSpec`` to ``get_zmq_handler_specs()`` in the ZMQ transport
    adapter.
-4. ``build_zmq_request_server()`` registers every ``HandlerSpec`` returned for
-   the loaded modules via ``add_handler_helper()`` — no manual registration
-   step is needed.
+4. ``create_request_server()`` selects the transport. Its ZMQ implementation
+   registers every ``HandlerSpec`` returned for the loaded modules — no manual
+   registration step is needed.
 
 Key Source Files
 ----------------

--- a/lmcache/v1/multiprocess/engine_module.py
+++ b/lmcache/v1/multiprocess/engine_module.py
@@ -5,55 +5,22 @@
 from __future__ import annotations
 
 # Standard
-from dataclasses import dataclass
-from enum import Enum, auto
-from typing import TYPE_CHECKING, Callable, Protocol
-
-# First Party
-from lmcache.v1.multiprocess.protocol import RequestType
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 
 
-class ThreadPoolType(Enum):
-    """Declares which thread pool a handler should run in."""
-
-    SYNC = auto()
-    AFFINITY = auto()
-    NORMAL = auto()
-
-
-@dataclass
-class HandlerSpec:
-    """Specification for a single message queue handler.
-
-    Args:
-        request_type: The ZMQ request type this handler serves.
-        handler: The callable that processes the request.
-        pool: Which thread pool the handler runs in.
-    """
-
-    request_type: RequestType
-    handler: Callable
-    pool: ThreadPoolType
-
-
 class EngineModule(Protocol):
     """Protocol for pluggable engine modules.
 
-    Each module owns its internal state and exposes handlers
-    that the compositor registers with the message queue server.
+    Each module owns transport-neutral business state and operations.
     """
 
     @property
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
-        ...
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves."""
         ...
 
     def report_status(self) -> dict:

--- a/lmcache/v1/multiprocess/modules/blend/module.py
+++ b/lmcache/v1/multiprocess/modules/blend/module.py
@@ -15,11 +15,7 @@ if TYPE_CHECKING:
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    InstanceLivenessTarget,
-    ThreadPoolType,
-)
+from lmcache.v1.multiprocess.engine_module import InstanceLivenessTarget
 from lmcache.v1.multiprocess.modules.blend.lookup import (
     LookupMixin,
     _CBUnifiedJob,
@@ -39,7 +35,6 @@ from lmcache.v1.multiprocess.modules.blend.store import (
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     LMCacheDrivenTransferModule,
 )
-from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.blend import handshake_response
 from lmcache.v1.multiprocess.session import Session
 
@@ -150,38 +145,6 @@ class BlendModule(
     @property
     def context(self) -> MPCacheServerContext:
         return self._ctx
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        # STORE shadows LMCacheDrivenTransfer's; the blend module is
-        # registered last so this handler wins.
-        return [
-            HandlerSpec(RequestType.STORE, self.store, ThreadPoolType.AFFINITY),
-            HandlerSpec(
-                RequestType.CB_REGISTER_ROPE,
-                self.cb_register_rope,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.CB_UNREGISTER_ROPE,
-                self.cb_unregister_rope,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.CB_UNIFIED_LOOKUP,
-                self.cb_unified_lookup,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.CB_RETRIEVE_PRE_COMPUTED,
-                self.cb_retrieve_pre_computed,
-                ThreadPoolType.AFFINITY,
-            ),
-            HandlerSpec(
-                RequestType.CB_PROTOCOL_HANDSHAKE,
-                self.cb_protocol_handshake,
-                ThreadPoolType.SYNC,
-            ),
-        ]
 
     def cb_protocol_handshake(self, client_version: int) -> tuple[int, bool]:
         return handshake_response(client_version)

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -21,12 +21,7 @@ from lmcache.v1.multiprocess.custom_types import (
     RegisterEngineDrivenContextPayload,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext, ShmPoolInfo
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    InstanceLivenessTarget,
-    ThreadPoolType,
-)
-from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.engine_module import InstanceLivenessTarget
 from lmcache.v1.multiprocess.protocols.engine import (
     PrepareRetrieveResponse,
     PrepareStoreResponse,
@@ -96,46 +91,6 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves.
-
-        Returns:
-            A list of HandlerSpec entries mapping request types to
-            their handler callables and thread pool assignments.
-        """
-        return [
-            HandlerSpec(
-                RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
-                self.register_kv_cache_engine_driven_context,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
-                self.unregister_kv_cache,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.PREPARE_STORE,
-                self.prepare_store,
-                ThreadPoolType.AFFINITY,
-            ),
-            HandlerSpec(
-                RequestType.COMMIT_STORE,
-                self.commit_store,
-                ThreadPoolType.AFFINITY,
-            ),
-            HandlerSpec(
-                RequestType.PREPARE_RETRIEVE,
-                self.prepare_retrieve,
-                ThreadPoolType.AFFINITY,
-            ),
-            HandlerSpec(
-                RequestType.COMMIT_RETRIEVE,
-                self.commit_retrieve,
-                ThreadPoolType.AFFINITY,
-            ),
-        ]
 
     def report_status(self) -> dict:
         """Return non-GPU transfer module status information.

--- a/lmcache/v1/multiprocess/modules/experimental/qstore.py
+++ b/lmcache/v1/multiprocess/modules/experimental/qstore.py
@@ -25,11 +25,7 @@ from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, KVCache
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    InstanceLivenessTarget,
-    ThreadPoolType,
-)
+from lmcache.v1.multiprocess.engine_module import InstanceLivenessTarget
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     ContextEntry,
@@ -38,7 +34,6 @@ from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     transfer_kv_per_object_group,
 )
 from lmcache.v1.multiprocess.native_completion import submit_callback_to_stream
-from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.lmcache_native as lmcache_native
 
@@ -190,31 +185,6 @@ class QStoreModule(InstanceLivenessTarget):
         if ipc_collect is not None:
             # Non-CUDA device modules (xpu / musa) do not expose ipc_collect.
             ipc_collect()
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves.
-
-        Returns:
-            A list of HandlerSpec entries mapping request types to
-            their handler callables and thread pool assignments.
-        """
-        return [
-            HandlerSpec(
-                RequestType.REGISTER_Q_CACHE,
-                self.register_q_cache,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.UNREGISTER_Q_CACHE,
-                self.unregister_q_cache,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.STORE_Q,
-                self.store_q,
-                ThreadPoolType.AFFINITY,
-            ),
-        ]
 
     def report_status(self) -> dict:
         """Return Q transfer module status information.

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -37,18 +37,13 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    InstanceLivenessTarget,
-    ThreadPoolType,
-)
+from lmcache.v1.multiprocess.engine_module import InstanceLivenessTarget
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.modules.lookup import resolve_prefetched_obj_keys
 from lmcache.v1.multiprocess.native_completion import (
     DeviceHostFuncDispatcher,
     submit_callback_to_stream,
 )
-from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
 from lmcache.v1.platform.base.event_ipc import (
     EventIPCBackend,
@@ -863,36 +858,6 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         if ipc_collect is not None:
             # Backends without IPC collection omit this optional operation.
             ipc_collect()
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves.
-
-        Returns:
-            A list of HandlerSpec entries mapping request types to
-            their handler callables and thread pool assignments.
-        """
-        return [
-            HandlerSpec(
-                RequestType.REGISTER_KV_CACHE,
-                self.register_kv_cache,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.UNREGISTER_KV_CACHE,
-                self.unregister_kv_cache,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.STORE,
-                self.store,
-                ThreadPoolType.AFFINITY,
-            ),
-            HandlerSpec(
-                RequestType.RETRIEVE,
-                self.retrieve,
-                ThreadPoolType.AFFINITY,
-            ),
-        ]
 
     def report_status(self) -> dict:
         """Return GPU transfer module status information.

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -22,11 +22,6 @@ from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.otel_init import register_gauge
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    ThreadPoolType,
-)
-from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
 logger = init_logger(__name__)
@@ -129,41 +124,6 @@ class LookupModule:
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves.
-
-        Returns:
-            List of handler specs for lookup-related request types.
-        """
-        return [
-            HandlerSpec(RequestType.LOOKUP, self.lookup, ThreadPoolType.NORMAL),
-            HandlerSpec(
-                RequestType.QUERY_PREFETCH_STATUS,
-                self.query_prefetch_status,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.WAIT_PREFETCH_STATUS,
-                self.wait_prefetch_status,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.QUERY_PREFETCH_LOOKUP_HITS,
-                self.query_prefetch_lookup_hits,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.FREE_LOOKUP_LOCKS,
-                self.free_lookup_locks,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.END_SESSION,
-                self.end_session,
-                ThreadPoolType.NORMAL,
-            ),
-        ]
 
     def report_status(self) -> dict[str, int]:
         """Return module-specific status information.

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -10,12 +10,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import BlockAllocationRecord
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    InstanceLivenessTarget,
-    ThreadPoolType,
-)
-from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.multiprocess.engine_module import InstanceLivenessTarget
 from lmcache.v1.periodic_thread import (
     PeriodicThread,
     ThreadLevel,
@@ -81,34 +76,6 @@ class ManagementModule:
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves.
-
-        Returns:
-            A list of HandlerSpec entries mapping request types to
-            their handler callables and thread pool assignments.
-        """
-        return [
-            HandlerSpec(RequestType.CLEAR, self.clear, ThreadPoolType.NORMAL),
-            HandlerSpec(
-                RequestType.GET_CHUNK_SIZE,
-                self.get_chunk_size,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(
-                RequestType.GET_EXPERIMENTAL,
-                self.get_experimental,
-                ThreadPoolType.SYNC,
-            ),
-            HandlerSpec(RequestType.PING, self.ping, ThreadPoolType.NORMAL),
-            HandlerSpec(RequestType.NOOP, self.debug, ThreadPoolType.SYNC),
-            HandlerSpec(
-                RequestType.REPORT_BLOCK_ALLOCATION,
-                self.report_block_allocations,
-                ThreadPoolType.NORMAL,
-            ),
-        ]
 
     def report_status(self) -> dict:
         """Return module-specific status information.

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -30,11 +30,6 @@ from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
 from lmcache.v1.mp_observability.otel_init import register_gauge
 from lmcache.v1.multiprocess.config import CoordinatorConfig, P2PConfig
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    HandlerSpec,
-    ThreadPoolType,
-)
-from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.periodic_thread import (
     PeriodicThread,
     ThreadLevel,
@@ -160,30 +155,6 @@ class P2PController:
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
-
-    def get_handlers(self) -> list[HandlerSpec]:
-        """Return handler specs for all request types this module serves.
-
-        Returns:
-            List of handler specs for lookup-related request types.
-        """
-        return [
-            HandlerSpec(
-                RequestType.P2P_LOOKUP_AND_LOCK,
-                self.p2p_lookup_and_lock,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.P2P_QUERY_LOOKUP_RESULTS,
-                self.p2p_query_lookup_results,
-                ThreadPoolType.NORMAL,
-            ),
-            HandlerSpec(
-                RequestType.P2P_UNLOCK_OBJECTS,
-                self.p2p_unlock_objects,
-                ThreadPoolType.NORMAL,
-            ),
-        ]
 
     def report_status(self) -> dict[str, object]:
         """Return module-specific status information.

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -8,9 +8,6 @@ import signal
 import sys
 import time
 
-# Third Party
-import zmq
-
 # First Party
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
@@ -45,12 +42,7 @@ from lmcache.v1.multiprocess.config import (
     parse_args_to_mp_server_config,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import (
-    EngineModule,
-    HandlerSpec,
-    InstanceLivenessTarget,
-    ThreadPoolType,
-)
+from lmcache.v1.multiprocess.engine_module import EngineModule, InstanceLivenessTarget
 from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
     EngineDrivenTransferModule,
 )
@@ -63,11 +55,7 @@ from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.modules.management import ManagementModule
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
 from lmcache.v1.multiprocess.mq import MessageQueueServer
-from lmcache.v1.multiprocess.protocol import (
-    RequestType,
-    get_handler_type,
-    get_payload_classes,
-)
+from lmcache.v1.multiprocess.transport.server_factory import create_request_server
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
 from lmcache.v1.platform.isolated_ipc import set_isolated_ipc
 
@@ -151,26 +139,6 @@ class MPCacheServer:
                 module.clear()
                 return
         raise RuntimeError("MPCacheServer.clear: no ManagementModule registered")
-
-
-def add_handler_helper(
-    server: MessageQueueServer, request_type: RequestType, handler_function
-):
-    """Register a handler with the message queue server.
-
-    Args:
-        server: The message queue server.
-        request_type: The request type to handle.
-        handler_function: The handler callable.
-    """
-    payload_classes = get_payload_classes(request_type)
-    handler_type = get_handler_type(request_type)
-    server.add_handler(
-        request_type,
-        payload_classes,
-        handler_type,
-        handler_function,
-    )
 
 
 def _build_modules(
@@ -413,33 +381,7 @@ def run_cache_server(
     InitializeL2ConnectorUsage(event_bus, ctx.storage_manager)
     InitializeL1Usage(event_bus, ctx.storage_manager)
 
-    zmq_context = zmq.Context.instance()
-    server = MessageQueueServer(
-        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
-        context=zmq_context,
-    )
-
-    all_specs: list[HandlerSpec] = []
-    for module in modules:
-        all_specs.extend(module.get_handlers())
-
-    for spec in all_specs:
-        add_handler_helper(server, spec.request_type, spec.handler)
-
-    affinity_types = [
-        s.request_type for s in all_specs if s.pool == ThreadPoolType.AFFINITY
-    ]
-    normal_types = [
-        s.request_type for s in all_specs if s.pool == ThreadPoolType.NORMAL
-    ]
-    if affinity_types:
-        server.add_affinity_thread_pool(
-            affinity_types, max_workers=mp_config.max_gpu_workers
-        )
-    if normal_types:
-        server.add_normal_thread_pool(
-            normal_types, max_workers=mp_config.max_cpu_workers
-        )
+    server = create_request_server(modules, mp_config)
 
     logger.info(
         "LMCache ZMQ cache server is running on tcp://%s:%d",

--- a/lmcache/v1/multiprocess/transport/server_factory.py
+++ b/lmcache/v1/multiprocess/transport/server_factory.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request server construction behind a transport-neutral boundary."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.config import MPServerConfig
+    from lmcache.v1.multiprocess.engine_module import EngineModule
+    from lmcache.v1.multiprocess.mq import MessageQueueServer
+
+
+def create_request_server(
+    modules: list[EngineModule],
+    mp_config: MPServerConfig,
+) -> MessageQueueServer:
+    """Create the ZMQ request server used by the multiprocess runtime.
+
+    Args:
+        modules: Ordered business modules composing the cache server.
+        mp_config: Multiprocess server configuration.
+
+    Returns:
+        Configured, but not yet started, ZMQ message queue server.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.transport.zmq_impl.server import (
+        build_zmq_request_server,
+    )
+
+    return build_zmq_request_server(modules, mp_config)
+
+
+__all__ = ["create_request_server"]

--- a/lmcache/v1/multiprocess/transport/zmq_impl/server.py
+++ b/lmcache/v1/multiprocess/transport/zmq_impl/server.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ZMQ request handlers and server construction for multiprocess requests."""
+
+# Standard
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Callable
+
+# Third Party
+import zmq
+
+# First Party
+from lmcache.v1.multiprocess.config import MPServerConfig
+from lmcache.v1.multiprocess.engine_module import EngineModule
+from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
+    EngineDrivenTransferModule,
+)
+from lmcache.v1.multiprocess.modules.experimental.qstore import QStoreModule
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    LMCacheDrivenTransferModule,
+)
+from lmcache.v1.multiprocess.modules.lookup import LookupModule
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
+from lmcache.v1.multiprocess.mq import MessageQueueServer
+from lmcache.v1.multiprocess.protocol import (
+    RequestType,
+    get_handler_type,
+    get_payload_classes,
+)
+
+
+class ThreadPoolType(Enum):
+    """Select the ZMQ worker pool for a request handler."""
+
+    SYNC = auto()
+    AFFINITY = auto()
+    NORMAL = auto()
+
+
+@dataclass(frozen=True)
+class HandlerSpec:
+    """Describe one ZMQ request handler and its worker pool.
+
+    Args:
+        request_type: ZMQ request type served by the handler.
+        handler: Callable that processes the decoded request payloads.
+        pool: ZMQ worker pool used to execute the handler.
+    """
+
+    request_type: RequestType
+    handler: Callable[..., Any]
+    pool: ThreadPoolType
+
+
+def add_handler_helper(
+    server: MessageQueueServer,
+    request_type: RequestType,
+    handler_function: Callable[..., Any],
+) -> None:
+    """Register one legacy request handler with a ZMQ server.
+
+    Args:
+        server: ZMQ message queue server.
+        request_type: Legacy request type to register.
+        handler_function: Callable that handles the decoded payloads.
+
+    Returns:
+        None.
+    """
+    server.add_handler(
+        request_type,
+        get_payload_classes(request_type),
+        get_handler_type(request_type),
+        handler_function,
+    )
+
+
+def get_zmq_handler_specs(module: EngineModule) -> list[HandlerSpec]:
+    """Build the ZMQ handler table for one transport-neutral engine module.
+
+    Args:
+        module: Business module whose public methods should serve ZMQ requests.
+
+    Returns:
+        Ordered ZMQ handler specifications for the module.
+
+    Raises:
+        TypeError: If the module has no ZMQ adapter.
+    """
+    if isinstance(module, LookupModule):
+        return [
+            HandlerSpec(RequestType.LOOKUP, module.lookup, ThreadPoolType.NORMAL),
+            HandlerSpec(
+                RequestType.QUERY_PREFETCH_STATUS,
+                module.query_prefetch_status,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.WAIT_PREFETCH_STATUS,
+                module.wait_prefetch_status,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.QUERY_PREFETCH_LOOKUP_HITS,
+                module.query_prefetch_lookup_hits,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.FREE_LOOKUP_LOCKS,
+                module.free_lookup_locks,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.END_SESSION,
+                module.end_session,
+                ThreadPoolType.NORMAL,
+            ),
+        ]
+    if isinstance(module, P2PController):
+        return [
+            HandlerSpec(
+                RequestType.P2P_LOOKUP_AND_LOCK,
+                module.p2p_lookup_and_lock,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.P2P_QUERY_LOOKUP_RESULTS,
+                module.p2p_query_lookup_results,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.P2P_UNLOCK_OBJECTS,
+                module.p2p_unlock_objects,
+                ThreadPoolType.NORMAL,
+            ),
+        ]
+    if isinstance(module, ManagementModule):
+        return [
+            HandlerSpec(RequestType.CLEAR, module.clear, ThreadPoolType.NORMAL),
+            HandlerSpec(
+                RequestType.GET_CHUNK_SIZE,
+                module.get_chunk_size,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.GET_EXPERIMENTAL,
+                module.get_experimental,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(RequestType.PING, module.ping, ThreadPoolType.NORMAL),
+            HandlerSpec(RequestType.NOOP, module.debug, ThreadPoolType.SYNC),
+            HandlerSpec(
+                RequestType.REPORT_BLOCK_ALLOCATION,
+                module.report_block_allocations,
+                ThreadPoolType.NORMAL,
+            ),
+        ]
+    if isinstance(module, LMCacheDrivenTransferModule):
+        return [
+            HandlerSpec(
+                RequestType.REGISTER_KV_CACHE,
+                module.register_kv_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.UNREGISTER_KV_CACHE,
+                module.unregister_kv_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(RequestType.STORE, module.store, ThreadPoolType.AFFINITY),
+            HandlerSpec(
+                RequestType.RETRIEVE,
+                module.retrieve,
+                ThreadPoolType.AFFINITY,
+            ),
+        ]
+    if isinstance(module, EngineDrivenTransferModule):
+        return [
+            HandlerSpec(
+                RequestType.REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+                module.register_kv_cache_engine_driven_context,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+                module.unregister_kv_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.PREPARE_STORE,
+                module.prepare_store,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.COMMIT_STORE,
+                module.commit_store,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.PREPARE_RETRIEVE,
+                module.prepare_retrieve,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.COMMIT_RETRIEVE,
+                module.commit_retrieve,
+                ThreadPoolType.AFFINITY,
+            ),
+        ]
+    if isinstance(module, QStoreModule):
+        return [
+            HandlerSpec(
+                RequestType.REGISTER_Q_CACHE,
+                module.register_q_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.UNREGISTER_Q_CACHE,
+                module.unregister_q_cache,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(RequestType.STORE_Q, module.store_q, ThreadPoolType.AFFINITY),
+        ]
+
+    # Blend is optional and expensive to import, so resolve its adapter only
+    # after all always-loaded module types have been ruled out.
+    # First Party
+    from lmcache.v1.multiprocess.modules.blend import BlendModule
+
+    if isinstance(module, BlendModule):
+        return [
+            # STORE intentionally shadows LMCacheDrivenTransferModule.store;
+            # module order keeps the Blend handler last.
+            HandlerSpec(RequestType.STORE, module.store, ThreadPoolType.AFFINITY),
+            HandlerSpec(
+                RequestType.CB_REGISTER_ROPE,
+                module.cb_register_rope,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.CB_UNREGISTER_ROPE,
+                module.cb_unregister_rope,
+                ThreadPoolType.SYNC,
+            ),
+            HandlerSpec(
+                RequestType.CB_UNIFIED_LOOKUP,
+                module.cb_unified_lookup,
+                ThreadPoolType.NORMAL,
+            ),
+            HandlerSpec(
+                RequestType.CB_RETRIEVE_PRE_COMPUTED,
+                module.cb_retrieve_pre_computed,
+                ThreadPoolType.AFFINITY,
+            ),
+            HandlerSpec(
+                RequestType.CB_PROTOCOL_HANDSHAKE,
+                module.cb_protocol_handshake,
+                ThreadPoolType.SYNC,
+            ),
+        ]
+    raise TypeError(f"No ZMQ handler adapter for {type(module).__name__}")
+
+
+def build_zmq_request_server(
+    modules: list[EngineModule],
+    mp_config: MPServerConfig,
+) -> MessageQueueServer:
+    """Build a ZMQ request server for the supplied business modules.
+
+    Args:
+        modules: Ordered business modules composing the cache server.
+        mp_config: Multiprocess server configuration.
+
+    Returns:
+        Configured, but not yet started, ZMQ message queue server.
+    """
+    server = MessageQueueServer(
+        bind_url=f"tcp://{mp_config.host}:{mp_config.port}",
+        context=zmq.Context.instance(),
+    )
+    all_specs = [spec for module in modules for spec in get_zmq_handler_specs(module)]
+    for spec in all_specs:
+        add_handler_helper(server, spec.request_type, spec.handler)
+
+    affinity_types = [
+        spec.request_type for spec in all_specs if spec.pool is ThreadPoolType.AFFINITY
+    ]
+    normal_types = [
+        spec.request_type for spec in all_specs if spec.pool is ThreadPoolType.NORMAL
+    ]
+    if affinity_types:
+        server.add_affinity_thread_pool(
+            affinity_types, max_workers=mp_config.max_gpu_workers
+        )
+    if normal_types:
+        server.add_normal_thread_pool(
+            normal_types, max_workers=mp_config.max_cpu_workers
+        )
+    return server
+
+
+__all__ = [
+    "HandlerSpec",
+    "ThreadPoolType",
+    "add_handler_helper",
+    "build_zmq_request_server",
+    "get_zmq_handler_specs",
+]

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
@@ -63,7 +63,10 @@ from lmcache.v1.multiprocess.config import (  # noqa: E402
 )
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController  # noqa: E402
 from lmcache.v1.multiprocess.mq import MessageQueueServer  # noqa: E402
-from lmcache.v1.multiprocess.protocol import get_payload_classes  # noqa: E402
+from lmcache.v1.multiprocess.transport.zmq_impl.server import (  # noqa: E402
+    add_handler_helper,
+    get_zmq_handler_specs,
+)
 
 _PAGE = 4096
 _NUM_KEYS = 3
@@ -154,13 +157,9 @@ def test_p2p_adapter_end_to_end():
         )
         peer_mq_url = f"tcp://{_next_url()}"
         mq_server = MessageQueueServer(peer_mq_url, zmq.Context.instance())
-        specs = controller.get_handlers()
+        specs = get_zmq_handler_specs(controller)
         for spec in specs:
-            mq_server.add_blocking_handler(
-                spec.request_type,
-                get_payload_classes(spec.request_type),
-                spec.handler,
-            )
+            add_handler_helper(mq_server, spec.request_type, spec.handler)
         mq_server.add_normal_thread_pool([s.request_type for s in specs], max_workers=4)
         mq_server.start()
 

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
@@ -30,8 +30,6 @@ if not torch_dev.is_available():
     )
 
 nixl = pytest.importorskip("nixl")
-# Third Party
-import zmq  # noqa: E402
 
 # First Party
 from lmcache.v1.distributed.api import (  # noqa: E402
@@ -59,13 +57,12 @@ from lmcache.v1.distributed.transfer_channel.impl.nixl_impl import (  # noqa: E4
 )
 from lmcache.v1.multiprocess.config import (  # noqa: E402
     CoordinatorConfig,
+    MPServerConfig,
     P2PConfig,
 )
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController  # noqa: E402
-from lmcache.v1.multiprocess.mq import MessageQueueServer  # noqa: E402
-from lmcache.v1.multiprocess.transport.zmq_impl.server import (  # noqa: E402
-    add_handler_helper,
-    get_zmq_handler_specs,
+from lmcache.v1.multiprocess.transport.server_factory import (  # noqa: E402
+    create_request_server,
 )
 
 _PAGE = 4096
@@ -155,12 +152,17 @@ def test_p2p_adapter_end_to_end():
             CoordinatorConfig(),
             instance_id="peer",
         )
-        peer_mq_url = f"tcp://{_next_url()}"
-        mq_server = MessageQueueServer(peer_mq_url, zmq.Context.instance())
-        specs = get_zmq_handler_specs(controller)
-        for spec in specs:
-            add_handler_helper(mq_server, spec.request_type, spec.handler)
-        mq_server.add_normal_thread_pool([s.request_type for s in specs], max_workers=4)
+        peer_mq_host_port = _next_url()
+        peer_mq_url = f"tcp://{peer_mq_host_port}"
+        peer_mq_host, peer_mq_port = peer_mq_host_port.rsplit(":", maxsplit=1)
+        mq_server = create_request_server(
+            [controller],
+            MPServerConfig(
+                host=peer_mq_host,
+                port=int(peer_mq_port),
+                max_cpu_workers=4,
+            ),
+        )
         mq_server.start()
 
         # --- Local side: global NIXL context over the destination buffer ---

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -2,6 +2,7 @@
 # Standard
 from multiprocessing.synchronize import Event as EventClass
 from typing import Any, Callable
+from unittest.mock import MagicMock
 import multiprocessing as mp
 import sys
 import threading
@@ -21,6 +22,7 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
 from lmcache.v1.multiprocess.mq import (
     BlockingRequestHandler,
     MessageQueueClient,
@@ -31,7 +33,10 @@ from lmcache.v1.multiprocess.protocol import (
     get_handler_type,
     get_payload_classes,
 )
-from lmcache.v1.multiprocess.server import add_handler_helper
+from lmcache.v1.multiprocess.transport.zmq_impl.server import (
+    add_handler_helper,
+    get_zmq_handler_specs,
+)
 
 # Test helpers
 from tests.v1.multiprocess import test_mq_handler_helpers
@@ -56,6 +61,19 @@ def create_cache_key(index: int, model: str = "testmodel") -> IPCCacheServerKey:
         end=chunk_size,
         request_id=f"test_request_{index}",
     )
+
+
+def test_zmq_handler_specs_cover_all_p2p_request_types() -> None:
+    """The ZMQ adapter wires exactly the three P2P request types."""
+    controller = MagicMock(spec=P2PController)
+
+    request_types = {spec.request_type for spec in get_zmq_handler_specs(controller)}
+
+    assert request_types == {
+        RequestType.P2P_LOOKUP_AND_LOCK,
+        RequestType.P2P_QUERY_LOOKUP_RESULTS,
+        RequestType.P2P_UNLOCK_OBJECTS,
+    }
 
 
 def _server_process(

--- a/tests/v1/multiprocess/test_p2p_controller.py
+++ b/tests/v1/multiprocess/test_p2p_controller.py
@@ -318,17 +318,6 @@ def test_report_status_counts_active_jobs():
     assert status["p2p_state"] == _P2PState.UNREGISTERED.value
 
 
-def test_get_handlers_covers_all_p2p_request_types():
-    """get_handlers wires exactly the three P2P request types."""
-    controller, _ = _make_controller()
-    request_types = {spec.request_type for spec in controller.get_handlers()}
-    assert request_types == {
-        RequestType.P2P_LOOKUP_AND_LOCK,
-        RequestType.P2P_QUERY_LOOKUP_RESULTS,
-        RequestType.P2P_UNLOCK_OBJECTS,
-    }
-
-
 # ============================================================================
 # Orchestration: adapter reconcile
 # ============================================================================


### PR DESCRIPTION
## Summary

- move ZMQ request handler specifications and thread-pool routing out of business modules into the ZMQ transport implementation
- keep `EngineModule` focused on transport-neutral business operations
- route request-server construction through a transport-neutral factory that still builds only the existing ZMQ server
- preserve the existing ZMQ request mapping and add focused adapter coverage

## Scope

This PR is split from #4953 and intentionally contains no gRPC implementation, protobuf definitions, gRPC dependencies, transport configuration, or CI matrix changes. A follow-up gRPC PR can be based on this refactor after it merges.

## Validation

- `701 passed, 35 skipped` from `pytest -q tests/v1/multiprocess`
- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`