### PR TITLE
docs: daily drift check — multi-process mode (2026-09-12)

### DIFF
--- a/docs/design/v1/platform/cuda/ipc_wrapper.md
+++ b/docs/design/v1/platform/cuda/ipc_wrapper.md
@@ -82,9 +82,14 @@ ordering hazard. The TRT-LLM adapter keeps instantiating
 ## Status
 
 Selected by `CudaDeviceSpec.ipc_wrapper_cls` behind the isolated-IPC
-switch, off by default. With both legs behind the switch, an
-isolated-IPC deployment has **zero `/dev/shm` dependencies** in the MP
-path — `--ipc host` / `hostIPC: true` can be dropped (see
-`docs/source/mp/deployment.rst`). Remaining series work: migrate the
-SGLang/CacheBlend/qstore call sites, flip the default, drop `hostIPC`
-from the operator.
+switch, off by default in the LMCache server itself. With both legs
+behind the switch, an isolated-IPC deployment has **zero `/dev/shm`
+dependencies** in the MP path — `--ipc host` / `hostIPC: true` can be
+dropped (see `docs/source/mp/deployment.rst`). The Kubernetes operator
+has already flipped: on `gpuVendor: nvidia` it now defaults to
+isolated IPC (`spec.isolatedIPC` unset resolves to true), starts the
+engine with `--isolated-ipc`, and injects vLLM pods without the host
+`/dev/shm` mount or `hostIPC` (see `docs/source/mp/operator.rst` and
+`operator/DESIGN.md`). Remaining series work: migrate the
+SGLang/CacheBlend/qstore call sites and flip the server-side default
+of `--isolated-ipc` itself.

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -67,12 +67,22 @@ Source: ``lmcache/v1/multiprocess/config.py``
        span (so telemetry and coordinator membership share one id).
        When the flag is not passed, defaults to a random UUID v4
        minted at startup.
+   * - ``--transport``
+     - ``zmq``
+     - Request transport used by the multiprocess cache server. Only
+       ``zmq`` has a runtime today; ``grpc`` is accepted by the parser
+       and reserved for the upcoming gRPC implementation (the schemas
+       and build-time generator now live under
+       ``lmcache/v1/multiprocess/transport/grpc_impl/`` -- see
+       :doc:`request_transport`) but selecting it raises
+       ``NotImplementedError`` at startup. Choices: ``zmq``, ``grpc``.
    * - ``--host``
      - ``localhost``
-     - Host address to bind the ZMQ server.
+     - Host address to bind the request server (currently the ZMQ
+       transport).
    * - ``--port``
      - ``5555``
-     - Port to bind the ZMQ server.
+     - Port to bind the request server (currently the ZMQ transport).
    * - ``--chunk-size``
      - ``256``
      - Chunk size for KV cache operations (in tokens).


### PR DESCRIPTION
## Summary

