### PR TITLE
feat(operator): add runtimeClassName override and NRI/CDI docs

### DIFF
--- a/docs/source/mp/deployment.rst
+++ b/docs/source/mp/deployment.rst
@@ -131,6 +131,12 @@ Prerequisites
 - At least 4 GPUs per node
 - ``kubectl`` configured to access your cluster
 
+Classic GPU Operator installs register RuntimeClass ``nvidia``. CDI+NRI
+installs often have no RuntimeClass objects. On those clusters omit
+``runtimeClassName`` on the LMCache DaemonSet and request a management CDI
+device (see *GPU Operator NRI/CDI* below). The operator path is
+:ref:`mp-operator-nri-cdi`.
+
 Step-by-Step
 ~~~~~~~~~~~~
 
@@ -206,10 +212,41 @@ Architecture Notes
   memory sharing (see *Isolated IPC* above for the plan to remove this
   requirement).
 - **GPUs are NOT requested in the DaemonSet** -- this allows GPUs to remain
-  exclusively allocated to vLLM pods.  The NVIDIA container runtime
-  automatically provides GPU access for IPC-based memory transfers.
+  exclusively allocated to vLLM pods. On classic GPU Operator installs the
+  NVIDIA container runtime (RuntimeClass ``nvidia``) provides GPU access
+  for IPC-based memory transfers. On CDI+NRI installs there is no
+  ``nvidia`` RuntimeClass; omit it and request a management CDI device
+  instead (see below).
 - **Multiple vLLM pods** on the same node automatically connect to the same
   LMCache DaemonSet instance.
+
+GPU Operator NRI/CDI
+^^^^^^^^^^^^^^^^^^^^
+
+If ``kubectl get runtimeclass`` is empty, do not set ``runtimeClassName``
+on the DaemonSet. Request the management CDI device on the pod (the
+container name must match the annotation key):
+
+.. code-block:: yaml
+
+    metadata:
+      annotations:
+        nvidia.cdi.k8s.io/container.lmcache-server: management.nvidia.com/gpu=all
+
+If the DaemonSet namespace is not the GPU Operator install namespace,
+NVIDIA Container Toolkit **≥ v1.20.0** takes extra namespaces from
+``NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES`` (Helm ``toolkit.env``, or
+``ClusterPolicy`` ``spec.toolkit.env``).
+(`NVIDIA: Requesting a Management CDI Device
+<https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html>`_)
+Below v1.20.0 that env is not available, so the DaemonSet can see GPUs
+only in the toolkit install namespace (typically ``gpu-operator``).
+
+For reference, toolkit v1.20.0 became the GPU Operator Helm default in
+v26.7.0. The default allowed namespace is the toolkit install namespace;
+from 1.20, additional namespaces can be listed in
+``NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES``, and the toolkit namespace remains
+allowed.
 
 .. note::
    LMCache pods on nodes without GPUs will crash with CUDA initialization

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -40,6 +40,9 @@ Prerequisites
 
 - Kubernetes 1.20+
 - ``kubectl`` configured to access your cluster
+- NVIDIA GPU Operator on NVIDIA clusters (default). Classic installs
+  register RuntimeClass ``nvidia``. CDI+NRI installs often have no
+  RuntimeClass objects; see :ref:`mp-operator-nri-cdi` below.
 - (Optional) `Prometheus Operator <https://github.com/prometheus-operator/prometheus-operator>`_
   for ServiceMonitor support
 
@@ -569,6 +572,14 @@ GPU & Security
      - ``nvidia``
      - GPU vendor: ``nvidia`` (uses the ``nvidia`` RuntimeClass) or ``amd``
        (runs on the default runtime).
+   * - ``runtimeClassName``
+     - vendor default
+     - Override the engine pod RuntimeClass. Unset keeps the vendor default
+       (``nvidia`` for NVIDIA, omitted for AMD). An empty string omits
+       ``runtimeClassName`` so pods use the default container runtime.
+       Empty does **not** add a CDI annotation; on GPU Operator NRI/CDI
+       clusters set that yourself via ``podAnnotations`` (see
+       :ref:`mp-operator-nri-cdi`).
    * - ``hostIPC``
      - ``false``
      - Run the pod in the host IPC namespace instead of mounting the host's
