### PR TITLE
[Fix][MP] Add atomic finish_write_and_delete

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -533,6 +533,65 @@ class L1Manager:
         )
         return ret
 
+    def _unlock_write_checked(
+        self,
+        key: ObjectKey,
+        op: str,
+    ) -> tuple[L1Error, "L1ObjectState | None"]:
+        """Validate that ``key`` is exclusively write-locked and unlock it.
+
+        Args:
+            key: The object key to unlock.
+            op: Operation name used in the wrong-state warning logs.
+
+        Returns:
+            (SUCCESS, entry) on success; (KEY_NOT_EXIST, None) or
+            (KEY_IN_WRONG_STATE, None) otherwise.
+        """
+        entry = self._objects.get(key, None)
+        if entry is None:
+            return L1Error.KEY_NOT_EXIST, None
+
+        if not entry.write_lock.is_locked():
+            logger.warning(
+                "L1Manager: %s on non-write-locked key %s, "
+                "potential inconsistent data might be written",
+                op,
+                key,
+            )
+            return L1Error.KEY_IN_WRONG_STATE, None
+
+        if entry.read_lock.is_locked():
+            logger.warning(
+                "L1Manager: %s on read-locked key %s, "
+                "potential inconsistent data might be written",
+                op,
+                key,
+            )
+            return L1Error.KEY_IN_WRONG_STATE, None
+
+        entry.write_lock.unlock()
+        return L1Error.SUCCESS, entry
+
+    def _free_and_report_deleted(
+        self,
+        keys: list[ObjectKey],
+        objs: list[MemoryObj],
+    ) -> None:
+        """Free ``objs`` and report ``keys`` as deleted to listeners and
+        the event bus."""
+        freed_meta = [self._object_meta(obj) for obj in objs]
+        self._memory_manager.free(objs)
+
+        for listener in self._registered_listeners:
+            listener.on_l1_keys_deleted_by_manager(keys)
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_KEYS_EVICTED,
+                metadata={"keys": keys, "meta": freed_meta},
+            )
+        )
+
     @l1_mgr_synchronized
     def finish_write(
         self,
@@ -560,31 +619,10 @@ class L1Manager:
         notification_keys_meta: list[L1ObjectMeta] = []
 
         for key in keys:
-            entry = self._objects.get(key, None)
-            if entry is None:
-                ret[key] = L1Error.KEY_NOT_EXIST
+            err, entry = self._unlock_write_checked(key, "finish write")
+            ret[key] = err
+            if err != L1Error.SUCCESS or entry is None:
                 continue
-
-            if not entry.write_lock.is_locked():
-                logger.warning(
-                    "L1Manager: finish write on non-write-locked key %s, "
-                    "potential inconsistent data might be written",
-                    key,
-                )
-                ret[key] = L1Error.KEY_IN_WRONG_STATE
-                continue
-
-            if entry.read_lock.is_locked():
-                logger.warning(
-                    "L1Manager: finish write on read-locked key %s, "
-                    "potential inconsistent data might be written",
-                    key,
-                )
-                ret[key] = L1Error.KEY_IN_WRONG_STATE
-                continue
-
-            entry.write_lock.unlock()
-            ret[key] = L1Error.SUCCESS
             if not entry.is_temporary:
                 notification_keys.append(key)
                 notification_keys_meta.append(self._object_meta(entry.memory_obj))
@@ -637,29 +675,12 @@ class L1Manager:
         successful_keys_meta: list[L1ObjectMeta] = []
 
         for key in keys:
-            entry = self._objects.get(key, None)
-            if entry is None:
-                ret[key] = (L1Error.KEY_NOT_EXIST, None)
+            err, entry = self._unlock_write_checked(
+                key, "finish_write_and_reserve_read"
+            )
+            if err != L1Error.SUCCESS or entry is None:
+                ret[key] = (err, None)
                 continue
-
-            if not entry.write_lock.is_locked():
-                logger.warning(
-                    "L1Manager: finish_write_and_reserve_read on "
-                    "non-write-locked key %s",
-                    key,
-                )
-                ret[key] = (L1Error.KEY_IN_WRONG_STATE, None)
-                continue
-
-            if entry.read_lock.is_locked():
-                logger.warning(
-                    "L1Manager: finish_write_and_reserve_read on read-locked key %s",
-                    key,
-                )
-                ret[key] = (L1Error.KEY_IN_WRONG_STATE, None)
-                continue
-
-            entry.write_lock.unlock()
             for _ in range(total):
                 entry.read_lock.lock()
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
@@ -718,17 +739,46 @@ class L1Manager:
             ret[key] = L1Error.SUCCESS
             successful_keys.append(key)
 
-        freed_meta = [self._object_meta(obj) for obj in need_to_free]
-        self._memory_manager.free(need_to_free)
+        self._free_and_report_deleted(successful_keys, need_to_free)
+        return ret
 
-        for listener in self._registered_listeners:
-            listener.on_l1_keys_deleted_by_manager(successful_keys)
-        self._event_bus.publish(
-            Event(
-                event_type=EventType.L1_KEYS_EVICTED,
-                metadata={"keys": successful_keys, "meta": freed_meta},
-            )
-        )
+    @l1_mgr_synchronized
+    def finish_write_and_delete(
+        self,
+        keys: list[ObjectKey],
+    ) -> dict[ObjectKey, L1Error]:
+        """Atomically finish write access and delete the given keys.
+
+        Unlock and deletion happen in one critical section, so no other
+        component can observe or lock the key in between. No
+        write-finished notification is emitted; deletions are reported
+        the same way as :meth:`delete`.
+
+        Args:
+            keys: The list of object keys to unlock and delete.
+
+        Returns:
+            A dictionary mapping each object key to an L1Error.
+
+        Errors:
+            KEY_NOT_EXIST: The key does not exist.
+            KEY_IN_WRONG_STATE: The key is not write-locked, or it's
+                read-locked.
+        """
+        need_to_free: list[MemoryObj] = []
+        ret: dict[ObjectKey, L1Error] = {}
+        successful_keys: list[ObjectKey] = []
+
+        for key in keys:
+            err, entry = self._unlock_write_checked(key, "finish_write_and_delete")
+            ret[key] = err
+            if err != L1Error.SUCCESS or entry is None:
+                continue
+            need_to_free.append(entry.memory_obj)
+            del self._objects[key]
+            successful_keys.append(key)
+
+        self._free_and_report_deleted(successful_keys, need_to_free)
         return ret
 
     def touch_keys(self, keys: list[ObjectKey]):

--- a/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
+++ b/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
@@ -379,8 +379,7 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
 
         if write_locked:
             try:
-                self._l1_manager.finish_write(write_locked)
-                self._l1_manager.delete(write_locked)
+                self._l1_manager.finish_write_and_delete(write_locked)
             except Exception:
                 logger.exception(
                     "Serde wrapper: error releasing write-locked leftover temps"
@@ -628,12 +627,11 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         return temp_keys, temp_objs
 
     def _release_write_temps(self, temp_keys: list[ObjectKey]) -> None:
-        """Release write-locked temps and delete them. No-op on empty."""
+        """Atomically release write-locked temps and delete them. No-op on empty."""
         if not temp_keys:
             return
         try:
-            self._l1_manager.finish_write(temp_keys)
-            self._l1_manager.delete(temp_keys)
+            self._l1_manager.finish_write_and_delete(temp_keys)
         except Exception:
             logger.exception("Serde wrapper: failed releasing write-locked temps")
 

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -1352,8 +1352,7 @@ class PrefetchController(StorageControllerInterface):
 
         # Clean up failed keys
         if failed_keys:
-            l1_mgr.finish_write(failed_keys)
-            l1_mgr.delete(failed_keys)
+            l1_mgr.finish_write_and_delete(failed_keys)
 
         self._event_bus.publish(
             Event(
@@ -1478,8 +1477,7 @@ class PrefetchController(StorageControllerInterface):
         for request in self._in_flight_requests.values():
             if request.phase == PrefetchPhase.PLAN_AND_LOAD:
                 if request.write_reserved_keys:
-                    l1_mgr.finish_write(request.write_reserved_keys)
-                    l1_mgr.delete(request.write_reserved_keys)
+                    l1_mgr.finish_write_and_delete(request.write_reserved_keys)
             self._release_l2_locks(request, keep={})
             if request.l1_readlocks.popcount() > 0:
                 l1_mgr.finish_read(

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -1182,6 +1182,35 @@ class TestFinishWriteAndReserveRead:
 
 
 # =============================================================================
+# Tests for L1Manager.finish_write_and_delete()
+# =============================================================================
+
+
+class TestFinishWriteAndDelete:
+    """Tests for L1Manager.finish_write_and_delete()."""
+
+    def test_deletes_write_locked_keys_only(self, basic_l1_config, basic_layout):
+        """Write-locked keys are deleted; other states error out intact."""
+        manager = L1Manager(basic_l1_config)
+        locked_key = make_object_key(1)
+        ready_key = make_object_key(2)
+        missing_key = make_object_key(3)
+
+        manager.reserve_write([locked_key, ready_key], [False, False], basic_layout)
+        manager.finish_write([ready_key])
+
+        result = manager.finish_write_and_delete([locked_key, ready_key, missing_key])
+
+        assert result[locked_key] == L1Error.SUCCESS
+        assert manager.get_object_state(locked_key) is None
+        assert result[ready_key] == L1Error.KEY_IN_WRONG_STATE
+        assert manager.get_object_state(ready_key) is not None
+        assert result[missing_key] == L1Error.KEY_NOT_EXIST
+
+        manager.close()
+
+
+# =============================================================================
 # Tests for L1Manager.delete()
 # =============================================================================
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 Following the discussion in https://github.com/LMCache/LMCache/pull/5058

Right now, race-condition windows like

```
        # Clean up failed keys
        if failed_keys:
            l1_mgr.finish_write(failed_keys)
            l1_mgr.delete(failed_keys)
```

exist in several places. This PR merges the unlock + delete into one atomic call (finish_write_and_delete), and extracts the common logic into helper functions for consistency.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
