### PR TITLE
ci: gate Buildkite pipelines on fast required checks

### DIFF
--- a/.buildkite/k3_tests/README.md
+++ b/.buildkite/k3_tests/README.md
@@ -69,6 +69,23 @@ To bypass the skip and force a full run, add the **`force-ci`** label to the
 PR on GitHub. Buildkite picks up PR labels automatically; when the filter
 sees `force-ci` it runs the full pipeline regardless of which files changed.
 
+### Fast required-check gate
+
+For a non-trivial pull request, `upload-pipeline.sh` waits for the GitHub
+`Check code quality` and `DCO` checks before uploading the test-specific
+`pipeline.yml`. This keeps the required, short checks ahead of GPU and
+integration work while preserving one shared gate for every K3 lane. The
+initial Buildkite upload step is expected to be scheduled by the webhook; only
+the expensive downstream steps are held back.
+
+The gate reads the PR head SHA from GitHub, so it also handles a Buildkite
+checkout that is a merge commit. It uses unauthenticated GitHub API requests
+for this public repository; set `GITHUB_TOKEN` in the Buildkite pipeline when
+an authenticated API budget is preferred. `BUILDKITE_REQUIRED_CHECKS_TIMEOUT_SECONDS`
+and `BUILDKITE_REQUIRED_CHECKS_POLL_SECONDS` can override the 30-minute timeout
+and initial 10-second polling interval when diagnosing CI infrastructure. The
+polling interval backs off to one minute to stay within GitHub API limits.
+
 
 ### Trigger strategy
 

--- a/.buildkite/k3_tests/common_scripts/upload-pipeline.sh
+++ b/.buildkite/k3_tests/common_scripts/upload-pipeline.sh
@@ -34,5 +34,7 @@ if should_skip_ci; then
     exit 0
 fi
 
+"${SCRIPT_DIR}/wait-for-required-checks.sh"
+
 echo "--- :pipeline: Uploading ${PIPELINE_FILE}"
 exec buildkite-agent pipeline upload "${PIPELINE_FILE}"

