### PR TITLE
[Docs][Recipes] Cover Qwen3.8 in the Qwen3.5 / Qwen3.6 hybrid recipe

### DIFF
--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -35,7 +35,7 @@ Recipe pages for the validated hybrid-attention architectures:
    * - gpt-oss
      - Sliding-window + full
      - :doc:`/recipes/gpt_oss`
-   * - Qwen3.5 / Qwen3.6 series
+   * - Qwen3.5 / Qwen3.6 / Qwen3.8 series
      - Mamba / GDN + full
      - :doc:`/recipes/qwen3_5`
    * - Kimi-Linear
@@ -134,8 +134,9 @@ Mamba / Linear-Attention Hybrids
 --------------------------------
 
 Models that interleave **Mamba / Gated-DeltaNet (GDN) linear-attention layers**
-with full attention — the Qwen3.5 and Qwen3.6 series (``Qwen/Qwen3.5-0.8B``,
-``Qwen/Qwen3.6-27B``, …), Qwen3-Next, Kimi-Linear
+with full attention — the Qwen3.5, Qwen3.6 and Qwen3.8 series
+(``Qwen/Qwen3.5-0.8B``, ``Qwen/Qwen3.6-27B``, ``Qwen/Qwen3.8-27B``, …),
+Qwen3-Next, Kimi-Linear
 (``moonshotai/Kimi-Linear-48B-A3B-Instruct``), Kimi K3
 (``moonshotai/Kimi-K3``), and other GDN hybrids — are supported.
 Unlike a paged key/value cache, their linear-attention layers keep a recurrent
@@ -199,6 +200,9 @@ example:
      - Unified block size ``N``
      - GPUs
    * - ``Qwen/Qwen3.6-27B``
+     - 784
+     - 1
+   * - ``Qwen/Qwen3.8-27B``
      - 784
      - 1
    * - ``Qwen/Qwen3.5-0.8B``
@@ -266,8 +270,8 @@ Caveats
   is not validated.
 - vLLM's Mamba prefix caching in ``align`` mode is marked experimental upstream.
 
-See the :doc:`Qwen3.5 / Qwen3.6 recipe <../recipes/qwen3_5>` for the validated
-end-to-end commands and the per-model block sizes.
+See the :doc:`Qwen3.5 / Qwen3.6 / Qwen3.8 recipe <../recipes/qwen3_5>` for the
+validated end-to-end commands and the per-model block sizes.
 
 Verifying Correctness
 ---------------------

--- a/docs/source/recipes/qwen3_5.rst
+++ b/docs/source/recipes/qwen3_5.rst
@@ -1,17 +1,19 @@
 .. _recipe_qwen3_5:
 
-Qwen3.5 / Qwen3.6 series
-========================
+Qwen3.5 / Qwen3.6 / Qwen3.8 series
+==================================
 
 A hybrid architecture interleaving Mamba / Gated-DeltaNet (GDN) linear-attention
-layers with full-attention layers, shared by the **Qwen3.5 and Qwen3.6**
-series. LMCache reinterprets the recurrent state caches as opaque pages at
-registration time; see :doc:`../mp/hybrid_models` for the general handling of
-Mamba / linear-attention models.
+layers with full-attention layers, shared by the **Qwen3.5, Qwen3.6 and
+Qwen3.8** series (all use the ``Qwen3_5ForConditionalGeneration``
+architecture). LMCache reinterprets the recurrent state caches as opaque pages
+at registration time; see :doc:`../mp/hybrid_models` for the general handling
+of Mamba / linear-attention models.
 
 Validated models
 ----------------
 
+- `Qwen/Qwen3.8-27B <https://huggingface.co/Qwen/Qwen3.8-27B>`_ (1 GPU)
 - `Qwen/Qwen3.6-27B <https://huggingface.co/Qwen/Qwen3.6-27B>`_ (1 GPU)
 - `Qwen/Qwen3.5-0.8B <https://huggingface.co/Qwen/Qwen3.5-0.8B>`_ (1 GPU)
 
@@ -39,6 +41,9 @@ Validated models
          * - Model
            - Unified block size ``N``
            - GPUs
+         * - ``Qwen/Qwen3.8-27B``
+           - 784
+           - 1
          * - ``Qwen/Qwen3.6-27B``
            - 784
            - 1
@@ -68,6 +73,12 @@ Validated models
              --max-num-batched-tokens 1567 \
              --kv-transfer-config \
              '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+      |
+
+      **Qwen3.8-27B** (1 GPU, ``N = 784`` → ``2N-1 = 1567``): same block size as
+      Qwen3.6-27B, so the commands above apply unchanged apart from the model
+      id.
 
       |
 
@@ -139,6 +150,7 @@ Caveats
   shared across engines with different attention backends or kernel block
   sizes.
 - vLLM's Mamba prefix caching in ``align`` mode is experimental.
-- ``Qwen/Qwen3.6-27B`` is a vision-language model (it loads a vision tower);
-  the LMCache validation covers **text** generation (the ``hma_lm_eval_qwen3_5``
-  gsm8k store-vs-retrieve gate). Caching of image/video KV is not validated.
+- ``Qwen/Qwen3.6-27B`` and ``Qwen/Qwen3.8-27B`` are vision-language models
+  (they load a vision tower); the LMCache validation covers **text**
+  generation (the ``hma_lm_eval_qwen3_5`` gsm8k store-vs-retrieve gate runs on
+  Qwen3.5 / Qwen3.6). Caching of image/video KV is not validated.


### PR DESCRIPTION
**What this PR does / why we need it**:

Qwen3.8-27B uses the same `Qwen3_5ForConditionalGeneration` architecture as the
Qwen3.5 and Qwen3.6 series, so it needs the same LMCache configuration: a chunk
size matched to vLLM's unified block size plus `--separate-object-groups` on the
server, and `--mamba-cache-mode align --enable-prefix-caching` with
`--max-num-batched-tokens >= N` on vLLM. Its unified block size is 784 — the same
as Qwen3.6-27B — so the existing launch commands apply with only the model id
swapped. Until now the docs listed no block size for Qwen3.8, leaving users to
probe it themselves or guess.

**Special notes for your reviewers**:

- Extends the shared recipe page rather than adding a new one, following the
  one-page-per-architecture convention (`Qwen3.5 / Qwen3.6` → `Qwen3.5 / Qwen3.6 /
  Qwen3.8`).
- N = 784 was read from vLLM's own startup line (`Setting attention block size to
  784 tokens`), not assumed from Qwen3.6-27B.
- Config was exercised on 1x H200 with `--load-format dummy`: KV cache registered
  across 64 layers, 784-token chunks stored, and a 4704-token retrieve served
  after vLLM's local prefix cache was reset. Generation quality was not compared —
  the `hma_lm_eval_qwen3_5` gsm8k store-vs-retrieve gate still runs only on
  Qwen3.5 / Qwen3.6, and the page's vision-language caveat says so explicitly.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
