### PR TITLE
[Bugfix] fs L2 adapter: load chunk files concurrently (load_concurrency)

### DIFF
--- a/docs/source/mp/l2_storage/fs.rst
+++ b/docs/source/mp/l2_storage/fs.rst
@@ -17,6 +17,10 @@ object is stored as a raw ``.data`` file whose name encodes the full
   bytes first (positive integer, optional).
 - ``use_odirect``: ``true`` or ``false`` (default ``false``) -- bypass the
   page cache via ``O_DIRECT``.
+- ``load_concurrency``: Maximum number of chunk files read in parallel
+  (positive integer, default ``16``). Size it to your storage's effective
+  read concurrency; the default already saturates a typical network-backed
+  volume, where each file costs one round trip.
 
 **Configuration examples:**
 
@@ -30,3 +34,6 @@ object is stored as a raw ``.data`` file whose name encodes the full
 
     # With O_DIRECT for bypassing page cache
     --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2", "use_odirect": true}'
+
+    # Bound parallel reads to the storage's effective concurrency (default 16)
+    --l2-adapter '{"type": "fs", "base_path": "/mnt/kv", "load_concurrency": 16}'

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -172,6 +172,9 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
     - base_path: directory for storing KV cache files.
     - relative_tmp_dir: optional relative sub-dir for
       temp files (same as fs_connector_relative_tmp_dir).
+    - read_ahead_size: optional read-ahead trigger size in bytes.
+    - use_odirect: bypass the page cache via O_DIRECT.
+    - load_concurrency: max chunk files read in parallel per adapter.
     """
 
     def __init__(
@@ -180,6 +183,7 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         relative_tmp_dir: Optional[str] = None,
         read_ahead_size: Optional[int] = None,
         use_odirect: bool = False,
+        load_concurrency: int = 16,
     ):
         """Initialize FSL2AdapterConfig.
 
@@ -194,11 +198,19 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
                 using O_DIRECT for both reads and writes.
                 Requires buffer sizes aligned to the
                 filesystem block size.
