### PR TITLE
[CI][Rust] Run raw-block Rust unit tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,32 @@ jobs:
         run: |
           pytest -m "not (cuda or musa or xpu or npu or neuron)"
 
+  rust-unit-tests:
+    needs: changes
+    if: needs.changes.outputs.raw_block == 'true'
+    name: Rust unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run Rust unit tests
+        run: cargo test --manifest-path rust/raw_block/Cargo.toml --no-default-features
+
   raw-block-tests:
     needs: changes
     if: needs.changes.outputs.raw_block == 'true'

--- a/rust/raw_block/Cargo.toml
+++ b/rust/raw_block/Cargo.toml
@@ -9,7 +9,12 @@ edition = "2021"
 name = "lmcache_rust_raw_block_io"
 crate-type = ["cdylib"]
 
+[features]
+# Disable extension-module for cargo test so test binaries link to libpython.
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = "0.24"
 libc = "0.2"
 io-uring = "0.7"

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -546,34 +546,6 @@ fn placement_id_to_u16(pid: i32) -> PyResult<u16> {
     u16::try_from(pid).map_err(|_| PyValueError::new_err("placement_id must be in range 1..=65535"))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn check_nvme_ioctl_result_accepts_success() {
-        assert!(check_nvme_ioctl_result(0, "NVMe ioctl failed").is_ok());
-    }
-
-    #[test]
-    fn check_nvme_ioctl_result_rejects_nvme_status() {
-        assert!(check_nvme_ioctl_result(1, "NVMe ioctl failed").is_err());
-    }
-
-    #[test]
-    fn placement_id_to_u16_accepts_valid_bounds() {
-        assert_eq!(placement_id_to_u16(1).unwrap(), 1);
-        assert_eq!(placement_id_to_u16(65535).unwrap(), 65535);
-    }
-
-    #[test]
-    fn placement_id_to_u16_rejects_reserved_and_out_of_range_values() {
-        assert!(placement_id_to_u16(0).is_err());
-        assert!(placement_id_to_u16(-1).is_err());
-        assert!(placement_id_to_u16(65536).is_err());
-    }
-}
-
 /// Prepare NVMe uring command for read/write operations
 #[allow(clippy::too_many_arguments)]
 fn nvme_uring_cmd_prep(
@@ -3352,3 +3324,6 @@ fn lmcache_rust_raw_block_io(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<(
     m.add_class::<RawBlockDevice>()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/raw_block/src/tests.rs
+++ b/rust/raw_block/src/tests.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{check_nvme_ioctl_result, placement_id_to_u16};
+
+#[test]
+fn check_nvme_ioctl_result_accepts_success() {
+    assert!(check_nvme_ioctl_result(0, "NVMe ioctl failed").is_ok());
+}
+
+#[test]
+fn check_nvme_ioctl_result_rejects_nvme_status() {
+    assert!(check_nvme_ioctl_result(1, "NVMe ioctl failed").is_err());
+}
+
+#[test]
+fn placement_id_to_u16_accepts_valid_bounds() {
+    assert_eq!(placement_id_to_u16(1).unwrap(), 1);
+    assert_eq!(placement_id_to_u16(65535).unwrap(), 65535);
+}
+
+#[test]
+fn placement_id_to_u16_rejects_reserved_and_out_of_range_values() {
+    assert!(placement_id_to_u16(0).is_err());
+    assert!(placement_id_to_u16(-1).is_err());
+    assert!(placement_id_to_u16(65536).is_err());
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The four existing raw-block Rust unit tests were not executed by the Python pytest jobs. Add a dedicated CI job that runs them when the existing raw-block change filter matches.

The separate test module and CI job also make it straightforward to add and run future Rust tests.

- Run `cargo test --manifest-path rust/raw_block/Cargo.toml --no-default-features` on Ubuntu with Python 3.11.
- Make PyO3's `extension-module` feature optional and enabled by default. Disabling it for Cargo tests allows test executables to link against `libpython`, while normal extension builds retain their current configuration.
- Move the four existing tests into `rust/raw_block/src/tests.rs`, preserving their assertions.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
