### PR TITLE
build: keep gRPC proto tooling out of package flow

### DIFF
--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -264,12 +264,6 @@ export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERS
 uv pip freeze | sort > /tmp/env-before-lmcache.txt
 uv pip install -e . --no-build-isolation
 
-# Editable installs do not run setuptools' build_py hook. Install the pinned
-# generator and create the ignored bindings required when server.py is imported.
-uv pip install -r requirements/proto.txt
-echo "--- :gear: Generating LMCache gRPC bindings"
-python "${REPO_ROOT}/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
-
 uv pip freeze | sort > /tmp/env-after-lmcache.txt
 if ! diff -q /tmp/env-before-lmcache.txt /tmp/env-after-lmcache.txt >/dev/null; then
     echo "--- :warning: Packages changed during LMCache install"

--- a/.buildkite/k3_harness/setup-lmcache-only-env.sh
+++ b/.buildkite/k3_harness/setup-lmcache-only-env.sh
@@ -20,11 +20,5 @@ echo "--- :python: Installing LMCache from source (no vLLM)"
 export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE:-0.0.0+ci}"
 uv pip install -e . --no-build-isolation
 
-# Editable installs do not run setuptools' build_py hook. Install the pinned
-# generator and create the ignored bindings required when server.py is imported.
-uv pip install -r requirements/proto.txt
-echo "--- :gear: Generating LMCache gRPC bindings"
-python "${REPO_ROOT}/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
-
 echo "--- :white_check_mark: Environment ready (LMCache only, no vLLM)"
 python -c "import lmcache; print('LMCache installed from source')"

--- a/.buildkite/k3_harness/setup-sglang-env.sh
+++ b/.buildkite/k3_harness/setup-sglang-env.sh
@@ -38,9 +38,5 @@ export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE="${SETUPTOOLS_SCM_PRETEND_VERS
 uv pip uninstall cupy-cuda12x 2>/dev/null || true
 uv pip install -e . --no-build-isolation
 
-uv pip install -r requirements/proto.txt
-echo "--- :gear: Generating LMCache gRPC bindings"
-python "${REPO_ROOT}/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py"
-
 python -c "import lmcache, sglang; print(f'sglang={sglang.__version__}; lmcache OK')"
 python -c "import cupy; print(f'cupy={cupy.__version__}')"

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -28,9 +28,6 @@ trap 'rm -rf "${LMCACHE_TEST_TMPDIR}" 2>/dev/null || true' EXIT
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt
-# Generated gRPC bindings are intentionally not tracked. Generate them only
-# after the test dependencies have installed grpcio-tools.
-python lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
 
 # ── Run unit tests with coverage ─────────────────────────────
 LMCACHE_TRACK_USAGE="false" \

--- a/.buildkite/scripts/amd-vllm-bench-container.sh
+++ b/.buildkite/scripts/amd-vllm-bench-container.sh
@@ -48,8 +48,6 @@ echo "AMD kernel mode: ${AMD_KERNEL_MODE}"
 
 uv pip install --system --no-cache -r requirements/build.txt
 uv pip install --system --no-cache --no-build-isolation -e .
-echo "Generating LMCache gRPC bindings"
-python3 lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
 uv pip install --system --no-cache openai pandas matplotlib
 
 # Fail during setup with the real import error instead of waiting for server

--- a/.github/scripts/install_lmcache_cpu.sh
+++ b/.github/scripts/install_lmcache_cpu.sh
@@ -23,8 +23,5 @@ ${PIP_BIN} install -r requirements/common.txt
 ${PIP_BIN} install -r requirements/cli.txt
 ${PIP_BIN} install -e . --no-deps --no-build-isolation
 
-echo "Generating LMCache gRPC bindings"
-python lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/_generate.py
-
 python -c "import lmcache, vllm; \
 print('lmcache:', lmcache.__version__, 'vllm:', vllm.__version__)"

--- a/docs/design/v1/multiprocess/transport/request_transport.md
+++ b/docs/design/v1/multiprocess/transport/request_transport.md
@@ -54,15 +54,12 @@ The planned gRPC transport keeps its wire contracts under
 `grpc_impl/protos/`. These `.proto` files are the source of truth for request
 and response messages; they do not enable the gRPC runtime by themselves.
 