+            load_concurrency: Maximum number of chunk files
+                read in parallel, shared by all load tasks
+                of the adapter. Sequential loads cost one
+                round trip per file, which dominates on
+                network-backed volumes. On the O_DIRECT path
+                reads run on the default executor, whose
+                size also bounds the effective parallelism.
         """
         self.base_path = base_path
         self.relative_tmp_dir = relative_tmp_dir
         self.read_ahead_size = read_ahead_size
         self.use_odirect = use_odirect
+        self.load_concurrency = load_concurrency
 
     @classmethod
     def from_dict(cls, d: dict) -> "FSL2AdapterConfig":
@@ -216,11 +228,19 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         use_odirect = d.get("use_odirect", False)
         if not isinstance(use_odirect, bool):
             raise ValueError("use_odirect must be a boolean")
+        load_concurrency = d.get("load_concurrency", 16)
+        if (
+            isinstance(load_concurrency, bool)
+            or not isinstance(load_concurrency, int)
+            or load_concurrency <= 0
+        ):
+            raise ValueError("load_concurrency must be a positive integer")
         return cls(
             base_path=base_path,
             relative_tmp_dir=relative_tmp_dir,
             read_ahead_size=read_ahead_size,
             use_odirect=use_odirect,
+            load_concurrency=load_concurrency,
         )
 
     @classmethod
@@ -236,7 +256,9 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
             "readahead by reading this many bytes first "
             "(optional)\n"
             "- use_odirect (bool): bypass page cache "
-            "via O_DIRECT (optional, default false)"
+            "via O_DIRECT (optional, default false)\n"
+            "- load_concurrency (int): max chunk files "
+            "read in parallel (optional, default 16)"
         )
 
 
@@ -280,6 +302,10 @@ class FSL2Adapter(L2AdapterInterface):
         # I/O tuning options aligned with FSConnector
         self._read_ahead_size = config.read_ahead_size
         self._use_odirect = config.use_odirect
+        self._load_concurrency = config.load_concurrency
+        # Adapter-wide: load tasks are fire-and-forget, so a per-task gate
+        # would not bound anything.
+        self._load_sem = asyncio.Semaphore(self._load_concurrency)
         self._os_disk_bs = 0
         if self._use_odirect:
             stat = os.statvfs(self._base_path)
@@ -304,11 +330,12 @@ class FSL2Adapter(L2AdapterInterface):
         logger.info(
             "Initialized FSL2Adapter with base_path=%s, "
             "relative_tmp_dir=%s, "
-            "read_ahead_size=%s, use_odirect=%s",
+            "read_ahead_size=%s, use_odirect=%s, load_concurrency=%d",
             self._base_path,
             self._relative_tmp_dir,
             self._read_ahead_size,
             self._use_odirect,
+            self._load_concurrency,
         )
 
     # ------------------------------------------------------------------
@@ -415,6 +442,7 @@ class FSL2Adapter(L2AdapterInterface):
             "type": "FSL2Adapter",
             "base_path": str(self._base_path),
             "use_odirect": self._use_odirect,
+            "load_concurrency": self._load_concurrency,
             "event_loop_alive": self._loop_thread.is_alive(),
         }
 
@@ -701,87 +729,91 @@ class FSL2Adapter(L2AdapterInterface):
         task_id: L2TaskId,
     ) -> None:
         bitmap = Bitmap(len(keys))
-        for i, key in enumerate(keys):
-            file_path = self._key_to_path(key)
-            try:
-                dst_buf = objects[i].byte_array
-                expected = len(dst_buf)
-                num_read: Optional[int] = None
 
-                # O_DIRECT path (sync, via executor)
-                if self._use_odirect:
-                    num_read = await self._loop.run_in_executor(
-                        None,
-                        self._read_with_odirect,
-                        file_path,
-                        dst_buf,
-                    )
-                    if num_read != expected:
-                        logger.warning(
-                            "Incomplete O_DIRECT read for %s: expected %d, got %d",
-                            file_path.name,
-                            expected,
-                            num_read or 0,
+        async def _load_one(i: int, key: ObjectKey) -> None:
+            file_path = self._key_to_path(key)
+            async with self._load_sem:
+                try:
+                    dst_buf = objects[i].byte_array
+                    expected = len(dst_buf)
+                    num_read: Optional[int] = None
+
+                    # O_DIRECT path (sync, via executor)
+                    if self._use_odirect:
+                        num_read = await self._loop.run_in_executor(
+                            None,
+                            self._read_with_odirect,
+                            file_path,
+                            dst_buf,
                         )
-                    else:
+                        if num_read != expected:
+                            logger.warning(
+                                "Incomplete O_DIRECT read for %s: expected %d, got %d",
+                                file_path.name,
+                                expected,
+                                num_read or 0,
+                            )
+                        else:
+                            bitmap.set(i)
+                            logger.debug(
+                                "FSL2Adapter loaded key %s (%d bytes, O_DIRECT)",
+                                file_path.name,
+                                num_read,
+                            )
+                        return
+
+                    # Standard async path with optional read-ahead
+                    async with aiofiles.open(file_path, "rb") as f:
+                        if self._read_ahead_size is None:
+                            num_read = await _async_readinto_full(f, dst_buf)
+                        else:
+                            if not isinstance(dst_buf, memoryview):
+                                dst_buf = memoryview(dst_buf)
+                            ra = self._read_ahead_size
+                            n_head = await _async_readinto_full(f, dst_buf[:ra])
+                            if n_head == ra:
+                                n_tail = await _async_readinto_full(f, dst_buf[ra:])
+                                num_read = n_head + n_tail
+                            else:
+                                num_read = n_head
+
+                        if num_read != expected:
+                            logger.warning(
+                                "Incomplete read for %s: expected %d, got %d",
+                                file_path.name,
+                                expected,
+                                num_read,
+                            )
+                            return
+
                         bitmap.set(i)
                         logger.debug(
-                            "FSL2Adapter loaded key %s (%d bytes, O_DIRECT)",
+                            "FSL2Adapter loaded key %s (%d bytes)",
                             file_path.name,
                             num_read,
                         )
-                    continue
-
-                # Standard async path with optional
-                # read-ahead
-                expected = len(dst_buf)
-                async with aiofiles.open(file_path, "rb") as f:
-                    if self._read_ahead_size is None:
-                        num_read = await _async_readinto_full(f, dst_buf)
-                    else:
-                        if not isinstance(dst_buf, memoryview):
-                            dst_buf = memoryview(dst_buf)
-                        # Trigger readahead with a
-                        # small initial read
-                        ra = self._read_ahead_size
-                        n_head = await _async_readinto_full(f, dst_buf[:ra])
-                        if n_head == ra:
-                            n_tail = await _async_readinto_full(f, dst_buf[ra:])
-                            num_read = n_head + n_tail
-                        else:
-                            num_read = n_head
-
-                    if num_read != expected:
-                        logger.warning(
-                            "Incomplete read for %s: expected %d, got %d",
-                            file_path.name,
-                            expected,
-                            num_read,
-                        )
-                        continue
-
-                    bitmap.set(i)
-                    logger.debug(
-                        "FSL2Adapter loaded key %s (%d bytes)",
-                        file_path.name,
-                        num_read,
+                except FileNotFoundError:
+                    return
+                except Exception:
+                    logger.exception(
+                        "FSL2Adapter failed to load %s",
+                        file_path,
                     )
-            except FileNotFoundError:
-                continue
-            except Exception:
-                logger.exception(
-                    "FSL2Adapter failed to load %s",
-                    file_path,
-                )
-                continue
+                    return
 
-        loaded_keys = [keys[i] for i in bitmap.get_indices_list()]
-        if loaded_keys:
-            self._notify_keys_accessed(loaded_keys)
+        try:
+            await asyncio.gather(
+                *(_load_one(i, key) for i, key in enumerate(keys)),
+                return_exceptions=True,
+            )
+        finally:
+            loaded_keys = [keys[i] for i in bitmap.get_indices_list()]
+            if loaded_keys:
+                self._notify_keys_accessed(loaded_keys)
 
-        with self._lock:
-            self._completed_load_tasks[task_id] = bitmap
-        self._load_efd.notify()
+            with self._lock:
+                self._completed_load_tasks[task_id] = bitmap
+            self._load_efd.notify()
 
     # ---- delete ---------------------------------------------------------
 

--- a/tests/v1/distributed/test_fs_l2_adapter_load_concurrency.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_load_concurrency.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for FSL2Adapter concurrent loads (``load_concurrency``).
+
+Loads used to be strictly sequential: one awaited file at a time. On a
+network-backed volume that is one round trip per chunk file, slower than
+recomputing the KV cache. These tests pin the concurrent path: every key
+lands with intact data, misses stay per-key (buffers untouched, accessed
+notification in key order), the read-ahead branch still works under the
+gate, the adapter-wide bound is reached and not exceeded, and the config
+knob is validated and documented.
+"""
+
+# Standard
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+import asyncio
+import time
+
+# Third Party
+import aiofiles
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+
+class _RecordingListener:
+    """Records ``on_l2_keys_accessed`` (duck-typed L2AdapterListener)."""
+
+    def __init__(self) -> None:
+        self.accessed: list[ObjectKey] = []
+
+    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+        pass
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        self.accessed.extend(keys)
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
+        pass
+
+
+class _Buf:
+    """Minimal MemoryObj stand-in: just the ``byte_array`` the FS
+    adapter's store/load paths read and write."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = bytearray(data)
+
+    @property
+    def byte_array(self) -> memoryview:
+        return memoryview(self._data)
+
+
+AdapterFixture = tuple[FSL2Adapter, _RecordingListener]
+
+
+def _indexed_key(i: int) -> ObjectKey:
+    """A distinct key per index (the chunk hash encodes ``i``)."""
+    return ObjectKey(
+        chunk_hash=i.to_bytes(4, "big"),
+        model_name="llama",
+        kv_rank=0,
+        cache_salt="",
+    )
+
+
+def _payloads(n: int, base: int = 1024) -> list[bytes]:
+    """Distinct content AND length per index, so a cross-wired buffer is
+    caught by either."""
+    return [bytes([i % 251]) * (base + i) for i in range(n)]
+
+
+def make_adapter(tmp_path: Path, **kwargs: Any) -> AdapterFixture:
+    adp = FSL2Adapter(FSL2AdapterConfig(base_path=str(tmp_path), **kwargs))
+    listener = _RecordingListener()
+    adp.register_listener(listener)  # type: ignore[arg-type]
+    return adp, listener
+
+
+@pytest.fixture
+def adapter(tmp_path: Path) -> Iterator[AdapterFixture]:
+    adp, listener = make_adapter(tmp_path, load_concurrency=4)
+    try:
+        yield adp, listener
+    finally:
+        adp.close()
+
+
+def _bufs(payloads: list[bytes]) -> list[MemoryObj]:
+    """Wrap raw payloads as MemoryObj-shaped buffers (see ``_Buf``)."""
+    return cast("list[MemoryObj]", [_Buf(p) for p in payloads])
+
+
+def _store_and_wait(
+    adp: FSL2Adapter, keys: list[ObjectKey], payloads: list[bytes]
+) -> None:
+    """Submit a store and poll until its result is available."""
+    task_id = adp.submit_store_task(keys, _bufs(payloads))
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        completed = adp.pop_completed_store_tasks()
+        if task_id in completed:
+            # L2StoreResult is an int: >= 0 success, -1 failure.
+            assert int(completed[task_id]) >= 0
+            return
+        time.sleep(0.01)
+    pytest.fail("store task did not complete within 5s")
+
+
+def _load_and_wait(
+    adp: FSL2Adapter, keys: list[ObjectKey], bufs: list[MemoryObj]
+) -> list[bool]:
+    """Submit a load and poll until its hit bitmap is available."""
+    task_id = adp.submit_load_task(keys, bufs)
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        bitmap = adp.query_load_result(task_id)
+        if bitmap is not None:
+            return [bitmap.test(i) for i in range(len(keys))]
+        time.sleep(0.01)
+    raise AssertionError("load task did not complete within 5s")
+
+
+class TestConcurrentLoad:
+    """``submit_load_task`` loads keys concurrently under ``load_concurrency``
+    with unchanged per-key semantics."""
+
+    def test_every_key_lands_with_intact_data(self, adapter: AdapterFixture) -> None:
+        adp, _ = adapter
+        n = 40
+        keys = [_indexed_key(i) for i in range(n)]
+        payloads = _payloads(n)
+        _store_and_wait(adp, keys, payloads)
+
+        bufs = _bufs([b"\x00" * len(p) for p in payloads])
+        hits = _load_and_wait(adp, keys, bufs)
+
+        assert hits == [True] * n
+        for buf, payload in zip(bufs, payloads, strict=True):
+            assert bytes(buf.byte_array) == payload
+
+    def test_missing_keys_are_per_key_misses_and_untouched(
+        self, adapter: AdapterFixture
+    ) -> None:
+        adp, listener = adapter
+        keys = [_indexed_key(i) for i in range(6)]
+        payloads = _payloads(6, base=64)
+        _store_and_wait(adp, keys[::2], payloads[::2])
+
+        bufs = _bufs([b"\x00" * len(p) for p in payloads])
+        hits = _load_and_wait(adp, keys, bufs)
+
+        assert hits == [True, False, True, False, True, False]
+        for i, (buf, payload) in enumerate(zip(bufs, payloads, strict=True)):
+            expected = payload if i % 2 == 0 else b"\x00" * len(payload)
+            assert bytes(buf.byte_array) == expected
+        assert listener.accessed == [keys[0], keys[2], keys[4]]
+
+    def test_read_ahead_path_survives_concurrency(self, tmp_path: Path) -> None:
+        adp, _ = make_adapter(tmp_path, load_concurrency=3, read_ahead_size=128)
+        try:
+            n = 8
+            keys = [_indexed_key(i) for i in range(n)]
+            payloads = _payloads(n, base=512)
+            _store_and_wait(adp, keys, payloads)
+
+            bufs = _bufs([b"\x00" * len(p) for p in payloads])
+            hits = _load_and_wait(adp, keys, bufs)
+
+            assert hits == [True] * n
+            for buf, payload in zip(bufs, payloads, strict=True):
+                assert bytes(buf.byte_array) == payload
+        finally:
+            adp.close()
+
+    def test_bound_is_reached_and_not_exceeded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The adapter-wide gate admits exactly ``load_concurrency`` files at
+        once. Sequential code would peak at 1, so the equality also proves
+        the loads really run concurrently."""
+        bound = 3
+        adp, _ = make_adapter(tmp_path, load_concurrency=bound)
+        try:
+            keys = [_indexed_key(i) for i in range(12)]
+            payloads = _payloads(12, base=256)
+            _store_and_wait(adp, keys, payloads)
+
+            in_flight = {"now": 0, "peak": 0}
+            real_open = aiofiles.open
+
+            class _Counted:
+                def __init__(self, cm: Any) -> None:
+                    self._cm = cm
+
+                async def __aenter__(self) -> Any:
+                    in_flight["now"] += 1
+                    in_flight["peak"] = max(in_flight["peak"], in_flight["now"])
+                    await asyncio.sleep(0.01)
+                    return await self._cm.__aenter__()
+
+                async def __aexit__(self, *args: Any) -> Any:
+                    in_flight["now"] -= 1
+                    return await self._cm.__aexit__(*args)
+
+            monkeypatch.setattr(
+                aiofiles, "open", lambda *a, **k: _Counted(real_open(*a, **k))
+            )
+
+            hits = _load_and_wait(
+                adp, keys, _bufs([b"\x00" * len(p) for p in payloads])
+            )
+
+            assert hits == [True] * 12
+            assert in_flight["peak"] == bound
+        finally:
+            adp.close()
+
+
+class TestLoadConcurrencyConfig:
+    """``load_concurrency`` is parsed, validated, defaulted and documented."""
+
+    def test_parses_from_dict(self) -> None:
+        cfg = FSL2AdapterConfig.from_dict(
+            {"base_path": "/tmp/x", "load_concurrency": 8}
+        )
+        assert cfg.load_concurrency == 8
+
+    def test_default_reaches_the_adapter(self, tmp_path: Path) -> None:
+        adp = FSL2Adapter(FSL2AdapterConfig.from_dict({"base_path": str(tmp_path)}))
+        try:
+            assert adp.report_status()["load_concurrency"] == 16
+        finally:
+            adp.close()
+
+    @pytest.mark.parametrize("bad", [0, -4, "16", 2.5, True])
+    def test_rejects_non_positive_non_int(self, bad: object) -> None:
+        with pytest.raises(ValueError, match="load_concurrency"):
+            FSL2AdapterConfig.from_dict(
+                {"base_path": "/tmp/x", "load_concurrency": bad}
+            )
+
+    def test_help_documents_the_field(self) -> None:
+        assert "load_concurrency" in FSL2AdapterConfig.help()


