### PR TITLE
[feat] Add HTTP endpoints for runtime L1 Device-DAX reconfiguration

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/dax.md
+++ b/docs/design/v1/distributed/l2_adapters/dax.md
@@ -32,10 +32,10 @@ pools for store, lookup, and load operations, and uses one or more
 `lmcache/v1/multiprocess/http_apis/reconfigure_api.py` exposes runtime
 reconfiguration endpoints:
 
-- `GET /reconfigure/dax/status`
-- `POST /reconfigure/dax/add`
-- `POST /reconfigure/dax/remove`
-- `POST /reconfigure/dax/resize`
+- `GET /reconfigure/l2/dax/status`
+- `POST /reconfigure/l2/dax/add`
+- `POST /reconfigure/l2/dax/remove`
+- `POST /reconfigure/l2/dax/resize`
 
 The HTTP layer routes `backend`, `operation`, and adapter-specific JSON payloads
 into the generic L2 adapter reconfiguration API on `StorageManager`.

--- a/docs/design/v1/distributed/l2_adapters/dax.md
+++ b/docs/design/v1/distributed/l2_adapters/dax.md
@@ -32,10 +32,10 @@ pools for store, lookup, and load operations, and uses one or more
 `lmcache/v1/multiprocess/http_apis/reconfigure_api.py` exposes runtime
 reconfiguration endpoints:
 
-- `GET /reconfigure/l2/dax/status`
-- `POST /reconfigure/l2/dax/add`
-- `POST /reconfigure/l2/dax/remove`
-- `POST /reconfigure/l2/dax/resize`
+- `GET /reconfigure/dax/l2/status`
+- `POST /reconfigure/dax/l2/add`
+- `POST /reconfigure/dax/l2/remove`
+- `POST /reconfigure/dax/l2/resize`
 
 The HTTP layer routes `backend`, `operation`, and adapter-specific JSON payloads
 into the generic L2 adapter reconfiguration API on `StorageManager`.

--- a/docs/design/v1/distributed/memory_manager/device-dax-l1.md
+++ b/docs/design/v1/distributed/memory_manager/device-dax-l1.md
@@ -95,10 +95,14 @@ The manager and allocator expose the same contract:
 
 Add:
 
-1. Validate the path is non-empty, the size is positive, the allocator is not
-   closed, and the path is not already mapped.
-2. Map the device: `open(O_RDWR)`, capacity check via `fstat.st_size`,
-   `mmap(MAP_SHARED, RW)`; build a `TensorMemoryAllocator`; best-effort pin.
+1. Canonicalize the path and reject if the allocator is closed or the current
+   node identity matches an already-mapped arena.
+2. Map the device -- the mapping attempt itself validates the request
+   (non-empty path, positive size, Device-DAX type, and the device's advertised
+   sysfs alignment) and acquires the resources: a single `open(O_RDWR)` whose
+   fd backs the identity and capacity checks and the `mmap(MAP_SHARED, RW)`.
+   The opened identity is checked again before the arena is built; then build a
+   `TensorMemoryAllocator` and best-effort pin it.
 3. Append the arena as `active` and non-primary. It is immediately available as
    overflow. Existing allocations are untouched.
 
