### PR TITLE
[Bugfix][MP] End request sessions after the final STORE completes

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -594,6 +594,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+            self._pending_finished_requests: set[str] = set()
 
             # GPU block pool reference
             self._gpu_block_pool: "BlockPool | None" = None
@@ -1232,6 +1233,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 connectors output.
         """
         if not self.lazy_offload:
+            finished = self._pending_finished_requests.intersection(
+                connector_output.finished_sending or ()
+            )
+            for req_id in finished:
+                self.scheduler_adapter.end_session(req_id)
+                self.scheduler_adapter.cleanup_lookup_result(req_id)
+                self._pending_finished_requests.remove(req_id)
             return
         if not self._gpu_block_pool:
             raise ValueError("Lazy offload is enabled but gpu block pool is not binded")
@@ -1287,7 +1295,16 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # Clean up request tracker to prevent memory leak
         self._cleanup_request_tracker(request.request_id)
 
-        # have not been offloaded, the touch operation in end_session is incorrect
+        # A final STORE can be submitted after generation finishes. Wait for
+        # all workers' finished_sending before ending a successful session.
+        if not self.lazy_offload and request.status in (
+            RequestStatus.FINISHED_STOPPED,
+            RequestStatus.FINISHED_LENGTH_CAPPED,
+        ):
+            self._pending_finished_requests.add(request.request_id)
+            return True, (return_params or None)
+
+        # Preserve lazy offload and abort/error cleanup behavior.
         # Notify LMCache to end the session for this request
         self.scheduler_adapter.end_session(request.request_id)
         # Drop lookup state for a request aborted before its lookup was

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -2123,7 +2123,9 @@ class LMCacheMPWorkerAdapter:
         """Converge the internal states about finished stores
         and returns the 'safe finished store request ids' back
         """
-        safe_finished_s = self.finished_stores.intersection(self.previously_finished)
+        safe_finished_s = self.finished_stores.intersection(
+            self.previously_finished
+        ).difference(self.store_futures)
         self.finished_stores.difference_update(self.previously_finished)
         self.previously_finished.difference_update(safe_finished_s)
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -4,8 +4,9 @@ stubbed (see ``fake_adapter``); no GPU or live server needed. End-to-end
 recovery: ``.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh``."""
 
 # Standard
-from typing import Callable, ClassVar
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from typing import Any, Callable, ClassVar
+from unittest.mock import MagicMock, call
 import gc
 import os
 import threading
@@ -29,6 +30,8 @@ from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.transport.base import RequestClient
 from lmcache.v1.platform.cuda.vmm_ipc import is_use_vmm_api, set_use_vmm_api
 from lmcache.v1.platform.isolated_ipc import is_isolated_ipc, set_isolated_ipc
+
+SchedulerConnectorFactory = Callable[..., tuple[Any, MagicMock]]
 
 
 class FakeCudaEvent:
@@ -1062,3 +1065,196 @@ def test_recovery_reports_the_ring_re_registration_result(fake_adapter, ring_ok)
     adapter.register_kv_caches({"layer.0": fake_tensor})
 
     assert adapter._reregister_kv_caches_callback() is ring_ok
+
+
+@pytest.fixture
+def scheduler_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> SchedulerConnectorFactory:
+    """Construct the scheduler connector with only external boundaries mocked."""
+    module = pytest.importorskip("lmcache.integration.vllm.lmcache_mp_connector")
+    pending_store = MagicMock()
+    monkeypatch.setattr(
+        module, "LazyOffloadPendingStore", MagicMock(return_value=pending_store)
+    )
+    monkeypatch.setattr(
+        module,
+        "build_parallel_strategy_from_vllm_config",
+        lambda *args: ParallelStrategy(False, 1, 0, 1, 1, 1),
+    )
+
+    def make(lazy_offload: bool = False) -> tuple[Any, MagicMock]:
+        extra_config = {"lmcache.mp.lazy_offload": lazy_offload}
+        config = SimpleNamespace(
+            model_config=SimpleNamespace(model="test-model"),
+            cache_config=SimpleNamespace(block_size=16),
+            parallel_config=SimpleNamespace(world_size=1),
+            kv_transfer_config=SimpleNamespace(
+                kv_connector_extra_config=extra_config,
+                get_from_extra_config=extra_config.get,
+            ),
+        )
+        adapter = MagicMock(lmcache_tokens_per_chunk=64)
+        monkeypatch.setattr(
+            module, "LMCacheMPSchedulerAdapter", MagicMock(return_value=adapter)
+        )
+        connector = module.LMCacheMPConnector(config, module.KVConnectorRole.SCHEDULER)
+        return connector, pending_store
+
+    return make
+
+
+@pytest.mark.parametrize(
+    "finish_status", ["FINISHED_STOPPED", "FINISHED_LENGTH_CAPPED"]
+)
+def test_successful_session_waits_for_worker_store_completion(
+    finish_status: str,
+    scheduler_connector: SchedulerConnectorFactory,
+) -> None:
+    """Final STORE retirement, not token generation, permits session removal."""
+    pytest.importorskip("vllm")
+    # Third Party
+    from vllm.v1.request import RequestStatus
+
+    connector, _ = scheduler_connector()
+    request = SimpleNamespace(
+        request_id="late-store", status=getattr(RequestStatus, finish_status)
+    )
+
+    assert connector.request_finished(request, [0]) == (True, None)
+    connector.scheduler_adapter.assert_not_called()
+    assert connector.scheduler_adapter.mock_calls == []
+    connector.update_connector_output(SimpleNamespace(finished_sending=None))
+    assert connector.scheduler_adapter.mock_calls == []
+    connector.update_connector_output(
+        SimpleNamespace(finished_sending={"unrelated", "late-store"})
+    )
+    assert connector.scheduler_adapter.mock_calls == [
+        call.end_session("late-store"),
+        call.cleanup_lookup_result("late-store"),
+    ]
+    connector.update_connector_output(SimpleNamespace(finished_sending={"late-store"}))
+    assert connector.scheduler_adapter.end_session.call_count == 1
+    assert connector.scheduler_adapter.cleanup_lookup_result.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "finish_status", ["FINISHED_ABORTED", "FINISHED_ERROR", "FINISHED_IGNORED"]
+)
+def test_abort_session_cleanup_does_not_wait_for_finished_sending(
+    finish_status: str,
+    scheduler_connector: SchedulerConnectorFactory,
+) -> None:
+    """Aborts that retire only through finished_recving retain existing cleanup."""
+    pytest.importorskip("vllm")
+    # Third Party
+    from vllm.v1.request import RequestStatus
+
+    connector, _ = scheduler_connector()
+    request = SimpleNamespace(
+        request_id="abort-receive", status=getattr(RequestStatus, finish_status)
+    )
+    assert connector.request_finished(request, [0]) == (True, None)
+    assert connector.scheduler_adapter.mock_calls == [
+        call.end_session("abort-receive"),
+        call.cleanup_lookup_result("abort-receive"),
+    ]
+    connector.update_connector_output(
+        SimpleNamespace(finished_sending=None, finished_recving={"abort-receive"})
+    )
+    connector.update_connector_output(
+        SimpleNamespace(finished_sending={"abort-receive"})
+    )
+    assert connector.scheduler_adapter.end_session.call_count == 1
+    assert connector.scheduler_adapter.cleanup_lookup_result.call_count == 1
+
+
+def test_lazy_request_finished_retains_immediate_cleanup(
+    scheduler_connector: SchedulerConnectorFactory,
+) -> None:
+    """The normal-store prerequisite leaves lazy offload ownership unchanged."""
+    pytest.importorskip("vllm")
+    # Third Party
+    from vllm.v1.request import RequestStatus
+
+    connector, pending_store = scheduler_connector(lazy_offload=True)
+    request = SimpleNamespace(
+        request_id="lazy", status=RequestStatus.FINISHED_LENGTH_CAPPED
+    )
+    assert connector.request_finished(request, [0]) == (False, None)
+    assert connector.scheduler_adapter.mock_calls == [
+        call.end_session("lazy"),
+        call.cleanup_lookup_result("lazy"),
+    ]
+    pending_store.mark_req_finished.assert_called_once_with("lazy")
+
+
+def test_older_store_completion_cannot_retire_newer_pending_store(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
+    """An earlier completed chunk must not authorize final-store block release."""
+    adapter, _, _ = fake_adapter
+    first = MagicMock()
+    first.query.return_value = True
+    first.result.return_value = True
+    adapter.store_futures["chunks"] = first
+    assert adapter.get_finished(set()) == (set(), set())
+
+    final = MagicMock()
+    final.query.return_value = False
+    final.result.return_value = True
+    adapter.store_futures["chunks"] = final
+    assert adapter.get_finished({"chunks"}) == (set(), set())
+    assert adapter.get_finished({"chunks"}) == (set(), set())
+    final.result.assert_not_called()
+
+    final.query.return_value = True
+    assert adapter.get_finished(set()) == ({"chunks"}, set())
+    assert adapter.get_finished({"chunks"}) == (set(), set())
+
+
+def test_no_store_request_still_finishes_once(
+    fake_adapter: tuple[LMCacheMPWorkerAdapter, MagicMock, MagicMock],
+) -> None:
+    """APC, miss, and nonwriter requests need no STORE future to retire."""
+    adapter, _, _ = fake_adapter
+    assert adapter.get_finished({"no-store"}) == ({"no-store"}, set())
+    assert adapter.get_finished({"no-store"}) == (set(), set())
+
+
+def test_session_waits_for_all_eight_worker_store_reports(
+    scheduler_connector: SchedulerConnectorFactory,
+) -> None:
+    """Seven worker reports cannot end a successful eight-rank session."""
+    pytest.importorskip("vllm")
+    # Third Party
+    from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
+    from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
+    from vllm.v1.request import RequestStatus
+
+    connector, _ = scheduler_connector()
+    request = SimpleNamespace(
+        request_id="eight-rank", status=RequestStatus.FINISHED_LENGTH_CAPPED
+    )
+    assert connector.request_finished(request, [0]) == (True, None)
+    aggregator = KVOutputAggregator(8)
+    for reporting_ranks in ({0, 1, 2, 3, 4, 5, 6}, {7}):
+        outputs = [
+            ModelRunnerOutput(
+                req_ids=[],
+                req_id_to_index={},
+                kv_connector_output=KVConnectorOutput(
+                    finished_sending={"eight-rank"} if rank in reporting_ranks else None
+                ),
+            )
+            for rank in range(8)
+        ]
+        aggregate = aggregator.aggregate(outputs)
+        assert aggregate is not None
+        connector.update_connector_output(aggregate.kv_connector_output)
+        if len(reporting_ranks) == 7:
+            assert connector.scheduler_adapter.mock_calls == []
+    assert connector.scheduler_adapter.mock_calls == [
+        call.end_session("eight-rank"),
+        call.cleanup_lookup_result("eight-rank"),
+    ]


### PR DESCRIPTION
**What this PR does / why we need it**:

A request can finish generating its answer while LMCache is still saving its KV cache (STORE). 
Today, the connector can delete the server's record for that request, called a session, too early. 
A late STORE then creates that session again, leaving it behind after the request has finished.

Keep the session until the workers report that the final STORE has completed. 
Also prevent an earlier completed STORE from marking the request finished while a newer STORE is still pending; that could let vLLM reuse its GPU blocks too soon.

```text
BEFORE: possible race
  Answer generation finishes
    -> END_SESSION removes the session
    -> Final STORE arrives and recreates it
    -> Session remains after the request is done

AFTER
  Answer generation finishes
    -> Final STORE finishes on each worker
    -> Workers report finished_sending
    -> END_SESSION removes the session
```

The answer can still be returned while the write finishes in the background. 
This uses the existing worker completion reports and vLLM's aggregation across workers.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
