### PR TITLE
fix(build): stabilize gRPC proto generation for wheels

### DIFF
--- a/.github/scripts/build_musa_wheel.sh
+++ b/.github/scripts/build_musa_wheel.sh
@@ -86,7 +86,7 @@ fi
 "${MUSA_PYTHON}" -c 'import torch; print("BUILD TORCH:", torch.__version__)'
 
 "${MUSA_PYTHON}" -m pip install --no-cache-dir \
-    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm wheel pybind11 auditwheel patchelf
+    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm grpcio==1.78.0 grpcio-tools==1.78.0 wheel pybind11 auditwheel patchelf
 
 cd "${PROJECT_DIR}"
 rm -rf build dist dist_musa

--- a/.github/scripts/build_musa_wheel.sh
+++ b/.github/scripts/build_musa_wheel.sh
@@ -86,7 +86,16 @@ fi
 "${MUSA_PYTHON}" -c 'import torch; print("BUILD TORCH:", torch.__version__)'
 
 "${MUSA_PYTHON}" -m pip install --no-cache-dir \
-    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm grpcio==1.78.0 grpcio-tools==1.78.0 wheel pybind11 auditwheel patchelf
+    ninja \
+    "packaging>=24.2" \
+    "setuptools>=77.0.3,<81.0.0" \
+    setuptools_scm \
+    grpcio==1.78.0 \
+    grpcio-tools==1.78.0 \
+    wheel \
+    pybind11 \
+    auditwheel \
+    patchelf
 
 cd "${PROJECT_DIR}"
 rm -rf build dist dist_musa
@@ -140,6 +149,8 @@ import sys
 import zipfile
 from pathlib import Path
 
+from packaging.version import Version
+
 wheel, destination, expected_version, expected_platform = sys.argv[1:]
 with zipfile.ZipFile(wheel) as archive:
     archive.extractall(destination)
@@ -149,7 +160,7 @@ version_line = next(
     line for line in metadata.read_text().splitlines() if line.startswith("Version: ")
 )
 actual_version = version_line.partition(": ")[2]
-if actual_version != expected_version:
+if Version(actual_version) != Version(expected_version):
     raise SystemExit(
         f"wheel version mismatch: expected {expected_version!r}, got {actual_version!r}"
     )

--- a/.github/scripts/build_rocm_wheel.sh
+++ b/.github/scripts/build_rocm_wheel.sh
@@ -48,7 +48,7 @@ $PY --version
 # Build against the public ROCm torch whose ABI matches the vLLM image.
 $PY -m pip install --no-cache-dir "${TORCH_ROCM_SPEC}" --index-url "${TORCH_ROCM_INDEX}"
 $PY -m pip install --no-cache-dir \
-    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm wheel pybind11
+    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm grpcio==1.78.0 grpcio-tools==1.78.0 wheel pybind11
 install_rocm_repair_tools "$PY"
 $PY -c 'import torch; print("BUILD TORCH:", torch.__version__, "hip:", torch.version.hip, "cxx11abi:", torch._C._GLIBCXX_USE_CXX11_ABI)'
 

--- a/.github/scripts/build_xpu_wheel.sh
+++ b/.github/scripts/build_xpu_wheel.sh
@@ -67,7 +67,7 @@ if [[ -z "$INSTALLED_TORCH" || "$INSTALLED_TORCH" != "$REQUESTED_TORCH" ]]; then
 fi
 
 $PY -m pip install --no-cache-dir \
-    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm wheel pybind11 auditwheel patchelf
+    ninja "setuptools>=77.0.3,<81.0.0" setuptools_scm grpcio==1.78.0 grpcio-tools==1.78.0 wheel pybind11 auditwheel patchelf
 $PY -c 'import torch; print("BUILD TORCH:", torch.__version__, "xpu:", hasattr(torch, "xpu"), "cxx11abi:", torch._C._GLIBCXX_USE_CXX11_ABI)'
 
 cd /work/LMCache

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
@@ -7,9 +7,6 @@ import re
 import subprocess
 import sys
 
