### PR TITLE
Fix TurboQuant asynchronous storage races

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -540,6 +540,10 @@ class L1Manager:
     ) -> dict[ObjectKey, L1Error]:
         """Finish write access for the given keys.
 
+        Temporary objects are unlocked normally but do not emit write-finished
+        notifications because they are internal staging buffers that must not
+        be routed to L2 storage.
+
         Args:
             keys: The list of object keys to finish write access for.
 
@@ -552,8 +556,8 @@ class L1Manager:
                 which means the writer may have caused inconsistent data.
         """
         ret: dict[ObjectKey, L1Error] = {}
-        successful_keys: list[ObjectKey] = []
-        successful_keys_meta: list[L1ObjectMeta] = []
+        notification_keys: list[ObjectKey] = []
+        notification_keys_meta: list[L1ObjectMeta] = []
 
         for key in keys:
             entry = self._objects.get(key, None)
@@ -581,17 +585,22 @@ class L1Manager:
 
             entry.write_lock.unlock()
             ret[key] = L1Error.SUCCESS
-            successful_keys.append(key)
-            successful_keys_meta.append(self._object_meta(entry.memory_obj))
+            if not entry.is_temporary:
+                notification_keys.append(key)
+                notification_keys_meta.append(self._object_meta(entry.memory_obj))
 
-        for listener in self._registered_listeners:
-            listener.on_l1_keys_write_finished(successful_keys)
-        self._event_bus.publish(
-            Event(
-                event_type=EventType.L1_WRITE_FINISHED,
-                metadata={"keys": successful_keys, "meta": successful_keys_meta},
+        if notification_keys:
+            for listener in self._registered_listeners:
+                listener.on_l1_keys_write_finished(notification_keys)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.L1_WRITE_FINISHED,
+                    metadata={
+                        "keys": notification_keys,
+                        "meta": notification_keys_meta,
+                    },
+                )
             )
-        )
         return ret
 
     @l1_mgr_synchronized

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -653,7 +653,16 @@ class StoreController(StorageControllerInterface):
                 continue
 
             adapter = self._l2_adapters[adapter_index]