@@ -587,6 +598,55 @@ GPU & Security
        RuntimeClass device injection, so privileged is the only path to
        ``/dev/kfd``/``/dev/dri``). Enabling it requires the namespace to allow
        the ``privileged`` Pod Security Standard.
+
+.. _mp-operator-nri-cdi:
+
+GPU Operator NRI/CDI
+~~~~~~~~~~~~~~~~~~~~
+
+CDI+NRI GPU Operator installs often have **no** ``RuntimeClass`` objects.
+The operator's NVIDIA default (``runtimeClassName: nvidia``) then leaves
+engine pods Pending (``RuntimeClass "nvidia" not found``).
+
+To see GPUs without claiming ``nvidia.com/gpu``:
+
+1. Set ``spec.runtimeClassName`` to an empty string so the operator omits
+   RuntimeClass.
+2. Request the management CDI device on the CR. The operator copies
+   ``spec.podAnnotations`` onto the DaemonSet pods. The engine container
+   name is ``lmcache``:
+
+   .. code-block:: yaml
+
+       spec:
+         runtimeClassName: ""
+         podAnnotations:
+           nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all
+
+Do not rely on an empty ``runtimeClassName`` to inject CDI. Clusters whose
+default runtime is already NVIDIA only need the empty field.
+
+3. If the engine namespace is not the GPU Operator install namespace:
+
+   - **3-1.** NVIDIA Container Toolkit **≥ v1.20.0**: add the engine
+     namespace to the NVIDIA Container Toolkit env
+     ``NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES``. Set it with Helm
+     ``toolkit.env`` at install time, or with ``ClusterPolicy``
+     ``spec.toolkit.env`` on an existing install.
+     (`NVIDIA: Requesting a Management CDI Device
+     <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html>`_)
+   - **3-2.** toolkit **< v1.20.0**: ``NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES``
+     is not available. The engine can see GPUs only if it runs in the
+     toolkit install namespace (typically ``gpu-operator``).
+
+For reference, toolkit v1.20.0 became the GPU Operator Helm default in
+v26.7.0. The default allowed namespace is the toolkit install namespace;
+from 1.20, additional namespaces can be listed in
+``NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES``, and the toolkit namespace remains
+allowed.
+
+A copy-paste CR is at
+``operator/config/samples/lmcache_v1alpha1_lmcacheengine_nri.yaml``.
 
 Scheduling
 ~~~~~~~~~~

--- a/operator/README.md
+++ b/operator/README.md
@@ -16,6 +16,8 @@ See [DESIGN.md](DESIGN.md) for architecture details, reconciliation logic, and C
 > [!IMPORTANT]
 > By default the operator runs LMCache pods with `runtimeClassName: nvidia` and `NVIDIA_VISIBLE_DEVICES=all` to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. On most clusters that is enough; on some, the engine cannot see the GPUs unless the pod is also privileged. Set `spec.privileged: true` to run the engine container in privileged mode (default `false`). When it is enabled, clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace.
 >
+> On GPU Operator CDI+NRI clusters there is often no `RuntimeClass` object. Set `spec.runtimeClassName: ""` and put the management CDI annotation on `spec.podAnnotations` (see [lmcache_v1alpha1_lmcacheengine_nri.yaml](config/samples/lmcache_v1alpha1_lmcacheengine_nri.yaml)). Empty `runtimeClassName` omits the field only; it does not inject CDI.
+>
 > On AMD ROCm clusters, `spec.gpuVendor: amd` omits `runtimeClassName` and skips NVIDIA-specific env vars.
 
 > [!WARNING]

