### PR TITLE
[Bugfix][MP] Fix warm-prefetch outcomes and report missing key indices

### DIFF
--- a/docs/design/v1/distributed/storage_controllers/prefetch_l1_lock_pass.md
+++ b/docs/design/v1/distributed/storage_controllers/prefetch_l1_lock_pass.md
@@ -105,7 +105,11 @@ Notes:
   idempotent from any intermediate state.
 - **WARM mode**: locks like LOOKUP, but finish releases every read lock it
   holds (there is no retriever to hand them to) and leaves loaded keys
-  unlocked (`finish_write` only).
+  unlocked (`finish_write` only). Its result is not the retained bitmap but
+  the keys this request loaded itself: a key already resident when the warm
+  started is left out, because it may be another lookup's temporary, gone
+  once that reader releases, and a caller acting per key on the result must
+  not take it as warmed.
 
 ## Why lock-all + explicit touch
 

--- a/docs/design/v1/mp_coordinator/l2_prefetch.md
+++ b/docs/design/v1/mp_coordinator/l2_prefetch.md
@@ -22,10 +22,14 @@ sequenceDiagram
     loop until completed
         Cl->>Co: GET /cache/prefetches/{instance_id}/{request_id}
         Co->>M: GET /cache/prefetches/{request_id}
-        M-->>Co: {status: pending | completed}
+        M-->>Co: pending | completed {found_keys, total_keys, missing_key_indices}
         Co-->>Cl: (relayed verbatim)
     end
 ```
+
+A completed response reports what this warm request loaded, excluding prior
+L1 hits. `missing_key_indices` is the ascending complement in the submitted
+key order; neither it nor `found_keys` is a current residency snapshot.
 
 A client names **one** registered MP server and a **token sequence** (plus the
 model/world_size and tenant salt, and the optional `source_tier`=`l2` /

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -1069,9 +1069,12 @@ verbatim with its code.
 
 .. code-block:: json
 
-    {"status": "completed", "found_keys": 12, "total_keys": 12}
+    {"status": "completed", "found_keys": 12, "total_keys": 12, "missing_key_indices": []}
 
-``found_keys`` of ``total_keys`` requested chunks were resident.
+``found_keys`` of ``total_keys`` requested keys were loaded;
+``missing_key_indices`` lists the positions (chunk-major, then rank) of the
+rest. See the MP server's ``GET /cache/prefetches/{request_id}`` in
+:doc:`http_api` for the counting rule.
 
 **HTTP status codes:**
 
@@ -1085,7 +1088,7 @@ verbatim with its code.
 .. code-block:: bash
 
     curl -s http://localhost:9300/cache/prefetches/server-1/abc123
-    # -> {"status": "completed", "found_keys": 12, "total_keys": 12}
+    # -> {"status": "completed", "found_keys": 12, "total_keys": 12, "missing_key_indices": []}
 
 **Pin/unpin (protecting cache from eviction).** Pin a token sequence's cache so
 it is not evicted from L2 until unpinned. The coordinator resolves the token

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -967,16 +967,27 @@ reports progress; the first poll that observes completion drops the job
 
 .. code-block:: json
 
-    {"status": "completed", "found_keys": 12, "total_keys": 12}
+    {"status": "completed", "found_keys": 12, "total_keys": 12, "missing_key_indices": []}
 
-``found_keys`` / ``total_keys`` count only chunks **loaded from L2** by this
-request; chunks already resident in L1 are skipped at ``reserve_write`` and not
-counted, so a partially-resident warm undercounts by the resident chunk count
-(a cold request loads and counts everything). The warm uses the gap-tolerant
-``SPARSE`` trim policy, so an already-resident chunk does not stop the rest from
-loading — it loads every not-yet-resident chunk and reports that count. Not
-counting the resident chunks is deliberate: an already-present entry may be a
+Counts are per-rank object keys. ``total_keys`` counts every key the request
+resolved to; ``found_keys`` counts the keys **this request loaded** into L1.
+A key already in L1 when the warm started is neither re-loaded nor counted
+(so a partially-resident warm undercounts by that many), and a key no adapter
+holds is not loaded at all. The warm uses the gap-tolerant ``SPARSE`` trim
+policy, so a resident or absent key does not stop the rest from loading. Not
+counting prior hits is deliberate: an already-present entry may be a
 transient temporary from another lookup, so claiming it as warmed could mislead.
+
+``missing_key_indices`` lists, ascending, the positions of the keys this
+request did **not** load -- the complement of the loaded set, so its length is
+``total_keys - found_keys`` -- for a caller that acts per key rather than
+on the aggregate counts. Positions index the request's resolved key
+order: chunk-major, then rank (chunk 0's ranks ``0..world_size-1``, then
+chunk 1's, and so on), the same order every node and the coordinator resolve a
+token sequence to keys in. Under the counting rule above, a prior L1 hit
+appears here alongside genuine misses. These fields describe what the request
+loaded; they are not a residency snapshot and nothing prevents a later
+eviction.
 
 **HTTP status codes:**
 
@@ -990,7 +1001,7 @@ transient temporary from another lookup, so claiming it as warmed could mislead.
 .. code-block:: bash
 
     curl -s http://localhost:8080/cache/prefetches/abc123
-    # -> {"status": "completed", "found_keys": 1, "total_keys": 1}
+    # -> {"status": "completed", "found_keys": 1, "total_keys": 1, "missing_key_indices": []}
 
 .. _mp-http-quota-api:
 

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -72,7 +72,9 @@ class PrefetchMode(enum.Enum):
 
     ``WARM`` -- speculative pre-warm with no imminent reader: loaded keys are
     retained and left unlocked (immediately resident and evictable), so a later
-    lookup can hit them.
+    lookup can hit them. Its result names only the keys it loaded: a key
+    already resident when it started is neither re-loaded nor reported (it
+    may be another lookup's temporary, gone once that reader releases).
     """
 
     LOOKUP = enum.auto()

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -464,15 +464,19 @@ class PrefetchController(StorageControllerInterface):
         """
         Query the result of a prefetch request.
 
-        Thread-safe. Returns the retained-key bitmap if the request
+        Thread-safe. Returns the completion bitmap if the request
         has completed, None if still in progress. Each result can only
-        be retrieved once (subsequent calls return None).
+        be retrieved once (subsequent calls return None). For a ``WARM``
+        request the bitmap names only the keys the request loaded itself;
+        keys already resident in L1 when it started are not in it.
 
         Args:
             request_id: The request ID from submit_prefetch_request.
 
         Returns:
-            Number of prefix hits, or None if not yet complete.
+            The retained-key bitmap for LOOKUP, or that bitmap excluding
+            prior L1 hits for WARM. Returns None if the request is still
+            running, unknown, or its result has already been consumed.
 
         Note:
             This function will pop the completed lookup results as well.
@@ -1297,7 +1301,9 @@ class PrefetchController(StorageControllerInterface):
         4. Fold loaded ∪ locked keys to the final hit length / retained set.
         5. Unlock everything outside the retained set (e.g. out of the
            final sliding window).
-        6. Report the hit if no earlier step did, then the retained bitmap.
+        6. Report the lookup-phase hit if no earlier step did, then the
+           completion bitmap: retained keys for LOOKUP, or retained keys
+           excluding prior L1 hits for WARM.
 
         End state (sliding-window view; loaded keys in the in L2-hit sw
         segment, L1 locks elsewhere)::
@@ -1394,16 +1400,22 @@ class PrefetchController(StorageControllerInterface):
             request.attn_desc,
         )
         if request.mode is PrefetchMode.WARM:
-            if request.l1_readlocks.popcount() > 0:
+            # Prior L1 hits may be temporaries owned by another lookup:
+            # release our read locks on them and leave them out of the WARM
+            # result, which names only what this request loaded.
+            prior_hits = request.l1_readlocks
+            if prior_hits.popcount() > 0:
                 l1_mgr.finish_read(
-                    request.l1_readlocks.gather(request.keys),
+                    prior_hits.gather(request.keys),
                     read_locks=request.num_kv_readers,
                 )
                 request.l1_readlocks = Bitmap(num_keys)
+            completed = retained & (~prior_hits)
         else:
             released = (result_bitmap & (~retained)).gather(request.keys)
             if released:
                 l1_mgr.finish_read(released, read_locks=request.num_kv_readers)
+            completed = retained
 
         # LRU: the retained keys are the ones this request actually serves;
         # touch them (locking/unlocking never refreshes recency).
@@ -1417,7 +1429,7 @@ class PrefetchController(StorageControllerInterface):
         if not request.hit_reported:
             self._report_lookup_hit(request, hit_length)
 
-        self._complete_request(request.request_id, retained)
+        self._complete_request(request.request_id, completed)
 
     # =========================================================================
     # Unlock helpers

--- a/lmcache/v1/multiprocess/cache_control/prefetch_service.py
+++ b/lmcache/v1/multiprocess/cache_control/prefetch_service.py
@@ -93,7 +93,10 @@ class PrefetchService:
 
         Returns:
             ``{"request_id", "status": "pending"}`` or ``{"request_id",
-            "status": "completed", "found_keys", "total_keys"}``.
+            "status": "completed", "found_keys", "total_keys",
+            "missing_key_indices"}`` -- the last being the ascending positions,
+            in the request's resolved key order, of the keys the load did not
+            bring into L1.
 
         Raises:
             NotFound: unknown id (already completed-and-consumed, or never
@@ -111,5 +114,6 @@ class PrefetchService:
                 "status": COMPLETED,
                 "found_keys": status.found_keys,
                 "total_keys": status.total_keys,
+                "missing_key_indices": list(status.missing_key_indices),
             }
         return {"request_id": request_id, "status": status.state}

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -131,7 +131,8 @@ async def get_prefetch(request_id: str, request: Request) -> dict[str, object]:
 
     Responses:
         200: ``{"request_id", "status": "pending"}`` or ``{"request_id",
-            "status": "completed", "found_keys", "total_keys"}``.
+            "status": "completed", "found_keys", "total_keys",
+            "missing_key_indices"}``.
         404: unknown id. 503: server not initialized.
     """
     return get_context(request).prefetch_service.status(request_id)

--- a/lmcache/v1/multiprocess/warm_prefetch.py
+++ b/lmcache/v1/multiprocess/warm_prefetch.py
@@ -7,11 +7,12 @@ loads every requested key not already in L1, and pins nothing -- there is no
 downstream reader to pin for.
 
 The table tracks in-flight warm prefetches: ``submit`` starts one and returns an
-opaque request id; ``poll`` reports its status (pending, then completed) and
-drops it once the load finishes. Status is observed reactively by the caller --
-there is no background polling -- and these calls do not block. A job whose
-status is never polled to completion simply lingers until a later cleanup drops
-it; since nothing is pinned, no L1 is held.
+opaque request id; ``poll`` reports its status (pending, then completed -- with
+the positions of the keys the load did not bring in, so a caller can act per
+key) and drops it once the load finishes. Status is observed reactively by the
+caller -- there is no background polling -- and these calls do not block. A job
+whose status is never polled to completion simply lingers until a later cleanup
+drops it; since nothing is pinned, no L1 is held.
 """
 
 # Standard
@@ -50,11 +51,17 @@ class WarmStatus:
         found_keys: Keys loaded into L1 (only meaningful when ``completed``).
         total_keys: Keys originally requested (only meaningful when
             ``completed``).
+        missing_key_indices: Positions, in the submitted key order, of the
+            keys this load did **not** bring into L1 -- not found on any L2
+            adapter, or already resident and therefore skipped. Ascending, and
+            ``len`` equals ``total_keys - found_keys``. Only meaningful when
+            ``completed``.
     """
 
     state: str
     found_keys: int = 0
     total_keys: int = 0
+    missing_key_indices: tuple[int, ...] = ()
 
 
 class WarmPrefetchJobs:
@@ -130,6 +137,7 @@ class WarmPrefetchJobs:
         with self._lock:
             self._jobs.pop(request_id, None)
         found_keys = found.popcount()
+        missing_key_indices = tuple((~found).get_indices_list())
         logger.info(
             "Warm prefetch %s completed: %d/%d keys loaded into L1",
             request_id,
@@ -140,4 +148,5 @@ class WarmPrefetchJobs:
             state=COMPLETED,
             found_keys=found_keys,
             total_keys=handle.total_requested_keys,
+            missing_key_indices=missing_key_indices,
         )

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -1536,6 +1536,62 @@ class TestPrefetchMode:
         ctrl.stop()
         adapter.close()
 
+    def test_warm_result_excludes_prior_l1_hits(self, l1_manager):
+        """A key already in L1 when the warm starts is neither re-loaded nor
+        reported: it may be another lookup's temporary, gone once that reader
+        releases, so a caller acting per key on the result must not take it
+        as loaded. The result names exactly the keys this warm brought in."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        # keys[1] is loadable from L2; keys[0] is a temporary another reader
+        # still holds; keys[2] exists nowhere.
+        store_keys_in_l2(adapter, [keys[1]], layout)
+        reserved = l1_manager.reserve_write(
+            [keys[0]], is_temporary=[True], layout_desc=layout, mode="new"
+        )
+        assert reserved[keys[0]][0] == L1Error.SUCCESS
+        held = l1_manager.finish_write_and_reserve_read([keys[0]])
+        assert held[keys[0]][0] == L1Error.SUCCESS
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+        try:
+            req_id = ctrl.submit_prefetch_request(
+                PrefetchRequestSpec(
+                    keys,
+                    {0: layout},
+                    policy=TrimPolicy.SPARSE,
+                    mode=PrefetchMode.WARM,
+                )
+            )
+            result = wait_for_prefetch_result_bitmap(ctrl, req_id)
+            assert result is not None
+            assert result.get_indices_list() == [1]
+
+            # The prior temporary was left alone: once its reader releases
+            # it, it is gone -- exactly why the warm must not have claimed it.
+            l1_manager.finish_read([keys[0]])
+            assert (
+                l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.KEY_NOT_EXIST
+            )
+            # What the warm did load remains resident after the probe read
+            # is released (retained, not temporary).
+            probe = l1_manager.reserve_read([keys[1]])
+            assert probe[keys[1]][0] == L1Error.SUCCESS
+            l1_manager.finish_read([keys[1]])
+            assert l1_manager.reserve_read([keys[1]])[keys[1]][0] == L1Error.SUCCESS
+            l1_manager.finish_read([keys[1]])
+        finally:
+            l1_manager.delete(keys)
+            ctrl.stop()
+            adapter.close()
+
     def test_default_deletes_keys_after_finish_read(self, l1_manager):
         """LOOKUP defers to ``DefaultPrefetchPolicy`` (temporary), so
         the keys are deleted from L1 once the read-lock is released."""

--- a/tests/v1/multiprocess/http_apis/test_cache_api.py
+++ b/tests/v1/multiprocess/http_apis/test_cache_api.py
@@ -441,23 +441,36 @@ class _PrefetchHandle:
 
 
 class _PrefetchBitmap:
-    def __init__(self, n: int) -> None:
-        self._n = n
+    """Stands in for the loaded-key ``Bitmap``: exactly ``loaded`` of ``size``
+    positions are set."""
+
+    def __init__(self, loaded: set[int], size: int) -> None:
+        self._loaded = loaded
+        self._size = size
 
     def popcount(self) -> int:
-        return self._n
+        return len(self._loaded)
+
+    def __invert__(self) -> "_PrefetchBitmap":
+        return _PrefetchBitmap(set(range(self._size)) - self._loaded, self._size)
+
+    def get_indices_list(self) -> list[int]:
+        return sorted(self._loaded)
 
 
 @dataclass
 class _PrefetchStorageManager:
     submit_calls: list[dict] = field(default_factory=list)
+    found: int | None = None
+    """Keys the load brings in; ``None`` means every requested key."""
 
     def submit_prefetch_task(self, spec, **_) -> _PrefetchHandle:
         self.submit_calls.append({"keys": list(spec.keys), "mode": spec.mode})
         return _PrefetchHandle(len(spec.keys))
 
     def query_prefetch_status(self, handle) -> _PrefetchBitmap:
-        return _PrefetchBitmap(handle.total_requested_keys)
+        found = handle.total_requested_keys if self.found is None else self.found
+        return _PrefetchBitmap(set(range(found)), handle.total_requested_keys)
 
 
 @dataclass
@@ -536,7 +549,25 @@ class TestPrefetchEndpoint:
         assert body["status"] == "completed"
         assert body["found_keys"] == 4
         assert body["total_keys"] == 4
+        assert body["missing_key_indices"] == []
         assert client.get(f"/cache/prefetches/{rid}").status_code == 404
+
+    def test_status_reports_missing_key_positions(self):
+        """A partial load reports the positions (chunk-major, then rank) of
+        the keys it did not bring into L1."""
+        ctx = _ctx(layout=object())
+        ctx.storage_manager.found = 1
+        client = TestClient(_make_prefetch_app(ctx))
+        rid = client.post(
+            "/cache/prefetches",
+            json=_prefetch_body([1, 2, 3, 4, 5, 6, 7, 8], world_size=2),
+        ).json()["request_id"]
+
+        body = client.get(f"/cache/prefetches/{rid}").json()
+        assert body["status"] == "completed"
+        assert body["found_keys"] == 1
+        assert body["total_keys"] == 4
+        assert body["missing_key_indices"] == [1, 2, 3]
 
     def test_status_unknown_request_id_404(self):
         client = TestClient(_make_prefetch_app(_ctx(layout=object())))

--- a/tests/v1/multiprocess/test_warm_prefetch.py
+++ b/tests/v1/multiprocess/test_warm_prefetch.py
@@ -8,8 +8,7 @@ path), status is polled reactively, and completion releases **nothing** (no
 """
 
 # Standard
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey, PrefetchMode, TrimPolicy
@@ -35,39 +34,47 @@ class _FakeHandle:
 
 
 class _FakeBitmap:
-    """Stands in for the found-key ``Bitmap``; ``popcount`` is the found count."""
+    """Stands in for the loaded-key ``Bitmap``: exactly ``loaded`` of ``size``
+    positions are set."""
 
-    def __init__(self, n: int) -> None:
-        self._n = n
+    def __init__(self, loaded: set[int], size: int) -> None:
+        self._loaded = loaded
+        self._size = size
 
     def popcount(self) -> int:
-        return self._n
+        return len(self._loaded)
+
+    def __invert__(self) -> "_FakeBitmap":
+        return _FakeBitmap(set(range(self._size)) - self._loaded, self._size)
+
+    def get_indices_list(self) -> list[int]:
+        return sorted(self._loaded)
 
 
 @dataclass
 class _FakeStorageManager:
-    found: int = 0
+    loaded: set[int] = field(default_factory=set)
+    """Positions the load brings into L1."""
     delay_polls: int = 0
+    """Status polls answered "still running" before the load completes."""
 
-    submit_args: Optional[dict] = None
+    submit_args: dict[str, object] = field(default_factory=dict)
     finish_called: bool = False
     _polls: int = 0
-    _total: int = 0
 
     def submit_prefetch_task(self, spec):
-        self._total = len(spec.keys)
         self.submit_args = {
             "keys": list(spec.keys),
             "mode": spec.mode,
             "policy": spec.policy,
         }
-        return _FakeHandle(self._total)
+        return _FakeHandle(len(spec.keys))
 
     def query_prefetch_status(self, handle):
         if self._polls < self.delay_polls:
             self._polls += 1
             return None
-        return _FakeBitmap(self.found)
+        return _FakeBitmap(self.loaded, handle.total_requested_keys)
 
     def finish_read_prefetched(self, keys, read_locks: int = 1) -> None:
         # Must never be called: the warm holds no lock.
@@ -78,11 +85,10 @@ def test_submit_uses_retain_and_poll_completes_without_release():
     """submit goes through the WARM (no-lock) path; the caller polls
     (pending → completed); completion releases nothing and consumes the job."""
     keys = [_key(0), _key(1)]
-    sm = _FakeStorageManager(found=2, delay_polls=2)
+    sm = _FakeStorageManager(loaded={0, 1}, delay_polls=2)
     jobs = WarmPrefetchJobs()
 
     request_id = jobs.submit(sm, keys, layout_desc=object())
-    assert sm.submit_args is not None
     assert sm.submit_args["mode"] is PrefetchMode.WARM
     assert sm.submit_args["policy"] is TrimPolicy.SPARSE
 
@@ -94,11 +100,43 @@ def test_submit_uses_retain_and_poll_completes_without_release():
     assert status.state == COMPLETED
     assert status.found_keys == 2
     assert status.total_keys == 2
+    assert status.missing_key_indices == ()
     # No lock was held, so nothing is released.
     assert sm.finish_called is False
 
     # Exactly-once: the completing poll consumed the job.
     assert jobs.poll(sm, request_id).state == UNKNOWN
+
+
+def test_completed_reports_missing_key_positions():
+    """A partial load names the positions it did not bring in, in submitted
+    key order, so a caller can act per key; the count agrees with found/total."""
+    keys = [_key(0), _key(1), _key(2)]
+    sm = _FakeStorageManager(loaded={0})
+    jobs = WarmPrefetchJobs()
+
+    request_id = jobs.submit(sm, keys, layout_desc=object())
+    status = jobs.poll(sm, request_id)
+    assert status.state == COMPLETED
+    assert status.found_keys == 1
+    assert status.total_keys == 3
+    assert status.missing_key_indices == (1, 2)
+    assert len(status.missing_key_indices) == status.total_keys - status.found_keys
+
+
+def test_completed_reports_sparse_missing_key_positions():
+    """Gaps in the loaded set are reported as the exact unloaded positions,
+    not as a prefix count."""
+    keys = [_key(i) for i in range(5)]
+    sm = _FakeStorageManager(loaded={1, 3})
+    jobs = WarmPrefetchJobs()
+
+    request_id = jobs.submit(sm, keys, layout_desc=object())
+    status = jobs.poll(sm, request_id)
+    assert status.state == COMPLETED
+    assert status.found_keys == 2
+    assert status.total_keys == 5
+    assert status.missing_key_indices == (0, 2, 4)
 
 
 def test_poll_unknown_request_id():


### PR DESCRIPTION
**What this PR does / why we need it**:

Warm prefetch currently reports keys that were already in L1 as loaded. An existing entry can belong to another lookup and disappear when that reader releases it. A caller therefore cannot treat the result as evidence that this warm request loaded those keys.

This change excludes prior L1 hits from the WARM result and adds `missing_key_indices` to completed status. The indices identify positions in the request that this warm did not load, including keys already present. Finding an existing entry does not establish that this warm request retained it.

This gives the move proposed in #5083 the per-key result it needs before requesting source deletion. I return positions rather than full keys to keep the response small. Callers still need to resolve keys in the same order as the target.

**Special notes for your reviewers**:

`found_keys` describes this request's loaded result, not current L1 residency. Loaded entries remain evictable. The regression test uses a real L1 manager to verify that an old temporary entry disappears after its reader releases it while the newly warmed entry remains available.

I ran the warm-prefetch, cache API and prefetch controller suites on a CUDA machine. All 95 tests passed, including the temporary L1 lifecycle regression.

Refs #5083.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests