### PR TITLE
[Bugfix] Compatible with CUDA 13.4.1

### DIFF
--- a/lmcache/v1/platform/cuda/ipc_wrapper.py
+++ b/lmcache/v1/platform/cuda/ipc_wrapper.py
@@ -39,7 +39,11 @@ import torch
 from lmcache import torch_device_type
 from lmcache.logging import init_logger
 from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
-from lmcache.v1.platform.cuda.utils import _cuda
+from lmcache.v1.platform.cuda.utils import (
+    _cuda,
+    cuda_ipc_handle_from_bytes,
+    cuda_ipc_handle_to_bytes,
+)
 from lmcache.v1.platform.isolated_ipc import is_isolated_ipc
 
 logger = init_logger(__name__)
@@ -309,7 +313,7 @@ class RawCudaIPCWrapper(DeviceIPCWrapper):
 
         # Store only what's needed for reconstruction. The handle maps
         # the whole allocation; the offset locates the tensor within it.
-        self._ipc_handle_reserved = bytes(ipc_handle.reserved)
+        self._ipc_handle_reserved = cuda_ipc_handle_to_bytes(ipc_handle)
         self._alloc_offset = data_ptr - int(
             alloc_base
         )  # offset in bytes not the same as storage offset
@@ -350,8 +354,7 @@ class RawCudaIPCWrapper(DeviceIPCWrapper):
         with _MAPPINGS_LOCK:
             entry = _MAPPED_ALLOCATIONS.get(self._ipc_handle_reserved)
             if entry is None:
-                handle = _cuda.runtime.cudaIpcMemHandle_t()
-                handle.reserved = self._ipc_handle_reserved
+                handle = cuda_ipc_handle_from_bytes(self._ipc_handle_reserved)
                 with torch.cuda.device(device_index):
                     err, ptr = _cuda.runtime.cudaIpcOpenMemHandle(
                         handle, _cuda.runtime.cudaIpcMemLazyEnablePeerAccess

--- a/lmcache/v1/platform/cuda/timeline_semaphore_event_ipc.py
+++ b/lmcache/v1/platform/cuda/timeline_semaphore_event_ipc.py
@@ -56,6 +56,8 @@ from lmcache.v1.platform.cuda.utils import (
     _cuda,
     _raw_stream_handle,
     _resolve_device_index,
+    cuda_ipc_handle_from_bytes,
+    cuda_ipc_handle_to_bytes,
     cudaStream_t,
 )
 
@@ -430,8 +432,7 @@ class TimelineSemaphoreEventIPCBackend:
                 if cached is not None:
                     base_ptr = cached
                 else:
-                    ipc_handle = _cuda.runtime.cudaIpcMemHandle_t()
-                    ipc_handle.reserved = handle_bytes
+                    ipc_handle = cuda_ipc_handle_from_bytes(handle_bytes)
                     with torch.cuda.device(device_index):
                         open_result = _cuda.runtime.cudaIpcOpenMemHandle(
                             ipc_handle,
@@ -612,7 +613,7 @@ class TimelineSemaphoreEventIPCBackend:
             buffer = _TimelineSemaphoreBuffer(
                 device_index=device_index,
                 base_ptr=int(base),
-                handle_bytes=bytes(handle.reserved),
+                handle_bytes=cuda_ipc_handle_to_bytes(handle),
                 buffer_ops_stream=buffer_stream,
             )
             with _HANDLE_REGISTRY_LOCK:

--- a/lmcache/v1/platform/cuda/utils.py
+++ b/lmcache/v1/platform/cuda/utils.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from functools import lru_cache
 from types import ModuleType
 from typing import TypeAlias
+import ctypes
 
 # Third Party
 import torch
@@ -53,6 +54,66 @@ class _CudaBindings:
 
 #: Shared lazy accessor for modules of the cuda platform package.
 _cuda = _CudaBindings()
+
+
+def _cuda_ipc_handle_size() -> int:
+    """Return the byte size of a CUDA IPC memory handle."""
+    return int(getattr(_cuda.runtime, "CUDA_IPC_HANDLE_SIZE", 64))
+
+
+def cuda_ipc_handle_to_bytes(handle: object) -> bytes:
+    """Copy an opaque CUDA IPC memory handle into a byte string.
+
+    cuda-bindings 13.4 no longer exposes the underlying ``reserved`` field on
+    ``cudaIpcMemHandle_t``. ``getPtr`` is available on both the old structured
+    representation and the new opaque representation.
+
+    Args:
+        handle: A cuda-python ``cudaIpcMemHandle_t`` instance.
+
+    Returns:
+        The fixed-size serialized CUDA IPC memory handle.
+
+    Raises:
+        TypeError: If ``handle`` does not expose cuda-python's ``getPtr`` API.
+    """
+    get_ptr = getattr(handle, "getPtr", None)
+    if not callable(get_ptr):
+        raise TypeError("CUDA IPC memory handle does not expose getPtr()")
+    return ctypes.string_at(int(get_ptr()), _cuda_ipc_handle_size())
+
+
+def cuda_ipc_handle_from_bytes(handle_bytes: bytes) -> object:
+    """Reconstruct an opaque CUDA IPC memory handle from bytes.
+
+    The bytes are copied through cuda-python's stable ``getPtr`` interface so
+    this works with both structured and opaque ``cudaIpcMemHandle_t`` objects.
+
+    Args:
+        handle_bytes: Bytes previously returned by
+            :func:`cuda_ipc_handle_to_bytes`.
+
+    Returns:
+        A cuda-python ``cudaIpcMemHandle_t`` instance owning a copy of the
+        supplied bytes.
+
+    Raises:
+        ValueError: If ``handle_bytes`` has the wrong size.
+        TypeError: If the cuda-python handle does not expose ``getPtr``.
+    """
+    handle_size = _cuda_ipc_handle_size()
+    if len(handle_bytes) != handle_size:
+        raise ValueError(
+            "Invalid CUDA IPC memory handle size: "
+            f"expected {handle_size} bytes, got {len(handle_bytes)}"
+        )
+
+    handle = _cuda.runtime.cudaIpcMemHandle_t()
+    get_ptr = getattr(handle, "getPtr", None)
+    if not callable(get_ptr):
+        raise TypeError("CUDA IPC memory handle does not expose getPtr()")
+    ctypes.memmove(int(get_ptr()), handle_bytes, handle_size)
+    return handle
 
 
 def _CHECK_CUDA(result: tuple[object, ...], what: str) -> None:

--- a/tests/v1/platform/test_timeline_semaphore_event_ipc.py
+++ b/tests/v1/platform/test_timeline_semaphore_event_ipc.py
@@ -24,6 +24,7 @@ from lmcache.v1.platform.base.event_ipc import (
 from lmcache.v1.platform.cuda.timeline_semaphore_event_ipc import (
     TimelineSemaphoreEventIPCBackend,
 )
+from lmcache.v1.platform.cuda.utils import cuda_ipc_handle_to_bytes
 from lmcache.v1.platform.isolated_ipc import set_isolated_ipc
 
 pytestmark = [
@@ -301,7 +302,7 @@ def test_ipc_mem_handle_stable_and_unique_across_live_allocations() -> None:
         err, handle = runtime.cudaIpcGetMemHandle(ptr)
         if int(err) != 0:
             raise RuntimeError(f"cudaIpcGetMemHandle failed: {err}")
-        return bytes(handle.reserved)
+        return cuda_ipc_handle_to_bytes(handle)
 
     torch.cuda.init()
     nbytes = 32768


### PR DESCRIPTION
## Problem

K3 unit tests started failing with `cuda-bindings==13.4.1`:

```text
AttributeError: 'cuda.bindings.runtime.cudaIpcMemHandle_t' has no attribute 'reserved'
```

Starting with cuda-bindings 13.4, `cudaIpcMemHandle_t` is exposed as an opaque handle and no longer provides the `reserved` Python attribute.

LMCache previously serialized and reconstructed CUDA IPC handles by directly reading and writing this attribute.

## Origin

The direct `cudaIpcMemHandle_t.reserved` access in `RawCudaIPCWrapper` was introduced by PR #3829.

The same assumption was later used by the timeline-semaphore IPC backend introduced in PR #4551.

PR #4579 added the floating dependency:

```text
cuda-python>=13,<14
```

Therefore, CI began resolving `cuda-bindings==13.4.1` after its release, exposing the existing compatibility issue. 