-            task_id = adapter.submit_store_task(successful_keys, successful_objs)
+            try:
+                task_id = adapter.submit_store_task(successful_keys, successful_objs)
+            except Exception:
+                logger.exception(
+                    "Failed to submit store task to adapter %d for %d keys.",
+                    adapter_index,
+                    len(successful_keys),
+                )
+                l1_mgr.finish_read(successful_keys)
+                continue
 
             self._in_flight_tasks[(adapter_index, task_id)] = InFlightStoreTask(
                 adapter_index=adapter_index,

--- a/tests/v1/distributed/serde/test_turboquant.py
+++ b/tests/v1/distributed/serde/test_turboquant.py
@@ -231,6 +231,62 @@ def _wait_for_prefetch_status(
     return None
 
 
+def _wait_for_mock_l2_store(
+    sm: StorageManager,
+    stored_before: int,
+    expected_new_objects: int,
+    timeout: float = 120.0,
+) -> bool:
+    """Wait for objects to reach mock L2 and for asynchronous cleanup."""
+
+    def store_completed() -> bool:
+        status = sm.report_status()
+        stored_total = sum(
+            adapter["stored_object_count"] for adapter in status["l2_adapters"]
+        )
+        controller = status["store_controller"]
+        l1 = status["l1_manager"]
+        return (
+            stored_total >= stored_before + expected_new_objects
+            and controller["in_flight_task_count"] == 0
+            and controller["pending_keys_count"] == 0
+            and l1["write_locked_count"] == 0
+            and l1["read_locked_count"] == 0
+            and l1["temporary_count"] == 0
+        )
+
+    return _wait_for_condition(store_completed, timeout=timeout)
+
+
+def _wait_for_fs_l2_store(
+    sm: StorageManager,
+    base_dir: str,
+    expected_files: int,
+    timeout: float = 120.0,
+) -> bool:
+    """Wait for final FS objects and for asynchronous cleanup."""
+
+    def store_completed() -> bool:
+        stored_files = [
+            path
+            for path in Path(base_dir).rglob("*")
+            if path.is_file() and path.suffix != ".tmp"
+        ]
+        status = sm.report_status()
+        controller = status["store_controller"]
+        l1 = status["l1_manager"]
+        return (
+            len(stored_files) >= expected_files
+            and controller["in_flight_task_count"] == 0
+            and controller["pending_keys_count"] == 0
+            and l1["write_locked_count"] == 0
+            and l1["read_locked_count"] == 0
+            and l1["temporary_count"] == 0
+        )
+
+    return _wait_for_condition(store_completed, timeout=timeout)
+
+
 def _finish_read_prefetched_until_clean(
     sm: StorageManager,
     keys: list[ObjectKey],
@@ -316,6 +372,9 @@ def test_turboquant_storage_manager_roundtrip(
     sm = _make_turboquant_storage_manager(preset)
     layout = _make_turboquant_layout()
     keys = [_make_turboquant_object_key(i) for i in range(3)]
+    stored_before = sum(
+        adapter["stored_object_count"] for adapter in sm.report_status()["l2_adapters"]
+    )
 
     try:
         ret = sm.reserve_write(keys, layout, mode="new")
@@ -339,17 +398,10 @@ def test_turboquant_storage_manager_roundtrip(
 
         sm.finish_write(list(ret.keys()))
 
-        # Wait until both the store controller and the serde wrapper cleanup
-        # have released temporary objects and locks.
-        ok = _wait_for_condition(
-            lambda: (
-                sm.report_status()["store_controller"]["in_flight_task_count"] == 0
-                and sm.report_status()["store_controller"]["pending_keys_count"] == 0
-                and sm.report_status()["l1_manager"]["write_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["read_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["temporary_count"] == 0
-            ),
-            timeout=120.0,
+        ok = _wait_for_mock_l2_store(
+            sm,
+            stored_before=stored_before,
+            expected_new_objects=len(keys),
         )
         assert ok, "Store to L2 did not fully complete"
 
@@ -576,15 +628,10 @@ def test_turboquant_fs_storage_manager_roundtrip(
 
         sm.finish_write(list(ret.keys()))
 
-        ok = _wait_for_condition(
-            lambda: (
-                sm.report_status()["store_controller"]["in_flight_task_count"] == 0
-                and sm.report_status()["store_controller"]["pending_keys_count"] == 0
-                and sm.report_status()["l1_manager"]["write_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["read_locked_count"] == 0
-                and sm.report_status()["l1_manager"]["temporary_count"] == 0
-            ),
-            timeout=120.0,
+        ok = _wait_for_fs_l2_store(
+            sm,
+            base_dir=base_dir,
+            expected_files=len(keys),
         )
         assert ok, "Store to FS L2 did not fully complete"
 

--- a/tests/v1/distributed/test_store_controller.py
+++ b/tests/v1/distributed/test_store_controller.py
@@ -10,7 +10,9 @@ the full integration without mocking internals.
 """
 
 # Standard
+from typing import NoReturn
 import select
+import threading
 import time
 
 # Third Party
@@ -21,6 +23,7 @@ import torch
 from lmcache import torch_dev, torch_device_type
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.eviction_policy.noop import (
     NoOpEvictionPolicy,
 )
@@ -39,6 +42,7 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
     DefaultStorePolicy,
     StorePolicy,
 )
+from lmcache.v1.memory_management import MemoryObj
 from tests.v1.distributed.utils import should_use_lazy_alloc
 
 if not torch_dev.is_available():
@@ -263,6 +267,71 @@ class TestStoreControllerLifecycle:
 
 class TestStoreControllerSingleAdapter:
     """Test StoreController with one MockL2Adapter."""
+
+    def test_temporary_l1_write_does_not_trigger_l2_store(self, l1_manager):
+        """Temporary staging objects should remain internal to L1."""
+        adapter = make_adapter()
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        result = l1_manager.reserve_write(
+            keys=keys,
+            is_temporary=[True],
+            layout_desc=layout,
+            mode="new",
+        )
+        assert result[keys[0]][1] is not None
+
+        l1_manager.finish_write(keys)
+        time.sleep(0.3)
+
+        assert adapter.debug_get_stored_object_count() == 0
+        assert l1_manager.delete(keys)[keys[0]] == L1Error.SUCCESS
+
+        ctrl.stop()
+        adapter.close()
+
+    def test_submit_failure_releases_l1_read_lock(self, l1_manager, monkeypatch):
+        """An adapter submission failure should not leak L1 read locks."""
+        adapter = make_adapter()
+        submission_attempted = threading.Event()
+
+        def fail_submit(
+            _keys: list[ObjectKey],
+            _memory_objs: list[MemoryObj],
+        ) -> NoReturn:
+            submission_attempted.set()
+            raise RuntimeError("injected store submission failure")
+
+        monkeypatch.setattr(adapter, "submit_store_task", fail_submit)
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+
+        layout = make_layout()
+        keys = [make_object_key(0)]
+        write_keys_to_l1(l1_manager, keys, layout)
+
+        assert submission_attempted.wait(timeout=5.0)
+        ok = wait_for_condition(
+            lambda: l1_manager.report_status()["read_locked_count"] == 0,
+            timeout=5.0,
+        )
+        assert ok, "Submission failure should release the acquired L1 read lock"
+
+        ctrl.stop()
+        adapter.close()
 
     def test_l1_write_triggers_l2_store(self, l1_manager):
         """Writing to L1 should cause the object to appear in L2."""


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes TurboQuant asynchronous storage races by preventing internal serde staging buffers from being sent back through L2 storage, releasing L1 read locks when adapter task submission fails, and waiting for actual L2 persistence before completing storage.

**Special notes for your reviewers**:

This issue was identified through intermittent failures in the XPU unit test `test_turboquant_storage_manager_roundtrip`. The test exposed races in TurboQuant asynchronous storage lifecycle handling. The regression tests cover the two affected lifecycle races: failed adapter task submission must not retain an L1 read lock, and TurboQuant completion must wait for the L2 persistence operation.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Validation**:

- `SKIP=rust-fmt,rust-clippy pre-commit run --all-files`