### PR TITLE
docs: daily drift check — multi-process mode (2026-09-10)

### DIFF
--- a/docs/design/cli/commands/describe.md
+++ b/docs/design/cli/commands/describe.md
@@ -329,7 +329,8 @@ endpoint is only known in `run_http_server()`. Since `run_http_server()` calls
 ### 3. Blend server
 
 The blend server is not a separate server: `--engine-type blend` composes
-`BlendModule` (`lmcache/v1/multiprocess/modules/blend.py`) into the same
+`BlendModule` (`lmcache/v1/multiprocess/modules/blend/module.py`, part of the
+`lmcache/v1/multiprocess/modules/blend/` package) into the same
 `MPCacheServer`, so the `start_time`, `zmq_endpoint`, and `http_endpoint`
 additions above cover it. `BlendModule.report_status()` only contributes the
 module's own fields.

--- a/docs/design/observability/request-event-span.md
+++ b/docs/design/observability/request-event-span.md
@@ -98,8 +98,8 @@ The `hit_tokens` / `requested_tokens` / `hit_rate` trio also appears on the
 specific to the MP path and are not set on `"cb.request"`.
 
 `CB_LOOKUP_END` carries the hit accounting in its metadata, computed at the
-emit site in `lmcache/v1/multiprocess/modules/blend.py`
-(`BlendModule.cb_unified_lookup`):
+emit site in `lmcache/v1/multiprocess/modules/blend/lookup.py`
+(`BlendModule.cb_unified_lookup`, the `LookupMixin` on `BlendModule`):
 
 | Field | Value |
 |-------|-------|
@@ -246,7 +246,7 @@ root "request"  [═════════════════════
 | `lmcache/v1/mp_observability/subscribers/tracing/mp_server.py` | Root span logic: `_pending_store_count`, `_pending_retrieve_count`, `_deferred_session_end_ts`; handlers `_on_request_start`, `_on_store_submitted`, `_on_retrieve_submitted`, `_on_session_end`; helpers `_get_or_create_request_span`, `_close_request_span` |
 | `lmcache/v1/mp_observability/subscribers/tracing/span_registry.py` | `SpanRegistry`: shared dict of open spans keyed by `(session_id, span_name)` for cross-subscriber parent lookup |
 | `tests/v1/mp_observability/subscribers/tracing/test_mp_server.py` | Tests for all scenarios including retrieve deferral |
-| `lmcache/v1/multiprocess/modules/blend.py` | `prefix_hits` and per-component hit tokens in `CB_LOOKUP_END` metadata |
+| `lmcache/v1/multiprocess/modules/blend/lookup.py` | `prefix_hits` and per-component hit tokens in `CB_LOOKUP_END` metadata (on `BlendModule.cb_unified_lookup`) |
 | `lmcache/v1/mp_observability/subscribers/tracing/cb_server.py` | Stamp `prefix_hits` and hit rates on `"cb.request"` root span from `CB_LOOKUP_END` |
 | `tests/v1/mp_observability/subscribers/tracing/test_cb_server.py` | `prefix_hits` attribute tests |
 

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -8,13 +8,15 @@ cache-event reporting) and **additive** (the local matcher still runs).
 
 Code: `lmcache/v1/mp_coordinator/blend_index.py`,
 `lmcache/v1/mp_coordinator/blend_client.py`,
-`lmcache/v1/multiprocess/modules/blend.py`.
+`lmcache/v1/multiprocess/modules/blend/` (package: `module.py`, `lookup.py`,
+`matcher.py`, `registration.py`, `store.py`, `retrieve.py`, `rope.py`,
+`read_set.py`).
 Index internals: [blend_index.md](blend_index.md).
 
 ## Why
 
 CacheBlend lookup on its own is **local to one mp-server**: the matcher
-(`BlendTokenRangeMatcher`, `modules/blend.py`) indexes only chunks that
+(`BlendTokenRangeMatcher`, `modules/blend/matcher.py`) indexes only chunks that
 server stored, so a request routed to a different replica recomputes KV a
 peer already holds. As replicas scale, cache sharding works against
 reuse. The coordinator federates content fleet-wide so any server can

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -265,7 +265,8 @@ inside `metadata` discriminates ops.
 
 ## Blend Server Lifecycle Sentinels
 
