### PR TITLE
build(multiprocess): add gRPC protobuf and test foundation

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -263,6 +263,13 @@ echo "--- :python: Installing LMCache from source"
 export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE:-0.0.0+ci}"
 uv pip freeze | sort > /tmp/env-before-lmcache.txt
 uv pip install -e . --no-build-isolation
+
+# Editable installs do not run setuptools' build_py hook. Install the pinned
+# generator and create the ignored bindings required when server.py is imported.
+uv pip install -r requirements/proto.txt
+echo "--- :gear: Generating LMCache gRPC bindings"
+python "${REPO_ROOT}/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
+
 uv pip freeze | sort > /tmp/env-after-lmcache.txt
 if ! diff -q /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt >/dev/null; then
     echo "--- :warning: Packages changed during LMCache install"

--- a/.buildkite/k3_harness/setup-lmcache-only-env.sh
+++ b/.buildkite/k3_harness/setup-lmcache-only-env.sh
@@ -20,5 +20,11 @@ echo "--- :python: Installing LMCache from source (no vLLM)"
 export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE:-0.0.0+ci}"
 uv pip install -e . --no-build-isolation
 
+# Editable installs do not run setuptools' build_py hook. Install the pinned
+# generator and create the ignored bindings required when server.py is imported.
+uv pip install -r requirements/proto.txt
+echo "--- :gear: Generating LMCache gRPC bindings"
+python "${REPO_ROOT}/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
+
 echo "--- :white_check_mark: Environment ready (LMCache only, no vLLM)"
 python -c "import lmcache; print('LMCache installed from source')"

--- a/.buildkite/k3_harness/setup-sglang-env.sh
+++ b/.buildkite/k3_harness/setup-sglang-env.sh
@@ -38,5 +38,9 @@ export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERS
 uv pip uninstall cupy-cuda12x 2>/dev/null || true
 uv pip install -e . --no-build-isolation
 
+uv pip install -r requirements/proto.txt
+echo "--- :gear: Generating LMCache gRPC bindings"
+python "${REPO_ROOT}/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
+
 python -c "import lmcache, sglang; print(f'sglang={sglang.__version__}; lmcache OK')"
 python -c "import cupy; print(f'cupy={cupy.__version__}')"

--- a/.buildkite/k3_tests/amd/pipeline.yml
+++ b/.buildkite/k3_tests/amd/pipeline.yml
@@ -14,7 +14,7 @@ steps:
       - "coverage-test.xml"
       - "coverage-test/**/*"
 
-  - label: "vLLM + LMCache E2E (AMD, {{matrix.mode}})"
+  - label: "vLLM + LMCache E2E (AMD, {{matrix.mode}}, {{matrix.request_transport}})"
     timeout_in_minutes: 90
     command: bash .buildkite/scripts/amd-vllm-bench.sh {{matrix.mode}}
     matrix:
@@ -22,6 +22,9 @@ steps:
         mode:
           - "serialized"
           - "unserialized"
+        request_transport:
+          - "zmq"
+    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
 
     artifact_paths:
       - "*.log"

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -14,6 +14,14 @@ x-flaky-retry: &flaky-retry
     - exit_status: "*"
       limit: 2
 
+# Keep request transport as a shared matrix dimension so gRPC can be enabled
+# later with a small matrix-only change. For now, only ZMQ jobs are scheduled.
+# Worker-side KV transfer modes remain separate matrix dimensions below.
+x-request-transport-matrix: &request-transport-matrix
+  setup:
+    request_transport:
+      - "zmq"
+
 # Keep the regular 1-GPU pod anchor available after the two lm_eval steps are
 # merged; engine_driven still needs its separate /dev/shm pod below.
 # Every pod mounts a 1Gi /dev/shm: the container runtime default is 64MB and
@@ -55,8 +63,10 @@ steps:
       # fp8 TP-shard load (plus the weight download on a cold hf-cache node)
       # needs the long timeout. The SM120 DeepGEMM build adds ~1-2 min,
       # measured in CI, so it does not move this budget.
-      - label: ":compression: dsv4_flash_tp"
+      - label: ":compression: dsv4_flash_tp / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh dsv4_flash_tp
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 90
         retry: *flaky-retry
         agents: { queue: "k8s" }
@@ -81,8 +91,10 @@ steps:
   - group: ":compression: Multiprocess (2-GPU)"
     if: build.env("VERIFY_AND_PIN_VLLM") !~ /true/
     steps:
-      - label: ":compression: vllm_bench"
+      - label: ":compression: vllm_bench / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh vllm_bench
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins:
@@ -101,24 +113,30 @@ steps:
                   - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
         artifact_paths: ["*.log"]
 
-      - label: ":compression: long_doc_qa"
+      - label: ":compression: long_doc_qa / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh long_doc_qa
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         retry: *flaky-retry
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: long_doc_qa_l2"
+      - label: ":compression: long_doc_qa_l2 / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh long_doc_qa_l2
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         retry: *flaky-retry
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: deadlock"
+      - label: ":compression: deadlock / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh deadlock
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
@@ -127,8 +145,10 @@ steps:
       # Two LMCache MP instances + two vLLM instances + one coordinator on a
       # single 2-GPU pod (localhost). Verifies engine B serves a long prompt's
       # KV from engine A over P2P.
-      - label: ":compression: p2p"
+      - label: ":compression: p2p / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh p2p
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
@@ -142,8 +162,10 @@ steps:
       # utils.py::mla_only) hands non-zero ranks rank 0's mamba shard and
       # diverges the output. Two 48B loads (cold + post-restart) need the long
       # timeout.
-      - label: ":compression: kimi_linear_tp"
+      - label: ":compression: kimi_linear_tp / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh kimi_linear_tp
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 60
         retry: *flaky-retry
         agents: { queue: "k8s" }
@@ -155,7 +177,7 @@ steps:
     steps:
       # Correctness coverage for both transfer modes. engine_driven requires
       # SHM transport, so both matrix jobs use the existing dshm pod spec.
-      - label: ":compression: lm_eval_{{matrix.mode}}"
+      - label: ":compression: lm_eval_{{matrix.mode}} / {{matrix.request_transport}}"
         command: |
           case "{{matrix.mode}}" in
             lmcache_driven) ;;
@@ -171,6 +193,9 @@ steps:
             mode:
               - "lmcache_driven"
               - "engine_driven"
+            request_transport:
+              - "zmq"
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         retry: *flaky-retry
         agents: { queue: "k8s" }
@@ -195,7 +220,7 @@ steps:
       # lm_eval load. Both steps reuse the same run.sh lm_eval_preemption
       # command; env vars select the transfer mode. Checks: no crash, score
       # drift < 0.01, preemption actually occurred, score >= SCORE_MIN.
-      - label: ":compression: lm_eval_preemption / {{matrix.mode}}"
+      - label: ":compression: lm_eval_preemption / {{matrix.mode}} / {{matrix.request_transport}}"
         command: |
           case "{{matrix.mode}}" in
             lmcache_driven) ;;
@@ -210,8 +235,11 @@ steps:
             mode:
               - "lmcache_driven"
               - "engine_driven"
+            request_transport:
+              - "zmq"
         timeout_in_minutes: 30
         env:
+          LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}"
           GPU_MEMORY_UTILIZATION: "0.4"
           NUM_CONCURRENT: "256"
           MAX_MODEL_LEN: "4096"
@@ -222,22 +250,28 @@ steps:
 
       # Temporarily disabled: hma_lm_eval_gemma4.
 
-      - label: ":compression: fault_tolerance"
+      - label: ":compression: fault_tolerance / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh fault_tolerance
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: restart_recovery"
+      - label: ":compression: restart_recovery / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh restart_recovery
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: cache_stats"
+      - label: ":compression: cache_stats / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh cache_stats
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
@@ -246,22 +280,28 @@ steps:
       # Real GPU MP integration: vLLM is launched with FIFO lazy offload
       # (threshold=2, select_count=1). Three requests verify that the first
       # two remain pending and the third drains the first request.
-      - label: ":compression: lazy_offload"
+      - label: ":compression: lazy_offload / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh lazy_offload
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: http_api"
+      - label: ":compression: http_api / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh http_api
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: gds_smoke_test"
+      - label: ":compression: gds_smoke_test / {{matrix.request_transport}}"
         command: .buildkite/k3_tests/multiprocess/run.sh gds_smoke_test
+        matrix: *request-transport-matrix
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins:
@@ -290,7 +330,7 @@ steps:
       # Note: LMCACHE_SHM_NAME uses `${VAR-default}` (not `:-`) in the
       # runner script, so an empty string ("") is meaningful and differs
       # from unset. `__default__` is the sentinel meaning "shm mode".
-      - label: ":compression: cpu_e2e_validation ({{matrix.mode}})"
+      - label: ":compression: cpu_e2e_validation ({{matrix.mode}} / {{matrix.request_transport}})"
         # matrix.adjustments does not support `env:` in Buildkite. Instead
         # we branch on {{matrix.mode}} inside the command to set the
         # per-mode env before invoking the shared runner script.
@@ -307,6 +347,9 @@ steps:
               - "shm"
               - "pickle"
               - "server_copy"
+            request_transport:
+              - "zmq"
+        env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins:
@@ -331,16 +374,17 @@ steps:
                   - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 4Gi } }
 
   # Canary path for VERIFY_AND_PIN_VLLM=true: skips every real test group
-  # above (each group's `if` evaluates to false) and instead runs a single
-  # vllm_bench step that proves the freshly-installed vLLM nightly works
-  # with LMCache. On success, the verified vllm wheel version is pushed to
-  # the `buildkite_latest_tested_vllm` branch so downstream builds can pin
-  # to a known-good nightly instead of resolving "latest" again.
-  - label: ":pushpin: Verify & pin vLLM nightly"
+  # above (each group's `if` evaluates to false) and instead runs vllm_bench
+  # across the enabled request-transport matrix. The matrix currently contains
+  # only ZMQ; gRPC can be added once its request-server runtime is available.
+  - label: ":test_tube: Verify vLLM nightly / {{matrix.request_transport}}"
     if: build.env("VERIFY_AND_PIN_VLLM") =~ /true/
     command: |
       .buildkite/k3_tests/multiprocess/run.sh vllm_bench
-      bash .github/scripts/pin-tested-vllm.sh
+      python3 -c 'import vllm; print(vllm.__version__)' \
+        > "verified_vllm_{{matrix.request_transport}}.txt"
+    matrix: *request-transport-matrix
+    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
     timeout_in_minutes: 30
     agents: { queue: "k8s" }
     plugins:
@@ -351,16 +395,34 @@ steps:
                 image: lmcache/ci-base:latest
                 imagePullPolicy: Never
                 resources: { limits: { "nvidia.com/gpu": "2" } }
-                env:
-                  - name: GITHUB_TOKEN
-                    valueFrom:
-                      secretKeyRef:
-                        name: buildkite-git-creds
-                        key: GITHUB_TOKEN
                 volumeMounts:
                   - { name: hf-cache, mountPath: /root/.cache/huggingface }
                   - { name: dshm, mountPath: /dev/shm }
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
               - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
-    artifact_paths: ["*.log"]
+    artifact_paths: ["*.log", "verified_vllm_*.txt"]
+
+  - wait
+
+  - label: ":pushpin: Pin verified vLLM nightly"
+    if: build.env("VERIFY_AND_PIN_VLLM") =~ /true/
+    command: |
+      buildkite-agent artifact download "verified_vllm_zmq.txt" .
+      VLLM_VERSION="$(cat verified_vllm_zmq.txt)" \
+        bash .github/scripts/pin-tested-vllm.sh
+    timeout_in_minutes: 10
+    agents: { queue: "k8s" }
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - name: container-0
+                image: lmcache/ci-base:latest
+                imagePullPolicy: Never
+                env:
+                  - name: GITHUB_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: buildkite-git-creds
+                        key: GITHUB_TOKEN

--- a/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
@@ -181,6 +181,7 @@ fi
 env "${DEVICE_AFFINITY_VAR}=${GPU_FOR_VLLM}" \
     "${VLLM_DEVICE_ENV[@]}" \
 lmcache server \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --l1-size-gb "$CPU_BUFFER_SIZE" \
     --eviction-policy LRU \
     --max-workers "$MAX_WORKERS" \
@@ -215,6 +216,7 @@ echo "Port: $vllm_port"
 # cache availability for batched store throughput without changing this script.
 KV_TRANSFER_CONFIG="$(
     LMCACHE_PORT="${LMCACHE_PORT}" \
+    LMCACHE_REQUEST_SCHEME="${LMCACHE_REQUEST_SCHEME}" \
     LMCACHE_MP_LAZY_OFFLOAD="${LMCACHE_MP_LAZY_OFFLOAD:-false}" \
     LMCACHE_MP_LAZY_OFFLOAD_THRESHOLD="${LMCACHE_MP_LAZY_OFFLOAD_THRESHOLD:-2}" \
     LMCACHE_MP_LAZY_OFFLOAD_SELECT_COUNT="${LMCACHE_MP_LAZY_OFFLOAD_SELECT_COUNT:-1}" \
@@ -223,6 +225,7 @@ import json
 import os
 
 extra_config = {
+    "lmcache.mp.host": os.environ["LMCACHE_REQUEST_SCHEME"] + "://localhost",
     "lmcache.mp.port": int(os.environ["LMCACHE_PORT"]),
     "lmcache.mp.mq_timeout": 10,
 }

--- a/.buildkite/k3_tests/multiprocess/scripts/run-deadlock.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-deadlock.sh
@@ -51,6 +51,7 @@ echo "=== Launching LMCache server ==="
 echo "Port: $LMCACHE_PORT"
 
 lmcache server \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --host localhost \
     --port "$LMCACHE_PORT" \
     --chunk-size 256 \
@@ -92,7 +93,7 @@ vllm serve "$MODEL" \
     --scheduling-policy fcfs \
     --port "$SAVED_VLLM_PORT" \
     --enforce-eager \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 60}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 60}}" \
     > "/tmp/build_${BUILD_ID}_vllm.log" 2>&1 &
 
 VLLM_PID=$!

