### PR TITLE
[Bugfix][vLLM] Reject request-local multimodal cache identities

### DIFF
--- a/docs/design/integration/vllm/multimodal_cache_keying.md
+++ b/docs/design/integration/vllm/multimodal_cache_keying.md
@@ -15,6 +15,21 @@ through interfaces that carry only token IDs (lookup RPC, MP connector
 metadata), so LMCache instead substitutes the placeholder token IDs with
 values derived from the multimodal identifier before hashing.
 
+## Identifier validity
+
+Substitution requires the input identifier to distinguish media in the first
+place. With `mm_processor_cache_gb=0` and prefix caching disabled, vLLM skips
+content hashing and overrides even user-supplied UUIDs with request-local
+identifiers. Frontend-local counters can repeat across restarts or replicas;
+the same ID for different media still produces identical LMCache keys, no
+matter how much entropy the substitution preserves.
+
+`validate_vllm_multimodal_cache_config` rejects this combination for multimodal
+models before connector initialization, in the in-process adapter and all
+LMCache-shipped MP variants. A positive processor-cache budget or enabled
+prefix caching preserves content hashing. Text-only model configs are allowed.
+This is an engine-level restriction, including text-only requests to a VLM.
+
 ## Contract
 
 `lmcache/integration/vllm/utils.py`:

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -8,6 +8,16 @@ server.  Arguments are grouped by the config module that defines them.
    :local:
    :depth: 2
 
+Multimodal cache identity
+-------------------------
+
+For multimodal models, the LMCache-shipped vLLM MP connectors reject startup
+when both ``--mm-processor-cache-gb 0`` and ``--no-enable-prefix-caching`` are
+set. vLLM then supplies request-local media IDs instead of content hashes;
+these IDs can repeat across frontend restarts or replicas sharing an MP server.
+Use a positive ``--mm-processor-cache-gb`` value, or enable vLLM prefix caching
+if supported by the model. See :doc:`../recipes/multimodal_models` for details.
+
 Per-request LMCache configuration
 ---------------------------------
 

--- a/docs/source/recipes/multimodal_models.rst
+++ b/docs/source/recipes/multimodal_models.rst
@@ -17,8 +17,23 @@ placeholder token ids for every image, so raw token ids cannot distinguish
 images. LMCache handles this automatically by overwriting each placeholder
 span with a per-position value sequence derived from the image's full content
 hash (``mm_hash``) before key hashing -- same text with different images gets
-distinct cache entries, and no configuration is required. This applies to
+distinct cache entries. This applies to
 both the in-process connector and MP mode.
+
+.. important::
+
+   For multimodal models, LMCache requires at least one of vLLM's prefix cache
+   or multimodal processor cache to be enabled. Disabling both replaces
+   content-based identifiers with request-local IDs that can repeat across
+   frontend restarts or replicas, causing a false hit for different media.
+   LMCache's in-process and MP connectors reject this configuration at startup.
+
+   If the model requires ``--no-enable-prefix-caching``, set
+   ``--mm-processor-cache-gb`` to a positive value, for example
+   ``--mm-processor-cache-gb 1``. Otherwise, keeping
+   ``--enable-prefix-caching`` also preserves content-based identifiers.
+   User-provided multimodal UUIDs do not work around this restriction: vLLM
+   overrides them when both caches are disabled. Text-only models are unaffected.
 
 Vision-encoder outputs are a separate, optional cache -- see
 :doc:`../non_kv_cache/encoder_cache` (in-process mode only; not yet available

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -56,6 +56,7 @@ from lmcache.integration.vllm.lmcache_mp_metadata import (
 )
 from lmcache.integration.vllm.utils import (
     mla_only,
+    validate_vllm_multimodal_cache_config,
     vllm_layout_hints,
 )
 from lmcache.utils import init_logger as lmcache_init_logger
@@ -472,6 +473,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig | None" = None,
     ):