--- a/.buildkite/k3_tests/common_scripts/wait-for-required-checks.sh
+++ b/.buildkite/k3_tests/common_scripts/wait-for-required-checks.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Wait for the fast GitHub checks that protect the PR before uploading the
+# expensive Buildkite pipeline steps.
+#
+# Buildkite receives the pull-request webhook at the same time as GitHub
+# Actions.  The initial Buildkite step is intentionally tiny, but without
+# this gate it immediately uploads GPU/integration jobs while Code Quality and
+# DCO are still running.  Keeping the wait in the common upload path applies
+# the same ordering to every K3 lane.
+
+set -euo pipefail
+
+if [[ -z "${BUILDKITE_PULL_REQUEST:-}" ||
+    "${BUILDKITE_PULL_REQUEST:-}" == "false" ]]; then
+    echo "required-checks: not a pull-request build; no GitHub gate needed"
+    exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    echo "required-checks: curl and jq are required to inspect GitHub checks" >&2
+    exit 1
+fi
+
+remote_url="$(git remote get-url origin 2>/dev/null || true)"
+repo="${remote_url#https://github.com/}"
+repo="${repo#http://github.com/}"
+repo="${repo#git@github.com:}"
+repo="${repo#ssh://git@github.com/}"
+repo="${repo%.git}"
+
+if [[ ! "$repo" =~ ^[^/]+/[^/]+$ ]]; then
+    echo "required-checks: could not derive a GitHub repository from origin: ${remote_url}" >&2
+    exit 1
+fi
+
+api_args=(
+    --fail
+    --silent
+    --show-error
+    --location
+    -H "Accept: application/vnd.github+json"
+    -H "X-GitHub-Api-Version: 2022-11-28"
+)
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    api_args+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" )
+fi
+
+github_api() {
+    curl "${api_args[@]}" "https://api.github.com${1}"
+}
+
+pr_number="${BUILDKITE_PULL_REQUEST}"
+pr_json="$(github_api "/repos/${repo}/pulls/${pr_number}")"
+head_sha="$(jq -r '.head.sha // empty' <<<"$pr_json")"
+if [[ -z "$head_sha" ]]; then
+    echo "required-checks: GitHub did not return a head SHA for PR #${pr_number}" >&2
+    exit 1
+fi
+
+timeout_seconds="${BUILDKITE_REQUIRED_CHECKS_TIMEOUT_SECONDS:-1800}"
+poll_seconds="${BUILDKITE_REQUIRED_CHECKS_POLL_SECONDS:-10}"
+max_poll_seconds=60
+deadline=$((SECONDS + timeout_seconds))
+
+echo "required-checks: waiting for Code Quality and DCO on ${repo}@${head_sha}"
+
+while (( SECONDS < deadline )); do
+    if ! checks_json="$(github_api "/repos/${repo}/commits/${head_sha}/check-runs?per_page=100")"; then
+        echo "required-checks: failed to query GitHub check runs" >&2
+        exit 1
+    fi
+    statuses_json=""
+    pending=0
+
+    for check_name in "Check code quality" "DCO"; do
+        check_json="$(jq -c --arg name "$check_name" '
+            [.check_runs[] | select(.name == $name)]
+            | sort_by(.id) | last // {}' <<<"$checks_json")"
+        status="$(jq -r '.status // empty' <<<"$check_json")"
+        conclusion="$(jq -r '.conclusion // empty' <<<"$check_json")"
+
+        # DCO has historically been reported as either a check run or a
+        # commit status.  Fall back to the latter so the gate remains
+        # compatible with both forms.
+        if [[ -z "$status" && "$check_name" == "DCO" ]]; then
+            if [[ -z "$statuses_json" ]]; then
+                if ! statuses_json="$(github_api "/repos/${repo}/commits/${head_sha}/status")"; then
+                    echo "required-checks: failed to query GitHub commit statuses" >&2
+                    exit 1
+                fi
+            fi
+            status="$(jq -r '[.statuses[] | select(.context == "DCO")]
+                | sort_by(.id) | last.state // empty' <<<"$statuses_json")"
+            conclusion="$(jq -r 'if . == "success" then "success"
+                elif . == "pending" then "" else . end' <<<"$status")"
+        fi
+
+        case "$conclusion" in
+            success|neutral)
+                echo "required-checks: ${check_name}: ${conclusion}"
+                ;;
+            skipped)
+                if [[ "$check_name" == "Check code quality" ]]; then
+                    echo "required-checks: ${check_name}: skipped (path-filtered)"
+                else
+                    echo "required-checks: ${check_name}: skipped; refusing to run downstream tests" >&2
+                    exit 1
+                fi
+                ;;
+            failure|cancelled|timed_out|action_required|stale)
+                echo "required-checks: ${check_name}: ${conclusion}; refusing to run downstream tests" >&2
+                exit 1
+                ;;
+            *)
+                pending=1
+                echo "required-checks: ${check_name}: ${status:-not reported yet}"
+                ;;
+        esac
+    done
+
+    if (( pending == 0 )); then
+        echo "required-checks: Code Quality and DCO passed; uploading downstream pipeline"
+        exit 0
+    fi
+
+    sleep "$poll_seconds"
+    if (( poll_seconds < max_poll_seconds )); then
+        poll_seconds=$((poll_seconds * 2))
+        if (( poll_seconds > max_poll_seconds )); then
+            poll_seconds="$max_poll_seconds"
+        fi
+    fi
+done
+
+echo "required-checks: timed out after ${timeout_seconds}s waiting for Code Quality and DCO" >&2
+exit 1

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - "dev"
       - "release-**"
+    types: [labeled]
     paths:
       - '.github/actions/*.ya?ml'
       - '.github/workflows/*.ya?ml'
@@ -29,6 +30,7 @@ permissions:
 
 jobs:
   actionlint:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     runs-on: ubuntu-latest
     steps:
       - name: "Harden Runner"

--- a/.github/workflows/aerospike_integration.yml
+++ b/.github/workflows/aerospike_integration.yml
@@ -18,6 +18,7 @@ on:
     branches:
       - "dev"
       - "release-**"
+    types: [labeled]
     paths:
       - "csrc/storage_backends/aerospike/**"
       - "lmcache/v1/distributed/l2_adapters/aerospike_l2_adapter.py"
@@ -38,6 +39,7 @@ env:
 
 jobs:
   aerospike-native-l2:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     name: Aerospike native L2
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/azure_integration.yml
+++ b/.github/workflows/azure_integration.yml
@@ -20,6 +20,7 @@ on:
     branches:
       - "dev"
       - "release-**"
+    types: [labeled]
     paths:
       - "lmcache/v1/storage_backend/connector/azure_connector.py"
       - "tests/v1/storage_backend/test_azure_connector.py"
