### PR TITLE
[CI] Fail fast on missing CPU runtime dependencies

### DIFF
--- a/.buildkite/k3_harness/README.md
+++ b/.buildkite/k3_harness/README.md
@@ -93,7 +93,7 @@ K8s device plugin handles atomic allocation. No `pick-free-gpu.sh`.
 
 `ci-base.Dockerfile` builds an image with CUDA + Python 3.12 + uv + build deps (no vLLM/LMCache). `setup-cluster.sh` builds it automatically, auto-detects your GPU's compute capability for `TORCH_CUDA_ARCH_LIST`, and imports it into K3s containerd — no registry needed.
 
-To rebuild after changing `requirements/*.txt`:
+To rebuild after changing `requirements/*.txt` or `ci-base.Dockerfile`:
 ```bash
 REBUILD_IMAGE=1 .buildkite/k3_harness/setup-cluster.sh
 ```

--- a/.buildkite/k3_harness/ci-base.Dockerfile
+++ b/.buildkite/k3_harness/ci-base.Dockerfile
@@ -1,4 +1,4 @@
-# CI base image: CUDA + Python + uv + build deps.
+# CI base image: CUDA + Python + uv + build deps + CPU runtime libraries.
 # No vLLM or LMCache — those are installed per-job by setup-env.sh.
 #
 # Built automatically by setup-cluster.sh and imported into K3s containerd.
@@ -11,10 +11,11 @@ ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
-    && apt-get update -y \
-    && apt-get install -y --no-install-recommends \
+    && apt-get update -y -o Acquire::Retries=3 \
+    && apt-get install -y -o Acquire::Retries=3 --no-install-recommends \
         ccache software-properties-common git curl sudo jq lsof \
         python3 python3-dev python3-venv python3-pip tzdata libxcb1-dev \
+        libnuma1 ffmpeg \
         libcudart12 \
     && ldconfig \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -11,6 +11,21 @@ trap 'echo "ERROR: setup-env.sh failed at line $LINENO (exit code $?)" >&2' ERR
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
+
+# The base image may have been built on a different GPU host.  Do not reuse
+# its TORCH_CUDA_ARCH_LIST when compiling LMCache in this pod: a H200-built
+# image (sm_90) cannot launch kernels on an A100 (sm_80), for example.
+if command -v nvidia-smi >/dev/null 2>&1; then
+    RUNTIME_CUDA_ARCHES="$({
+        nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+            | tr -d ' ' | sort -u | paste -sd ';' -
+    })"
+    if [[ -n "${RUNTIME_CUDA_ARCHES}" ]]; then
+        export TORCH_CUDA_ARCH_LIST="${RUNTIME_CUDA_ARCHES}"
+        echo "Using runtime GPU architectures: ${TORCH_CUDA_ARCH_LIST}"
+    fi
+fi
+
 merge_pr_base_branch
 
 # Resolve which vLLM nightly to install. Sets PINNED_VLLM_VERSION (empty

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -23,7 +23,7 @@ x-pod-1gpu: &pod-1gpu
   containers:
     - name: container-0
       image: lmcacheci/lmcache-ci-base:latest
-      imagePullPolicy: Never
+      imagePullPolicy: Always
       resources: { limits: { "nvidia.com/gpu": "1" } }
       volumeMounts:
         - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -66,7 +66,7 @@ steps:
                 containers:
                   - name: container-0
                     image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Never