-Python protobuf modules are generated into `grpc_impl/_proto_gen/` during a
-package build. Most generated files remain ignored, while the type stubs used
-by handwritten adapters are tracked so static analysis also works from a
-source checkout. Regenerate the bindings after changing a schema with:
-
-```bash
-pip install -r requirements/proto.txt
-python -m lmcache.v1.multiprocess.transport.grpc_impl._proto_gen._generate
-```
+Package builds do not generate Python protobuf modules or add gRPC runtime
+dependencies while the transport remains disabled. Most generated files remain
+ignored, while the type stubs used by handwritten adapters are tracked so
+static analysis also works from a source checkout. For local schema
+development, the manual generator remains available under `_proto_gen`, but
+default installs, tests, and package builds do not invoke it.
 
 The generator cleans stale outputs, compiles every schema, rewrites generated
 imports to use the package-qualified path, and verifies that all generated

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -570,7 +570,7 @@ Key Source Files
    * - ``lmcache/v1/multiprocess/transport/grpc_impl/protos/``
      - Protobuf wire contracts for the planned gRPC request transport
    * - ``lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/``
-     - Build-time protobuf generator and generated Python package
+     - Manual protobuf generator for local schema development
    * - ``lmcache/v1/multiprocess/modules/``
      - Engine module implementations: ``lookup.py`` (``LookupModule``),
        ``management.py`` (``ManagementModule``), ``lmcache_driven_transfer.py``

--- a/docs/source/mp/request_transport.rst
+++ b/docs/source/mp/request_transport.rst
@@ -31,18 +31,14 @@ gRPC schema development
 -----------------------
 
 The protobuf schemas for the planned gRPC transport live under
-``lmcache/v1/multiprocess/transport/grpc_impl/protos``. Package builds generate
-their Python bindings under the sibling ``_proto_gen`` package. Landing these
-schemas and the build-time generator does not enable the gRPC client or server;
-``grpc://`` endpoints remain unavailable until the runtime implementation
-lands.
+``lmcache/v1/multiprocess/transport/grpc_impl/protos``. Landing these schemas
+and the manual generator does not add gRPC runtime dependencies, generate
+bindings during package builds, or enable the gRPC client or server. ``grpc://``
+endpoints remain unavailable until the runtime implementation lands.
 
-After changing a schema, regenerate and validate all bindings with:
-
-.. code-block:: bash
-
-   pip install -r requirements/proto.txt
-   python -m lmcache.v1.multiprocess.transport.grpc_impl._proto_gen._generate
+For local schema development, the manual generator remains available under the
+``_proto_gen`` package, but default installs, tests, and package builds do not
+invoke it.
 
 For a single vLLM connector, set the scheme in ``lmcache.mp.host`` and keep the
 port in ``lmcache.mp.port``. The current ZMQ configuration is:

--- a/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/__init__.py
+++ b/lmcache/v1/multiprocess/transport/grpc_impl/_proto_gen/__init__.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Generated protobuf and gRPC modules for the multiprocess transport.
 
