### PR TITLE
docs: match scrollbars with the active color theme

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,12 @@
+/* Match native browser controls, including scrollbars, to the site theme. */
+html {
+    color-scheme: light;
+}
+
+html.dark {
+    color-scheme: dark;
+}
+
 /* Force white background on all Mermaid diagrams and fix sizing */
 .mermaid {
     background-color: #ffffff !important;


### PR DESCRIPTION
**What this PR does / why we need it**:

Declare the document color scheme for both light and dark themes.

This allows native browser controls, including scrollbars, to match the theme selected on the documentation site. Without this declaration, scrollbars may remain light when the site is manually switched to dark mode, especially when the operating system uses a different theme.

The change relies on native browser styling instead of introducing custom scrollbar colors.

**Special notes for your reviewers**:

Validated locally with both light and dark themes:

- `html` uses `color-scheme: light` in light mode.
- `html.dark` uses `color-scheme: dark` in dark mode.
- The Sphinx HTML build completed successfully using `uv run --no-project --with-requirements requirements/docs.txt sphinx-build -b html docs/source docs/build/html`.
- Existing unrelated documentation warnings remain in the build output.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
