### PR TITLE
[observability]   lookup hit-rate summary in the  server log

### DIFF
--- a/lmcache/v1/mp_observability/subscribers/logging/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/logging/cb_server.py
@@ -5,6 +5,9 @@
 # Future
 from __future__ import annotations
 
+# Standard
+import time
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -15,6 +18,17 @@ logger = init_logger(__name__)
 
 class BlendLoggingSubscriber(EventSubscriber):
     """Logs cache blending (CB) events at debug level."""
+
+    #: Minimum seconds between two hit-rate summary lines.
+    HIT_RATE_LOG_INTERVAL_S = 30.0
+
+    def __init__(self) -> None:
+        # Token-weighted hit-rate accumulators, reset at each summary line.
+        self._requested = 0
+        self._prefix_hit = 0
+        self._non_prefix_hit = 0
+        self._lookups = 0
+        self._next_log = 0.0
 
     def get_subscriptions(self) -> dict[EventType, EventCallback]:
         """Return the mapping of event types to handler callbacks."""
@@ -45,6 +59,29 @@ class BlendLoggingSubscriber(EventSubscriber):
             event.metadata.get("stale_chunks"),
             event.metadata.get("no_gpu_context"),
         )
+        md = event.metadata
+        requested = int(md.get("requested_tokens") or 0)
+        if requested <= 0:
+            return
+        self._requested += requested
+        # Segmented-tail chunks are pure loads, so they count as prefix.
+        self._prefix_hit += int(md.get("prefix_hit_tokens") or 0) + int(
+            md.get("segmented_prefix_hit_tokens") or 0
+        )
+        self._non_prefix_hit += int(md.get("non_prefix_hit_tokens") or 0)
+        self._lookups += 1
+        now = time.monotonic()
+        if now < self._next_log:
+            return
+        self._next_log = now + self.HIT_RATE_LOG_INTERVAL_S
+        logger.info(
+            "lookup hit rate (over %d lookup(s)): prefix=%.1f%% non_prefix=%.1f%%",
+            self._lookups,
+            100.0 * self._prefix_hit / self._requested,
+            100.0 * self._non_prefix_hit / self._requested,
+        )
+        self._requested = self._prefix_hit = self._non_prefix_hit = 0
+        self._lookups = 0
 
     def _on_retrieve_start(self, event: Event) -> None:
         logger.debug(

--- a/lmcache/v1/mp_observability/subscribers/logging/mp_server.py
+++ b/lmcache/v1/mp_observability/subscribers/logging/mp_server.py
@@ -11,6 +11,9 @@ is installed, ``init_logger`` automatically attaches an OTel
 # Future
 from __future__ import annotations
 
+# Standard
+import time
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -21,6 +24,16 @@ logger = init_logger(__name__)
 
 class MPServerLoggingSubscriber(EventSubscriber):
     """Logs MP server store/retrieve/lookup events at debug level."""
+
+    #: Minimum seconds between two hit-rate summary lines.
+    HIT_RATE_LOG_INTERVAL_S = 30.0
+
+    def __init__(self) -> None:
+        # Token-weighted hit-rate accumulators, reset at each summary line.
+        self._requested = 0
+        self._hit = 0
+        self._lookups = 0
+        self._next_log = 0.0
 
     def get_subscriptions(self) -> dict[EventType, EventCallback]:
         return {
@@ -75,6 +88,22 @@ class MPServerLoggingSubscriber(EventSubscriber):
             event.session_id,
             event.metadata.get("found_count"),
         )
+        requested = int(event.metadata.get("requested_tokens") or 0)
+        if requested <= 0:
+            return  # early-exit lookup: nothing was actually looked up
+        self._requested += requested
+        self._hit += int(event.metadata.get("hit_tokens") or 0)
+        self._lookups += 1
+        now = time.monotonic()
+        if now < self._next_log:
+            return
+        self._next_log = now + self.HIT_RATE_LOG_INTERVAL_S
+        logger.info(
+            "lookup hit rate (over %d lookup(s)): prefix=%.1f%%",
+            self._lookups,
+            100.0 * self._hit / self._requested,
+        )
+        self._requested = self._hit = self._lookups = 0
 
     def _on_block_allocation(self, event: Event) -> None:
         records = event.metadata.get("records", [])

--- a/tests/v1/mp_observability/subscribers/logging/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/logging/test_cb_server.py
@@ -147,3 +147,35 @@ class TestBlendLoggingSubscriber:
             )
         time.sleep(0.15)
         bus.stop()
+
+
+class TestLookupHitRateSummary:
+    """CB_LOOKUP_END feeds a throttled prefix + non-prefix summary."""
+
+    def _end(self, requested, prefix, seg_tail, non_prefix):
+        return Event(
+            event_type=EventType.CB_LOOKUP_END,
+            session_id="req-1",
+            metadata={
+                "requested_tokens": requested,
+                "prefix_hit_tokens": prefix,
+                "segmented_prefix_hit_tokens": seg_tail,
+                "non_prefix_hit_tokens": non_prefix,
+            },
+        )
+
+    def test_both_planes_with_segmented_tail_as_prefix(self, subscriber, caplog):
+        with caplog.at_level("INFO"):
+            subscriber._on_lookup_end(self._end(1024, 512, 256, 256))
+        assert (
+            "lookup hit rate (over 1 lookup(s)): prefix=75.0% non_prefix=25.0%"
+            in caplog.text
+        )
+
+    def test_miss_counts_zero(self, subscriber, caplog):
+        with caplog.at_level("INFO"):
+            subscriber._on_lookup_end(self._end(512, 0, 0, 0))
+        assert (
+            "lookup hit rate (over 1 lookup(s)): prefix=0.0% non_prefix=0.0%"
+            in caplog.text
+        )