-The ``../protos/*.proto`` schemas are the source of truth. Package builds
-generate ``*_pb2.py``, ``*_pb2.pyi``, and ``*_pb2_grpc.py`` modules in this
-package. The type stubs used directly by custom adapters are tracked so static
-analysis also works before a package build. Regenerate all bindings after
-changing a schema with::
-
-    pip install -r requirements/proto.txt
-    python -m lmcache.v1.multiprocess.transport.grpc_impl._proto_gen._generate
+The ``../protos/*.proto`` schemas are the source of truth. Package builds do
+not generate or import gRPC bindings while the runtime transport is still
+disabled. The type stubs used directly by custom adapters are tracked so static
+analysis works from a source checkout. For local schema development, bindings
+can be generated manually from ``_generate.py`` in an isolated development
+environment.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools_scm>=8",
-    "grpcio-tools==1.78.0",
     "torch==2.13.0",
     "wheel",
 ]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,6 @@ ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools_scm>=8
-grpcio-tools==1.78.0
 # torch is not here because vllm installation will implicitly install it for the dockerfile
 # and users should be deliberate about choosing their torch version (or letting their serving
 # engine be deliberate for them)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -25,8 +25,6 @@ py-cpuinfo
 pytest
 pyyaml
 pyzmq >= 25.0.0
-grpcio>=1.78.0
-protobuf>=6.31.1,<7
 redis
 safetensors
 setuptools>=77.0.3,<81.0.0

--- a/requirements/proto.txt
+++ b/requirements/proto.txt
@@ -1,2 +1,0 @@
-# Pinned for deterministic local and CI generation; outputs are not tracked.
-grpcio-tools==1.78.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,3 @@
--r proto.txt
-
 buildkite-test-collector
 pytest>=7.0,<9.1  # avoid some plugins breaking in 8.x
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ zero changes to this file.
 
 # Standard
 from pathlib import Path
-from types import ModuleType
-import importlib.util
 import sys
 
 ROOT_DIR = Path(__file__).parent
@@ -20,7 +18,6 @@ if str(ROOT_DIR) not in sys.path:
 
 # Third Party
 from setuptools import find_packages, setup  # noqa: E402
-from setuptools.command.build_py import build_py as _build_py  # noqa: E402
 
 # First Party
 from setup_extensions import BuildPolicy, BuildProfile  # noqa: E402
@@ -37,44 +34,10 @@ def _read_requirements(path: Path) -> list[str]:
     return reqs
 
 
-def _load_proto_generator() -> ModuleType:
-    """Load the proto generator without importing the LMCache package."""
-    generator_path = (
-        ROOT_DIR
-        / "lmcache"
-        / "v1"
-        / "multiprocess"
-        / "transport"
-        / "grpc_impl"
-        / "_proto_gen"
-        / "_generate.py"
-    )
-    spec = importlib.util.spec_from_file_location(
-        "_lmcache_proto_generate", generator_path
-    )
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Cannot load gRPC proto generator: {generator_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-class _BuildPyWithGrpcStubs(_build_py):
-    """Generate ignored gRPC bindings before packaging LMCache."""
-
-    def run(self) -> None:
-        distribution_name = self.distribution.get_name().replace("_", "-").lower()
-        if distribution_name != "lmcache-cli":
-            generator = _load_proto_generator()
-            generator.generate()
-        super().run()
-
-
 if __name__ == "__main__":
     policy = BuildPolicy()
     profile = policy.resolve_profile()
     ext_modules, cmdclass, req_file = policy.collect_extensions(profile)
-    cmdclass["build_py"] = _BuildPyWithGrpcStubs
 
     install_requires = _read_requirements(ROOT_DIR / "requirements" / "common.txt")
     extras_require: dict[str, list[str]] = {}


### PR DESCRIPTION
## Summary
- remove the direct gRPC/protobuf dependencies from LMCache's default build, runtime, and test requirement paths
- stop package builds and default CI/setup scripts from generating gRPC bindings
- keep the planned gRPC proto/generator files in the repository while documenting that they are manual development assets only for now

## Motivation
The v0.5.5rc6 release workflow started building from the gRPC/protobuf foundation commit, which made wheel packaging install grpcio-tools and run proto generation even though the gRPC transport runtime is still disabled. This keeps those files in the repo without affecting package/release flows.

## Testing
- bash -n .github/scripts/install_lmcache_cpu.sh .buildkite/scripts/amd-vllm-bench-container.sh .buildkite/k3_harness/setup-env.sh .buildkite/k3_harness/setup-lmcache-only-env.sh .buildkite/k3_harness/setup-sglang-env.sh .buildkite/k3_tests/unit/run.sh
- NO_NATIVE_EXT=1 SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LMCACHE=0.0.0+nogrpc .venv/bin/python setup.py sdist bdist_wheel --dist-dir /tmp/lmcache-no-grpc-setuppy-26159
- inspected the built wheel/sdist: no direct grpcio/protobuf metadata deps, no requirements/proto.txt, and no generated _pb2.py/_pb2_grpc.py
- .venv/bin/python smoke check: grpc:// transport still raises NotImplementedError without generated bindings
- SKIP=rust-fmt,rust-clippy .venv/bin/pre-commit run --all-files
- PATH="../.venv/bin:$PATH" make clean html from docs/ (succeeds with the existing 31 warnings)

## Notes
- Full pytest through the repo root conftest was not used as the primary local check on macOS because this checkout was installed with NO_NATIVE_EXT=1, so the root conftest reaches native-extension-only imports. The direct smoke check covers the changed transport boundary.