--- a/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-dsv4-flash-tp.sh
@@ -106,7 +106,7 @@ GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.8}"
 # Readiness timeout for the vLLM launch. Owned by the test (a 160GB fp8
 # TP-shard load is slow, and the first CI run also downloads the weights);
 # deliberately does NOT reuse MAX_WAIT_SECONDS, which run-single-test.sh
-# pre-exports to 300s -- that would shadow the value here.
+# pre-exports to 600s -- that would shadow the value here.
 VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-2700}"
 # DeepSeek-V4-Flash has multiple KV cache groups with different block
 # geometries. Keep per-group registration explicit instead of depending on the
@@ -356,6 +356,7 @@ provision_deepgemm_sm120
 # ── 1. Launch LMCache MP server with an explicit L1 pool ────
 echo "=== Launching LMCache MP server (port $LMCACHE_PORT, L1 ${L1_SIZE_GB}GB) ==="
 lmcache server \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --host localhost \
     --port "$LMCACHE_PORT" \
     --chunk-size "$CHUNK_SIZE" \
@@ -432,7 +433,7 @@ VLLM_SERVER_DEV_MODE=1 vllm serve "$MODEL" \
     --max-model-len auto \
     --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
     --port "$saved_port" \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 120}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 120}}" \
     > "$VLLM_LOG" 2>&1 &
 VLLM_PID=$!
 echo "$VLLM_PID" >> "$PID_FILE"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-fault-tolerance.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-fault-tolerance.sh
@@ -69,6 +69,7 @@ fi
 # Launch LMCache with L1 config
 CUDA_VISIBLE_DEVICES="${GPU_DEVICE}" \
 lmcache server \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --l1-size-gb "$CPU_BUFFER_SIZE" \
     --eviction-policy LRU \
     --max-workers "$MAX_WORKERS" \
@@ -94,7 +95,7 @@ env -u VLLM_PORT \
     VLLM_BATCH_INVARIANT=1 \
     PYTHONHASHSEED=0 \
 vllm serve "$MODEL" \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
     --attention-backend FLASH_ATTN \
     --port "$VLLM_PORT" \
     --no-async-scheduling \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -58,7 +58,7 @@ MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1500}"
 GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.8}"
 # Readiness timeout per vLLM launch. This is owned by the test (a 48B TP-shard
 # load is slow) and deliberately does NOT reuse MAX_WAIT_SECONDS, which
-# run-single-test.sh pre-exports to 300s -- that would shadow the value here.
+# run-single-test.sh pre-exports to 600s -- that would shadow the value here.
 VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-900}"
 # Seconds to wait for vLLM's GPU memory to be released after a restart before
 # relaunching (avoids an OOM racing the dying process).
@@ -129,7 +129,7 @@ launch_vllm() {
         --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
         --port "$saved_port" \
         --block-size 944 \
-        --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 120}}" \
+        --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 120}}" \
         > "$log_file" 2>&1 &
     VLLM_PID=$!
     echo "$VLLM_PID" >> "$PID_FILE"
@@ -242,6 +242,7 @@ count_retrieves() {
 # ── 1. Launch LMCache MP server (kept alive across the vLLM restart) ──
 echo "=== Launching LMCache MP server (port $LMCACHE_PORT) ==="
 lmcache server \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --host localhost \
     --port "$LMCACHE_PORT" \
     --chunk-size "$CHUNK_SIZE" \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-long-doc-qa-l2.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-long-doc-qa-l2.sh
@@ -116,6 +116,7 @@ GPU_DEVICE="${GPU_FOR_VLLM:-0}"
 
 CUDA_VISIBLE_DEVICES="${GPU_DEVICE}" \
 lmcache server \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --l1-size-gb "$CPU_BUFFER_SIZE" \
     --eviction-policy noop \
     --l2-store-policy skip_l1 \
@@ -150,7 +151,7 @@ env -u VLLM_PORT \
     VLLM_BATCH_INVARIANT=1 \
     PYTHONHASHSEED=0 \
 vllm serve "$MODEL" \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
     --attention-backend FLASH_ATTN \
     --port "$VLLM_PORT" \
     --no-async-scheduling \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-p2p.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-p2p.sh
@@ -72,13 +72,14 @@ fi
 
 CONNECTOR_CONFIG() {
     # $1 = lmcache mp port
-    echo "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $1, \"lmcache.mp.mq_timeout\": 10}}"
+    echo "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $1, \"lmcache.mp.mq_timeout\": 10}}"
 }
 
 launch_lmcache() {
-    # $1=gpu $2=zmq_port $3=http_port $4=p2p_advertise $5=instance_id $6=logname
+    # $1=gpu $2=request_port $3=http_port $4=p2p_advertise $5=instance_id $6=logname
     CUDA_VISIBLE_DEVICES="$1" \
     lmcache server \
+        --transport "$LMCACHE_REQUEST_TRANSPORT" \
         --l1-size-gb "$CPU_BUFFER_SIZE" \
         --eviction-policy LRU \
         --max-workers "$MAX_WORKERS" \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
@@ -183,6 +183,7 @@ restart_lmcache() {
 
     echo "Relaunching LMCache on port ${LMCACHE_PORT} / HTTP ${LMCACHE_HTTP_PORT}..."
     lmcache server \
+        --transport "$LMCACHE_REQUEST_TRANSPORT" \
         --l1-size-gb "$CPU_BUFFER_SIZE" \
         --eviction-policy LRU \
         --max-workers "$MAX_WORKERS" \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -20,9 +20,22 @@ source .buildkite/k3_tests/common_scripts/helpers.sh
 export LMCACHE_PORT="${LMCACHE_PORT:-6555}"
 export VLLM_PORT="${VLLM_PORT:-8000}"
 export VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
-export MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
+# Keep this aligned with wait-for-servers.sh. Large-model startup can exceed
+# five minutes on cold or contended CI nodes before the service is unhealthy.
+export MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-600}"
 export BUILD_ID="${BUILDKITE_BUILD_ID:-local_$$}"
 export DEFAULT_MODEL="${DEFAULT_MODEL:-Qwen/Qwen3-14B}"
+export LMCACHE_REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
+
+case "${LMCACHE_REQUEST_TRANSPORT}" in
+    zmq) export LMCACHE_REQUEST_SCHEME="tcp" ;;
+    grpc) export LMCACHE_REQUEST_SCHEME="grpc" ;;
+    *)
+        echo "Unknown LMCACHE_REQUEST_TRANSPORT='${LMCACHE_REQUEST_TRANSPORT}'"
+        echo "Valid values: zmq, grpc"
+        exit 1
+        ;;
+esac
 
 # gds_smoke_test enables the GDS L1 NVMe-slab tier
 GDS_SCRATCH="${GDS_SCRATCH:-/scratch}"
@@ -99,6 +112,7 @@ echo "============================================"
 echo "Build ID: $BUILD_ID"
 echo "Model: $MODEL"
 echo "LMCache port: $LMCACHE_PORT"
+echo "Request transport: $LMCACHE_REQUEST_TRANSPORT"
 echo "vLLM port: $VLLM_PORT"
 echo "vLLM baseline port: $VLLM_BASELINE_PORT"
 echo "Results dir: $RESULTS_DIR"

--- a/.buildkite/k3_tests/multiprocess/scripts/wait-for-servers.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/wait-for-servers.sh
@@ -151,17 +151,6 @@ wait_for_vllm_server() {
         current_time=$(date +%s)
         elapsed=$((current_time - start_time))
 
-        if [ "$current_time" -ge "$end_time" ]; then
-            echo "Timeout: $description did not become ready within ${MAX_WAIT_SECONDS}s"
-            echo ""
-            echo "=== $description log diagnostics ==="
-            print_log_diagnostics "$logfile"
-            echo ""
-            echo "=== $description process diagnostics ==="
-            print_engine_timeout_diagnostics "$logfile"
-            return 1
-        fi
-
         if ! process_alive "$expected_pid"; then
             echo "$description exited before becoming ready (pid=${expected_pid:-unknown})"
             echo ""
@@ -173,6 +162,8 @@ wait_for_vllm_server() {
             return 1
         fi
 
+        # Probe before enforcing the deadline so a server that becomes ready
+        # during the final polling interval is not reported as timed out.
         # Bypass proxy for localhost checks; CI often exports http_proxy.
         if curl --noproxy '*' -sf "$health_url" > /dev/null 2>&1; then
             echo "$description is ready! (took ${elapsed}s)"
@@ -182,6 +173,17 @@ wait_for_vllm_server() {
         if curl --noproxy '*' -sf "$models_url" > /dev/null 2>&1; then
             echo "$description is ready! (took ${elapsed}s)"
             return 0
+        fi
+
+        if [ "$current_time" -ge "$end_time" ]; then
+            echo "Timeout: $description did not become ready within ${MAX_WAIT_SECONDS}s"
+            echo ""
+            echo "=== $description log diagnostics ==="
+            print_log_diagnostics "$logfile"
+            echo ""
+            echo "=== $description process diagnostics ==="
+            print_engine_timeout_diagnostics "$logfile"
+            return 1
         fi
 
         echo "Waiting for $description... (${elapsed}s elapsed)"

--- a/.buildkite/k3_tests/sglang/pipeline.yml
+++ b/.buildkite/k3_tests/sglang/pipeline.yml
@@ -3,9 +3,20 @@
 # 2) Performance: LMCache makes TTFT smaller.
 
 steps:
-  - label: ":test_tube: SGLang+LMCache — Correctness"
+  - label: ":test_tube: SGLang+LMCache — Correctness / {{matrix.request_transport}}"
     command: .buildkite/k3_tests/sglang/run.sh correctness
-    timeout_in_minutes: 15
+    matrix:
+      setup:
+        request_transport:
+          - "zmq"
+    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - exit_status: 100
+          limit: 2
     agents: { queue: "k8s" }
     plugins:
       - kubernetes:
@@ -25,14 +36,21 @@ steps:
       - "*.log"
       - "*.json"
 
-  - label: ":zap: SGLang+LMCache — Performance"
+  - label: ":zap: SGLang+LMCache — Performance / {{matrix.request_transport}}"
     command: .buildkite/k3_tests/sglang/run.sh perf
-    timeout_in_minutes: 15
+    matrix:
+      setup:
+        request_transport:
+          - "zmq"
+    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
+    timeout_in_minutes: 30
     retry:
       automatic:
         - exit_status: -1
           limit: 2
         - exit_status: 1
+          limit: 2
+        - exit_status: 100
           limit: 2
     agents: { queue: "k8s" }
     plugins:

--- a/.buildkite/k3_tests/sglang/scripts/common.sh
+++ b/.buildkite/k3_tests/sglang/scripts/common.sh
@@ -5,6 +5,17 @@ MODEL="${MODEL:-Qwen/Qwen2.5-7B-Instruct}"
 DAEMON_PORT="${DAEMON_PORT:-6200}"
 DAEMON_HTTP_PORT="${DAEMON_HTTP_PORT:-7200}"
 LMC_CONFIG_FILE="${LMC_CONFIG_FILE:-/tmp/lmcache_mp_ci.yaml}"
+LMCACHE_REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
+
+case "${LMCACHE_REQUEST_TRANSPORT}" in
+    zmq) LMCACHE_REQUEST_SCHEME="tcp" ;;
+    grpc) LMCACHE_REQUEST_SCHEME="grpc" ;;
+    *)
+        echo "Unknown LMCACHE_REQUEST_TRANSPORT='${LMCACHE_REQUEST_TRANSPORT}'" >&2
+        echo "Valid values: zmq, grpc" >&2
+        exit 1
+        ;;
+esac
 
 DAEMON_PID=""
 SGLANG_PID=""