--- a/operator/api/v1alpha1/cacheblendengine_types.go
+++ b/operator/api/v1alpha1/cacheblendengine_types.go
@@ -109,6 +109,16 @@ type CacheBlendEngineSpec struct {
 	// +kubebuilder:validation:Enum=nvidia;amd
 	GPUVendor *string `json:"gpuVendor,omitempty"`
 
+	// runtimeClassName overrides the RuntimeClass for the engine pods. When unset,
+	// it is derived from gpuVendor: "nvidia" uses the NVIDIA GPU Operator's
+	// "nvidia" RuntimeClass, "amd" uses none (the default container runtime). An
+	// empty string omits runtimeClassName so pods use the default container
+	// runtime. On GPU Operator NRI/CDI clusters, combine an empty string with
+	// spec.podAnnotations nvidia.cdi.k8s.io/container.lmcache:
+	// management.nvidia.com/gpu=all.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+
 	// image defines the container image to use for the blend engine. This
 	// may be a PRIVATE image; use imagePullSecrets to pull it.
 	// +optional

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -423,6 +423,18 @@ type LMCacheEngineSpec struct {
 	// +kubebuilder:validation:Enum=nvidia;amd
 	GPUVendor *string `json:"gpuVendor,omitempty"`
 
+	// runtimeClassName overrides the RuntimeClass for the engine pods. When unset,
+	// it is derived from gpuVendor: "nvidia" uses the NVIDIA GPU Operator's
+	// "nvidia" RuntimeClass, "amd" uses none (the default container runtime). Set
+	// it explicitly to run on a cluster whose GPU runtime is already the default
+	// (e.g. NVIDIA nodes without the GPU Operator, where no "nvidia" RuntimeClass
+	// object exists); an empty string omits runtimeClassName so pods use the
+	// default container runtime. On GPU Operator NRI/CDI clusters, combine an
+	// empty string with spec.podAnnotations
+	// nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+
 	// image defines the container image to use.
 	// +optional
 	Image *ImageSpec `json:"image,omitempty"`

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -150,6 +150,11 @@ func (in *CacheBlendEngineSpec) DeepCopyInto(out *CacheBlendEngineSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(ImageSpec)
@@ -843,6 +848,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 	*out = *in
 	if in.GPUVendor != nil {
 		in, out := &in.GPUVendor, &out.GPUVendor
+		*out = new(string)
+		**out = **in
+	}
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
 		*out = new(string)
 		**out = **in
 	}

--- a/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1678,6 +1678,16 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              runtimeClassName:
+                description: |-
+                  runtimeClassName overrides the RuntimeClass for the engine pods. When unset,
+                  it is derived from gpuVendor: "nvidia" uses the NVIDIA GPU Operator's
+                  "nvidia" RuntimeClass, "amd" uses none (the default container runtime). An
+                  empty string omits runtimeClassName so pods use the default container
+                  runtime. On GPU Operator NRI/CDI clusters, combine an empty string with
+                  spec.podAnnotations nvidia.cdi.k8s.io/container.lmcache:
+                  management.nvidia.com/gpu=all.
+                type: string
               server:
                 description: |-
                   server defines server configuration. chunkSize defaults to 256 because

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -3202,6 +3202,18 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              runtimeClassName:
+                description: |-
+                  runtimeClassName overrides the RuntimeClass for the engine pods. When unset,
+                  it is derived from gpuVendor: "nvidia" uses the NVIDIA GPU Operator's
+                  "nvidia" RuntimeClass, "amd" uses none (the default container runtime). Set
+                  it explicitly to run on a cluster whose GPU runtime is already the default
+                  (e.g. NVIDIA nodes without the GPU Operator, where no "nvidia" RuntimeClass
+                  object exists); an empty string omits runtimeClassName so pods use the
+                  default container runtime. On GPU Operator NRI/CDI clusters, combine an
+                  empty string with spec.podAnnotations
+                  nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all.
+                type: string
               server:
                 description: server defines server configuration.
                 properties:

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
@@ -143,6 +143,16 @@ spec:
   # cannot see them otherwise. Requires the namespace to allow the privileged
   # Pod Security Standard.
   # privileged: false
+  #
+  # GPU Operator NRI/CDI clusters have no RuntimeClass objects. Set this to an
+  # empty string so the operator omits runtimeClassName, and set podAnnotations
+  # to nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all.
+  # The engine namespace must be in NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES (or be
+  # the GPU Operator install namespace), and the NVIDIA Container Toolkit must
+  # be v1.20.0+. See lmcache_v1alpha1_lmcacheengine_nri.yaml.
+  # runtimeClassName: ""
+  # podAnnotations:
+  #   nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all
 
   # -- Extra CLI flags (appended last, can override any auto-generated flag) --
   # extraArgs: []

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine_nri.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine_nri.yaml
@@ -1,0 +1,20 @@
+# LMCacheEngine for NVIDIA GPU Operator NRI/CDI clusters that have no
+# RuntimeClass objects (typical of GPU Operator v25+/v26 with CDI+NRI).
+#
+# Cluster prerequisites:
+#   - NVIDIA Container Toolkit v1.20.0+ (NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES)
+#   - ClusterPolicy env NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES includes this
+#     namespace (comma-separated; the GPU Operator install ns stays allowed)
+#
+# Empty runtimeClassName omits the field. Request GPU visibility yourself via
+# spec.podAnnotations (container name is always "lmcache").
+apiVersion: lmcache.lmcache.ai/v1alpha1
+kind: LMCacheEngine
+metadata:
+  name: my-cache
+spec:
+  runtimeClassName: ""
+  podAnnotations:
+    nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all
+  l1:
+    sizeGB: 10

--- a/operator/internal/resources/cacheblend_engine.go
+++ b/operator/internal/resources/cacheblend_engine.go
@@ -63,6 +63,7 @@ const (
 func cbSpecToEngineSpec(spec *lmcachev1alpha1.CacheBlendEngineSpec) *lmcachev1alpha1.LMCacheEngineSpec {
 	return &lmcachev1alpha1.LMCacheEngineSpec{
 		GPUVendor:          spec.GPUVendor,
+		RuntimeClassName:   spec.RuntimeClassName,
 		Image:              spec.Image,
 		ImagePullSecrets:   spec.ImagePullSecrets,
 		Server:             spec.Server,

--- a/operator/internal/resources/cacheblend_engine_test.go
+++ b/operator/internal/resources/cacheblend_engine_test.go
@@ -129,6 +129,9 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	if podSpec.RuntimeClassName == nil || *podSpec.RuntimeClassName != nvidiaRuntimeClass {
 		t.Fatalf("expected RuntimeClassName=nvidia, got %v", podSpec.RuntimeClassName)
 	}
+	if _, ok := ds.Spec.Template.Annotations["nvidia.cdi.k8s.io/container."+engineContainerName]; ok {
+		t.Fatal("default nvidia RuntimeClass should not set the NRI/CDI annotation")
+	}
 
 	if len(podSpec.Containers) != 1 {
 		t.Fatalf("expected 1 container, got %d", len(podSpec.Containers))
@@ -233,6 +236,22 @@ func TestBuildCBEngineDaemonSet_AMDNoRuntimeClass(t *testing.T) {
 	ds = BuildCBEngineDaemonSet(engine)
 	if !ds.Spec.Template.Spec.HostIPC {
 		t.Fatal("expected HostIPC=true when spec.hostIPC=true for AMD")
+	}
+}
+
+func TestBuildCBEngineDaemonSet_RuntimeClassNameEmptyOmitsWithoutCDI(t *testing.T) {
+	engine := minimalCBEngine()
+	engine.Spec.RuntimeClassName = ptr("")
+
+	ds := BuildCBEngineDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	if podSpec.RuntimeClassName != nil {
+		t.Fatalf("expected nil RuntimeClassName when spec.runtimeClassName is empty, got %q", *podSpec.RuntimeClassName)
+	}
+	wantCDI := "nvidia.cdi.k8s.io/container." + engineContainerName
+	if _, ok := ds.Spec.Template.Annotations[wantCDI]; ok {
+		t.Fatal("empty runtimeClassName must not auto-add the NRI/CDI annotation")
 	}
 }
 

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -29,8 +29,15 @@ import (
 
 const (
 	// nvidiaRuntimeClass is the RuntimeClass name registered by the NVIDIA GPU
-	// Operator; engine pods request it when gpuVendor is nvidia.
+	// Operator; engine pods request it when gpuVendor is nvidia unless
+	// spec.runtimeClassName overrides it.
 	nvidiaRuntimeClass = "nvidia"
+
+	// engineContainerName is the engine container name. GPU Operator NRI/CDI
+	// clusters that omit runtimeClassName must annotate this same name, e.g.
+	// nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all via
+	// spec.podAnnotations.
+	engineContainerName = "lmcache"
 
 	// lmcacheServerBinary is the entrypoint binary for the LMCache server inside
 	// the engine image.
@@ -116,6 +123,19 @@ func buildDaemonSetCore(
 	if gpuVendor == lmcachev1alpha1.GPUVendorNvidia {
 		rc := nvidiaRuntimeClass
 		runtimeClassName = &rc
+	}
+	// spec.runtimeClassName wins: "" clears it (default container runtime),
+	// any other value is used as-is. Unset keeps the vendor default.
+	// GPU Operator NRI/CDI clusters also omit runtimeClassName; set
+	// spec.podAnnotations to request the management CDI device. The operator
+	// does not add that annotation itself.
+	if spec.RuntimeClassName != nil {
+		if *spec.RuntimeClassName == "" {
+			runtimeClassName = nil
+		} else {
+			rc := *spec.RuntimeClassName
+			runtimeClassName = &rc
+		}
 	}
 	privileged := derefBool(spec.Privileged, false)
 	hostIPC := derefBool(spec.HostIPC, false)
@@ -343,7 +363,7 @@ func buildDaemonSetCore(
 					InitContainers:     spec.InitContainers,
 					Containers: []corev1.Container{
 						{
-							Name:            "lmcache",
+							Name:            engineContainerName,
 							Image:           fmt.Sprintf("%s:%s", imgRepo, imgTag),
 							ImagePullPolicy: imgPullPolicy,
 							Command:         containerCommand,

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1428,6 +1428,9 @@ func TestBuildDaemonSet_GPUVendorNvidiaDefault(t *testing.T) {
 	if podSpec.RuntimeClassName == nil || *podSpec.RuntimeClassName != nvidiaRuntimeClass {
 		t.Fatalf("expected RuntimeClassName=nvidia, got %v", podSpec.RuntimeClassName)
 	}
+	if _, ok := ds.Spec.Template.Annotations["nvidia.cdi.k8s.io/container."+engineContainerName]; ok {
+		t.Fatal("default nvidia RuntimeClass should not set the NRI/CDI annotation")
+	}
 
 	c := podSpec.Containers[0]
 	if !hasEnvAll(c.Env, "NVIDIA_VISIBLE_DEVICES") {
@@ -1449,12 +1452,73 @@ func TestBuildDaemonSet_GPUVendorAMD(t *testing.T) {
 	if podSpec.RuntimeClassName != nil {
 		t.Fatalf("expected nil RuntimeClassName for AMD, got %q", *podSpec.RuntimeClassName)
 	}
+	if _, ok := ds.Spec.Template.Annotations["nvidia.cdi.k8s.io/container."+engineContainerName]; ok {
+		t.Fatal("AMD vendor should not set the NVIDIA NRI/CDI annotation")
+	}
 
 	c := podSpec.Containers[0]
 	for _, e := range c.Env {
 		if e.Name == "NVIDIA_VISIBLE_DEVICES" || e.Name == "NVIDIA_DRIVER_CAPABILITIES" {
 			t.Fatalf("unexpected NVIDIA env var on AMD vendor: %s=%s", e.Name, e.Value)
 		}
+	}
+}
+
+func TestBuildDaemonSet_RuntimeClassNameEmptyOmitsWithoutCDI(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.RuntimeClassName = ptr("")
+	engine.SetDefaults()
+
+	ds := BuildDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	if podSpec.RuntimeClassName != nil {
+		t.Fatalf("expected nil RuntimeClassName when spec.runtimeClassName is empty, got %q", *podSpec.RuntimeClassName)
+	}
+	wantCDI := "nvidia.cdi.k8s.io/container." + engineContainerName
+	if _, ok := ds.Spec.Template.Annotations[wantCDI]; ok {
+		t.Fatal("empty runtimeClassName must not auto-add the NRI/CDI annotation")
+	}
+
+	c := podSpec.Containers[0]
+	if !hasEnvAll(c.Env, "NVIDIA_VISIBLE_DEVICES") {
+		t.Fatal("empty runtimeClassName must keep NVIDIA_VISIBLE_DEVICES=all")
+	}
+}
+
+func TestBuildDaemonSet_RuntimeClassNameOverride(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.RuntimeClassName = ptr("nvidia-cdi")
+	engine.SetDefaults()
+
+	ds := BuildDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	if podSpec.RuntimeClassName == nil || *podSpec.RuntimeClassName != "nvidia-cdi" {
+		t.Fatalf("expected RuntimeClassName=nvidia-cdi, got %v", podSpec.RuntimeClassName)
+	}
+	if _, ok := ds.Spec.Template.Annotations["nvidia.cdi.k8s.io/container."+engineContainerName]; ok {
+		t.Fatal("explicit RuntimeClass should not add the NRI/CDI annotation")
+	}
+}
+
+func TestBuildDaemonSet_RuntimeClassNameEmptyPreservesPodAnnotations(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.RuntimeClassName = ptr("")
+	engine.Spec.PodAnnotations = map[string]string{
+		"example.com/keep": "yes",
+		"nvidia.cdi.k8s.io/container." + engineContainerName: "management.nvidia.com/gpu=all",
+	}
+	engine.SetDefaults()
+
+	ds := BuildDaemonSet(engine)
+	ann := ds.Spec.Template.Annotations
+	if ann["example.com/keep"] != "yes" {
+		t.Fatalf("expected user podAnnotation to be preserved, got %v", ann)
+	}
+	wantCDI := "nvidia.cdi.k8s.io/container." + engineContainerName
+	if ann[wantCDI] != "management.nvidia.com/gpu=all" {
+		t.Fatalf("expected user CDI podAnnotation to be copied, got %v", ann)
 	}
 }
 


### PR DESCRIPTION
## Summary

GPU Operator CDI+NRI installs often have no `RuntimeClass` objects. The operator's NVIDIA default (`runtimeClassName: nvidia`) then leaves engine pods Pending (`RuntimeClass "nvidia" not found`).

This PR adds `spec.runtimeClassName` so an empty string omits the field. It does **not** auto-inject a management CDI annotation. On NRI clusters, set that annotation explicitly on `spec.podAnnotations` (the operator already copies those onto the DaemonSet pods).

Extends #4580: empty `runtimeClassName` is enough when the default runtime is already NVIDIA (e.g. Nebius). Auto-adding CDI on empty RC would attach a device those clusters do not use.

To see GPUs **without** claiming `nvidia.com/gpu`:

1. Omit RuntimeClass (`spec.runtimeClassName: ""`).
2. Set the management CDI annotation on the CR:

```yaml
spec:
  runtimeClassName: ""
  podAnnotations:
    nvidia.cdi.k8s.io/container.lmcache: management.nvidia.com/gpu=all
```

3. If the engine namespace is not the GPU Operator install namespace:
   - **3-1.** NVIDIA Container Toolkit **≥ v1.20.0**: add the engine namespace to the NVIDIA Container Toolkit env `NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES`. Set it with Helm `toolkit.env` at install time, or with `ClusterPolicy` `spec.toolkit.env` on an existing install. ([NVIDIA: Requesting a Management CDI Device](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/cdi.html))
   - **3-2.** toolkit **< v1.20.0**: `NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES` is not available. The engine can see GPUs only if it runs in the toolkit install namespace (typically `gpu-operator`).

For reference, toolkit v1.20.0 became the GPU Operator Helm default in v26.7.0. The default allowed namespace is the toolkit install namespace; from 1.20, additional namespaces can be listed in `NRI_MANAGEMENT_CDI_DEVICE_NAMESPACES`, and the toolkit namespace remains allowed.

| Cluster | What to set |
|---|---|
| Default runtime already NVIDIA (#4580) | `runtimeClassName: ""` only |
| GPU Operator NRI | empty RC, **and the CDI annotation set explicitly on the CR** (`spec.podAnnotations`) |
| Classic GPU Operator (`RuntimeClass nvidia` exists) | leave defaults |

Docs: `docs/source/mp/operator.rst`, `docs/source/mp/deployment.rst`. Sample: `operator/config/samples/lmcache_v1alpha1_lmcacheengine_nri.yaml`.

Reproduced on GPU Operator **v26.7.0** with CDI/NRI and toolkit **v1.20.0**. Empty RC alone: pod runs, no `/dev/nvidia*`, `accelerator available: False`. Setting the annotation on the CR copies it to the pod and CUDA comes up.

## Test plan

- [ ] Default NVIDIA: DaemonSet still gets `runtimeClassName: nvidia` and no CDI annotation
- [ ] `runtimeClassName: ""` omits RuntimeClass and does **not** add CDI
- [ ] `runtimeClassName: ""` + `podAnnotations` copies the CDI key onto the DaemonSet pod
- [ ] Explicit `runtimeClassName: nvidia-cdi` is passed through without CDI
- [ ] AMD path still omits RuntimeClass and NVIDIA env
- [ ] (optional) GPU Operator NRI cluster: empty RC + CR annotation → CUDA
