### PR TITLE
[Bugfix] Reject unsupported CircularBufferSpec cache groups

### DIFF
--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -98,13 +98,20 @@ def _leaf_specs(spec: KVCacheSpec) -> list[KVCacheSpec]:
     return [spec]
 
 
-def _is_circular_buffer_spec(spec: KVCacheSpec) -> bool:
-    """Return whether a spec is vLLM's request-scoped circular buffer.
+def _is_non_prefix_cacheable_spec(spec: KVCacheSpec) -> bool:
+    """Return whether a spec holds request-scoped, non-shareable state.
 
-    Detection by class name keeps this module importable with older supported
-    vLLM releases that do not define ``CircularBufferSpec``.
+    Current vLLM releases expose this through ``prefix_cacheable``. The class
+    name fallback covers older revisions that define these scratch specs but
+    do not expose the property on ``KVCacheSpec``.
     """
-    return any(cls.__name__ == "CircularBufferSpec" for cls in type(spec).__mro__)
+    prefix_cacheable = getattr(spec, "prefix_cacheable", None)
+    if prefix_cacheable is not None:
+        return prefix_cacheable is False
+    return any(
+        cls.__name__ in ("CircularBufferSpec", "KpoolTailSpec")
+        for cls in type(spec).__mro__
+    )
 
 
 def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
@@ -113,8 +120,9 @@ def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
     Rejected, with one aggregated error listing every offending group:
 
     - ``CrossAttentionSpec`` (encoder-decoder caches).
-    - ``CircularBufferSpec``: one request-lifetime ring block cannot provide
-      the historical per-chunk snapshots required by LMCache prefix storage.
+    - Specs with ``prefix_cacheable=False``, including ``CircularBufferSpec``
+      and ``KpoolTailSpec``: request-scoped scratch state cannot provide the
+      historical per-chunk snapshots required by LMCache prefix storage.
     - Mamba groups with ``mamba_cache_mode`` other than ``"align"`` or
       ``"all"``: the remaining mode (``"none"``) keeps no reusable per-block
       state snapshots.
@@ -136,14 +144,15 @@ def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
     unsupported: list[str] = []
     for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
         for spec in _leaf_specs(group.kv_cache_spec):
-            kind = get_kv_cache_spec_kind(spec)
-            if _is_circular_buffer_spec(spec):
+            if _is_non_prefix_cacheable_spec(spec):
                 unsupported.append(
-                    f"group {group_idx}: CircularBufferSpec "
-                    "(one request-lifetime ring block cannot provide "
-                    "per-chunk snapshots)"
+                    f"group {group_idx}: {type(spec).__name__} "
+                    "(non-prefix-cacheable request-scoped state cannot "
+                    "provide per-chunk snapshots)"
                 )
-            elif kind == KVCacheSpecKind.CROSS_ATTENTION:
+                continue
+            kind = get_kv_cache_spec_kind(spec)
+            if kind == KVCacheSpecKind.CROSS_ATTENTION:
                 unsupported.append(f"group {group_idx}: CrossAttentionSpec")
             elif kind == KVCacheSpecKind.MAMBA and getattr(
                 spec, "mamba_cache_mode", "none"

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Mapping
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 # Third Party
 from vllm.v1.kv_cache_interface import (
@@ -49,9 +49,12 @@ from vllm.v1.kv_cache_interface import (
 )
 import torch
 
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.gpu_connector.utils import LayoutHints
+
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.gpu_connector.utils import LayoutHints
 
 logger = init_logger(__name__)
 
@@ -95,12 +98,23 @@ def _leaf_specs(spec: KVCacheSpec) -> list[KVCacheSpec]:
     return [spec]
 
 
+def _is_circular_buffer_spec(spec: KVCacheSpec) -> bool:
+    """Return whether a spec is vLLM's request-scoped circular buffer.
+
+    Detection by class name keeps this module importable with older supported
+    vLLM releases that do not define ``CircularBufferSpec``.
+    """
+    return any(cls.__name__ == "CircularBufferSpec" for cls in type(spec).__mro__)
+
+
 def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
     """Reject KV cache group specs the transfer path cannot serve correctly.
 
     Rejected, with one aggregated error listing every offending group:
 
     - ``CrossAttentionSpec`` (encoder-decoder caches).
+    - ``CircularBufferSpec``: one request-lifetime ring block cannot provide
+      the historical per-chunk snapshots required by LMCache prefix storage.
     - Mamba groups with ``mamba_cache_mode`` other than ``"align"`` or
       ``"all"``: the remaining mode (``"none"``) keeps no reusable per-block
       state snapshots.
@@ -123,7 +137,13 @@ def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
     for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
         for spec in _leaf_specs(group.kv_cache_spec):
             kind = get_kv_cache_spec_kind(spec)
