### PR TITLE
refactor(mp): encapsulate transfer context unregistration

### DIFF
--- a/lmcache/integration/atom/multi_process_adapter.py
+++ b/lmcache/integration/atom/multi_process_adapter.py
@@ -443,7 +443,6 @@ class AtomMPWorkerAdapter:
             future = context.submit_store(
                 request_id,
                 self._create_key(request_id, spec),
-                self.instance_id,
                 kv_caches,
                 block_ids,
                 event,
@@ -483,7 +482,6 @@ class AtomMPWorkerAdapter:
             future = context.submit_retrieve(
                 request_id,
                 self._create_key(request_id, spec),
-                self.instance_id,
                 kv_caches,
                 block_ids,
                 event,
@@ -538,9 +536,9 @@ class AtomMPWorkerAdapter:
 
             if registered and transfer_context is not None:
                 try:
-                    self._client.unregister_kv_cache(self.instance_id).result(
-                        timeout=self._mq_timeout
-                    )
+                    future = transfer_context.unregister()
+                    if future is not None:
+                        future.result(timeout=self._mq_timeout)
                 except Exception:
                     logger.warning(
                         "ATOM LMCache unregister failed during shutdown",
@@ -578,15 +576,15 @@ class AtomMPWorkerAdapter:
         try:
             transfer_context = create_transfer_context(
                 kv_caches,
+                instance_id=self.instance_id,
+                req_client=self._client,
                 mode=self._transfer_mode,
             )
             transfer_context.register(
-                self.instance_id,
                 kv_caches,
                 self._model_name,
                 self._parallel.world_size,
                 self.blocks_in_chunk,
-                self._client,
                 self._mq_timeout,
                 layout_hints={},
                 engine_group_infos=engine_group_infos,
@@ -653,9 +651,9 @@ class AtomMPWorkerAdapter:
         # late server registration and never publish its local context.
         try:
             try:
-                self._client.unregister_kv_cache(self.instance_id).result(
-                    timeout=self._mq_timeout
-                )
+                future = transfer_context.unregister()
+                if future is not None:
+                    future.result(timeout=self._mq_timeout)
             except Exception:
                 logger.warning(
                     "Failed to remove late ATOM LMCache registration",
@@ -777,9 +775,9 @@ class AtomMPWorkerAdapter:
     ) -> None:
         """Best-effort removal of an ambiguously registered candidate."""
         try:
-            self._client.unregister_kv_cache(self.instance_id).result(
-                timeout=self._mq_timeout
-            )
+            future = transfer_context.unregister()
+            if future is not None:
+                future.result(timeout=self._mq_timeout)
         except Exception:
             logger.warning(
                 "Failed to roll back rejected ATOM LMCache registration",

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -32,7 +32,6 @@ from lmcache.v1.multiprocess.group_view import (
 )
 from lmcache.v1.multiprocess.mq import MessagingFuture
 from lmcache.v1.multiprocess.transfer_context import (
-    EngineDrivenTransferContext,
     TransferContext,
     create_transfer_context,
 )
@@ -1425,7 +1424,12 @@ class LMCacheMPWorkerAdapter:
                 mq_timeout.
         """
         self.kv_caches = kv_caches
-        transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
+        transfer_ctx = create_transfer_context(
+            kv_caches,
+            instance_id=self.instance_id,
+            req_client=self.req_client,
+            mode=self._mp_transfer_mode,
+        )
         layout_hints = self._layout_hints
         self.transfer_ctx = transfer_ctx
         try:
@@ -1433,12 +1437,10 @@ class LMCacheMPWorkerAdapter:
             # shutdown() may null self.transfer_ctx between publish and this
             # call. The local is always non-None.
             transfer_ctx.register(
-                self.instance_id,
                 kv_caches,
                 self.model_name,
                 self.world_size,
                 self.blocks_in_chunk,
-                self.req_client,
                 self._mq_timeout,
                 layout_hints=layout_hints,
                 engine_group_infos=self.engine_group_infos,
@@ -1599,7 +1601,6 @@ class LMCacheMPWorkerAdapter:
         future = self.transfer_ctx.submit_store(
             request_id,
             key,
-            self.instance_id,
             self.kv_caches,
             self._block_ids_per_group(op),
             event,
@@ -1658,7 +1659,6 @@ class LMCacheMPWorkerAdapter:
         future = self.transfer_ctx.submit_retrieve(
             request_id,
             key,
-            self.instance_id,
             self.kv_caches,
             self._block_ids_per_group(op),
             event,
@@ -2091,21 +2091,18 @@ class LMCacheMPWorkerAdapter:
             if self._heartbeat is not None:
                 self._heartbeat.stop()
 
-        logger.info("Unregistering kv caches")
-        try:
-            if isinstance(self.transfer_ctx, EngineDrivenTransferContext):
-                future = self.req_client.unregister_kv_cache_engine_driven_context(
-                    self.instance_id
+        if self.transfer_ctx is not None:
+            logger.info("Unregistering kv caches")
+            try:
+                future = self.transfer_ctx.unregister()
+                if future is not None:
+                    future.result(timeout=self._mq_timeout)
+            except TimeoutError:
+                logger.warning(
+                    "LMCache server did not respond to unregister within %ss. "
+                    "Proceeding with shutdown.",
+                    self._mq_timeout,
                 )
-            else:
-                future = self.req_client.unregister_kv_cache(self.instance_id)
-            future.result(timeout=self._mq_timeout)
-        except TimeoutError:
-            logger.warning(
-                "LMCache server did not respond to unregister within %ss. "
-                "Proceeding with shutdown.",
-                self._mq_timeout,
-            )
 
         if self.dispatcher is not None:
             dispatch(self.dispatcher, "shutdown")

--- a/lmcache/sdk/context.py
+++ b/lmcache/sdk/context.py
@@ -223,7 +223,11 @@ class LMCacheSDKContext:
                 for i in range(num_layers)
             }
 
-        transfer_ctx = create_transfer_context(self._kv_caches)
+        transfer_ctx = create_transfer_context(
+            self._kv_caches,
+            instance_id=self.instance_id,
+            req_client=self._req_client,
+        )
         self.blocks_in_chunk = self._chunk_size // block_size
         layout_hints = LayoutHints(
             kv_layout="HND",
@@ -233,12 +237,10 @@ class LMCacheSDKContext:
         )
 
         transfer_ctx.register(
-            self.instance_id,
             self._kv_caches,
             self._model_name,
             self._world_size,
             self.blocks_in_chunk,
-            self._req_client,
             self._mq_timeout,
             layout_hints=layout_hints,
         )

--- a/lmcache/sdk/qringbuffer.py
+++ b/lmcache/sdk/qringbuffer.py
@@ -625,12 +625,10 @@ class QRingBufferAdapter:
             raise RuntimeError("Q ring is not initialized yet.")
         try:
             self._adapter.transfer_ctx.register_q(
-                self._adapter.instance_id,
                 self.q_ring.tensors,
                 self.q_model_name,
                 self._adapter.world_size,
                 self._adapter.blocks_in_chunk,
-                self._adapter.req_client,
                 self._adapter._mq_timeout,
                 layout_hints=vllm_layout_hints(),
                 engine_group_infos=self.q_engine_group_infos,
@@ -710,7 +708,6 @@ class QRingBufferAdapter:
         future = self._adapter.transfer_ctx.submit_q_store(
             request_id,
             key,
-            self._adapter.instance_id,
             self.q_ring.tensors,
             [ring_block_ids],
             event,

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -19,6 +19,7 @@ from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     IPCEvent,
     _single_group_block_ids,
 )
+from lmcache.v1.multiprocess.transport.base import RequestClient
 
 logger = init_logger(__name__)
 
@@ -66,16 +67,20 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
 
     def __init__(
         self,
+        instance_id: int,
+        req_client: RequestClient,
         commit_workers: int = DEFAULT_ENGINE_DRIVEN_COMMIT_WORKERS,
     ) -> None:
         """Initialize the async context and create its async resources.
 
         Args:
+            instance_id: Worker process instance identifier.
+            req_client: Transport client for this worker.
             commit_workers: Number of background threads used to run commit
                 (CPU->server) work. >1 so a slow gather for one store does not
                 block the commit of another whose gather is already done.
         """
-        super().__init__()
+        super().__init__(instance_id, req_client)
         self._commit_workers = max(1, int(commit_workers))
         self._copy_stream: Any = torch_dev.Stream()
         self._commit_executor: ThreadPoolExecutor = ThreadPoolExecutor(
@@ -174,7 +179,6 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
         self,
         _request_id: str,
         key: Any,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         _event: IPCEvent | None,
@@ -191,7 +195,6 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
         Args:
             _request_id: External request identifier (used for logging).
             key: LMCache key object for the store range.
-            instance_id: Worker process instance identifier.
             kv_caches: Worker KV cache tensors keyed by layer name.
             block_ids: vLLM block IDs to store, indexed by LMCache KV group id.
             _event: Synchronization event; ``wait()`` is called in background.
@@ -240,7 +243,7 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                     # --- Phase 1: prepare_store ---
                     # In pickle mode this is the costliest step (sync RPC
                     # round-trip).  Running it here keeps the forward thread free.
-                    result = engine_driven_context.prepare_store(key, instance_id)
+                    result = engine_driven_context.prepare_store(key, self._instance_id)
                     out_buffers, chunk_indices = (
                         result if result is not None else (None, None)
                     )
@@ -308,7 +311,7 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                     # --- Phase 3: commit ---
                     with self._commit_lock:
                         ok = engine_driven_context.commit_store(
-                            key, instance_id, gather_target
+                            key, self._instance_id, gather_target
                         )
 
                     if not ok:

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -5,8 +5,9 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
-from typing import Any, Protocol, cast
+from typing import Any, Callable, Protocol, cast
 import os
+import threading
 
 # Third Party
 import torch
@@ -83,7 +84,10 @@ def _supports_async_primitives() -> bool:
     return True
 
 
-def _build_engine_driven_context() -> "TransferContext":
+def _build_engine_driven_context(
+    instance_id: int,
+    req_client: RequestClient,
+) -> "TransferContext":
     """Build the engine-driven context, async when device-capable else sync.
 
     Routes the ``ENGINE_DRIVEN`` and AUTO branches through a single capability
@@ -102,10 +106,10 @@ def _build_engine_driven_context() -> "TransferContext":
         )
 
         logger.info("Using AsyncEngineDrivenTransferContext for store path")
-        return AsyncEngineDrivenTransferContext()
+        return AsyncEngineDrivenTransferContext(instance_id, req_client)
 
     logger.info("Using EngineDrivenTransferContext (sync) for store path")
-    return EngineDrivenTransferContext()
+    return EngineDrivenTransferContext(instance_id, req_client)
 
 
 class MPTransferMode(str, Enum):
@@ -143,7 +147,11 @@ def _resolve_mode(mode: "str | MPTransferMode | None") -> MPTransferMode:
         ) from exc
 
 
-def _build_lmcache_driven_context(device_type: str) -> "TransferContext":
+def _build_lmcache_driven_context(
+    device_type: str,
+    instance_id: int,
+    req_client: RequestClient,
+) -> "TransferContext":
     """Build a :class:`LMCacheDrivenTransferContext` after capability check."""
     try:
         resolve_kv_wrapper_factory(device_type)
@@ -160,7 +168,7 @@ def _build_lmcache_driven_context(device_type: str) -> "TransferContext":
             "%r: required platform capability checks failed. "
             "Use mode 'engine_driven' or 'auto' instead." % device_type
         )
-    return LMCacheDrivenTransferContext()
+    return LMCacheDrivenTransferContext(instance_id, req_client)
 
 
 class IPCEvent(Protocol):
@@ -205,15 +213,62 @@ class TransferContext(ABC):
     gather/scatter synchronously and return already-resolved futures.
     """
 
+    def __init__(self, instance_id: int, req_client: RequestClient) -> None:
+        """Bind this context to a single worker and request client.
+
+        Args:
+            instance_id: Worker process instance identifier used by all
+                context-owned transport requests.
+            req_client: Transport-neutral client used by this context. The
+                adapter retains ownership and closes it after the context.
+        """
+        self._instance_id = instance_id
+        self._req_client = req_client
+        self._registration_request_sent = False
+        self._closed = False
+        self._lifecycle_lock = threading.Lock()
+
+    def _submit_registration(
+        self, submit: Callable[[], MessagingFuture[Any]]
+    ) -> MessagingFuture[Any]:
+        """Submit REGISTER before allowing a concurrent UNREGISTER.
+
+        If shutdown won the race before the request was sent, registration is
+        rejected. Once submission begins, unregistration remains available even
+        if waiting for the registration response times out.
+        """
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("Transfer context is closed.")
+            self._registration_request_sent = True
+            return submit()
+
+    def _submit_unregistration(
+        self, submit: Callable[[], MessagingFuture[Any]]
+    ) -> MessagingFuture[Any] | None:
+        """Submit UNREGISTER only after this context sent REGISTER."""
+        with self._lifecycle_lock:
+            if not self._registration_request_sent:
+                return None
+            return submit()
+
+    def _is_closed(self) -> bool:
+        """Return whether adapter shutdown closed this context."""
+        with self._lifecycle_lock:
+            return self._closed
+
+    def _mark_closed(self) -> None:
+        """Prevent future registration requests from a racing caller."""
+        with self._lifecycle_lock:
+            self._closed = True
+
     @abstractmethod
     def register(
         self,
-        instance_id: int,
         _kv_caches: dict[str, torch.Tensor],
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -222,12 +277,10 @@ class TransferContext(ABC):
         """Register KV caches with the server and wait for ACK.
 
         Args:
-            instance_id: Worker process instance identifier.
             kv_caches: Worker KV cache tensors keyed by layer name.
             model_name: Model name used by cache keys.
             world_size: KV world size.
             blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
-            req_client: Transport-neutral client used for server requests.
             mq_timeout: Timeout in seconds for synchronous request wait.
             layout_hints: Optional inference-engine-provided layout hints.
             engine_group_infos: LMCache-owned engine KV cache group metadata.
@@ -243,28 +296,39 @@ class TransferContext(ABC):
             RuntimeError: If a concrete context cannot initialize.
         """
 
+    @abstractmethod
+    def unregister(self) -> MessagingFuture[Any] | None:
+        """Start unregistering this context's server-side KV-cache state.
+
+        Concrete contexts select the unregister RPC that matches the protocol
+        used by :meth:`register`. The returned future lets the caller apply
+        its own lifecycle timeout policy before :meth:`close` releases local
+        state.
+
+        Returns:
+            A future that resolves when the server acknowledges unregistration,
+            or ``None`` when no registration request was sent.
+
+        """
+
     def register_q(
         self,
-        instance_id: int,
         q_caches: dict[str, torch.Tensor],
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
         """Register the paged Q ring with the server under the same worker
-        instance_id but different model_name (model_name##query).
+        instance ID but different model_name (model_name##query).
 
         Args:
-            instance_id: Worker process instance identifier.
             q_caches: Worker Q cache tensors keyed by layer name.
             model_name: Model name used by cache keys (model_name##query).
             world_size: KV world size.
             blocks_in_chunk: Number of Q ring blocks per LMCache chunk.
-            req_client: Transport-neutral client used for server requests.
             mq_timeout: Timeout in seconds for synchronous request wait.
             layout_hints: Optional inference-engine-provided layout hints.
             engine_group_infos: LMCache-owned engine KV cache group metadata.
@@ -298,7 +362,6 @@ class TransferContext(ABC):
         self,
         request_id: str,
         key: Any,
-        instance_id: int,
         q_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent,
@@ -309,7 +372,6 @@ class TransferContext(ABC):
         Args:
             request_id: External request identifier.
             key: LMCache key for the Q store range (query-specific model_name).
-            instance_id: Worker process instance identifier (shared with KV).
             q_caches: Q ring tensors keyed by layer name.
             block_ids: Q ring block IDs to store, indexed by LMCache KV group id.
             event: Synchronization event object.
@@ -332,7 +394,6 @@ class TransferContext(ABC):
         self,
         request_id: str,
         key: Any,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent | None,
@@ -343,7 +404,6 @@ class TransferContext(ABC):
         Args:
             request_id: External request identifier.
             key: LMCache key object for the store range.
-            instance_id: Worker process instance identifier.
             kv_caches: Worker KV cache tensors keyed by layer name.
             block_ids: vLLM block IDs to store, indexed by LMCache KV group id.
             event: Synchronization event object, or ``None`` when the concrete
@@ -362,7 +422,6 @@ class TransferContext(ABC):
         self,
         request_id: str,
         key: Any,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent | None,
@@ -374,7 +433,6 @@ class TransferContext(ABC):
         Args:
             request_id: External request identifier.
             key: LMCache key object for the retrieve range.
-            instance_id: Worker process instance identifier.
             kv_caches: Worker KV cache tensors keyed by layer name.
             block_ids: vLLM block IDs to retrieve into, indexed by LMCache KV
                 group id.
@@ -414,19 +472,23 @@ class LMCacheDrivenTransferContext(TransferContext):
     performs direct device-side data transfer.
     """
 
-    def __init__(self) -> None:
-        self._req_client: RequestClient | None = None
+    def __init__(self, instance_id: int, req_client: RequestClient) -> None:
+        """Initialize a handle-path context bound to one worker.
+
+        Args:
+            instance_id: Worker process instance identifier.
+            req_client: Transport client for this worker.
+        """
+        super().__init__(instance_id, req_client)
         self._device: torch.device | None = None
         self._event_backend: EventIPCBackend | None = None
 
     def register(
         self,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         model_name: str,
         world_size: int,
         _blocks_in_chunk: int,
-        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -435,12 +497,10 @@ class LMCacheDrivenTransferContext(TransferContext):
         """Register the worker KV cache with the LMCache server.
 
         Args:
-            instance_id: Worker process instance identifier.
             kv_caches: Worker KV-cache tensors keyed by layer name.
             model_name: Model identifier used by the server.
             world_size: Tensor-parallel world size.
             _blocks_in_chunk: Engine blocks per LMCache chunk.
-            req_client: Transport-neutral client used for server requests.
             mq_timeout: Timeout for the registration response.
             layout_hints: Optional KV-layout metadata.
             engine_group_infos: Optional engine KV-group metadata.
@@ -454,17 +514,20 @@ class LMCacheDrivenTransferContext(TransferContext):
         event_backend = get_event_ipc_backend(device)
         event_backend.check_event_support(device)
 
-        self._req_client = req_client
-        future = req_client.register_kv_cache(
-            instance_id,
-            wrap_kv_caches(kv_caches),
-            model_name,
-            world_size,
-            engine_type,
-            layout_hints,
-            list(engine_group_infos),
+        future = self._submit_registration(
+            lambda: self._req_client.register_kv_cache(
+                self._instance_id,
+                wrap_kv_caches(kv_caches),
+                model_name,
+                world_size,
+                engine_type,
+                layout_hints,
+                list(engine_group_infos),
+            )
         )
         future.result(timeout=mq_timeout)
+        if self._is_closed():
+            return
         self._device = device
         self._event_backend = event_backend
 
@@ -486,21 +549,29 @@ class LMCacheDrivenTransferContext(TransferContext):
         self._event_backend.record_event(event, torch_dev.current_stream())
         return cast(IPCEvent, event)
 
+    def unregister(self) -> MessagingFuture[Any] | None:
+        """Start handle-path unregistration for this worker instance.
+
+        Returns:
+            A future for the server's unregister acknowledgement.
+
+        """
+        return self._submit_unregistration(
+            lambda: self._req_client.unregister_kv_cache(self._instance_id)
+        )
+
     def register_q(
         self,
-        instance_id: int,
         q_caches: dict[str, torch.Tensor],
         model_name: str,
         world_size: int,
         _blocks_in_chunk: int,
-        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
-        self._req_client = req_client
-        future = req_client.register_q_cache(
-            instance_id,
+        future = self._req_client.register_q_cache(
+            self._instance_id,
             wrap_kv_caches(q_caches),
             model_name,
             world_size,
@@ -514,7 +585,6 @@ class LMCacheDrivenTransferContext(TransferContext):
         self,
         _request_id: str,
         key: Any,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent | None,
@@ -525,7 +595,6 @@ class LMCacheDrivenTransferContext(TransferContext):
         Args:
             _request_id: External request identifier (unused by this transport).
             key: LMCache key for the store range.
-            instance_id: Worker process instance identifier.
             _kv_caches: Worker KV-cache tensors accepted for interface
                 consistency; the registered device is reused.
             block_ids: Engine block IDs indexed by LMCache KV group.
@@ -539,11 +608,7 @@ class LMCacheDrivenTransferContext(TransferContext):
             RuntimeError: If the context is not registered or event IPC is
                 unsupported.
         """
-        if (
-            self._req_client is None
-            or self._device is None
-            or self._event_backend is None
-        ):
+        if self._device is None or self._event_backend is None:
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_store()."
@@ -552,7 +617,7 @@ class LMCacheDrivenTransferContext(TransferContext):
             raise RuntimeError("LMCache-driven transfer requires an IPC event.")
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._req_client.store(
-            key, instance_id, block_ids, event_ipc_handle
+            key, self._instance_id, block_ids, event_ipc_handle
         ).to_device_future(
             device=self._device,
             event_backend=self._event_backend,
@@ -562,24 +627,19 @@ class LMCacheDrivenTransferContext(TransferContext):
         self,
         _request_id: str,
         key: Any,
-        instance_id: int,
         _q_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent,
         _blocks_in_chunk: int,
     ) -> MessagingFuture:
-        if (
-            self._req_client is None
-            or self._device is None
-            or self._event_backend is None
-        ):
+        if self._device is None or self._event_backend is None:
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_q_store()."
             )
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._req_client.store_q(
-            key, instance_id, block_ids, event_ipc_handle
+            key, self._instance_id, block_ids, event_ipc_handle
         ).to_device_future(
             device=self._device,
             event_backend=self._event_backend,
@@ -589,7 +649,6 @@ class LMCacheDrivenTransferContext(TransferContext):
         self,
         _request_id: str,
         key: Any,
-        instance_id: int,
         _kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent | None,
@@ -601,7 +660,6 @@ class LMCacheDrivenTransferContext(TransferContext):
         Args:
             _request_id: External request identifier (unused by this transport).
             key: LMCache key for the retrieve range.
-            instance_id: Worker process instance identifier.
             _kv_caches: Worker KV-cache tensors accepted for interface
                 consistency; the registered device is reused.
             block_ids: Engine block IDs indexed by LMCache KV group.
@@ -616,11 +674,7 @@ class LMCacheDrivenTransferContext(TransferContext):
             RuntimeError: If the context is not registered or event IPC is
                 unsupported.
         """
-        if (
-            self._req_client is None
-            or self._device is None
-            or self._event_backend is None
-        ):
+        if self._device is None or self._event_backend is None:
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_retrieve()."
@@ -630,7 +684,7 @@ class LMCacheDrivenTransferContext(TransferContext):
         event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._req_client.retrieve(
             key,
-            instance_id,
+            self._instance_id,
             block_ids,
             event_ipc_handle,
             skip_first_n_tokens,
@@ -641,7 +695,7 @@ class LMCacheDrivenTransferContext(TransferContext):
 
     def close(self) -> None:
         """Release the message queue and cached event-backend state."""
-        self._req_client = None
+        self._mark_closed()
         self._device = None
         self._event_backend = None
 
@@ -657,7 +711,14 @@ class EngineDrivenTransferContext(TransferContext):
     message-queue, and the server side persists/rehydrates from storage.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, instance_id: int, req_client: RequestClient) -> None:
+        """Initialize an engine-driven context bound to one worker.
+
+        Args:
+            instance_id: Worker process instance identifier.
+            req_client: Transport client for this worker.
+        """
+        super().__init__(instance_id, req_client)
         self._engine_driven_context: EngineDrivenContext | None = None
         self._layout_hints: LayoutHints | None = None
         self._engine_kv_format: Any = None
@@ -677,12 +738,10 @@ class EngineDrivenTransferContext(TransferContext):
 
     def register(
         self,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
-        req_client: RequestClient,
         mq_timeout: float,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -724,20 +783,24 @@ class EngineDrivenTransferContext(TransferContext):
         dtype = getattr(torch, dtype_str)
         layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
 
-        future = req_client.register_kv_cache_engine_driven_context(
-            RegisterEngineDrivenContextPayload(
-                instance_id=instance_id,
-                model_name=model_name,
-                world_size=world_size,
-                block_size=block_size,
-                num_layers=num_layers,
-                hidden_dim_size=hidden_dim_size,
-                dtype_str=dtype_str,
-                use_mla=use_mla_flag,
-                num_physical_slots=blocks_in_chunk * block_size,
+        future = self._submit_registration(
+            lambda: self._req_client.register_kv_cache_engine_driven_context(
+                RegisterEngineDrivenContextPayload(
+                    instance_id=self._instance_id,
+                    model_name=model_name,
+                    world_size=world_size,
+                    block_size=block_size,
+                    num_layers=num_layers,
+                    hidden_dim_size=hidden_dim_size,
+                    dtype_str=dtype_str,
+                    use_mla=use_mla_flag,
+                    num_physical_slots=blocks_in_chunk * block_size,
+                )
             )
         )
         response = future.result(timeout=mq_timeout)
+        if self._is_closed():
+            return
         shm_name = ""
         pool_size = 0
         if isinstance(response, RegisterEngineDrivenContextResponse):
@@ -751,7 +814,7 @@ class EngineDrivenTransferContext(TransferContext):
         )
         self._engine_driven_context = create_engine_driven_context(
             metadata,
-            req_client,
+            self._req_client,
             mq_timeout,
             shm_name=shm_name,
             pool_size=pool_size,
@@ -759,8 +822,21 @@ class EngineDrivenTransferContext(TransferContext):
         supported_transfer_mode = "SHM" if shm_name and pool_size > 0 else "pickle"
         logger.info(
             "Worker non-GPU transfer context registered (instance_id=%d, mode=%s)",
-            instance_id,
+            self._instance_id,
             supported_transfer_mode,
+        )
+
+    def unregister(self) -> MessagingFuture[Any] | None:
+        """Start engine-driven unregistration for this worker instance.
+
+        Returns:
+            A future for the server's unregister acknowledgement.
+
+        """
+        return self._submit_unregistration(
+            lambda: self._req_client.unregister_kv_cache_engine_driven_context(
+                self._instance_id
+            )
         )
 
     def create_recorded_event(self) -> IPCEvent | None:
@@ -784,7 +860,6 @@ class EngineDrivenTransferContext(TransferContext):
         self,
         _request_id: str,
         key: Any,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         _event: IPCEvent | None,
@@ -797,7 +872,7 @@ class EngineDrivenTransferContext(TransferContext):
             )
 
         torch_dev.synchronize()
-        result = self._engine_driven_context.prepare_store(key, instance_id)
+        result = self._engine_driven_context.prepare_store(key, self._instance_id)
         out_buffers, chunk_indices = result if result is not None else (None, None)
         # All chunks already in cache — nothing to gather or commit.
         if chunk_indices is not None and len(chunk_indices) == 0:
@@ -819,7 +894,9 @@ class EngineDrivenTransferContext(TransferContext):
         # complete first, so this is unconditional -- guarding it on out_buffers
         # left the pickle path serializing a buffer still being written.
         torch_dev.synchronize()
-        ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
+        ok = self._engine_driven_context.commit_store(
+            key, self._instance_id, cpu_chunks
+        )
 
         future = MessagingFuture()
         future.set_result(ok)
@@ -829,7 +906,6 @@ class EngineDrivenTransferContext(TransferContext):
         self,
         _request_id: str,
         key: Any,
-        instance_id: int,
         kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         _event: IPCEvent | None,
@@ -842,7 +918,9 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
-        src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
+        src_buffers = self._engine_driven_context.prepare_retrieve(
+            key, self._instance_id
+        )
         ok = src_buffers is not None
         if src_buffers is not None:
             try:
@@ -861,13 +939,14 @@ class EngineDrivenTransferContext(TransferContext):
             # SHM path: ensure all device writes are complete before releasing
             # the SHM slot (server may immediately reuse it after commit_retrieve).
             torch_dev.synchronize()
-        self._engine_driven_context.commit_retrieve(key, instance_id)
+        self._engine_driven_context.commit_retrieve(key, self._instance_id)
 
         future: MessagingFuture[bool] = MessagingFuture()
         future.set_result(ok)
         return future
 
     def close(self) -> None:
+        self._mark_closed()
         if self._engine_driven_context is not None:
             self._engine_driven_context.close()
             self._engine_driven_context = None
@@ -878,6 +957,9 @@ class EngineDrivenTransferContext(TransferContext):
 
 def create_transfer_context(
     kv_caches: dict[str, torch.Tensor],
+    *,
+    instance_id: int,
+    req_client: RequestClient,
     mode: "str | MPTransferMode | None" = None,
     **_kwargs: Any,
 ) -> TransferContext:
@@ -889,6 +971,9 @@ def create_transfer_context(
 
     Args:
         kv_caches: Worker KV cache tensors keyed by layer name.
+        instance_id: Worker process instance identifier bound to the context.
+        req_client: Transport client bound to the context. The caller retains
+            ownership and must close it after the context.
         mode: Optional routing override. When ``None`` the value of
             ``LMCACHE_MP_TRANSFER_MODE`` is consulted, defaulting to
             :attr:`MPTransferMode.AUTO`.
@@ -917,10 +1002,10 @@ def create_transfer_context(
         resolved_mode.value,
     )
     if resolved_mode is MPTransferMode.LMCACHE_DRIVEN:
-        return _build_lmcache_driven_context(device_type)
+        return _build_lmcache_driven_context(device_type, instance_id, req_client)
     if resolved_mode is MPTransferMode.ENGINE_DRIVEN:
-        return _build_engine_driven_context()
+        return _build_engine_driven_context(instance_id, req_client)
     # AUTO: dispatch by device type (CUDA -> handle path, else -> data path).
     if device_type == "cuda":
-        return LMCacheDrivenTransferContext()
-    return _build_engine_driven_context()
+        return LMCacheDrivenTransferContext(instance_id, req_client)
+    return _build_engine_driven_context(instance_id, req_client)

--- a/tests/v1/multiprocess/test_async_engine_driven_transfer_context.py
+++ b/tests/v1/multiprocess/test_async_engine_driven_transfer_context.py
@@ -124,7 +124,7 @@ def _new_context(
 ) -> AsyncEngineDrivenTransferContext:
     monkeypatch.setattr(async_engine_driven, "torch_dev", _FakeTorchDev(gather_gate))
     _install_fake_gather(monkeypatch)
-    ctx = AsyncEngineDrivenTransferContext(commit_workers=max_inflight)
+    ctx = AsyncEngineDrivenTransferContext(1, MagicMock(), commit_workers=max_inflight)
     ctx._engine_driven_context = (
         _FakeStoreContext(commit_impl=commit_impl)  # type: ignore[assignment]
     )
@@ -139,7 +139,7 @@ def test_submit_store_returns_pending_future_until_gather_and_commit(
         monkeypatch, gather_gate=gather_gate, commit_impl=lambda _c: True
     )
     future = ctx.submit_store(
-        "r1", object(), 1, {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
+        "r1", object(), {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
     )
     assert not future.query()
     gather_gate.set()
@@ -155,7 +155,7 @@ def test_create_recorded_event_uses_local_device_event(
     event = fake_torch_dev.Event.return_value
     stream = fake_torch_dev.current_stream.return_value
     monkeypatch.setattr(async_engine_driven, "torch_dev", fake_torch_dev)
-    ctx = AsyncEngineDrivenTransferContext()
+    ctx = AsyncEngineDrivenTransferContext(1, MagicMock())
     ctx._engine_driven_context = MagicMock()
 
     assert ctx.create_recorded_event() is event
@@ -176,7 +176,7 @@ def test_submit_store_commit_waits_for_gather_done(
 
     ctx = _new_context(monkeypatch, gather_gate=gather_gate, commit_impl=_commit)
     future = ctx.submit_store(
-        "r1", object(), 1, {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
+        "r1", object(), {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
     )
     assert not commit_called.wait(timeout=0.05)
     gather_gate.set()
@@ -196,7 +196,7 @@ def test_close_drains_inflight_async_store(monkeypatch: pytest.MonkeyPatch) -> N
 
     ctx = _new_context(monkeypatch, gather_gate=gather_gate, commit_impl=_commit)
     future = ctx.submit_store(
-        "r1", object(), 1, {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
+        "r1", object(), {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
     )
     closed = threading.Event()
 
@@ -225,7 +225,7 @@ def test_commit_failure_sets_false_and_logs(
     monkeypatch.setattr(async_engine_driven.logger, "exception", log_exception)
     ctx = _new_context(monkeypatch, gather_gate=gather_gate, commit_impl=_commit)
     future = ctx.submit_store(
-        "r1", object(), 1, {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
+        "r1", object(), {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
     )
     gather_gate.set()
     assert future.result(timeout=1) is False
@@ -259,7 +259,7 @@ def test_sync_engine_driven_context_returns_resolved_future(
     fake = _RecordingTorchDev()
     monkeypatch.setattr(worker_transfer, "torch_dev", fake)
     _install_fake_gather(monkeypatch)
-    ctx = EngineDrivenTransferContext()
+    ctx = EngineDrivenTransferContext(1, MagicMock())
     ctx._engine_driven_context = (
         _FakeStoreContext(commit_impl=lambda _c: True)  # type: ignore[assignment]
     )
@@ -267,7 +267,6 @@ def test_sync_engine_driven_context_returns_resolved_future(
     future = ctx.submit_store(
         "r1",
         object(),
-        1,
         {"k": torch.zeros(1)},
         [[0]],
         _FakeEvent(threading.Event()),
@@ -284,7 +283,7 @@ def test_sync_engine_driven_context_returns_resolved_future(
 
 
 def test_sync_engine_driven_context_has_no_async_resources() -> None:
-    ctx = EngineDrivenTransferContext()
+    ctx = EngineDrivenTransferContext(1, MagicMock())
     assert not hasattr(ctx, "_copy_stream")
     assert not hasattr(ctx, "_commit_executor")
     assert not hasattr(ctx, "_inflight_semaphore")
@@ -301,12 +300,12 @@ def test_build_engine_driven_context_dispatches_on_capability(
     monkeypatch.setattr(
         async_engine_driven, "torch_dev", _FakeTorchDev(threading.Event())
     )
-    capable = worker_transfer._build_engine_driven_context()
+    capable = worker_transfer._build_engine_driven_context(1, MagicMock())
     assert isinstance(capable, AsyncEngineDrivenTransferContext)
     capable.close()
 
     monkeypatch.setattr(worker_transfer, "_supports_async_primitives", lambda: False)
-    fallback = worker_transfer._build_engine_driven_context()
+    fallback = worker_transfer._build_engine_driven_context(1, MagicMock())
     assert isinstance(fallback, EngineDrivenTransferContext)
     assert not isinstance(fallback, AsyncEngineDrivenTransferContext)
     fallback.close()
@@ -344,13 +343,13 @@ def test_flush_inflight_stores_waits_for_pending_gather(
     )
     _install_fake_gather(monkeypatch)
 
-    ctx = AsyncEngineDrivenTransferContext(commit_workers=1)
+    ctx = AsyncEngineDrivenTransferContext(1, MagicMock(), commit_workers=1)
     ctx._engine_driven_context = (
         _FakeStoreContext(commit_impl=lambda _c: True)  # type: ignore[assignment]
     )
 
     ctx.submit_store(
-        "r1", object(), 1, {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
+        "r1", object(), {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
     )
 
     # Wait until the background thread has started (entered stream()), proving
@@ -403,7 +402,6 @@ def test_commit_store_serialized_by_commit_lock(
         ctx.submit_store(
             f"r{i}",
             object(),
-            1,
             {"k": torch.zeros(1)},
             [[0]],
             _FakeEvent(gather_gate),
@@ -444,7 +442,7 @@ def test_prepare_store_runs_on_background_thread_not_forward_thread(
     monkeypatch.setattr(async_engine_driven, "torch_dev", _FakeTorchDev(gather_gate))
     _install_fake_gather(monkeypatch)
 
-    ctx = AsyncEngineDrivenTransferContext(commit_workers=1)
+    ctx = AsyncEngineDrivenTransferContext(1, MagicMock(), commit_workers=1)
     ctx._engine_driven_context = _FakeStoreContext(  # type: ignore[assignment]
         commit_impl=lambda _c: True,
         prepare_impl=_slow_prepare,
@@ -454,7 +452,7 @@ def test_prepare_store_runs_on_background_thread_not_forward_thread(
 
     def _submit() -> None:
         ctx.submit_store(
-            "r1", object(), 1, {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
+            "r1", object(), {"k": torch.zeros(1)}, [[0]], _FakeEvent(gather_gate), 1
         )
         submit_returned.set()
 

--- a/tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py
+++ b/tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py
@@ -79,7 +79,7 @@ def test_pickle_store_syncs_before_commit_serializes() -> None:
     from lmcache.v1.multiprocess.transfer_context import worker_transfer
 
     order: list[str] = []
-    ctx = worker_transfer.EngineDrivenTransferContext()
+    ctx = worker_transfer.EngineDrivenTransferContext(1, MagicMock())
     ctx._engine_driven_context = MagicMock()
     ctx._engine_driven_context.prepare_store.return_value = None  # pickle mode
 
@@ -103,7 +103,6 @@ def test_pickle_store_syncs_before_commit_serializes() -> None:
         ctx.submit_store(
             "req",
             MagicMock(),  # key
-            1,  # instance_id
             {"layer_0": torch.zeros(2, 4, 4, 2, 8)},
             [[0, 1, 2, 3]],
             MagicMock(),  # event (unused on this transport)

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -306,7 +306,9 @@ def test_create_transfer_context_uses_default_context_on_cpu() -> None:
         create_transfer_context,
     )
 
-    context = create_transfer_context({"layer_0": torch.randn(2, 2)})
+    context = create_transfer_context(
+        {"layer_0": torch.randn(2, 2)}, instance_id=1, req_client=MagicMock()
+    )
     assert isinstance(context, EngineDrivenTransferContext)
 
 
@@ -367,7 +369,10 @@ def test_extra_config_default_lets_env_var_select_mp_transfer_mode(
     # EngineDrivenTransferContext.
     monkeypatch.setenv(ENV_MP_TRANSFER_MODE, "engine_driven")
     context = create_transfer_context(
-        {"layer_0": torch.randn(2, 2)}, mode=resolved_mode
+        {"layer_0": torch.randn(2, 2)},
+        instance_id=1,
+        req_client=MagicMock(),
+        mode=resolved_mode,
     )
     assert isinstance(context, EngineDrivenTransferContext)
 
@@ -387,7 +392,10 @@ def test_create_transfer_context_force_lmcache_driven_mode() -> None:
     import lmcache.v1.platform.cpu  # noqa: F401
 
     context = create_transfer_context(
-        {"layer_0": torch.randn(2, 2)}, mode=MPTransferMode.LMCACHE_DRIVEN
+        {"layer_0": torch.randn(2, 2)},
+        instance_id=1,
+        req_client=MagicMock(),
+        mode=MPTransferMode.LMCACHE_DRIVEN,
     )
     assert isinstance(context, LMCacheDrivenTransferContext)
 
@@ -402,7 +410,10 @@ def test_create_transfer_context_force_engine_driven_mode_on_cpu() -> None:
     )
 
     context = create_transfer_context(
-        {"layer_0": torch.randn(2, 2)}, mode="engine_driven"
+        {"layer_0": torch.randn(2, 2)},
+        instance_id=1,
+        req_client=MagicMock(),
+        mode="engine_driven",
     )
     assert isinstance(context, EngineDrivenTransferContext)
 
@@ -429,7 +440,11 @@ def test_auto_non_cuda_context_does_not_require_event_ipc(
         fail_event_backend_resolution,
     )
 
-    context = worker_transfer.create_transfer_context({"layer_0": MagicMock()})
+    context = worker_transfer.create_transfer_context(
+        {"layer_0": MagicMock()},
+        instance_id=1,
+        req_client=MagicMock(),
+    )
 
     assert isinstance(context, worker_transfer.EngineDrivenTransferContext)
 
@@ -440,7 +455,12 @@ def test_create_transfer_context_invalid_mode_raises() -> None:
     from lmcache.v1.multiprocess.transfer_context import create_transfer_context
 
     with pytest.raises(ValueError, match="Invalid MP transfer mode"):
-        create_transfer_context({"layer_0": torch.randn(2, 2)}, mode="bogus")
+        create_transfer_context(
+            {"layer_0": torch.randn(2, 2)},
+            instance_id=1,
+            req_client=MagicMock(),
+            mode="bogus",
+        )
 
 
 def test_create_transfer_context_handle_mode_unsupported_device_raises(
@@ -462,7 +482,12 @@ def test_create_transfer_context_handle_mode_unsupported_device_raises(
         property(lambda self: None),
     )
     with pytest.raises(ValueError, match="not supported for device type"):
-        create_transfer_context({"layer_0": torch.randn(2, 2)}, mode="lmcache_driven")
+        create_transfer_context(
+            {"layer_0": torch.randn(2, 2)},
+            instance_id=1,
+            req_client=MagicMock(),
+            mode="lmcache_driven",
+        )
 
 
 @pytest.mark.musa
@@ -498,15 +523,13 @@ def test_musa_data_context_keeps_layout_validation_device_agnostic(
     future.result.return_value = RegisterEngineDrivenContextResponse()
     req_client = MagicMock()
     req_client.register_kv_cache_engine_driven_context.return_value = future
-    ctx = EngineDrivenTransferContext()
+    ctx = EngineDrivenTransferContext(1, req_client)
 
     ctx.register(
-        instance_id=1,
         kv_caches=_make_hnd_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        req_client=req_client,
         mq_timeout=1.0,
     )
 
@@ -558,23 +581,20 @@ def test_musa_data_context_store_uses_device_agnostic_gather(
         return [torch.zeros(2, 2, 8, 16)]
 
     monkeypatch.setattr(worker_transfer, "gather_paged_kv_to_cpu", _fake_gather)
-    ctx = EngineDrivenTransferContext()
     req_client = MagicMock()
     req_client.register_kv_cache_engine_driven_context.return_value = future
+    ctx = EngineDrivenTransferContext(1, req_client)
     ctx.register(
-        instance_id=1,
         kv_caches=_make_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        req_client=req_client,
         mq_timeout=1.0,
     )
 
     result = ctx.submit_store(
         "req",
         _default_key(),
-        1,
         _make_kv_caches(),
         [[0, 1]],
         MagicMock(),
@@ -631,23 +651,20 @@ def test_musa_data_context_retrieve_uses_device_agnostic_scatter(
         captured_kwargs.update(kwargs)
 
     monkeypatch.setattr(worker_transfer, "scatter_cpu_to_paged_kv", _fake_scatter)
-    ctx = EngineDrivenTransferContext()
     req_client = MagicMock()
     req_client.register_kv_cache_engine_driven_context.return_value = future
+    ctx = EngineDrivenTransferContext(1, req_client)
     ctx.register(
-        instance_id=1,
         kv_caches=_make_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=2,
-        req_client=req_client,
         mq_timeout=1.0,
     )
 
     result = ctx.submit_retrieve(
         "req",
         _default_key(),
-        1,
         _make_kv_caches(),
         [[0, 1]],
         MagicMock(),
@@ -677,7 +694,9 @@ def test_create_transfer_context_env_var_overrides_default(
     import lmcache.v1.platform.cpu  # noqa: F401
 
     monkeypatch.setenv(ENV_MP_TRANSFER_MODE, "lmcache_driven")
-    context = create_transfer_context({"layer_0": torch.randn(2, 2)})
+    context = create_transfer_context(
+        {"layer_0": torch.randn(2, 2)}, instance_id=1, req_client=MagicMock()
+    )
     assert isinstance(context, LMCacheDrivenTransferContext)
 
 
@@ -863,20 +882,73 @@ def test_engine_driven_register_sends_num_physical_slots(
     req_client = MagicMock()
     req_client.register_kv_cache_engine_driven_context.return_value = future
 
-    EngineDrivenTransferContext().register(
-        instance_id=1,
+    context = EngineDrivenTransferContext(1, req_client)
+    context.register(
         kv_caches=_make_fused_nhd_kv_caches(),
         model_name="m",
         world_size=1,
         blocks_in_chunk=8,
-        req_client=req_client,
         mq_timeout=1.0,
         layout_hints={"kv_layout": "NHD"},
     )
 
+    unregister_future = context.unregister()
+
     payload = req_client.register_kv_cache_engine_driven_context.call_args.args[0]
     assert isinstance(payload, RegisterEngineDrivenContextPayload)
     assert payload.num_physical_slots == 128
+    assert (
+        unregister_future
+        is req_client.unregister_kv_cache_engine_driven_context.return_value
+    )
+    req_client.unregister_kv_cache_engine_driven_context.assert_called_once_with(1)
+
+
+def test_engine_driven_context_unregister_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unregister is a no-op before REGISTER but rolls back a timed-out one."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        EngineDrivenTransferContext,
+        worker_transfer,
+    )
+
+    req_client = MagicMock()
+    context = EngineDrivenTransferContext(7, req_client)
+    assert context.unregister() is None
+    req_client.unregister_kv_cache_engine_driven_context.assert_not_called()
+
+    monkeypatch.setattr(
+        worker_transfer,
+        "compute_kv_layout",
+        lambda *_args, **_kwargs: (
+            16,
+            2,
+            576,
+            "float32",
+            lmcache_native.EngineKVFormat.NL_X_NB_BS_NH_CS,
+            1,
+        ),
+    )
+    register_future = MagicMock()
+    register_future.result.side_effect = TimeoutError()
+    req_client.register_kv_cache_engine_driven_context.return_value = register_future
+
+    with pytest.raises(TimeoutError):
+        context.register(
+            _make_fused_nhd_kv_caches(),
+            "m",
+            1,
+            8,
+            1.0,
+        )
+
+    assert (
+        context.unregister()
+        is req_client.unregister_kv_cache_engine_driven_context.return_value
+    )
+    req_client.unregister_kv_cache_engine_driven_context.assert_called_once_with(7)
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -120,17 +120,16 @@ def test_worker_exports_events_through_platform_backend(
     client.store.return_value = MessagingFuture()
     client.retrieve.return_value = MessagingFuture()
 
-    context = worker_transfer.LMCacheDrivenTransferContext()
+    context = worker_transfer.LMCacheDrivenTransferContext(1, client)
     kv_caches = {"layer_0": torch.empty(1)}
     context.register(
-        1,
         kv_caches,
         "model",
         1,
         1,
-        client,
         1.0,
     )
+    unregister_future = context.unregister()
     stream = MagicMock(name="current_stream")
     monkeypatch.setattr(worker_transfer.torch_dev, "current_stream", lambda: stream)
     event = context.create_recorded_event()
@@ -138,7 +137,6 @@ def test_worker_exports_events_through_platform_backend(
     store_future = context.submit_store(
         "request",
         "key",
-        1,
         kv_caches,
         [[0]],
         event,
@@ -147,7 +145,6 @@ def test_worker_exports_events_through_platform_backend(
     retrieve_future = context.submit_retrieve(
         "request",
         "key",
-        1,
         kv_caches,
         [[0]],
         event,
@@ -157,6 +154,8 @@ def test_worker_exports_events_through_platform_backend(
 
     assert isinstance(store_future, DeviceMessagingFuture)
     assert isinstance(retrieve_future, DeviceMessagingFuture)
+    assert unregister_future is client.unregister_kv_cache.return_value
+    client.unregister_kv_cache.assert_called_once_with(1)
     client.store.assert_called_once_with("key", 1, [[0]], b"completion-handle")
     client.retrieve.assert_called_once_with("key", 1, [[0]], b"completion-handle", 2)
     assert [call[0] for call in backend.calls] == [

--- a/tests/v1/platform/musa/test_musa_mp_handle.py
+++ b/tests/v1/platform/musa/test_musa_mp_handle.py
@@ -3,6 +3,7 @@
 # Standard
 from types import SimpleNamespace
 from typing import NoReturn, cast
+from unittest.mock import MagicMock
 import importlib
 
 # Third Party
@@ -275,7 +276,9 @@ def test_create_transfer_context_auto_keeps_musa_on_data_path() -> None:
         create_transfer_context,
     )
 
-    context = create_transfer_context(_fake_musa_kv_caches())
+    context = create_transfer_context(
+        _fake_musa_kv_caches(), instance_id=1, req_client=MagicMock()
+    )
 
     assert isinstance(context, EngineDrivenTransferContext)
 
@@ -286,7 +289,12 @@ def test_create_transfer_context_musa_handle_requires_capability() -> None:
     from lmcache.v1.multiprocess.transfer_context import create_transfer_context
 
     with pytest.raises(ValueError, match="not available"):
-        create_transfer_context(_fake_musa_kv_caches(), mode="lmcache_driven")
+        create_transfer_context(
+            _fake_musa_kv_caches(),
+            instance_id=1,
+            req_client=MagicMock(),
+            mode="lmcache_driven",
+        )
 
 
 def test_create_transfer_context_musa_handle_allowed_when_available(
@@ -308,6 +316,8 @@ def test_create_transfer_context_musa_handle_allowed_when_available(
 
     context = create_transfer_context(
         _fake_musa_kv_caches(),
+        instance_id=1,
+        req_client=MagicMock(),
         mode="lmcache_driven",
     )
 

--- a/tests/v1/test_atom_mp_adapter.py
+++ b/tests/v1/test_atom_mp_adapter.py
@@ -252,7 +252,7 @@ def test_atom_submit_returns_future_and_expands_physical_groups(
     assert event in returned._retained_references
     submit_call = getattr(transfer_context, submit_name).call_args
     assert submit_call.args[1].require_num_kv_readers() == 1
-    assert submit_call.args[4] == [[7, 8, 9, 10], [7, 8, 9, 10]]
+    assert submit_call.args[3] == [[7, 8, 9, 10], [7, 8, 9, 10]]
 
     future.set_result(True)
     assert returned.result(timeout=0) is True
@@ -393,13 +393,13 @@ def test_atom_initial_registration_failure_rolls_back_candidate(
     transfer_context.register.side_effect = register_error
     rollback_future: MessagingFuture[None] = MessagingFuture()
     rollback_future.set_result(None)
-    client.unregister_kv_cache.return_value = rollback_future
+    transfer_context.unregister.return_value = rollback_future
 
     with pytest.raises(type(register_error)) as exc_info:
         worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
 
     assert exc_info.value is register_error
-    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
+    transfer_context.unregister.assert_called_once_with()
     transfer_context.close.assert_called_once_with()
     client.close.assert_called_once_with()
     assert worker.is_healthy is False
@@ -414,7 +414,7 @@ def test_atom_initial_registration_preserves_error_across_cleanup_failures(
     worker, transfer_context, caches = worker_with_transfer_context
     client = _mock_client(worker)
     transfer_context.register.side_effect = ValueError("original register failure")
-    client.unregister_kv_cache.side_effect = RuntimeError("rollback failed")
+    transfer_context.unregister.side_effect = RuntimeError("rollback failed")
     transfer_context.close.side_effect = RuntimeError("context close failed")
     client.close.side_effect = RuntimeError("client close failed")
 
@@ -432,7 +432,6 @@ def test_atom_failed_recovery_rolls_back_candidate_and_keeps_old_context(
 ) -> None:
     """A failed recovery cleans its candidate and can retry the old registration."""
     worker, old_context, caches = worker_with_transfer_context
-    client = _mock_client(worker)
     worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
     heartbeat = _FakeHeartbeatThread.instances[0]
     heartbeat.mark_unhealthy()
@@ -450,7 +449,7 @@ def test_atom_failed_recovery_rolls_back_candidate_and_keeps_old_context(
     )
     rollback_future: MessagingFuture[None] = MessagingFuture()
     rollback_future.set_result(None)
-    client.unregister_kv_cache.return_value = rollback_future
+    failed_candidate.unregister.return_value = rollback_future
 
     assert heartbeat.recover() is False
     failed_candidate.close.assert_called_once_with()
@@ -458,7 +457,7 @@ def test_atom_failed_recovery_rolls_back_candidate_and_keeps_old_context(
     assert worker._transfer_context is old_context
     assert worker._registered is True
     assert worker.is_healthy is False
-    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
+    failed_candidate.unregister.assert_called_once_with()
 
     assert heartbeat.recover() is True
     old_context.close.assert_called_once_with()
@@ -821,12 +820,11 @@ def test_atom_shutdown_unregisters_gpu_context(
 ) -> None:
     """ATOM removes its LMCache-driven GPU registration during shutdown."""
     worker, transfer_context, caches = worker_with_transfer_context
-    client = _mock_client(worker)
     worker.register_kv_caches(caches, engine_group_infos=_atom_groups())
 
     worker.shutdown()
 
-    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
+    transfer_context.unregister.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -871,7 +869,7 @@ def test_atom_shutdown_drains_unresolved_operation_before_unregister(
     assert wait_started.wait(timeout=5.0)
     transfer_context.close.assert_not_called()
     client.close.assert_not_called()
-    client.unregister_kv_cache.assert_not_called()
+    transfer_context.unregister.assert_not_called()
 
     future.set_result(True)
     shutdown_thread.join(timeout=5.0)
@@ -881,7 +879,7 @@ def test_atom_shutdown_drains_unresolved_operation_before_unregister(
     assert returned.result(timeout=0) is True
     transfer_context.close.assert_called_once_with()
     client.close.assert_called_once_with()
-    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
+    transfer_context.unregister.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -933,7 +931,7 @@ def test_atom_restart_window_transfer_and_shutdown_terminate(
     assert raw_wait_started.wait(timeout=5.0)
     transfer_context.close.assert_not_called()
     client.close.assert_not_called()
-    client.unregister_kv_cache.assert_not_called()
+    transfer_context.unregister.assert_not_called()
 
     raw_future.set_result((b"", False))
     shutdown_thread.join(timeout=5.0)
@@ -942,7 +940,7 @@ def test_atom_restart_window_transfer_and_shutdown_terminate(
     assert returned.result(timeout=0) is False
     transfer_context.close.assert_called_once_with()
     client.close.assert_called_once_with()
-    client.unregister_kv_cache.assert_called_once_with(worker.instance_id)
+    transfer_context.unregister.assert_called_once_with()
 
 
 def test_atom_shutdown_finally_closes_client_when_context_close_fails(

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -133,8 +133,13 @@ def _patch_transfer_context_factory(
     contexts: list[MagicMock] = []
 
     def fake_create_transfer_context(
-        kv_caches: dict[str, torch.Tensor], mode: str
+        kv_caches: dict[str, torch.Tensor],
+        *,
+        instance_id: int,
+        req_client: RequestClient,
+        mode: str,
     ) -> MagicMock:
+        del kv_caches, instance_id, req_client, mode
         ctx = MagicMock(name=f"transfer_ctx_{len(contexts)}")
         contexts.append(ctx)
         return ctx
@@ -303,7 +308,7 @@ def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
     assert transfer_ctx.submit_store.call_args.args[1].request_configs == {
         "lmcache.skip_save": True
     }
-    assert transfer_ctx.submit_store.call_args.args[4] == [[0]]
+    assert transfer_ctx.submit_store.call_args.args[3] == [[0]]
     assert adapter.store_futures["req-1"] is fake_future
 
 
@@ -331,7 +336,7 @@ def test_submit_store_request_expands_block_ids_to_views(fake_adapter, monkeypat
 
     adapter.submit_store_request("req-1", op, event=MagicMock())
 
-    assert transfer_ctx.submit_store.call_args.args[4] == [
+    assert transfer_ctx.submit_store.call_args.args[3] == [
         [0, 1],
         [0, 1],
         [10, 11],
@@ -369,7 +374,7 @@ def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatc
     assert transfer_ctx.submit_retrieve.call_args.args[1].request_configs == {
         "lmcache.skip_save": True
     }
-    assert transfer_ctx.submit_retrieve.call_args.args[4] == [[0]]
+    assert transfer_ctx.submit_retrieve.call_args.args[3] == [[0]]
     assert adapter.retrieve_futures["req-1"] == (fake_future, [0])
 
 
@@ -451,8 +456,13 @@ def test_isolated_ipc_is_set_before_transfer_context_creation(
     transfer_ctx = MagicMock(name="transfer_ctx")
 
     def create_context(
-        _kv_caches: dict[str, torch.Tensor], mode: str | None
+        _kv_caches: dict[str, torch.Tensor],
+        *,
+        instance_id: int,
+        req_client: RequestClient,
+        mode: str | None,
     ) -> MagicMock:
+        del instance_id, req_client, mode
         calls.append(("create_transfer_context", is_isolated_ipc()))
         return transfer_ctx
 
@@ -831,34 +841,36 @@ def test_shutdown_stops_heartbeat_before_unregister(fake_adapter) -> None:
     """shutdown() stops the heartbeat before sending UNREGISTER, so no
     stray heartbeat ping can race the closing req_client."""
     adapter, req_client, future = fake_adapter
-    adapter.transfer_ctx = MagicMock()
+    transfer_context = MagicMock()
+    adapter.transfer_ctx = transfer_context
     adapter.submit_store_request("req-1", _op([[0]]), MagicMock())
     heartbeat = FakeHeartbeatThread.instances[0]
 
     stop_state_at_unregister: list[bool] = []
 
-    def record_unregister(_instance_id: int) -> MagicMock:
+    def record_unregister() -> MagicMock:
         stop_state_at_unregister.append(heartbeat.stop_requested)
         return future
 
-    req_client.unregister_kv_cache.side_effect = record_unregister
+    transfer_context.unregister.side_effect = record_unregister
 
     adapter.shutdown()
 
     assert "stop" in heartbeat.calls
     assert stop_state_at_unregister == [True]
+    transfer_context.unregister.assert_called_once_with()
+    req_client.unregister_kv_cache.assert_not_called()
 
 
-def test_shutdown_without_heartbeat_sends_unregister(fake_adapter) -> None:
+def test_cold_shutdown_skips_unregister(fake_adapter) -> None:
     """shutdown() on an adapter whose heartbeat was never lazily started
-    (cold shutdown before any traffic) still sends UNREGISTER and does
-    not raise."""
+    (cold shutdown before registration) does not send UNREGISTER."""
     adapter, req_client, _future = fake_adapter
 
     adapter.shutdown()
 
     assert FakeHeartbeatThread.instances == []
-    req_client.unregister_kv_cache.assert_called_once_with(adapter.instance_id)
+    req_client.unregister_kv_cache.assert_not_called()
 
 
 def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> None:
@@ -965,7 +977,7 @@ def test_register_uses_local_context_when_self_transfer_ctx_nulled(
     monkeypatch.setattr("lmcache.integration.vllm.utils.vllm_layout_hints", lambda: {})
     local_ctx = MagicMock(name="local_transfer_ctx")
     monkeypatch.setattr(
-        adapter_mod, "create_transfer_context", lambda kv, mode: local_ctx
+        adapter_mod, "create_transfer_context", lambda kv, **_kwargs: local_ctx
     )
 
     parallel_strategy = ParallelStrategy(


### PR DESCRIPTION
## Summary
- bind each transfer context to its worker `instance_id` and `RequestClient` at factory construction; remove the repeated binding from register/store/retrieve calls
- make `unregister()` protocol-owned by the context and return no future when REGISTER was never sent, so cold shutdown emits no spurious RPC
- retain rollback after an ambiguous registration timeout, and cover both handle and engine-driven paths plus vLLM/ATOM lifecycle handling
- preserve the upstream device-future event backend propagation during the rebase

## Testing
- `SKIP=rust-fmt,rust-clippy uvx pre-commit run --all-files`
- `uv run pytest -q -o log_cli=false tests/v1/test_vllm_mp_adapter.py tests/v1/test_atom_mp_adapter.py tests/v1/multiprocess/test_event_ipc_handle_path.py tests/v1/multiprocess/test_engine_driven_async_copy_lifetime.py tests/v1/multiprocess/test_async_engine_driven_transfer_context.py tests/v1/multiprocess/test_engine_driven_transfer.py -k 'not test_engine_context_shm_pool_info and not test_server_'` (128 passed, 1 skipped, 12 deselected)