@@ -28,16 +39,18 @@ cleanup_all() {
 launch_daemon() {
     local log_file="$1"
     cat > "${LMC_CONFIG_FILE}" <<EOF
-mp_host: 127.0.0.1
+mp_host: ${LMCACHE_REQUEST_SCHEME}://127.0.0.1
 mp_port: ${DAEMON_PORT}
 EOF
     lmcache server \
+        --transport "${LMCACHE_REQUEST_TRANSPORT}" \
         --host 127.0.0.1 --port "${DAEMON_PORT}" --http-port "${DAEMON_HTTP_PORT}" \
         --chunk-size 256 --l1-size-gb 20 --eviction-policy LRU \
         > "${log_file}" 2>&1 &
     DAEMON_PID=$!
     for ((i = 0; i < 60; i++)); do
-        if grep -q "ZMQ cache server is running" "${log_file}" 2>/dev/null; then
+        if curl -sf "http://127.0.0.1:${DAEMON_HTTP_PORT}/healthcheck" \
+                >/dev/null 2>&1; then
             echo "  daemon ready (${i}s, log=${log_file})"
             return 0
         fi

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -28,6 +28,9 @@ trap 'rm -rf "${LMCACHE_TEST_TMPDIR}" 2>/dev/null || true' EXIT
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt
+# Generated gRPC bindings are intentionally not tracked. Generate them only
+# after the test dependencies have installed grpcio-tools.
+python lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
 
 # ── Run unit tests with coverage ─────────────────────────────
 LMCACHE_TRACK_USAGE="false" \

--- a/.buildkite/pipelines/multiprocessing-test.yml
+++ b/.buildkite/pipelines/multiprocessing-test.yml
@@ -2,9 +2,14 @@ env:
   DOCKER_BUILDKIT: 1
 
 steps:
-  - label: ":compression: Multiprocessing tests"
+  - label: ":compression: Multiprocessing tests / {{matrix.request_transport}}"
     key: "test"
     timeout_in_minutes: 60
+    matrix:
+      setup:
+        request_transport:
+          - "zmq"
+    env: { LMCACHE_REQUEST_TRANSPORT: "{{matrix.request_transport}}" }
     commands:
       - .buildkite/scripts/should-run-comprehensive.sh || exit 0 # Reuse the trigger condition for comprehensive tests
       - chmod +x .buildkite/scripts/multiprocessing-test/*.sh

--- a/.buildkite/scripts/amd-vllm-bench-container.sh
+++ b/.buildkite/scripts/amd-vllm-bench-container.sh
@@ -18,6 +18,12 @@ export CXX=hipcc
 export BUILD_WITH_HIP=1
 export TORCH_DONT_CHECK_COMPILER_ABI=1
 export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE:-0.0.0+ci}"
+# This entry point invokes the shared test orchestrator directly, so provide
+# the device settings normally initialized by k3_tests/multiprocess/run.sh.
+# ROCm exposes devices through torch.cuda and preserves the existing
+# CUDA_VISIBLE_DEVICES-based per-process affinity behavior.
+export VLLM_TARGET_DEVICE="${VLLM_TARGET_DEVICE:-cuda}"
+export DEVICE_AFFINITY_VAR="${DEVICE_AFFINITY_VAR:-CUDA_VISIBLE_DEVICES}"
 
 # This path calls run-single-test.sh directly, bypassing the common run.sh
 # entrypoint that normally configures the shared multiprocess launcher. ROCm
@@ -42,6 +48,8 @@ echo "AMD kernel mode: ${AMD_KERNEL_MODE}"
 
 uv pip install --system --no-cache -r requirements/build.txt
 uv pip install --system --no-cache --no-build-isolation -e .
+echo "Generating LMCache gRPC bindings"
+python3 lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
 uv pip install --system --no-cache openai pandas matplotlib
 
 # Fail during setup with the real import error instead of waiting for server

--- a/.buildkite/scripts/amd-vllm-bench.sh
+++ b/.buildkite/scripts/amd-vllm-bench.sh
@@ -119,6 +119,7 @@ echo "Pulling ${VLLM_ROCM_IMAGE}"
     --env "GPU_FOR_BASELINE=${GPU_FOR_BASELINE}" \
     --env "PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH:-gfx942}" \
     --env "AMD_KERNEL_MODE=${MODE}" \
+    --env "LMCACHE_REQUEST_TRANSPORT=${LMCACHE_REQUEST_TRANSPORT:-zmq}" \
     "${SERIALIZE_ENV[@]}" \
     --env ATTENTION_BACKEND=auto \
     --env BATCH_INVARIANT=0 \

--- a/.buildkite/scripts/multiprocessing-test/launch-containers.sh
+++ b/.buildkite/scripts/multiprocessing-test/launch-containers.sh
@@ -67,6 +67,7 @@ docker run -d \
     --l1-size-gb "$CPU_BUFFER_SIZE" \
     --eviction-policy LRU \
     --max-workers "$MAX_WORKERS" \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --port "$LMCACHE_PORT" \
     --http-port "$LMCACHE_HTTP_PORT"
 
@@ -92,7 +93,7 @@ docker run -d \
     --env PYTHONHASHSEED=0 \
     lmcache/vllm-openai:test \
     "$MODEL" \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
     --attention-backend FLASH_ATTN \
     --port "$VLLM_PORT" \
     $GPU_MEMORY_UTIL_ARG
@@ -123,4 +124,3 @@ echo "vLLM baseline container started"
 
 echo "=== Containers launched ==="
 docker ps --filter "name=$LMCACHE_CONTAINER_NAME" --filter "name=$VLLM_CONTAINER_NAME" --filter "name=$VLLM_BASELINE_CONTAINER_NAME"
-

--- a/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
+++ b/.buildkite/scripts/multiprocessing-test/run-mp-test.sh
@@ -15,6 +15,17 @@ export VLLM_PORT="${VLLM_PORT:-8000}"
 export VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
 export MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
 export BUILD_ID="${BUILD_ID:-local_$$}"
+export LMCACHE_REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
+
+case "${LMCACHE_REQUEST_TRANSPORT}" in
+    zmq) export LMCACHE_REQUEST_SCHEME="tcp" ;;
+    grpc) export LMCACHE_REQUEST_SCHEME="grpc" ;;
+    *)
+        echo "Unknown LMCACHE_REQUEST_TRANSPORT='${LMCACHE_REQUEST_TRANSPORT}'"
+        echo "Valid values: zmq, grpc"
+        exit 1
+        ;;
+esac
 
 # Track the overall test result
 TEST_RESULT=0
@@ -39,6 +50,7 @@ echo "LMCache container: $LMCACHE_CONTAINER_NAME"
 echo "vLLM container: $VLLM_CONTAINER_NAME"
 echo "vLLM baseline container: $VLLM_BASELINE_CONTAINER_NAME"
 echo "LMCache port: $LMCACHE_PORT"
+echo "Request transport: $LMCACHE_REQUEST_TRANSPORT"
 echo "vLLM port: $VLLM_PORT"
 echo "vLLM baseline port: $VLLM_BASELINE_PORT"
 echo ""
@@ -125,4 +137,3 @@ echo "=== ✅ All tests passed! ==="
 echo "============================================"
 
 # Step 8: Cleanup runs automatically via trap
-

--- a/.buildkite/scripts/multiprocessing-test/test-launch.sh
+++ b/.buildkite/scripts/multiprocessing-test/test-launch.sh
@@ -17,6 +17,17 @@ VLLM_BASELINE_PORT="${VLLM_BASELINE_PORT:-9000}"
 CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-80}"
 MAX_WORKERS="${MAX_WORKERS:-4}"
 MODEL="${MODEL:-Qwen/Qwen3-14B}"
+LMCACHE_REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
+
+case "${LMCACHE_REQUEST_TRANSPORT}" in
+    zmq) LMCACHE_REQUEST_SCHEME="tcp" ;;
+    grpc) LMCACHE_REQUEST_SCHEME="grpc" ;;
+    *)
+        echo "Unknown LMCACHE_REQUEST_TRANSPORT='${LMCACHE_REQUEST_TRANSPORT}'"
+        echo "Valid values: zmq, grpc"
+        exit 1
+        ;;
+esac
 
 # Check GPU memory and set gpu-memory-utilization if > 100GB
 GPU_MEMORY_UTIL_ARG=""
@@ -44,6 +55,7 @@ docker run -d \
     -m lmcache.v1.multiprocess.server \
     --cpu-buffer-size "$CPU_BUFFER_SIZE" \
     --max-workers "$MAX_WORKERS" \
+    --transport "$LMCACHE_REQUEST_TRANSPORT" \
     --port "$LMCACHE_PORT"
 
 echo "LMCache container started"
@@ -70,7 +82,7 @@ docker run -d \
     --env PYTHONHASHSEED=0 \
     lmcache/vllm-openai:test \
     "$MODEL" \
-    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
+    --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"$LMCACHE_REQUEST_SCHEME://localhost\", \"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
     --port "$VLLM_PORT" \
     --no-async-scheduling \
     $GPU_MEMORY_UTIL_ARG
@@ -103,4 +115,3 @@ echo "vLLM baseline container started"
 
 echo "=== Containers launched ==="
 docker ps --filter "name=$LMCACHE_CONTAINER_NAME" --filter "name=$VLLM_CONTAINER_NAME" --filter "name=$VLLM_BASELINE_CONTAINER_NAME"
-

--- a/.github/scripts/cpu_device_test.sh
+++ b/.github/scripts/cpu_device_test.sh
@@ -13,10 +13,11 @@
 #   LMCACHE_E2E_TRANSPORT_MODE   engine_driven|lmcache_driven|shm|pickle
 #                                (default: engine_driven)
 #   LMCACHE_E2E_DATA_MODE        shm|pickle (default: shm)
+#   LMCACHE_REQUEST_TRANSPORT    zmq|grpc (default: zmq)
 #   LMCACHE_HTTP_PORT_BENCH      HTTP port for bench (default: 18080)
-#   LMCACHE_ZMQ_PORT_BENCH       ZMQ port for bench (default: 15555)
+#   LMCACHE_REQUEST_PORT_BENCH   request port for bench (default: 15555)
 #   LMCACHE_HTTP_PORT_E2E        HTTP port for e2e (default: 18081)
-#   LMCACHE_ZMQ_PORT_E2E         ZMQ port for e2e (default: 15557)
+#   LMCACHE_REQUEST_PORT_E2E     request port for e2e (default: 15557)
 #   VLLM_PORT_E2E                HTTP port for vLLM (default: 18000)
 
 set -euo pipefail
@@ -33,16 +34,26 @@ BENCH_TRANSFER_MODE="${LMCACHE_BENCH_TRANSFER_MODE:-engine_driven}"
 E2E_TRANSPORT_MODE="${LMCACHE_E2E_TRANSPORT_MODE:-engine_driven}"
 E2E_DATA_MODE="${LMCACHE_E2E_DATA_MODE:-shm}"
 HTTP_PORT_BENCH="${LMCACHE_HTTP_PORT_BENCH:-18080}"
-ZMQ_PORT_BENCH="${LMCACHE_ZMQ_PORT_BENCH:-15555}"
+REQUEST_PORT_BENCH="${LMCACHE_REQUEST_PORT_BENCH:-${LMCACHE_ZMQ_PORT_BENCH:-15555}}"
 HTTP_PORT_E2E="${LMCACHE_HTTP_PORT_E2E:-18081}"
-ZMQ_PORT_E2E="${LMCACHE_ZMQ_PORT_E2E:-15557}"
+REQUEST_PORT_E2E="${LMCACHE_REQUEST_PORT_E2E:-${LMCACHE_ZMQ_PORT_E2E:-15557}}"
 VLLM_PORT_E2E="${VLLM_PORT_E2E:-18000}"
+REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
 
 # Validate modes
 case "${BENCH_TRANSFER_MODE}" in
   lmcache_driven|engine_driven) ;;
   *)
     echo "!! Unknown LMCACHE_BENCH_TRANSFER_MODE='${BENCH_TRANSFER_MODE}'"
+    exit 1
+    ;;
+esac
+
+case "${REQUEST_TRANSPORT}" in
+  zmq|grpc) ;;
+  *)
+    echo "!! Unknown LMCACHE_REQUEST_TRANSPORT='${REQUEST_TRANSPORT}'"
+    echo "   Valid values: zmq, grpc"
     exit 1
     ;;
 esac
@@ -71,7 +82,8 @@ esac
 
 echo "    Bench transfer mode: ${BENCH_TRANSFER_MODE}"
 echo "    E2E transport mode: ${E2E_TRANSPORT_MODE}"
-echo "    Ports: bench=${HTTP_PORT_BENCH}/${ZMQ_PORT_BENCH}, e2e=${HTTP_PORT_E2E}/${ZMQ_PORT_E2E}/${VLLM_PORT_E2E}"
+echo "    Request transport: ${REQUEST_TRANSPORT}"
+echo "    Ports: bench=${HTTP_PORT_BENCH}/${REQUEST_PORT_BENCH}, e2e=${HTTP_PORT_E2E}/${REQUEST_PORT_E2E}/${VLLM_PORT_E2E}"
 
 # Reap any LMCache/vLLM children started by this run on exit so the
 # next workflow step does not collide on default ZMQ/HTTP ports.
@@ -95,9 +107,10 @@ run_server_bench() {
     # Set environment for bench test
     export LMCACHE_BENCH_TRANSFER_MODE="${BENCH_TRANSFER_MODE}"
     export LMCACHE_HTTP_PORT="${HTTP_PORT_BENCH}"
-    export LMCACHE_ZMQ_PORT="${ZMQ_PORT_BENCH}"
-    export LMCACHE_LOG_FILE="/tmp/cpu_device_bench_${BENCH_TRANSFER_MODE}_lmcache.log"
-    export BENCH_OUTPUT_LOG="/tmp/cpu_device_bench_${BENCH_TRANSFER_MODE}_output.log"
+    export LMCACHE_REQUEST_PORT="${REQUEST_PORT_BENCH}"
+    export LMCACHE_REQUEST_TRANSPORT="${REQUEST_TRANSPORT}"
+    export LMCACHE_LOG_FILE="/tmp/cpu_device_bench_${BENCH_TRANSFER_MODE}_${REQUEST_TRANSPORT}_lmcache.log"
+    export BENCH_OUTPUT_LOG="/tmp/cpu_device_bench_${BENCH_TRANSFER_MODE}_${REQUEST_TRANSPORT}_output.log"
     export LMCACHE_HEALTHCHECK_TIMEOUT="30"
     export BENCH_NUM_REQUESTS="3"
     export BENCH_NUM_TOKENS="512"
@@ -117,10 +130,11 @@ run_vllm_e2e() {
     export LMCACHE_TRANSPORT_MODE="${MAPPED_TRANSPORT_MODE}"
     export LMCACHE_DATA_MODE="${MAPPED_DATA_MODE}"
     export LMCACHE_HTTP_PORT="${HTTP_PORT_E2E}"
-    export LMCACHE_ZMQ_PORT="${ZMQ_PORT_E2E}"
+    export LMCACHE_REQUEST_PORT="${REQUEST_PORT_E2E}"
     export VLLM_PORT="${VLLM_PORT_E2E}"
-    export LMCACHE_LOG_FILE="/tmp/cpu_device_e2e_${E2E_TRANSPORT_MODE}_lmcache.log"
-    export VLLM_LOG_FILE="/tmp/cpu_device_e2e_${E2E_TRANSPORT_MODE}_vllm.log"
+    export LMCACHE_REQUEST_TRANSPORT="${REQUEST_TRANSPORT}"
+    export LMCACHE_LOG_FILE="/tmp/cpu_device_e2e_${E2E_TRANSPORT_MODE}_${REQUEST_TRANSPORT}_lmcache.log"
+    export VLLM_LOG_FILE="/tmp/cpu_device_e2e_${E2E_TRANSPORT_MODE}_${REQUEST_TRANSPORT}_vllm.log"
     export LMCACHE_HEALTHCHECK_TIMEOUT="30"
     export VLLM_READY_TIMEOUT="300"
     
@@ -154,3 +168,4 @@ echo "==> CPU device test passed for modes:"
 echo "    Test mode: ${TEST_MODE}"
 echo "    Server bench: ${BENCH_TRANSFER_MODE}"
 echo "    vLLM e2e: ${E2E_TRANSPORT_MODE}"
+echo "    Request transport: ${REQUEST_TRANSPORT}"

--- a/.github/scripts/cpu_server_bench_test.sh
+++ b/.github/scripts/cpu_server_bench_test.sh
@@ -12,8 +12,9 @@
 # Environment variables (all optional, defaults shown):
 #   LMCACHE_BENCH_TRANSFER_MODE  lmcache_driven|engine_driven
 #                                (default: engine_driven)
+#   LMCACHE_REQUEST_TRANSPORT    zmq|grpc (default: zmq)
 #   LMCACHE_HTTP_PORT            HTTP port            (default: 18080)
-#   LMCACHE_ZMQ_PORT             ZMQ RPC port         (default: 15555)
+#   LMCACHE_REQUEST_PORT         request RPC port     (default: 15555)
 #   LMCACHE_LOG_FILE             server log path      (default: /tmp/...)
 #   LMCACHE_HEALTHCHECK_TIMEOUT  seconds              (default: 60)
 #   BENCH_NUM_REQUESTS           requests to run      (default: 3)
@@ -27,11 +28,12 @@ echo "    Python: $(python3 --version 2>&1 || true)"
 
 TRANSFER_MODE="${LMCACHE_BENCH_TRANSFER_MODE:-engine_driven}"
 HTTP_PORT="${LMCACHE_HTTP_PORT:-18080}"
-ZMQ_PORT="${LMCACHE_ZMQ_PORT:-15555}"
+REQUEST_PORT="${LMCACHE_REQUEST_PORT:-${LMCACHE_ZMQ_PORT:-15555}}"
 LOG_FILE="${LMCACHE_LOG_FILE:-/tmp/cpu_server_bench_lmcache.log}"
 HEALTHCHECK_TIMEOUT="${LMCACHE_HEALTHCHECK_TIMEOUT:-60}"
 BENCH_NUM_REQUESTS="${BENCH_NUM_REQUESTS:-3}"
 BENCH_NUM_TOKENS="${BENCH_NUM_TOKENS:-512}"
+REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
 
 case "${TRANSFER_MODE}" in
   lmcache_driven|engine_driven) ;;
@@ -42,8 +44,19 @@ case "${TRANSFER_MODE}" in
     ;;
 esac
 
+case "${REQUEST_TRANSPORT}" in
+  zmq) REQUEST_SCHEME="tcp" ;;
+  grpc) REQUEST_SCHEME="grpc" ;;
+  *)
+    echo "!! Unknown LMCACHE_REQUEST_TRANSPORT='${REQUEST_TRANSPORT}'"
+    echo "   Valid values: zmq, grpc"
+    exit 1
+    ;;
+esac
+
 echo "    TRANSFER_MODE=${TRANSFER_MODE}"
-echo "    HTTP_PORT=${HTTP_PORT}  ZMQ_PORT=${ZMQ_PORT}"
+echo "    REQUEST_TRANSPORT=${REQUEST_TRANSPORT}"
+echo "    HTTP_PORT=${HTTP_PORT}  REQUEST_PORT=${REQUEST_PORT}"
 echo "    BENCH_NUM_REQUESTS=${BENCH_NUM_REQUESTS}"
 echo "    BENCH_NUM_TOKENS=${BENCH_NUM_TOKENS}"
 
@@ -66,7 +79,8 @@ if [ "${TRANSFER_MODE}" = "engine_driven" ]; then
 fi
 
 lmcache server \
-  --port "${ZMQ_PORT}" \
+  --transport "${REQUEST_TRANSPORT}" \
+  --port "${REQUEST_PORT}" \
   --http-port "${HTTP_PORT}" \
   --l1-size-gb 1 \
   --eviction-policy LRU \
@@ -124,7 +138,7 @@ echo "==> Running: lmcache bench server" \
 
 BENCH_LOG="${BENCH_OUTPUT_LOG:-/tmp/cpu_server_bench_output.log}"
 lmcache bench server \
-  --rpc-url "tcp://127.0.0.1:${ZMQ_PORT}" \
+  --rpc-url "${REQUEST_SCHEME}://127.0.0.1:${REQUEST_PORT}" \
   --url "http://127.0.0.1:${HTTP_PORT}" \
   --mode cpu \
   --transfer-mode "${TRANSFER_MODE}" \

--- a/.github/scripts/cpu_vllm_e2e_test.sh
+++ b/.github/scripts/cpu_vllm_e2e_test.sh
@@ -13,6 +13,8 @@
 #   lmcache_driven -> LMCACHE_DATA_MODE selects shm (default) or pickle
 #
 # Environment variables (all optional, defaults shown):
+#   LMCACHE_REQUEST_TRANSPORT Request RPC transport: zmq|grpc (default: zmq)
+#   LMCACHE_REQUEST_PORT      Request RPC port (default: 5555)
 #   LMCACHE_TRANSPORT_MODE   Transport: engine_driven|lmcache_driven
 #                             (default: engine_driven)
 #   LMCACHE_DATA_MODE        Data transfer mode: shm|pickle (default: shm)

--- a/.github/scripts/install_lmcache_cpu.sh
+++ b/.github/scripts/install_lmcache_cpu.sh
@@ -23,5 +23,8 @@ ${PIP_BIN} install -r requirements/common.txt
 ${PIP_BIN} install -r requirements/cli.txt
 ${PIP_BIN} install -e . --no-deps --no-build-isolation
 
+echo "Generating LMCache gRPC bindings"
+python lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
+
 python -c "import lmcache, vllm; \
 print('lmcache:', lmcache.__version__, 'vllm:', vllm.__version__)"

--- a/.github/scripts/nightly-aggregate-vllm-verify.sh
+++ b/.github/scripts/nightly-aggregate-vllm-verify.sh
@@ -10,10 +10,10 @@
 # per OS rather than requiring one shared version across all of them.
 # pin-tested-vllm.sh writes latest_tested_vllm_<os>.txt accordingly.
 #
-# Results come from cpu_device.yml, whose matrix is (os x model), so one
-# OS contributes several legs. An OS is only pinned as tested when every
-# one of its legs passed the full CPU device suite (server bench + e2e);
-# "importable" is not enough.
+# Results come from cpu_device.yml, whose matrix is
+# (os x model x request transport), so one OS contributes several legs.
+# An OS is only pinned as tested when every one of its legs passed the full
+# CPU device suite (server bench + e2e); "importable" is not enough.
 #
 # Expects artifacts under verify-results/*/verify_result.json (one
 # subdirectory per matrix leg, from download-artifact).
@@ -55,18 +55,19 @@ for d in verify-results/*/; do
     fi
     # Read all fields in a single python3 invocation (tab-separated) to
     # avoid spawning one interpreter per field.
-    IFS=$'\t' read -r os model st ver rsn < <(python3 -c '
+    IFS=$'\t' read -r os model transport st ver rsn < <(python3 -c '
 import json, sys
 d = json.load(open(sys.argv[1]))
 print("\t".join([
     d["os"],
     d.get("model", "-"),
+    d.get("request_transport", "zmq"),
     d["status"],
     d.get("vllm_version", ""),
     d.get("reason", ""),
 ]))
 ' "$f")
-    OS_LEGS["$os"]="${OS_LEGS[$os]:-} ${model}=${st}"
+    OS_LEGS["$os"]="${OS_LEGS[$os]:-} ${model}/${transport}=${st}"
     # Record a version from any leg that reported one, even a failing
     # one, so the report can name the build that broke.
     [ -n "$ver" ] && OS_VERSION["$os"]="$ver"

--- a/.github/scripts/nightly-collect-verify-result.py
+++ b/.github/scripts/nightly-collect-verify-result.py
@@ -3,7 +3,8 @@
 """Write a per-leg verify result JSON for the aggregator to consume.
 
 Runs as the last step of one ``cpu_device.yml`` matrix leg (one OS + one
-model) and writes ``verify_result.json`` to the current directory.
+model + one request transport) and writes ``verify_result.json`` to the
+current directory.
 
 The verdict comes from ``JOB_STATUS`` (GitHub's ``job.status``) rather
 than a single step outcome, so any failing step in the leg — install,
@@ -12,8 +13,8 @@ and ``INSTALL_LMC_OUTCOME`` are only used to phrase a more specific
 reason.
 
 Required env:
-    JOB_STATUS, MATRIX_OS, MATRIX_MODEL, GITHUB_RUN_ID,
-    GITHUB_SERVER_URL, GITHUB_REPOSITORY
+    JOB_STATUS, MATRIX_OS, MATRIX_MODEL, MATRIX_REQUEST_TRANSPORT,
+    GITHUB_RUN_ID, GITHUB_SERVER_URL, GITHUB_REPOSITORY
 Optional env:
     INSTALL_VLLM_OUTCOME, INSTALL_LMC_OUTCOME
 """
@@ -52,10 +53,11 @@ def resolve_vllm_version() -> str:
 JOB_STATUS = os.environ["JOB_STATUS"]
 MATRIX_OS = os.environ["MATRIX_OS"]
 MATRIX_MODEL = os.environ["MATRIX_MODEL"]
+MATRIX_REQUEST_TRANSPORT = os.environ["MATRIX_REQUEST_TRANSPORT"]
 INSTALL_VLLM = os.environ.get("INSTALL_VLLM_OUTCOME", "")
 INSTALL_LMC = os.environ.get("INSTALL_LMC_OUTCOME", "")
 
-LEG = MATRIX_OS + " / " + MATRIX_MODEL
+LEG = MATRIX_OS + " / " + MATRIX_MODEL + " / " + MATRIX_REQUEST_TRANSPORT
 
 is_ok = JOB_STATUS == "success"
 version = resolve_vllm_version()
@@ -72,6 +74,7 @@ else:
 result = {
     "os": MATRIX_OS,
     "model": MATRIX_MODEL,
+    "request_transport": MATRIX_REQUEST_TRANSPORT,
     "status": "ok" if is_ok else "failed",
     # Keep the version even for a failed leg: the aggregator reports it in
     # the tracking issue so a human can tell which build broke.

--- a/.github/scripts/run-cpu-e2e-validation.sh
+++ b/.github/scripts/run-cpu-e2e-validation.sh
@@ -17,7 +17,8 @@ VLLM_LOG="${VLLM_LOG_FILE:-/tmp/build_${BUILD_ID}_vllm_cpu_validation.log}"
 LMCACHE_PID=""
 VLLM_PID=""
 LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
-LMCACHE_ZMQ_PORT="${LMCACHE_ZMQ_PORT:-5555}"
+LMCACHE_REQUEST_PORT="${LMCACHE_REQUEST_PORT:-${LMCACHE_ZMQ_PORT:-5555}}"
+LMCACHE_REQUEST_TRANSPORT="${LMCACHE_REQUEST_TRANSPORT:-zmq}"
 VLLM_PORT="${VLLM_PORT:-8000}"
 LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-1}"
 LMCACHE_EVICTION_POLICY="${LMCACHE_EVICTION_POLICY:-LRU}"
@@ -78,6 +79,16 @@ VLLM_HF_OFFLINE="${VLLM_HF_OFFLINE:-1}"
 #   LMCACHE_MP_TRANSFER_MODE=lmcache_driven -> lmcache-driven IPC handle path
 LMCACHE_SHM_NAME="${LMCACHE_SHM_NAME-__default__}"
 LMCACHE_MP_TRANSFER_MODE="${LMCACHE_MP_TRANSFER_MODE:-engine_driven}"
+
+case "${LMCACHE_REQUEST_TRANSPORT}" in
+  zmq) LMCACHE_REQUEST_SCHEME="tcp" ;;
+  grpc) LMCACHE_REQUEST_SCHEME="grpc" ;;
+  *)
+    echo "Unknown LMCACHE_REQUEST_TRANSPORT='${LMCACHE_REQUEST_TRANSPORT}'" >&2
+    echo "Valid values: zmq, grpc" >&2
+    exit 1
+    ;;
+esac
 # Set SKIP_INSTALL=1 to skip Phase 1 (install) — useful when the caller
 # has already installed everything (e.g. macOS CI workflow steps).
 SKIP_INSTALL="${SKIP_INSTALL:-0}"
@@ -323,8 +334,8 @@ start_vllm() {
   kv_cache_bytes="$(python3 -c "print(int(${VLLM_CPU_KVCACHE_SPACE} * 1024 * 1024 * 1024))")"
   # Tell LMCacheMPConnector where the lmcache server actually listens.
   # Without this it falls back to tcp://localhost:5555 and dies with
-  # "Cannot reach the LMCache MP server" whenever we run multiple e2e
-  # steps in parallel/sequence on different ZMQ ports.
+  # "Cannot reach the LMCache MP server" whenever the selected request
+  # transport or port differs from that legacy default.
   local kv_transfer_config
   kv_transfer_config="$(python3 -c "
 import json
@@ -333,8 +344,8 @@ print(json.dumps({
     'kv_role': 'kv_both',
     'kv_connector_module_path': 'lmcache.integration.vllm.lmcache_mp_connector',
     'kv_connector_extra_config': {
-        'lmcache.mp.host': 'tcp://localhost',
-        'lmcache.mp.port': int('${LMCACHE_ZMQ_PORT}'),
+        'lmcache.mp.host': '${LMCACHE_REQUEST_SCHEME}://localhost',
+        'lmcache.mp.port': int('${LMCACHE_REQUEST_PORT}'),
     },
 }))")"
   # Optional flags — appended only when set, so unrelated callers stay
@@ -485,7 +496,8 @@ echo "[Phase 2 / Step 3] Starting LMCache server"
 echo "LMCache log: ${LMCACHE_LOG}"
 # Build lmcache server args
 LMCACHE_ARGS=(
-  --port "${LMCACHE_ZMQ_PORT}"
+  --transport "${LMCACHE_REQUEST_TRANSPORT}"
+  --port "${LMCACHE_REQUEST_PORT}"
   --http-port "${LMCACHE_HTTP_PORT}"
   --l1-size-gb "${LMCACHE_L1_SIZE_GB}"
   --eviction-policy "${LMCACHE_EVICTION_POLICY}"

--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -80,13 +80,16 @@ jobs:
   cpu-device-test:
     needs: changes
     if: needs.changes.outputs.lmcache == 'true'
-    name: CPU device (${{ matrix.os }} / ${{ matrix.model.name }})
+    name: CPU device (${{ matrix.os }} / ${{ matrix.model.name }} / ${{ matrix.request_transport }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest]
+        # Keep the shared transport dimension ready, but do not run gRPC until
+        # the request-server implementation lands.
+        request_transport: [zmq]
         # Each entry is a self-contained model profile the e2e steps
         # thread through env vars. Adding a new model = adding a new
         # entry here. All models share the same downloader
@@ -142,6 +145,9 @@ jobs:
       # models that would normally route through MLA. Required on CPU
       # today because vLLM's CPU backend raises for MLA.
       VLLM_MLA_DISABLE: ${{ matrix.model.mla_disable }}
+      # Request/RPC transport between vLLM and the LMCache MP server.
+      # This is independent of the worker-side KV data transfer mode.
+      LMCACHE_REQUEST_TRANSPORT: ${{ matrix.request_transport }}
 
     steps:
       - name: Harden Runner
@@ -232,7 +238,7 @@ jobs:
         run: |
           LMCACHE_BENCH_TRANSFER_MODE=lmcache_driven \
           LMCACHE_HTTP_PORT_BENCH=18080 \
-          LMCACHE_ZMQ_PORT_BENCH=15555 \
+          LMCACHE_REQUEST_PORT_BENCH=15555 \
             bash .github/scripts/cpu_device_test.sh server_bench
 
       - name: Server bench — Engine-driven
@@ -240,7 +246,7 @@ jobs:
         run: |
           LMCACHE_BENCH_TRANSFER_MODE=engine_driven \
           LMCACHE_HTTP_PORT_BENCH=18081 \
-          LMCACHE_ZMQ_PORT_BENCH=15556 \
+          LMCACHE_REQUEST_PORT_BENCH=15556 \
             bash .github/scripts/cpu_device_test.sh server_bench
 
       - name: Prepare model — ${{ matrix.model.name }}
@@ -266,7 +272,7 @@ jobs:
         run: |
           LMCACHE_E2E_TRANSPORT_MODE=pickle \
           LMCACHE_HTTP_PORT_E2E=18082 \
-          LMCACHE_ZMQ_PORT_E2E=15557 \
+          LMCACHE_REQUEST_PORT_E2E=15557 \
           VLLM_PORT_E2E=18000 \
             bash .github/scripts/cpu_device_test.sh vllm_e2e
 
@@ -281,7 +287,7 @@ jobs:
         run: |
           LMCACHE_E2E_TRANSPORT_MODE=shm \
           LMCACHE_HTTP_PORT_E2E=18083 \
-          LMCACHE_ZMQ_PORT_E2E=15558 \
+          LMCACHE_REQUEST_PORT_E2E=15558 \
           VLLM_PORT_E2E=18001 \
             bash .github/scripts/cpu_device_test.sh vllm_e2e
 
@@ -297,7 +303,7 @@ jobs:
         run: |
           LMCACHE_E2E_TRANSPORT_MODE=lmcache_driven \
           LMCACHE_HTTP_PORT_E2E=18084 \
-          LMCACHE_ZMQ_PORT_E2E=15559 \
+          LMCACHE_REQUEST_PORT_E2E=15559 \
           VLLM_PORT_E2E=18002 \
             bash .github/scripts/cpu_device_test.sh vllm_e2e
 
@@ -305,7 +311,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: cpu-device-logs-${{ matrix.os }}-${{ matrix.model.name }}
+          name: cpu-device-logs-${{ matrix.os }}-${{ matrix.model.name }}-${{ matrix.request_transport }}
           path: |
             /tmp/cpu_device_*.log
           if-no-files-found: ignore
@@ -322,11 +328,12 @@ jobs:
           INSTALL_LMC_OUTCOME: ${{ steps.install-lmcache.outcome }}
           MATRIX_OS: ${{ matrix.os }}
           MATRIX_MODEL: ${{ matrix.model.name }}
+          MATRIX_REQUEST_TRANSPORT: ${{ matrix.request_transport }}
         run: python3 .github/scripts/nightly-collect-verify-result.py
 
       - name: Upload verify result
         if: always() && inputs.nightly_verify
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: verify-result-${{ matrix.os }}-${{ matrix.model.name }}
+          name: verify-result-${{ matrix.os }}-${{ matrix.model.name }}-${{ matrix.request_transport }}
           path: verify_result.json

--- a/docs/design/v1/multiprocess/transport/request_transport.md
+++ b/docs/design/v1/multiprocess/transport/request_transport.md
@@ -48,6 +48,26 @@ currently raises `NotImplementedError`.
 This abstraction covers MP request RPCs only. It does not select the mechanism
 used to move KV data between an engine worker and the server.
 
+## Protobuf contracts
+
+The planned gRPC transport keeps its wire contracts under
+`grpc_impl/protos/`. These `.proto` files are the source of truth for request
+and response messages; they do not enable the gRPC runtime by themselves.
+
+Python protobuf modules are generated into `grpc_impl/_proto_gen/` during a
+package build. Most generated files remain ignored, while the type stubs used
+by handwritten adapters are tracked so static analysis also works from a
+source checkout. Regenerate the bindings after changing a schema with:
+
+```bash
+pip install -r requirements/proto.txt
+python -m lmcache.v1.multiprocess.transport.grpc_impl._proto_gen._generate
+```
+
+The generator cleans stale outputs, compiles every schema, rewrites generated
+imports to use the package-qualified path, and verifies that all generated
+Python modules import successfully.
+
 ## Extending the transport
 
 A new transport implements the `RequestClient` contract inside its own

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -567,6 +567,10 @@ Key Source Files
    * - ``lmcache/v1/multiprocess/transport/zmq_impl/server.py``
      - ZMQ ``HandlerSpec`` and ``ThreadPoolType`` definitions, per-module
        handler adapters, and message queue server construction
+   * - ``lmcache/v1/multiprocess/transport/grpc_impl/protos/``
+     - Protobuf wire contracts for the planned gRPC request transport
+   * - ``lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/``
+     - Build-time protobuf generator and generated Python package
    * - ``lmcache/v1/multiprocess/modules/``
      - Engine module implementations: ``lookup.py`` (``LookupModule``),
        ``management.py`` (``ManagementModule``), ``lmcache_driven_transfer.py``

--- a/docs/source/mp/request_transport.rst
+++ b/docs/source/mp/request_transport.rst
@@ -27,6 +27,23 @@ Transport schemes
      - gRPC
      - Not supported yet. gRPC support is planned soon.
 
+gRPC schema development
+-----------------------
+
+The protobuf schemas for the planned gRPC transport live under
+``lmcache/v1/multiprocess/transport/grpc_impl/protos``. Package builds generate
+their Python bindings under the sibling ``_proto_gen`` package. Landing these
+schemas and the build-time generator does not enable the gRPC client or server;
+``grpc://`` endpoints remain unavailable until the runtime implementation
+lands.
+
+After changing a schema, regenerate and validate all bindings with:
+
+.. code-block:: bash
+
+   pip install -r requirements/proto.txt
+   python -m lmcache.v1.multiprocess.transport.grpc_impl._proto_gen._generate
+
 For a single vLLM connector, set the scheme in ``lmcache.mp.host`` and keep the
 port in ``lmcache.mp.port``. The current ZMQ configuration is:
 

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Configuration for the multiprocess (ZMQ) server and HTTP frontend.
+Configuration for the multiprocess server and HTTP frontend.
 """
 
 # Standard
@@ -21,13 +21,17 @@ logger = init_logger(__name__)
 
 @dataclass
 class MPServerConfig:
-    """Configuration for the ZMQ-based multiprocess cache server."""
+    """Configuration for the multiprocess cache server."""
+
+    transport: Literal["zmq", "grpc"] = "zmq"
+    """Request transport. gRPC is configurable for forward-compatible test
+    plumbing, but its runtime server is not available yet."""
 
     host: str = "localhost"
-    """ZMQ server host."""
+    """Request server host."""
 
     port: int = 5555
-    """ZMQ server port."""
+    """Request server port."""
 
     chunk_size: int = 256
     """Chunk size for KV cache operations."""
@@ -263,7 +267,7 @@ def add_mp_server_args(
         The same parser with MP server arguments added.
     """
     mp_group = parser.add_argument_group(
-        "MP Server", "Configuration for the ZMQ multiprocess cache server"
+        "MP Server", "Configuration for the multiprocess cache server"
     )
     mp_group.add_argument(
         "--instance-id",
@@ -275,10 +279,18 @@ def add_mp_server_args(
         "minted at startup.",
     )
     mp_group.add_argument(
+        "--transport",
+        type=str,
+        choices=["zmq", "grpc"],
+        default="zmq",
+        help="Request transport. gRPC is reserved for the upcoming runtime "
+        "implementation. Default is zmq.",
+    )
+    mp_group.add_argument(
         "--host",
         type=str,
         default="localhost",
-        help="Host to bind the ZMQ server. Default is localhost.",
+        help="Host to bind the request server. Default is localhost.",
     )
     mp_group.add_argument(
         "--port",
@@ -456,6 +468,7 @@ def parse_args_to_mp_server_config(
         raise ValueError("--runtime-plugin-config is not valid JSON: %s" % exc) from exc
     return MPServerConfig(
         instance_id=args.instance_id or str(uuid.uuid4()),
+        transport=args.transport,
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/.gitignore
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/.gitignore
@@ -1,0 +1,6 @@
+# Runtime bindings and unused type stubs are generated during build/test.
+*_pb2.py
+*_pb2.pyi
+!common_pb2.pyi
+!p2p_service_pb2.pyi
+*_pb2_grpc.py

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generated protobuf and gRPC modules for the multiprocess transport.
+
+The ``../protos/*.proto`` schemas are the source of truth. Package builds
+generate ``*_pb2.py``, ``*_pb2.pyi``, and ``*_pb2_grpc.py`` modules in this
+package. The type stubs used directly by custom adapters are tracked so static
+analysis also works before a package build. Regenerate all bindings after
+changing a schema with::
+
+    pip install -r requirements/proto.txt
+    python -m lmcache.v1.multiprocess.transport.grpc_impl._proto_gen._generate
+"""

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Python gRPC bindings from the multiprocess service schemas."""
+
+# Standard
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+# Third Party
+from grpc_tools import protoc
+
+GENERATED_DIR = Path(__file__).resolve().parent
+PROTO_DIR = GENERATED_DIR.parent / "protos"
+PROJECT_ROOT = GENERATED_DIR.parents[5]
+GENERATED_PACKAGE = "lmcache.v1.multiprocess.transport.grpc_impl._proto_gen"
+
+SPDX_HEADER = "# SPDX-License-Identifier: Apache-2.0\n"
+MYPY_IGNORE = "# mypy: ignore-errors\n"
+RUFF_IGNORE = "# ruff: noqa\n"
+FORMAT_OFF = "# fmt: off\n"
+ISORT_SKIP = "# isort: skip_file\n"
+FLAT_PB2_IMPORT_RE = re.compile(
+    r"^import ([A-Za-z_][A-Za-z0-9_]*_pb2) as ([A-Za-z_][A-Za-z0-9_]*)$",
+    re.MULTILINE,
+)
+
+
+def _generated_files(directory: Path) -> tuple[Path, ...]:
+    """Return generated protobuf modules, stubs, and gRPC modules."""
+    return (
+        tuple(directory.glob("*_pb2.py"))
+        + tuple(directory.glob("*_pb2.pyi"))
+        + tuple(directory.glob("*_pb2_grpc.py"))
+    )
+
+
+def _cleanup_generated_files() -> None:
+    """Remove current output and legacy output next to the proto sources."""
+    for path in _generated_files(GENERATED_DIR) + _generated_files(PROTO_DIR):
+        path.unlink(missing_ok=True)
+
+
+def _patch_generated_file(path: Path) -> None:
+    """Make generated imports package-safe and add repository headers."""
+    text = path.read_text()
+    text = FLAT_PB2_IMPORT_RE.sub(
+        rf"from {GENERATED_PACKAGE} import \1 as \2",
+        text,
+    )
+    prefix = ""
+    if not text.startswith(SPDX_HEADER):
+        prefix += SPDX_HEADER
+    if path.suffix == ".py":
+        if MYPY_IGNORE not in text.splitlines()[:5]:
+            prefix += MYPY_IGNORE
+    else:
+        if RUFF_IGNORE not in text.splitlines()[:5]:
+            prefix += RUFF_IGNORE
+        if FORMAT_OFF not in text.splitlines()[:5]:
+            prefix += FORMAT_OFF
+        if ISORT_SKIP not in text.splitlines()[:5]:
+            prefix += ISORT_SKIP
+    path.write_text(prefix + text)
+
+
+def generate() -> None:
+    """Generate all protobuf and gRPC modules under ``_proto_gen``.
+
+    Returns:
+        None.
+
+    Raises:
+        RuntimeError: If no schemas exist, compilation fails, or a generated
+            module cannot be imported.
+    """
+    proto_files = tuple(sorted(PROTO_DIR.glob("*.proto")))
+    if not proto_files:
+        raise RuntimeError(f"No proto sources found under {PROTO_DIR}")
+
+    _cleanup_generated_files()
+    result = protoc.main(
+        [
+            "grpc_tools.protoc",
+            f"-I{PROTO_DIR}",
+            f"--python_out={GENERATED_DIR}",
+            f"--pyi_out={GENERATED_DIR}",
+            f"--grpc_python_out={GENERATED_DIR}",
+            *(str(path) for path in proto_files),
+        ]
+    )
+    if result != 0:
+        raise RuntimeError(f"grpc_tools.protoc failed with exit code {result}")
+
+    generated_files = _generated_files(GENERATED_DIR)
+    for path in generated_files:
+        _patch_generated_file(path)
+
+    modules = "; ".join(
+        f"import {GENERATED_PACKAGE}.{path.stem}"
+        for path in generated_files
+        if path.suffix == ".py"
+    )
+    result = subprocess.call(
+        [sys.executable, "-c", modules],
+        cwd=PROJECT_ROOT,
+    )
+    if result != 0:
+        _cleanup_generated_files()
+        raise RuntimeError("Generated gRPC modules failed their import check")
+
+
+if __name__ == "__main__":
+    generate()

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/common_pb2.pyi
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/common_pb2.pyi
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa
+# fmt: off
+# isort: skip_file
+from google.protobuf.internal import containers as _containers
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from collections.abc import Iterable as _Iterable
+from typing import ClassVar as _ClassVar, Optional as _Optional
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class IpcCacheServerKey(_message.Message):
+    __slots__ = ("model_name", "world_size", "worker_id", "token_ids", "start", "end", "request_id", "cache_salt", "encoded_request_configs", "num_kv_readers")
+    MODEL_NAME_FIELD_NUMBER: _ClassVar[int]
+    WORLD_SIZE_FIELD_NUMBER: _ClassVar[int]
+    WORKER_ID_FIELD_NUMBER: _ClassVar[int]
+    TOKEN_IDS_FIELD_NUMBER: _ClassVar[int]
+    START_FIELD_NUMBER: _ClassVar[int]
+    END_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    CACHE_SALT_FIELD_NUMBER: _ClassVar[int]
+    ENCODED_REQUEST_CONFIGS_FIELD_NUMBER: _ClassVar[int]
+    NUM_KV_READERS_FIELD_NUMBER: _ClassVar[int]
+    model_name: str
+    world_size: int
+    worker_id: int
+    token_ids: _containers.RepeatedScalarFieldContainer[int]
+    start: int
+    end: int
+    request_id: str
+    cache_salt: str
+    encoded_request_configs: bytes
+    num_kv_readers: int
+    def __init__(self, model_name: _Optional[str] = ..., world_size: _Optional[int] = ..., worker_id: _Optional[int] = ..., token_ids: _Optional[_Iterable[int]] = ..., start: _Optional[int] = ..., end: _Optional[int] = ..., request_id: _Optional[str] = ..., cache_salt: _Optional[str] = ..., encoded_request_configs: _Optional[bytes] = ..., num_kv_readers: _Optional[int] = ...) -> None: ...
+
+class EventIpcHandleResult(_message.Message):
+    __slots__ = ("event_ipc_handle", "success")
+    EVENT_IPC_HANDLE_FIELD_NUMBER: _ClassVar[int]
+    SUCCESS_FIELD_NUMBER: _ClassVar[int]
+    event_ipc_handle: bytes
+    success: bool
+    def __init__(self, event_ipc_handle: _Optional[bytes] = ..., success: bool = ...) -> None: ...
+
+class BlockIdGroup(_message.Message):
+    __slots__ = ("block_ids",)
+    BLOCK_IDS_FIELD_NUMBER: _ClassVar[int]
+    block_ids: _containers.RepeatedScalarFieldContainer[int]
+    def __init__(self, block_ids: _Optional[_Iterable[int]] = ...) -> None: ...
+
+class DeviceIpcWrapper(_message.Message):
+    __slots__ = ("pickled_payload",)
+    PICKLED_PAYLOAD_FIELD_NUMBER: _ClassVar[int]
+    pickled_payload: bytes
+    def __init__(self, pickled_payload: _Optional[bytes] = ...) -> None: ...
+
+class EngineGroupInfo(_message.Message):
+    __slots__ = ("engine_group_id", "layer_indices", "tokens_per_block", "sw_size_tokens", "extra_object_group_tag", "recurrent_state")
+    ENGINE_GROUP_ID_FIELD_NUMBER: _ClassVar[int]
+    LAYER_INDICES_FIELD_NUMBER: _ClassVar[int]
+    TOKENS_PER_BLOCK_FIELD_NUMBER: _ClassVar[int]
+    SW_SIZE_TOKENS_FIELD_NUMBER: _ClassVar[int]
+    EXTRA_OBJECT_GROUP_TAG_FIELD_NUMBER: _ClassVar[int]
+    RECURRENT_STATE_FIELD_NUMBER: _ClassVar[int]
+    engine_group_id: int
+    layer_indices: _containers.RepeatedScalarFieldContainer[int]
+    tokens_per_block: int
+    sw_size_tokens: int
+    extra_object_group_tag: int
+    recurrent_state: bool
+    def __init__(self, engine_group_id: _Optional[int] = ..., layer_indices: _Optional[_Iterable[int]] = ..., tokens_per_block: _Optional[int] = ..., sw_size_tokens: _Optional[int] = ..., extra_object_group_tag: _Optional[int] = ..., recurrent_state: bool = ...) -> None: ...

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/p2p_service_pb2.pyi
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/p2p_service_pb2.pyi
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa
+# fmt: off
+# isort: skip_file
+from google.protobuf.internal import containers as _containers
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from collections.abc import Iterable as _Iterable, Mapping as _Mapping
+from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ObjectKey(_message.Message):
+    __slots__ = ("chunk_hash", "model_name", "kv_rank", "object_group_id", "cache_salt")
+    CHUNK_HASH_FIELD_NUMBER: _ClassVar[int]
+    MODEL_NAME_FIELD_NUMBER: _ClassVar[int]
+    KV_RANK_FIELD_NUMBER: _ClassVar[int]
+    OBJECT_GROUP_ID_FIELD_NUMBER: _ClassVar[int]
+    CACHE_SALT_FIELD_NUMBER: _ClassVar[int]
+    chunk_hash: bytes
+    model_name: str
+    kv_rank: int
+    object_group_id: int
+    cache_salt: str
+    def __init__(self, chunk_hash: _Optional[bytes] = ..., model_name: _Optional[str] = ..., kv_rank: _Optional[int] = ..., object_group_id: _Optional[int] = ..., cache_salt: _Optional[str] = ...) -> None: ...
+
+class TensorShape(_message.Message):
+    __slots__ = ("dims",)
+    DIMS_FIELD_NUMBER: _ClassVar[int]
+    dims: _containers.RepeatedScalarFieldContainer[int]
+    def __init__(self, dims: _Optional[_Iterable[int]] = ...) -> None: ...
+
+class MemoryLayoutDesc(_message.Message):
+    __slots__ = ("shapes", "dtypes")
+    SHAPES_FIELD_NUMBER: _ClassVar[int]
+    DTYPES_FIELD_NUMBER: _ClassVar[int]
+    shapes: _containers.RepeatedCompositeFieldContainer[TensorShape]
+    dtypes: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, shapes: _Optional[_Iterable[_Union[TensorShape, _Mapping]]] = ..., dtypes: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class TransferChannelAddress(_message.Message):
+    __slots__ = ("offset", "size")
+    OFFSET_FIELD_NUMBER: _ClassVar[int]
+    SIZE_FIELD_NUMBER: _ClassVar[int]
+    offset: int
+    size: int
+    def __init__(self, offset: _Optional[int] = ..., size: _Optional[int] = ...) -> None: ...
+
+class P2pLookupAndLockRequest(_message.Message):
+    __slots__ = ("keys", "group_layout_descs")
+    class GroupLayoutDescsEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: int
+        value: MemoryLayoutDesc
+        def __init__(self, key: _Optional[int] = ..., value: _Optional[_Union[MemoryLayoutDesc, _Mapping]] = ...) -> None: ...
+    KEYS_FIELD_NUMBER: _ClassVar[int]
+    GROUP_LAYOUT_DESCS_FIELD_NUMBER: _ClassVar[int]
+    keys: _containers.RepeatedCompositeFieldContainer[ObjectKey]
+    group_layout_descs: _containers.MessageMap[int, MemoryLayoutDesc]
+    def __init__(self, keys: _Optional[_Iterable[_Union[ObjectKey, _Mapping]]] = ..., group_layout_descs: _Optional[_Mapping[int, MemoryLayoutDesc]] = ...) -> None: ...
+
+class P2pLookupAndLockResponse(_message.Message):
+    __slots__ = ("task_id",)
+    TASK_ID_FIELD_NUMBER: _ClassVar[int]
+    task_id: int
+    def __init__(self, task_id: _Optional[int] = ...) -> None: ...
+
+class P2pQueryLookupResultsRequest(_message.Message):
+    __slots__ = ("task_id",)
+    TASK_ID_FIELD_NUMBER: _ClassVar[int]
+    task_id: int
+    def __init__(self, task_id: _Optional[int] = ...) -> None: ...
+
+class TransferChannelAddressList(_message.Message):
+    __slots__ = ("addresses",)
+    ADDRESSES_FIELD_NUMBER: _ClassVar[int]
+    addresses: _containers.RepeatedCompositeFieldContainer[TransferChannelAddress]
+    def __init__(self, addresses: _Optional[_Iterable[_Union[TransferChannelAddress, _Mapping]]] = ...) -> None: ...
+
+class P2pQueryLookupResultsResponse(_message.Message):
+    __slots__ = ("addresses",)
+    ADDRESSES_FIELD_NUMBER: _ClassVar[int]
+    addresses: TransferChannelAddressList
+    def __init__(self, addresses: _Optional[_Union[TransferChannelAddressList, _Mapping]] = ...) -> None: ...
+
+class P2pUnlockObjectsRequest(_message.Message):
+    __slots__ = ("keys",)
+    KEYS_FIELD_NUMBER: _ClassVar[int]
+    keys: _containers.RepeatedCompositeFieldContainer[ObjectKey]
+    def __init__(self, keys: _Optional[_Iterable[_Union[ObjectKey, _Mapping]]] = ...) -> None: ...
+
+class P2pUnlockObjectsResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source protobuf schemas for the LMCache multiprocess gRPC transport."""

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/blend_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/blend_service.proto
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// BlendService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "common.proto";
+
+message CbMatchResult {
+  int64 old_st = 1;
+  int64 old_ed = 2;
+  int64 cur_st = 3;
+  int64 cur_ed = 4;
+  bytes hash = 5;
+}
+
+message CbProtocolHandshakeRequest {
+  int64 client_version = 1;
+}
+
+message CbProtocolHandshakeResponse {
+  int64 server_version = 1;
+  bool client_compatible = 2;
+}
+
+message CbUnregisterRopeRequest {
+  int64 instance_id = 1;
+}
+
+message CbUnregisterRopeResponse {}
+
+message CbRetrievePreComputedRequest {
+  IpcCacheServerKey key = 1;
+  repeated CbMatchResult cb_match_result = 2;
+  repeated BlockIdGroup gpu_block_ids = 3;
+  int64 instance_id = 4;
+  bytes event_ipc_handle = 5;
+}
+
+message CbRetrievePreComputedResponse {
+  EventIpcHandleResult result = 1;
+}
+
+message CbUnifiedLookupRequest {
+  IpcCacheServerKey key = 1;
+  int64 tp_size = 2;
+}
+
+message CbUnifiedLookupPayload {
+  int64 prefix_coverage_tokens = 1;
+  repeated CbMatchResult non_prefix_segments = 2;
+  repeated CbMatchResult segmented_prefix_segments = 3;
+}
+
+message CbUnifiedLookupResponse {
+  optional CbUnifiedLookupPayload payload = 1;
+}
+
+message RopeWindow {
+  repeated int64 values = 1;
+}
+
+message CbRegisterRopeRequest {
+  int64 instance_id = 1;
+  repeated DeviceIpcWrapper cos_sin_caches_ipc = 2;
+  int64 head_size = 3;
+  bool is_neox_style = 4;
+  repeated int64 group_to_cache = 5;
+  repeated RopeWindow group_rot = 6;
+}
+
+message CbRegisterRopeResponse {}
+
+service BlendService {
+  rpc CbProtocolHandshake(CbProtocolHandshakeRequest)
+      returns (CbProtocolHandshakeResponse);
+  rpc CbRegisterRope(CbRegisterRopeRequest) returns (CbRegisterRopeResponse);
+  rpc CbUnregisterRope(CbUnregisterRopeRequest)
+      returns (CbUnregisterRopeResponse);
+  rpc CbRetrievePreComputed(CbRetrievePreComputedRequest)
+      returns (CbRetrievePreComputedResponse);
+  rpc CbUnifiedLookup(CbUnifiedLookupRequest) returns (CbUnifiedLookupResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/common.proto
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared message types for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+// Cache key used by engine and CacheBlend RPCs.
+message IpcCacheServerKey {
+  string model_name = 1;
+  int64 world_size = 2;
+  optional int64 worker_id = 3;
+  repeated int64 token_ids = 4;
+  int64 start = 5;
+  int64 end = 6;
+  string request_id = 7;
+  string cache_salt = 8;
+  optional bytes encoded_request_configs = 9;
+  int64 num_kv_readers = 10;
+}
+
+// Store / Retrieve and CacheBlend retrieve share this reply shape.
+message EventIpcHandleResult {
+  bytes event_ipc_handle = 1;
+  bool success = 2;
+}
+
+// One list of block IDs per KV group in kernel order.
+message BlockIdGroup {
+  repeated int64 block_ids = 1;
+}
+
+// Device IPC wrappers preserve concrete Python subclass identity.
+message DeviceIpcWrapper {
+  bytes pickled_payload = 1;
+}
+
+// EngineGroupInfo mirrors the Python msgspec.Struct field-by-field.
+message EngineGroupInfo {
+  int64 engine_group_id = 1;
+  repeated int64 layer_indices = 2;
+  int64 tokens_per_block = 3;
+  int64 sw_size_tokens = 4;
+  int64 extra_object_group_tag = 5;
+  bool recurrent_state = 6;
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/controller_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/controller_service.proto
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ControllerService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message ClearRequest {}
+
+message ClearResponse {}
+
+message GetChunkSizeRequest {}
+
+message GetChunkSizeResponse {
+  int64 chunk_size = 1;
+}
+
+message GetExperimentalRequest {}
+
+message GetExperimentalResponse {
+  repeated string names = 1;
+}
+
+message PingRequest {
+  optional int64 instance_id = 1;
+}
+
+message PingResponse {
+  bool ok = 1;
+}
+
+service ControllerService {
+  rpc Clear(ClearRequest) returns (ClearResponse);
+  rpc GetChunkSize(GetChunkSizeRequest) returns (GetChunkSizeResponse);
+  rpc GetExperimental(GetExperimentalRequest) returns (GetExperimentalResponse);
+  rpc Ping(PingRequest) returns (PingResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/debug_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/debug_service.proto
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// DebugService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message NoopRequest {}
+
+message NoopResponse {
+  string message = 1;
+}
+
+service DebugService {
+  rpc Noop(NoopRequest) returns (NoopResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/engine_driven_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/engine_driven_service.proto
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Engine-driven transfer wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "common.proto";
+
+message RegisterKvCacheEngineDrivenContextRequest {
+  int64 instance_id = 1;
+  string model_name = 2;
+  int64 world_size = 3;
+  int64 block_size = 4;
+  int64 num_layers = 5;
+  int64 hidden_dim_size = 6;
+  string dtype_str = 7;
+  bool use_mla = 8;
+  optional int64 num_physical_slots = 9;
+}
+
+message RegisterKvCacheEngineDrivenContextResponse {
+  string shm_name = 1;
+  int64 pool_size = 2;
+}
+
+message UnregisterKvCacheEngineDrivenContextRequest {
+  int64 instance_id = 1;
+}
+
+message UnregisterKvCacheEngineDrivenContextResponse {}
+
+message PrepareStoreRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+}
+
+message PrepareStoreResponse {
+  bytes encoded_context = 1;
+}
+
+message CommitStoreRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+  bytes data = 3;
+}
+
+message CommitStoreResponse {
+  bool success = 1;
+}
+
+message PrepareRetrieveRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+}
+
+message PrepareRetrieveResponse {
+  bool success = 1;
+  bytes data = 2;
+  bytes encoded_context = 3;
+}
+
+message CommitRetrieveRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+}
+
+message CommitRetrieveResponse {
+  bool success = 1;
+}
+
+service EngineDrivenService {
+  rpc RegisterKvCacheEngineDrivenContext(
+      RegisterKvCacheEngineDrivenContextRequest)
+      returns (RegisterKvCacheEngineDrivenContextResponse);
+  rpc UnregisterKvCacheEngineDrivenContext(
+      UnregisterKvCacheEngineDrivenContextRequest)
+      returns (UnregisterKvCacheEngineDrivenContextResponse);
+  rpc PrepareStore(PrepareStoreRequest) returns (PrepareStoreResponse);
+  rpc CommitStore(CommitStoreRequest) returns (CommitStoreResponse);
+  rpc PrepareRetrieve(PrepareRetrieveRequest) returns (PrepareRetrieveResponse);
+  rpc CommitRetrieve(CommitRetrieveRequest) returns (CommitRetrieveResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/lmcache_driven_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/lmcache_driven_service.proto
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// LMCache-driven transfer wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "common.proto";
+
+message RegisterKvCacheRequest {
+  int64 instance_id = 1;
+  repeated DeviceIpcWrapper kv_cache = 2;
+  string model_name = 3;
+  int64 world_size = 4;
+  string engine_type = 5;
+  bytes encoded_layout_hints = 6;
+  repeated EngineGroupInfo engine_group_infos = 7;
+}
+
+message RegisterKvCacheResponse {}
+
+message UnregisterKvCacheRequest {
+  int64 instance_id = 1;
+}
+
+message UnregisterKvCacheResponse {}
+
+message StoreRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+  repeated BlockIdGroup gpu_block_ids = 3;
+  bytes event_ipc_handle = 4;
+}
+
+message StoreResponse {
+  EventIpcHandleResult result = 1;
+}
+
+message RetrieveRequest {
+  IpcCacheServerKey key = 1;
+  int64 instance_id = 2;
+  repeated BlockIdGroup gpu_block_ids = 3;
+  bytes event_ipc_handle = 4;
+  int64 skip_first_n_tokens = 5;
+}
+
+message RetrieveResponse {
+  EventIpcHandleResult result = 1;
+}
+
+service LMCacheDrivenService {
+  rpc RegisterKvCache(RegisterKvCacheRequest) returns (RegisterKvCacheResponse);
+  rpc UnregisterKvCache(UnregisterKvCacheRequest)
+      returns (UnregisterKvCacheResponse);
+  rpc Store(StoreRequest) returns (StoreResponse);
+  rpc Retrieve(RetrieveRequest) returns (RetrieveResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/lookup_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/lookup_service.proto
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lookup wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "common.proto";
+
+message LookupRequest {
+  IpcCacheServerKey key = 1;
+  int64 tp_size = 2;
+}
+
+message LookupResponse {}
+
+message QueryPrefetchStatusRequest {
+  string request_id = 1;
+}
+
+message QueryPrefetchStatusResponse {
+  optional int64 chunk_count = 1;
+}
+
+message WaitPrefetchStatusRequest {
+  string request_id = 1;
+  double timeout = 2;
+}
+
+message WaitPrefetchStatusResponse {
+  optional int64 chunk_count = 1;
+}
+
+message QueryPrefetchLookupHitsRequest {
+  string request_id = 1;
+}
+
+message QueryPrefetchLookupHitsResponse {
+  optional int64 chunk_count = 1;
+}
+
+message FreeLookupLocksRequest {
+  IpcCacheServerKey key = 1;
+  int64 tp_size = 2;
+}
+
+message FreeLookupLocksResponse {}
+
+message EndSessionRequest {
+  string request_id = 1;
+}
+
+message EndSessionResponse {}
+
+service LookupService {
+  rpc Lookup(LookupRequest) returns (LookupResponse);
+  rpc QueryPrefetchStatus(QueryPrefetchStatusRequest)
+      returns (QueryPrefetchStatusResponse);
+  rpc WaitPrefetchStatus(WaitPrefetchStatusRequest)
+      returns (WaitPrefetchStatusResponse);
+  rpc QueryPrefetchLookupHits(QueryPrefetchLookupHitsRequest)
+      returns (QueryPrefetchLookupHitsResponse);
+  rpc FreeLookupLocks(FreeLookupLocksRequest) returns (FreeLookupLocksResponse);
+  rpc EndSession(EndSessionRequest) returns (EndSessionResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/observability_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/observability_service.proto
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ObservabilityService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message BlockAllocationRecord {
+  string req_id = 1;
+  repeated int64 new_block_ids = 2;
+  repeated int64 new_token_ids = 3;
+}
+
+message ReportBlockAllocationRequest {
+  int64 instance_id = 1;
+  string model_name = 2;
+  repeated BlockAllocationRecord records = 3;
+}
+
+message ReportBlockAllocationResponse {}
+
+service ObservabilityService {
+  rpc ReportBlockAllocation(ReportBlockAllocationRequest)
+      returns (ReportBlockAllocationResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/p2p_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/p2p_service.proto
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// P2PService wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+message ObjectKey {
+  bytes chunk_hash = 1;
+  string model_name = 2;
+  int64 kv_rank = 3;
+  int64 object_group_id = 4;
+  string cache_salt = 5;
+}
+
+message TensorShape {
+  repeated int64 dims = 1;
+}
+
+message MemoryLayoutDesc {
+  repeated TensorShape shapes = 1;
+  repeated string dtypes = 2;
+}
+
+message TransferChannelAddress {
+  int64 offset = 1;
+  int64 size = 2;
+}
+
+message P2pLookupAndLockRequest {
+  repeated ObjectKey keys = 1;
+  map<int64, MemoryLayoutDesc> group_layout_descs = 2;
+}
+
+message P2pLookupAndLockResponse {
+  int64 task_id = 1;
+}
+
+message P2pQueryLookupResultsRequest {
+  int64 task_id = 1;
+}
+
+message TransferChannelAddressList {
+  repeated TransferChannelAddress addresses = 1;
+}
+
+message P2pQueryLookupResultsResponse {
+  optional TransferChannelAddressList addresses = 1;
+}
+
+message P2pUnlockObjectsRequest {
+  repeated ObjectKey keys = 1;
+}
+
+message P2pUnlockObjectsResponse {}
+
+service P2PService {
+  rpc P2PLookupAndLock(P2pLookupAndLockRequest)
+      returns (P2pLookupAndLockResponse);
+  rpc P2PQueryLookupResults(P2pQueryLookupResultsRequest)
+      returns (P2pQueryLookupResultsResponse);
+  rpc P2PUnlockObjects(P2pUnlockObjectsRequest)
+      returns (P2pUnlockObjectsResponse);
+}

--- a/lmcache/v1/multiprocess/transport/grpc_impl/protos/qstore_service.proto
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/protos/qstore_service.proto
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Experimental QStore wire contract for LMCache mp-mode gRPC.
+
+syntax = "proto3";
+
+package lmcache.mp;
+
+import "lmcache_driven_service.proto";
+
+service QStoreService {
+  rpc RegisterQCache(RegisterKvCacheRequest) returns (RegisterKvCacheResponse);
+  rpc UnregisterQCache(UnregisterKvCacheRequest)
+      returns (UnregisterKvCacheResponse);
+  rpc StoreQ(StoreRequest) returns (StoreResponse);
+}

--- a/lmcache/v1/multiprocess/transport/server_factory.py
+++ b/lmcache/v1/multiprocess/transport/server_factory.py
@@ -18,15 +18,23 @@ def create_request_server(
     modules: list[EngineModule],
     mp_config: MPServerConfig,
 ) -> MessageQueueServer:
-    """Create the ZMQ request server used by the multiprocess runtime.
+    """Create the configured request server used by the multiprocess runtime.
 
     Args:
         modules: Ordered business modules composing the cache server.
         mp_config: Multiprocess server configuration.
 
     Returns:
-        Configured, but not yet started, ZMQ message queue server.
+        Configured, but not yet started, request server.
+
+    Raises:
+        NotImplementedError: If the selected transport runtime is not available.
     """
+    if mp_config.transport != "zmq":
+        raise NotImplementedError(
+            f"Request transport {mp_config.transport!r} is not available yet"
+        )
+
     # First Party
     from lmcache.v1.multiprocess.transport.zmq_impl.server import (
         build_zmq_request_server,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
+    "grpcio-tools==1.78.0",
     "torch==2.13.0",
     "wheel",
 ]
@@ -151,6 +152,13 @@ disallow_untyped_calls = false
 warn_return_any = false
 
 follow_imports = "silent"
+
+[[tool.mypy.overrides]]
+module = [
+    "lmcache.v1.multiprocess.transport.grpc_impl._proto_gen.*",
+]
+ignore_errors = true
+follow_imports = "skip"
 
 [tool.codespell]
 ignore-words-list = "afterall,allready,notin,te,cann"

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,8 +4,8 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
+grpcio-tools==1.78.0
 # torch is not here because vllm installation will implicitly install it for the dockerfile
 # and users should be deliberate about choosing their torch version (or letting their serving
 # engine be deliberate for them)
 wheel
-

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,6 +25,8 @@ py-cpuinfo
 pytest
 pyyaml
 pyzmq >= 25.0.0
+grpcio>=1.78.0
+protobuf>=6.31.1,<7
 redis
 safetensors
 setuptools>=77.0.3,<81.0.0

--- a/requirements/proto.txt
+++ b/requirements/proto.txt
@@ -1,0 +1,2 @@
+# Pinned for deterministic local and CI generation; outputs are not tracked.
+grpcio-tools==1.78.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,5 @@
+-r proto.txt
+
 buildkite-test-collector
 pytest>=7.0,<9.1  # avoid some plugins breaking in 8.x
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ zero changes to this file.
 
 # Standard
 from pathlib import Path
+from types import ModuleType
+import importlib.util
 import sys
 
 ROOT_DIR = Path(__file__).parent
@@ -18,6 +20,7 @@ if str(ROOT_DIR) not in sys.path:
 
 # Third Party
 from setuptools import find_packages, setup  # noqa: E402
+from setuptools.command.build_py import build_py as _build_py  # noqa: E402
 
 # First Party
 from setup_extensions import BuildPolicy, BuildProfile  # noqa: E402
@@ -34,10 +37,44 @@ def _read_requirements(path: Path) -> list[str]:
     return reqs
 
 
+def _load_proto_generator() -> ModuleType:
+    """Load the proto generator without importing the LMCache package."""
+    generator_path = (
+        ROOT_DIR
+        / "lmcache"
+        / "v1"
+        / "multiprocess"
+        / "transport"
+        / "grpc_impl"
+        / "_proto_gen"
+        / "_generate.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_lmcache_proto_generate", generator_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load gRPC proto generator: {generator_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _BuildPyWithGrpcStubs(_build_py):
+    """Generate ignored gRPC bindings before packaging LMCache."""
+
+    def run(self) -> None:
+        distribution_name = self.distribution.get_name().replace("_", "-").lower()
+        if distribution_name != "lmcache-cli":
+            generator = _load_proto_generator()
+            generator.generate()
+        super().run()
+
+
 if __name__ == "__main__":
     policy = BuildPolicy()
     profile = policy.resolve_profile()
     ext_modules, cmdclass, req_file = policy.collect_extensions(profile)
+    cmdclass["build_py"] = _BuildPyWithGrpcStubs
 
     install_requires = _read_requirements(ROOT_DIR / "requirements" / "common.txt")
     extras_require: dict[str, list[str]] = {}

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -147,6 +147,15 @@ def _parse_mp(argv: list[str]) -> MPServerConfig:
     return parse_args_to_mp_server_config(parser.parse_args(argv))
 
 
+def test_transport_defaults_to_zmq():
+    assert _parse_mp([]).transport == "zmq"
+    assert MPServerConfig().transport == "zmq"
+
+
+def test_transport_flag_is_parsed_without_starting_grpc():
+    assert _parse_mp(["--transport", "grpc"]).transport == "grpc"
+
+
 def test_instance_id_defaults_to_uuid4():
     # No --instance-id flag => a random UUID v4 is minted.
     config = _parse_mp([])

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Tests for the FREE_LOOKUP_LOCKS protocol: enum registration, protocol definition,
-message-queue round-trip, server handler, and client-side adapter API.
+request-transport round-trip, server handler, and client-side adapter API.
 """
 
 # Standard
 from unittest.mock import MagicMock, patch
 import threading
+
+# Third Party
+import pytest
 
 # First Party
 from lmcache.v1.distributed.api import AttnWindowDesc
@@ -19,12 +22,17 @@ from lmcache.v1.multiprocess.protocol import (
 )
 from lmcache.v1.multiprocess.protocols.base import HandlerType
 from lmcache.v1.multiprocess.transport.base import RequestClient
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 
 # Test helpers
-from tests.v1.multiprocess import test_mq_handler_helpers
 from tests.v1.multiprocess.test_mq import (
-    MessageQueueTestHelper,
     create_cache_key,
+)
+from tests.v1.multiprocess.transport_test_utils import (
+    REQUEST_TRANSPORTS,
+    RequestTransport,
+    request_server_url,
+    start_lookup_request_server,
 )
 
 # ============================================================================
@@ -59,28 +67,38 @@ def test_free_locks_handler_type():
 
 
 # ============================================================================
-# Message-queue round-trip test
+# Request-transport round-trip test
 # ============================================================================
 
 
-def test_mq_free_locks():
-    """
-    Test MessageQueue with FREE_LOOKUP_LOCKS request type.
-    FREE_LOOKUP_LOCKS takes (key: KeyType) and returns None.
-    """
+class _FreeLocksHandler:
+    """Record FREE_LOOKUP_LOCKS calls from a request server."""
+
+    def __init__(self) -> None:
+        self.call: tuple[IPCCacheServerKey, int] | None = None
+
+    def free_lookup_locks(self, key: IPCCacheServerKey, tp_size: int) -> None:
+        """Record the decoded request payload."""
+        self.call = (key, tp_size)
+
+
+@pytest.mark.parametrize("request_transport", REQUEST_TRANSPORTS)
+def test_free_locks_request_transport(request_transport: RequestTransport) -> None:
+    """FREE_LOOKUP_LOCKS round-trips over each enabled request transport."""
     key = create_cache_key(0)
-
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5570")
-    helper.register_handler(
-        RequestType.FREE_LOOKUP_LOCKS, test_mq_handler_helpers.free_locks_handler
+    handler = _FreeLocksHandler()
+    server_url = request_server_url(
+        request_transport,
+        15570 if request_transport == "zmq" else 15571,
     )
-
-    helper.run_test(
-        request_type=RequestType.FREE_LOOKUP_LOCKS,
-        payloads=[key, 1],
-        expected_response=None,
-        num_requests=1,
-    )
+    server = start_lookup_request_server(request_transport, server_url, handler)
+    client = RequestClientFactory.create(server_url)
+    try:
+        assert client.free_lookup_locks(key, 1).result(timeout=5) is None
+        assert handler.call == (key, 1)
+    finally:
+        client.close()
+        server.close()
 
 
 # ============================================================================

--- a/tests/v1/multiprocess/test_query_lookup_hits.py
+++ b/tests/v1/multiprocess/test_query_lookup_hits.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Tests for the QUERY_PREFETCH_LOOKUP_HITS protocol: enum registration,
-protocol definition, message-queue round-trip, and server handler.
+protocol definition, request-transport round-trip, and server handler.
 """
 
 # Standard
 from unittest.mock import MagicMock
 import time
+
+# Third Party
+import pytest
 
 # First Party
 from lmcache.v1.distributed.api import (
@@ -24,10 +27,14 @@ from lmcache.v1.multiprocess.protocol import (
     get_response_class,
 )
 from lmcache.v1.multiprocess.protocols.base import HandlerType
+from lmcache.v1.multiprocess.transport.factory import RequestClientFactory
 
 # Test helpers
-from tests.v1.multiprocess.test_mq import (
-    MessageQueueTestHelper,
+from tests.v1.multiprocess.transport_test_utils import (
+    REQUEST_TRANSPORTS,
+    RequestTransport,
+    request_server_url,
+    start_lookup_request_server,
 )
 
 # ============================================================================
@@ -61,50 +68,42 @@ def test_query_prefetch_lookup_hits_handler_type():
 
 
 # ============================================================================
-# Message-queue round-trip test
+# Request-transport round-trip tests
 # ============================================================================
 
 
-def _query_lookup_hits_handler(request_id: str) -> int | None:
-    """Dummy handler for QUERY_PREFETCH_LOOKUP_HITS requests."""
-    assert isinstance(request_id, str)
-    return 42
+class _QueryLookupHitsHandler:
+    """Return a configured lookup-hit result and record the request ID."""
+
+    def __init__(self, result: int | None) -> None:
+        self.result = result
+        self.request_id: str | None = None
+
+    def query_prefetch_lookup_hits(self, request_id: str) -> int | None:
+        """Record the request ID and return the configured result."""
+        self.request_id = request_id
+        return self.result
 
 
-def test_mq_query_prefetch_lookup_hits():
-    """Test MessageQueue with QUERY_PREFETCH_LOOKUP_HITS request type."""
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5575")
-    helper.register_handler(
-        RequestType.QUERY_PREFETCH_LOOKUP_HITS, _query_lookup_hits_handler
-    )
-
-    helper.run_test(
-        request_type=RequestType.QUERY_PREFETCH_LOOKUP_HITS,
-        payloads=["req-1"],
-        expected_response=42,
-        num_requests=1,
-    )
-
-
-def _query_lookup_hits_none_handler(request_id: str) -> int | None:
-    """Dummy handler that returns None (lookup still in progress)."""
-    assert isinstance(request_id, str)
-    return None
-
-
-def test_mq_query_prefetch_lookup_hits_none_response():
-    """Test MessageQueue returns None when lookup is still in progress."""
-    helper = MessageQueueTestHelper(server_url="tcp://127.0.0.1:5576")
-    helper.register_handler(
-        RequestType.QUERY_PREFETCH_LOOKUP_HITS, _query_lookup_hits_none_handler
-    )
-
-    helper.run_test(
-        request_type=RequestType.QUERY_PREFETCH_LOOKUP_HITS,
-        payloads=["req-1"],
-        expected_response=None,
-        num_requests=1,
-    )
+@pytest.mark.parametrize("request_transport", REQUEST_TRANSPORTS)
+@pytest.mark.parametrize("expected", [42, None])
+def test_query_prefetch_lookup_hits_request_transport(
+    request_transport: RequestTransport,
+    expected: int | None,
+) -> None:
+    """Lookup-hit results round-trip over each enabled request transport."""
+    handler = _QueryLookupHitsHandler(expected)
+    port = 15575 if request_transport == "zmq" else 15576
+    server_url = request_server_url(request_transport, port)
+    server = start_lookup_request_server(request_transport, server_url, handler)
+    client = RequestClientFactory.create(server_url)
+    try:
+        result = client.query_prefetch_lookup_hits("req-1").result(timeout=5)
+        assert result == expected
+        assert handler.request_id == "req-1"
+    finally:
+        client.close()
+        server.close()
 
 
 # ============================================================================

--- a/tests/v1/multiprocess/transport_test_utils.py
+++ b/tests/v1/multiprocess/transport_test_utils.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for request-transport integration tests."""
+
+# Standard
+from typing import Any, Literal, Protocol
+import importlib
+
+# Third Party
+import zmq
+
+# First Party
+from lmcache.v1.multiprocess.mq import MessageQueueServer
+from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.multiprocess.transport.zmq_impl.server import add_handler_helper
+
+RequestTransport = Literal["zmq", "grpc"]
+
+# Keep the gRPC type and URL path ready, but do not execute gRPC tests until
+# the runtime implementation lands. Enabling both transports is a one-line
+# change to this tuple.
+REQUEST_TRANSPORTS: tuple[RequestTransport, ...] = ("zmq",)
+
+
+class RequestServer(Protocol):
+    """Common lifecycle used by request-transport test servers."""
+
+    def close(self) -> None: ...
+
+
+_LOOKUP_HANDLERS = {
+    RequestType.LOOKUP: "lookup",
+    RequestType.QUERY_PREFETCH_STATUS: "query_prefetch_status",
+    RequestType.WAIT_PREFETCH_STATUS: "wait_prefetch_status",
+    RequestType.QUERY_PREFETCH_LOOKUP_HITS: "query_prefetch_lookup_hits",
+    RequestType.FREE_LOOKUP_LOCKS: "free_lookup_locks",
+    RequestType.END_SESSION: "end_session",
+}
+
+
+def request_server_url(transport: RequestTransport, port: int) -> str:
+    """Build a loopback request URL for a test transport.
+
+    Args:
+        transport: Request transport to exercise.
+        port: Loopback TCP port used by the test server.
+
+    Returns:
+        A transport-specific request URL.
+    """
+    scheme = "tcp" if transport == "zmq" else "grpc"
+    return f"{scheme}://127.0.0.1:{port}"
+
+
+def start_lookup_request_server(
+    transport: RequestTransport,
+    server_url: str,
+    lookup: Any,
+) -> RequestServer:
+    """Start a minimal lookup service over the selected request transport.
+
+    Args:
+        transport: Request transport to exercise.
+        server_url: Endpoint on which the server should listen.
+        lookup: Object implementing the lookup methods used by the test.
+
+    Returns:
+        The started request server. The caller must close it.
+    """
+    if transport == "grpc":
+        grpc_server_module = importlib.import_module(
+            "lmcache.v1.multiprocess.transport.grpc_impl.server"
+        )
+        grpc_server_class = vars(grpc_server_module)["GrpcMultiprocessServer"]
+        grpc_server = grpc_server_class(
+            server_url,
+            max_cpu_workers=4,
+            max_gpu_workers=1,
+        )
+        grpc_server.add_modules([lookup])
+        grpc_server.start()
+        return grpc_server
+
+    zmq_server = MessageQueueServer(server_url, zmq.Context.instance())
+    blocking_types: list[RequestType] = []
+    for request_type, method_name in _LOOKUP_HANDLERS.items():
+        handler = getattr(lookup, method_name, None)
+        if not callable(handler):
+            continue
+        add_handler_helper(zmq_server, request_type, handler)
+        blocking_types.append(request_type)
+    if blocking_types:
+        zmq_server.add_normal_thread_pool(blocking_types, max_workers=4)
+    zmq_server.start()
+    return zmq_server

--- a/tests/v1/multiprocess/transport_test_utils.py
+++ b/tests/v1/multiprocess/transport_test_utils.py
@@ -9,9 +9,7 @@ import importlib
 import zmq
 
 # First Party
-from lmcache.v1.multiprocess.mq import MessageQueueServer
 from lmcache.v1.multiprocess.protocol import RequestType
-from lmcache.v1.multiprocess.transport.zmq_impl.server import add_handler_helper
 
 RequestTransport = Literal["zmq", "grpc"]
 
@@ -80,7 +78,15 @@ def start_lookup_request_server(
         grpc_server.start()
         return grpc_server
 
-    zmq_server = MessageQueueServer(server_url, zmq.Context.instance())
+    # Keep concrete transport imports inside the selected branch. This helper
+    # is intentionally transport-neutral: the repository's import-boundary
+    # test rejects leaking implementation modules through shared test code.
+    mq_module = importlib.import_module("lmcache.v1.multiprocess.mq")
+    zmq_server_module = importlib.import_module(
+        "lmcache.v1.multiprocess.transport.zmq_impl.server"
+    )
+    zmq_server = mq_module.MessageQueueServer(server_url, zmq.Context.instance())
+    add_handler_helper = zmq_server_module.add_handler_helper
     blocking_types: list[RequestType] = []
     for request_type, method_name in _LOOKUP_HANDLERS.items():
         handler = getattr(lookup, method_name, None)


### PR DESCRIPTION
## Summary

Extract the deterministic protobuf, build, documentation, CI, and test foundation from #5065 so the runtime transport work can stay focused:

- add the multiprocess gRPC service schemas and generated-module package
- add the reproducible binding generator and build-time generation hook
- add protobuf/gRPC build, runtime, test, and type-check configuration
- document the schema source of truth and regeneration workflow
- add a shared request-transport round-trip test harness used by `FREE_LOOKUP_LOCKS` and `QUERY_PREFETCH_LOOKUP_HITS`
- parameterize the request transport across the existing `.buildkite/` and `.github/` test/setup/result-aggregation paths
- add the transport configuration surface needed by those shared CI runners

## Test transport scope

This PR does **not** enable the gRPC client/server runtime or schedule any gRPC test job.

The shared Python test framework defines both transport types and keeps its enabled tuple at:

```python
REQUEST_TRANSPORTS: tuple[RequestTransport, ...] = ("zmq",)
```

The Buildkite and GitHub Actions jobs similarly retain a `request_transport` matrix dimension, while every enabled matrix currently contains only `zmq`. The runner scripts already thread the selected transport, URL scheme, ports, artifacts, and nightly verification metadata through the common paths. Selecting `grpc` manually is rejected explicitly because its request-server runtime is not part of this PR.

Once the gRPC runtime and message handlers land, the follow-up only needs to add `grpc` to the desired Python/CI matrices and connect the server factory implementation.

## Validation

- generated the protobuf bindings from the checked-in schemas
- built an sdist, rebuilt a wheel from it, and verified all 10 `.proto` files and 20 generated Python modules are packaged
- installed the wheel into a clean Python 3.12 environment and imported all 20 generated modules
- parsed all 60 Buildkite/GitHub Actions YAML files successfully
- ran `bash -n` for every modified shell script
- `pytest -q tests/v1/multiprocess/test_config.py tests/v1/multiprocess/test_free_locks.py tests/v1/multiprocess/test_query_lookup_hits.py` — 76 passed; all request-transport round trips are ZMQ only
- `SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files`
- Sphinx HTML build completed successfully with the same 31 pre-existing repository warnings
- all three commits contain `Signed-off-by`