+        validate_vllm_multimodal_cache_config(vllm_config)
+
         # Older supported vLLM releases allow connectors to omit this value,
         # while current vLLM's type declaration requires it.
         super().__init__(vllm_config, role, kv_cache_config)  # type: ignore[arg-type]

--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -13,6 +13,7 @@ from lmcache.integration.vllm.utils import (
     extract_mm_features,
     extract_request_configs_from_request,
     mla_enabled,
+    validate_vllm_multimodal_cache_config,
 )
 from lmcache.utils import (
     check_interprocess_event_support,
@@ -503,6 +504,8 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig | None" = None,
     ):
+        validate_vllm_multimodal_cache_config(vllm_config)
+
         super().__init__(vllm_config, role, kv_cache_config)
 
         # fast-fail if interprocess is not supported

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -12,6 +12,7 @@ from lmcache.integration.vllm.utils import (
     extract_mm_features,
     extract_request_configs_from_request,
     mla_only,
+    validate_vllm_multimodal_cache_config,
 )
 from lmcache.utils import (
     check_interprocess_event_support,
@@ -500,6 +501,8 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig | None" = None,
     ):
+        validate_vllm_multimodal_cache_config(vllm_config)
+
         super().__init__(vllm_config, role, kv_cache_config)
 
         # fast-fail if interprocess is not supported

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -40,6 +40,44 @@ def is_false(value: str) -> bool:
     return value.lower() in ("false", "0", "no", "n", "off")
 
 
+def validate_vllm_multimodal_cache_config(vllm_config: "VllmConfig") -> None:
+    """Require reusable multimodal identifiers before initializing a connector.
+
+    When both vLLM's prefix cache and multimodal processor cache are disabled,
+    vLLM replaces content hashes (even user-provided UUIDs) with request-local
+    identifiers. These can repeat across frontend restarts or replicas, so
+    hashing them cannot safely identify KV stored in LMCache.
+
+    Args:
+        vllm_config: The active vLLM configuration.
+
+    Returns:
+        None when the configuration is safe for multimodal cache keying.
+
+    Raises:
+        ValueError: If a multimodal model disables both vLLM caches.
+
+    Notes:
+        Text-only models and older model configs without multimodal settings
+        are unaffected. Validation runs before any connector services start.
+    """
+    model_config = getattr(vllm_config, "model_config", None)
+    mm_config = getattr(model_config, "multimodal_config", None)
+    if (
+        mm_config is not None
+        and getattr(mm_config, "mm_processor_cache_gb", None) == 0
+        and not vllm_config.cache_config.enable_prefix_caching
+    ):
+        raise ValueError(
+            "LMCache requires stable multimodal identifiers. Disabling both "
+            "vLLM prefix caching and the multimodal processor cache produces "
+            "request-local IDs that can repeat across restarts or replicas, "
+            "causing different media to reuse the same KV cache. Set "
+            "--mm-processor-cache-gb to a positive value, or enable "
+            "--enable-prefix-caching if the model supports it."
+        )
+
+
 def vllm_layout_hints(vllm_config: "VllmConfig | None" = None) -> "LayoutHints":
     """Build layout_hints dict by querying vLLM at runtime."""
     hints: dict[str, str] = {}

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -36,6 +36,7 @@ from lmcache.integration.vllm.utils import (
     extract_mm_features,
     extract_request_configs_from_sampling_params,
     lmcache_get_or_create_config,
+    validate_vllm_multimodal_cache_config,
 )
 from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
 from lmcache.logging import init_logger
@@ -450,6 +451,8 @@ class LMCacheConnectorV1Impl:
         role: KVConnectorRole,
         parent: KVConnectorBase_V1,
     ):
+        validate_vllm_multimodal_cache_config(vllm_config)
+
         # Banner from the scheduler role only, so tensor-parallel
         # deployments print it once rather than once per worker.
         if role == KVConnectorRole.SCHEDULER:

