### PR TITLE
[feat][vllm] publish MP connector KV events

### DIFF
--- a/docs/source/production/kv_cache_events.rst
+++ b/docs/source/production/kv_cache_events.rst
@@ -85,7 +85,7 @@ How to Generate KV Cache events
       .. code-block:: bash
 
           Received event batch at 1765529395.2132685:
-        - BlockStored(block_hashes=[b'\x96\x95[h6\x1dE$v\x03\xe8\xf0\xc20\xcd\xe8\xa7#\x9cS\xe0\x16\xba\xab7\xf7z\x10P]\xfaT'], parent_block_hash=None, token_ids=[27, 91, 7265, 3575, 4326, 91, 1784, 91, 8948, 91, 397, 2610, 525, 264, 10950, 15235, 17847, 624, 27, 91, 872, 91, 397, 3838, 374, 279, 16158, 1685, 1370, 276, 5267, 27, 91, 77091, 91, 29], block_size=36, lora_id=None, medium='cpu')
+        - BlockStored(block_hashes=[b'\x96\x95[h6\x1dE$v\x03\xe8\xf0\xc20\xcd\xe8\xa7#\x9cS\xe0\x16\xba\xab7\xf7z\x10P]\xfaT'], parent_block_hash=None, token_ids=[27, 91, 7265, 3575, 4326, 91, 1784, 91, 8948, 91, 397, 2610, 525, 264, 10950, 15235, 17847, 624, 27, 91, 872, 91, 397, 3838, 374, 279, 16158, 1685, 1370, 276, 5267, 27, 91, 77091, 91, 29], block_size=36, lora_id=None, medium='CPU')
 
       This is the event generated after the cache store operation.
 
@@ -157,4 +157,4 @@ How to Generate KV Cache events
             - BlockStored(block_hashes=[8695562889830890067], parent_block_hash=-2282733302929094006, token_ids=[4396, 382, 7039, 11, 279, 1196, 6801, 311, 1414], block_size=8, lora_id=None)
             - BlockStored(block_hashes=[-6034740625096789744], parent_block_hash=8695562889830890067, token_ids=[1414, 911, 279, 15817, 16182, 315, 27950, 323, 20980], block_size=8, lora_id=None)
 
-      This is the event generated after the cache store operation. 
+      This is the event generated after the cache store operation.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -8,6 +8,12 @@ import sys
 
 # Third Party
 from vllm.config import VllmConfig