-CPU-synchronous sentinels published by `modules/blend.py` (`BlendModule`) to
+CPU-synchronous sentinels published by `modules/blend/` (`BlendModule`, in
+`modules/blend/module.py`) to
 bracket request scope and guard GPU callback races.  Published via
 `EventBus.publish()` (not `publish_on_stream`).
 

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -113,9 +113,14 @@ and/or ``EngineDrivenTransferModule`` depending on
 registers handlers for every ``RequestType`` exposed by the loaded
 modules, and blocks in a keep-alive loop.
 
-**``modules/blend.py``** -- Defines ``BlendModule``, the paged-aware
+**``modules/blend/``** -- Package that defines ``BlendModule``
+(in ``modules/blend/module.py``), the paged-aware
 blend pipeline that enables non-prefix KV cache reuse (e.g. across
-document paragraphs) on the sparse-prefetch path. KV-cache registration
+document paragraphs) on the sparse-prefetch path. The package is split
+into ``module.py`` (composition + handlers), the mixins ``lookup.py``,
+``registration.py``, ``store.py``, ``retrieve.py``, and the pure helpers
+``matcher.py``, ``rope.py``, ``read_set.py`` (see
+``docs/design/v1/multiprocess/modules/blend.md``). KV-cache registration
 rides the standard ``REGISTER_KV_CACHE``; the module adds only the CB RPCs
 (``CB_REGISTER_ROPE``, ``CB_UNREGISTER_ROPE``,
 ``CB_RETRIEVE_PRE_COMPUTED``, ``CB_UNIFIED_LOOKUP``) and wraps
@@ -571,9 +576,9 @@ Key Source Files
      - Engine module implementations: ``lookup.py`` (``LookupModule``),
        ``management.py`` (``ManagementModule``), ``lmcache_driven_transfer.py``
        (``LMCacheDrivenTransferModule``), ``engine_driven_transfer.py``
-       (``EngineDrivenTransferModule``), and ``blend.py``
-       (``BlendModule``, the paged-aware blend pipeline selected by
-       ``--engine-type blend``).
+       (``EngineDrivenTransferModule``), and the ``blend/`` package
+       (``BlendModule`` in ``blend/module.py``, the paged-aware blend
+       pipeline selected by ``--engine-type blend``).
    * - ``lmcache/v1/multiprocess/http_server.py``
      - FastAPI wrapper with health check and many other useful APIs
    * - ``lmcache/v1/multiprocess/http_api_registry.py``


### PR DESCRIPTION
## Summary

Daily automated drift check between LMCache multi-process documentation and the actual code layout. This pass found stale references to the pre-split `modules/blend.py` file across both `docs/source/` and `docs/design/`.

The blend module was refactored into a `modules/blend/` package in [#5012](https://github.com/LMCache/LMCache/pull/5012) (commit [`2a07cc2`](https://github.com/LMCache/LMCache/commit/2a07cc2e94411355fc86d2ea1215139731406645)). That PR added a new design doc at `docs/design/v1/multiprocess/modules/blend.md` describing the split, but did not update the other docs still referencing the old file path.

### Drift found in `docs/source/` (user-facing, highest priority)

- **`docs/source/mp/index.rst`** — two references to the (removed) `modules/blend.py`:
  - The `**modules/blend.py**` section heading (~line 116) describing `BlendModule`.
  - The "Key Source Files" table entry listing `blend.py` (`BlendModule`) under `lmcache/v1/multiprocess/modules/`.

### Drift found in `docs/design/` (secondary)

- **`docs/design/v1/mp_observability/EVENTS.md`** — the "Blend Server Lifecycle Sentinels" section attributes emissions to `modules/blend.py`.
- **`docs/design/v1/mp_coordinator/blend_lookup.md`** — the "Code:" list and the `BlendTokenRangeMatcher` prose both point at `modules/blend.py`.
- **`docs/design/observability/request-event-span.md`** — both the `CB_LOOKUP_END` emit-site paragraph and the file-table row point at `modules/blend.py`.
- **`docs/design/cli/commands/describe.md`** — the "Blend server" section resolves `BlendModule` to `modules/blend.py`.

## Evidence

Code — the file no longer exists; `BlendModule` now lives in the `blend/` package:

- Package: [`lmcache/v1/multiprocess/modules/blend/`](https://github.com/LMCache/LMCache/tree/c1276856c29905513a536b3c1d71e3504bc4cc3a/lmcache/v1/multiprocess/modules/blend)
- `BlendModule`: [`blend/module.py`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/lmcache/v1/multiprocess/modules/blend/module.py)
- `BlendTokenRangeMatcher`: [`blend/matcher.py`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/lmcache/v1/multiprocess/modules/blend/matcher.py)
- `CB_LOOKUP_END` emit site (`BlendModule.cb_unified_lookup`, the `LookupMixin`): [`blend/lookup.py`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/lmcache/v1/multiprocess/modules/blend/lookup.py)
- New design doc describing the split: [`docs/design/v1/multiprocess/modules/blend.md`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/v1/multiprocess/modules/blend.md)

Stale doc locations (on `dev` at `c127685`):

- [`docs/source/mp/index.rst#L116`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/source/mp/index.rst#L116)
- [`docs/source/mp/index.rst#L574`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/source/mp/index.rst#L574)
- [`docs/design/v1/mp_observability/EVENTS.md#L268`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/v1/mp_observability/EVENTS.md#L268)
- [`docs/design/v1/mp_coordinator/blend_lookup.md#L11`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/v1/mp_coordinator/blend_lookup.md#L11)
- [`docs/design/v1/mp_coordinator/blend_lookup.md#L17`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/v1/mp_coordinator/blend_lookup.md#L17)
- [`docs/design/observability/request-event-span.md#L101`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/observability/request-event-span.md#L101)
- [`docs/design/observability/request-event-span.md#L249`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/observability/request-event-span.md#L249)
- [`docs/design/cli/commands/describe.md#L332`](https://github.com/LMCache/LMCache/blob/c1276856c29905513a536b3c1d71e3504bc4cc3a/docs/design/cli/commands/describe.md#L332)

## Proposed fix (applied in this PR)

Docs-only, one commit:

- `docs/source/mp/index.rst`: rewrite the `**modules/blend.py**` heading + prose block to name the `modules/blend/` package, explicitly locate `BlendModule` in `blend/module.py`, and mention the mixin split (`module`, `lookup`, `registration`, `store`, `retrieve`) and pure helpers (`matcher`, `rope`, `read_set`) so readers can find each symbol. Point at the new design doc. Update the "Key Source Files" table entry accordingly.
- `docs/design/v1/mp_observability/EVENTS.md`: repoint the Blend Sentinels prose at `modules/blend/module.py`.
- `docs/design/v1/mp_coordinator/blend_lookup.md`: expand the `Code:` list to name the package files and point `BlendTokenRangeMatcher` at `modules/blend/matcher.py`.
- `docs/design/observability/request-event-span.md`: repoint the emit-site prose and the file-table row at `modules/blend/lookup.py` (the `LookupMixin` on `BlendModule`).
- `docs/design/cli/commands/describe.md`: repoint the blend-server prose at `modules/blend/module.py` (and the containing `modules/blend/` package).

Note: `docs/source/locale/zh_CN/LC_MESSAGES/mp/index.po` still carries the old wording. Sphinx translation catalogs are usually regenerated from the English source by tooling, so it is left alone here — the translator or the next `sphinx-intl` refresh will pick up the new source.

No code changes.

## Notes

- This PR was **auto-generated by the daily docs drift-check routine** (multi-process mode focus). Human review is required before merge — please spot-check the wording, the linked design doc's title (`docs/design/v1/multiprocess/modules/blend.md`), and that the mixin/pure-helper split I describe matches the intended long-term contract.
- Only doc files are touched; no code is modified.
- No apparent code bug was found — the drift is stale documentation, not a code regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoq7hwbTqFAxnr5rRM2XX

---
_Generated by [Claude Code](https://claude.ai/code/session_011qoq7hwbTqFAxnr5rRM2XX)_