@@ -41,6 +42,7 @@ permissions:
 
 jobs:
   azure-blob-azurite:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     name: Azure connector (Azurite)
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -5,15 +5,6 @@ name: Build CLI Artifacts
 
 on:
     workflow_call:
-    pull_request:
-        branches:
-            - dev
-            - "release-**"
-        paths:
-            - 'lmcache/cli/**.py'
-            - 'pyproject_cli.toml'
-            - 'requirements/cli.txt'
-            - '.github/workflows/build_cli_artifacts.yml'
 
 env:
     LC_ALL: en_US.UTF-8

--- a/.github/workflows/build_cpu_artifacts.yml
+++ b/.github/workflows/build_cpu_artifacts.yml
@@ -5,18 +5,6 @@ name: Build CPU Artifacts
 
 on:
     workflow_call:
-    pull_request:
-        branches:
-            - dev
-            - "release-**"
-        paths:
-            - 'setup.py'
-            - 'pyproject.toml'
-            - 'csrc/**'
-            - 'requirements/common.txt'
-            - 'requirements/build.txt'
-            - 'lmcache/__init__.py'
-            - '.github/workflows/build_cpu_artifacts.yml'
 
 env:
     LC_ALL: en_US.UTF-8

--- a/.github/workflows/ci-fast-gate.yml
+++ b/.github/workflows/ci-fast-gate.yml
@@ -1,0 +1,148 @@
+name: CI Fast Gate
+
+# Code Quality is the only GitHub Actions workflow started directly by a PR.
+# This workflow waits for it and the external DCO check, then adds a temporary
+# label that admits the other PR workflows. It runs from the base repository and
+# never checks out or executes code from the pull request.
+on:
+  pull_request_target:
+    branches:
+      - dev
+      - "release-**"
+    types: [opened, synchronize, reopened]
+
+permissions:
+  checks: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+# A new push supersedes the previous gate. The final head-SHA check below
+# also protects against an older run finishing during cancellation.
+concurrency:
+  group: ci-fast-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Wait for Code Quality and DCO
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      READY_LABEL: ci-ready
+    steps:
+      - name: Wait for fast required checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          api_args=(
+            --fail
+            --silent
+            --show-error
+            --location
+            -H "Accept: application/vnd.github+json"
+            -H "Authorization: Bearer ${GH_TOKEN}"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          )
+
+          github_api() {
+            local path="${1}"
+            shift
+            curl "${api_args[@]}" "$@" "https://api.github.com${path}"
+          }
+
+          # A new commit invalidates the previous admission. Removing the
+          # label also prevents the old label from triggering downstream
+          # workflows while the new commit is still being checked.
+          label_status="$(curl --silent --show-error --location \
+            --output /dev/null --write-out '%{http_code}' \
+            "${api_args[@]}" --request DELETE \
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/labels/${READY_LABEL}" || true)"
+          if [[ "${label_status}" != "204" && "${label_status}" != "404" ]]; then
+            echo "Failed to remove ${READY_LABEL} from PR #${PR_NUMBER} (HTTP ${label_status})" >&2
+            exit 1
+          fi
+
+          timeout_seconds=1800
+          poll_seconds=10
+          deadline=$((SECONDS + timeout_seconds))
+
+          echo "Waiting for Check code quality and DCO on ${REPOSITORY}@${HEAD_SHA}"
+          while (( SECONDS < deadline )); do
+            checks_json="$(github_api "/repos/${REPOSITORY}/commits/${HEAD_SHA}/check-runs?per_page=100")"
+            code_quality="$(jq -r '[.check_runs[] | select(.name == "Check code quality")]
+              | sort_by(.id) | last.conclusion // empty' <<<"${checks_json}")"
+            dco="$(jq -r '[.check_runs[] | select(.name == "DCO")]
+              | sort_by(.id) | last.conclusion // empty' <<<"${checks_json}")"
+
+            if [[ -z "${dco}" ]]; then
+              statuses_json="$(github_api "/repos/${REPOSITORY}/commits/${HEAD_SHA}/status")"
+              dco="$(jq -r '[.statuses[] | select(.context == "DCO")]
+                | sort_by(.id) | last.state // empty' <<<"${statuses_json}")"
+            fi
+
+            echo "Check code quality: ${code_quality:-not reported}; DCO: ${dco:-not reported}"
+
+            case "${code_quality}" in
+              success|neutral|skipped) code_ready=1 ;;
+              failure|cancelled|timed_out|action_required|stale)
+                echo "Check code quality finished with ${code_quality}; refusing admission" >&2
+                exit 1
+                ;;
+              *) code_ready=0 ;;
+            esac
+
+            if [[ "${dco}" == "success" ]]; then
+              dco_ready=1
+            elif [[ "${dco}" == "failure" || "${dco}" == "error" ]]; then
+              echo "DCO finished with ${dco}; refusing admission" >&2
+              exit 1
+            else
+              dco_ready=0
+            fi
+
+            if (( code_ready == 1 && dco_ready == 1 )); then
+              break
+            fi
+
+            sleep "${poll_seconds}"
+            if (( poll_seconds < 60 )); then
+              poll_seconds=$((poll_seconds * 2))
+              if (( poll_seconds > 60 )); then
+                poll_seconds=60
+              fi
+            fi
+          done
+
+          if (( SECONDS >= deadline )); then
+            echo "Timed out waiting for Code Quality and DCO" >&2
+            exit 1
+          fi
+
+          current_head_sha="$(github_api "/repos/${REPOSITORY}/pulls/${PR_NUMBER}" | jq -r '.head.sha')"
+          if [[ "${current_head_sha}" != "${HEAD_SHA}" ]]; then
+            echo "PR head moved from ${HEAD_SHA} to ${current_head_sha}; refusing stale admission" >&2
+            exit 1
+          fi
+
+          # The label is created lazily so repository setup does not need a
+          # one-time manual label change. A 422 means another run created it.
+          create_status="$(curl --silent --show-error --location \
+            --output /dev/null --write-out '%{http_code}' \
+            "${api_args[@]}" --request POST \
+            --data '{"name":"ci-ready","color":"1d76db","description":"Fast required checks passed; admit downstream CI"}' \
+            "https://api.github.com/repos/${REPOSITORY}/labels" || true)"
+          if [[ "${create_status}" != "201" && "${create_status}" != "422" ]]; then
+            echo "Failed to create ${READY_LABEL} (HTTP ${create_status})" >&2
+            exit 1
+          fi
+
+          github_api "/repos/${REPOSITORY}/issues/${PR_NUMBER}/labels" \
+            --request POST \
+            --data '{"labels":["ci-ready"]}' >/dev/null
+          echo "${READY_LABEL} added; downstream PR workflows may now run"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,11 +16,13 @@ on:
     branches: [ "dev" ]
   pull_request:
     branches: [ "dev" ]