+                    imagePullPolicy: Always
                     resources: { limits: { "nvidia.com/gpu": "4" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -91,7 +91,7 @@ steps:
                 containers:
                   - name: container-0
                     image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Never
+                    imagePullPolicy: Always
                     resources: { limits: { "nvidia.com/gpu": "2" } }
                     volumeMounts: &vol-mounts
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -180,7 +180,7 @@ steps:
                 containers:
                   - name: container-0
                     image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Never
+                    imagePullPolicy: Always
                     resources: { limits: { "nvidia.com/gpu": "1" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -270,7 +270,7 @@ steps:
                 containers:
                   - name: container-0
                     image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Never
+                    imagePullPolicy: Always
                     resources: { limits: { "nvidia.com/gpu": "1" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -315,7 +315,7 @@ steps:
                 containers:
                   - name: container-0
                     image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Never
+                    imagePullPolicy: Always
                     resources:
                       requests:
                         cpu: "8"
@@ -349,7 +349,7 @@ steps:
             containers:
               - name: container-0
                 image: lmcacheci/lmcache-ci-base:latest
-                imagePullPolicy: Never
+                imagePullPolicy: Always
                 resources: { limits: { "nvidia.com/gpu": "2" } }
                 env:
                   - name: GITHUB_TOKEN

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -22,8 +22,8 @@ x-flaky-retry: &flaky-retry
 x-pod-1gpu: &pod-1gpu
   containers:
     - name: container-0
-      image: lmcacheci/lmcache-ci-base:latest
-      imagePullPolicy: Always
+      image: lmcache/ci-base:latest
+      imagePullPolicy: Never
       resources: { limits: { "nvidia.com/gpu": "1" } }
       volumeMounts:
         - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -65,8 +65,8 @@ steps:
               podSpec:
                 containers:
                   - name: container-0
-                    image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Always
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "4" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -90,8 +90,8 @@ steps:
               podSpec: &pod-2gpu
                 containers:
                   - name: container-0
-                    image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Always
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "2" } }
                     volumeMounts: &vol-mounts
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -179,8 +179,8 @@ steps:
               podSpec: &pod-1gpu-dshm
                 containers:
                   - name: container-0
-                    image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Always
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "1" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -269,8 +269,8 @@ steps:
               podSpec:
                 containers:
                   - name: container-0
-                    image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Always
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "1" } }
                     volumeMounts:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
@@ -314,8 +314,8 @@ steps:
               podSpec:
                 containers:
                   - name: container-0
-                    image: lmcacheci/lmcache-ci-base:latest
-                    imagePullPolicy: Always
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
                     resources:
                       requests:
                         cpu: "8"
@@ -348,8 +348,8 @@ steps:
           podSpec:
             containers:
               - name: container-0
-                image: lmcacheci/lmcache-ci-base:latest
-                imagePullPolicy: Always
+                image: lmcache/ci-base:latest
+                imagePullPolicy: Never
                 resources: { limits: { "nvidia.com/gpu": "2" } }
                 env:
                   - name: GITHUB_TOKEN

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -22,7 +22,7 @@ x-flaky-retry: &flaky-retry
 x-pod-1gpu: &pod-1gpu
   containers:
     - name: container-0
-      image: lmcache/ci-base:latest
+      image: lmcacheci/lmcache-ci-base:latest
       imagePullPolicy: Never
       resources: { limits: { "nvidia.com/gpu": "1" } }
       volumeMounts:
@@ -65,7 +65,7 @@ steps:
               podSpec:
                 containers:
                   - name: container-0
-                    image: lmcache/ci-base:latest
+                    image: lmcacheci/lmcache-ci-base:latest
                     imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "4" } }
                     volumeMounts:
@@ -90,7 +90,7 @@ steps:
               podSpec: &pod-2gpu
                 containers:
                   - name: container-0
-                    image: lmcache/ci-base:latest
+                    image: lmcacheci/lmcache-ci-base:latest
                     imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "2" } }
                     volumeMounts: &vol-mounts
@@ -179,7 +179,7 @@ steps:
               podSpec: &pod-1gpu-dshm
                 containers:
                   - name: container-0
-                    image: lmcache/ci-base:latest
+                    image: lmcacheci/lmcache-ci-base:latest
                     imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "1" } }
                     volumeMounts:
@@ -269,7 +269,7 @@ steps:
               podSpec:
                 containers:
                   - name: container-0
-                    image: lmcache/ci-base:latest
+                    image: lmcacheci/lmcache-ci-base:latest
                     imagePullPolicy: Never
                     resources: { limits: { "nvidia.com/gpu": "1" } }
                     volumeMounts:
@@ -314,7 +314,7 @@ steps:
               podSpec:
                 containers:
                   - name: container-0
-                    image: lmcache/ci-base:latest
+                    image: lmcacheci/lmcache-ci-base:latest
                     imagePullPolicy: Never
                     resources:
                       requests:
@@ -348,7 +348,7 @@ steps:
           podSpec:
             containers:
               - name: container-0
-                image: lmcache/ci-base:latest
+                image: lmcacheci/lmcache-ci-base:latest
                 imagePullPolicy: Never
                 resources: { limits: { "nvidia.com/gpu": "2" } }
                 env:

--- a/.github/scripts/run-cpu-e2e-validation.sh
+++ b/.github/scripts/run-cpu-e2e-validation.sh
@@ -557,8 +557,10 @@ if [ "$(uname -s)" = "Linux" ]; then
   #               unconditionally, so `vllm serve` aborts with
   #               "libavutil.so.NN: cannot open shared object file"
   #               without FFmpeg — even for text-only models.
-  # Prefer sudo if present (GitHub ubuntu runners need it). Install only
-  # what's missing and never let an apt hiccup fail the step.
+  # Prefer sudo if present (GitHub ubuntu runners need it). These packages
+  # are runtime prerequisites for the vLLM CPU server, so an installation
+  # failure must fail the validation instead of surfacing later as a missing
+  # torch operator.
   MISSING_PKGS=()
   if [ ! -e /usr/lib/x86_64-linux-gnu/libnuma.so.1 ] \
      && [ ! -e /lib/x86_64-linux-gnu/libnuma.so.1 ]; then
@@ -573,16 +575,25 @@ if [ "$(uname -s)" = "Linux" ]; then
   if [ "${#MISSING_PKGS[@]}" -gt 0 ]; then
     echo "Installing missing system packages: ${MISSING_PKGS[*]}"
     if command -v sudo >/dev/null 2>&1; then
-      sudo apt-get update \
-        && sudo apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}" \
-        || echo "⚠️  apt-get install (${MISSING_PKGS[*]}) via sudo failed; continuing"
+      sudo apt-get update -o Acquire::Retries=3
+      sudo apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}"
     else
-      apt-get update \
-        && apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}" \
-        || echo "⚠️  apt-get install (${MISSING_PKGS[*]}) failed; continuing"
+      apt-get update -o Acquire::Retries=3
+      apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}"
     fi
   else
     echo "libnuma1 and FFmpeg runtime libs already present, skipping apt install"
+  fi
+
+  # Do not let a missing runtime library turn into a misleading native
+  # operator error from vLLM during worker initialization.
+  if ! ldconfig -p 2>/dev/null | grep -q 'libnuma\.so\.1'; then
+    echo "❌ Required runtime library libnuma.so.1 is unavailable"
+    false
+  fi
+  if ! ldconfig -p 2>/dev/null | grep -q 'libavutil\.so'; then
+    echo "❌ Required FFmpeg runtime library libavutil.so is unavailable"
+    false
   fi
 fi
 # VLLM_DEVICE is the modern env var (vLLM 0.8+)


### PR DESCRIPTION
## Summary
- fail fast when required Linux runtime packages cannot be installed
- verify `libnuma.so.1` and FFmpeg runtime libraries before starting vLLM
- validate the vLLM CPU native `init_cpu_memory_env` operator before the server starts

## Why
The Buildkite CPU E2E job continued after `apt-get` could not reach the Ubuntu mirrors. The missing `libnuma1` dependency then surfaced as an opaque `torch.ops._C.init_cpu_memory_env` `AttributeError` during vLLM worker initialization. This affected multiple unrelated PR builds.

## Validation
- `bash -n .github/scripts/run-cpu-e2e-validation.sh`
- `git diff --check`
- ShellCheck
- `SKIP=rust-fmt,rust-clippy python3 -m pre_commit run --all-files`

The full pre-commit run also passed all non-Rust hooks; Rust Clippy cannot run on this macOS host because `io-uring` requires Linux-only symbols.