--- a/tests/v1/test_vllm_mm_cache_config.py
+++ b/tests/v1/test_vllm_mm_cache_config.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reject vLLM configs that cannot supply reusable multimodal identities."""
+
+# Standard
+from types import SimpleNamespace
+import importlib
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="The connectors require vLLM")
+
+# Third Party
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (  # noqa: E402
+    KVConnectorRole,
+)
+
+
+class _InitializationStarted(RuntimeError):
+    """Stop construction before any services or device resources are created."""
+
+
+@pytest.fixture(
+    params=[
+        "lmcache_mp_connector",
+        "lmcache_mp_connector_0180",
+        "lmcache_mp_connector_0201",
+        "vllm_v1_adapter",
+    ]
+)
+def implementation(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture(params=[KVConnectorRole.SCHEDULER, KVConnectorRole.WORKER])
+def role(request: pytest.FixtureRequest) -> KVConnectorRole:
+    return request.param
+
+
+def _make_config(
+    mm_cache_gb: float | None, prefix_caching: bool | None
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            multimodal_config=(
+                SimpleNamespace(mm_processor_cache_gb=mm_cache_gb)
+                if mm_cache_gb is not None
+                else None
+            )
+        ),
+        cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching),
+        device_config=SimpleNamespace(device="cpu"),
+        kv_transfer_config=SimpleNamespace(kv_role="kv_both"),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
+    )
+
+
+def _initialize_connector(
+    implementation: str,
+    config: SimpleNamespace,
+    role: KVConnectorRole,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module(f"lmcache.integration.vllm.{implementation}")
+
+    def stop_initialization(*args: object, **kwargs: object) -> None:
+        raise _InitializationStarted
+
+    if implementation == "vllm_v1_adapter":
+        monkeypatch.setattr(module, "print_banner_once", lambda *args: None)
+        monkeypatch.setattr(module, "lmcache_get_or_create_config", stop_initialization)
+        module.LMCacheConnectorV1Impl(config, role, parent=None)
+    else:
+        monkeypatch.setattr(module.KVConnectorBase_V1, "__init__", stop_initialization)
+        module.LMCacheMPConnector(config, role)
+
+
+@pytest.mark.parametrize("prefix_caching", [False, None])
+def test_rejects_request_scoped_mm_ids_before_initialization(
+    implementation: str,
+    role: KVConnectorRole,
+    prefix_caching: bool | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_config(mm_cache_gb=0, prefix_caching=prefix_caching)
+
+    with pytest.raises(ValueError, match="--mm-processor-cache-gb"):
+        _initialize_connector(implementation, config, role, monkeypatch)
+
+
+@pytest.mark.parametrize(
+    "mm_cache_gb,prefix_caching",
+    [(4.0, True), (4.0, False), (0.0, True), (None, False)],
+    ids=["defaults", "processor-cache-only", "prefix-cache-only", "text-model"],
+)
+def test_allows_configs_with_stable_mm_ids_or_text_models(
+    implementation: str,
+    role: KVConnectorRole,
+    mm_cache_gb: float | None,
+    prefix_caching: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_config(mm_cache_gb, prefix_caching)
+
+    with pytest.raises(_InitializationStarted):
+        _initialize_connector(implementation, config, role, monkeypatch)
+
+
+def test_allows_model_config_without_multimodal_config(
+    implementation: str,
+    role: KVConnectorRole,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_config(mm_cache_gb=None, prefix_caching=False)
+    config.model_config = SimpleNamespace()
+
+    with pytest.raises(_InitializationStarted):
+        _initialize_connector(implementation, config, role, monkeypatch)


### PR DESCRIPTION
**What this PR does / why we need it**:

This catches a separate false-hit case that remains after #4783: the input
multimodal identifier itself can repeat for different media.

When both vLLM prefix caching and the multimodal processor cache are disabled,
vLLM skips content hashing and overrides even user-supplied UUIDs with
request-local IDs. A fresh frontend can produce `renderer0-mm-1-image-0` again.
If the LMCache server survives the restart, or replicas share it, different
images with the same prompt can hit the same KV entry.

I reproduced this with the real vLLM `HfRenderer`, `Request`, LMCache MP tracker,
and MP token hasher. A red image and a blue image, each processed by a fresh
renderer, both get `renderer0-mm-1-image-0` and the same first 256-token chunk
hash. Distinct user UUIDs do not help. With a positive processor-cache budget,
the two images get different keys and repeating the same image still gives the
same key. This needs only preprocessing, not model-weight loading or inference.

The fix validates the configuration before connector initialization in all
four LMCache-owned vLLM implementations: main MP, the 0.18.0 and 0.20.1 MP
adapters, and the in-process adapter. The error asks for a positive
`--mm-processor-cache-gb` value, or `--enable-prefix-caching` where the model
supports it. No hash, RPC, or request-lifecycle changes are needed.

I also checked the UUID override in the
[vLLM 0.18.0 source](https://github.com/vllm-project/vllm/blob/v0.18.0/vllm/renderers/base.py#L573-L586)
and [0.20.1 source](https://github.com/vllm-project/vllm/blob/v0.20.1/vllm/renderers/base.py#L655-L668).
Both have the same condition, which is why the guard covers the two pinned
connectors as well. Those are source checks, not full inference tests on the
older engines.

**Validation**:

- On unpatched `dev` at `edfef840`: all 16 rejection cases fail; 40
  allowed-configuration cases pass. After the fix: all 56 configuration tests pass.
- 261 related tests pass on `dev` at `edfef840` plus this patch, across
  multimodal keying, connectors, DCP, layouts,
  preemption, and lazy offload.
- Real preprocessing reproduction: vLLM `4fc943b8676e`, `baidu/Unlimited-OCR`,
  279 prompt tokens including a 273-token image span. With both caches off,
  red and blue produce the same chunk hash
  `9838cf75e1b70d70ffefb527fbc32d6a832b60fff304b08b767ea2fdd7facb14`.
- Pre-commit passes for changed files; unchanged Rust hooks are skipped.
- Changed Sphinx pages render without new diagnostics. The full `-W` build
  reports the same 31 warnings/errors as a clean `dev` build; the warning
  logs match after normalizing checkout paths.

**Special notes for your reviewers**:

This is an engine-level check: a multimodal model with both caches disabled
will refuse startup even if it would only receive text requests. Text-only
models and the default multimodal configuration are unchanged. The check is
in LMCache-owned connectors; it does not patch vLLM's vendored implementations.

#5019 includes a narrower check for its R-SWA support. This patch covers the
other multimodal models and connector paths too; the R-SWA patch can reuse this
helper when the two are integrated. The pinned connectors are still in `dev`.
If #4961 lands first, their small hunks and test cases can be dropped.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

<details>
<summary>Preprocessing reproduction (no model weights)</summary>

With vLLM `4fc943b8676e` and LMCache installed from the checkout, save the
following as `reproduce_mm_renderer_identity.py` and run:

```bash
CUDA_VISIBLE_DEVICES=4 python reproduce_mm_renderer_identity.py --model baidu/Unlimited-OCR
```

Adjust the visible GPU index for your machine. vLLM uses it for platform
detection; this script only preprocesses images and derives keys, without
loading model weights or running inference. It also runs on unpatched `dev`,
where `guard_rejected` is `null` because the validator is absent.

```python
# SPDX-License-Identifier: Apache-2.0
"""Reproduce frontend-local media ID reuse without loading model weights.