+    types: [labeled]
   schedule:
     - cron: '29 4 * * 0'
 
 jobs:
   analyze:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -20,6 +20,7 @@ on:
     branches:
       - "dev"
       - "release-**"
+    types: [labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,6 +35,7 @@ defaults:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
@@ -79,7 +81,7 @@ jobs:
 
   cpu-device-test:
     needs: changes
-    if: needs.changes.outputs.lmcache == 'true'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')) && needs.changes.outputs.lmcache == 'true'
     name: CPU device (${{ matrix.os }} / ${{ matrix.model.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120

--- a/.github/workflows/operator_ci.yml
+++ b/.github/workflows/operator_ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - dev
       - "release-**"
+    types: [labeled]
 
 permissions:
   contents: read
@@ -20,6 +21,7 @@ defaults:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
@@ -43,7 +45,7 @@ jobs:
 
   ci:
     needs: changes
-    if: needs.changes.outputs.operator == 'true'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')) && needs.changes.outputs.operator == 'true'
     name: Format, lint, and test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr_full_build.yml
+++ b/.github/workflows/pr_full_build.yml
@@ -1,9 +1,11 @@
 name: PR Full Build
 
 # Build all release artifacts (sdist + CUDA wheel, CLI wheel, cu129 wheel)
-# on PRs carrying the `full` label. The `full` label is added automatically
-# by automerge-labeler.yml when auto-merge is enabled on a code-change PR,
-# so this acts as a pre-merge sanity check that wheels still build.
+# on PRs carrying both `full` and the fast-gate `ci-ready` labels. The `full`
+# label is added automatically by automerge-labeler.yml when auto-merge is
+# enabled on a code-change PR, while `ci-ready` is added only after Code
+# Quality and DCO pass. This keeps the expensive artifact builds behind the
+# fast required checks.
 #
 # No tests, no code-quality checks, no publishing — those are covered by
 # test.yml / code_quality_checks.yml (per-PR) and publish.yml (on merge).
@@ -13,7 +15,7 @@ on:
         branches:
             - dev
             - "release-**"
-        types: [opened, synchronize, reopened, labeled]
+        types: [labeled]
 
 # Cancel older in-flight runs on the same PR. github.ref is
 # refs/pull/<N>/merge on pull_request events, so each PR gets its own group.
@@ -30,27 +32,27 @@ jobs:
 
     build-main:
         name: Build main
-        if: contains(github.event.pull_request.labels.*.name, 'full')
+        if: contains(github.event.pull_request.labels.*.name, 'full') && contains(github.event.pull_request.labels.*.name, 'ci-ready')
         uses: ./.github/workflows/build_main_artifacts.yml
 
     build-main-arm64:
         name: Build main (arm64)
-        if: contains(github.event.pull_request.labels.*.name, 'full')
+        if: contains(github.event.pull_request.labels.*.name, 'full') && contains(github.event.pull_request.labels.*.name, 'ci-ready')
         uses: ./.github/workflows/build_main_artifacts_arm64.yml
 
     build-cli:
         name: Build CLI
-        if: contains(github.event.pull_request.labels.*.name, 'full')
+        if: contains(github.event.pull_request.labels.*.name, 'full') && contains(github.event.pull_request.labels.*.name, 'ci-ready')
         uses: ./.github/workflows/build_cli_artifacts.yml
 
     build-cpu:
         name: Build CPU
-        if: contains(github.event.pull_request.labels.*.name, 'full')
+        if: contains(github.event.pull_request.labels.*.name, 'full') && contains(github.event.pull_request.labels.*.name, 'ci-ready')
         uses: ./.github/workflows/build_cpu_artifacts.yml
 
     build-cu129:
         name: Build cu129
-        if: contains(github.event.pull_request.labels.*.name, 'full')
+        if: contains(github.event.pull_request.labels.*.name, 'full') && contains(github.event.pull_request.labels.*.name, 'ci-ready')
         uses: ./.github/workflows/build_cu129_artifacts.yml
         # Fork PRs won't expose DOCKERHUB_TOKEN even with `inherit`; the login
         # step in build_cu129_artifacts.yml guards on the token being non-empty.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - "dev"
       - "release-**"
+    types: [labeled]
 
 env:
   LC_ALL: en_US.UTF-8
@@ -26,6 +27,7 @@ permissions:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
@@ -62,7 +64,7 @@ jobs:
 
   test:
     needs: changes
-    if: needs.changes.outputs.lmcache == 'true'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')) && needs.changes.outputs.lmcache == 'true'
     name: "test: ${{ matrix.python }} on ${{ matrix.platform }}"
     runs-on: "${{ matrix.platform }}"
     strategy:
@@ -117,7 +119,7 @@ jobs:
 
   raw-block-tests:
     needs: changes
-    if: needs.changes.outputs.raw_block == 'true'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ready')) && needs.changes.outputs.raw_block == 'true'
     name: raw-block temp-file tests
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## What does this PR do?

This PR makes pull-request CI two-stage:

- Code Quality and the external DCO check remain the fast admission checks.
- GitHub Actions workflows that consume substantial runner time now listen for the `ci-ready` label instead of starting on every `synchronize` event.
- A base-repository `pull_request_target` gate waits for the exact PR head SHA to pass Code Quality and DCO, then adds `ci-ready`; a newer push removes the label and invalidates the previous admission.
- Full artifact builds require both the existing `full` label and `ci-ready`. Direct triggers were removed from the reusable artifact workflows.
- The shared Buildkite upload gate remains in place for K3 lanes.

The gate deliberately does not check out or execute pull-request code. Since GitHub only runs `pull_request_target` from the target repository's existing base workflow, this bootstrap PR itself cannot execute the newly added target gate until it is merged. For this PR, `ci-ready` can be added after Code Quality and DCO pass; subsequent PRs will be fully automatic.

## Validation

- YAML parsed successfully for all `.github/workflows/*.yml`.
- actionlint 1.7.7 passed (Docker was unavailable locally, so the pinned binary was used).
- `bash -n` and `git diff --check`.
- `SKIP=rust-fmt,rust-clippy uvx pre-commit run --all-files` passed.
- Existing stale queued/in-progress runs from the previous commit were cancelled; no downstream workflow was created for the new commit before `ci-ready`.
- Buildkite gate was exercised on PR #5071 and held downstream upload while Code Quality was pending.