### PR TITLE
fix(cli): lmcache bench avoid hanging on bench ZMQ shutdown

### DIFF
--- a/lmcache/cli/commands/bench/server_bench/client.py
+++ b/lmcache/cli/commands/bench/server_bench/client.py
@@ -735,6 +735,7 @@ class ServerBenchClient:
             % (config.rpc_url, config.mode)
         )
         self._zmq_context = zmq.Context()
+        self._zmq_context.setsockopt(zmq.LINGER, 0)
         self._req_client = RequestClientFactory.create(
             config.rpc_url,
             context=self._zmq_context,

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -1130,6 +1130,10 @@ class TestClientMultiWorker:
         class FakeContext:
             terminated = False
 
+            def setsockopt(self, option: int, value: int) -> None:
+                """Accept socket defaults without creating a real socket."""
+                pass
+
             def term(self) -> None:
                 self.terminated = True
 
@@ -1253,6 +1257,10 @@ class TestClientMultiWorker:
             return None
 
         class FakeContext:
+            def setsockopt(self, option: int, value: int) -> None:
+                """Accept socket defaults without creating a real socket."""
+                pass
+
             def term(self) -> None:
                 pass
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Sets ZMQ_LINGER=0 before creating the bench client's socket. This prevents ctx.term() from waiting indefinitely for unsent RPC messages when the server is unreachable, allowing startup errors to propagate and the command to exit.

example:
Before — the command hangs during cleanup without reporting the error:
```
[rank 0] REGISTER_KV_CACHE: FAIL
```
After — the command reports the error and exits:
```
[rank 0] REGISTER_KV_CACHE: FAIL
ERROR: REGISTER_KV_CACHE failed for rank 0 (instance_id=1000)
```
**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