Uses vLLM's public HfRenderer, actual Request objects, LMCache's MP tracker,
and the MP TokenHasher. Each renderer is new, as after a frontend restart.
Validated with vLLM 4fc943b8 and baidu/Unlimited-OCR on 2026-09-08.
"""

from __future__ import annotations

import argparse
import hashlib
import json
from typing import Any

from PIL import Image
from vllm.config import CacheConfig, ModelConfig, VllmConfig
from vllm.multimodal.inputs import MultiModalFeatureSpec
from vllm.renderers.hf import HfRenderer
from vllm.sampling_params import SamplingParams
from vllm.tokenizers.registry import cached_tokenizer_from_config
from vllm.v1.request import Request

from lmcache.integration.vllm import utils as lmcache_vllm_utils
from lmcache.integration.vllm.lmcache_mp_metadata import LMCacheMPRequestTracker
from lmcache.v1.multiprocess.token_hasher import TokenHasher


def render_image(
    config: VllmConfig, hasher: TokenHasher, color: str, use_uuid: bool
) -> dict[str, Any]:
    """Render one synthetic image and derive its real LMCache chunk keys."""
    renderer = HfRenderer(config, cached_tokenizer_from_config(config.model_config))
    image = Image.new("RGB", (256, 256), color=color)
    prompt = {
        "prompt": "<image>\nDescribe the image.",
        "multi_modal_data": {"image": image},
    }
    if use_uuid:
        prompt["multi_modal_uuids"] = {"image": f"test-image-{color}"}
    try:
        inputs = renderer.render_cmpl([prompt])[0]
    finally:
        renderer.shutdown()

    identifier = inputs["mm_hashes"]["image"][0]
    position = inputs["mm_placeholders"]["image"][0]
    request = Request(
        request_id=f"frontend-{color}",
        prompt_token_ids=inputs["prompt_token_ids"],
        sampling_params=SamplingParams(max_tokens=1),
        pooling_params=None,
        mm_features=[
            MultiModalFeatureSpec(
                data=None,
                modality="image",
                identifier=identifier,
                mm_position=position,
            )
        ],
    )
    tokens = LMCacheMPRequestTracker(request).get_token_ids()
    hashes = hasher.compute_chunk_hashes(tokens)
    assert hashes, "The fixture must cover at least one complete LMCache chunk"
    return {
        "color": color,
        "image_sha256": hashlib.sha256(image.tobytes()).hexdigest(),
        "supplied_uuid": f"test-image-{color}" if use_uuid else None,
        "identifier": identifier,
        "num_prompt_tokens": len(tokens),
        "image_span": [position.offset, position.length],
        "chunk_hashes": [hasher.hash_to_bytes(value).hex() for value in hashes],
    }


def main() -> None:
    """Compare unsafe configurations with content-hashed, safe configurations."""
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--model", required=True, help="Unlimited-OCR snapshot or HF ID")
    args = parser.parse_args()
    hasher = TokenHasher(chunk_size=256, hash_algorithm="blake3")
    results = []
    for mm_cache_gb, use_uuid in [(0.0, False), (0.0, True), (1.0, False)]:
        model_config = ModelConfig(
            model=args.model,
            trust_remote_code=True,
            max_model_len=2048,
            mm_processor_cache_gb=mm_cache_gb,
        )
        config = VllmConfig(
            model_config=model_config,
            cache_config=CacheConfig(enable_prefix_caching=False),
        )
        # The same reproduction also runs against an unpatched checkout.
        validator = getattr(
            lmcache_vllm_utils, "validate_vllm_multimodal_cache_config", None
        )
        rejected = None
        if validator is not None:
            try:
                validator(config)
                rejected = False
            except ValueError:
                rejected = True
            assert rejected == (mm_cache_gb == 0)

        red = render_image(config, hasher, "red", use_uuid)
        blue = render_image(config, hasher, "blue", use_uuid)
        assert red["image_sha256"] != blue["image_sha256"]
        same_keys = red["chunk_hashes"] == blue["chunk_hashes"]
        assert same_keys == (mm_cache_gb == 0)
        if mm_cache_gb > 0:
            red_again = render_image(config, hasher, "red", use_uuid)
            assert red["chunk_hashes"] == red_again["chunk_hashes"]
        results.append(
            {
                "mm_processor_cache_gb": mm_cache_gb,
                "use_uuid": use_uuid,
                "guard_rejected": rejected,
                "different_media_same_keys": same_keys,
                "red": red,
                "blue": blue,
            }
        )
    print(json.dumps(results, indent=2))


if __name__ == "__main__":
    main()
```

</details>