+from vllm.distributed.kv_events import (
+    BlockStored,
+    KVCacheEvent,
+    KVConnectorKVEvents,
+    KVEventAggregator,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
@@ -27,6 +33,7 @@ except ImportError:
 
 # Third Party
 from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import RequestStatus
@@ -93,7 +100,6 @@ except ImportError:
 
 if TYPE_CHECKING:
     # Third Party
-    from vllm.distributed.kv_events import KVCacheEvent
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
         KVConnectorStats,
@@ -110,6 +116,49 @@ logger = lmcache_init_logger(__name__)
 
 _DCP_LAYOUT_NAMESPACE = "##lmcache-dcp-layout-v1-"
 _MAX_LCM_EXPANSION_FACTOR = 4
+
+
+def _convert_kv_event_hash(block_hash: bytes | int | None) -> bytes | int | None:
+    """Convert LMCache event hashes to vLLM's configured external format."""
+    if isinstance(block_hash, bytes):
+        return maybe_convert_block_hash(BlockHash(block_hash))
+    return block_hash
+
+
+class LMCacheMPKVEvents(KVConnectorKVEvents):
+    """KV event container used by LMCache multiprocess workers."""
+
+    def __init__(self, num_workers: int) -> None:
+        self._aggregator = KVEventAggregator(num_workers)
+
+    def add_events(self, events: list[KVCacheEvent]) -> None:
+        """Add events from one worker."""
+        self._aggregator.add_events(events)
+
+    def aggregate(self) -> "LMCacheMPKVEvents":
+        """Retain only events seen from every contributing worker."""
+        common_events = self._aggregator.get_common_events()
+        self._aggregator.clear_events()
+        self._aggregator.add_events(common_events)
+        self._aggregator.reset_workers()
+        return self
+
+    def increment_workers(self, count: int = 1) -> None:
+        """Track an additional worker contribution."""
+        self._aggregator.increment_workers(count)
+
+    def get_all_events(self) -> list[KVCacheEvent]:
+        """Return all buffered events."""
+        return self._aggregator.get_all_events()
+
+    def get_number_of_workers(self) -> int:
+        """Return the number of contributing workers."""
+        return self._aggregator.get_number_of_workers()
+
+    def clear_events(self) -> None:
+        """Clear buffered events and reset the worker count."""
+        self._aggregator.clear_events()
+        self._aggregator.reset_workers()
 
 
 # Helper functions
@@ -491,6 +540,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         assert vllm_config.kv_transfer_config is not None
 
+        self._enable_kv_events = bool(
+            getattr(vllm_config, "kv_events_config", None) is not None
+            and vllm_config.kv_events_config.enable_kv_cache_events
+        )
+
         self._eager_prefetch: bool = bool(
             vllm_config.kv_transfer_config.get_from_extra_config(
                 "lmcache.mp.eager_prefetch", False
@@ -594,6 +648,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+            self._kv_cache_events: LMCacheMPKVEvents | None = None
 
             # GPU block pool reference
             self._gpu_block_pool: "BlockPool | None" = None
@@ -619,6 +674,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 vllm_block_size=scheduler_block_size,
                 parallel_strategy=parallel_strategy,
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
+                enable_kv_events=self._enable_kv_events,
             )
             if self.transfer_intermediate_tensors:
                 # First Party
@@ -943,6 +999,38 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         return self.worker_adapter.get_block_ids_with_load_errors()
 
+    def get_kv_connector_kv_cache_events(self) -> LMCacheMPKVEvents | None:
+        """Return worker-side KV cache events collected since the last step.
+
+        Returns:
+            A vLLM KV event container with completed LMCache store events, or
+            None when disabled or when no store completed.
+        """
+        if not self._enable_kv_events:
+            return None
+        events = self.worker_adapter.get_kv_events()
+        if not events:
+            return None
+
+        blocks = [
+            BlockStored(
+                block_hashes=[
+                    _convert_kv_event_hash(block_hash)
+                    for block_hash in event.block_hashes
+                ],
+                parent_block_hash=_convert_kv_event_hash(event.parent_block_hash),
+                token_ids=event.token_ids,
+                lora_id=event.lora_id,
+                block_size=event.block_size,
+                medium=event.medium,
+                lora_name=event.lora_name,
+            )
+            for event in events
+        ]
+        kv_events = LMCacheMPKVEvents(num_workers=1)
+        kv_events.add_events(blocks)
+        return kv_events
+
     def shutdown(self):
         """
         Shutdown the connector. This is called when the worker process
@@ -1231,6 +1319,16 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             connector_output (KVConnectorOutput): the worker-side
                 connectors output.
         """
+        kv_cache_events = connector_output.kv_cache_events
+        if kv_cache_events and isinstance(kv_cache_events, LMCacheMPKVEvents):
+            if self._kv_cache_events is None:
+                self._kv_cache_events = kv_cache_events
+            else:
+                self._kv_cache_events.add_events(kv_cache_events.get_all_events())
+                self._kv_cache_events.increment_workers(
+                    kv_cache_events.get_number_of_workers()
+                )
+
         if not self.lazy_offload:
             return
         if not self._gpu_block_pool:
@@ -1314,7 +1412,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         Yields:
             New KV cache events since the last call.
         """
-        return ()
+        if self._kv_cache_events is not None:
+            self._kv_cache_events.aggregate()
+            yield from self._kv_cache_events.get_all_events()
+            self._kv_cache_events.clear_events()
+            self._kv_cache_events = None
 
     def has_pending_push_work(self) -> bool:
         """Return whether vLLM should keep stepping for pending push work.

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -20,7 +20,12 @@ from lmcache import torch_dev
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
 from lmcache.integration.vllm.experimental import dispatch
 from lmcache.integration.vllm.utils import vllm_layout_hints
-from lmcache.utils import EngineType, _lmcache_nvtx_annotate, init_logger
+from lmcache.utils import (
+    CacheStoreEvent,
+    EngineType,
+    _lmcache_nvtx_annotate,
+    init_logger,
+)
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
@@ -31,6 +36,7 @@ from lmcache.v1.multiprocess.group_view import (
     expand_engine_block_ids,
 )
 from lmcache.v1.multiprocess.mq import MessagingFuture
+from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.multiprocess.transfer_context import (
     EngineDrivenTransferContext,
     TransferContext,
@@ -94,6 +100,9 @@ class ExtraConfigDefault(enum.Enum):
     # VMM IPC instead of legacy CUDA IPC handles; see
     # lmcache/v1/platform/cuda/vmm_ipc.py.
     use_vmm_api = False
+    # Must match the MP server's --hash-algorithm setting because KV events
+    # expose the same chunk hashes used by server-side object keys.
+    hash_algorithm = "blake3"
 
 
 # Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
@@ -1168,6 +1177,7 @@ class LMCacheMPWorkerAdapter:
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
         extra_config: dict[str, Any] | None = None,
+        enable_kv_events: bool = False,
     ):
         """Initialize the worker adapter for current or legacy vLLM callers.
 
@@ -1188,6 +1198,8 @@ class LMCacheMPWorkerAdapter:
             extra_config: Optional dict with keys starting with
                 ``lmcache.mp.`` (e.g., ``lmcache.mp.mq_timeout``). When
                 provided, it overrides ``mq_timeout`` / ``heartbeat_interval``.
+            enable_kv_events: Whether to collect completed store operations
+                for vLLM's KV event publisher.
 
         Raises:
             TypeError: If the connector argument shape is unsupported.
@@ -1198,10 +1210,12 @@ class LMCacheMPWorkerAdapter:
             legacy_block_size,
             mq_timeout,
         )
+        hash_algorithm = ExtraConfigDefault.hash_algorithm.default
         if extra_config is not None:
             cfg = _resolve_extra_config(extra_config)
             mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
             heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+            hash_algorithm = cfg[ExtraConfigDefault.hash_algorithm.name]
             # Only treat ``mp_transfer_mode`` as an explicit override when
             # the user actually set it in extra_config; otherwise leave it
             # as ``None`` so ``create_transfer_context`` can still consult
@@ -1276,6 +1290,17 @@ class LMCacheMPWorkerAdapter:
             self.req_client.close()
             _raise_server_unreachable(server_url, self._mq_timeout)
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
+        self._kv_events_enabled = enable_kv_events
+        self._kv_event_hasher = (
+            TokenHasher(
+                chunk_size=lmcache_tokens_per_chunk,
+                hash_algorithm=hash_algorithm,
+            )
+            if enable_kv_events
+            else None
+        )
+        self._pending_store_kv_events: dict[str, list[CacheStoreEvent]] = {}
+        self._kv_events: list[CacheStoreEvent] = []
         if lmcache_tokens_per_chunk % vllm_block_size != 0:
             raise ValueError(
                 f"LMCache chunk size {lmcache_tokens_per_chunk} must be a "
@@ -1608,6 +1633,10 @@ class LMCacheMPWorkerAdapter:
         self.store_futures[request_id] = future
         if event is not None:
             self.store_events[request_id] = event
+        if self._kv_events_enabled:
+            self._pending_store_kv_events.setdefault(request_id, []).extend(
+                self._build_store_kv_events(key)
+            )
 
     @_lmcache_nvtx_annotate
     def submit_retrieve_request(
@@ -1829,6 +1858,7 @@ class LMCacheMPWorkerAdapter:
             self.retrieve_futures.clear()
             self.store_events.clear()
             self.retrieve_events.clear()
+            self._pending_store_kv_events.clear()
 
             # Retrieves dropped at submit time still must be reported,
             # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
@@ -1860,10 +1890,15 @@ class LMCacheMPWorkerAdapter:
             finished_stores.add(request_id)
 
             if not s_result:
+                self._pending_store_kv_events.pop(request_id, None)
                 logger.error(
                     "Something went wrong when processing the "
                     "store request for request_id=%s",
                     request_id,
+                )
+            else:
+                self._kv_events.extend(
+                    self._pending_store_kv_events.pop(request_id, [])
                 )
 
         for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
@@ -1957,6 +1992,7 @@ class LMCacheMPWorkerAdapter:
             self.retrieve_futures.clear()
             self.store_events.clear()
             self.retrieve_events.clear()
+            self._pending_store_kv_events.clear()
 
             # Retrieves dropped at submit time still must be reported,
             # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
@@ -1981,10 +2017,15 @@ class LMCacheMPWorkerAdapter:
             finished_stores.add(request_id)
 
             if not s_result:
+                self._pending_store_kv_events.pop(request_id, None)
                 logger.error(
                     "Something went wrong when processing the "
                     "store request for request_id=%s",
                     request_id,
+                )
+            else:
+                self._kv_events.extend(
+                    self._pending_store_kv_events.pop(request_id, [])
                 )
 
         for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
@@ -2044,6 +2085,20 @@ class LMCacheMPWorkerAdapter:
         self._completed_store_requests = {}
         return completed_store_requests
 
+    def get_kv_events(self) -> list[CacheStoreEvent]:
+        """Return completed store events since the last call.
+
+        Returns:
+            A list of LMCache cache-store events for stores that completed
+            successfully. Returns an empty list when KV events are disabled or
+            no new store completed.
+        """
+        if not self._kv_events_enabled or not self._kv_events:
+            return []
+        events = self._kv_events
+        self._kv_events = []
+        return events
+
     def num_blocks_per_chunk(self) -> int:
         """
         Returns:
@@ -2078,6 +2133,47 @@ class LMCacheMPWorkerAdapter:
         self.transfer_ctx.flush_inflight_stores()
         # Force device sync here, compare to preemption, perf panelty is trivial
         torch_dev.synchronize()
+
+    def _build_store_kv_events(
+        self,
+        key: IPCCacheServerKey,
+    ) -> list[CacheStoreEvent]:
+        """Build LMCache cache-store events for a submitted store key."""
+        if self._kv_event_hasher is None:
+            return []
+
+        token_ids = list(key.token_ids)
+        chunk_size = self.lmcache_tokens_per_chunk
+        hashes = self._kv_event_hasher.compute_chunk_hashes(
+            token_ids,
+            end=key.end,
+        )
+        start_chunk = key.start // chunk_size
+        end_chunk = key.end // chunk_size
+        if start_chunk >= end_chunk:
+            return []
+
+        events = []
+        parent_hash = hashes[start_chunk - 1] if start_chunk > 0 else None
+        for chunk_idx, block_hash in enumerate(
+            hashes[start_chunk:end_chunk],
+            start=start_chunk,
+        ):
+            start = chunk_idx * chunk_size
+            end = start + chunk_size
+            events.append(
+                CacheStoreEvent(
+                    block_hashes=[block_hash],
+                    parent_block_hash=parent_hash,
+                    token_ids=token_ids[start:end],
+                    block_size=chunk_size,
+                    lora_id=None,
+                    medium="CPU",
+                    lora_name=None,
+                )
+            )
+            parent_hash = block_hash
+        return events
 
     def shutdown(self) -> None:
         """

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -628,8 +628,8 @@ class LayerCacheEngineKey(CacheEngineKey):
 
 @dataclass
 class CacheStoreEvent:
-    block_hashes: list[int]
-    parent_block_hash: int | None
+    block_hashes: list[int | bytes]
+    parent_block_hash: int | bytes | None
     token_ids: list[int]
     block_size: int
 

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -528,7 +528,7 @@ class LMCacheEngine:
                         token_ids=[],
                         block_size=num_tokens,
                         lora_id=None,
-                        medium="cpu",
+                        medium="CPU",
                         lora_name=None,
                     )
                     if tokens is not None:
@@ -537,8 +537,6 @@ class LMCacheEngine:
                             start,
                             end,
                         )
-                        if isinstance(tokens, torch.Tensor):
-                            stored_event.medium = tokens.device
                     elif hashes is not None:
                         stored_event.token_ids = hashes[start : end + 1]
                     logger.debug(
@@ -711,7 +709,7 @@ class LMCacheEngine:
                     token_ids=[],
                     block_size=num_tokens,
                     lora_id=None,
-                    medium="cpu",
+                    medium="CPU",
                     lora_name=None,
                 )
                 if tokens is not None:
@@ -720,8 +718,6 @@ class LMCacheEngine:
                         start,
                         end,
                     )
-                    if isinstance(tokens, torch.Tensor):
-                        stored_event.medium = tokens.device
                 logger.debug(
                     "Added kv cache event '%s' to kv cache events queue",
                     stored_event,

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -4,7 +4,7 @@ stubbed (see ``fake_adapter``); no GPU or live server needed. End-to-end
 recovery: ``.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh``."""
 
 # Standard
-from typing import Callable, ClassVar
+from typing import Any, Callable, ClassVar
 from unittest.mock import MagicMock
 import gc
 import os
@@ -97,6 +97,7 @@ class FakeHeartbeatThread:
 
 def _make_worker_adapter(
     extra_config: dict[str, object] | None = None,
+    enable_kv_events: bool = False,
 ) -> LMCacheMPWorkerAdapter:
     """Construct a worker adapter with the standard test arguments; the
     network boundary must already be patched (see ``fake_adapter``).
@@ -117,6 +118,7 @@ def _make_worker_adapter(
         parallel_strategy=parallel_strategy,
         mq_timeout=5.0,
         extra_config=extra_config,
+        enable_kv_events=enable_kv_events,
     )
 
 
@@ -336,6 +338,111 @@ def test_submit_store_request_expands_block_ids_to_views(fake_adapter, monkeypat
         [0, 1],
         [10, 11],
     ]
+
+
+def test_store_kv_events_are_reported_after_successful_store(
+    fake_adapter,
+    monkeypatch,
+):
+    """Completed MP stores are exposed once as LMCache cache-store events."""
+    # First Party
+    from lmcache.v1.multiprocess.token_hasher import TokenHasher
+
+    adapter = _make_worker_adapter(enable_kv_events=True)
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    transfer_ctx = MagicMock()
+    store_future = MagicMock()
+    store_future.query.return_value = True
+    store_future.result.return_value = True
+    transfer_ctx.submit_store.return_value = store_future
+    adapter.transfer_ctx = transfer_ctx
+
+    chunk_size = adapter.lmcache_tokens_per_chunk
+    token_ids = list(range(chunk_size * 2))
+    op = LoadStoreOp(
+        token_ids=token_ids,
+        block_ids=[[1]],
+        start=chunk_size,
+        end=chunk_size * 2,
+    )
+    adapter.submit_store_request("req-1", op, event=None)
+
+    assert adapter.get_kv_events() == []
+
+    adapter.get_finished({"req-1"})
+    events = adapter.get_kv_events()
+    expected_hashes = TokenHasher(chunk_size=chunk_size).compute_chunk_hashes(
+        token_ids,
+        end=chunk_size * 2,
+    )
+
+    assert len(events) == 1
+    assert events[0].block_hashes == [expected_hashes[1]]
+    assert events[0].parent_block_hash == expected_hashes[0]
+    assert events[0].token_ids == token_ids[chunk_size : chunk_size * 2]
+    assert events[0].block_size == chunk_size
+    assert events[0].medium == "CPU"
+    assert adapter.get_kv_events() == []
+
+
+def test_store_kv_events_are_discarded_after_failed_store(
+    fake_adapter,
+    monkeypatch,
+):
+    """Failed MP stores must not emit cache-store events."""
+    adapter = _make_worker_adapter(enable_kv_events=True)
+    monkeypatch.setattr(adapter, "_ensure_heartbeat_started", lambda: None)
+    transfer_ctx = MagicMock()
+    store_future = MagicMock()
+    store_future.query.return_value = True
+    store_future.result.return_value = False
+    transfer_ctx.submit_store.return_value = store_future
+    adapter.transfer_ctx = transfer_ctx
+
+    chunk_size = adapter.lmcache_tokens_per_chunk
+    op = LoadStoreOp(
+        token_ids=list(range(chunk_size)),
+        block_ids=[[0]],
+        start=0,
+        end=chunk_size,
+    )
+    adapter.submit_store_request("req-1", op, event=None)
+
+    adapter.get_finished({"req-1"})
+
+    assert adapter.get_kv_events() == []
+
+
+def test_store_kv_events_use_hash_algorithm_extra_config(
+    fake_adapter,
+    monkeypatch,
+):
+    """KV event hashes use the hash algorithm configured for the MP server."""
+    captured: dict[str, object] = {}
+
+    class FakeTokenHasher:
+        def __init__(self, chunk_size: int, hash_algorithm: str) -> None:
+            captured["chunk_size"] = chunk_size
+            captured["hash_algorithm"] = hash_algorithm
+
+        def compute_chunk_hashes(
+            self,
+            token_ids: list[int],
+            end: int | None = None,
+        ) -> list[bytes]:
+            return [b"hash"]
+
+    monkeypatch.setattr(adapter_mod, "TokenHasher", FakeTokenHasher)
+
+    adapter = _make_worker_adapter(
+        extra_config={"lmcache.mp.hash_algorithm": "builtin"},
+        enable_kv_events=True,
+    )
+
+    assert captured == {
+        "chunk_size": adapter.lmcache_tokens_per_chunk,
+        "hash_algorithm": "builtin",
+    }
 
 
 def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatch):
@@ -685,6 +792,100 @@ def test_failed_full_retrieve_is_recomputed_instead_of_retried_remotely() -> Non
     blocks.get_block_ids.return_value = ([7],)
     connector.update_state_after_alloc(request, blocks, num_external_tokens=0)
     assert tracker.state == LMCacheMPRequestState.READY
+
+
+def test_connector_converts_worker_kv_events_to_vllm_events() -> None:
+    """Worker LMCache events are wrapped in vLLM's KV event container."""
+    kv_events_mod = pytest.importorskip(
+        "vllm.distributed.kv_events",
+        exc_type=ModuleNotFoundError,
+    )
+    BlockStored = kv_events_mod.BlockStored
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector
+    from lmcache.utils import CacheStoreEvent
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector._enable_kv_events = True
+    connector.worker_adapter = MagicMock()
+    connector.worker_adapter.get_kv_events.return_value = [
+        CacheStoreEvent(
+            block_hashes=[b"hash-1"],
+            parent_block_hash=None,
+            token_ids=[1, 2, 3, 4],
+            block_size=4,
+            lora_id=None,
+            medium="CPU",
+            lora_name=None,
+        )
+    ]
+
+    kv_events = connector.get_kv_connector_kv_cache_events()
+
+    assert kv_events is not None
+    events = kv_events.get_all_events()
+    assert len(events) == 1
+    assert isinstance(events[0], BlockStored)
+    assert events[0].token_ids == [1, 2, 3, 4]
+    assert events[0].block_size == 4
+    assert events[0].medium == kv_events_mod.MEDIUM_CPU
+
+
+def test_connector_take_events_aggregates_and_drains_once() -> None:
+    """Scheduler-side ``take_events`` publishes common worker events once."""
+    kv_events_mod = pytest.importorskip(
+        "vllm.distributed.kv_events",
+        exc_type=ModuleNotFoundError,
+    )
+    BlockStored = kv_events_mod.BlockStored
+
+    # Third Party
+    from vllm.v1.outputs import KVConnectorOutput
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        LMCacheMPConnector,
+        LMCacheMPKVEvents,
+    )
+
+    def make_container(*events: Any) -> LMCacheMPKVEvents:
+        container = LMCacheMPKVEvents(num_workers=1)
+        container.add_events(list(events))
+        return container
+
+    common = BlockStored(
+        block_hashes=[b"common"],
+        parent_block_hash=None,
+        token_ids=[1, 2, 3, 4],
+        block_size=4,
+        lora_id=None,
+        medium=kv_events_mod.MEDIUM_CPU,
+        lora_name=None,
+    )
+    worker_only = BlockStored(
+        block_hashes=[b"worker-only"],
+        parent_block_hash=None,
+        token_ids=[5, 6, 7, 8],
+        block_size=4,
+        lora_id=None,
+        medium=kv_events_mod.MEDIUM_CPU,
+        lora_name=None,
+    )
+
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector._kv_cache_events = None
+    connector.lazy_offload = False
+
+    connector.update_connector_output(
+        KVConnectorOutput(kv_cache_events=make_container(common, worker_only))
+    )
+    connector.update_connector_output(
+        KVConnectorOutput(kv_cache_events=make_container(common))
+    )
+
+    assert list(connector.take_events()) == [common]
+    assert list(connector.take_events()) == []
 
 
 def test_instance_id_is_uuid_derived_63_bit_int(fake_adapter) -> None:


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3661.

LMCache MP stores and retrieves KV correctly, but its vLLM connector does not currently publish completed MP stores through vLLM's KV-event path. 
KV-aware routers therefore cannot see which worker owns an LMCache host-cache prefix.

This change:

- records MP store events only after the store future succeeds;
- discards events for failed or degraded-mode stores;
- computes event hashes with the MP server's configured hash algorithm;
- converts completed stores to vLLM `BlockStored` events;
- emits canonical `medium="CPU"` in both in-process and MP store events;
- keeps cache residency independent from the input token tensor's device;
- aggregates multi-worker events before `take_events()` drains them;
- accepts both integer and byte-backed cache hashes.

@maobaolong : either #4995 or this one fine. I made based on #4995 

**Special notes for your reviewers**:

This is a store-only integration. 
It does not publish `BlockRemoved` or `AllBlocksCleared` for MP host-cache eviction. 
Until those lifecycle events exist, use this only where host-cache entries are not evicted during the routing window.
I will work on this for next step.

Runtime requirements:

- Enable vLLM KV events.
- Match LMCache chunk size to the vLLM/Dynamo routing block size.
- Set `lmcache.mp.hash_algorithm` to the MP server's hash algorithm.
- Use the same `PYTHONHASHSEED` for the coordinator, MP servers, and workers.

Validation:

- `tests/v1/test_vllm_mp_adapter.py`: 51 passed.
- Ruff check and format check passed.
- Two-worker Kubernetes routing with stock vLLM and Dynamo: 12/12 correct owners versus 4/12 without events.
- Both MP caches served 24,000 host-cache hit tokens.
- Coordinator ownership was exact for all 3,000 target chunks.
- Dynamo reported zero KV-event application errors.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