Daily automated drift check between LMCache multi-process documentation and the actual code layout, focused on changes that landed on `dev` since the last drift check ([#5060](https://github.com/LMCache/LMCache/pull/5060), 2026-09-10). This pass found two items — one in `docs/source/` and one in `docs/design/` — both stemming from multi-process PRs that landed on 2026-09-11 / 2026-09-12.

### Drift found in `docs/source/` (user-facing, highest priority)

- **`docs/source/mp/configuration.rst`** — the "MP Server" argument table is missing the new `--transport` flag introduced by [#5066](https://github.com/LMCache/LMCache/pull/5066) (`build(multiprocess): add gRPC protobuf and test foundation`). The page opens with "This page documents every CLI argument accepted by the LMCache multiprocess server", so the new flag needs an entry. Additionally, the `--host` and `--port` rows still describe them as binding "the ZMQ server", while the argparse help text was generalized to "request server" in the same PR (only `--host`'s help was updated in code; `--port` remains inconsistent — the doc reflects the pre-generalization wording for both).

### Drift found in `docs/design/` (secondary)

- **`docs/design/v1/platform/cuda/ipc_wrapper.md`** — the "Status" paragraph's `Remaining series work` list still names "drop `hostIPC` from the operator". After [#4807](https://github.com/LMCache/LMCache/pull/4807) (`[Operator] Default to isolated IPC; drop hostIPC and /dev/shm sharing`) landed, that item is done: on `gpuVendor: nvidia` the operator now resolves `spec.isolatedIPC` to true by default, starts the engine with `--isolated-ipc`, and injects vLLM pods without the host `/dev/shm` mount or `hostIPC`.

## Evidence

### `--transport` flag (docs/source drift)

- Argparse definition (server-side `--transport`, `choices=["zmq", "grpc"]`, `default="zmq"`):
  [`lmcache/v1/multiprocess/config.py#L281-L288`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/lmcache/v1/multiprocess/config.py#L281-L288)
- `MPServerConfig.transport` field:
  [`lmcache/v1/multiprocess/config.py#L26-L28`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/lmcache/v1/multiprocess/config.py#L26-L28)
- `create_request_server` raises `NotImplementedError` for anything but `zmq`:
  [`lmcache/v1/multiprocess/transport/server_factory.py#L21-L37`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/lmcache/v1/multiprocess/transport/server_factory.py#L21-L37)
- `--host` argparse help updated to "request server" (but doc still says ZMQ):
  [`lmcache/v1/multiprocess/config.py#L293`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/lmcache/v1/multiprocess/config.py#L293)
- Stale doc lines (before this PR):
  [`docs/source/mp/configuration.rst#L70-L75`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/docs/source/mp/configuration.rst#L70-L75) — `--host` / `--port` say "ZMQ server"; the whole `--transport` row is absent.

### Operator isolated-IPC default (docs/design drift)

- Operator resolves `spec.isolatedIPC` to true by default for NVIDIA:
  [`operator/api/v1alpha1/lmcacheengine_defaults.go`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/operator/api/v1alpha1/lmcacheengine_defaults.go) (`IsolatedIPCEnabled`)
- Field doc on the CRD spec (`isolatedIPC` auto-enables on NVIDIA; when true, the pods get neither `hostIPC` nor the shared `/dev/shm`, and the server runs with `--isolated-ipc`):
  [`operator/api/v1alpha1/lmcacheengine_types.go`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/operator/api/v1alpha1/lmcacheengine_types.go)
- Updated user-facing operator docs describing the new default:
  [`docs/source/mp/operator.rst`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/docs/source/mp/operator.rst) (see `mp-operator-isolated-ipc`)
- Stale design-doc lines (before this PR):
  [`docs/design/v1/platform/cuda/ipc_wrapper.md#L84-L90`](https://github.com/LMCache/LMCache/blob/05a013b29da78cf2321b9b46ec5039dde2fb0bb0/docs/design/v1/platform/cuda/ipc_wrapper.md#L84-L90) — "Remaining series work" still names "drop `hostIPC` from the operator".

## Proposed fix (applied in this PR)

Docs-only, one commit:

- **`docs/source/mp/configuration.rst`** — add a `--transport` row to the MP Server table with default `zmq`, note that only `zmq` has a runtime today and `grpc` currently raises `NotImplementedError` at startup, and cross-reference the existing `:doc:\`request_transport\`` page for the client-side URL-scheme selection. Rewrite the `--host` / `--port` description to say "request server (currently the ZMQ transport)" so it matches the generalized argparse help.
- **`docs/design/v1/platform/cuda/ipc_wrapper.md`** — rewrite the "Status" paragraph's `Remaining series work` note: keep the "off by default in the LMCache server itself" framing, add a sentence recording that the Kubernetes operator has already flipped (NVIDIA default → isolated IPC; no host `/dev/shm` or `hostIPC` in the injected vLLM pods), and reduce the outstanding list to the SGLang/CacheBlend/qstore call-site migration + flipping the server-side default of `--isolated-ipc` itself.

No code changes.

## Notes

- This PR was **auto-generated by the daily docs drift-check routine** (multi-process mode focus). Human review is required before merge — please spot-check the wording, especially the operator's default-resolution phrasing (it is auto on NVIDIA, not a static CRD default), and the cross-reference to the request-transport page.
- Only doc files are touched; no code is modified.
- No apparent code bug was found — the drift is stale documentation, not a code regression. The one small code inconsistency spotted along the way (only `--host`'s argparse help was generalized to "request server"; `--port`'s help still says "ZMQ server") is called out here for a follow-up but not fixed in this docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRktYm2YMZB6HUT7zhJ4Qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRktYm2YMZB6HUT7zhJ4Qb)_