### PR DESCRIPTION
## Problem

`FSL2Adapter._execute_load` reads chunk files strictly one at a time (a `for` loop with one awaited read per key). On network-backed storage that is one round trip per chunk file, and the disk tier ends up **slower than recomputing the KV cache**.

Measured on a Modal Volume (vLLM 0.28.0, Qwen3.8-27B hybrid GDN, MP mode, 1600-token chunks, ~50 MB per chunk file):

| prompt | files | prefetch before (sequential) | prefetch after (concurrent) |
|---|---|---|---|
| 12k tokens | 32 | 22 s | **0.66 s** |
| 40k tokens | 108 (~5.6 GB) | 94 s | **0.13 s** |

Recomputing the 40k prompt takes ~6.6 s, so before this change a disk hit cost 14x more than a miss. A single reader on that volume measures ~60 MB/s; 16 parallel readers measure ~370 MB/s cold and ~1.4 GB/s warm.

## Change

- New `FSL2AdapterConfig` field `load_concurrency` (default 16; validated in `from_dict`, `bool` rejected; documented in the class/`__init__` docstrings, `help()`, the init log line, `report_status()`, and `docs/source/mp/l2_storage/fs.rst`).
- `_execute_load` gathers one coroutine per key under **one adapter-wide** `asyncio.Semaphore` (created in `__init__`, bound lazily to the adapter loop). Adapter-wide rather than per task because `submit_load_task` is fire-and-forget, so a per-task semaphore would multiply the bound by the number of tasks in flight.
- `gather(..., return_exceptions=True)` and the completion record + `_load_efd` notification in a `finally`: a failing key can neither detach its siblings nor leave the task without a result (previously the caller could poll forever).
- Per-key semantics unchanged: each coroutine sets only its own bitmap index; `FileNotFoundError` stays a per-key miss; incomplete reads warn and are not marked; the O_DIRECT path still runs in the executor; `_notify_keys_accessed` still reports in key order.

Stores are left sequential on purpose: loads sit on the TTFT critical path, stores do not. Happy to follow up on stores if wanted.

## Tests

`tests/v1/distributed/test_fs_l2_adapter_load_concurrency.py`: data integrity across 40 concurrent loads (distinct content and length per key), per-key misses with untouched buffers, the read-ahead branch under the gate, key-ordered `on_l2_keys_accessed`, the bound being reached exactly (sequential code peaks at 1, so `peak == bound` pins the fix), and config parsing/validation/default/`help()`. Existing `test_fs_l2_adapter_delete.py` and `test_fs_l2_adapter_keys.py` pass unchanged. Note `tests/v1/distributed/` is excluded from the command in CONTRIBUTING.md, so these were run explicitly; the CI workflow collects them. `pre-commit run` is clean.