-# Third Party
-from grpc_tools import protoc
-
 GENERATED_DIR = Path(__file__).resolve().parent
 PROTO_DIR = GENERATED_DIR.parent / "protos"
 PROJECT_ROOT = GENERATED_DIR.parents[5]
@@ -64,6 +61,42 @@ def _patch_generated_file(path: Path) -> None:
     path.write_text(prefix + text)
 
 
+def _check_generated_imports(generated_files: tuple[Path, ...]) -> bool:
+    """Import generated modules without importing ``lmcache.__init__``."""
+    module_names = tuple(path.stem for path in generated_files if path.suffix == ".py")
+    script = f"""
+from pathlib import Path
+import importlib
+import sys
+import types
+
+package = {GENERATED_PACKAGE!r}
+project_root = Path({str(PROJECT_ROOT)!r})
+generated_dir = Path({str(GENERATED_DIR)!r})
+parts = package.split(".")
+
+for index in range(1, len(parts) + 1):
+    name = ".".join(parts[:index])
+    package_path = (
+        generated_dir
+        if index == len(parts)
+        else project_root.joinpath(*parts[:index])
+    )
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(package_path)]
+        sys.modules[name] = module
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name:
+        setattr(sys.modules[parent_name], child_name, module)
+
+for stem in {module_names!r}:
+    importlib.import_module(f"{{package}}.{{stem}}")
+"""
+    return subprocess.call([sys.executable, "-c", script], cwd=PROJECT_ROOT) == 0
+
+
 def generate() -> None:
     """Generate all protobuf and gRPC modules under ``_proto_gen``.
 
@@ -77,6 +110,9 @@ def generate() -> None:
     proto_files = tuple(sorted(PROTO_DIR.glob("*.proto")))
     if not proto_files:
         raise RuntimeError(f"No proto sources found under {PROTO_DIR}")
+
+    # Third Party
+    from grpc_tools import protoc
 
     _cleanup_generated_files()
     result = protoc.main(
@@ -96,16 +132,7 @@ def generate() -> None:
     for path in generated_files:
         _patch_generated_file(path)
 
-    modules = "; ".join(
-        f"import {GENERATED_PACKAGE}.{path.stem}"
-        for path in generated_files
-        if path.suffix == ".py"
-    )
-    result = subprocess.call(
-        [sys.executable, "-c", modules],
-        cwd=PROJECT_ROOT,
-    )
-    if result != 0:
+    if not _check_generated_imports(generated_files):
         _cleanup_generated_files()
         raise RuntimeError("Generated gRPC modules failed their import check")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
+    "grpcio==1.78.0",
     "grpcio-tools==1.78.0",
     "torch==2.13.0",
     "wheel",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,6 +4,7 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
+grpcio==1.78.0
 grpcio-tools==1.78.0
 # torch is not here because vllm installation will implicitly install it for the dockerfile
 # and users should be deliberate about choosing their torch version (or letting their serving

--- a/requirements/proto.txt
+++ b/requirements/proto.txt
@@ -1,2 +1,3 @@
 # Pinned for deterministic local and CI generation; outputs are not tracked.
+grpcio==1.78.0
 grpcio-tools==1.78.0

--- a/tests/v1/multiprocess/transport/test_proto_generator.py
+++ b/tests/v1/multiprocess/transport/test_proto_generator.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+import importlib.util
+
+
+def _load_proto_generator() -> ModuleType:
+    repo_root = Path(__file__).resolve().parents[4]
+    generator_path = (
+        repo_root
+        / "lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
+    )
+    spec = importlib.util.spec_from_file_location("proto_generator", generator_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generated_import_check_does_not_import_lmcache_root(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    generator = _load_proto_generator()
+    package = "lmcache.v1.multiprocess.transport.grpc_impl._proto_gen"
+    package_parts = package.split(".")
+    package_dir = tmp_path.joinpath(*package.split("."))
+    package_dir.mkdir(parents=True)
+    root_init = tmp_path / "lmcache/__init__.py"
+    root_init.write_text("raise RuntimeError('lmcache root import leaked')\n")
+
+    pb2 = package_dir / "sample_pb2.py"
+    pb2.write_text("VALUE = 'ok'\n")
+    pb2_grpc = package_dir / "sample_pb2_grpc.py"
+    pb2_grpc.write_text(
+        "from lmcache.v1.multiprocess.transport.grpc_impl._proto_gen "
+        "import sample_pb2 as sample__pb2\n"
+        "assert sample__pb2.VALUE == 'ok'\n"
+    )
+
+    monkeypatch.setattr(generator, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(generator, "GENERATED_DIR", package_dir)
+    monkeypatch.setattr(generator, "GENERATED_PACKAGE", ".".join(package_parts))
+
+    assert generator._check_generated_imports((pb2, pb2_grpc))

--- a/tests/v1/platform/musa/test_musa_wheel_workflow.py
+++ b/tests/v1/platform/musa/test_musa_wheel_workflow.py
@@ -4,11 +4,21 @@
 # Standard
 from pathlib import Path
 import stat
+import subprocess
+import sys
+import zipfile
 
 # Third Party
 import yaml
 
 ROOT = Path(__file__).resolve().parents[4]
+
+
+def _extract_musa_wheel_metadata_verifier() -> str:
+    script = (ROOT / ".github/scripts/build_musa_wheel.sh").read_text()
+    start = script.index("<<'PY'\n") + len("<<'PY'\n")
+    end = script.index('\nPY\n\necho "=== bundled MUSA/torch libraries', start)
+    return script[start:end]
 
 
 def _load_workflow(relative_path: str) -> dict:
@@ -124,3 +134,49 @@ def test_publish_workflow_wires_musa_build_and_release() -> None:
     assert "nightly-musa" in publish_step["run"]
     assert "--prerelease" in publish_step["run"]
     assert "MUSA_VERSION" in publish_step["env"]
+
+
+def test_musa_wheel_metadata_verifier_accepts_pep440_normalized_version(
+    tmp_path: Path,
+) -> None:
+    """Wheel metadata may canonicalize release segments such as 1.0001 -> 1.1."""
+    wheel = tmp_path / "lmcache-1.1+musa-cp310-cp310-manylinux_2_35_x86_64.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            "lmcache-1.1+musa.dist-info/METADATA",
+            "\n".join(
+                [
+                    "Metadata-Version: 2.4",
+                    "Name: lmcache",
+                    "Version: 1.1+musa",
+                    "",
+                ]
+            ),
+        )
+        archive.writestr(
+            "lmcache-1.1+musa.dist-info/WHEEL",
+            "\n".join(
+                [
+                    "Wheel-Version: 1.0",
+                    "Generator: test",
+                    "Root-Is-Purelib: false",
+                    "Tag: cp310-cp310-manylinux_2_35_x86_64",
+                    "",
+                ]
+            ),
+        )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _extract_musa_wheel_metadata_verifier(),
+            str(wheel),
+            str(tmp_path / "check"),
+            "1.0001+musa",
+            "manylinux_2_35_x86_64",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- install pinned grpcio/grpcio-tools in ROCm, XPU, and MUSA wheel build scripts
- pin the same grpcio version in build and proto generation requirements
- make the generated gRPC module import check avoid lmcache.__init__, so packaging does not depend on runtime logging/OpenTelemetry state
- add a regression test that fails if the proto import check leaks into the LMCache top-level package

## Testing
- git diff --check
- bash -n .github/scripts/build_rocm_wheel.sh .github/scripts/build_xpu_wheel.sh .github/scripts/build_musa_wheel.sh
- isolated _proto_gen/_generate.py check with grpcio==1.78.0 and grpcio-tools==1.78.0; generated *_pb2_grpc.py files report GRPC_GENERATED_VERSION = 1.78.0
- uv run --with pytest python -m pytest tests/v1/multiprocess/transport/test_proto_generator.py -q
- python3 -m pre_commit run --all-files (passes except rust-clippy fails on macOS while compiling Linux-only io-uring symbols)
- SKIP=rust-clippy python3 -m pre_commit run --all-files

Fixes variant wheel failures where setup.py imports grpc_tools.protoc during build_py, avoids generated stubs requiring a newer grpcio runtime than the build environment provides, and prevents the generated-module import check from importing lmcache.__init__ during packaging.