--- a/tests/v1/mp_observability/subscribers/logging/test_mp_server.py
+++ b/tests/v1/mp_observability/subscribers/logging/test_mp_server.py
@@ -129,3 +129,38 @@ class TestMPServerLoggingSubscriber:
             )
         time.sleep(0.15)
         bus.stop()
+
+
+class TestLookupHitRateSummary:
+    """MP_LOOKUP_PREFETCH_END feeds a throttled token-weighted summary that
+    resets at each line (rate over the lookups since the previous line)."""
+
+    def _end(self, requested, hit):
+        return Event(
+            event_type=EventType.MP_LOOKUP_PREFETCH_END,
+            session_id="req-1",
+            metadata={"requested_tokens": requested, "hit_tokens": hit},
+        )
+
+    def test_first_lookup_logs_and_resets(self, subscriber, caplog):
+        with caplog.at_level("INFO"):
+            subscriber._on_lookup_prefetch_end(self._end(1024, 768))
+        assert "lookup hit rate (over 1 lookup(s)): prefix=75.0%" in caplog.text
+        assert subscriber._requested == 0
+
+    def test_throttled_then_token_weighted_aggregate(self, subscriber, caplog):
+        subscriber._on_lookup_prefetch_end(self._end(1024, 768))  # logs + resets
+        caplog.clear()
+        with caplog.at_level("INFO"):
+            subscriber._on_lookup_prefetch_end(self._end(100, 0))
+            subscriber._on_lookup_prefetch_end(self._end(100, 100))
+            assert "hit rate" not in caplog.text  # within the interval
+            subscriber._next_log = 0.0
+            subscriber._on_lookup_prefetch_end(self._end(200, 100))
+        assert "lookup hit rate (over 3 lookup(s)): prefix=50.0%" in caplog.text
+
+    def test_early_exit_is_not_counted(self, subscriber, caplog):
+        with caplog.at_level("INFO"):
+            subscriber._on_lookup_prefetch_end(self._end(0, 0))
+        assert "hit rate" not in caplog.text
+        assert subscriber._lookups == 0


### PR DESCRIPTION
## What

A token-weighted hit-rate summary in the MP server log, at most one line every 30 s, covering the lookups since the previous line. **No new class or module** — the state is four integer accumulators on each existing logging subscriber, reset at each summary, fed by the same `MP_LOOKUP_PREFETCH_END` / `CB_LOOKUP_END` events that already drive the OTel hit-rate counters (`lmcache_mp.lookup_*`, `lmcache_blend.lookup_*_tokens`) for Grafana. Lookup hot paths untouched; both subscribers are registered by default (`logging_enabled: True`).

- **`MPServerLoggingSubscriber`** (standard engine):
  ```
  lookup hit rate (over N lookup(s)): prefix=X%
  ```
  Early-exit lookups (`requested_tokens == 0`) are not counted.
- **`BlendLoggingSubscriber`** (blend engine):
  ```
  lookup hit rate (over N lookup(s)): prefix=X% non_prefix=Y%
  ```
  Prefix = prefix coverage + segmented tail (both pure-load); non-prefix = unique token coverage of the retrievable matches. The non-prefix plane exists only on the blend subscriber — an engine emits one of the two lines, per its engine type.

Rates are `sum(hit)/sum(requested)`, so long prompts weigh proportionally more than short ones. The 30 s check is log cadence only — the math is token-based.

## Verified (e2e, gpt-oss-20b dummy-load, long-doc-permutator 50×41k tokens)

Two live stacks side by side — blend server + CBKVConnector vLLM on one GPU, standard MP server + LMCacheMPConnector vLLM on another, same permutation traffic:

- Blend server log: `prefix=0.0% non_prefix=0.0%` cold, then `(over 19 lookup(s)): prefix=2.1% non_prefix=52.7%` as the permutations blend.
- Standard server log: `prefix=0.7% → 1.5% → 2.4%` (permuted docs are invisible to prefix matching; only same-first-doc collisions hit) and no `non_prefix` field, as expected.
- Tests in `tests/v1/mp_observability/subscribers/logging/` (existing files): token weighting, throttle + reset-at-summary, early-exit skip, both event wirings.
- Full `tests/v1/mp_observability/` + `tests/v1/multiprocess/` suites pass; all pre-commit hooks pass.

## Notes for review

- Diff is 4 files, +133/−0, all under `mp_observability/subscribers/logging/`.
- Based on `blend-major-refactor` (#5012) but touches none of its files; can retarget to `dev` directly if preferred.