### PR TITLE
fix(fs-l2): reject ambiguous model-name path marker

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -51,6 +51,9 @@ logger = init_logger(__name__)
 _KEY_SEP = "@"
 # ``@`` in both ``model_name`` and ``cache_salt`` is rejected by
 # ObjectKey.__post_init__, so splitting on ``@`` is unambiguous.
+# ``-SEP-`` is reserved by the filesystem codec for escaped slashes. A
+# literal occurrence in ``model_name`` would otherwise be indistinguishable
+# from a slash after decoding.
 # Kept in sync with native_connector_l2_adapter.py and
 # csrc/storage_backends/fs/connector.cpp.
 _PATH_SLASH_REPLACEMENT = "-SEP-"
@@ -111,6 +114,11 @@ def _object_key_to_filename(key: ObjectKey) -> str:
     of the bitmap ``(ws<<24)|(rank<<16)|(local_ws<<8)|local``
     is directly readable. ``object_group_id`` is written in plain hex.
     """
+    if _PATH_SLASH_REPLACEMENT in key.model_name:
+        raise ValueError(
+            "model_name contains the reserved filesystem encoding marker "
+            f"{_PATH_SLASH_REPLACEMENT!r}"
+        )
     safe_model = key.model_name.replace("/", _PATH_SLASH_REPLACEMENT)
     base = (
         f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}"

--- a/tests/v1/distributed/test_fs_l2_adapter_keys.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_keys.py
@@ -69,6 +69,17 @@ class TestFilenameRoundtrip:
         )
         assert fn0 != fn1
 
+    def test_reserved_marker_in_model_name_is_rejected(self):
+        """A literal slash escape marker must not collide with a slash."""
+        key = ObjectKey(
+            chunk_hash=b"\xde\xad\xbe\xef",
+            model_name="org/model-SEP-name",
+            kv_rank=42,
+        )
+
+        with pytest.raises(ValueError, match="reserved filesystem encoding marker"):
+            _object_key_to_filename(key)
+
     def test_unsalted_format(self):
         """Unsalted keys use the 4-field shape."""
         fn = "llama@0x0000002a@0@deadbeef.data"


### PR DESCRIPTION
Fixes #5069

## Summary

The filesystem L2 codec replaces `/` with `-SEP-` but previously accepted a literal `-SEP-` in `ObjectKey.model_name`. Those two distinct model names then mapped to the same `.data` path.

That could make a later store skip an existing file, report a false lookup hit, and load KV bytes belonging to another model.

## Changes

- Reject model names containing the filesystem codec's reserved slash marker before generating a filename.
- Add a regression test for the colliding model names.
- Preserve the existing filename format for supported model names.

This is intentionally a validation fix so existing cache filenames remain backward compatible.

## Validation

- 39 targeted distributed filename/IPC tests passed in a CPU-only venv.
- The new regression test passes.
- `compileall` and `git diff --check` pass.
- Reproduced and verified the behavior in a `python:3.12-slim` Docker container without GPU/CUDA.