-            if kind == KVCacheSpecKind.CROSS_ATTENTION:
+            if _is_circular_buffer_spec(spec):
+                unsupported.append(
+                    f"group {group_idx}: CircularBufferSpec "
+                    "(one request-lifetime ring block cannot provide "
+                    "per-chunk snapshots)"
+                )
+            elif kind == KVCacheSpecKind.CROSS_ATTENTION:
                 unsupported.append(f"group {group_idx}: CrossAttentionSpec")
             elif kind == KVCacheSpecKind.MAMBA and getattr(
                 spec, "mamba_cache_mode", "none"

--- a/tests/v1/test_kv_cache_group_edits.py
+++ b/tests/v1/test_kv_cache_group_edits.py
@@ -4,14 +4,20 @@
 # Standard
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 # Third Party
 import pytest
 
 pytest.importorskip("vllm", reason="KV cache group validation imports vLLM")
 
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.gpu_connector.utils import LayoutHints
+
 # First Party
 from lmcache.integration.vllm.kv_cache_group_edits import (  # noqa: E402
+    apply_kv_cache_group_edits,
     validate_kv_cache_groups,
 )
 
@@ -29,6 +35,17 @@ class CircularBufferSpec:
 @dataclass
 class DerivedCircularBufferSpec(CircularBufferSpec):
     pass
+
+
+@dataclass
+class KpoolTailSpec:
+    block_size: int = 4
+
+
+@dataclass
+class NonPrefixCacheableSpec:
+    block_size: int = 4
+    prefix_cacheable: bool = False
 
 
 @dataclass
@@ -52,7 +69,7 @@ def test_validate_kv_cache_groups_rejects_circular_buffer() -> None:
         ValueError,
         match=(
             r"group 1: CircularBufferSpec .*"
-            r"request-lifetime ring block cannot provide per-chunk snapshots"
+            r"request-scoped state cannot provide per-chunk snapshots"
         ),
     ):
         validate_kv_cache_groups(_config(FullAttentionSpec(), CircularBufferSpec()))
@@ -66,5 +83,27 @@ def test_validate_kv_cache_groups_rejects_wrapped_circular_buffer() -> None:
         }
     )
 
-    with pytest.raises(ValueError, match=r"group 0: CircularBufferSpec"):
+    with pytest.raises(ValueError, match=r"group 0: DerivedCircularBufferSpec"):
         validate_kv_cache_groups(_config(wrapped))
+
+
+def test_validate_kv_cache_groups_rejects_non_prefix_cacheable_spec() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"group 0: KpoolTailSpec .*non-prefix-cacheable request-scoped state",
+    ):
+        validate_kv_cache_groups(_config(KpoolTailSpec()))
+
+
+def test_validate_kv_cache_groups_uses_prefix_cacheable_contract() -> None:
+    with pytest.raises(ValueError, match=r"group 0: NonPrefixCacheableSpec"):
+        validate_kv_cache_groups(_config(NonPrefixCacheableSpec()))
+
+
+def test_apply_kv_cache_group_edits_validates_before_registration() -> None:
+    with pytest.raises(ValueError, match=r"group 0: KpoolTailSpec"):
+        apply_kv_cache_group_edits(
+            _config(KpoolTailSpec()),
+            {},
+            layout_hints=cast("LayoutHints", SimpleNamespace()),
+        )

--- a/tests/v1/test_kv_cache_group_edits.py
+++ b/tests/v1/test_kv_cache_group_edits.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for validation of vLLM KV cache group compatibility."""
+
+# Standard
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="KV cache group validation imports vLLM")
+
+# First Party
+from lmcache.integration.vllm.kv_cache_group_edits import (  # noqa: E402
+    validate_kv_cache_groups,
+)
+
+
+@dataclass
+class FullAttentionSpec:
+    block_size: int = 16
+
+
+@dataclass
+class CircularBufferSpec:
+    block_size: int = 8
+
+
+@dataclass
+class DerivedCircularBufferSpec(CircularBufferSpec):
+    pass
+
+
+@dataclass
+class UniformTypeKVCacheSpecs:
+    block_size: int = 16
+    kv_cache_specs: dict[str, object] = field(default_factory=dict)
+
+
+def _config(*specs: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec) for spec in specs]
+    )
+
+
+def test_validate_kv_cache_groups_allows_regular_attention() -> None:
+    validate_kv_cache_groups(_config(FullAttentionSpec()))
+
+
+def test_validate_kv_cache_groups_rejects_circular_buffer() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"group 1: CircularBufferSpec .*"
+            r"request-lifetime ring block cannot provide per-chunk snapshots"
+        ),
+    ):
+        validate_kv_cache_groups(_config(FullAttentionSpec(), CircularBufferSpec()))
+
+
+def test_validate_kv_cache_groups_rejects_wrapped_circular_buffer() -> None:
+    wrapped = UniformTypeKVCacheSpecs(
+        kv_cache_specs={
+            "attention": FullAttentionSpec(),
+            "compressor": DerivedCircularBufferSpec(),
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"group 0: CircularBufferSpec"):
+        validate_kv_cache_groups(_config(wrapped))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4966

LMCache currently treats every vLLM cache group as part of its chunk-addressed store and retrieve ranges

Request-scoped scratch groups marked `prefix_cacheable=False` own only one reusable block, so they cannot provide the historical per-chunk snapshots required by LMCache

This change rejects those groups during startup with a clear error instead of allowing serving to continue without STORE metadata

**Special notes for your reviewers**:

Current vLLM marks both `CircularBufferSpec` and `KpoolTailSpec` as non-prefix-cacheable

The validation uses vLLM's public `prefix_cacheable` contract and retains MRO name checks for compatibility with releases that do not expose that property

Dropping a scratch group or repeating its single block for every chunk would produce incomplete or stale restored state, so this change intentionally fails fast

@Kangwenqiao please review the updated compatibility decision and validation path

**Validation**:

- `VLLM_TARGET_DEVICE=cpu pytest -q --confcutdir=tests/v1 tests/v1/test_kv_cache_group_edits.py` with 6 tests passed
- A real vLLM 0.29.0 `CircularBufferSpec` raises the expected startup validation error while `FullAttentionSpec` remains accepted
- The original PR accepted a `prefix_cacheable=False` Kpool-tail spec while the updated branch rejects it
- `VLLM_TARGET_DEVICE=cpu SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files` passed all enabled hooks

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