@@ -126,7 +130,9 @@ supported here; see Current Limits.
 
 Configure the initial Device-DAX device when the server starts, either with the
 MP server CLI flag `--l1-devdax-path /dev/dax0.0` (the mapped size follows the
-L1 size settings) or programmatically:
+L1 size settings) or programmatically. The Device-DAX namespace must already
+exist and expose the requested capacity; namespace provisioning remains the
+operator's responsibility.
 
 ```python
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
@@ -167,14 +173,17 @@ A `DRAINING` device accepts no new allocations, keeps serving reads for the KV
 entries already on it, and unmaps automatically once the last of them is freed
 (deleted or evicted). Poll `get_arena_statuses()` until the path disappears
 from the list; `active_allocations` on the draining entry shows how many
-allocations still gate the unmap. Calling `remove_device` again on a draining
-path is safe and returns the current status.
+allocations still gate the unmap. Calling `remove_device` again while the path
+is still draining is safe and returns the current status; once the arena has
+been unmapped the path is no longer known and a repeat is rejected.
 
-`add_device` rejects paths that are already mapped, and `remove_device`
-rejects the primary arena (the initial device in pure Device-DAX mode); both
-raise `ValueError`. The device must already exist and be readable and
-writable; runtime reconfigure does not provision DAX namespaces (see Current
-Limits).
+`add_device` rejects devices that are already mapped under another spelling,
+and `remove_device` rejects the primary arena (the initial device in pure
+Device-DAX mode). Lookups accept another path to the same device and statuses
+report the canonical path recorded when the arena was mapped. These errors
+raise `ValueError`. The Device-DAX path must already exist, be readable and
+writable, and expose enough capacity. Runtime reconfigure does not provision
+or resize DAX namespaces (see Current Limits).
 
 ## Thread Safety
 
@@ -193,6 +202,23 @@ the arena buffer, and the ctypes array) is released before `mmap.close()`,
 because CPython refuses to close a buffer that still has exported pointers.
 `mmap` dups the underlying file descriptor, so unmap releases both the opened fd
 and the mmap's dup.
+
+## Device Identity
+
+The allocator identifies what it opened rather than comparing path strings.
+It records `st_rdev` for a character device and `(st_dev, st_ino)` for a
+regular file used as test backing; other file types are rejected. Device-DAX
+nodes that expose the same `major:minor` therefore cannot be mapped twice.
+Paths are canonicalized for stable status responses, while add, remove, and
+status lookup use the device identity.
+
+Device-DAX character devices normally report `st_size == 0`, so their type,
+capacity, and alignment are verified through sysfs by device number rather
+than by path basename. `/sys/dev/char/<major>:<minor>` is tried first; if it is
+not visible, `/sys/bus/dax/devices` is searched for a matching `dev` attribute.
+The entry must be on the `dax` subsystem and expose readable, positive `size`
+and `align` values. Verification fails closed when sysfs does not expose enough
+information. Regular mmap test files use `fstat` and never consult sysfs.
 
 CUDA host-memory registration (pinning) is per-arena and best-effort; a pin
 failure is logged and the arena falls back to pageable host copies.
@@ -235,8 +261,8 @@ real `/dev/dax` devices via `LMCACHE_TEST_DEVDAX_L1_PATHS`.
   live requests read and write, so relocation requires hooking L1 eviction.
 - The primary arena in pure Device-DAX mode cannot be removed at runtime.
 - Existing arenas cannot be resized; the pool grows and shrinks by whole arenas
-  (add / remove only).
-- Runtime reconfigure maps and unmaps already-provisioned devices; it does not
-  perform kernel-level CXL or DAX reconfiguration.
+  (`add_device` / `remove_device`).
+- Runtime reconfigure maps and unmaps already-provisioned Device-DAX devices;
+  it does not perform kernel-level CXL/DAX namespace reconfiguration.
 - No HTTP control surface yet; the reconfigure methods are the programmatic
   entry point.

--- a/docs/design/v1/distributed/memory_manager/device-dax-l1.md
+++ b/docs/design/v1/distributed/memory_manager/device-dax-l1.md
@@ -22,7 +22,10 @@ process keeps running.
 `DevDaxL1MemoryManager`, the L1 tier object. It is thin: it stores its config,
 delegates `allocate` / `free` / `get_memory_usage` / `get_l1_memory_desc` to the
 pooled allocator, and exposes the runtime-reconfigure surface
-(`add_device`, `remove_device`, `get_arena_statuses`).
+(`add_device`, `remove_device`, `get_arena_statuses`). The manager translates
+allocator failures into the HTTP-mappable `L1ReconfigureError`
+(`memory_manager/reconfiguration.py`); the allocator itself remains HTTP-free
+and raises plain `ValueError` / `RuntimeError` / `OSError`.
 
 `lmcache/v1/memory_allocators/devdax_memory_allocator.py` defines
 `DevDaxMemoryAllocator`, which owns the arena pool, the `host_mem_lock`, the
@@ -32,13 +35,23 @@ best-effort CUDA host-memory pinning. `_DevDaxArena` is the per-arena record.
 reconfigure types.
 
 `lmcache/v1/distributed/l1_manager.py` selects `DevDaxL1MemoryManager` when
-`memory_config.devdax_path` is set, in preference to the CPU-only and GDS L1
-managers.
+`memory_config.devdax_path` is set and GDS L1 is not configured. It exposes
+Device-DAX status, add, and remove as narrow delegation methods.
+`lmcache/v1/distributed/storage_manager.py` provides matching public methods
+for the HTTP layer, so HTTP handlers do not access either manager's private
+state.
 
-The runtime-reconfigure HTTP surface is not part of this design; when added it
-is intended to mirror the L2 `/reconfigure/l2/dax/*` endpoints (see
-[../l2_adapters/dax.md](../l2_adapters/dax.md)) and route only `operation` plus
-payload down to the manager.
+The runtime-reconfigure HTTP surface lives in
+`lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py` as tier-first routes:
+`GET /reconfigure/l1/dax/status` and `POST /reconfigure/l1/dax/{add,remove}`.
+Handlers stay thin -- request-shape validation (422 schema / 400 size values)
+happens at the HTTP layer, domain status-code decisions (404 lookup miss, 409
+state conflict or non-Device-DAX L1) come from the manager via
+`L1ReconfigureError`, the HTTP resolver answers 503 before engine or storage
+manager initialization, and arena mechanics stay in the allocator. L1 and L2
+use separate tier prefixes. An L1 URL that omits the `dax` segment, such as
+`/reconfigure/l1/status`, returns `404`. See
+[../l2_adapters/dax.md](../l2_adapters/dax.md) for the L2 counterpart.
 
 ## Arena Pool
 
@@ -86,7 +99,8 @@ local allocator.
 
 ## Runtime Reconfigure
 
-The manager and allocator expose the same contract:
+The manager and allocator expose the same return values; the manager translates
+allocator failures into `L1ReconfigureError` for the HTTP layer:
 
 - `add_device(device_path, size_in_bytes) -> DevDaxArenaStatus`
 - `remove_device(device_path, mode=DevDaxRemoveMode.DRAIN) -> DevDaxArenaStatus`
@@ -150,40 +164,41 @@ l1 = L1Manager(
 )
 ```
 
-Until the HTTP control surface lands, reconfiguration is programmatic, on the
-`DevDaxL1MemoryManager` owned by the `L1Manager`:
+Reconfiguration is available over HTTP (`/reconfigure/l1/dax/*`) and through
+the `L1Manager` delegation methods:
 
 ```python
-manager = l1._memory_manager  # DevDaxL1MemoryManager
-
 # Grow: map an already-provisioned device and add it to the pool. It serves
 # overflow allocations immediately.
-status = manager.add_device("/dev/dax1.0", 32 << 30)
+status = l1.add_devdax_device("/dev/dax1.0", 32 << 30)
 
 # Inspect per-device usage: used/free bytes, live allocations, state.
-for arena in manager.get_arena_statuses():
+for arena in l1.get_devdax_arena_statuses():
     print(arena.device_path, arena.state, arena.used_bytes, arena.free_bytes)
 
-# Shrink: drain-remove a device. REMOVED means it was empty and is already
-# unmapped; DRAINING means cached entries still live on it.
-status = manager.remove_device("/dev/dax1.0")
+# Shrink: remove a device (currently drain mode only). REMOVED means it was
+# empty and is already unmapped; DRAINING means cached entries still live on it.
+status = l1.remove_devdax_device("/dev/dax1.0")
 ```
 
 A `DRAINING` device accepts no new allocations, keeps serving reads for the KV
 entries already on it, and unmaps automatically once the last of them is freed
-(deleted or evicted). Poll `get_arena_statuses()` until the path disappears
-from the list; `active_allocations` on the draining entry shows how many
-allocations still gate the unmap. Calling `remove_device` again while the path
-is still draining is safe and returns the current status; once the arena has
-been unmapped the path is no longer known and a repeat is rejected.
+(deleted or evicted). Poll `get_devdax_arena_statuses()` until the path
+disappears from the list; `active_allocations` on the draining entry shows how
+many allocations still gate the unmap. Calling `remove_devdax_device` again
+while the path is still draining is safe and returns the current status; once
+the arena has been unmapped the path is no longer known and a repeat raises the
+404-mapped lookup error.
 
 `add_device` rejects devices that are already mapped under another spelling,
 and `remove_device` rejects the primary arena (the initial device in pure
 Device-DAX mode). Lookups accept another path to the same device and statuses
-report the canonical path recorded when the arena was mapped. These errors
-raise `ValueError`. The Device-DAX path must already exist, be readable and
-writable, and expose enough capacity. Runtime reconfigure does not provision
-or resize DAX namespaces (see Current Limits).
+report the canonical path recorded when the arena was mapped. At the allocator
+level these raise `ValueError`; the manager translates them into
+`L1ReconfigureError` (409, or 404 when the path is not mapped at all). The
+Device-DAX path must already exist, be readable and writable, and expose enough
+capacity. Runtime reconfigure does not provision or resize DAX namespaces (see
+Current Limits).
 
 ## Thread Safety
 
@@ -225,10 +240,11 @@ failure is logged and the arena falls back to pageable host copies.
 
 ## Transfer-Channel Compatibility
 
-Device-DAX L1 is not a single registerable memory region:
-`l1_exposes_single_memory_region()` returns `False`, and P2P / NIXL reject
-Device-DAX L1. Arenas can therefore be added and removed without invalidating a
-whole-arena transfer registration.
+P2P does not support Device-DAX L1 because
+`l1_exposes_single_memory_region()` returns `False`. NIXL-based adapters and
+Mooncake over RDMA require a single L1 memory region, so they cannot be used
+with hybrid or multi-arena Device-DAX L1. Other adapters allow arenas to be
+added and removed normally.
 
 ## Capacity
 
@@ -246,13 +262,15 @@ by capacity that is being removed.
 
 `tests/v1/distributed/test_devdax_l1_allocator.py` unit-tests the pool:
 add/remove lifecycle, drain gating, per-arena usage, deferred unmap while
-external views are alive, and mapping release on setup failure.
+external views are alive, mapping release on setup failure, and the
+`StorageManager` reconfiguration delegates.
 `tests/v1/distributed/test_devdax_l1_reconfigure_integration.py` (opt-in via
 `RUN_DEVDAX_L1_INTEGRATION=1`) drives real mmap-backed devices end to end,
-both at the memory-manager level and through the `L1Manager` KV-cache path:
-KV entries land on a runtime-added device, stay readable while it drains, and
-the device is unmapped only after the last cached entry is deleted. It accepts
-real `/dev/dax` devices via `LMCACHE_TEST_DEVDAX_L1_PATHS`.
+at the memory-manager level, through the `L1Manager` KV-cache path, and through
+the `/reconfigure/l1/dax/*` HTTP lifecycle. KV entries land on a runtime-added
+device, stay readable while it drains, and the device is unmapped only after
+the last cached entry is deleted. It accepts real `/dev/dax` devices via
+`LMCACHE_TEST_DEVDAX_L1_PATHS`.
 
 ## Current Limits
 
@@ -264,5 +282,17 @@ real `/dev/dax` devices via `LMCACHE_TEST_DEVDAX_L1_PATHS`.
   (`add_device` / `remove_device`).
 - Runtime reconfigure maps and unmaps already-provisioned Device-DAX devices;
   it does not perform kernel-level CXL/DAX namespace reconfiguration.
-- No HTTP control surface yet; the reconfigure methods are the programmatic
-  entry point.
+- The HTTP control surface is `/reconfigure/l1/dax/*`
+  (`l1_reconfigure_api.py`); the `L1Manager` delegation methods remain the
+  programmatic entry point.
+
+## Open Decisions / Deferred Work
+
+Decisions intentionally left to the upstream RFC; the behavior described here
+is what the code does today.
+
+- **Coordinator-owned shared pools (upstream RFC #4307).** These endpoints assume
+  the server privately owns its Device-DAX L1. In a shared-pool deployment the
+  region lifecycle belongs to the coordinator, so local reconfiguration must be
+  refused there. Guard insertion point: the public L1 Device-DAX methods on
+  `StorageManager`; not implemented until the shared-pool design lands upstream.

--- a/docs/design/v1/distributed/memory_manager/device-dax-l1.md
+++ b/docs/design/v1/distributed/memory_manager/device-dax-l1.md
@@ -36,7 +36,7 @@ reconfigure types.
 managers.
 
 The runtime-reconfigure HTTP surface is not part of this design; when added it
-is intended to mirror the L2 `/reconfigure/dax/*` endpoints (see
+is intended to mirror the L2 `/reconfigure/l2/dax/*` endpoints (see
 [../l2_adapters/dax.md](../l2_adapters/dax.md)) and route only `operation` plus
 payload down to the manager.
 

--- a/docs/design/v1/distributed/memory_manager/device-dax-l1.md
+++ b/docs/design/v1/distributed/memory_manager/device-dax-l1.md
@@ -42,15 +42,19 @@ for the HTTP layer, so HTTP handlers do not access either manager's private
 state.
 
 The runtime-reconfigure HTTP surface lives in
-`lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py` as tier-first routes:
-`GET /reconfigure/l1/dax/status` and `POST /reconfigure/l1/dax/{add,remove}`.
+`lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py` as backend-first,
+tier-scoped routes: `GET /reconfigure/dax/l1/status` and
+`POST /reconfigure/dax/l1/{add,remove}`.
 Handlers stay thin -- request-shape validation (422 schema / 400 size values)
 happens at the HTTP layer, domain status-code decisions (404 lookup miss, 409
 state conflict or non-Device-DAX L1) come from the manager via
 `L1ReconfigureError`, the HTTP resolver answers 503 before engine or storage
-manager initialization, and arena mechanics stay in the allocator. L1 and L2
-use separate tier prefixes. An L1 URL that omits the `dax` segment, such as
-`/reconfigure/l1/status`, returns `404`. See
+manager initialization, and arena mechanics stay in the allocator. The current
+L1 surface fixes `dax` as the backend and `l1` as the tier segment, keeping it
+disjoint from the parametric L2 family (`/reconfigure/{backend}/l2/*`).
+Additional L1 backends are not exposed by this API and require corresponding
+routing and delegation support. A URL that omits the tier segment, such as
+`/reconfigure/dax/status`, returns `404`. See
 [../l2_adapters/dax.md](../l2_adapters/dax.md) for the L2 counterpart.
 
 ## Arena Pool
@@ -164,7 +168,7 @@ l1 = L1Manager(
 )
 ```
 
-Reconfiguration is available over HTTP (`/reconfigure/l1/dax/*`) and through
+Reconfiguration is available over HTTP (`/reconfigure/dax/l1/*`) and through
 the `L1Manager` delegation methods:
 
 ```python
@@ -267,7 +271,7 @@ external views are alive, mapping release on setup failure, and the
 `tests/v1/distributed/test_devdax_l1_reconfigure_integration.py` (opt-in via
 `RUN_DEVDAX_L1_INTEGRATION=1`) drives real mmap-backed devices end to end,
 at the memory-manager level, through the `L1Manager` KV-cache path, and through
-the `/reconfigure/l1/dax/*` HTTP lifecycle. KV entries land on a runtime-added
+the `/reconfigure/dax/l1/*` HTTP lifecycle. KV entries land on a runtime-added
 device, stay readable while it drains, and the device is unmapped only after
 the last cached entry is deleted. It accepts real `/dev/dax` devices via
 `LMCACHE_TEST_DEVDAX_L1_PATHS`.
@@ -282,7 +286,7 @@ the last cached entry is deleted. It accepts real `/dev/dax` devices via
   (`add_device` / `remove_device`).
 - Runtime reconfigure maps and unmaps already-provisioned Device-DAX devices;
   it does not perform kernel-level CXL/DAX namespace reconfiguration.
-- The HTTP control surface is `/reconfigure/l1/dax/*`
+- The HTTP control surface is `/reconfigure/dax/l1/*`
   (`l1_reconfigure_api.py`); the `L1Manager` delegation methods remain the
   programmatic entry point.
 

--- a/docs/design/v1/distributed/memory_manager/device-dax-l1.md
+++ b/docs/design/v1/distributed/memory_manager/device-dax-l1.md
@@ -22,10 +22,8 @@ process keeps running.
 `DevDaxL1MemoryManager`, the L1 tier object. It is thin: it stores its config,
 delegates `allocate` / `free` / `get_memory_usage` / `get_l1_memory_desc` to the
 pooled allocator, and exposes the runtime-reconfigure surface
-(`add_device`, `remove_device`, `get_arena_statuses`). The manager translates
-allocator failures into the HTTP-mappable `L1ReconfigureError`
-(`memory_manager/reconfiguration.py`); the allocator itself remains HTTP-free
-and raises plain `ValueError` / `RuntimeError` / `OSError`.
+(`add_device`, `remove_device`, `get_arena_statuses`). It also owns the
+reconfiguration error boundary, keeping HTTP concerns out of the allocator.
 
 `lmcache/v1/memory_allocators/devdax_memory_allocator.py` defines
 `DevDaxMemoryAllocator`, which owns the arena pool, the `host_mem_lock`, the
@@ -37,9 +35,8 @@ reconfigure types.
 `lmcache/v1/distributed/l1_manager.py` selects `DevDaxL1MemoryManager` when
 `memory_config.devdax_path` is set and GDS L1 is not configured. It exposes
 Device-DAX status, add, and remove as narrow delegation methods.
-`lmcache/v1/distributed/storage_manager.py` provides matching public methods
-for the HTTP layer, so HTTP handlers do not access either manager's private
-state.
+`lmcache/v1/distributed/storage_manager.py` provides the HTTP-facing delegates
+and publishes capacity after add and drain transitions.
 
 The runtime-reconfigure HTTP surface lives in
 `lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py` as backend-first,
@@ -49,9 +46,10 @@ Handlers stay thin -- request-shape validation (422 schema / 400 size values)
 happens at the HTTP layer, domain status-code decisions (404 lookup miss, 409
 state conflict or non-Device-DAX L1) come from the manager via
 `L1ReconfigureError`, the HTTP resolver answers 503 before engine or storage
-manager initialization, and arena mechanics stay in the allocator. The current
-L1 surface fixes `dax` as the backend and `l1` as the tier segment, keeping it
-disjoint from the parametric L2 family (`/reconfigure/{backend}/l2/*`).
+manager initialization, and arena mechanics stay in the allocator. The HTTP
+layer fixes `dax` as the backend and `l1` as the tier segment, keeping it
+disjoint from the parametric L2 family
+(`/reconfigure/{backend}/l2/*`).
 Additional L1 backends are not exposed by this API and require corresponding
 routing and delegation support. A URL that omits the tier segment, such as
 `/reconfigure/dax/status`, returns `404`. See
@@ -103,8 +101,9 @@ local allocator.
 
 ## Runtime Reconfigure
 
-The manager and allocator expose the same return values; the manager translates
-allocator failures into `L1ReconfigureError` for the HTTP layer:
+The manager and allocator expose the same return values. The manager translates
+request-validation and pre-transition state failures into
+`L1ReconfigureError` for the HTTP layer:
 
 - `add_device(device_path, size_in_bytes) -> DevDaxArenaStatus`
 - `remove_device(device_path, mode=DevDaxRemoveMode.DRAIN) -> DevDaxArenaStatus`
@@ -123,6 +122,8 @@ Add:
    `TensorMemoryAllocator` and best-effort pin it.
 3. Append the arena as `active` and non-primary. It is immediately available as
    overflow. Existing allocations are untouched.
+4. The `StorageManager` entry point publishes the current whole capacity
+   topology.
 
 If any setup step fails (mapping, allocator construction, or pin registration),
 the freshly opened fd and mmap are released before the error propagates.
@@ -136,6 +137,9 @@ Remove (drain):
    automatically (auto-reap). If the unmap is blocked by lingering external
    views into the mapping (e.g. freed tensors awaiting garbage collection), the
    arena stays `draining` and later frees retry the reap.
+4. After drain begins, the `StorageManager` entry point publishes the
+   post-transition capacity topology even if synchronization or cleanup later
+   fails; a later remove retries cleanup while the path remains mapped.
 
 State machine: `active -> draining -> removed`. `removed` is a report-only
 terminal value; a removed arena has already left the pool, so it is never
@@ -168,8 +172,9 @@ l1 = L1Manager(
 )
 ```
 
-Reconfiguration is available over HTTP (`/reconfigure/dax/l1/*`) and through
-the `L1Manager` delegation methods:
+Reconfiguration is available over HTTP (`/reconfigure/dax/l1/*`).
+`StorageManager` is the system entry point that publishes capacity changes;
+the `L1Manager` methods below are lower-level delegation methods:
 
 ```python
 # Grow: map an already-provisioned device and add it to the pool. It serves
@@ -262,12 +267,23 @@ above total (ratio > 1), which is intentional -- it keeps the eviction
 watermark tracking real pressure on the active pool instead of being diluted
 by capacity that is being removed.
 
+`L1Manager.get_capacity_bytes_by_backend()` is also used by `report_status()`
+and `StorageManager` capacity snapshots. CPU, GDS, and the DRAM half of a hybrid
+tier retain their boot-configured values; the Device-DAX entry is the sum of
+active arena sizes. Capacity-changing calls through `StorageManager` publish
+`SM_CAPACITY_CHANGED` with the whole topology. Delivery is asynchronous and
+best-effort, so operation success confirms the local topology change rather
+than coordinator receipt.
+
 ## Verification
 
 `tests/v1/distributed/test_devdax_l1_allocator.py` unit-tests the pool:
 add/remove lifecycle, drain gating, per-arena usage, deferred unmap while
 external views are alive, mapping release on setup failure, and the
 `StorageManager` reconfiguration delegates.
+`tests/v1/distributed/test_memory_capacity.py` verifies capacity reporting and
+whole-topology `SM_CAPACITY_CHANGED` publication after successful add/remove
+and after a drain transition whose cleanup fails.
 `tests/v1/distributed/test_devdax_l1_reconfigure_integration.py` (opt-in via
 `RUN_DEVDAX_L1_INTEGRATION=1`) drives real mmap-backed devices end to end,
 at the memory-manager level, through the `L1Manager` KV-cache path, and through
@@ -286,17 +302,3 @@ the last cached entry is deleted. It accepts real `/dev/dax` devices via
   (`add_device` / `remove_device`).
 - Runtime reconfigure maps and unmaps already-provisioned Device-DAX devices;
   it does not perform kernel-level CXL/DAX namespace reconfiguration.
-- The HTTP control surface is `/reconfigure/dax/l1/*`
-  (`l1_reconfigure_api.py`); the `L1Manager` delegation methods remain the
-  programmatic entry point.
-
-## Open Decisions / Deferred Work
-
-Decisions intentionally left to the upstream RFC; the behavior described here
-is what the code does today.
-
-- **Coordinator-owned shared pools (upstream RFC #4307).** These endpoints assume
-  the server privately owns its Device-DAX L1. In a shared-pool deployment the
-  region lifecycle belongs to the coordinator, so local reconfiguration must be
-  refused there. Guard insertion point: the public L1 Device-DAX methods on
-  `StorageManager`; not implemented until the shared-pool design lands upstream.

--- a/docs/design/v1/mp_coordinator/memory_pressure.md
+++ b/docs/design/v1/mp_coordinator/memory_pressure.md
@@ -23,11 +23,11 @@ translation.
 
 **Declaring capacity** (MP server → coordinator):
 
-1. Something changes: the server registers, or an L2 adapter is added,
-   removed, or reconfigured.
-2. `StorageManager.publish_capacity()` builds the topology —
-   `get_configured_capacity_bytes()` for L1 per medium, each adapter's
-   `get_usage().total_capacity_bytes` for L2 — and publishes
+1. Something changes: the server registers, a Device-DAX L1 arena is added or
+   starts draining, or an L2 adapter is added, removed, or reconfigured.
+2. The `StorageManager` capacity-publication path builds the topology —
+   `L1Manager.get_capacity_bytes_by_backend()` for L1 per medium, each
+   adapter's `get_usage().total_capacity_bytes` for L2 — and publishes
    `SM_CAPACITY_CHANGED` on the observability bus.
 3. `CacheEventSubscriber` turns it into one `config` batch per compartment,
    all stamped with one `capacity_revision`, and flushes them with whatever
@@ -82,16 +82,16 @@ the other consumers, all of which are entries-driven and need no change.
 
 ## Declarations, not deltas
 
-A declaration is always the whole topology. That is what makes a lossy
-channel acceptable: a dropped batch is repaired by the next declaration,
-where a dropped byte delta would be permanent. The emitter also holds an
-unsent declaration across a publish failure.
+A declaration is always the whole topology. A later declaration can repair a
+dropped batch, whereas a dropped byte delta would be permanent.
 
 `(incarnation, capacity_revision)` groups batches: a newer stamp starts a
 fresh set, an equal one extends it, an older one is dropped. **This is what
-retires a compartment** — a declaration that omits it never re-adds it, so a
-deleted L2 adapter stops being reported. Incarnation fencing and seq dedup
-come from the gate; nothing here duplicates them.
+retires a capacity compartment** — a declaration that omits it never re-adds
+it, so a deleted L2 adapter or the last active Device-DAX arena stops being
+declared. Surviving usage for an omitted compartment remains visible with
+unknown capacity. Incarnation fencing and seq dedup come from the gate; nothing
+here duplicates them.
 
 The revision is assigned by the subscriber, beside `seq` and for the same
 reason: the bus drains on one thread, so neither counter needs a lock and a
@@ -106,17 +106,18 @@ Two gotchas:
   `_build_capacities` emits one entry per medium and adapter, so a correct
   producer cannot do it.
 
-## Capacity is the configured size, not the live heap
+## Capacity is the declared usable size, not the live heap
 
-| Manager | `get_memory_usage()[1]` | `get_configured_capacity_bytes()` |
+| Manager | `get_memory_usage()[1]` | Declared capacity |
 | --- | --- | --- |
-| `L1MemoryManager` (default, lazy) | grown heap | `{dram: size_in_bytes}` |
-| `GDSL1MemoryManager` | configured slab | `{gds: size_in_bytes}` |
-| `DevDaxL1MemoryManager` | live arenas | `{devdax: …}` + `{dram: …}` if hybrid |
+| `L1MemoryManager` (default, lazy) | grown heap | configured DRAM size |
+| `GDSL1MemoryManager` | configured slab | configured GDS slab size |
+| `DevDaxL1MemoryManager` | DRAM + active arenas | active Device-DAX arenas + configured DRAM if hybrid |
 
 The lazy allocator's total is the heap it has grown so far, so a freshly
 booted server would report itself nearly full and appear to drain as the pool
-warms. The configured size is stable from boot.
+warms. CPU, GDS, and hybrid DRAM capacities are fixed at startup. Device-DAX
+capacity is the sum of active arenas; draining arenas are excluded.
 
 L1 is declared **per medium** because one tier can span two: a hybrid
 Device-DAX tier backs objects with both `devdax` and `dram`, and each
@@ -135,8 +136,9 @@ So `usage_ratio` is `null` — not `0.0`, not `-1.0`. A number there reads as
 real occupancy, and a fleet view that treats capacity-less backends as empty
 reports "healthy" regardless of what is happening.
 
-Ratios above `1.0` are **not clamped**: a tier holding more than its declared
-cap means the declaration is wrong, and hiding that hides a misconfiguration.
+Ratios above `1.0` are **not clamped**. They can expose a bad declaration, and
+are also expected while a draining Device-DAX arena still holds live bytes that
+no longer count as usable capacity.
 
 ## Shared pools are counted once
 

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -63,6 +63,10 @@ Producers:
 | `SM_READ_PREFETCHED_FINISHED` | `succeeded_keys`, `failed_keys` | `list[ObjectKey]`, `list[ObjectKey]` |
 | `SM_WRITE_RESERVED` | `succeeded_keys`, `failed_keys` | `list[ObjectKey]`, `list[ObjectKey]` |
 | `SM_WRITE_FINISHED` | `succeeded_keys`, `failed_keys` | `list[ObjectKey]`, `list[ObjectKey]` |
+| `SM_CAPACITY_CHANGED` | `snapshot` | `CapacitySnapshot` |
+
+`SM_CAPACITY_CHANGED` carries a whole L1/L2 capacity snapshot, not a delta, and
+is emitted on registration and capacity-changing reconfiguration.
 
 ---
 

--- a/docs/source/kv_cache/storage_backends/dax.rst
+++ b/docs/source/kv_cache/storage_backends/dax.rst
@@ -124,14 +124,14 @@ Use JSON bodies because DAX paths contain slashes:
 
 .. code-block:: bash
 
-   curl http://127.0.0.1:9000/reconfigure/dax/status
-   curl -X POST http://127.0.0.1:9000/reconfigure/dax/add \
+   curl http://127.0.0.1:9000/reconfigure/l2/dax/status
+   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/add \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "size": "100GiB"}'
-   curl -X POST http://127.0.0.1:9000/reconfigure/dax/remove \
+   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/remove \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "mode": "migrate"}'
-   curl -X POST http://127.0.0.1:9000/reconfigure/dax/resize \
+   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/resize \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "size": "200GiB"}'
 
@@ -160,27 +160,27 @@ Hardware Validation Flow
 ------------------------
 
 Use the same Qwen 8B or 14B long-context workload before and after a runtime
-capacity change. Without hotplug support, ``/reconfigure/dax/status`` and
-``/reconfigure/dax/add`` are not available; changing the DAX device set
+capacity change. Without hotplug support, ``/reconfigure/l2/dax/status`` and
+``/reconfigure/l2/dax/add`` are not available; changing the DAX device set
 requires restarting LMCache with a new ``--l2-adapter`` value, which drops the
 volatile DAX key index.
 
 .. code-block:: bash
 
    export MODEL=Qwen/Qwen3-8B  # or a local Qwen 8B/14B checkpoint
-   curl http://127.0.0.1:9000/reconfigure/dax/status
+   curl http://127.0.0.1:9000/reconfigure/l2/dax/status
    python benchmarks/long_doc_qa/long_doc_qa.py \
      --model "$MODEL" --num-documents 1 --document-length 1024 \
      --output-len 16 --repeat-count 2 --repeat-mode tile \
      --completions --host 127.0.0.1 --port 8000 --json-output
-   curl -X POST http://127.0.0.1:9000/reconfigure/dax/add \
+   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/add \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "size": "100GiB"}'
-   curl http://127.0.0.1:9000/reconfigure/dax/status
+   curl http://127.0.0.1:9000/reconfigure/l2/dax/status
 
 Record these fields for the comparison:
 
-- ``total_capacity_bytes`` before and after ``/reconfigure/dax/add``.
+- ``total_capacity_bytes`` before and after ``/reconfigure/l2/dax/add``.
 - ``total_used_bytes`` while the Qwen workload is running.
 - Whether an LMCache restart was required.
 - Whether the same cached prompt remains retrievable after the capacity change.

--- a/docs/source/kv_cache/storage_backends/dax.rst
+++ b/docs/source/kv_cache/storage_backends/dax.rst
@@ -124,14 +124,14 @@ Use JSON bodies because DAX paths contain slashes:
 
 .. code-block:: bash
 
-   curl http://127.0.0.1:9000/reconfigure/l2/dax/status
-   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/add \
+   curl http://127.0.0.1:9000/reconfigure/dax/l2/status
+   curl -X POST http://127.0.0.1:9000/reconfigure/dax/l2/add \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "size": "100GiB"}'
-   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/remove \
+   curl -X POST http://127.0.0.1:9000/reconfigure/dax/l2/remove \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "mode": "migrate"}'
-   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/resize \
+   curl -X POST http://127.0.0.1:9000/reconfigure/dax/l2/resize \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "size": "200GiB"}'
 
@@ -160,27 +160,27 @@ Hardware Validation Flow
 ------------------------
 
 Use the same Qwen 8B or 14B long-context workload before and after a runtime
-capacity change. Without hotplug support, ``/reconfigure/l2/dax/status`` and
-``/reconfigure/l2/dax/add`` are not available; changing the DAX device set
+capacity change. Without hotplug support, ``/reconfigure/dax/l2/status`` and
+``/reconfigure/dax/l2/add`` are not available; changing the DAX device set
 requires restarting LMCache with a new ``--l2-adapter`` value, which drops the
 volatile DAX key index.
 
 .. code-block:: bash
 
    export MODEL=Qwen/Qwen3-8B  # or a local Qwen 8B/14B checkpoint
-   curl http://127.0.0.1:9000/reconfigure/l2/dax/status
+   curl http://127.0.0.1:9000/reconfigure/dax/l2/status
    python benchmarks/long_doc_qa/long_doc_qa.py \
      --model "$MODEL" --num-documents 1 --document-length 1024 \
      --output-len 16 --repeat-count 2 --repeat-mode tile \
      --completions --host 127.0.0.1 --port 8000 --json-output
-   curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/add \
+   curl -X POST http://127.0.0.1:9000/reconfigure/dax/l2/add \
      -H 'Content-Type: application/json' \
      -d '{"device_path": "/dev/daxX.X", "size": "100GiB"}'
-   curl http://127.0.0.1:9000/reconfigure/l2/dax/status
+   curl http://127.0.0.1:9000/reconfigure/dax/l2/status
 
 Record these fields for the comparison:
 
-- ``total_capacity_bytes`` before and after ``/reconfigure/l2/dax/add``.
+- ``total_capacity_bytes`` before and after ``/reconfigure/dax/l2/add``.
 - ``total_used_bytes`` while the Qwen workload is running.
 - Whether an LMCache restart was required.
 - Whether the same cached prompt remains retrievable after the capacity change.

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -311,7 +311,9 @@ Source: ``lmcache/v1/distributed/config.py``
        backing arena.  When set, disable lazy allocation with
        ``--no-l1-use-lazy`` and leave ``--shm-name`` at its default ``""``
        (SHM transfer disabled) because the L1 bytes live in the DAX
-       mapping.  If a
+       mapping. Device-DAX character devices are verified through sysfs at
+       startup; containers must expose ``/sys/dev/char`` or
+       ``/sys/bus/dax/devices`` (a read-only sysfs mount is sufficient). If a
        DAX L2 adapter with the same ``device_path`` is registered, that
        adapter's ``max_dax_size_gb`` is used as the L1 Device-DAX overflow
        size.

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -1309,10 +1309,10 @@ of a backing medium, or one L2 adapter. It is identified by
 
 Two inputs are joined, and both ride the cache-event stream. **Usage** is
 derived from the events the servers already publish. **Capacity** arrives as
-a capacity report on the same stream -- once at startup, then whenever an
-adapter is added, removed, or reconfigured. Both are automatic; there is
-nothing to configure beyond pointing servers at a coordinator and leaving
-event reporting enabled.
+a capacity report on the same stream -- after registration, when a Device-DAX
+L1 arena is added or starts draining, and whenever an L2 adapter is added,
+removed, or reconfigured. Both are automatic; there is nothing to configure
+beyond pointing servers at a coordinator and leaving event reporting enabled.
 
 .. note::
 
@@ -1332,9 +1332,9 @@ on them.
    ``capacity_bytes``. A ``null`` means *unknown*, never *empty* -- do not
    treat it as ``0``.
 
-   Ratios above ``1.0`` are reported as-is rather than capped. A compartment
-   holding more than its declared capacity means the declaration is wrong, and
-   that is worth seeing.
+   Ratios above ``1.0`` are reported as-is rather than capped. They can expose
+   an incorrect declaration, and are also expected while a draining Device-DAX
+   arena still holds live bytes that no longer count as usable capacity.
 
 ``GET /instances/usage``
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1410,6 +1410,8 @@ above.
 A server whose L1 pool uses the default lazy allocator grows its heap on
 demand. Capacity here is the **configured** size, not the grown heap, so a
 freshly started server correctly reads near ``0``\% rather than near full.
+Device-DAX L1 capacity is the sum of active arenas; draining arenas are
+excluded.
 
 CacheBlend fragment lookup
 --------------------------

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -203,6 +203,25 @@ compatibility with the vLLM-embedded API server.
      - ``/reconfigure/l2/{backend}/{operation}``
      - Apply one runtime reconfiguration operation to a backend adapter.
 
+**Runtime L1 reconfiguration (Device-DAX)**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
+   * - GET
+     - ``/reconfigure/l1/dax/status``
+     - Report every Device-DAX L1 arena with usage and lifecycle state.
+   * - POST
+     - ``/reconfigure/l1/dax/add``
+     - Map an additional Device-DAX device.
+   * - POST
+     - ``/reconfigure/l1/dax/remove``
+     - Remove one mapped Device-DAX L1 device (currently drain mode only).
+
 **Observability**
 
 .. list-table::
@@ -1299,6 +1318,90 @@ dict). A successful DAX ``add`` looks like:
 
 See :doc:`/kv_cache/storage_backends/dax` for detailed request examples,
 mode semantics, and validation guidance.
+
+Runtime L1 Reconfiguration (Device-DAX)
+---------------------------------------
+
+These routes manage the Device-DAX L1 arena pool configured with
+``--l1-devdax-path``. Devices must already be provisioned, and requests do not
+use ``adapter_index``.
+
+``GET /reconfigure/l1/dax/status``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "arenas": [
+        {
+          "device_path": "/dev/dax1.1",
+          "size_in_bytes": 17179869184,
+          "used_bytes": 4294967296,
+          "free_bytes": 12884901888,
+          "active_allocations": 2048,
+          "state": "active",
+          "is_primary": false
+        }
+      ]
+    }
+
+``POST /reconfigure/l1/dax/add``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Request body:** ``device_path`` (string) and ``size`` (integer byte count or a
+string such as ``"16GiB"``).
+
+**Response** (``200 OK``): ``{"added": <arena>}``.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s -X POST http://localhost:8080/reconfigure/l1/dax/add \
+        -H 'Content-Type: application/json' \
+        -d '{"device_path": "/dev/dax1.2", "size": "16GiB"}'
+
+``POST /reconfigure/l1/dax/remove``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Only drain mode is supported. A draining arena accepts no new allocations and
+is unmapped after its live allocations are freed. The primary arena cannot be
+removed.
+
+**Request body:** ``device_path`` (string) and optional ``mode`` (``drain``;
+default ``drain``).
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "removed": {
+        "device_path": "/dev/dax1.2",
+        "arenas": [
+          {
+            "device_path": "/dev/dax1.2",
+            "state": "draining",
+            "active_allocations": 3,
+            "size_in_bytes": 17179869184,
+            "used_bytes": 6291456,
+            "free_bytes": 17173577728,
+            "is_primary": false
+          }
+        ]
+      }
+    }
+
+**HTTP status codes:**
+
+- ``200``: success.
+- ``400``: invalid ``size``.
+- ``404``: device is not mapped.
+- ``409``: incompatible L1 or device state, or mapping validation failure.
+- ``422``: invalid request body.
+- ``503``: engine not initialized.
 
 Observability
 -------------

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -195,12 +195,12 @@ compatibility with the vLLM-embedded API server.
      - Path
      - Purpose
    * - GET
-     - ``/reconfigure/l2/{backend}/status``
+     - ``/reconfigure/{backend}/l2/status``
      - Report runtime-manageable L2 adapters for one backend type. (To discover
        reconfigurable backends, use ``GET /config/adapters`` and read the
        ``reconfigurable`` flag.)
    * - POST
-     - ``/reconfigure/l2/{backend}/{operation}``
+     - ``/reconfigure/{backend}/l2/{operation}``
      - Apply one runtime reconfiguration operation to a backend adapter.
 
 **Runtime L1 reconfiguration (Device-DAX)**
@@ -213,13 +213,13 @@ compatibility with the vLLM-embedded API server.
      - Path
      - Purpose
    * - GET
-     - ``/reconfigure/l1/dax/status``
+     - ``/reconfigure/dax/l1/status``
      - Report every Device-DAX L1 arena with usage and lifecycle state.
    * - POST
-     - ``/reconfigure/l1/dax/add``
+     - ``/reconfigure/dax/l1/add``
      - Map an additional Device-DAX device.
    * - POST
-     - ``/reconfigure/l1/dax/remove``
+     - ``/reconfigure/dax/l1/remove``
      - Remove one mapped Device-DAX L1 device (currently drain mode only).
 
 **Observability**
@@ -506,7 +506,7 @@ This is the single live adapter listing; it supersedes the old
 ``primary`` is ``true`` only on the first entry. ``reconfigurable`` is
 ``true`` for adapters that accept ``/reconfigure`` operations — pass that
 adapter's ``type_name`` as the ``{backend}`` path parameter to
-``GET /reconfigure/l2/{backend}/status`` and the reconfigure operations. An
+``GET /reconfigure/{backend}/l2/status`` and the reconfigure operations. An
 engine that has no L2 backends returns ``{"adapters": []}`` (still ``200`` —
 the engine is initialized, it just has no L2 storage).
 
@@ -1189,9 +1189,11 @@ writable by the server. The endpoint routes ``backend``, ``operation``, and the
 JSON request body into the generic L2 adapter reconfiguration API, while
 backend-specific validation and migration semantics stay inside the adapter.
 
-**Changed:** the reconfigure family is tier-scoped -- these endpoints moved
-from ``/reconfigure/{backend}/...`` to ``/reconfigure/l2/{backend}/...``,
-and the unscoped form was removed (it now returns ``404``).
+**Changed:** the reconfigure family is backend-first and tier-scoped -- these
+endpoints moved from ``/reconfigure/{backend}/status`` and
+``/reconfigure/{backend}/{operation}`` to ``/reconfigure/{backend}/l2/status``
+and ``/reconfigure/{backend}/l2/{operation}``; the unscoped form was removed
+(it now returns ``404``).
 
 ``backend`` and ``operation`` path segments are normalized (stripped and
 lower-cased). Within a request body, ``adapter_index`` (default ``0``) is
@@ -1205,7 +1207,7 @@ string is still the configured L2 adapter type, not the serde wrapper type.
    ``GET /config/adapters``: each adapter whose ``reconfigurable`` flag is
    ``true`` can be addressed by its ``type_name``.
 
-``GET /reconfigure/l2/{backend}/status``
+``GET /reconfigure/{backend}/l2/status``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Report the runtime-manageable adapters for one backend type. Each adapter
@@ -1241,9 +1243,9 @@ An unknown or empty backend returns ``enabled=false``, ``num_adapters=0``,
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/reconfigure/l2/dax/status | jq
+    curl -s http://localhost:8080/reconfigure/dax/l2/status | jq
 
-``POST /reconfigure/l2/{backend}/{operation}``
+``POST /reconfigure/{backend}/l2/{operation}``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Apply one reconfiguration operation to a backend adapter. The request body is
@@ -1312,7 +1314,7 @@ dict). A successful DAX ``add`` looks like:
 
 .. code-block:: bash
 
-    curl -s -X POST http://localhost:8080/reconfigure/l2/dax/add \
+    curl -s -X POST http://localhost:8080/reconfigure/dax/l2/add \
         -H 'Content-Type: application/json' \
         -d '{"device_path": "/dev/dax0.0", "size": "100GiB"}'
 
@@ -1326,7 +1328,7 @@ These routes manage the Device-DAX L1 arena pool configured with
 ``--l1-devdax-path``. Devices must already be provisioned, and requests do not
 use ``adapter_index``.
 
-``GET /reconfigure/l1/dax/status``
+``GET /reconfigure/dax/l1/status``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Response** (``200 OK``):
@@ -1347,7 +1349,7 @@ use ``adapter_index``.
       ]
     }
 
-``POST /reconfigure/l1/dax/add``
+``POST /reconfigure/dax/l1/add``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Request body:** ``device_path`` (string) and ``size`` (integer byte count or a
@@ -1359,11 +1361,11 @@ string such as ``"16GiB"``).
 
 .. code-block:: bash
 
-    curl -s -X POST http://localhost:8080/reconfigure/l1/dax/add \
+    curl -s -X POST http://localhost:8080/reconfigure/dax/l1/add \
         -H 'Content-Type: application/json' \
         -d '{"device_path": "/dev/dax1.2", "size": "16GiB"}'
 
-``POST /reconfigure/l1/dax/remove``
+``POST /reconfigure/dax/l1/remove``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Only drain mode is supported. A draining arena accepts no new allocations and

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -1403,7 +1403,10 @@ default ``drain``).
 - ``404``: device is not mapped.
 - ``409``: incompatible L1 or device state, or mapping validation failure.
 - ``422``: invalid request body.
+- ``500``: synchronization or cleanup failure after draining starts.
 - ``503``: engine not initialized.
+
+See :doc:`coordinator` for capacity reporting.
 
 Observability
 -------------

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -195,12 +195,12 @@ compatibility with the vLLM-embedded API server.
      - Path
      - Purpose
    * - GET
-     - ``/reconfigure/{backend}/status``
+     - ``/reconfigure/l2/{backend}/status``
      - Report runtime-manageable L2 adapters for one backend type. (To discover
        reconfigurable backends, use ``GET /config/adapters`` and read the
        ``reconfigurable`` flag.)
    * - POST
-     - ``/reconfigure/{backend}/{operation}``
+     - ``/reconfigure/l2/{backend}/{operation}``
      - Apply one runtime reconfiguration operation to a backend adapter.
 
 **Observability**
@@ -487,7 +487,7 @@ This is the single live adapter listing; it supersedes the old
 ``primary`` is ``true`` only on the first entry. ``reconfigurable`` is
 ``true`` for adapters that accept ``/reconfigure`` operations — pass that
 adapter's ``type_name`` as the ``{backend}`` path parameter to
-``GET /reconfigure/{backend}/status`` and the reconfigure operations. An
+``GET /reconfigure/l2/{backend}/status`` and the reconfigure operations. An
 engine that has no L2 backends returns ``{"adapters": []}`` (still ``200`` —
 the engine is initialized, it just has no L2 storage).
 
@@ -1170,6 +1170,10 @@ writable by the server. The endpoint routes ``backend``, ``operation``, and the
 JSON request body into the generic L2 adapter reconfiguration API, while
 backend-specific validation and migration semantics stay inside the adapter.
 
+**Changed:** the reconfigure family is tier-scoped -- these endpoints moved
+from ``/reconfigure/{backend}/...`` to ``/reconfigure/l2/{backend}/...``,
+and the unscoped form was removed (it now returns ``404``).
+
 ``backend`` and ``operation`` path segments are normalized (stripped and
 lower-cased). Within a request body, ``adapter_index`` (default ``0``) is
 **backend-local** — it indexes only the adapters of that backend, not the
@@ -1182,8 +1186,8 @@ string is still the configured L2 adapter type, not the serde wrapper type.
    ``GET /config/adapters``: each adapter whose ``reconfigurable`` flag is
    ``true`` can be addressed by its ``type_name``.
 
-``GET /reconfigure/{backend}/status``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``GET /reconfigure/l2/{backend}/status``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Report the runtime-manageable adapters for one backend type. Each adapter
 entry's ``adapter_index`` is rewritten to its **backend-local** 0-based index
@@ -1218,10 +1222,10 @@ An unknown or empty backend returns ``enabled=false``, ``num_adapters=0``,
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/reconfigure/dax/status | jq
+    curl -s http://localhost:8080/reconfigure/l2/dax/status | jq
 
-``POST /reconfigure/{backend}/{operation}``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``POST /reconfigure/l2/{backend}/{operation}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Apply one reconfiguration operation to a backend adapter. The request body is
 a JSON object whose accepted fields depend on the backend and operation. The
@@ -1289,7 +1293,7 @@ dict). A successful DAX ``add`` looks like:
 
 .. code-block:: bash
 
-    curl -s -X POST http://localhost:8080/reconfigure/dax/add \
+    curl -s -X POST http://localhost:8080/reconfigure/l2/dax/add \
         -H 'Content-Type: application/json' \
         -d '{"device_path": "/dev/dax0.0", "size": "100GiB"}'
 

--- a/docs/source/mp/l2_storage/dax.rst
+++ b/docs/source/mp/l2_storage/dax.rst
@@ -28,8 +28,8 @@ the DAX device, but they are unreachable after the LMCache server restarts.
 **Optional fields:**
 
 - ``hotplug_enabled`` (bool, default ``false``): Enables runtime
-  ``/reconfigure/l2/dax/status``, ``/reconfigure/l2/dax/add``,
-  ``/reconfigure/l2/dax/remove``, and ``/reconfigure/l2/dax/resize``.
+  ``/reconfigure/dax/l2/status``, ``/reconfigure/dax/l2/add``,
+  ``/reconfigure/dax/l2/remove``, and ``/reconfigure/dax/l2/resize``.
 - ``num_store_workers`` (int, default ``1``): Store worker threads.
 - ``num_lookup_workers`` (int, default ``1``): Lookup worker threads.
 - ``num_load_workers`` (int, default ``min(4, os.cpu_count())``): Load worker
@@ -82,8 +82,8 @@ future adapters such as P2P.
 
 .. code-block:: bash
 
-    curl http://127.0.0.1:9000/reconfigure/l2/dax/status
-    curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/add \
+    curl http://127.0.0.1:9000/reconfigure/dax/l2/status
+    curl -X POST http://127.0.0.1:9000/reconfigure/dax/l2/add \
       -H 'Content-Type: application/json' \
       -d '{"device_path": "/dev/daxX.X", "size": "100GiB"}'
 

--- a/docs/source/mp/l2_storage/dax.rst
+++ b/docs/source/mp/l2_storage/dax.rst
@@ -28,8 +28,8 @@ the DAX device, but they are unreachable after the LMCache server restarts.
 **Optional fields:**
 
 - ``hotplug_enabled`` (bool, default ``false``): Enables runtime
-  ``/reconfigure/dax/status``, ``/reconfigure/dax/add``,
-  ``/reconfigure/dax/remove``, and ``/reconfigure/dax/resize``.
+  ``/reconfigure/l2/dax/status``, ``/reconfigure/l2/dax/add``,
+  ``/reconfigure/l2/dax/remove``, and ``/reconfigure/l2/dax/resize``.
 - ``num_store_workers`` (int, default ``1``): Store worker threads.
 - ``num_lookup_workers`` (int, default ``1``): Lookup worker threads.
 - ``num_load_workers`` (int, default ``min(4, os.cpu_count())``): Load worker
@@ -82,8 +82,8 @@ future adapters such as P2P.
 
 .. code-block:: bash
 
-    curl http://127.0.0.1:9000/reconfigure/dax/status
-    curl -X POST http://127.0.0.1:9000/reconfigure/dax/add \
+    curl http://127.0.0.1:9000/reconfigure/l2/dax/status
+    curl -X POST http://127.0.0.1:9000/reconfigure/l2/dax/add \
       -H 'Content-Type: application/json' \
       -d '{"device_path": "/dev/daxX.X", "size": "100GiB"}'
 

--- a/lmcache/usage_telemetry/messages.py
+++ b/lmcache/usage_telemetry/messages.py
@@ -223,8 +223,9 @@ class MPServerMessage(UsageMessage):
 
         l1_config = storage_manager_config.l1_manager_config
         memory_config = l1_config.memory_config
-        # Shared derivation, so this and the fleet memory view agree. The
-        # medium label stays here: its exact strings are wire format.
+        # Startup snapshot from config. Runtime Device-DAX changes reach the
+        # fleet memory view through capacity events instead. The medium label
+        # stays here: its exact strings are wire format.
         l1_size_bytes = sum(get_configured_capacity_bytes(l1_config).values())
         if l1_config.gds_l1_config is not None:
             l1_medium = "gds"

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -264,7 +264,7 @@ class EncodedObjectKey:
 
 @dataclass(frozen=True)
 class ModuleMemoryCapacity:
-    """One compartment's configured capacity: an L1 medium or an L2 adapter.
+    """One compartment's declared capacity: an L1 medium or an L2 adapter.
 
     Keyed on the same ``(tier, backend)`` axis cache events use.
 
@@ -272,7 +272,7 @@ class ModuleMemoryCapacity:
         tier: ``Tier.L1`` or ``Tier.L2``.
         backend: Medium within the tier (``"dram"``, ``"devdax"``,
             ``"gds"``, or an L2 adapter type such as ``"s3"``).
-        capacity_bytes: Configured capacity. ``0`` means undeclared --
+        capacity_bytes: Declared usable capacity. ``0`` means undeclared --
             reported as unknown, not as full.
         shared: Set when instances mount this pool, so its capacity must
             not be summed across them.

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -223,14 +223,15 @@ class L1ManagerConfig:
 def get_configured_capacity_bytes(
     config: L1ManagerConfig,
 ) -> dict[L1BackendType, int]:
-    """Return the configured L1 capacity of each backing medium.
+    """Return the boot-configured L1 capacity of each backing medium.
 
-    The single source for "how large is L1". Unlike
+    The boot-time source for "how large is L1". Unlike
     ``L1Manager.get_memory_usage()``, whose total is the grown heap on the
     lazy tier, this is stable from boot. Keyed per medium because a hybrid
     Device-DAX tier spans two, matching how L1 events tag placements.
     Reports the *configured* topology, so devices added later via
-    ``add_device`` are not counted.
+    ``add_device`` are not counted. ``L1Manager`` overlays live Device-DAX
+    arena capacity when it builds a runtime declaration.
 
     Expects a **normalized** config: ``normalize_storage_manager_config``
     back-fills ``devdax_size_in_bytes`` from a matching DAX L2 adapter,

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -31,9 +31,13 @@ _HYBRID_L1_SINGLE_REGION_L2_ADAPTERS = {
 }
 
 
-def _requires_single_l1_memory_region(
+def requires_single_l1_memory_region(
     adapter_config: L2AdapterConfigBase,
 ) -> str | None:
+    """Return the adapter type requiring a single L1 memory region, if any."""
+    inner_config = getattr(adapter_config, "inner_config", None)
+    if isinstance(inner_config, L2AdapterConfigBase):
+        return requires_single_l1_memory_region(inner_config)
     type_name = get_type_name_for_config(adapter_config)
     if type_name in _HYBRID_L1_SINGLE_REGION_L2_ADAPTERS:
         return type_name
@@ -366,7 +370,7 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
     incompatible_adapters = [
         adapter_name
         for adapter_config in config.l2_adapter_config.adapters
-        if (adapter_name := _requires_single_l1_memory_region(adapter_config))
+        if (adapter_name := requires_single_l1_memory_region(adapter_config))
         is not None
     ]
     if incompatible_adapters:

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -23,6 +23,13 @@ from lmcache.v1.distributed.memory_manager import (
 from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
     DevDaxL1MemoryManager,
 )
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
+from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaStatus,
+    DevDaxRemoveMode,
+)
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
@@ -851,6 +858,73 @@ class L1Manager:
         """Return an L1MemoryDesc describing the underlying L1 memory buffer."""
         return self._memory_manager.get_l1_memory_desc()
 
+    def get_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]:
+        """Return runtime status for every Device-DAX arena.
+
+        Returns:
+            One status per mapped arena, in pool order.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed.
+        """
+        return self._require_devdax_memory_manager().get_arena_statuses()
+
+    def memory_region_count(self) -> int:
+        """Return how many memory regions back L1 for transfer registration.
+
+        A Device-DAX L1 counts its DRAM tier (hybrid mode) plus every mapped
+        arena, active or draining. Other memory managers expose one buffer.
+
+        Returns:
+            The number of memory regions.
+        """
+        manager = self._memory_manager
+        if isinstance(manager, DevDaxL1MemoryManager):
+            return manager.memory_region_count()
+        return 1
+
+    def add_devdax_device(
+        self,
+        device_path: str,
+        size_in_bytes: int,
+    ) -> DevDaxArenaStatus:
+        """Add a Device-DAX device to the L1 arena pool.
+
+        Args:
+            device_path: Path of the Device-DAX device to map.
+            size_in_bytes: Number of bytes to map.
+
+        Returns:
+            Status of the newly added arena.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed or the request
+                cannot be applied.
+        """
+        return self._require_devdax_memory_manager().add_device(
+            device_path, size_in_bytes
+        )
+
+    def remove_devdax_device(
+        self,
+        device_path: str,
+        mode: DevDaxRemoveMode = DevDaxRemoveMode.DRAIN,
+    ) -> DevDaxArenaStatus:
+        """Remove a Device-DAX device from the L1 arena pool.
+
+        Args:
+            device_path: Path of the mapped Device-DAX device.
+            mode: Removal strategy. Only drain mode is currently supported.
+
+        Returns:
+            Status of the arena after the removal request.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed or the request
+                cannot be applied.
+        """
+        return self._require_devdax_memory_manager().remove_device(device_path, mode)
+
     def close(self) -> None:
         """Close the L1Manager and free all resources."""
         with self._lock:
@@ -934,3 +1008,12 @@ class L1Manager:
             size_bytes=memory_obj.get_size(),
             backend=self._memory_manager.get_backend_type(memory_obj),
         )
+
+    def _require_devdax_memory_manager(self) -> DevDaxL1MemoryManager:
+        """Return the Device-DAX manager or raise a reconfiguration error."""
+        if not isinstance(self._memory_manager, DevDaxL1MemoryManager):
+            raise L1ReconfigureError(
+                409,
+                "L1 is not Device-DAX backed (--l1-devdax-path not set)",
+            )
+        return self._memory_manager

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -11,7 +11,7 @@ import threading
 # First Party
 from lmcache.lmcache_native import TTLLock
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.api import L1BackendType, MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import L1ManagerConfig, get_configured_capacity_bytes
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.internal_api import L1ManagerListener, L1ObjectMeta
@@ -27,6 +27,7 @@ from lmcache.v1.distributed.memory_manager.reconfiguration import (
     L1ReconfigureError,
 )
 from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaState,
     DevDaxArenaStatus,
     DevDaxRemoveMode,
 )
@@ -208,11 +209,9 @@ class L1Manager:
         else:
             self._memory_manager = L1MemoryManager(config.memory_config)
 
-        # Precomputed: it derives from config alone and never changes, and
-        # report_status runs under the global L1 lock on a hot polling path.
-        self._configured_capacity_bytes = sum(
-            get_configured_capacity_bytes(config).values()
-        )
+        # CPU and GDS capacity is fixed at boot. Device-DAX overlays its entry
+        # from the live arena pool because devices can be added or drained.
+        self._boot_capacity_bytes_by_backend = get_configured_capacity_bytes(config)
         self._write_ttl_seconds = config.write_ttl_seconds
         self._read_ttl_seconds = config.read_ttl_seconds
 
@@ -854,6 +853,36 @@ class L1Manager:
         """
         return self._memory_manager.get_memory_usage()
 
+    def get_capacity_bytes_by_backend(self) -> dict[L1BackendType, int]:
+        """Return the current declared L1 capacity per backing medium.
+
+        CPU and GDS retain their boot-configured capacity. For Device-DAX,
+        only active arenas count as usable capacity; draining arenas stop
+        accepting allocations and are excluded immediately.
+
+        Returns:
+            A fresh mapping from backing-medium type to usable capacity in
+            bytes, with zero-sized media omitted.
+
+        Note:
+            Device-DAX arena state is snapshotted under the allocator's pool
+            lock. A separate usage query may observe an adjacent topology if
+            reconfiguration is concurrent.
+        """
+        capacities = self._boot_capacity_bytes_by_backend.copy()
+        manager = self._memory_manager
+        if isinstance(manager, DevDaxL1MemoryManager):
+            active_bytes = sum(
+                status.size_in_bytes
+                for status in manager.get_arena_statuses()
+                if status.state is DevDaxArenaState.ACTIVE
+            )
+            if active_bytes > 0:
+                capacities[L1BackendType.DEVDAX] = active_bytes
+            else:
+                capacities.pop(L1BackendType.DEVDAX, None)
+        return capacities
+
     def get_l1_memory_desc(self):
         """Return an L1MemoryDesc describing the underlying L1 memory buffer."""
         return self._memory_manager.get_l1_memory_desc()
@@ -868,6 +897,21 @@ class L1Manager:
             L1ReconfigureError: If L1 is not Device-DAX backed.
         """
         return self._require_devdax_memory_manager().get_arena_statuses()
+
+    def get_devdax_arena_status(self, device_path: str) -> DevDaxArenaStatus:
+        """Return the status of the Device-DAX arena mapped at ``device_path``.
+
+        Args:
+            device_path: Path (or any alias) of the mapped device.
+
+        Returns:
+            The arena's current status.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed (409) or no
+                arena is mapped at ``device_path`` (404).
+        """
+        return self._require_devdax_memory_manager().get_arena_status(device_path)
 
     def memory_region_count(self) -> int:
         """Return how many memory regions back L1 for transfer registration.
@@ -950,8 +994,8 @@ class L1Manager:
                 temporary += 1
         used, total = self._memory_manager.get_memory_usage()
         # ``memory_total_bytes`` is what the allocator currently backs (the
-        # grown heap on the lazy tier); this is the declared size. Summed to
-        # fit this dict's flat shape; ``0`` means undeclared.
+        # grown heap on the lazy tier). ``memory_configured_bytes`` is the
+        # current declared capacity, summed to fit this dict's flat shape.
         return {
             "is_healthy": self._memory_manager.memcheck(),
             "total_object_count": len(self._objects),
@@ -960,7 +1004,9 @@ class L1Manager:
             "temporary_count": temporary,
             "memory_used_bytes": used,
             "memory_total_bytes": total,
-            "memory_configured_bytes": self._configured_capacity_bytes,
+            "memory_configured_bytes": sum(
+                self.get_capacity_bytes_by_backend().values()
+            ),
             "memory_usage_ratio": used / total if total > 0 else 0.0,
             "write_ttl_seconds": self._write_ttl_seconds,
             "read_ttl_seconds": self._read_ttl_seconds,

--- a/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, Optional, Protocol, cast
 import os
+import stat
 import threading
 
 if TYPE_CHECKING:
@@ -59,6 +60,28 @@ HotplugRemoveMode = Literal["migrate", "evict", "drain"]
 HotplugResizeMode = Literal["migrate", "evict"]
 DaxHotplugError = L2ReconfigureError
 _DAX_RECONFIGURE_OPERATIONS = ["status", "add", "remove", "resize"]
+_DaxDeviceIdentity = tuple[bool, int, int]
+
+
+def _device_identity(fd_status: os.stat_result) -> _DaxDeviceIdentity | None:
+    """Return the physical identity of a supported DAX backing object.
+
+    Character devices are identified by ``st_rdev``. Regular mmap files used
+    by tests are identified by filesystem device and inode. Other file types
+    are not valid DAX backing objects and have no identity here.
+
+    Args:
+        fd_status: Result of ``stat`` or ``fstat`` for the backing object.
+
+    Returns:
+        A comparable identity tuple, or ``None`` for an unsupported file type.
+    """
+    if stat.S_ISCHR(fd_status.st_mode):
+        return True, fd_status.st_rdev, 0
+    if stat.S_ISREG(fd_status.st_mode):
+        return False, fd_status.st_dev, fd_status.st_ino
+    return None
+
 
 _READABLE_STATES: set[DaxDeviceState] = {
     "active",
@@ -387,6 +410,43 @@ class DaxL2Adapter(L2AdapterInterface):
             File descriptor owned by this adapter's load notifier.
         """
         return self._load_efd.fileno()
+
+    def owns_device(self, device_path: str) -> bool:
+        """Return whether this adapter maps the physical device at a path.
+
+        Device identity, rather than the path string, is compared so aliases of
+        one Device-DAX node cannot be assigned to another storage tier. An open
+        character device uses ``st_rdev``; a regular mmap test file uses
+        ``(st_dev, st_ino)``.
+
+        Args:
+            device_path: Path whose physical backing identity should be checked.
+
+        Returns:
+            ``True`` if a currently open DAX core maps the same device;
+            otherwise ``False``. Missing, uninterpretable, and unsupported
+            paths return ``False`` so their normal add validation remains the
+            error boundary.
+        """
+        try:
+            requested_identity = _device_identity(os.stat(device_path))
+        except (OSError, ValueError):
+            return False
+        if requested_identity is None:
+            return False
+
+        with self._device_lock:
+            for entry in self._devices:
+                fd = entry.core.fd
+                if fd is None:
+                    continue
+                try:
+                    mapped_identity = _device_identity(os.fstat(fd))
+                except OSError:
+                    continue
+                if mapped_identity == requested_identity:
+                    return True
+        return False
 
     def submit_store_task(
         self,

--- a/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
@@ -302,7 +302,7 @@ class DaxL2AdapterConfig(L2AdapterConfigBase):
             "- max_dax_size_gb (float): legacy single-device mapped size in GiB\n"
             "- devices (list): optional multi-device entries with device_path and "
             "max_dax_size_gb\n"
-            "- hotplug_enabled (bool): enables runtime /reconfigure/l2/dax/* "
+            "- hotplug_enabled (bool): enables runtime /reconfigure/dax/l2/* "
             "management APIs\n"
             "- slot_bytes (int): fixed slot size in bytes (required, >0)\n"
             "- num_store_workers (int): store worker threads (optional, default 1)\n"

--- a/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
@@ -279,7 +279,7 @@ class DaxL2AdapterConfig(L2AdapterConfigBase):
             "- max_dax_size_gb (float): legacy single-device mapped size in GiB\n"
             "- devices (list): optional multi-device entries with device_path and "
             "max_dax_size_gb\n"
-            "- hotplug_enabled (bool): enables runtime /reconfigure/dax/* "
+            "- hotplug_enabled (bool): enables runtime /reconfigure/l2/dax/* "
             "management APIs\n"
             "- slot_bytes (int): fixed slot size in bytes (required, >0)\n"
             "- num_store_workers (int): store worker threads (optional, default 1)\n"

--- a/lmcache/v1/distributed/l2_adapters/reconfiguration.py
+++ b/lmcache/v1/distributed/l2_adapters/reconfiguration.py
@@ -40,6 +40,23 @@ class L2ReconfigureStatus(TypedDict):
 
 
 @runtime_checkable
+class L2DeviceOwner(Protocol):
+    """Protocol for L2 adapters that own a local physical device."""
+
+    def owns_device(self, device_path: str) -> bool:
+        """Return whether the adapter currently maps ``device_path``.
+
+        Args:
+            device_path: Path whose physical backing identity should be checked.
+
+        Returns:
+            ``True`` when the adapter owns the same physical device, even if it
+            was opened through another path; otherwise ``False``.
+        """
+        ...
+
+
+@runtime_checkable
 class L2ReconfigurableAdapter(Protocol):
     """Protocol implemented by L2 adapters with runtime reconfiguration."""
 

--- a/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
@@ -116,9 +116,10 @@ class DevDaxL1MemoryManager(L1MemoryManager):
 
         Raises:
             ValueError: If ``device_path`` is empty, ``size_in_bytes`` is not
-                positive, or the device is already mapped.
-            RuntimeError: If the underlying allocator is closed or the device
-                capacity is smaller than ``size_in_bytes``.
+                positive, the device is already mapped, or the mapping violates
+                the device's advertised alignment.
+            RuntimeError: If the allocator is closed or the device capacity is
+                smaller than ``size_in_bytes``.
             OSError: If the device cannot be opened or mapped.
         """
         allocator = cast(DevDaxMemoryAllocator, self._allocator)

--- a/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
@@ -10,9 +10,13 @@ from lmcache.v1.distributed.api import L1BackendType
 from lmcache.v1.distributed.config import L1MemoryManagerConfig
 from lmcache.v1.distributed.internal_api import L1MemoryDesc
 from lmcache.v1.distributed.memory_manager.l1_memory_manager import L1MemoryManager
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
 from lmcache.v1.memory_allocators.devdax_memory_allocator import (
     DevDaxArenaStatus,
     DevDaxMemoryAllocator,
+    DevDaxNotMappedError,
     DevDaxRemoveMode,
 )
 from lmcache.v1.memory_management import MemoryObj
@@ -115,15 +119,15 @@ class DevDaxL1MemoryManager(L1MemoryManager):
             The status of the newly added arena.
 
         Raises:
-            ValueError: If ``device_path`` is empty, ``size_in_bytes`` is not
-                positive, the device is already mapped, or the mapping violates
-                the device's advertised alignment.
-            RuntimeError: If the allocator is closed or the device capacity is
-                smaller than ``size_in_bytes``.
-            OSError: If the device cannot be opened or mapped.
+            L1ReconfigureError: 409 when the request conflicts with the device
+                or pool state (already mapped, alignment violation, capacity
+                exceeded, allocator closed, device not openable).
         """
         allocator = cast(DevDaxMemoryAllocator, self._allocator)
-        return allocator.add_device(device_path, size_in_bytes)
+        try:
+            return allocator.add_device(device_path, size_in_bytes)
+        except (ValueError, RuntimeError, OSError) as exc:
+            raise L1ReconfigureError(409, str(exc)) from exc
 
     def remove_device(
         self,
@@ -147,11 +151,26 @@ class DevDaxL1MemoryManager(L1MemoryManager):
             immediately, otherwise ``DRAINING`` with the live allocation count.
 
         Raises:
-            ValueError: If ``mode`` is unsupported, no arena is mapped at
-                ``device_path``, or the arena is the primary (non-removable) one.
+            L1ReconfigureError: 404 when no arena is mapped at ``device_path``;
+                409 when ``mode`` is unsupported or the arena is primary and
+                non-removable.
         """
         allocator = cast(DevDaxMemoryAllocator, self._allocator)
-        return allocator.remove_device(device_path, mode)
+        try:
+            return allocator.remove_device(device_path, mode)
+        except DevDaxNotMappedError as exc:
+            raise L1ReconfigureError(404, str(exc)) from exc
+        except ValueError as exc:
+            raise L1ReconfigureError(409, str(exc)) from exc
+
+    def memory_region_count(self) -> int:
+        """Return the number of memory regions backing L1.
+
+        Returns:
+            One for the DRAM tier of a hybrid configuration, if present, plus
+            one per mapped Device-DAX arena, active or draining.
+        """
+        return cast(DevDaxMemoryAllocator, self._allocator).memory_region_count()
 
     def get_arena_statuses(self) -> list[DevDaxArenaStatus]:
         """Return a status snapshot of every Device-DAX arena in the L1 pool.

--- a/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
@@ -64,9 +64,6 @@ class DevDaxL1MemoryManager(L1MemoryManager):
             shm_name=config.shm_name or None,
             align_bytes=config.align_bytes,
         )
-        # Retained so runtime reconfiguration can report the configured topology
-        # alongside the live arena pool.
-        self._config = config
         self._size_in_bytes = config.size_in_bytes
         self._align_bytes = config.align_bytes
 
@@ -162,6 +159,24 @@ class DevDaxL1MemoryManager(L1MemoryManager):
             raise L1ReconfigureError(404, str(exc)) from exc
         except ValueError as exc:
             raise L1ReconfigureError(409, str(exc)) from exc
+
+    def get_arena_status(self, device_path: str) -> DevDaxArenaStatus:
+        """Return the status of the Device-DAX arena mapped at ``device_path``.
+
+        Args:
+            device_path: Path (or any alias) of the mapped device.
+
+        Returns:
+            The arena's current status.
+
+        Raises:
+            L1ReconfigureError: 404 when no arena is mapped at ``device_path``.
+        """
+        allocator = cast(DevDaxMemoryAllocator, self._allocator)
+        try:
+            return allocator.arena_status(device_path)
+        except DevDaxNotMappedError as exc:
+            raise L1ReconfigureError(404, str(exc)) from exc
 
     def memory_region_count(self) -> int:
         """Return the number of memory regions backing L1.

--- a/lmcache/v1/distributed/memory_manager/reconfiguration.py
+++ b/lmcache/v1/distributed/memory_manager/reconfiguration.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP-mappable error type for runtime L1 memory reconfiguration.
+
+This module provides the L1 counterpart to
+:class:`~lmcache.v1.distributed.l2_adapters.reconfiguration.L2ReconfigureError`.
+L1 currently uses concrete memory-manager and arena-status types. A generic L1
+reconfiguration status and manager protocol can be added here if additional L1
+backends gain runtime reconfiguration support. The L1 memory manager translates
+allocator failures into this error while the allocator remains free of HTTP
+concerns.
+"""
+
+
+class L1ReconfigureError(RuntimeError):
+    """HTTP-mappable runtime L1 reconfiguration error."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        *,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        """Create a runtime reconfiguration error.
+
+        Args:
+            status_code: HTTP status code the API should return.
+            message: Human-readable error message.
+            payload: Optional response body. When omitted, ``{"error": message}``
+                is used.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload: dict[str, object] = (
+            payload if payload is not None else {"error": message}
+        )

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -28,7 +28,6 @@ from lmcache.v1.distributed.bitmap_ops import fold_unfold_ranked
 from lmcache.v1.distributed.config import (
     EvictionConfig,
     StorageManagerConfig,
-    get_configured_capacity_bytes,
     requires_single_l1_memory_region,
 )
 from lmcache.v1.distributed.error import L1Error, strerror
@@ -63,6 +62,7 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
     create_store_policy,
 )
 from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaState,
     DevDaxArenaStatus,
     DevDaxRemoveMode,
 )
@@ -84,9 +84,6 @@ logger = init_logger(__name__)
 class StorageManager:
     def __init__(self, config: StorageManagerConfig):
         self._l1_manager = L1Manager(config.l1_manager_config)
-        # Retained for the L1 half of the capacity report; L1's configured
-        # size is a pure function of it.
-        self._l1_config = config.l1_manager_config
         self._event_bus = get_event_bus()
 
         # L1 eviction controller
@@ -104,6 +101,9 @@ class StorageManager:
         self._next_adapter_id = 0
         # Serializes add_l2_adapter / delete_l2_adapter against each other.
         self._lifecycle_lock = threading.Lock()
+        # Keeps capacity snapshots ordered by the point at which they are
+        # built. Registration can publish concurrently with runtime changes.
+        self._capacity_publish_lock = threading.Lock()
         # Guards the _l2_adapters and _adapter_descriptors dicts.
         self._adapters_lock = threading.Lock()
         self._registered_l2_listeners: list[L2AdapterListener] = []
@@ -873,9 +873,9 @@ class StorageManager:
                 capacity_bytes=configured,
                 shared=False,
             )
-            for backend, configured in get_configured_capacity_bytes(
-                self._l1_config
-            ).items()
+            for backend, configured in (
+                self._l1_manager.get_capacity_bytes_by_backend().items()
+            )
         ]
         for _adapter_id, desc, adapter in self._snapshot_adapters():
             try:
@@ -926,6 +926,8 @@ class StorageManager:
     ) -> DevDaxArenaStatus:
         """Add a Device-DAX device to the L1 arena pool.
 
+        A successful addition publishes the current whole capacity topology.
+
         The addition is refused while an L2 adapter that registers a single L1
         memory region is configured, because such adapters register only the
         primary arena: NIXL addresses objects by offset into it and would
@@ -967,7 +969,9 @@ class StorageManager:
                     "is already mapped by L2 adapter(s) "
                     f"({', '.join(device_owners)})",
                 )
-            return self._l1_manager.add_devdax_device(device_path, size_in_bytes)
+            status = self._l1_manager.add_devdax_device(device_path, size_in_bytes)
+        self._publish_capacity_changed()
+        return status
 
     def remove_l1_devdax_device(
         self,
@@ -975,6 +979,10 @@ class StorageManager:
         mode: DevDaxRemoveMode = DevDaxRemoveMode.DRAIN,
     ) -> DevDaxArenaStatus:
         """Remove a Device-DAX device from the L1 arena pool.
+
+        Whenever the call changes usable capacity, it publishes the current
+        whole topology. This includes a drain transition whose later device
+        cleanup raises an exception.
 
         Args:
             device_path: Path of the mapped Device-DAX device.
@@ -986,8 +994,30 @@ class StorageManager:
         Raises:
             L1ReconfigureError: If L1 is not Device-DAX backed or the request
                 cannot be applied.
+            RuntimeError: If device synchronization or cleanup fails after the
+                drain transition.
+            OSError: If unmapping or closing the device fails after the drain
+                transition.
         """
-        return self._l1_manager.remove_devdax_device(device_path, mode)
+        target_was_active = self._l1_devdax_arena_is_active(device_path)
+        try:
+            status = self._l1_manager.remove_devdax_device(device_path, mode)
+        except Exception:
+            # Draining begins before an empty arena is synchronized and
+            # unmapped. If that cleanup raises, usable capacity has still
+            # changed and the coordinator must not retain the old topology.
+            try:
+                if target_was_active and not self._l1_devdax_arena_is_active(
+                    device_path
+                ):
+                    self._publish_capacity_changed()
+            except Exception:
+                logger.exception(
+                    "Failed to reconcile L1 capacity after a Device-DAX remove error"
+                )
+            raise
+        self._publish_capacity_changed()
+        return status
 
     def _single_region_adapter_names(self) -> list[str]:
         """Return type names of registered L2 adapters needing one L1 region.
@@ -1002,6 +1032,18 @@ class StorageManager:
             for descriptor in descriptors
             if (name := requires_single_l1_memory_region(descriptor.config)) is not None
         ]
+
+    def _l1_devdax_arena_is_active(self, device_path: str) -> bool:
+        """Return whether an ACTIVE Device-DAX arena is mapped at ``device_path``.
+
+        Any alias of the mapped path resolves to the same arena. ``False``
+        when L1 is not Device-DAX backed or nothing is mapped there.
+        """
+        try:
+            status = self._l1_manager.get_devdax_arena_status(device_path)
+        except L1ReconfigureError:
+            return False
+        return status.state is DevDaxArenaState.ACTIVE
 
     def get_usage_bytes_by_cache_salt(self) -> dict[str, int]:
         """Aggregate ``cache_salt`` byte usage across every L2 adapter.
@@ -1066,29 +1108,23 @@ class StorageManager:
     def _publish_capacity_changed(self) -> None:
         """Announce the current capacity topology on the event bus.
 
-        Lock-free. ``_build_capacities`` guards its own reads
-        (``_snapshot_adapters`` takes ``_adapters_lock``), and ordering is
-        not this class's problem: the cache-event subscriber numbers
-        declarations as it emits them, on the one bus drain thread, so a
-        number cannot come apart from the topology it labels. Callers here
-        are concurrent -- registration publishes from the event loop while a
-        worker may be adding an adapter -- which is exactly why the counter
-        does not live here.
+        Snapshot construction and enqueue are serialized because registration
+        can publish concurrently with runtime reconfiguration. The subscriber
+        assigns revisions in queue order, so an older snapshot must not be
+        enqueued after a newer one. Individual L1 and L2 reads retain their own
+        locks; this lock only orders declarations and does not replace them.
 
-        The event carries the whole topology, not a delta, so a dropped one
-        is repaired by the next rather than leaving the coordinator
-        permanently wrong.
+        The event carries the whole topology, not a delta, so a later
+        publication can repair a dropped declaration.
         """
-        self._event_bus.publish(
-            Event(
-                event_type=EventType.SM_CAPACITY_CHANGED,
-                metadata={
-                    "snapshot": CapacitySnapshot(
-                        modules=tuple(self._build_capacities())
-                    )
-                },
+        with self._capacity_publish_lock:
+            snapshot = CapacitySnapshot(modules=tuple(self._build_capacities()))
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.SM_CAPACITY_CHANGED,
+                    metadata={"snapshot": snapshot},
+                )
             )
-        )
 
     def reconfigure_l2_adapter(
         self,
@@ -1109,8 +1145,6 @@ class StorageManager:
         adapter = self._get_reconfigurable_l2_adapter(adapter_index)
         result = adapter.reconfigure(operation, payload)
         result["adapter_index"] = adapter_index
-        # Lock-free: reconfigure did not serialize against adapter
-        # add/delete before, and publishing is no reason to start.
         self._publish_capacity_changed()
         return result
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -29,6 +29,7 @@ from lmcache.v1.distributed.config import (
     EvictionConfig,
     StorageManagerConfig,
     get_configured_capacity_bytes,
+    requires_single_l1_memory_region,
 )
 from lmcache.v1.distributed.error import L1Error, strerror
 from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
@@ -37,10 +38,14 @@ from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import AdapterUsage, L2AdapterInterface
 from lmcache.v1.distributed.l2_adapters.config import L2AdapterConfigBase
 from lmcache.v1.distributed.l2_adapters.reconfiguration import (
+    L2DeviceOwner,
     L2ReconfigurableAdapter,
     L2ReconfigureError,
 )
 from lmcache.v1.distributed.l2_adapters.serde_wrapper import SerdeL2AdapterWrapper
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
 from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.distributed.serde import create_serde_processor
 from lmcache.v1.distributed.storage_controllers import (
@@ -56,6 +61,10 @@ from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
     create_store_policy,
+)
+from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaStatus,
+    DevDaxRemoveMode,
 )
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
@@ -898,6 +907,102 @@ class StorageManager:
         """
         return self._l1_manager.get_memory_usage()
 
+    # L1 reconfiguration APIs
+    def get_l1_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]:
+        """Return runtime status for every Device-DAX L1 arena.
+
+        Returns:
+            One status per mapped arena, in pool order.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed.
+        """
+        return self._l1_manager.get_devdax_arena_statuses()
+
+    def add_l1_devdax_device(
+        self,
+        device_path: str,
+        size_in_bytes: int,
+    ) -> DevDaxArenaStatus:
+        """Add a Device-DAX device to the L1 arena pool.
+
+        The addition is refused while an L2 adapter that registers a single L1
+        memory region is configured, because such adapters register only the
+        primary arena: NIXL addresses objects by offset into it and would
+        transfer the wrong bytes for objects on a second arena, and Mooncake
+        over RDMA rejects buffers outside its registered region so their
+        stores and loads fail. The check and the addition run under
+        ``_lifecycle_lock`` so a concurrent ``add_l2_adapter`` cannot
+        interleave with them.
+
+        Args:
+            device_path: Path of the Device-DAX device to map.
+            size_in_bytes: Number of bytes to map.
+
+        Returns:
+            Status of the newly added arena.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed, a single-region
+                L2 adapter is configured (409), the physical device is already
+                mapped by L2 (409), or the request cannot be applied.
+        """
+        with self._lifecycle_lock:
+            # Report the L1 backing error before adapter compatibility.
+            self._l1_manager.get_devdax_arena_statuses()
+            incompatible = self._single_region_adapter_names()
+            if incompatible:
+                raise L1ReconfigureError(
+                    409,
+                    "cannot add a Device-DAX L1 arena: L2 adapters that "
+                    "register a single L1 memory region are configured "
+                    f"({', '.join(incompatible)}); their transfers cover "
+                    "only the primary arena",
+                )
+            device_owners = self._l2_device_owner_names(device_path)
+            if device_owners:
+                raise L1ReconfigureError(
+                    409,
+                    "cannot add a Device-DAX L1 arena: the physical device "
+                    "is already mapped by L2 adapter(s) "
+                    f"({', '.join(device_owners)})",
+                )
+            return self._l1_manager.add_devdax_device(device_path, size_in_bytes)
+
+    def remove_l1_devdax_device(
+        self,
+        device_path: str,
+        mode: DevDaxRemoveMode = DevDaxRemoveMode.DRAIN,
+    ) -> DevDaxArenaStatus:
+        """Remove a Device-DAX device from the L1 arena pool.
+
+        Args:
+            device_path: Path of the mapped Device-DAX device.
+            mode: Removal strategy. Only drain mode is currently supported.
+
+        Returns:
+            Status of the arena after the removal request.
+
+        Raises:
+            L1ReconfigureError: If L1 is not Device-DAX backed or the request
+                cannot be applied.
+        """
+        return self._l1_manager.remove_devdax_device(device_path, mode)
+
+    def _single_region_adapter_names(self) -> list[str]:
+        """Return type names of registered L2 adapters needing one L1 region.
+
+        The caller holds ``_lifecycle_lock`` so the answer stays valid while
+        it acts on it; ``_adapters_lock`` only guards the dict read.
+        """
+        with self._adapters_lock:
+            descriptors = list(self._adapter_descriptors.values())
+        return [
+            name
+            for descriptor in descriptors
+            if (name := requires_single_l1_memory_region(descriptor.config)) is not None
+        ]
+
     def get_usage_bytes_by_cache_salt(self) -> dict[str, int]:
         """Aggregate ``cache_salt`` byte usage across every L2 adapter.
 
@@ -1017,8 +1122,24 @@ class StorageManager:
 
         Returns:
             The stable id assigned to the new adapter.
+
+        Raises:
+            ValueError: If the adapter registers a single L1 memory region
+                while L1 spans more than one (hybrid DRAM + Device-DAX, or
+                more than one Device-DAX arena).
         """
         with self._lifecycle_lock:
+            # Mirror of the check in add_l1_devdax_device: a single-region
+            # adapter may only be added while L1 is exactly one memory region.
+            adapter_name = requires_single_l1_memory_region(config)
+            region_count = self._l1_manager.memory_region_count()
+            if adapter_name is not None and region_count > 1:
+                raise ValueError(
+                    f"{adapter_name} registers a single L1 memory region, but "
+                    f"L1 currently spans {region_count} regions (hybrid DRAM + "
+                    "Device-DAX, or more than one Device-DAX arena); remove the "
+                    "additional Device-DAX regions before adding it"
+                )
             adapter_id, adapter, descriptor = self._build_l2_adapter(config)
             for listener in self._registered_l2_listeners:
                 adapter.register_listener(listener)
@@ -1259,6 +1380,26 @@ class StorageManager:
             return inner
 
         return None
+
+    def _l2_device_owner_names(self, device_path: str) -> list[str]:
+        """Return L2 type names that own the physical device at a path.
+
+        The caller holds ``_lifecycle_lock`` so registered adapters cannot be
+        added or deleted between this check and the L1 mapping attempt.
+
+        Args:
+            device_path: Candidate Device-DAX path for the L1 arena.
+
+        Returns:
+            Registered adapter type names whose open device has the same
+            physical identity.
+        """
+        owners: list[str] = []
+        for _adapter_id, descriptor, adapter in self._snapshot_adapters():
+            owner = self._unwrap_reconfigurable_l2_adapter(adapter)
+            if isinstance(owner, L2DeviceOwner) and owner.owns_device(device_path):
+                owners.append(descriptor.type_name)
+        return owners
 
     def _list_reconfigurable_l2_adapters(
         self,

--- a/lmcache/v1/memory_allocators/devdax_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/devdax_memory_allocator.py
@@ -175,7 +175,11 @@ def _sysfs_attr_int(device_dir: str, attribute: str) -> int | None:
 
 
 class DevDaxNotMappedError(ValueError):
-    """No Device-DAX arena is mapped from the requested device path."""
+    """No Device-DAX arena is mapped from the requested device path.
+
+    A specialized ``ValueError`` that lets the manager distinguish a lookup
+    miss from other invalid allocator requests.
+    """
 
 
 class DevDaxArenaState(Enum):
@@ -1063,6 +1067,22 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
             raise DevDaxNotMappedError("no Device-DAX arena mapped at ''")
         with self.host_mem_lock:
             return self._find_arena_locked(device_path).status()
+
+    def memory_region_count(self) -> int:
+        """Return how many distinct memory regions back this allocator.
+
+        The DRAM local allocator of a hybrid configuration is one region and
+        every mapped Device-DAX arena, active or draining, is another. A
+        transfer channel that registers a single L1 region (the buffer
+        returned by ``get_l1_memory_desc``) addresses objects correctly only
+        while this count is 1.
+
+        Returns:
+            The number of memory regions.
+        """
+        with self.host_mem_lock:
+            arena_count = len(self._arenas)
+        return (1 if self.local_allocator is not None else 0) + arena_count
 
     def memcheck(self) -> bool:
         local_ok = True

--- a/lmcache/v1/memory_allocators/devdax_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/devdax_memory_allocator.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional, Union
 import ctypes
 import mmap
 import os
+import stat
 import threading
 
 # Third Party
@@ -26,6 +27,155 @@ from lmcache.v1.memory_management import (
     logger,
 )
 import lmcache.v1.memory_management as memory_management
+
+# sysfs exposes every character device under ``/sys/dev/char/<major>:<minor>``
+# as a symlink to its device directory. Resolving a device through its number
+# rather than its path name keeps aliases (``/dev//dax1.0``, symlinks,
+# ``/dev/char/<major>:<minor>``) from bypassing the Device-DAX checks.
+_SYSFS_CHAR_ROOT = "/sys/dev/char"
+_DAX_BUS_ROOT = "/sys/bus/dax/devices"
+_DAX_SUBSYSTEM = "dax"
+
+
+@dataclass(frozen=True)
+class _DeviceIdentity:
+    """Identity of an opened backing object, independent of the path used.
+
+    Character devices are identified by their device number: every node or
+    symlink with the same ``major:minor`` is the same device. Other files
+    (regular files used as test backing) are identified by ``(st_dev,
+    st_ino)``.
+    """
+
+    is_char_device: bool
+    device_number: int
+    inode: int
+
+    @classmethod
+    def from_stat(cls, fd_status: os.stat_result) -> "_DeviceIdentity":
+        if stat.S_ISCHR(fd_status.st_mode):
+            return cls(True, fd_status.st_rdev, 0)
+        return cls(False, fd_status.st_dev, fd_status.st_ino)
+
+
+def _sysfs_char_device_dir(st_rdev: int) -> str | None:
+    """Return the sysfs device directory of a character device.
+
+    Args:
+        st_rdev: The device number reported by ``fstat`` on the opened node.
+
+    Returns:
+        The resolved device directory, or ``None`` when sysfs does not expose
+        the device (sysfs not mounted, or masked in a container).
+    """
+    link = os.path.join(_SYSFS_CHAR_ROOT, f"{os.major(st_rdev)}:{os.minor(st_rdev)}")
+    try:
+        if not os.path.isdir(link):
+            return None
+        return os.path.realpath(link)
+    except OSError:
+        return None
+
+
+def _sysfs_subsystem(device_dir: str) -> str | None:
+    """Return the subsystem (bus) name a sysfs device directory belongs to."""
+    try:
+        return os.path.basename(os.readlink(os.path.join(device_dir, "subsystem")))
+    except OSError:
+        return None
+
+
+def _dax_bus_device_dir(major: int, minor: int) -> str | None:
+    """Find a device on the dax bus listing by its device number.
+
+    Used when ``/sys/dev/char`` is not visible but ``/sys/bus/dax/devices``
+    is. Every entry's ``dev`` attribute holds ``major:minor``.
+
+    Args:
+        major: Device major number.
+        minor: Device minor number.
+
+    Returns:
+        The resolved device directory, or ``None`` when no entry matches.
+    """
+    wanted = f"{major}:{minor}"
+    try:
+        names = os.listdir(_DAX_BUS_ROOT)
+    except OSError:
+        return None
+    for name in names:
+        entry = os.path.join(_DAX_BUS_ROOT, name)
+        try:
+            with open(os.path.join(entry, "dev")) as f:
+                if f.read().strip() == wanted:
+                    return os.path.realpath(entry)
+        except OSError:
+            continue
+    return None
+
+
+def _resolve_dax_device_dir(device_path: str, st_rdev: int) -> str:
+    """Return the sysfs directory of the Device-DAX device behind ``st_rdev``.
+
+    ``/sys/dev/char/<major>:<minor>`` is tried first and must belong to the
+    ``dax`` subsystem; when that tree is not visible, or its ``subsystem``
+    link cannot be read, the dax bus listing is searched by device number. A
+    device that sysfs does not expose cannot be verified and is refused.
+
+    Args:
+        device_path: Path the caller used, for error messages.
+        st_rdev: Device number of the opened character device.
+
+    Returns:
+        The device's sysfs directory.
+
+    Raises:
+        ValueError: If the device is on another subsystem or sysfs does not
+            expose it.
+    """
+    major, minor = os.major(st_rdev), os.minor(st_rdev)
+    device_dir = _sysfs_char_device_dir(st_rdev)
+    if device_dir is not None:
+        subsystem = _sysfs_subsystem(device_dir)
+        if subsystem == _DAX_SUBSYSTEM:
+            return device_dir
+        if subsystem is not None:
+            raise ValueError(
+                f"{device_path} is not a Device-DAX device "
+                f"(sysfs subsystem: {subsystem})"
+            )
+    # No char entry, or its subsystem link is unreadable: the dax bus listing
+    # can still identify the device positively.
+    bus_dir = _dax_bus_device_dir(major, minor)
+    if bus_dir is not None:
+        return bus_dir
+    raise ValueError(
+        f"cannot verify {device_path} as a Device-DAX device: sysfs exposes "
+        f"neither a readable {_SYSFS_CHAR_ROOT}/{major}:{minor} subsystem nor "
+        f"a {_DAX_BUS_ROOT} entry with that device number (mount sysfs in "
+        "the container)"
+    )
+
+
+def _sysfs_attr_int(device_dir: str, attribute: str) -> int | None:
+    """Read an integer sysfs attribute.
+
+    Args:
+        device_dir: The device's sysfs directory.
+        attribute: Attribute file name, e.g. ``size`` or ``align``.
+
+    Returns:
+        The attribute value, or ``None`` when it is missing or unreadable.
+    """
+    try:
+        with open(os.path.join(device_dir, attribute)) as f:
+            return int(f.read().strip(), 0)
+    except (OSError, ValueError):
+        return None
+
+
+class DevDaxNotMappedError(ValueError):
+    """No Device-DAX arena is mapped from the requested device path."""
 
 
 class DevDaxArenaState(Enum):
@@ -60,7 +210,8 @@ class DevDaxArenaStatus:
     """Immutable snapshot of one Device-DAX arena's runtime state.
 
     Attributes:
-        device_path: Path of the Device-DAX device backing this arena.
+        device_path: Canonical path (symlinks resolved) of the device backing
+            this arena.
         size_in_bytes: Mapped size of the arena in bytes.
         used_bytes: Bytes currently handed out to live allocations.
         free_bytes: Bytes still available for allocation.
@@ -88,7 +239,9 @@ class _DevDaxArena:
     :class:`TensorMemoryAllocator`. Allocations carry the owning
     :class:`DevDaxMemoryAllocator` as their parent; frees are routed back to the
     correct arena by locating the arena whose ``[base_ptr, base_ptr + size)``
-    range contains the object's data pointer.
+    range contains the object's data pointer. ``identity`` records which
+    backing device the mmap was opened on, so a second mapping of the same
+    device under another path is refused.
     """
 
     device_path: str
@@ -99,6 +252,7 @@ class _DevDaxArena:
     buffer: torch.Tensor
     allocator: TensorMemoryAllocator
     is_primary: bool
+    identity: _DeviceIdentity
     state: DevDaxArenaState = DevDaxArenaState.ACTIVE
     pinned_ptr: int | None = None
     # Captured at map time so ``contains`` stays correct after a deferred
@@ -193,7 +347,9 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
         # Primary (non-removable) only in pure Device-DAX mode. The constructor
         # runs single-threaded, so no lock is needed here.
         self._map_and_append_arena(
-            device_path, size, is_primary=self.local_allocator is None
+            os.path.realpath(device_path),
+            size,
+            is_primary=self.local_allocator is None,
         )
 
     @property
@@ -235,13 +391,55 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
         self,
         device_path: str,
         size: int,
-    ) -> tuple[int, mmap.mmap, Any, torch.Tensor]:
+    ) -> tuple[int, mmap.mmap, Any, torch.Tensor, _DeviceIdentity]:
+        """Validate and map one Device-DAX arena.
+
+        Character devices are validated against DAX sysfs metadata. Regular
+        files are supported as test backings.
+
+        Args:
+            device_path: Path to the Device-DAX device.
+            size: Number of bytes to map.
+
+        Returns:
+            The mapping resources and identity of the opened device.
+
+        Raises:
+            ValueError: If the arguments or device metadata are invalid.
+            RuntimeError: If the requested size exceeds the device capacity.
+            OSError: If the device cannot be opened or mapped read-write.
+        """
+        if not device_path:
+            raise ValueError("device_path must be a non-empty string")
+        if size <= 0:
+            raise ValueError("size_in_bytes must be > 0")
         fd: int | None = None
         mmap_obj: mmap.mmap | None = None
         try:
             fd = os.open(device_path, os.O_RDWR)
-            capacity = os.fstat(fd).st_size
-            if capacity > 0 and size > capacity:
+            fd_status = os.fstat(fd)
+            identity = _DeviceIdentity.from_stat(fd_status)
+            if not identity.is_char_device and not stat.S_ISREG(fd_status.st_mode):
+                raise ValueError(
+                    f"{device_path} is neither a character device nor a regular file"
+                )
+            # ``fstat`` reports 0 for character devices: capacity unknown.
+            capacity: int | None = fd_status.st_size or None
+            if identity.is_char_device:
+                device_dir = _resolve_dax_device_dir(device_path, fd_status.st_rdev)
+                align = _sysfs_attr_int(device_dir, "align")
+                capacity = _sysfs_attr_int(device_dir, "size")
+                if not align or not capacity:
+                    raise ValueError(
+                        f"cannot verify {device_path}: DAX sysfs attributes are "
+                        f"unreadable or zero (align={align}, size={capacity})"
+                    )
+                if size % align != 0:
+                    raise ValueError(
+                        f"size ({size}) must be a multiple of the device "
+                        f"alignment ({align})"
+                    )
+            if capacity is not None and size > capacity:
                 raise RuntimeError(
                     f"l1 devdax size ({size} bytes) exceeds "
                     f"{device_path} capacity ({capacity} bytes)"
@@ -256,7 +454,7 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
             array_type = ctypes.c_uint8 * size
             mmap_buffer = array_type.from_buffer(mmap_obj)
             buffer = torch.frombuffer(mmap_buffer, dtype=torch.uint8)
-            return fd, mmap_obj, mmap_buffer, buffer
+            return fd, mmap_obj, mmap_buffer, buffer, identity
         except Exception:
             if mmap_obj is not None:
                 mmap_obj.close()
@@ -286,12 +484,26 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
             The newly mapped arena.
 
         Raises:
+            ValueError: If the mapping arguments are invalid, the device is not
+                a Device-DAX device, the size violates the device's advertised
+                alignment, or the same device is already mapped under another
+                path.
             RuntimeError: If the device capacity is smaller than ``size``.
             OSError: If the device cannot be opened or mapped.
         """
-        fd, mmap_obj, mmap_buffer, buffer = self._open_devdax_mapping(device_path, size)
+        fd, mmap_obj, mmap_buffer, buffer, identity = self._open_devdax_mapping(
+            device_path, size
+        )
         arena: _DevDaxArena | None = None
         try:
+            # Authoritative duplicate check: the opened device, not the path
+            # string, decides whether this device is already in the pool.
+            for mapped in self._arenas:
+                if mapped.identity == identity:
+                    raise ValueError(
+                        f"Device-DAX arena {device_path} is already mapped "
+                        f"as {mapped.device_path}"
+                    )
             allocator = TensorMemoryAllocator(buffer, align_bytes=self.align_bytes)
             arena = _DevDaxArena(
                 device_path=device_path,
@@ -302,6 +514,7 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
                 buffer=buffer,
                 allocator=allocator,
                 is_primary=is_primary,
+                identity=identity,
             )
             self._register_arena_pin(arena)
         except Exception:
@@ -361,15 +574,45 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
         ]
 
     def _find_arena_locked(self, device_path: str) -> _DevDaxArena:
-        """Return the arena mapped at ``device_path``. Caller holds the lock.
+        """Return the arena backed by the device at ``device_path``.
+
+        The node's current identity decides: any alias of a mapped device
+        resolves to its arena, and a different device that now sits at a
+        mapped path is not found. The canonical path recorded at map time is
+        consulted only when ``stat`` reports that the node is missing. A
+        spelling the OS cannot interpret (for example one with an embedded NUL
+        byte) names nothing and is a lookup miss. The caller holds the lock.
 
         Raises:
-            ValueError: If no arena is mapped at ``device_path``.
+            DevDaxNotMappedError: If no arena is mapped at ``device_path``.
         """
-        for arena in self._arenas:
-            if arena.device_path == device_path:
-                return arena
-        raise ValueError(f"no Device-DAX arena mapped at {device_path}")
+        try:
+            path_status = os.stat(device_path)
+        except ValueError:
+            # ``os.stat`` raises ValueError, not OSError, for a path the OS
+            # cannot interpret (embedded NUL byte): nothing can be mapped
+            # there, so report a miss rather than let the error escape.
+            raise DevDaxNotMappedError(
+                f"no Device-DAX arena mapped at {device_path!r}"
+            ) from None
+        except FileNotFoundError:
+            identity = None
+        except OSError:
+            raise DevDaxNotMappedError(
+                f"no Device-DAX arena mapped at {device_path!r}"
+            ) from None
+        else:
+            identity = _DeviceIdentity.from_stat(path_status)
+        if identity is not None:
+            for arena in self._arenas:
+                if arena.identity == identity:
+                    return arena
+        else:
+            canonical = os.path.realpath(device_path)
+            for arena in self._arenas:
+                if arena.device_path == canonical:
+                    return arena
+        raise DevDaxNotMappedError(f"no Device-DAX arena mapped at {device_path}")
 
     def _arena_for_obj_locked(self, memory_obj: MemoryObj) -> _DevDaxArena:
         """Return the arena that owns ``memory_obj``. Caller holds the lock.
@@ -713,7 +956,8 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
 
         Args:
             device_path: Path to a readable and writable Device-DAX device that
-                is not already mapped by this allocator.
+                is not already mapped by this allocator under any alias. The
+                arena records the canonical path.
             size_in_bytes: Number of bytes to map from the device.
 
         Returns:
@@ -721,24 +965,35 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
 
         Raises:
             ValueError: If ``device_path`` is empty, ``size_in_bytes`` is not
-                positive, or the device is already mapped.
+                positive, the device is already mapped, the character device
+                is not a Device-DAX device, or the mapping violates the
+                device's advertised alignment.
             RuntimeError: If the allocator is closed or the device capacity is
                 smaller than ``size_in_bytes``.
             OSError: If the device cannot be opened or mapped.
         """
         if not device_path:
             raise ValueError("device_path must be a non-empty string")
-        if size_in_bytes <= 0:
-            raise ValueError("size_in_bytes must be > 0")
+        device_path = os.path.realpath(device_path)
         with self.host_mem_lock:
             if self._unregistered:
                 raise RuntimeError(
                     "cannot add a device to a closed DevDaxMemoryAllocator"
                 )
+            # Refuse a duplicate before open + mmap when the node can be
+            # inspected; the opened fd is checked again in
+            # _map_and_append_arena, which is the authoritative check.
+            try:
+                identity: _DeviceIdentity | None = _DeviceIdentity.from_stat(
+                    os.stat(device_path)
+                )
+            except OSError:
+                identity = None
             for arena in self._arenas:
-                if arena.device_path == device_path:
+                if identity is not None and arena.identity == identity:
                     raise ValueError(
-                        f"Device-DAX arena {device_path} is already mapped"
+                        f"Device-DAX arena {device_path} is already mapped "
+                        f"as {arena.device_path}"
                     )
             arena = self._map_and_append_arena(
                 device_path, size_in_bytes, is_primary=False
@@ -757,7 +1012,7 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
         automatically once its last allocation is freed.
 
         Args:
-            device_path: Path of the arena to remove.
+            device_path: Path (or any alias) of the arena to remove.
             mode: Removal strategy. Only :attr:`DevDaxRemoveMode.DRAIN` is
                 supported.
 
@@ -771,6 +1026,8 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
         """
         if mode != DevDaxRemoveMode.DRAIN:
             raise ValueError(f"unsupported Device-DAX L1 remove mode: {mode}")
+        if not device_path:
+            raise DevDaxNotMappedError("no Device-DAX arena mapped at ''")
         with self.host_mem_lock:
             arena = self._find_arena_locked(device_path)
             if arena.is_primary:
@@ -785,6 +1042,27 @@ class DevDaxMemoryAllocator(MemoryAllocatorInterface):
         """Return a status snapshot of every arena currently in the pool."""
         with self.host_mem_lock:
             return [arena.status() for arena in self._arenas]
+
+    def arena_status(self, device_path: str) -> DevDaxArenaStatus:
+        """Return the status of the arena mapped at ``device_path``.
+
+        Any alias of the mapped device (a symlink, another spelling, a hard
+        link, or a second node with the same device number) resolves to the
+        same arena; a different device at a mapped path does not.
+
+        Args:
+            device_path: Path of the arena to look up.
+
+        Returns:
+            The arena's current status.
+
+        Raises:
+            DevDaxNotMappedError: If no arena is mapped at ``device_path``.
+        """
+        if not device_path:
+            raise DevDaxNotMappedError("no Device-DAX arena mapped at ''")
+        with self.host_mem_lock:
+            return self._find_arena_locked(device_path).status()
 
     def memcheck(self) -> bool:
         local_ok = True

--- a/lmcache/v1/mp_coordinator/api.py
+++ b/lmcache/v1/mp_coordinator/api.py
@@ -31,8 +31,8 @@ class CacheEventType(str, Enum):
     ``STORE`` commits placements; ``DELETE`` removes them (owners report
     evictions as deletes); ``ACCESS`` refreshes recency and counts a use
     without changing placement state. ``CONFIG`` carries no placement at
-    all: it declares one compartment's configured capacity, so the fleet
-    view has a denominator for the bytes the other three report.
+    all: it declares one compartment's declared usable capacity, so the
+    fleet view has a denominator for the bytes the other three report.
     """
 
     STORE = "store"

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -57,10 +57,10 @@ class EventType(Enum):
     # L2 Eviction Controller events
     L2_KEYS_EVICTED = "l2.keys.evicted"
 
-    # L2 adapter key-level events.
-    # Capacity topology changed (adapter added/removed/reconfigured).
+    # StorageManager capacity topology changed (L1 arena or L2 adapter).
     SM_CAPACITY_CHANGED = "sm.capacity.changed"
 
+    # L2 adapter key-level events.
     L2_KEYS_STORED = "l2.keys.stored"
     L2_KEYS_ACCESSED = "l2.keys.accessed"
     L2_KEYS_DELETED = "l2.keys.deleted"

--- a/lmcache/v1/multiprocess/http_apis/config_api.py
+++ b/lmcache/v1/multiprocess/http_apis/config_api.py
@@ -79,7 +79,7 @@ async def list_adapters(request: Request) -> dict[str, object]:
         dict[str, object]: ``{"adapters": [{"index", "type_name", "tier",
         "primary", "reconfigurable"}, ...]}``. Pass a ``reconfigurable``
         adapter's ``type_name`` as the ``{backend}`` path parameter to
-        ``GET /reconfigure/l2/{backend}/status`` and the reconfigure operations.
+        ``GET /reconfigure/{backend}/l2/status`` and the reconfigure operations.
 
     Raises:
         HTTPException: ``503`` if the engine context is not initialized yet.

--- a/lmcache/v1/multiprocess/http_apis/config_api.py
+++ b/lmcache/v1/multiprocess/http_apis/config_api.py
@@ -79,7 +79,7 @@ async def list_adapters(request: Request) -> dict[str, object]:
         dict[str, object]: ``{"adapters": [{"index", "type_name", "tier",
         "primary", "reconfigurable"}, ...]}``. Pass a ``reconfigurable``
         adapter's ``type_name`` as the ``{backend}`` path parameter to
-        ``GET /reconfigure/{backend}/status`` and the reconfigure operations.
+        ``GET /reconfigure/l2/{backend}/status`` and the reconfigure operations.
 
     Raises:
         HTTPException: ``503`` if the engine context is not initialized yet.

--- a/lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py
+++ b/lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime Device-DAX L1 reconfiguration endpoints for MP mode.
+
+See ``docs/source/mp/http_api.rst`` for the public HTTP contract and
+``docs/design/v1/distributed/memory_manager/device-dax-l1.md`` for design details.
+"""
+
+# Standard
+from dataclasses import asdict
+from typing import Protocol, cast
+
+# Third Party
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
+from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaStatus,
+    DevDaxRemoveMode,
+)
+from lmcache.v1.multiprocess.http_apis.reconfigure_schemas import (
+    SIZE_ERROR,
+    SizeRequest,
+    get_engine_from_request,
+    reconfigure_error_response,
+    resolve_size_bytes,
+)
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+class _StorageManagerLike(Protocol):
+    def get_l1_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]: ...
+
+    def add_l1_devdax_device(
+        self,
+        device_path: str,
+        size_in_bytes: int,
+    ) -> DevDaxArenaStatus: ...
+
+    def remove_l1_devdax_device(
+        self,
+        device_path: str,
+        mode: DevDaxRemoveMode,
+    ) -> DevDaxArenaStatus: ...
+
+
+class L1DaxAddRequest(BaseModel):
+    """Request body for ``POST /reconfigure/l1/dax/add``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    device_path: str
+    size: SizeRequest
+
+
+class L1DaxRemoveRequest(BaseModel):
+    """Request body for ``POST /reconfigure/l1/dax/remove``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    device_path: str
+    mode: DevDaxRemoveMode = DevDaxRemoveMode.DRAIN
+
+
+def _get_storage_manager(request: Request) -> _StorageManagerLike | JSONResponse:
+    """Resolve the storage manager used by the L1 reconfigure routes.
+
+    Args:
+        request: Incoming request whose application state holds the engine.
+
+    Returns:
+        The storage manager, or a 503 response before engine initialization.
+    """
+    engine = get_engine_from_request(request)
+    if engine is None:
+        return JSONResponse(
+            status_code=503, content={"error": "engine not initialized"}
+        )
+    storage_manager = getattr(engine, "storage_manager", None)
+    if storage_manager is None:
+        return JSONResponse(
+            status_code=503, content={"error": "engine not initialized"}
+        )
+    return cast(_StorageManagerLike, storage_manager)
+
+
+def _arena_dict(status: DevDaxArenaStatus) -> dict[str, object]:
+    """Convert an arena status to a JSON-safe dictionary.
+
+    Args:
+        status: Arena status returned by the Device-DAX L1 manager.
+
+    Returns:
+        The arena fields with the lifecycle state represented as a string.
+    """
+    d = asdict(status)
+    d["state"] = status.state.value
+    return d
+
+
+def _device_dict(
+    device_path: str, arenas: list[DevDaxArenaStatus]
+) -> dict[str, object]:
+    """Build the device-level response envelope.
+
+    Args:
+        device_path: Path identifying the mapped Device-DAX device.
+        arenas: Arena statuses associated with the device operation.
+
+    Returns:
+        A JSON-safe device object containing its arena statuses.
+    """
+    return {
+        "device_path": device_path,
+        "arenas": [_arena_dict(arena) for arena in arenas],
+    }
+
+
+@router.get("/reconfigure/l1/dax/status")
+async def l1_dax_status(request: Request) -> JSONResponse:
+    """Return Device-DAX L1 arena status.
+
+    Args:
+        request: Incoming request used to resolve the running engine.
+
+    Returns:
+        A response containing the arena statuses or a mapped error.
+    """
+    storage_manager = _get_storage_manager(request)
+    if isinstance(storage_manager, JSONResponse):
+        return storage_manager
+    try:
+        statuses = storage_manager.get_l1_devdax_arena_statuses()
+    except L1ReconfigureError as exc:
+        return reconfigure_error_response(exc)
+    return JSONResponse(
+        status_code=200,
+        content={"arenas": [_arena_dict(status) for status in statuses]},
+    )
+
+
+@router.post("/reconfigure/l1/dax/add")
+async def l1_dax_add(
+    body: L1DaxAddRequest,
+    request: Request,
+) -> JSONResponse:
+    """Add a Device-DAX device to the L1 arena pool.
+
+    Args:
+        body: Device path and mapped size requested by the client.
+        request: Incoming request used to resolve the running engine.
+
+    Returns:
+        A response containing the added arena status or a mapped error.
+    """
+    storage_manager = _get_storage_manager(request)
+    if isinstance(storage_manager, JSONResponse):
+        return storage_manager
+    try:
+        size_bytes = resolve_size_bytes(body.size)
+    except ValueError:
+        return JSONResponse(status_code=400, content={"error": SIZE_ERROR})
+    try:
+        status = storage_manager.add_l1_devdax_device(body.device_path, size_bytes)
+    except L1ReconfigureError as exc:
+        logger.warning("l1 dax add failed for %s: %s", body.device_path, exc)
+        return reconfigure_error_response(exc)
+    return JSONResponse(status_code=200, content={"added": _arena_dict(status)})
+
+
+@router.post("/reconfigure/l1/dax/remove")
+async def l1_dax_remove(
+    body: L1DaxRemoveRequest,
+    request: Request,
+) -> JSONResponse:
+    """Remove a Device-DAX device using the currently supported drain mode.
+
+    The response envelope reports the arena's canonical path, which may differ
+    from the alias used in the request.
+
+    Args:
+        body: Device path and removal mode requested by the client.
+        request: Incoming request used to resolve the running engine.
+
+    Returns:
+        A response containing the removed arena status or a mapped error.
+    """
+    storage_manager = _get_storage_manager(request)
+    if isinstance(storage_manager, JSONResponse):
+        return storage_manager
+    try:
+        status = storage_manager.remove_l1_devdax_device(body.device_path, body.mode)
+    except L1ReconfigureError as exc:
+        logger.warning("l1 dax remove failed for %s: %s", body.device_path, exc)
+        return reconfigure_error_response(exc)
+    return JSONResponse(
+        status_code=200,
+        content={"removed": _device_dict(status.device_path, [status])},
+    )

--- a/lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py
+++ b/lmcache/v1/multiprocess/http_apis/l1_reconfigure_api.py
@@ -53,7 +53,7 @@ class _StorageManagerLike(Protocol):
 
 
 class L1DaxAddRequest(BaseModel):
-    """Request body for ``POST /reconfigure/l1/dax/add``."""
+    """Request body for ``POST /reconfigure/dax/l1/add``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -62,7 +62,7 @@ class L1DaxAddRequest(BaseModel):
 
 
 class L1DaxRemoveRequest(BaseModel):
-    """Request body for ``POST /reconfigure/l1/dax/remove``."""
+    """Request body for ``POST /reconfigure/dax/l1/remove``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -124,7 +124,7 @@ def _device_dict(
     }
 
 
-@router.get("/reconfigure/l1/dax/status")
+@router.get("/reconfigure/dax/l1/status")
 async def l1_dax_status(request: Request) -> JSONResponse:
     """Return Device-DAX L1 arena status.
 
@@ -147,7 +147,7 @@ async def l1_dax_status(request: Request) -> JSONResponse:
     )
 
 
-@router.post("/reconfigure/l1/dax/add")
+@router.post("/reconfigure/dax/l1/add")
 async def l1_dax_add(
     body: L1DaxAddRequest,
     request: Request,
@@ -176,7 +176,7 @@ async def l1_dax_add(
     return JSONResponse(status_code=200, content={"added": _arena_dict(status)})
 
 
-@router.post("/reconfigure/l1/dax/remove")
+@router.post("/reconfigure/dax/l1/remove")
 async def l1_dax_remove(
     body: L1DaxRemoveRequest,
     request: Request,

--- a/lmcache/v1/multiprocess/http_apis/reconfigure_api.py
+++ b/lmcache/v1/multiprocess/http_apis/reconfigure_api.py
@@ -39,7 +39,7 @@ class _EngineLike(Protocol):
 
 
 class GenericReconfigureRequest(BaseModel):
-    """Request body for generic ``POST /reconfigure/{backend}/{operation}``."""
+    """Request body for generic ``POST /reconfigure/l2/{backend}/{operation}``."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -47,7 +47,7 @@ class GenericReconfigureRequest(BaseModel):
 
 
 class DaxAddRequest(BaseModel):
-    """Request body for ``POST /reconfigure/dax/add``."""
+    """Request body for ``POST /reconfigure/l2/dax/add``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -57,7 +57,7 @@ class DaxAddRequest(BaseModel):
 
 
 class DaxRemoveRequest(BaseModel):
-    """Request body for ``POST /reconfigure/dax/remove``."""
+    """Request body for ``POST /reconfigure/l2/dax/remove``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -68,7 +68,7 @@ class DaxRemoveRequest(BaseModel):
 
 
 class DaxResizeRequest(BaseModel):
-    """Request body for ``POST /reconfigure/dax/resize``."""
+    """Request body for ``POST /reconfigure/l2/dax/resize``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -233,7 +233,7 @@ def _operation_payload(
     return _generic_operation_payload(payload)
 
 
-@router.get("/reconfigure/{backend}/status", response_model=None)
+@router.get("/reconfigure/l2/{backend}/status", response_model=None)
 async def reconfigure_status(backend: str, request: Request) -> dict | JSONResponse:
     """Return runtime reconfiguration status for one backend type."""
     sm = _get_storage_manager(request)
@@ -247,7 +247,7 @@ async def reconfigure_status(backend: str, request: Request) -> dict | JSONRespo
         return reconfigure_error_response(exc)
 
 
-@router.post("/reconfigure/{backend}/{operation}", response_model=None)
+@router.post("/reconfigure/l2/{backend}/{operation}", response_model=None)
 async def reconfigure_backend(
     backend: str,
     operation: str,

--- a/lmcache/v1/multiprocess/http_apis/reconfigure_api.py
+++ b/lmcache/v1/multiprocess/http_apis/reconfigure_api.py
@@ -39,7 +39,7 @@ class _EngineLike(Protocol):
 
 
 class GenericReconfigureRequest(BaseModel):
-    """Request body for generic ``POST /reconfigure/l2/{backend}/{operation}``."""
+    """Request body for generic ``POST /reconfigure/{backend}/l2/{operation}``."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -47,7 +47,7 @@ class GenericReconfigureRequest(BaseModel):
 
 
 class DaxAddRequest(BaseModel):
-    """Request body for ``POST /reconfigure/l2/dax/add``."""
+    """Request body for ``POST /reconfigure/dax/l2/add``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -57,7 +57,7 @@ class DaxAddRequest(BaseModel):
 
 
 class DaxRemoveRequest(BaseModel):
-    """Request body for ``POST /reconfigure/l2/dax/remove``."""
+    """Request body for ``POST /reconfigure/dax/l2/remove``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -68,7 +68,7 @@ class DaxRemoveRequest(BaseModel):
 
 
 class DaxResizeRequest(BaseModel):
-    """Request body for ``POST /reconfigure/l2/dax/resize``."""
+    """Request body for ``POST /reconfigure/dax/l2/resize``."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -233,7 +233,7 @@ def _operation_payload(
     return _generic_operation_payload(payload)
 
 
-@router.get("/reconfigure/l2/{backend}/status", response_model=None)
+@router.get("/reconfigure/{backend}/l2/status", response_model=None)
 async def reconfigure_status(backend: str, request: Request) -> dict | JSONResponse:
     """Return runtime reconfiguration status for one backend type."""
     sm = _get_storage_manager(request)
@@ -247,7 +247,7 @@ async def reconfigure_status(backend: str, request: Request) -> dict | JSONRespo
         return reconfigure_error_response(exc)
 
 
-@router.post("/reconfigure/l2/{backend}/{operation}", response_model=None)
+@router.post("/reconfigure/{backend}/l2/{operation}", response_model=None)
 async def reconfigure_backend(
     backend: str,
     operation: str,

--- a/lmcache/v1/multiprocess/http_apis/reconfigure_api.py
+++ b/lmcache/v1/multiprocess/http_apis/reconfigure_api.py
@@ -2,7 +2,6 @@
 """Runtime L2 adapter reconfiguration endpoints for MP mode."""
 
 # Standard
-from decimal import Decimal
 from typing import Literal, Protocol, cast
 
 # Third Party
@@ -12,28 +11,16 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 # First Party
 from lmcache.v1.distributed.l2_adapters.reconfiguration import L2ReconfigureError
+from lmcache.v1.multiprocess.http_apis.reconfigure_schemas import (
+    SIZE_ERROR,
+    SizeRequest,
+    get_engine_from_request,
+    reconfigure_error_response,
+    resolve_size_bytes,
+    validation_error_response,
+)
 
 router = APIRouter()
-
-_MAX_SIZE_STRING_LEN = 64
-_SIZE_ERROR = "size must be a positive integer byte count or a string like '100GiB'"
-_SIZE_UNITS = {
-    "": 1,
-    "b": 1,
-    "k": 1024,
-    "kb": 1024,
-    "kib": 1024,
-    "m": 1024**2,
-    "mb": 1024**2,
-    "mib": 1024**2,
-    "g": 1024**3,
-    "gb": 1024**3,
-    "gib": 1024**3,
-    "t": 1024**4,
-    "tb": 1024**4,
-    "tib": 1024**4,
-}
-SizeRequest = int | str
 
 
 class _StorageManagerLike(Protocol):
@@ -93,58 +80,13 @@ class DaxResizeRequest(BaseModel):
 
 
 def _get_storage_manager(request: Request) -> _StorageManagerLike | JSONResponse:
-    engine = getattr(request.app.state, "engine", None)
+    engine = get_engine_from_request(request)
     if engine is None:
         return JSONResponse(
             status_code=503,
             content={"error": "engine not initialized"},
         )
     return cast(_EngineLike, engine).storage_manager
-
-
-def _parse_size_string(size: str) -> int:
-    text = size.strip()
-    if not text or len(text) > _MAX_SIZE_STRING_LEN:
-        raise ValueError(_SIZE_ERROR)
-
-    unit_start = len(text)
-    while unit_start > 0 and text[unit_start - 1].isalpha():
-        unit_start -= 1
-
-    value_text = text[:unit_start].strip()
-    unit = text[unit_start:].lower()
-    if unit not in _SIZE_UNITS:
-        raise ValueError(_SIZE_ERROR)
-    if "." in value_text:
-        whole, fraction = value_text.split(".", 1)
-        if not whole or not fraction:
-            raise ValueError(_SIZE_ERROR)
-        if not whole.isdigit() or not fraction.isdigit():
-            raise ValueError(_SIZE_ERROR)
-    elif not value_text.isdigit():
-        raise ValueError(_SIZE_ERROR)
-
-    value = Decimal(value_text)
-    if value <= 0:
-        raise ValueError(_SIZE_ERROR)
-    return int(value * _SIZE_UNITS[unit])
-
-
-def _resolve_size_bytes(size: SizeRequest) -> int:
-    if isinstance(size, bool):
-        raise ValueError(_SIZE_ERROR)
-    resolved = size if isinstance(size, int) else _parse_size_string(size)
-    if resolved <= 0:
-        raise ValueError(_SIZE_ERROR)
-    return resolved
-
-
-def _api_error_response(exc: L2ReconfigureError) -> JSONResponse:
-    return JSONResponse(status_code=exc.status_code, content=exc.payload)
-
-
-def _validation_error_response(exc: ValidationError) -> JSONResponse:
-    return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
 
 def _normalize_backend(backend: str) -> str:
@@ -223,9 +165,9 @@ def _dax_operation_payload(
         if operation == "add":
             add_body = DaxAddRequest.model_validate(payload)
             try:
-                size_bytes = _resolve_size_bytes(add_body.size)
+                size_bytes = resolve_size_bytes(add_body.size)
             except ValueError:
-                return JSONResponse(status_code=400, content={"error": _SIZE_ERROR})
+                return JSONResponse(status_code=400, content={"error": SIZE_ERROR})
             return (
                 add_body.adapter_index,
                 {
@@ -248,9 +190,9 @@ def _dax_operation_payload(
         if operation == "resize":
             resize_body = DaxResizeRequest.model_validate(payload)
             try:
-                size_bytes = _resolve_size_bytes(resize_body.size)
+                size_bytes = resolve_size_bytes(resize_body.size)
             except ValueError:
-                return JSONResponse(status_code=400, content={"error": _SIZE_ERROR})
+                return JSONResponse(status_code=400, content={"error": SIZE_ERROR})
             return (
                 resize_body.adapter_index,
                 {
@@ -261,7 +203,7 @@ def _dax_operation_payload(
                 },
             )
     except ValidationError as exc:
-        return _validation_error_response(exc)
+        return validation_error_response(exc)
 
     raise L2ReconfigureError(
         400,
@@ -275,7 +217,7 @@ def _generic_operation_payload(
     try:
         body = GenericReconfigureRequest.model_validate(payload)
     except ValidationError as exc:
-        return _validation_error_response(exc)
+        return validation_error_response(exc)
 
     operation_payload = dict(body.model_extra or {})
     return body.adapter_index, operation_payload
@@ -302,7 +244,7 @@ async def reconfigure_status(backend: str, request: Request) -> dict | JSONRespo
         status = sm.get_l2_adapter_reconfigure_status()
         return _backend_status_response(status, normalized_backend)
     except L2ReconfigureError as exc:
-        return _api_error_response(exc)
+        return reconfigure_error_response(exc)
 
 
 @router.post("/reconfigure/{backend}/{operation}", response_model=None)
@@ -334,4 +276,4 @@ async def reconfigure_backend(
             operation_payload,
         )
     except L2ReconfigureError as exc:
-        return _api_error_response(exc)
+        return reconfigure_error_response(exc)

--- a/lmcache/v1/multiprocess/http_apis/reconfigure_schemas.py
+++ b/lmcache/v1/multiprocess/http_apis/reconfigure_schemas.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared wire vocabulary for the ``/reconfigure`` endpoint family.
+
+Human-friendly size parsing, the family's error-response helpers, and engine
+lookup, shared by the family's route modules so every tier follows one wire
+contract.
+
+The family error contract implemented by these helpers:
+
+- request-schema violations -> ``422 {"detail": [...]}`` (the same outer
+  response envelope FastAPI's own validation produces);
+- value errors on well-formed fields (size strings) -> ``400 {"error": ...}``;
+- domain errors -> the status carried by the raised reconfigure error
+  (404 lookup miss, 409 state conflict, ...), body ``{"error": ...}`` unless
+  the error supplies its own payload.
+"""
+
+# Standard
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Protocol, TypeAlias
+
+# Third Party
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from pydantic import StrictInt, ValidationError
+
+SIZE_ERROR = "size must be a positive integer byte count or a string like '100GiB'"
+# Strict on the wire: JSON booleans and floats are schema violations (422),
+# never silently coerced into byte counts.
+SizeRequest: TypeAlias = StrictInt | str
+
+_MAX_SIZE_STRING_LEN = 64
+_SIZE_UNITS = {
+    "": 1,
+    "b": 1,
+    "k": 1024,
+    "kb": 1024,
+    "kib": 1024,
+    "m": 1024**2,
+    "mb": 1024**2,
+    "mib": 1024**2,
+    "g": 1024**3,
+    "gb": 1024**3,
+    "gib": 1024**3,
+    "t": 1024**4,
+    "tb": 1024**4,
+    "tib": 1024**4,
+}
+
+
+class _ReconfigureErrorLike(Protocol):
+    """Shape shared by the tiers' HTTP-mappable reconfiguration errors."""
+
+    @property
+    def status_code(self) -> int:
+        """Return the HTTP status carried by the domain error."""
+        ...
+
+    @property
+    def payload(self) -> Mapping[str, object]:
+        """Return the JSON object carried by the domain error."""
+        ...
+
+
+def parse_size_string(size: str) -> int:
+    """Parse a human-friendly size string into a byte count.
+
+    Args:
+        size: A size such as ``"100GiB"``, ``"512mb"``, or ``"1048576"``.
+            Decimal values (``"1.5GiB"``) are accepted; the unit suffix is
+            case-insensitive and binary (1024-based).
+
+    Returns:
+        The size in bytes.
+
+    Raises:
+        ValueError: If the string cannot be parsed or is not positive.
+    """
+    text = size.strip()
+    if not text or len(text) > _MAX_SIZE_STRING_LEN:
+        raise ValueError(SIZE_ERROR)
+
+    unit_start = len(text)
+    while unit_start > 0 and text[unit_start - 1].isalpha():
+        unit_start -= 1
+
+    value_text = text[:unit_start].strip()
+    unit = text[unit_start:].lower()
+    if unit not in _SIZE_UNITS:
+        raise ValueError(SIZE_ERROR)
+    if "." in value_text:
+        whole, fraction = value_text.split(".", 1)
+        if not whole or not fraction:
+            raise ValueError(SIZE_ERROR)
+        if not whole.isdigit() or not fraction.isdigit():
+            raise ValueError(SIZE_ERROR)
+    elif not value_text.isdigit():
+        raise ValueError(SIZE_ERROR)
+
+    value = Decimal(value_text)
+    if value <= 0:
+        raise ValueError(SIZE_ERROR)
+    return int(value * _SIZE_UNITS[unit])
+
+
+def resolve_size_bytes(size: SizeRequest) -> int:
+    """Resolve a wire-level size value into a positive byte count.
+
+    Args:
+        size: A positive integer byte count or a size string accepted by
+            :func:`parse_size_string`.
+
+    Returns:
+        The size in bytes.
+
+    Raises:
+        ValueError: If the value is not a positive size.
+    """
+    if isinstance(size, bool):
+        raise ValueError(SIZE_ERROR)
+    resolved = size if isinstance(size, int) else parse_size_string(size)
+    if resolved <= 0:
+        raise ValueError(SIZE_ERROR)
+    return resolved
+
+
+def validation_error_response(exc: ValidationError) -> JSONResponse:
+    """Return the family's 422 response for a request-schema violation.
+
+    Args:
+        exc: The validation error raised by a request model.
+
+    Returns:
+        A 422 response whose body is ``{"detail": [...]}`` -- the same outer
+        response envelope FastAPI's own request validation produces.
+    """
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
+
+def reconfigure_error_response(exc: _ReconfigureErrorLike) -> JSONResponse:
+    """Return the response for an HTTP-mappable reconfiguration error.
+
+    Args:
+        exc: A domain error carrying an HTTP ``status_code`` and a JSON
+            ``payload``.
+
+    Returns:
+        A response with the error's status code and its payload as the body.
+    """
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
+
+
+def get_engine_from_request(request: Request) -> object | None:
+    """Return the app's engine, or ``None`` before engine initialization.
+
+    Args:
+        request: The FastAPI request whose app state holds the engine.
+
+    Returns:
+        The engine object, or ``None`` while the server is still starting up.
+    """
+    return getattr(request.app.state, "engine", None)

--- a/tests/v1/distributed/test_dax_l2_adapter.py
+++ b/tests/v1/distributed/test_dax_l2_adapter.py
@@ -29,6 +29,7 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import AdapterUsage, L2AdapterInterface
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
@@ -468,16 +469,18 @@ def _wire_capacity_publishing(sm: StorageManager) -> None:
     """Give a bare StorageManager the state its capacity publish needs.
 
     Reconfiguring an adapter also announces the new topology, which reads
-    the L1 config, the adapter descriptors, and the event bus.
+    the L1 manager, the adapter descriptors, and the event bus.
 
     Args:
         sm: The partially-constructed storage manager to wire up.
     """
     sm._lifecycle_lock = threading.Lock()
+    sm._capacity_publish_lock = threading.Lock()
     sm._event_bus = cast(EventBus, _RecordingBus())
     # Declares no L1, keeping these tests about the L2 path.
-    sm._l1_config = L1ManagerConfig(
-        memory_config=L1MemoryManagerConfig(size_in_bytes=0, use_lazy=True)
+    sm._l1_manager = cast(
+        L1Manager,
+        SimpleNamespace(get_capacity_bytes_by_backend=lambda: {}),
     )
     if not hasattr(sm, "_adapter_descriptors"):
         sm._adapter_descriptors = {

--- a/tests/v1/distributed/test_devdax_l1_allocator.py
+++ b/tests/v1/distributed/test_devdax_l1_allocator.py
@@ -28,6 +28,7 @@ from lmcache.v1.distributed.config import (
     StorageManagerConfig,
     add_storage_manager_args,
     parse_args_to_config,
+    requires_single_l1_memory_region,
 )
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
@@ -36,9 +37,21 @@ from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
     get_type_name_for_config,
 )
+from lmcache.v1.distributed.l2_adapters.dax_l2_adapter import (
+    DaxDeviceConfig,
+    DaxL2AdapterConfig,
+)
+from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
+    FaultInjectL2AdapterConfig,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConfig
 from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
     DevDaxL1MemoryManager,
 )
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
 from lmcache.v1.memory_allocators.devdax_memory_allocator import (
     DevDaxArenaState,
     DevDaxMemoryAllocator,
@@ -785,6 +798,272 @@ def test_l1_manager_round_trip_on_devdax_mapping(tmp_path):
         assert f.read(1) == bytes([0x23])
 
 
+def test_storage_manager_routes_l1_devdax_reconfigure(tmp_path: Path) -> None:
+    primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
+    extra = _make_mmap_file(tmp_path, size=4096, name="extra.bin")
+    storage_manager = StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=L1ManagerConfig(
+                memory_config=L1MemoryManagerConfig(
+                    size_in_bytes=4096,
+                    use_lazy=False,
+                    shm_name="",
+                    align_bytes=4096,
+                    devdax_path=primary,
+                )
+            ),
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+        )
+    )
+    try:
+        (primary_status,) = storage_manager.get_l1_devdax_arena_statuses()
+        assert primary_status.device_path == primary
+        assert primary_status.is_primary is True
+
+        # An uninterpretable user path is a 404 lookup miss through the full
+        # manager chain rather than an unhandled 500.
+        with pytest.raises(L1ReconfigureError) as nul_lookup_miss:
+            storage_manager.remove_l1_devdax_device(
+                "bad\x00path", DevDaxRemoveMode.DRAIN
+            )
+        assert nul_lookup_miss.value.status_code == 404
+
+        added = storage_manager.add_l1_devdax_device(extra, 4096)
+        assert added.device_path == extra
+        assert added.state == DevDaxArenaState.ACTIVE
+
+        removed = storage_manager.remove_l1_devdax_device(extra, DevDaxRemoveMode.DRAIN)
+        assert removed.device_path == extra
+        assert removed.state == DevDaxArenaState.REMOVED
+
+        # Once unmapped the path is unknown: the allocator lookup miss is
+        # translated into the HTTP-mappable 404, not a 409 state conflict.
+        with pytest.raises(L1ReconfigureError) as lookup_miss:
+            storage_manager.remove_l1_devdax_device(extra, DevDaxRemoveMode.DRAIN)
+        assert lookup_miss.value.status_code == 404
+    finally:
+        storage_manager.close()
+
+
+def test_storage_manager_l1_devdax_reconfigure_rejects_cpu_l1() -> None:
+    storage_manager = StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=L1ManagerConfig(
+                memory_config=L1MemoryManagerConfig(
+                    size_in_bytes=4096,
+                    use_lazy=False,
+                    shm_name="",
+                    align_bytes=4096,
+                )
+            ),
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+        )
+    )
+    try:
+        with pytest.raises(L1ReconfigureError, match="Device-DAX"):
+            storage_manager.get_l1_devdax_arena_statuses()
+        with pytest.raises(L1ReconfigureError, match="not Device-DAX backed"):
+            storage_manager.add_l1_devdax_device("unused", 4096)
+    finally:
+        storage_manager.close()
+
+
+def _pure_devdax_storage_manager(
+    primary: str, adapters: list[L2AdapterConfigBase] | None = None
+) -> StorageManager:
+    return StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=L1ManagerConfig(
+                memory_config=L1MemoryManagerConfig(
+                    size_in_bytes=4096,
+                    use_lazy=False,
+                    shm_name="",
+                    align_bytes=4096,
+                    devdax_path=primary,
+                )
+            ),
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+            l2_adapter_config=L2AdaptersConfig(adapters=adapters or []),
+        )
+    )
+
+
+def _mock_l2_config() -> MockL2AdapterConfig:
+    return MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+
+
+_SINGLE_REGION_PREDICATE = (
+    "lmcache.v1.distributed.storage_manager.requires_single_l1_memory_region"
+)
+
+
+def test_storage_manager_rejects_l1_devdax_add_with_single_region_adapter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Removing the last single-region adapter permits runtime arena add."""
+    primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
+    extra = _make_mmap_file(tmp_path, size=4096, name="extra.bin")
+    # The mock adapter stands in for NIXL, which needs a transfer engine.
+    monkeypatch.setattr(_SINGLE_REGION_PREDICATE, lambda _config: "nixl_store")
+    storage_manager = _pure_devdax_storage_manager(primary, [_mock_l2_config()])
+    try:
+        with pytest.raises(L1ReconfigureError, match="nixl_store") as rejected:
+            storage_manager.add_l1_devdax_device(extra, 4096)
+        assert rejected.value.status_code == 409
+        statuses = storage_manager.get_l1_devdax_arena_statuses()
+        assert [s.device_path for s in statuses] == [primary]
+        assert _open_fd_count(extra) == 0
+
+        storage_manager.delete_l2_adapter(0)
+        added = storage_manager.add_l1_devdax_device(extra, 4096)
+        assert added.device_path == extra
+        assert added.state == DevDaxArenaState.ACTIVE
+    finally:
+        storage_manager.close()
+
+
+def test_storage_manager_rejects_l1_add_of_l2_dax_device_alias(
+    tmp_path: Path,
+) -> None:
+    """L1 cannot map a physical device already owned by DAX L2."""
+    primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
+    l2_device = _make_mmap_file(tmp_path, size=4096, name="l2-device.bin")
+    l1_alias = tmp_path / "l1-alias.bin"
+    os.link(l2_device, l1_alias)
+    dax_config = DaxL2AdapterConfig(
+        devices=[
+            DaxDeviceConfig(
+                device_path=l2_device,
+                max_dax_size_gb=4096 / (1024**3),
+            )
+        ],
+        slot_bytes=4096,
+    )
+    storage_manager = _pure_devdax_storage_manager(primary, [dax_config])
+    try:
+        with pytest.raises(L1ReconfigureError) as conflict:
+            storage_manager.add_l1_devdax_device(str(l1_alias), 4096)
+        assert conflict.value.status_code == 409
+        assert "already mapped by L2" in str(conflict.value)
+        statuses = storage_manager.get_l1_devdax_arena_statuses()
+        assert [status.device_path for status in statuses] == [primary]
+    finally:
+        storage_manager.close()
+
+
+def test_storage_manager_rejects_single_region_adapter_with_runtime_arenas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The mirror check: with two arenas mapped a NIXL-like adapter is refused
+    until L1 is back to a single arena."""
+    primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
+    extra = _make_mmap_file(tmp_path, size=4096, name="extra.bin")
+    storage_manager = _pure_devdax_storage_manager(primary)
+    try:
+        storage_manager.add_l1_devdax_device(extra, 4096)
+        monkeypatch.setattr(_SINGLE_REGION_PREDICATE, lambda _config: "nixl_store")
+        with pytest.raises(ValueError, match="nixl_store"):
+            storage_manager.add_l2_adapter(_mock_l2_config())
+
+        removed = storage_manager.remove_l1_devdax_device(extra, DevDaxRemoveMode.DRAIN)
+        assert removed.state == DevDaxArenaState.REMOVED
+        adapter_id = storage_manager.add_l2_adapter(_mock_l2_config())
+        assert adapter_id >= 0
+    finally:
+        storage_manager.close()
+
+
+def _wrapped_in_fault_inject(inner: L2AdapterConfigBase) -> FaultInjectL2AdapterConfig:
+    return FaultInjectL2AdapterConfig(
+        inner_config=inner, rate=0.0, seed=0, gap_indices=()
+    )
+
+
+def _type_name_nixl_unless_wrapper(config: object) -> str:
+    return (
+        "fault_inject"
+        if isinstance(config, FaultInjectL2AdapterConfig)
+        else "nixl_store"
+    )
+
+
+def test_single_region_predicate_sees_through_wrapper_configs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "lmcache.v1.distributed.config.get_type_name_for_config",
+        _type_name_nixl_unless_wrapper,
+    )
+    wrapper = _wrapped_in_fault_inject(_mock_l2_config())
+    assert requires_single_l1_memory_region(wrapper) == "nixl_store"
+
+
+def test_storage_manager_rejects_single_region_adapter_while_arena_drains(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A draining arena holding a live object still counts as a region."""
+    primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
+    extra = _make_mmap_file(tmp_path, size=4096, name="extra.bin")
+    storage_manager = _pure_devdax_storage_manager(primary)
+    try:
+        key_a, key_b = _key(1), _key(2)
+        # A fills the primary arena.
+        assert set(storage_manager.reserve_write([key_a], _layout(), "new")) == {key_a}
+        storage_manager.finish_write([key_a])
+        storage_manager.add_l1_devdax_device(extra, 4096)
+        # B lands on the extra arena and stays write-reserved, so it can be
+        # neither evicted nor freed while the arena drains.
+        pending = storage_manager.reserve_write([key_b], _layout(), "new")
+        assert set(pending) == {key_b}
+        draining = storage_manager.remove_l1_devdax_device(
+            extra, DevDaxRemoveMode.DRAIN
+        )
+        assert draining.state == DevDaxArenaState.DRAINING
+        assert draining.active_allocations == 1
+
+        monkeypatch.setattr(_SINGLE_REGION_PREDICATE, lambda _config: "nixl_store")
+        with pytest.raises(ValueError, match="2 regions"):
+            storage_manager.add_l2_adapter(_mock_l2_config())
+
+        storage_manager.finish_write([key_b])
+        del pending
+        storage_manager.delete_l1_keys([key_b])
+        gc.collect()
+        statuses = storage_manager.get_l1_devdax_arena_statuses()
+        assert [s.device_path for s in statuses] == [primary]
+        assert storage_manager.add_l2_adapter(_mock_l2_config()) >= 0
+    finally:
+        storage_manager.close()
+
+
+def test_storage_manager_rejects_single_region_adapter_on_hybrid_l1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hybrid DRAM + Device-DAX is already two regions with a single arena."""
+    path = _make_mmap_file(tmp_path)
+    storage_manager = StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=L1ManagerConfig(
+                memory_config=L1MemoryManagerConfig(
+                    size_in_bytes=1024 * 1024,
+                    use_lazy=False,
+                    shm_name="",
+                    devdax_path=path,
+                    devdax_size_in_bytes=1024 * 1024,
+                )
+            ),
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+            l2_adapter_config=L2AdaptersConfig(adapters=[]),
+        )
+    )
+    try:
+        monkeypatch.setattr(_SINGLE_REGION_PREDICATE, lambda _config: "nixl_store")
+        with pytest.raises(ValueError, match="2 regions"):
+            storage_manager.add_l2_adapter(_mock_l2_config())
+    finally:
+        storage_manager.close()
+
+
 def test_devdax_l1_memory_manager_spills_from_dram_to_devdax(tmp_path):
     path = _make_mmap_file(tmp_path, size=8192)
     manager = DevDaxL1MemoryManager(
@@ -1337,7 +1616,7 @@ def test_remove_primary_arena_rejected(tmp_path):
     primary = _make_mmap_file(tmp_path, size=4096)
     manager = _pure_devdax_manager(primary)
 
-    with pytest.raises(ValueError, match="primary"):
+    with pytest.raises(L1ReconfigureError, match="primary"):
         manager.remove_device(primary)
 
     # The primary arena survives the rejected removal.
@@ -1351,7 +1630,7 @@ def test_add_duplicate_device_rejected(tmp_path):
 
     extra = _make_mmap_file(tmp_path, size=4096, name="extra.bin")
     manager.add_device(extra, 4096)
-    with pytest.raises(ValueError, match="already mapped"):
+    with pytest.raises(L1ReconfigureError, match="already mapped"):
         manager.add_device(extra, 4096)
 
     assert len(manager.get_arena_statuses()) == 2
@@ -1362,9 +1641,9 @@ def test_add_device_validates_arguments(tmp_path):
     primary = _make_mmap_file(tmp_path, size=4096)
     manager = _pure_devdax_manager(primary)
 
-    with pytest.raises(ValueError, match="device_path"):
+    with pytest.raises(L1ReconfigureError, match="device_path"):
         manager.add_device("", 4096)
-    with pytest.raises(ValueError, match="size_in_bytes"):
+    with pytest.raises(L1ReconfigureError, match="size_in_bytes"):
         manager.add_device(str(tmp_path / "unused.bin"), 0)
 
     manager.close()

--- a/tests/v1/distributed/test_devdax_l1_allocator.py
+++ b/tests/v1/distributed/test_devdax_l1_allocator.py
@@ -7,11 +7,13 @@ manager wiring while keeping CI portable.
 """
 
 # Standard
+from pathlib import Path
 from typing import Any, cast
 import argparse
 import gc
 import json
 import os
+import stat
 
 # Third Party
 import pytest
@@ -40,6 +42,7 @@ from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
 from lmcache.v1.memory_allocators.devdax_memory_allocator import (
     DevDaxArenaState,
     DevDaxMemoryAllocator,
+    DevDaxRemoveMode,
 )
 from lmcache.v1.multiprocess.config import add_mp_server_args
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
@@ -53,6 +56,19 @@ def _make_mmap_file(
     with open(path, "wb") as f:
         f.truncate(size)
     return str(path)
+
+
+def _open_fd_count(path: str) -> int:
+    """Count this process's open descriptors that resolve to ``path``."""
+    target = os.path.realpath(path)
+    count = 0
+    for name in os.listdir("/proc/self/fd"):
+        try:
+            if os.readlink(f"/proc/self/fd/{name}") == target:
+                count += 1
+        except OSError:
+            continue
+    return count
 
 
 def _key(seed: int = 0) -> ObjectKey:
@@ -235,6 +251,431 @@ def test_devdax_allocator_uses_mmap_backing_file(tmp_path):
 
     with open(path, "rb") as f:
         assert f.read(4096) == bytes([0x5A]) * 4096
+
+
+_FAKE_DAX_MAJOR = 511
+
+
+def _fake_char_devices(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    devices: dict[str, dict[str, Any]],
+) -> list[str]:
+    """Make descriptors opened on ``devices`` impersonate character devices.
+
+    ``devices`` maps a mapping-file path to ``{"minor": int, "subsystem":
+    str | None, "size": int | None, "align": int | None, "mode": int,
+    "expose": str}``. ``mode`` defaults to ``stat.S_IFCHR``. ``expose``
+    selects how the fake sysfs lists the device: ``"char"`` (default) creates
+    a ``char/<major>:<minor>`` symlink like the kernel's ``/sys/dev/char``,
+    ``"bus"`` creates only a ``bus/dax/<name>`` entry with a ``dev``
+    attribute like ``/sys/bus/dax/devices``, ``"both"`` creates both, and
+    ``"none"`` (or ``subsystem=None``) exposes nothing. Two paths given the
+    same minor impersonate two nodes of one device.
+
+    Returns:
+        Canonical paths whose opened descriptors were reported as fake
+        character devices.
+    """
+    sysfs_root = tmp_path / "sysfs"
+    char_root = sysfs_root / "char"
+    char_root.mkdir(parents=True, exist_ok=True)
+    dax_bus_root = sysfs_root / "bus" / "dax"
+    dax_bus_root.mkdir(parents=True, exist_ok=True)
+    node_by_path: dict[str, tuple[int, int]] = {}
+    for device_path, spec in devices.items():
+        rdev = os.makedev(_FAKE_DAX_MAJOR, spec["minor"])
+        canonical_path = os.path.realpath(device_path)
+        node = (
+            rdev,
+            spec.get("mode", stat.S_IFCHR),
+        )
+        node_by_path[canonical_path] = node
+        subsystem = spec.get("subsystem")
+        expose = spec.get("expose", "char")
+        char_link = char_root / f"{os.major(rdev)}:{os.minor(rdev)}"
+        if subsystem is None or expose == "none" or char_link.exists():
+            continue
+        name = os.path.basename(device_path)
+        device_dir = sysfs_root / "devices" / name
+        device_dir.mkdir(parents=True)
+        bus_dir = sysfs_root / "bus" / subsystem
+        bus_dir.mkdir(parents=True, exist_ok=True)
+        (device_dir / "subsystem").symlink_to(bus_dir)
+        (device_dir / "dev").write_text(f"{os.major(rdev)}:{os.minor(rdev)}")
+        for attribute in ("size", "align"):
+            if spec.get(attribute) is not None:
+                (device_dir / attribute).write_text(str(spec[attribute]))
+        if expose in ("bus", "both"):
+            (dax_bus_root / name).symlink_to(device_dir)
+        if expose in ("char", "both"):
+            char_link.symlink_to(device_dir)
+    monkeypatch.setattr(
+        "lmcache.v1.memory_allocators.devdax_memory_allocator._SYSFS_CHAR_ROOT",
+        str(char_root),
+    )
+    monkeypatch.setattr(
+        "lmcache.v1.memory_allocators.devdax_memory_allocator._DAX_BUS_ROOT",
+        str(dax_bus_root),
+    )
+    real_stat = os.stat
+    real_fstat = os.fstat
+    fake_fstat_calls: list[str] = []
+
+    def fake_device_status(
+        path_status: os.stat_result,
+        node: tuple[int, int],
+    ) -> os.stat_result:
+        rdev, mode = node
+        fields = list(path_status)[:10]
+        fields[stat.ST_MODE] = mode | 0o600
+        fields[stat.ST_SIZE] = 0
+        return os.stat_result(fields, {"st_rdev": rdev})
+
+    def character_device_stat(
+        path: int | str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> os.stat_result:
+        path_status = real_stat(
+            path,
+            dir_fd=dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+        if isinstance(path, int) or dir_fd is not None or not follow_symlinks:
+            return path_status
+        canonical_path = os.path.realpath(path)
+        if isinstance(canonical_path, bytes):
+            canonical_path = os.fsdecode(canonical_path)
+        node = node_by_path.get(canonical_path)
+        if node is None:
+            return path_status
+        return fake_device_status(path_status, node)
+
+    def character_device_fstat(fd: int) -> os.stat_result:
+        # Only descriptors opened on the listed mapping files impersonate a
+        # DAX character device; every other caller keeps the real result.
+        fd_status = real_fstat(fd)
+        try:
+            target = os.readlink(f"/proc/self/fd/{fd}")
+        except OSError:
+            return fd_status
+        node = node_by_path.get(target)
+        if node is None:
+            return fd_status
+        fake_fstat_calls.append(target)
+        return fake_device_status(fd_status, node)
+
+    monkeypatch.setattr(
+        "lmcache.v1.memory_allocators.devdax_memory_allocator.os.stat",
+        character_device_stat,
+    )
+    monkeypatch.setattr(
+        "lmcache.v1.memory_allocators.devdax_memory_allocator.os.fstat",
+        character_device_fstat,
+    )
+    return fake_fstat_calls
+
+
+def _single_arena_allocator(primary: str) -> DevDaxMemoryAllocator:
+    return DevDaxMemoryAllocator(size=4096, device_path=primary, align_bytes=4096)
+
+
+def test_character_device_uses_dax_sysfs_capacity_and_alignment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A character device is checked against the DAX sysfs entry found by its
+    device number, not by its path name."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    capacity_limited = _make_mmap_file(tmp_path, size=8192, name="dax0.1")
+    # Named unlike a DAX node on purpose: the sysfs lookup must not depend on
+    # the basename.
+    strictly_aligned = _make_mmap_file(tmp_path, size=8192, name="by-id-link")
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            capacity_limited: {
+                "minor": 1,
+                "subsystem": "dax",
+                "size": 4096,
+                "align": 4096,
+            },
+            strictly_aligned: {
+                "minor": 2,
+                "subsystem": "dax",
+                "size": 8192,
+                "align": 8192,
+            },
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        with pytest.raises(RuntimeError, match="exceeds.*capacity"):
+            allocator.add_device(capacity_limited, 8192)
+        with pytest.raises(ValueError, match="multiple of the device alignment"):
+            allocator.add_device(strictly_aligned, 4096)
+        # Both rejections happen before mmap: the pool is untouched and the
+        # descriptor opened for validation is released.
+        assert [s.device_path for s in allocator.arena_statuses()] == [primary]
+        assert _open_fd_count(capacity_limited) == 0
+        assert _open_fd_count(strictly_aligned) == 0
+    finally:
+        allocator.close()
+
+
+def test_character_device_alias_uses_device_number_for_runtime_lookup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second node with the same device number resolves to one arena."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    extra = _make_mmap_file(tmp_path, size=8192, name="dax0.1")
+    alias = _make_mmap_file(tmp_path, size=8192, name="char-511-1")
+    fake_fstat_calls = _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            extra: {"minor": 1, "subsystem": "dax", "size": 8192, "align": 4096},
+            alias: {"minor": 1, "subsystem": "dax", "size": 8192, "align": 4096},
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        allocator.add_device(extra, 4096)
+        assert allocator.arena_status(alias).device_path == extra
+
+        calls_before = len(fake_fstat_calls)
+        with pytest.raises(ValueError, match="already mapped"):
+            allocator.add_device(alias, 4096)
+        assert len(fake_fstat_calls) == calls_before
+
+        removed = allocator.remove_device(alias, DevDaxRemoveMode.DRAIN)
+        assert removed.device_path == extra
+        assert removed.state == DevDaxArenaState.REMOVED
+        assert [status.device_path for status in allocator.arena_statuses()] == [
+            primary
+        ]
+    finally:
+        allocator.close()
+
+
+def test_non_dax_character_device_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A character device outside the dax subsystem (e.g. /dev/zero) fails."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    zero_like = _make_mmap_file(tmp_path, size=8192, name="zero")
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            zero_like: {"minor": 5, "subsystem": "mem"},
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        with pytest.raises(ValueError, match="not a Device-DAX device"):
+            allocator.add_device(zero_like, 4096)
+        assert [s.device_path for s in allocator.arena_statuses()] == [primary]
+        assert _open_fd_count(zero_like) == 0
+    finally:
+        allocator.close()
+
+
+def test_block_device_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only character devices and regular files can back an arena."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    disk = _make_mmap_file(tmp_path, size=8192, name="sdb")
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            disk: {"minor": 16, "subsystem": None, "mode": stat.S_IFBLK},
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        with pytest.raises(ValueError, match="neither a character device"):
+            allocator.add_device(disk, 4096)
+        assert [s.device_path for s in allocator.arena_statuses()] == [primary]
+        assert _open_fd_count(disk) == 0
+    finally:
+        allocator.close()
+
+
+def test_character_device_without_sysfs_entry_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A character device that sysfs does not expose cannot be verified."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    unlisted = _make_mmap_file(tmp_path, size=8192, name="dax9.9")
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            unlisted: {"minor": 9, "subsystem": "dax", "expose": "none"},
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        with pytest.raises(ValueError, match="cannot verify"):
+            allocator.add_device(unlisted, 4096)
+        assert [s.device_path for s in allocator.arena_statuses()] == [primary]
+        assert _open_fd_count(unlisted) == 0
+    finally:
+        allocator.close()
+
+
+def test_character_device_resolves_through_dax_bus_listing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With /sys/dev/char masked, the dax bus listing identifies the device."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    bus_only = _make_mmap_file(tmp_path, size=8192, name="dax0.3")
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            bus_only: {
+                "minor": 3,
+                "subsystem": "dax",
+                "size": 4096,
+                "align": 4096,
+                "expose": "bus",
+            },
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        # The size attribute is read through the bus entry: 8192 > 4096.
+        with pytest.raises(RuntimeError, match="exceeds.*capacity"):
+            allocator.add_device(bus_only, 8192)
+        added = allocator.add_device(bus_only, 4096)
+        assert added.device_path == bus_only
+        assert added.state == DevDaxArenaState.ACTIVE
+    finally:
+        allocator.close()
+
+
+def test_character_device_with_unreadable_dax_attributes_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dax device whose align or size cannot be read is refused."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    opaque = _make_mmap_file(tmp_path, size=8192, name="dax0.4")
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            opaque: {"minor": 4, "subsystem": "dax"},
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        with pytest.raises(ValueError, match="unreadable or zero"):
+            allocator.add_device(opaque, 4096)
+        assert [s.device_path for s in allocator.arena_statuses()] == [primary]
+        assert _open_fd_count(opaque) == 0
+    finally:
+        allocator.close()
+
+
+@pytest.mark.parametrize(
+    ("zero_attribute", "expected_message"),
+    [("align", "align=0, size=8192"), ("size", "align=4096, size=0")],
+)
+def test_character_device_with_zero_dax_attribute_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    zero_attribute: str,
+    expected_message: str,
+) -> None:
+    """Readable but zero DAX alignment or capacity is unverifiable."""
+    primary = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    invalid = _make_mmap_file(tmp_path, size=8192, name="dax0.7")
+    invalid_spec = {
+        "minor": 7,
+        "subsystem": "dax",
+        "size": 8192,
+        "align": 4096,
+    }
+    invalid_spec[zero_attribute] = 0
+    _fake_char_devices(
+        tmp_path,
+        monkeypatch,
+        {
+            primary: {"minor": 0, "subsystem": "dax", "size": 8192, "align": 4096},
+            invalid: invalid_spec,
+        },
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        with pytest.raises(ValueError, match=expected_message):
+            allocator.add_device(invalid, 4096)
+        assert [status.device_path for status in allocator.arena_statuses()] == [
+            primary
+        ]
+        assert _open_fd_count(invalid) == 0
+    finally:
+        allocator.close()
+
+
+def test_regular_file_never_consults_sysfs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A regular file named like a DAX node ignores a conflicting sysfs entry.
+
+    Guards against reintroducing basename-keyed sysfs lookups: the base code
+    already gated sysfs on the character-device type, so this passes there too.
+    """
+    primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
+    lookalike = _make_mmap_file(tmp_path, size=8192, name="dax0.0")
+    sysfs_root = tmp_path / "sysfs"
+    device_dir = sysfs_root / "devices" / "dax0.0"
+    device_dir.mkdir(parents=True)
+    # Either attribute would reject an 8192-byte mapping if it were consulted.
+    (device_dir / "size").write_text("4096")
+    (device_dir / "align").write_text("8192")
+    (device_dir / "dev").write_text(f"{_FAKE_DAX_MAJOR}:0")
+    dax_bus_root = sysfs_root / "bus" / "dax"
+    dax_bus_root.mkdir(parents=True)
+    (dax_bus_root / "dax0.0").symlink_to(device_dir)
+    char_root = sysfs_root / "char"
+    char_root.mkdir()
+    (char_root / f"{_FAKE_DAX_MAJOR}:0").symlink_to(device_dir)
+    monkeypatch.setattr(
+        "lmcache.v1.memory_allocators.devdax_memory_allocator._SYSFS_CHAR_ROOT",
+        str(char_root),
+    )
+    monkeypatch.setattr(
+        "lmcache.v1.memory_allocators.devdax_memory_allocator._DAX_BUS_ROOT",
+        str(dax_bus_root),
+    )
+
+    allocator = _single_arena_allocator(primary)
+    try:
+        added = allocator.add_device(lookalike, 8192)
+        assert added.size_in_bytes == 8192
+    finally:
+        allocator.close()
 
 
 def test_devdax_allocator_registers_cuda_host_mapping(tmp_path, monkeypatch):

--- a/tests/v1/distributed/test_devdax_l1_allocator.py
+++ b/tests/v1/distributed/test_devdax_l1_allocator.py
@@ -20,7 +20,11 @@ import pytest
 import torch
 
 # First Party
-from lmcache.v1.distributed.api import L1BackendType, MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.api import (
+    L1BackendType,
+    MemoryLayoutDesc,
+    ObjectKey,
+)
 from lmcache.v1.distributed.config import (
     EvictionConfig,
     L1ManagerConfig,
@@ -1445,21 +1449,39 @@ def test_draining_arena_capacity_excluded_from_total(tmp_path):
     # count as used. Otherwise the eviction watermark (used / total) is diluted
     # by capacity that is going away and eviction never triggers.
     primary = _make_mmap_file(tmp_path, size=4096, name="primary.bin")
-    manager = _pure_devdax_manager(primary)
+    manager = L1Manager(
+        L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=4096,
+                use_lazy=False,
+                shm_name="",
+                align_bytes=4096,
+                devdax_path=primary,
+            )
+        )
+    )
+    first_key = _key(1)
+    second_key = _key(2)
 
-    error, first = manager.allocate(_layout(4096), count=1)
-    assert error == L1Error.SUCCESS
+    first = manager.reserve_write([first_key], [False], _layout(4096))
+    assert first[first_key][0] == L1Error.SUCCESS
+    assert manager.finish_write([first_key])[first_key] == L1Error.SUCCESS
+    del first
 
     extra = _make_mmap_file(tmp_path, size=8192, name="extra.bin")
-    manager.add_device(extra, 8192)
-    error, second = manager.allocate(_layout(4096), count=1)
-    assert error == L1Error.SUCCESS
+    manager.add_devdax_device(extra, 8192)
+    second = manager.reserve_write([second_key], [False], _layout(4096))
+    assert second[second_key][0] == L1Error.SUCCESS
+    assert manager.finish_write([second_key])[second_key] == L1Error.SUCCESS
+    del second
 
     # Both arenas active: total counts all capacity.
     used, total = manager.get_memory_usage()
     assert (used, total) == (8192, 12288)
+    assert manager.get_capacity_bytes_by_backend() == {L1BackendType.DEVDAX: 12288}
+    assert manager.report_status()["memory_configured_bytes"] == 12288
 
-    status = manager.remove_device(extra)
+    status = manager.remove_devdax_device(extra)
     assert status.state == DevDaxArenaState.DRAINING
 
     # Draining: the extra arena's 8192 bytes leave the total, but its live 4096
@@ -1467,16 +1489,16 @@ def test_draining_arena_capacity_excluded_from_total(tmp_path):
     # watermark is satisfied.
     used, total = manager.get_memory_usage()
     assert (used, total) == (8192, 4096)
+    assert manager.get_capacity_bytes_by_backend() == {L1BackendType.DEVDAX: 4096}
+    assert manager.report_status()["memory_configured_bytes"] == 4096
 
     # Once the draining arena is unmapped, both totals reflect the primary only.
-    manager.free(second)
-    del second
+    assert manager.delete([second_key])[second_key] == L1Error.SUCCESS
     gc.collect()
     used, total = manager.get_memory_usage()
     assert (used, total) == (4096, 4096)
 
-    manager.free(first)
-    del first
+    assert manager.delete([first_key])[first_key] == L1Error.SUCCESS
     gc.collect()
     manager.close()
 
@@ -1653,30 +1675,40 @@ def test_hybrid_initial_devdax_arena_is_removable(tmp_path):
     # In hybrid mode DRAM is the primary L1 region, so the initial Device-DAX
     # arena is removable overflow rather than primary.
     path = _make_mmap_file(tmp_path, size=4096)
-    manager = DevDaxL1MemoryManager(
-        L1MemoryManagerConfig(
-            size_in_bytes=4096,
-            use_lazy=False,
-            shm_name="",
-            align_bytes=4096,
-            devdax_path=path,
-            devdax_size_in_bytes=4096,
+    manager = L1Manager(
+        L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=4096,
+                use_lazy=False,
+                shm_name="",
+                align_bytes=4096,
+                devdax_path=path,
+                devdax_size_in_bytes=4096,
+            )
         )
     )
 
-    statuses = manager.get_arena_statuses()
+    statuses = manager.get_devdax_arena_statuses()
     assert len(statuses) == 1
     assert statuses[0].is_primary is False
+    assert manager.get_capacity_bytes_by_backend() == {
+        L1BackendType.DEVDAX: 4096,
+        L1BackendType.DRAM: 4096,
+    }
 
-    status = manager.remove_device(path)
+    status = manager.remove_devdax_device(path)
     assert status.state == DevDaxArenaState.REMOVED
-    assert manager.get_arena_statuses() == []
+    assert manager.get_devdax_arena_statuses() == []
+    assert manager.get_capacity_bytes_by_backend() == {L1BackendType.DRAM: 4096}
+    assert manager.report_status()["memory_configured_bytes"] == 4096
 
     # DRAM still serves allocations after the overflow arena is gone.
-    error, objs = manager.allocate(_layout(4096), count=1)
-    assert error == L1Error.SUCCESS
-    manager.free(objs)
-    del objs
+    key = _key(3)
+    result = manager.reserve_write([key], [False], _layout(4096))
+    assert result[key][0] == L1Error.SUCCESS
+    assert manager.finish_write([key])[key] == L1Error.SUCCESS
+    del result
+    assert manager.delete([key])[key] == L1Error.SUCCESS
     gc.collect()
     manager.close()
 

--- a/tests/v1/distributed/test_devdax_l1_reconfigure_integration.py
+++ b/tests/v1/distributed/test_devdax_l1_reconfigure_integration.py
@@ -13,25 +13,38 @@ LMCACHE_TEST_DEVDAX_L1_SLOT_BYTES.
 
 # Standard
 from collections.abc import Iterator
+from types import SimpleNamespace
 import gc
 import os
 
 # Third Party
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
     DevDaxL1MemoryManager,
 )
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
 from lmcache.v1.memory_allocators.devdax_memory_allocator import (
     DevDaxArenaState,
     DevDaxRemoveMode,
 )
+from lmcache.v1.multiprocess.http_apis.l1_reconfigure_api import router
 
 RUN_IT = os.environ.get("RUN_DEVDAX_L1_INTEGRATION") == "1"
 REAL_DEVICE_PATHS = [
@@ -197,7 +210,7 @@ def test_runtime_add_and_drain_remove_lifecycle(devices):
         assert _open_fd_count(third) == 0
 
         # The primary arena backs get_l1_memory_desc and cannot be removed.
-        with pytest.raises(ValueError, match="primary"):
+        with pytest.raises(L1ReconfigureError, match="primary"):
             manager.remove_device(primary)
 
         manager.free(primary_objs)
@@ -213,6 +226,63 @@ def test_runtime_add_and_drain_remove_lifecycle(devices):
     if not USING_REAL_DEVICES:
         with open(primary, "rb") as handle:
             assert handle.read(SLOT_BYTES) == bytes([0xAB]) * SLOT_BYTES
+
+
+def test_http_reconfigure_lifecycle(devices: _DeviceProvider) -> None:
+    """Exercise HTTP and production StorageManager delegates on live mappings."""
+    primary = devices.acquire(SLOT_BYTES)
+    storage_manager = StorageManager(
+        StorageManagerConfig(
+            l1_manager_config=L1ManagerConfig(
+                memory_config=L1MemoryManagerConfig(
+                    size_in_bytes=SLOT_BYTES,
+                    use_lazy=False,
+                    shm_name="",
+                    align_bytes=4096,
+                    devdax_path=primary,
+                ),
+            ),
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+        )
+    )
+    try:
+        app = FastAPI()
+        app.include_router(router)
+        app.state.engine = SimpleNamespace(storage_manager=storage_manager)
+        with TestClient(app) as client:
+            response = client.get("/reconfigure/l1/dax/status")
+            assert response.status_code == 200
+            (primary_status,) = response.json()["arenas"]
+            assert primary_status["device_path"] == primary
+            assert primary_status["is_primary"] is True
+
+            extra = devices.acquire(SLOT_BYTES)
+            response = client.post(
+                "/reconfigure/l1/dax/add",
+                json={"device_path": extra, "size": SLOT_BYTES},
+            )
+            assert response.status_code == 200
+            assert response.json()["added"]["device_path"] == extra
+            assert _open_fd_count(extra) > 0
+
+            response = client.post(
+                "/reconfigure/l1/dax/remove",
+                json={"device_path": extra},
+            )
+            assert response.status_code == 200
+            (removed,) = response.json()["removed"]["arenas"]
+            assert removed["state"] == "removed"
+            assert _open_fd_count(extra) == 0
+
+            response = client.get("/reconfigure/l1/dax/status")
+            assert response.status_code == 200
+            assert [arena["device_path"] for arena in response.json()["arenas"]] == [
+                primary
+            ]
+    finally:
+        storage_manager.close()
+
+    assert _open_fd_count(primary) == 0
 
 
 def test_kv_cache_drain_gates_device_removal(devices):
@@ -231,8 +301,6 @@ def test_kv_cache_drain_gates_device_removal(devices):
             )
         )
     )
-    memory_manager = l1._memory_manager
-    assert isinstance(memory_manager, DevDaxL1MemoryManager)
     try:
         # KV entry A fills the primary device.
         key_a, key_b, key_c = _key(1), _key(2), _key(3)
@@ -244,7 +312,7 @@ def test_kv_cache_drain_gates_device_removal(devices):
 
         # Add a device at runtime; KV entries B and C land on it as overflow.
         overflow = devices.acquire(2 * SLOT_BYTES)
-        added = memory_manager.add_device(overflow, 2 * SLOT_BYTES)
+        added = l1.add_devdax_device(overflow, 2 * SLOT_BYTES)
         assert added.state == DevDaxArenaState.ACTIVE
         for key, fill in ((key_b, 0xB2), (key_c, 0xC3)):
             write = l1.reserve_write([key], [False], _layout())
@@ -255,7 +323,7 @@ def test_kv_cache_drain_gates_device_removal(devices):
         gc.collect()
 
         # Per-device usage: the primary holds A, the added device holds B and C.
-        statuses = {s.device_path: s for s in memory_manager.get_arena_statuses()}
+        statuses = {s.device_path: s for s in l1.get_devdax_arena_statuses()}
         assert statuses[primary].used_bytes == SLOT_BYTES
         assert statuses[primary].active_allocations == 1
         assert statuses[overflow].used_bytes == 2 * SLOT_BYTES
@@ -263,7 +331,7 @@ def test_kv_cache_drain_gates_device_removal(devices):
         assert statuses[overflow].free_bytes == 0
 
         # Request removal while B and C are still cached: the device drains.
-        removing = memory_manager.remove_device(overflow, DevDaxRemoveMode.DRAIN)
+        removing = l1.remove_devdax_device(overflow, DevDaxRemoveMode.DRAIN)
         assert removing.state == DevDaxArenaState.DRAINING
         assert removing.active_allocations == 2
         assert _open_fd_count(overflow) > 0
@@ -279,7 +347,7 @@ def test_kv_cache_drain_gates_device_removal(devices):
         # Deleting one of the two entries keeps the device mapped and draining.
         assert l1.delete([key_b])[key_b] == L1Error.SUCCESS
         gc.collect()
-        statuses = {s.device_path: s for s in memory_manager.get_arena_statuses()}
+        statuses = {s.device_path: s for s in l1.get_devdax_arena_statuses()}
         assert statuses[overflow].state == DevDaxArenaState.DRAINING
         assert statuses[overflow].active_allocations == 1
         assert _open_fd_count(overflow) > 0
@@ -287,7 +355,7 @@ def test_kv_cache_drain_gates_device_removal(devices):
         # Deleting the last entry on the device unmaps it automatically.
         assert l1.delete([key_c])[key_c] == L1Error.SUCCESS
         gc.collect()
-        assert [s.device_path for s in memory_manager.get_arena_statuses()] == [primary]
+        assert [s.device_path for s in l1.get_devdax_arena_statuses()] == [primary]
         assert _open_fd_count(overflow) == 0
 
         # KV on the remaining device is untouched by the removal.

--- a/tests/v1/distributed/test_devdax_l1_reconfigure_integration.py
+++ b/tests/v1/distributed/test_devdax_l1_reconfigure_integration.py
@@ -250,7 +250,7 @@ def test_http_reconfigure_lifecycle(devices: _DeviceProvider) -> None:
         app.include_router(router)
         app.state.engine = SimpleNamespace(storage_manager=storage_manager)
         with TestClient(app) as client:
-            response = client.get("/reconfigure/l1/dax/status")
+            response = client.get("/reconfigure/dax/l1/status")
             assert response.status_code == 200
             (primary_status,) = response.json()["arenas"]
             assert primary_status["device_path"] == primary
@@ -258,7 +258,7 @@ def test_http_reconfigure_lifecycle(devices: _DeviceProvider) -> None:
 
             extra = devices.acquire(SLOT_BYTES)
             response = client.post(
-                "/reconfigure/l1/dax/add",
+                "/reconfigure/dax/l1/add",
                 json={"device_path": extra, "size": SLOT_BYTES},
             )
             assert response.status_code == 200
@@ -266,7 +266,7 @@ def test_http_reconfigure_lifecycle(devices: _DeviceProvider) -> None:
             assert _open_fd_count(extra) > 0
 
             response = client.post(
-                "/reconfigure/l1/dax/remove",
+                "/reconfigure/dax/l1/remove",
                 json={"device_path": extra},
             )
             assert response.status_code == 200
@@ -274,7 +274,7 @@ def test_http_reconfigure_lifecycle(devices: _DeviceProvider) -> None:
             assert removed["state"] == "removed"
             assert _open_fd_count(extra) == 0
 
-            response = client.get("/reconfigure/l1/dax/status")
+            response = client.get("/reconfigure/dax/l1/status")
             assert response.status_code == 200
             assert [arena["device_path"] for arena in response.json()["arenas"]] == [
                 primary

--- a/tests/v1/distributed/test_memory_capacity.py
+++ b/tests/v1/distributed/test_memory_capacity.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the MP server's memory-capacity declaration.
 
-Capacity comes from config, not from the lazily grown heap, and a tier
-spanning several mediums declares one compartment per medium.
+CPU and GDS capacity comes from config rather than the lazily grown heap;
+Device-DAX capacity follows its active arenas. A tier spanning several
+mediums declares one compartment per medium.
 """
 
 # Standard
+from dataclasses import replace
 from typing import cast
 import threading
 
@@ -22,7 +24,14 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.memory_manager.l1_manager_protocol import L1ManagerProtocol
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
 from lmcache.v1.distributed.storage_manager import StorageManager
+from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaState,
+    DevDaxArenaStatus,
+)
 from lmcache.v1.mp_observability.event import Event, EventType
 
 GIB = 1 << 30
@@ -63,6 +72,25 @@ class _FakeAdapter:
         return _FakeUsage(self._capacity_bytes)
 
 
+class _FakeL1Manager:
+    """An L1 manager that reports a fixed per-medium capacity snapshot."""
+
+    def __init__(self, capacities: dict[L1BackendType, int]) -> None:
+        self._capacities = capacities
+
+    def get_capacity_bytes_by_backend(self) -> dict[L1BackendType, int]:
+        return self._capacities.copy()
+
+    def get_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]:
+        return []
+
+    def get_devdax_arena_status(self, device_path: str) -> DevDaxArenaStatus:
+        for status in self.get_devdax_arena_statuses():
+            if status.device_path == device_path:
+                return status
+        raise L1ReconfigureError(404, f"no Device-DAX arena mapped at {device_path}")
+
+
 class _RecordingBus:
     """Captures what the publish path emits."""
 
@@ -81,10 +109,14 @@ class _StorageManagerStub:
         l1: dict[L1BackendType, int],
         adapters: list[tuple[_FakeDescriptor, _FakeAdapter]],
     ) -> None:
-        # A real config, so the stub exercises the actual L1 derivation.
-        self._l1_config = _config_yielding(l1)
+        self._l1_manager = _FakeL1Manager(l1)
         self._adapters = adapters
+        self._adapter_descriptors = {
+            index: desc for index, (desc, _adapter) in enumerate(adapters)
+        }
         self._lifecycle_lock = threading.Lock()
+        self._adapters_lock = threading.Lock()
+        self._capacity_publish_lock = threading.Lock()
         self._event_bus = _RecordingBus()
 
     def _build_capacities(self) -> list[ModuleMemoryCapacity]:
@@ -92,6 +124,17 @@ class _StorageManagerStub:
 
     def _publish_capacity_changed(self) -> None:
         StorageManager._publish_capacity_changed(cast("StorageManager", self))
+
+    def _single_region_adapter_names(self) -> list[str]:
+        return StorageManager._single_region_adapter_names(cast("StorageManager", self))
+
+    def _l2_device_owner_names(self, _device_path: str) -> list[str]:
+        return []
+
+    def _l1_devdax_arena_is_active(self, device_path: str) -> bool:
+        return StorageManager._l1_devdax_arena_is_active(
+            cast("StorageManager", self), device_path
+        )
 
     def _snapshot_adapters(
         self,
@@ -109,7 +152,7 @@ def _capacities(
     """Run ``StorageManager._build_capacities`` against fakes.
 
     Args:
-        l1: Configured L1 capacity per backing medium.
+        l1: Current declared L1 capacity per backing medium.
         adapters: The L2 adapters to report, as ``(descriptor, adapter)``.
 
     Returns:
@@ -158,7 +201,7 @@ def _config_yielding(capacities: dict[L1BackendType, int]) -> L1ManagerConfig:
 
 
 class TestConfiguredL1Capacity:
-    """The single derivation of "how large is L1", from config alone."""
+    """The boot-capacity derivation for each L1 configuration."""
 
     def _config(self, **memory: object) -> L1ManagerConfig:
         """Build an L1ManagerConfig with the given memory-config fields."""
@@ -235,7 +278,7 @@ class TestConfiguredL1Capacity:
         assert derived[L1BackendType.DRAM] == local_size
 
     def test_total_matches_what_usage_telemetry_reports(self) -> None:
-        # usage_telemetry sums the same derivation; drift would split the views.
+        # Startup telemetry records the same boot-configured total.
         memory_config = L1MemoryManagerConfig(
             size_in_bytes=10 * GIB,
             devdax_path="/dev/dax0.0",
@@ -332,9 +375,8 @@ class TestReportStatusSharesTheSource:
 
         manager = L1Manager.__new__(L1Manager)
         manager._memory_manager = cast("L1ManagerProtocol", _MemoryManager())
-        # report_status reads the total precomputed at construction.
-        manager._configured_capacity_bytes = sum(
-            get_configured_capacity_bytes(_config_yielding(configured)).values()
+        manager._boot_capacity_bytes_by_backend = get_configured_capacity_bytes(
+            _config_yielding(configured)
         )
         manager._objects = {}
         manager._write_ttl_seconds = 600
@@ -357,8 +399,7 @@ class TestReportStatusSharesTheSource:
         assert manager.report_status()["memory_configured_bytes"] == 110 * GIB
 
     def test_status_and_capacity_report_agree(self) -> None:
-        # The point of one shared derivation: the two consumers of it --
-        # report_status and the coordinator capacity report -- cannot drift.
+        # Both consumers use the same point-in-time capacity derivation.
         configured = {L1BackendType.DEVDAX: 100 * GIB, L1BackendType.DRAM: 10 * GIB}
         manager = self._l1_manager(configured)
         reported = sum(
@@ -384,18 +425,6 @@ class TestCapacityChangePublishing:
         """A stub wired with the bus plumbing the publish path needs."""
         return _StorageManagerStub({L1BackendType.DRAM: 40 * GIB}, [])
 
-    def test_publish_emits_one_event_per_call(self) -> None:
-        # The snapshot carries no revision: the cache-event subscriber
-        # numbers declarations as it emits them, on the one bus thread.
-        stub = self._stub()
-        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
-        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
-        assert len(stub._event_bus.events) == 2
-        assert all(
-            not hasattr(e.metadata["snapshot"], "revision")
-            for e in stub._event_bus.events
-        )
-
     def test_published_event_carries_the_whole_declaration(self) -> None:
         # A delta would leave the coordinator permanently wrong if dropped.
         stub = self._stub()
@@ -405,16 +434,101 @@ class TestCapacityChangePublishing:
             (Tier.L1, "dram", 40 * GIB)
         ]
 
-    def test_event_type_is_the_capacity_one(self) -> None:
-        stub = self._stub()
-        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
-        assert stub._event_bus.events[0].event_type == EventType.SM_CAPACITY_CHANGED
+    def test_reconfigure_publishes_post_operation_capacity(self) -> None:
+        active = DevDaxArenaStatus(
+            "/dev/dax0.1", 4096, 0, 4096, 0, DevDaxArenaState.ACTIVE, False
+        )
 
-    def test_snapshot_carries_the_whole_topology(self) -> None:
-        stub = self._stub()
-        StorageManager._publish_capacity_changed(cast("StorageManager", stub))
-        snapshot = stub._event_bus.events[0].metadata["snapshot"]
-        assert len(snapshot.modules) == 1
+        class _ReconfigurableL1Manager(_FakeL1Manager):
+            def __init__(self) -> None:
+                super().__init__({L1BackendType.DEVDAX: 4096})
+
+            def get_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]:
+                return (
+                    [active] if self._capacities[L1BackendType.DEVDAX] == 8192 else []
+                )
+
+            def add_devdax_device(
+                self, _device_path: str, _size_in_bytes: int
+            ) -> DevDaxArenaStatus:
+                self._capacities = {L1BackendType.DEVDAX: 8192}
+                return active
+
+            def remove_devdax_device(
+                self, _device_path: str, _mode: object
+            ) -> DevDaxArenaStatus:
+                if self._capacities[L1BackendType.DEVDAX] == 4096:
+                    raise ValueError("Device-DAX arena is not mapped")
+                self._capacities = {L1BackendType.DEVDAX: 4096}
+                return replace(active, state=DevDaxArenaState.REMOVED)
+
+        stub = _StorageManagerStub({L1BackendType.DEVDAX: 4096}, [])
+        stub._l1_manager = _ReconfigurableL1Manager()  # type: ignore[assignment]
+
+        StorageManager.add_l1_devdax_device(
+            cast("StorageManager", stub), active.device_path, 4096
+        )
+        StorageManager.remove_l1_devdax_device(
+            cast("StorageManager", stub), active.device_path
+        )
+        with pytest.raises(ValueError, match="not mapped"):
+            StorageManager.remove_l1_devdax_device(
+                cast("StorageManager", stub), active.device_path
+            )
+
+        events = stub._event_bus.events
+        assert [event.event_type for event in events] == [
+            EventType.SM_CAPACITY_CHANGED,
+            EventType.SM_CAPACITY_CHANGED,
+        ]
+        assert [
+            next(
+                module.capacity_bytes
+                for module in event.metadata["snapshot"].modules
+                if module.tier is Tier.L1
+                and module.backend == L1BackendType.DEVDAX.value
+            )
+            for event in events
+        ] == [8192, 4096]
+
+    def test_remove_transition_is_published_when_total_is_unchanged(self) -> None:
+        class _FailingRemoveL1Manager(_FakeL1Manager):
+            def __init__(self) -> None:
+                super().__init__({L1BackendType.DEVDAX: 40 * GIB})
+                self._target_state = DevDaxArenaState.ACTIVE
+
+            def get_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]:
+                return [
+                    DevDaxArenaStatus(
+                        device_path="/dev/dax0.1",
+                        size_in_bytes=20 * GIB,
+                        used_bytes=0,
+                        free_bytes=20 * GIB,
+                        active_allocations=0,
+                        state=self._target_state,
+                        is_primary=False,
+                    )
+                ]
+
+            def remove_devdax_device(self, _device_path: str, _mode: object) -> None:
+                self._target_state = DevDaxArenaState.DRAINING
+                raise RuntimeError("cleanup failed after drain started")
+
+        stub = _StorageManagerStub({L1BackendType.DEVDAX: 40 * GIB}, [])
+        stub._l1_manager = _FailingRemoveL1Manager()  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            StorageManager.remove_l1_devdax_device(
+                cast("StorageManager", stub), "/dev/dax0.1"
+            )
+
+        assert len(stub._event_bus.events) == 1
+        event = stub._event_bus.events[0]
+        assert event.event_type == EventType.SM_CAPACITY_CHANGED
+        # A concurrent same-sized add can keep the aggregate unchanged. The
+        # target arena's ACTIVE -> DRAINING transition still needs an event to
+        # supersede any older declaration already queued by that add.
+        assert event.metadata["snapshot"].modules[0].capacity_bytes == 40 * GIB
 
     def test_publish_capacity_declares_without_any_reconfiguration(self) -> None:
         # The only path by which a server that never reconfigures reaches
@@ -426,13 +540,13 @@ class TestCapacityChangePublishing:
         assert [(m.tier, m.backend) for m in snapshot.modules] == [(Tier.L1, "dram")]
 
 
-class TestCapacityPublishTakesNoLock:
+class TestCapacityPublishDoesNotTakeLifecycleLock:
     """Publishing must not queue behind adapter lifecycle work."""
 
     def test_publish_does_not_take_the_lifecycle_lock(self) -> None:
-        # add/delete/reconfigure hold _lifecycle_lock, and delete can hold
-        # it for its full timeout. Publishing runs on every registration, so
-        # taking that lock would stall registration behind a teardown.
+        # Add/delete hold _lifecycle_lock, and delete can hold it for its full
+        # timeout. Publishing runs on every registration, so taking that lock
+        # would stall registration behind a teardown.
         stub = _StorageManagerStub({L1BackendType.DRAM: 8 * GIB}, [])
         stub._lifecycle_lock.acquire()
         try:

--- a/tests/v1/multiprocess/http_apis/test_l1_reconfigure_api.py
+++ b/tests/v1/multiprocess/http_apis/test_l1_reconfigure_api.py
@@ -112,7 +112,7 @@ def test_l1_dax_routes_requests_to_storage_manager() -> None:
     storage_manager = _FakeStorageManager()
     client = _client(storage_manager)
 
-    response = client.get("/reconfigure/l1/dax/status")
+    response = client.get("/reconfigure/dax/l1/status")
     assert response.status_code == 200
     (arena,) = response.json()["arenas"]
     assert arena["device_path"] == _PRIMARY
@@ -120,7 +120,7 @@ def test_l1_dax_routes_requests_to_storage_manager() -> None:
     assert arena["is_primary"] is True
 
     response = client.post(
-        "/reconfigure/l1/dax/add",
+        "/reconfigure/dax/l1/add",
         json={"device_path": _EXTRA, "size": "4KiB"},
     )
     assert response.status_code == 200
@@ -129,7 +129,7 @@ def test_l1_dax_routes_requests_to_storage_manager() -> None:
 
     remove_alias = "/dev//dax0.1"
     response = client.post(
-        "/reconfigure/l1/dax/remove",
+        "/reconfigure/dax/l1/remove",
         json={"device_path": remove_alias},
     )
     assert response.status_code == 200
@@ -149,7 +149,7 @@ def test_l1_dax_reconfigure_error_status_is_preserved() -> None:
         raise_error=L1ReconfigureError(409, "mapping conflict")
     )
     response = _client(storage_manager).post(
-        "/reconfigure/l1/dax/add",
+        "/reconfigure/dax/l1/add",
         json={"device_path": _EXTRA, "size": _MAPPED_BYTES},
     )
 
@@ -166,20 +166,20 @@ def test_l1_dax_wire_validation() -> None:
     # The wire type is strict: a JSON boolean is a schema violation, never
     # silently coerced into a byte count.
     response = client.post(
-        "/reconfigure/l1/dax/add", json={"device_path": _EXTRA, "size": True}
+        "/reconfigure/dax/l1/add", json={"device_path": _EXTRA, "size": True}
     )
     assert response.status_code == 422
     assert "detail" in response.json()
     # A well-formed size string with a nonsense value is a 400 value error.
     response = client.post(
-        "/reconfigure/l1/dax/add", json={"device_path": _EXTRA, "size": "4Zi"}
+        "/reconfigure/dax/l1/add", json={"device_path": _EXTRA, "size": "4Zi"}
     )
     assert response.status_code == 400
     assert "error" in response.json()
     # The field is reserved for future remove strategies, but only the
     # currently implemented drain mode is accepted.
     response = client.post(
-        "/reconfigure/l1/dax/remove",
+        "/reconfigure/dax/l1/remove",
         json={"device_path": _EXTRA, "mode": "evict"},
     )
     assert response.status_code == 422
@@ -189,6 +189,6 @@ def test_l1_dax_wire_validation() -> None:
 def test_l1_dax_missing_engine_returns_503() -> None:
     app = FastAPI()
     app.include_router(router)
-    response = TestClient(app).get("/reconfigure/l1/dax/status")
+    response = TestClient(app).get("/reconfigure/dax/l1/status")
     assert response.status_code == 503
     assert "engine" in response.json()["error"]

--- a/tests/v1/multiprocess/http_apis/test_l1_reconfigure_api.py
+++ b/tests/v1/multiprocess/http_apis/test_l1_reconfigure_api.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MP runtime Device-DAX L1 reconfiguration HTTP endpoints."""
+
+# Standard
+from dataclasses import dataclass, field
+import os
+
+# Third Party
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# First Party
+from lmcache.v1.distributed.memory_manager.reconfiguration import (
+    L1ReconfigureError,
+)
+from lmcache.v1.memory_allocators.devdax_memory_allocator import (
+    DevDaxArenaState,
+    DevDaxArenaStatus,
+    DevDaxRemoveMode,
+)
+from lmcache.v1.multiprocess.http_apis.l1_reconfigure_api import router
+
+_PRIMARY = "/dev/dax0.0"
+_EXTRA = "/dev/dax0.1"
+_MAPPED_BYTES = 4096
+
+
+def _arena_status(
+    device_path: str,
+    *,
+    state: DevDaxArenaState = DevDaxArenaState.ACTIVE,
+    is_primary: bool = False,
+) -> DevDaxArenaStatus:
+    """Build an arena status used by the fake storage manager.
+
+    Args:
+        device_path: Path represented by the arena.
+        state: Lifecycle state to report.
+        is_primary: Whether the arena is the non-removable primary mapping.
+
+    Returns:
+        A fixed-size arena status suitable for HTTP response assertions.
+    """
+    return DevDaxArenaStatus(
+        device_path=device_path,
+        size_in_bytes=_MAPPED_BYTES,
+        used_bytes=0,
+        free_bytes=_MAPPED_BYTES if state == DevDaxArenaState.ACTIVE else 0,
+        active_allocations=0,
+        state=state,
+        is_primary=is_primary,
+    )
+
+
+@dataclass
+class _FakeStorageManager:
+    calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    raise_error: L1ReconfigureError | None = None
+
+    def _raise_if_configured(self) -> None:
+        if self.raise_error is not None:
+            raise self.raise_error
+
+    def get_l1_devdax_arena_statuses(self) -> list[DevDaxArenaStatus]:
+        self.calls.append(("status", ()))
+        self._raise_if_configured()
+        return [_arena_status(_PRIMARY, is_primary=True)]
+
+    def add_l1_devdax_device(
+        self,
+        device_path: str,
+        size_in_bytes: int,
+    ) -> DevDaxArenaStatus:
+        self.calls.append(("add", (device_path, size_in_bytes)))
+        self._raise_if_configured()
+        return _arena_status(device_path)
+
+    def remove_l1_devdax_device(
+        self,
+        device_path: str,
+        mode: DevDaxRemoveMode,
+    ) -> DevDaxArenaStatus:
+        self.calls.append(("remove", (device_path, mode)))
+        self._raise_if_configured()
+        return _arena_status(
+            os.path.normpath(device_path), state=DevDaxArenaState.REMOVED
+        )
+
+
+@dataclass
+class _FakeEngine:
+    storage_manager: _FakeStorageManager
+
+
+def _client(sm: _FakeStorageManager) -> TestClient:
+    """Create a test client whose engine exposes ``sm``.
+
+    Args:
+        sm: Fake storage manager receiving route delegation calls.
+
+    Returns:
+        A client with only the L1 reconfigure router registered.
+    """
+    app = FastAPI()
+    app.include_router(router)
+    app.state.engine = _FakeEngine(storage_manager=sm)
+    return TestClient(app)
+
+
+def test_l1_dax_routes_requests_to_storage_manager() -> None:
+    """The HTTP surface translates requests into StorageManager calls."""
+    storage_manager = _FakeStorageManager()
+    client = _client(storage_manager)
+
+    response = client.get("/reconfigure/l1/dax/status")
+    assert response.status_code == 200
+    (arena,) = response.json()["arenas"]
+    assert arena["device_path"] == _PRIMARY
+    assert arena["state"] == "active"
+    assert arena["is_primary"] is True
+
+    response = client.post(
+        "/reconfigure/l1/dax/add",
+        json={"device_path": _EXTRA, "size": "4KiB"},
+    )
+    assert response.status_code == 200
+    added = response.json()["added"]
+    assert (added["device_path"], added["state"]) == (_EXTRA, "active")
+
+    remove_alias = "/dev//dax0.1"
+    response = client.post(
+        "/reconfigure/l1/dax/remove",
+        json={"device_path": remove_alias},
+    )
+    assert response.status_code == 200
+    removed = response.json()["removed"]
+    assert removed["device_path"] == _EXTRA
+    assert removed["arenas"][0]["state"] == "removed"
+
+    assert storage_manager.calls == [
+        ("status", ()),
+        ("add", (_EXTRA, _MAPPED_BYTES)),
+        ("remove", (remove_alias, DevDaxRemoveMode.DRAIN)),
+    ]
+
+
+def test_l1_dax_reconfigure_error_status_is_preserved() -> None:
+    storage_manager = _FakeStorageManager(
+        raise_error=L1ReconfigureError(409, "mapping conflict")
+    )
+    response = _client(storage_manager).post(
+        "/reconfigure/l1/dax/add",
+        json={"device_path": _EXTRA, "size": _MAPPED_BYTES},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"error": "mapping conflict"}
+    assert storage_manager.calls == [("add", (_EXTRA, _MAPPED_BYTES))]
+
+
+def test_l1_dax_wire_validation() -> None:
+    """Representative wire rejections: strict 422s and a size-value 400."""
+    storage_manager = _FakeStorageManager()
+    client = _client(storage_manager)
+
+    # The wire type is strict: a JSON boolean is a schema violation, never
+    # silently coerced into a byte count.
+    response = client.post(
+        "/reconfigure/l1/dax/add", json={"device_path": _EXTRA, "size": True}
+    )
+    assert response.status_code == 422
+    assert "detail" in response.json()
+    # A well-formed size string with a nonsense value is a 400 value error.
+    response = client.post(
+        "/reconfigure/l1/dax/add", json={"device_path": _EXTRA, "size": "4Zi"}
+    )
+    assert response.status_code == 400
+    assert "error" in response.json()
+    # The field is reserved for future remove strategies, but only the
+    # currently implemented drain mode is accepted.
+    response = client.post(
+        "/reconfigure/l1/dax/remove",
+        json={"device_path": _EXTRA, "mode": "evict"},
+    )
+    assert response.status_code == 422
+    assert storage_manager.calls == []
+
+
+def test_l1_dax_missing_engine_returns_503() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    response = TestClient(app).get("/reconfigure/l1/dax/status")
+    assert response.status_code == 503
+    assert "engine" in response.json()["error"]

--- a/tests/v1/multiprocess/http_apis/test_reconfigure_api.py
+++ b/tests/v1/multiprocess/http_apis/test_reconfigure_api.py
@@ -82,9 +82,9 @@ def test_calls_storage_manager_without_timeout_and_without_accepted_response():
     sm = _FakeStorageManager()
     client = _client(sm)
 
-    status_resp = client.get("/reconfigure/dax/status")
+    status_resp = client.get("/reconfigure/l2/dax/status")
     add_resp = client.post(
-        "/reconfigure/dax/add",
+        "/reconfigure/l2/dax/add",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -92,7 +92,7 @@ def test_calls_storage_manager_without_timeout_and_without_accepted_response():
         },
     )
     remove_resp = client.post(
-        "/reconfigure/dax/remove",
+        "/reconfigure/l2/dax/remove",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -101,7 +101,7 @@ def test_calls_storage_manager_without_timeout_and_without_accepted_response():
         },
     )
     resize_resp = client.post(
-        "/reconfigure/dax/resize",
+        "/reconfigure/l2/dax/resize",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -167,7 +167,7 @@ def test_status_filters_non_dax_reconfigurable_adapters():
         }
     )
 
-    resp = _client(sm).get("/reconfigure/dax/status")
+    resp = _client(sm).get("/reconfigure/l2/dax/status")
 
     assert resp.status_code == 200
     assert resp.json() == {
@@ -203,7 +203,7 @@ def test_add_resolves_public_dax_index_to_generic_reconfigure_index():
     )
 
     resp = _client(sm).post(
-        "/reconfigure/dax/add",
+        "/reconfigure/l2/dax/add",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -229,8 +229,21 @@ def test_add_rejects_invalid_size_payloads(
     payload: dict[str, object],
     status_code: int,
 ):
-    resp = _client(_FakeStorageManager()).post("/reconfigure/dax/add", json=payload)
+    resp = _client(_FakeStorageManager()).post("/reconfigure/l2/dax/add", json=payload)
     assert resp.status_code == status_code
+
+
+def test_size_rejects_boolean_and_float_payloads() -> None:
+    """The strict wire type keeps booleans/floats out of ``size`` (422)."""
+    resp = _client(_FakeStorageManager()).post(
+        "/reconfigure/l2/dax/add", json={"device_path": "/dev/daxX.X", "size": True}
+    )
+    assert resp.status_code == 422
+    resp = _client(_FakeStorageManager()).post(
+        "/reconfigure/l2/dax/resize",
+        json={"device_path": "/dev/daxX.X", "size": 4096.0},
+    )
+    assert resp.status_code == 422
 
 
 def test_add_rejects_pathological_size_string_without_echoing_input():
@@ -238,7 +251,7 @@ def test_add_rejects_pathological_size_string_without_echoing_input():
     bad_size = "9" + " " * 5000 + "x"
 
     resp = _client(sm).post(
-        "/reconfigure/dax/add",
+        "/reconfigure/l2/dax/add",
         json={"device_path": "/dev/daxX.X", "size": bad_size},
     )
 
@@ -251,15 +264,15 @@ def test_add_rejects_pathological_size_string_without_echoing_input():
     ("path", "payload"),
     [
         (
-            "/reconfigure/dax/remove",
+            "/reconfigure/l2/dax/remove",
             {"device_path": "/dev/daxX.X", "timeout_s": 1},
         ),
         (
-            "/reconfigure/dax/resize",
+            "/reconfigure/l2/dax/resize",
             {"device_path": "/dev/daxX.X", "size": 1024, "timeout_s": 1},
         ),
         (
-            "/reconfigure/dax/resize",
+            "/reconfigure/l2/dax/resize",
             {"device_path": "/dev/daxX.X", "size": 1024, "mode": "drain"},
         ),
     ],
@@ -280,7 +293,7 @@ def test_hotplug_error_status_code_is_preserved():
         )
     )
     resp = _client(sm).post(
-        "/reconfigure/dax/add",
+        "/reconfigure/l2/dax/add",
         json={
             "device_path": "/dev/daxX.X",
             "size": 1024,
@@ -303,7 +316,7 @@ def test_generic_backend_routes_payload_to_matching_reconfigurable_adapter():
     )
 
     resp = _client(sm).post(
-        "/reconfigure/fake/flip",
+        "/reconfigure/l2/fake/flip",
         json={"adapter_index": 0, "enabled": True},
     )
 
@@ -325,12 +338,15 @@ def test_reconfigure_post_rejects_missing_backend_adapter():
         }
     )
 
-    resp = _client(sm).post("/reconfigure/fake/flip", json={"enabled": True})
+    resp = _client(sm).post("/reconfigure/l2/fake/flip", json={"enabled": True})
 
     assert resp.status_code == 404
     assert resp.json() == {"error": "fake adapter not found"}
 
 
-def test_old_dax_routes_are_not_registered():
+def test_old_dax_routes_are_not_registered() -> None:
     resp = _client(_FakeStorageManager()).get("/dax/status")
+    assert resp.status_code == 404
+    # The pre-tier /reconfigure/{backend}/... form moved under /l2.
+    resp = _client(_FakeStorageManager()).get("/reconfigure/dax/status")
     assert resp.status_code == 404

--- a/tests/v1/multiprocess/http_apis/test_reconfigure_api.py
+++ b/tests/v1/multiprocess/http_apis/test_reconfigure_api.py
@@ -82,9 +82,9 @@ def test_calls_storage_manager_without_timeout_and_without_accepted_response():
     sm = _FakeStorageManager()
     client = _client(sm)
 
-    status_resp = client.get("/reconfigure/l2/dax/status")
+    status_resp = client.get("/reconfigure/dax/l2/status")
     add_resp = client.post(
-        "/reconfigure/l2/dax/add",
+        "/reconfigure/dax/l2/add",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -92,7 +92,7 @@ def test_calls_storage_manager_without_timeout_and_without_accepted_response():
         },
     )
     remove_resp = client.post(
-        "/reconfigure/l2/dax/remove",
+        "/reconfigure/dax/l2/remove",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -101,7 +101,7 @@ def test_calls_storage_manager_without_timeout_and_without_accepted_response():
         },
     )
     resize_resp = client.post(
-        "/reconfigure/l2/dax/resize",
+        "/reconfigure/dax/l2/resize",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -167,7 +167,7 @@ def test_status_filters_non_dax_reconfigurable_adapters():
         }
     )
 
-    resp = _client(sm).get("/reconfigure/l2/dax/status")
+    resp = _client(sm).get("/reconfigure/dax/l2/status")
 
     assert resp.status_code == 200
     assert resp.json() == {
@@ -203,7 +203,7 @@ def test_add_resolves_public_dax_index_to_generic_reconfigure_index():
     )
 
     resp = _client(sm).post(
-        "/reconfigure/l2/dax/add",
+        "/reconfigure/dax/l2/add",
         json={
             "adapter_index": 0,
             "device_path": "/dev/daxX.X",
@@ -229,18 +229,18 @@ def test_add_rejects_invalid_size_payloads(
     payload: dict[str, object],
     status_code: int,
 ):
-    resp = _client(_FakeStorageManager()).post("/reconfigure/l2/dax/add", json=payload)
+    resp = _client(_FakeStorageManager()).post("/reconfigure/dax/l2/add", json=payload)
     assert resp.status_code == status_code
 
 
 def test_size_rejects_boolean_and_float_payloads() -> None:
     """The strict wire type keeps booleans/floats out of ``size`` (422)."""
     resp = _client(_FakeStorageManager()).post(
-        "/reconfigure/l2/dax/add", json={"device_path": "/dev/daxX.X", "size": True}
+        "/reconfigure/dax/l2/add", json={"device_path": "/dev/daxX.X", "size": True}
     )
     assert resp.status_code == 422
     resp = _client(_FakeStorageManager()).post(
-        "/reconfigure/l2/dax/resize",
+        "/reconfigure/dax/l2/resize",
         json={"device_path": "/dev/daxX.X", "size": 4096.0},
     )
     assert resp.status_code == 422
@@ -251,7 +251,7 @@ def test_add_rejects_pathological_size_string_without_echoing_input():
     bad_size = "9" + " " * 5000 + "x"
 
     resp = _client(sm).post(
-        "/reconfigure/l2/dax/add",
+        "/reconfigure/dax/l2/add",
         json={"device_path": "/dev/daxX.X", "size": bad_size},
     )
 
@@ -264,15 +264,15 @@ def test_add_rejects_pathological_size_string_without_echoing_input():
     ("path", "payload"),
     [
         (
-            "/reconfigure/l2/dax/remove",
+            "/reconfigure/dax/l2/remove",
             {"device_path": "/dev/daxX.X", "timeout_s": 1},
         ),
         (
-            "/reconfigure/l2/dax/resize",
+            "/reconfigure/dax/l2/resize",
             {"device_path": "/dev/daxX.X", "size": 1024, "timeout_s": 1},
         ),
         (
-            "/reconfigure/l2/dax/resize",
+            "/reconfigure/dax/l2/resize",
             {"device_path": "/dev/daxX.X", "size": 1024, "mode": "drain"},
         ),
     ],
@@ -293,7 +293,7 @@ def test_hotplug_error_status_code_is_preserved():
         )
     )
     resp = _client(sm).post(
-        "/reconfigure/l2/dax/add",
+        "/reconfigure/dax/l2/add",
         json={
             "device_path": "/dev/daxX.X",
             "size": 1024,
@@ -316,7 +316,7 @@ def test_generic_backend_routes_payload_to_matching_reconfigurable_adapter():
     )
 
     resp = _client(sm).post(
-        "/reconfigure/l2/fake/flip",
+        "/reconfigure/fake/l2/flip",
         json={"adapter_index": 0, "enabled": True},
     )
 
@@ -338,7 +338,7 @@ def test_reconfigure_post_rejects_missing_backend_adapter():
         }
     )
 
-    resp = _client(sm).post("/reconfigure/l2/fake/flip", json={"enabled": True})
+    resp = _client(sm).post("/reconfigure/fake/l2/flip", json={"enabled": True})
 
     assert resp.status_code == 404
     assert resp.json() == {"error": "fake adapter not found"}
@@ -347,6 +347,6 @@ def test_reconfigure_post_rejects_missing_backend_adapter():
 def test_old_dax_routes_are_not_registered() -> None:
     resp = _client(_FakeStorageManager()).get("/dax/status")
     assert resp.status_code == 404
-    # The pre-tier /reconfigure/{backend}/... form moved under /l2.
+    # The unscoped /reconfigure/{backend}/... form now carries the l2 tier segment.
     resp = _client(_FakeStorageManager()).get("/reconfigure/dax/status")
     assert resp.status_code == 404


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Refs #3972. 
Refs #3264.

PR #3972 added runtime add/remove operations for Device-DAX-backed L1 arenas, while PR #3264 established the MP HTTP reconfiguration flow for L2 DAX. This PR adds the missing MP HTTP control surface for L1 Device-DAX. 
L2 reconfiguration moves to `/reconfigure/{backend}/l2/*` so both route families use an explicit tier segment.

- Add the L1 Device-DAX endpoints:
  - `GET /reconfigure/dax/l1/status`
  - `POST /reconfigure/dax/l1/add`
  - `POST /reconfigure/dax/l1/remove`
- Route L1 requests through public `StorageManager` and `L1Manager` methods, without exposing the concrete L1 memory manager to the HTTP layer.
- Share size parsing, validation responses, error envelopes, and engine lookup across the L1 and L2 reconfiguration route families.
- Prevent runtime multi-arena L1 configurations from coexisting with L2 adapters that register only one L1 memory region.
- Derive Device-DAX declared capacity from active arenas and publish the existing whole-topology capacity event after add or drain transitions, so coordinator reporting can follow active-arena capacity when event reporting is enabled.

#### Breaking HTTP changes

The existing L2 reconfiguration routes move to a backend-first, tier-scoped layout. Compatibility aliases are not retained:

| Before | After |
| --- | --- |
| `GET /reconfigure/{backend}/status` | `GET /reconfigure/{backend}/l2/status` |
| `POST /reconfigure/{backend}/{operation}` | `POST /reconfigure/{backend}/l2/{operation}` |

The former unscoped routes now return `404`. Adapter discovery is unchanged: clients continue to use the adapter `type_name` reported by `GET /config/adapters` as `{backend}`.

The shared `size` field now rejects JSON booleans and floats with `422`.

#### L1 Device-DAX behavior

`add` maps an already-provisioned Device-DAX device as an overflow arena and does not disturb existing allocations. `remove` currently supports only `mode: "drain"`: the arena stops accepting new allocations, remains readable while live allocations reference it, and is unmapped when it is no longer in use. Live objects are not migrated. 
The primary arena of a pure Device-DAX L1 configuration cannot be removed.

A `200 OK` response with the `removed` envelope may still report an arena in `draining` state. Exported views can also defer unmapping after the last allocation is freed; release those views and retry `remove`.

Validation errors and state conflicts use the documented HTTP error envelope. Reported Device-DAX capacity excludes draining arenas.

Synchronization or cleanup failures after drain starts can return `500`; the arena may already be draining and excluded from usable capacity, so inspect status before retrying.

**Special notes for your reviewers**:

- The L1 handler is specific to Device-DAX and its runtime arena operations.
- LMCache creates and removes userspace mappings for already-provisioned Device-DAX devices. It does not provision or resize kernel DAX namespaces.
- L1 resize and `migrate`/`evict` removal modes and runtime reconfiguration for non-Device-DAX L1 allocators are outside this PR.
- When coordinator event reporting is enabled, capacity publication is asynchronous and best-effort. A successful HTTP response confirms the local operation, not coordinator delivery.
- Portable tests use temporary mmap-backed files. Operators remain responsible for provisioning real Device-DAX devices with suitable capacity and alignment.

#### Validation

- Focused HTTP, allocator, DAX L2, capacity, and mmap integration tests: **107 passed**, including **3** opt-in mmap integration cases.
- Related coordinator tests: **132 passed, 0 skipped**.
- Real Device-DAX L1 integration tests: **3 passed, 0 skipped**. Runtime add/drain, HTTP reconfiguration, and KV-cache drain lifecycle were verified with three real Device-DAX character devices using CPU operations.
- Native extension build and import checks passed.
- Ruff check and format verification passed for all changed Python files.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests